### PR TITLE
Fixes syntax errors in a few live examples

### DIFF
--- a/src/Button/Button.doc.js
+++ b/src/Button/Button.doc.js
@@ -88,9 +88,7 @@ card(
   'Example',
   <Example
     defaultCode={`
-const ButtonExample = () => (
-  <Button text="Medium Sized Button" />
-);
+<Button text="Medium Sized Button" />
 `}
     scope={{ Box, Button, Text }}
   />,
@@ -106,16 +104,14 @@ card(
   `,
   <Example
     defaultCode={`
-const ButtonExample = () => (
-  <Box>
-    <Box padding={2}>
-      <Button text="inline button" inline />
-    </Box>
-    <Box padding={2}>
-      <Button text="default full width button" />
-    </Box>
+<Box margin={-2}>
+  <Box padding={2}>
+    <Button text="inline button" inline />
   </Box>
-);
+  <Box padding={2}>
+    <Button text="default full width button" />
+  </Box>
+</Box>
 `}
     scope={{ Box, Button, Text }}
   />,
@@ -129,30 +125,27 @@ card(
   `,
   <Example
     defaultCode={`
-const ButtonExample = () => (
-  <Box color="darkGray" maxWidth={320} shape="rounded">
-    <Box padding={2}>
-      <Text bold color="white" size="lg">
-        New! Explore today’s trending ideas, curated finds, and personalized
-        picks.
-      </Text>
+<Box color="darkGray" maxWidth={320} shape="rounded" padding={4}>
+  <Box marginBottom={4}>
+    <Text color="white">
+      Explore today’s trending ideas, curated finds, and personalized
+      picks.
+    </Text>
+  </Box>
+  <Box
+    display="flex"
+    direction="row"
+    marginLeft={-2}
+    marginRight={-2}
+  >
+    <Box display="flex" direction="row" column={6} paddingX={2}>
+      <Button color="transparent" text="Later" />
     </Box>
-    <Box
-      display="flex"
-      direction="row"
-      marginLeft={-1}
-      marginRight={-1}
-      padding={2}
-    >
-      <Box display="flex" direction="row" column={6} paddingX={1}>
-        <Button color="transparent" text="Later" />
-      </Box>
-      <Box column={6} paddingX={1}>
-        <Button color="white" text="Learn more" />
-      </Box>
+    <Box column={6} paddingX={2}>
+      <Button color="white" text="Learn more" />
     </Box>
   </Box>
-);
+</Box>
 `}
     scope={{ Box, Button, Text }}
   />,
@@ -168,16 +161,14 @@ card(
 
   <Example
     defaultCode={`
-const ButtonExample = () => (
-  <Box>
-    <Box padding={2}>
-      <Button onClick={() => {}} text="Clear" type="button" />
-    </Box>
-    <Box padding={2}>
-      <Button color="red" text="Submit" type="submit" />
-    </Box>
+<Box margin={-2}>
+  <Box padding={2}>
+    <Button onClick={() => {}} text="Clear" type="button" />
   </Box>
-);
+  <Box padding={2}>
+    <Button color="red" text="Submit" type="submit" />
+  </Box>
+</Box>
 `}
     scope={{ Box, Button, Text }}
   />,
@@ -194,16 +185,14 @@ card(
   `,
   <Example
     defaultCode={`
-const ButtonExample = () => (
-  <Box>
-    <Box padding={2}>
-      <Button accessibilityLabel="Add James" text="Add" />
-    </Box>
-    <Box padding={2}>
-      <Button accessibilityLabel="Add Irene" text="Add" />
-    </Box>
+<Box margin={-2}>
+  <Box padding={2}>
+    <Button accessibilityLabel="Add James" text="Add" />
   </Box>
-);
+  <Box padding={2}>
+    <Button accessibilityLabel="Add Irene" text="Add" />
+  </Box>
+</Box>
 `}
     scope={{ Box, Button, Text }}
   />,

--- a/src/Checkbox/Checkbox.doc.js
+++ b/src/Checkbox/Checkbox.doc.js
@@ -115,39 +115,41 @@ card(
   `,
   <Example
     defaultCode={`
-const CheckboxExample = (props) => {
-	const CheckboxWithLabel = ({ id, label }) => (
-    <Box
-      alignItems="center"
-      direction="row"
-      display="flex"
-    >
-      <Checkbox
-        checked
-        id={id}
-        onChange={() => {}}
-      />
-      <Label htmlFor={id}>
-        <Box paddingX={2}>
-          <Text>{label}</Text>
-        </Box>
-      </Label>
-    </Box>
-  );
-
-	return (
-		<Box display="flex" direction="column" justifyContent="around">
-			<Box paddingY={1}>
-        <CheckboxWithLabel label="Email" id="email" />
-			</Box>
-			<Box paddingY={1}>
-				<CheckboxWithLabel label="Mobile push" id="push" />
-			</Box>
-			<Box paddingY={1}>
-        <CheckboxWithLabel label="Carrier pidgeon" id="pidgeon" />
+class CheckboxExample extends React.Component {
+  render() {
+    const CheckboxWithLabel = ({ id, label }) => (
+      <Box
+        alignItems="center"
+        direction="row"
+        display="flex"
+      >
+        <Checkbox
+          checked
+          id={id}
+          onChange={() => {}}
+        />
+        <Label htmlFor={id}>
+          <Box paddingX={2}>
+            <Text>{label}</Text>
+          </Box>
+        </Label>
       </Box>
-		</Box>
-	);
+    );
+
+  	return (
+  		<Box display="flex" direction="column" justifyContent="around" marginTop={-1} marginBottom={-1}>
+  			<Box paddingY={1}>
+          <CheckboxWithLabel label="Email" id="email" />
+  			</Box>
+  			<Box paddingY={1}>
+  				<CheckboxWithLabel label="Mobile push" id="push" />
+  			</Box>
+  			<Box paddingY={1}>
+          <CheckboxWithLabel label="Carrier pidgeon" id="pidgeon" />
+        </Box>
+  		</Box>
+  	);
+  }
 }
 `}
     scope={{ Box, Checkbox, Label, Text }}

--- a/src/Link/Link.doc.js
+++ b/src/Link/Link.doc.js
@@ -46,24 +46,22 @@ card(
   `,
   <Example
     defaultCode={`
-const LinkA11YExample = () => (
-  <Box>
-    <Link href="https://pinterest.com">
-      <Box padding={2}>
-        <Text bold>Pinterest.com</Text>
-      </Box>
-    </Link>
-    <Box color="darkGray">
-      <Text color="white" bold>
-        <Link href="https://pinterest.com">
-          <Box padding={2}>
-            Pinterest.com
-          </Box>
-        </Link>
-      </Text>
+<Box>
+  <Link href="https://pinterest.com">
+    <Box padding={2}>
+      <Text bold>Pinterest.com</Text>
     </Box>
+  </Link>
+  <Box color="darkGray">
+    <Text color="white" bold>
+      <Link href="https://pinterest.com">
+        <Box padding={2}>
+          Pinterest.com
+        </Box>
+      </Link>
+    </Text>
   </Box>
-);
+</Box>
 `}
     scope={{ Box, Link, Text }}
   />,
@@ -77,17 +75,13 @@ card(
   `,
   <Example
     defaultCode={`
-const LinkA11YExample = () => (
-  <Box>
-      <Link>
-        <Box padding={2}>
-          <a href="https://pinterest.com" style={{ textDecoration: 'none' }}>
-            <Text bold>Pinterest.com</Text>
-          </a>
-        </Box>
-      </Link>
+<Link>
+  <Box padding={2}>
+    <a href="https://pinterest.com" style={{ textDecoration: 'none' }}>
+      <Text bold>Pinterest.com</Text>
+    </a>
   </Box>
-);
+</Link>
 `}
     scope={{ Box, Link, Text }}
   />,
@@ -101,35 +95,35 @@ card(
   `,
   <Example
     defaultCode={`
-const LinkA11YExample = () => (
-  <Box>
+<Box>
+  <Heading size="sm">
+    Bad ❌
+  </Heading>
+  <Text>
+    For more information,{' '}
+    <Text inline bold>
+      <Link inline href="https://pinterest.com">
+        click here
+      </Link>
+    </Text>.
+  </Text>
+  <Box paddingY={4}>
     <Heading size="sm">
-      Bad ❌
+      Good ✅
     </Heading>
     <Text>
-      For more information,{' '}
+      Visit
+      {' '}
       <Text inline bold>
         <Link inline href="https://pinterest.com">
-          click here
+          Pinterest.com
         </Link>
-      </Text>.
-    </Text>
-    <Box paddingY={4}>
-      <Heading size="sm">
-        Good ✅
-      </Heading>
-      <Text>
-        Visit{' '}
-        <Text inline bold>
-          <Link inline href="https://pinterest.com">
-            Pinterest.com
-          </Link>
-        </Text>{' '}
-        for more information.
       </Text>
-    </Box>
+      {' '}
+      for more information.
+    </Text>
   </Box>
-);
+</Box>
 `}
     scope={{ Box, Link, Text }}
   />,


### PR DESCRIPTION
Currently in the live docs there are a few syntax errors that area stopping the examples from showing up:

<img width="543" alt="screen shot 2018-02-17 at 9 56 24 am" src="https://user-images.githubusercontent.com/718/36344280-a34ab9ac-13cc-11e8-8765-5a82a01c9484.png">
