### PR TITLE
Internal: Add changelog.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+## [Unreleased]
+<details>
+  <summary>
+    Changes that have landed in master but are not yet released.
+    Click to see more.
+  </summary>
+
+### Minor
+### Patch
+
+</details>
+
+## [0.57.1] (Feb 22, 2018)
+### Patch
+* Internal: Fix docs (StateRecorder) + run development mode locally + fix propType error #25
+
+## [0.57.0] (Feb 22, 2018)
+## Minor
+* Sticky: Add zIndex support (#21)
+* SearchField: Add custom `onBlur` prop / Rename syntheticEvent => event / Use stricter flowtype on event to remove if check (#17)
+* Flyout: Allow for custom width (#16)
+* ExperimentalMasonry: Reference measurementStore from props instead of instance (#14)
+
+## Patch
+* Docs: Netlify: Live preview with every PR (#18)
+* Docs: Updates Heading, Image, Label & Text to use Example (#10)
+* Docs: Container / ErrorFlyout / IconButton / Label / Pog / SearchField: add live docs (#12)
+* Docs: Flyout / Mask / Pulsar: add live docs (#15)
+* Docs: Readme updates (#3) (#8)
+* Docs: Publish docs when releasing (#1)
+* Docs: Fixes syntax errors in a few live examples (#6)
+* Docs: Move .corkboard/ to docs/ and isolate components (#9)
+* Docs: Removes function syntax from cards (#7)
+* Build: Fixes repo url in docs build script (#4)
+* Internal: Webpack 3 upgrade (#11)
+
+[0.57.1]: https://deploy-preview-26--gestalt.netlify.com/
+[0.57.0]: https://deploy-preview-24--gestalt.netlify.com/


### PR DESCRIPTION
- Follows a convention of http://keepachangelog.com/en/1.0.0
- Makes `Unreleased` collapsable: https://github.com/facebook/react/blob/master/CHANGELOG.md
- Add links to docs per release