### PR TITLE
Docs: Fix directly browsing to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Docs: Add live docs to Tabs (#65)
 * Docs: Add live docs to Spinner (#66)
 * Flow: Update the Flow typing for `children` prop to be up to date with Flow version (#70)
+* Docs: Fix directly browsing to components (#72)
 
 </details>
 

--- a/scripts/netlify.sh
+++ b/scripts/netlify.sh
@@ -4,3 +4,4 @@ set -e
 
 (cd packages/gestalt && yarn build)
 (cd docs && PUBLIC_URL=$DEPLOY_PRIME_URL yarn build)
+(cd docs/build && echo "/*    /index.html   200" > _redirects)


### PR DESCRIPTION
https://deploy-preview-72--gestalt.netlify.com/Avatar => Should work
https://deploy-preview-70--gestalt.netlify.com/Avatar => Results in a 404

See https://www.netlify.com/docs/redirects/#history-pushstate-and-single-page-apps