### PR TITLE
Fix SelectList value type annotation to support string enums

### DIFF
--- a/packages/gestalt/src/SelectList/SelectList.js
+++ b/packages/gestalt/src/SelectList/SelectList.js
@@ -21,7 +21,7 @@ type Props = {|
   onChange: ({ event: SyntheticInputEvent<>, value: string }) => void,
   options: Array<{
     label: string,
-    value: string,
+    value: $Subtype<string>,
   }>,
   placeholder?: string,
   value?: ?string,


### PR DESCRIPTION
This should fix #60.

I didn't update the docs because I think the `$Subtype<string>` syntax harms readability for little  gain. (If people are interested in the nitty-gritty flowtypes, they'll be reading the source anyway.) Happy to update the docs if desired.