### PR TITLE
Added explanations for autofocus and onSubmit to TextField/TextArea

### DIFF
--- a/src/TextArea/TextArea.doc.js
+++ b/src/TextArea/TextArea.doc.js
@@ -170,3 +170,26 @@ card(
     )}
   />
 );
+
+card(
+  'Autofocus',
+  md`
+    \`TextArea\` intentionally lacks support for autofocus. Generally speaking,
+    autofocus interrupts normal page flow for screen readers making it an
+    anti-pattern for accessibility.
+  `
+);
+
+card(
+  'onSubmit',
+  md`
+    \`TextArea\` is commonly used as an input in forms along side submit buttons.
+    In these cases, users will expect the pressing Enter or Return with the input
+    focused to submit the form.
+
+    Out of the box, \`TextArea\` doesn't expose an \`onSubmit\` handler or
+    individual key event handlers due to the complexities of handling these
+    properly. Instead, developers are encouraged to wrap the \`TextArea\`
+    in a \`form\` and to attach an \`onSubmit\` handler to that \`form\`.
+  `
+);

--- a/src/TextArea/TextArea.doc.js
+++ b/src/TextArea/TextArea.doc.js
@@ -184,8 +184,8 @@ card(
   'onSubmit',
   md`
     \`TextArea\` is commonly used as an input in forms along side submit buttons.
-    In these cases, users will expect the pressing Enter or Return with the input
-    focused to submit the form.
+    In these cases, users expect that pressing Enter or Return with the input
+    focused will submit the form.
 
     Out of the box, \`TextArea\` doesn't expose an \`onSubmit\` handler or
     individual key event handlers due to the complexities of handling these

--- a/src/TextField/TextField.doc.js
+++ b/src/TextField/TextField.doc.js
@@ -197,3 +197,26 @@ card(
     )}
   />
 );
+
+card(
+  'Autofocus',
+  md`
+    \`TextField\` intentionally lacks support for autofocus. Generally speaking,
+    autofocus interrupts normal page flow for screen readers making it an
+    anti-pattern for accessibility.
+  `
+);
+
+card(
+  'onSubmit',
+  md`
+    \`TextField\` is commonly used as an input in forms along side submit buttons.
+    In these cases, users will expect the pressing Enter or Return with the input
+    focused to submit the form.
+
+    Out of the box, \`TextField\` doesn't expose an \`onSubmit\` handler or
+    individual key event handlers due to the complexities of handling these
+    properly. Instead, developers are encouraged to wrap the \`TextField\`
+    in a \`form\` and to attach an \`onSubmit\` handler to that \`form\`.
+  `
+);

--- a/src/TextField/TextField.doc.js
+++ b/src/TextField/TextField.doc.js
@@ -211,8 +211,8 @@ card(
   'onSubmit',
   md`
     \`TextField\` is commonly used as an input in forms along side submit buttons.
-    In these cases, users will expect the pressing Enter or Return with the input
-    focused to submit the form.
+    In these cases, users expect that pressing Enter or Return with the input
+    focused will submit the form.
 
     Out of the box, \`TextField\` doesn't expose an \`onSubmit\` handler or
     individual key event handlers due to the complexities of handling these


### PR DESCRIPTION
I had questions why `TextArea` and `TextField` didn't have `onSubmit` or `autofocus` in the past. Rather than keeping the answers to those questions myself, I figured I'd add it to the docs.