### PR TITLE
Fix the Flow typing in component and docs for all React children props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Docs: Add live docs for Tooltip (#63)
 * Docs: Add live docs to Tabs (#65)
 * Docs: Add live docs to Spinner (#66)
+* Flow: Update the Flow typing for `children` prop to be up to date with Flow version (#70)
 
 </details>
 

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -30,7 +30,7 @@ card(
       },
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'display',

--- a/docs/src/Column.doc.js
+++ b/docs/src/Column.doc.js
@@ -21,7 +21,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'span',

--- a/docs/src/Container.doc.js
+++ b/docs/src/Container.doc.js
@@ -21,7 +21,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
     ]}
     heading={false}

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -34,7 +34,7 @@ card(
       },
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'onDismiss',

--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -27,7 +27,7 @@ card(
       },
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'color',

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -30,10 +30,6 @@ card(
           'String that clients such as VoiceOver will read to describe the element. Always localize the label.',
       },
       {
-        name: 'children',
-        type: 'any',
-      },
-      {
         name: 'color',
         type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
         defaultValue: 'gray',

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -27,7 +27,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'alt',

--- a/docs/src/Label.doc.js
+++ b/docs/src/Label.doc.js
@@ -21,7 +21,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'htmlFor',

--- a/docs/src/Letterbox.doc.js
+++ b/docs/src/Letterbox.doc.js
@@ -28,7 +28,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'contentAspectRatio',

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -21,7 +21,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'href',

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -24,7 +24,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'height',

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -36,7 +36,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'accessibilityCloseLabel',
@@ -54,7 +54,7 @@ card(
       },
       {
         name: 'footer',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'heading',

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -30,7 +30,7 @@ card(
       },
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'color',

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -39,7 +39,7 @@ card(
       },
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'onDismiss',

--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -22,7 +22,7 @@ card(
     props={[
       {
         name: 'children',
-        type: 'any',
+        type: 'React.Node',
       },
       {
         name: 'fullHeight',

--- a/packages/gestalt/src/Box/Box.js
+++ b/packages/gestalt/src/Box/Box.js
@@ -87,7 +87,7 @@ type Margin =
   | 12;
 type Padding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 type PropType = {
-  children?: any,
+  children?: React.Node,
   dangerouslySetInlineStyle?: { __style: { [key: string]: any } },
 
   xs?: ResponsiveProps,

--- a/packages/gestalt/src/Column/Column.js
+++ b/packages/gestalt/src/Column/Column.js
@@ -9,14 +9,14 @@ type Columns = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 type ColumnProps =
   | {|
-      children?: any,
+      children?: React.Node,
       span: Columns,
       smSpan?: Columns,
       mdSpan?: Columns,
       lgSpan?: Columns,
     |}
   | {|
-      children?: any,
+      children?: React.Node,
       xs?: DeprecatedColumns,
       sm?: DeprecatedColumns,
       md?: DeprecatedColumns,

--- a/packages/gestalt/src/Container/Container.js
+++ b/packages/gestalt/src/Container/Container.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Box from '../Box/Box';
 
 type Props = {|
-  children?: any,
+  children?: React.Node,
 |};
 
 export default function Container(props: Props) {

--- a/packages/gestalt/src/Heading/Heading.js
+++ b/packages/gestalt/src/Heading/Heading.js
@@ -8,7 +8,7 @@ import typography from '../Typography.css';
 
 type Props = {|
   accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6,
-  children?: any,
+  children?: React.Node,
   color?:
     | 'blue'
     | 'darkGray'

--- a/packages/gestalt/src/Image/Image.js
+++ b/packages/gestalt/src/Image/Image.js
@@ -8,7 +8,7 @@ const shouldScaleImage = fit => fit === 'cover' || fit === 'contain';
 
 type Props = {|
   alt: string,
-  children?: any,
+  children?: React.Node,
   color: string,
   fit: 'contain' | 'cover' | 'none',
   naturalHeight: number,

--- a/packages/gestalt/src/Label/Label.js
+++ b/packages/gestalt/src/Label/Label.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import styles from './Label.css';
 
 type Props = {|
-  children?: any,
+  children?: React.Node,
   htmlFor: string,
 |};
 

--- a/packages/gestalt/src/Letterbox/Letterbox.js
+++ b/packages/gestalt/src/Letterbox/Letterbox.js
@@ -15,7 +15,7 @@ import Mask from '../Mask/Mask';
 const aspectRatio = (width, height) => width / height;
 
 type PropType = {|
-  children?: any,
+  children?: React.Node,
   contentAspectRatio: number,
   height: number,
   width: number,

--- a/packages/gestalt/src/Link/Link.js
+++ b/packages/gestalt/src/Link/Link.js
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import styles from './Link.css';
 
 type Props = {|
-  children?: any,
+  children?: React.Node,
   href: string,
   inline?: boolean,
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,

--- a/packages/gestalt/src/Mask/Mask.js
+++ b/packages/gestalt/src/Mask/Mask.js
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import styles from './Mask.css';
 
 type Props = {|
-  children?: any,
+  children?: React.Node,
   height?: number | string,
   shape?: 'circle' | 'rounded' | 'square',
   width?: number | string,

--- a/packages/gestalt/src/Modal/Modal.js
+++ b/packages/gestalt/src/Modal/Modal.js
@@ -27,8 +27,8 @@ const ESCAPE_KEY_CODE = 27;
 type Props = {|
   accessibilityCloseLabel: string,
   accessibilityModalLabel: string,
-  children?: any,
-  footer?: any,
+  children?: React.Node,
+  footer?: React.Node,
   heading: string,
   onDismiss: () => void,
   role?: 'alertdialog' | 'dialog',

--- a/packages/gestalt/src/Text/Text.js
+++ b/packages/gestalt/src/Text/Text.js
@@ -33,7 +33,7 @@ export default function Text({
 }: {|
   align?: 'left' | 'right' | 'center' | 'justify',
   bold?: boolean,
-  children?: any,
+  children?: React.Node,
   color?:
     | 'green'
     | 'pine'

--- a/packages/gestalt/src/Tooltip/Tooltip.js
+++ b/packages/gestalt/src/Tooltip/Tooltip.js
@@ -5,7 +5,7 @@ import Controller from '../FlyoutUtils/Controller';
 
 type Props = {|
   anchor: ?any,
-  children?: any,
+  children?: React.Node,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
   positionRelativeToAnchor?: boolean,

--- a/packages/gestalt/src/Touchable/Touchable.js
+++ b/packages/gestalt/src/Touchable/Touchable.js
@@ -26,7 +26,7 @@ type MouseCursor =
   | 'zoomOut';
 
 type Props = {|
-  children?: any,
+  children?: React.Node,
   fullHeight?: boolean,
   fullWidth?: boolean,
   mouseCursor?: MouseCursor,


### PR DESCRIPTION
Since we upgraded our Flow version, we can now change all these to be the correct Flow type for anything React can render. Also noticed that `<Icon />` doesn't have a `children` prop in the source code so I killed it in the docs as well.