### PR TITLE
Netlify: Live preview with every PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^15.4.1"
   },
   "scripts": {
-    "build_docs": "webpack --config webpack.config.corkboard.js --colors --progress --optimize-minimize --output-public-path '/gestalt' --output-path docs",
+    "build_docs": "webpack --config webpack.config.corkboard.js --colors --progress --optimize-minimize --output-path docs",
     "eslint": "eslint .",
     "flow": "flow",
     "ghost": "BUILDKITE_PARALLEL_JOB_COUNT=${BUILDKITE_PARALLEL_JOB_COUNT} BUILDKITE_PARALLEL_JOB=${BUILDKITE_PARALLEL_JOB} ./run_integration_tests",

--- a/scripts/ghpages.sh
+++ b/scripts/ghpages.sh
@@ -13,7 +13,7 @@ set -x
 repo=${1:-https://github.com/pinterest/gestalt.git}
 
 git checkout -b tmp-deploy
-npm run build_docs
+npm run build_docs -- --output-public-path '/gestalt'
 git add -f docs
 git commit -m "Deployed to Github Pages"
 git push ${repo} :gh-pages


### PR DESCRIPTION
Updating our `package.json` so Netlify can run `yarn run build_docs` instead of the custom webpack command.