### PR TITLE
Create custom width property for flyout

### DIFF
--- a/src/Flyout/Flyout.js
+++ b/src/Flyout/Flyout.js
@@ -9,7 +9,7 @@ type Props = {|
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
   positionRelativeToAnchor?: boolean,
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number,
 |};
 
 export default class Flyout extends React.PureComponent<Props> {
@@ -52,5 +52,8 @@ Flyout.propTypes = {
   idealDirection: PropTypes.oneOf(['up', 'right', 'down', 'left']),
   onDismiss: PropTypes.func.isRequired,
   positionRelativeToAnchor: PropTypes.bool,
-  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']), // default: sm
+  size: PropTypes.oneOfType(
+    PropTypes.number,
+    PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']) // default: sm
+  ),
 };

--- a/src/FlyoutUtils/Contents.js
+++ b/src/FlyoutUtils/Contents.js
@@ -47,7 +47,7 @@ type ControllerProps = {|
   onDismiss: () => void,
   positionRelativeToAnchor: boolean,
   shouldFocus?: boolean,
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number,
 |};
 
 type Window = {

--- a/src/FlyoutUtils/Controller.js
+++ b/src/FlyoutUtils/Controller.js
@@ -12,7 +12,7 @@ type Props = {|
   onDismiss: () => void,
   positionRelativeToAnchor: boolean,
   shouldFocus?: boolean,
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number,
 |};
 
 const SIZE_WIDTH_MAP = {
@@ -121,7 +121,7 @@ export default class Controller extends React.Component<Props, State> {
       return null;
     }
     const size = this.props.size ? this.props.size : 'sm';
-    const width = SIZE_WIDTH_MAP[size];
+    const width = typeof size === 'string' ? SIZE_WIDTH_MAP[size] : size;
     return (
       <Box>
         <div
@@ -162,5 +162,8 @@ Controller.propTypes = {
   onDismiss: PropTypes.func.isRequired,
   positionRelativeToAnchor: PropTypes.bool,
   shouldFocus: PropTypes.bool,
-  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']), // default: sm
+  size: PropTypes.oneOfType(
+    PropTypes.number,
+    PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']) // default: sm
+  ),
 };


### PR DESCRIPTION
Sometimes design specifications could require the Flyout to extend pass the five standardized sizes. Because the flyout has no method for extending beyond the size, this PR adds a width property to the Flyout component in order to allow the flyout to have custom sizes for when the Flyout must be a different size other than the standardized sizes.

_Pros_
- allows for flexibility in designing components that use the fly-out
- avoids having to add extra sizes for larger fly-outs (i.e. xxl, xxxl, xxxxl)

_Cons_
- less consistency in fly-outs if developers and engineers choose not to use the standardized sizes

<img width="1368" alt="custom flyout width screenshot" src="https://user-images.githubusercontent.com/36522522/36441374-4800d786-1627-11e8-9ae7-9ece8d7942d7.png">

