### PR TITLE
Textfield- Remove duplicate logic opening the error flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * GroupAvatar: Fix text sizes for 1 collaborator (#32)
 * Internal: Adds [Danger](http://danger.systems/js/) to pull requests. (#27)
+* TextField: Remove duplicate logic opening the error flyout (#34)
 * Internal: Re-exports flowtypes (#35)
 
 

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -82,10 +82,6 @@ export default class TextField extends React.Component<Props, State> {
         event,
         value: event.target.value,
       });
-
-      if (this.props.errorMessage) {
-        this.setState({ errorIsOpen: true });
-      }
     }
   };
 


### PR DESCRIPTION
We are currently setting state for errorIsOpen in bot handleChange and
componentWillReceiveProps.  This caused the element to render
unnecessarily and lose the cursor location.

Before:
![textfieldcursorbugbroken](https://user-images.githubusercontent.com/10646092/36697353-a7411322-1afb-11e8-9990-ce356fae2772.gif)

After:
![uploadwebsitefixed](https://user-images.githubusercontent.com/10646092/36697359-ae194de0-1afb-11e8-91e0-15df53cebd3e.gif)
