### PR TITLE
Sticky: Add zIndex support

### DIFF
--- a/src/Sticky/Sticky.doc.js
+++ b/src/Sticky/Sticky.doc.js
@@ -18,7 +18,7 @@ card(
         type: 'number',
       },
       {
-        name: 'children',
+        name: 'children?',
         type: 'React.Node',
       },
       {
@@ -40,9 +40,6 @@ card(
       },
     ]}
   />,
-  md`
-    **Note**: if no threshold is passed to Sticky, it will behave the same as a relatively positioned element
-  `,
   { stacked: true }
 );
 

--- a/src/Sticky/Sticky.doc.js
+++ b/src/Sticky/Sticky.doc.js
@@ -19,7 +19,7 @@ card(
       },
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'left',
@@ -32,6 +32,11 @@ card(
       {
         name: 'top',
         type: 'number',
+      },
+      {
+        name: 'dangerouslySetZIndex',
+        type: 'number',
+        defaultValue: 1,
       },
     ]}
   />,
@@ -53,15 +58,15 @@ card(
           <Text>This should stick</Text>
         </Box>
       </Sticky>
-      <Box marginTop={10}>
+      <Box marginTop={10} position="relative">
         <Text>Scroll</Text>
         <Text>Keep scrolling</Text>
         <Text>Scroll more</Text>
       </Box>
     </Box>
     <Box>
-      <Sticky top={0}>
-      <Box alignItems="center" color="lightGray" display="flex" height={40}>
+      <Sticky top={0} dangerouslySetZIndex={3}>
+      <Box alignItems="center" color="lightGray" display="flex" height={40} position="relative" dangerouslySetInlineStyle={{ __style: { zIndex: 2 } }}>
           <Text>This should also stick</Text>
         </Box>
       </Sticky>

--- a/src/Sticky/Sticky.doc.js
+++ b/src/Sticky/Sticky.doc.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Box from '../Box/Box';
 import Sticky from './Sticky';
 import Text from '../Text/Text';
-import { ns, card, md, Example, PropTable } from '../../docs/src/cards';
+import { ns, card, Example, PropTable } from '../../docs/src/cards';
 
 ns(
   'Sticky',

--- a/src/Sticky/Sticky.doc.js
+++ b/src/Sticky/Sticky.doc.js
@@ -18,7 +18,7 @@ card(
         type: 'number',
       },
       {
-        name: 'children?',
+        name: 'children',
         type: 'React.Node',
       },
       {

--- a/src/Sticky/Sticky.doc.js
+++ b/src/Sticky/Sticky.doc.js
@@ -35,8 +35,8 @@ card(
       },
       {
         name: 'dangerouslySetZIndex',
-        type: 'number',
-        defaultValue: 1,
+        type: '{ __zIndex: number }',
+        defaultValue: '{ __zIndex: 1 }',
       },
     ]}
   />,
@@ -62,7 +62,7 @@ card(
       </Box>
     </Box>
     <Box>
-      <Sticky top={0} dangerouslySetZIndex={3}>
+      <Sticky top={0} dangerouslySetZIndex={{ __zIndex: 3 }}>
       <Box alignItems="center" color="lightGray" display="flex" height={40} position="relative" dangerouslySetInlineStyle={{ __style: { zIndex: 2 } }}>
           <Text>This should also stick</Text>
         </Box>

--- a/src/Sticky/Sticky.js
+++ b/src/Sticky/Sticky.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import layout from '../Layout.css';
 
 type Threshold =
@@ -13,7 +13,7 @@ type Threshold =
   | {| top: number, left: number, right: number, bottom: number |};
 
 type Props = {|
-  children: any,
+  children: React.Node,
   dangerouslySetZIndex?: number,
   ...Threshold,
 |};

--- a/src/Sticky/Sticky.js
+++ b/src/Sticky/Sticky.js
@@ -14,19 +14,22 @@ type Threshold =
 
 type Props = {|
   children: any,
+  dangerouslySetZIndex?: number,
   ...Threshold,
 |};
 
 export default function Sticky(props: Props) {
+  const { dangerouslySetZIndex = 1, children } = props;
   const style = {
     top: typeof props.top === 'number' ? props.top : undefined,
     left: typeof props.left === 'number' ? props.left : undefined,
     right: typeof props.right === 'number' ? props.right : undefined,
     bottom: typeof props.bottom === 'number' ? props.bottom : undefined,
+    zIndex: dangerouslySetZIndex,
   };
   return (
     <div className={layout.sticky} style={style}>
-      {props.children}
+      {children}
     </div>
   );
 }

--- a/src/Sticky/Sticky.js
+++ b/src/Sticky/Sticky.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import layout from '../Layout.css';
 
 type Threshold =
@@ -14,18 +15,18 @@ type Threshold =
 
 type Props = {|
   children: React.Node,
-  dangerouslySetZIndex?: number,
+  dangerouslySetZIndex?: { __zIndex: number },
   ...Threshold,
 |};
 
 export default function Sticky(props: Props) {
-  const { dangerouslySetZIndex = 1, children } = props;
+  const { dangerouslySetZIndex = { __zIndex: 1 }, children } = props;
   const style = {
     top: typeof props.top === 'number' ? props.top : undefined,
     left: typeof props.left === 'number' ? props.left : undefined,
     right: typeof props.right === 'number' ? props.right : undefined,
     bottom: typeof props.bottom === 'number' ? props.bottom : undefined,
-    zIndex: dangerouslySetZIndex,
+    zIndex: dangerouslySetZIndex.__zIndex,
   };
   return (
     <div className={layout.sticky} style={style}>

--- a/src/Sticky/Sticky.js
+++ b/src/Sticky/Sticky.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import layout from '../Layout.css';
 
 type Threshold =
@@ -26,6 +25,7 @@ export default function Sticky(props: Props) {
     left: typeof props.left === 'number' ? props.left : undefined,
     right: typeof props.right === 'number' ? props.right : undefined,
     bottom: typeof props.bottom === 'number' ? props.bottom : undefined,
+    // eslint-disable-next-line no-underscore-dangle
     zIndex: dangerouslySetZIndex.__zIndex,
   };
   return (

--- a/src/Sticky/__tests__/__snapshots__/Sticky.test.js.snap
+++ b/src/Sticky/__tests__/__snapshots__/Sticky.test.js.snap
@@ -9,6 +9,7 @@ exports[`Sticky correctly sets thresholds 1`] = `
       "left": 2,
       "right": 3,
       "top": 4,
+      "zIndex": 1,
     }
   }
 >
@@ -25,6 +26,7 @@ exports[`Sticky renders 1`] = `
       "left": undefined,
       "right": undefined,
       "top": 1,
+      "zIndex": 1,
     }
   }
 >


### PR DESCRIPTION
Currently, if any element that appears after `Sticky` sets a `position` attribute, it will be stacked on top.  This makes `Sticky` somewhat useless since, most of the time, it will be followed by some sort of scrollable content.  

This PR updates `Sticky` so that, by default, it sets a z-index of 1.  This should handle the 99% case where elements that appear after Sticky set a position attribute, but no z-index.  For the other 1% case where we might have to set a z-index, I've added a `dangerouslySetZIndex` prop.  

cc @PFarejowicz 