### PR TITLE
Flyout: update docs with correct flowtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Patch
 
+* Flyout: Update the docs with correct flowtypes
+
 </details>
 
 ## [0.58.0] (Feb 26, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Patch
 
-* Flyout: Update the docs with correct flowtypes
+* Flyout: Update the docs with correct flowtypes (#37)
 
 </details>
 

--- a/src/Flyout/Flyout.doc.js
+++ b/src/Flyout/Flyout.doc.js
@@ -43,7 +43,7 @@ card(
       },
       {
         name: 'size',
-        type: `"xs" | "sm" | "md" | "lg" | "xl"`,
+        type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | number`,
         description: `xs: 185px, sm: 230px, md: 284px, lg: 320px, xl:375px`,
         defaultValue: 'sm',
       },

--- a/src/Flyout/Flyout.doc.js
+++ b/src/Flyout/Flyout.doc.js
@@ -18,7 +18,7 @@ card(
         name: 'anchor',
         type: '?any',
         required: true,
-        description: 'Ref for the element that the ErrorFlyout will attach to',
+        description: 'Ref for the element that the Flyout will attach to',
       },
       {
         name: 'idealDirection',
@@ -39,7 +39,7 @@ card(
         type: 'boolean',
         defaultValue: true,
         description:
-          'Depicts if the ErrorFlyout shares a relative root with the anchor element',
+          'Depicts if the Flyout shares a relative root with the anchor element',
       },
       {
         name: 'size',


### PR DESCRIPTION
We added this in #16 but didn't update our docs.