### PR TITLE
ExperimentalMasonry: Reference measurementStore from props instead of instance

### DIFF
--- a/test/containers/ExperimentalMasonryExample.js
+++ b/test/containers/ExperimentalMasonryExample.js
@@ -293,7 +293,7 @@ export default class MasonryExample extends React.Component {
             comp={this.renderItem}
             flexible={Boolean(this.props.flexible)}
             items={this.state.items}
-            measurementStore={this.props.externalCache ? store : null}
+            measurementStore={this.props.externalCache ? store : undefined}
             ref={ref => {
               this.gridRef = ref;
             }}


### PR DESCRIPTION
This PR updates Masonry so that it always references `measurementStore` from props instead of `this.measurementStore`.  

Currently the measurementStore is bound to the instance in the constructor.  Because of this, if a new measurementStore is passed in during `componentWillReceiveProps`, we actually end up referencing the wrong measurementStore.  