### PR TITLE
Add React proptying to components that were missing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Docs: Add live docs to Tabs (#65)
 * Docs: Add live docs to Spinner (#66)
 * Flow: Update the Flow typing for `children` prop to be up to date with Flow version (#70)
+* ErrorFlyout / Toast / Tooltip: Add missing React proptyping to components (#73)
 
 </details>
 

--- a/packages/gestalt/src/ErrorFlyout/ErrorFlyout.js
+++ b/packages/gestalt/src/ErrorFlyout/ErrorFlyout.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import Box from '../Box/Box';
 import Controller from '../FlyoutUtils/Controller';
+import PropTypes from 'prop-types';
 import Text from '../Text/Text';
 
 type Props = {|
@@ -46,3 +47,15 @@ export default function ErrorFlyout(props: Props) {
     </Controller>
   );
 }
+
+ErrorFlyout.propTypes = {
+  anchor: PropTypes.shape({
+    contains: PropTypes.func,
+    getBoundingClientRect: PropTypes.func,
+  }),
+  idealDirection: PropTypes.oneOf(['up', 'right', 'down', 'left']),
+  message: PropTypes.string.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+  positionRelativeToAnchor: PropTypes.bool,
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
+};

--- a/packages/gestalt/src/Icon/Icon.js
+++ b/packages/gestalt/src/Icon/Icon.js
@@ -6,7 +6,7 @@ import styles from './Icon.css';
 import icons from './icons';
 import colors from '../Colors.css';
 
-type IconProps = {
+type Props = {
   accessibilityLabel: string,
   color?:
     | 'blue'
@@ -33,7 +33,7 @@ type IconProps = {
 
 const IconNames = Object.keys(icons);
 
-export default function Icon(props: IconProps) {
+export default function Icon(props: Props) {
   const { accessibilityLabel, color = 'gray', icon, inline, size = 16 } = props;
 
   const cs = classnames(styles.icon, colors[color], {

--- a/packages/gestalt/src/Label/Label.js
+++ b/packages/gestalt/src/Label/Label.js
@@ -19,6 +19,6 @@ export default function Label(props: Props) {
 }
 
 Label.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   htmlFor: PropTypes.string.isRequired,
 };

--- a/packages/gestalt/src/Letterbox/Letterbox.js
+++ b/packages/gestalt/src/Letterbox/Letterbox.js
@@ -14,7 +14,7 @@ import Mask from '../Mask/Mask';
 
 const aspectRatio = (width, height) => width / height;
 
-type PropType = {|
+type Props = {|
   children?: React.Node,
   contentAspectRatio: number,
   height: number,
@@ -26,7 +26,7 @@ export default function Letterbox({
   contentAspectRatio,
   height,
   width,
-}: PropType) {
+}: Props) {
   const viewportAspectRatio = aspectRatio(width, height);
 
   let contentHeight;

--- a/packages/gestalt/src/Pulsar/Pulsar.js
+++ b/packages/gestalt/src/Pulsar/Pulsar.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import Box from '../Box/Box';
+import PropTypes from 'prop-types';
 import styles from './Pulsar.css';
 
 type Props = {
@@ -30,3 +31,8 @@ export default function Pulsar(props: Props) {
     </Box>
   );
 }
+
+Pulsar.propTypes = {
+  paused: PropTypes.bool,
+  size: PropTypes.number,
+};

--- a/packages/gestalt/src/Text/Text.js
+++ b/packages/gestalt/src/Text/Text.js
@@ -15,22 +15,7 @@ const SIZE_SCALE: { [size: ?string]: number } = {
   xl: 5,
 };
 
-export default function Text({
-  align = 'left',
-  bold = false,
-  children,
-  color = 'darkGray',
-  inline = false,
-  italic = false,
-  overflow = 'breakWord',
-  size = 'md',
-  smSize,
-  mdSize,
-  lgSize,
-  leading = 'short',
-  truncate = false,
-  __dangerouslyIncreaseLineHeight = false,
-}: {|
+type Props = {|
   align?: 'left' | 'right' | 'center' | 'justify',
   bold?: boolean,
   children?: React.Node,
@@ -62,7 +47,24 @@ export default function Text({
   truncate?: boolean,
   leading?: 'tall' | 'short',
   __dangerouslyIncreaseLineHeight?: boolean,
-|}) {
+|};
+
+export default function Text({
+  align = 'left',
+  bold = false,
+  children,
+  color = 'darkGray',
+  inline = false,
+  italic = false,
+  overflow = 'breakWord',
+  size = 'md',
+  smSize,
+  mdSize,
+  lgSize,
+  leading = 'short',
+  truncate = false,
+  __dangerouslyIncreaseLineHeight = false,
+}: Props) {
   const scale = SIZE_SCALE[size];
   const smScale = SIZE_SCALE[smSize];
   const mdScale = SIZE_SCALE[mdSize];

--- a/packages/gestalt/src/Toast/Toast.js
+++ b/packages/gestalt/src/Toast/Toast.js
@@ -4,6 +4,7 @@ import Box from '../Box/Box';
 import Mask from '../Mask/Mask';
 import Text from '../Text/Text';
 import Icon from '../Icon/Icon';
+import PropTypes from 'prop-types';
 
 type Props = {|
   color?: 'darkGray' | 'orange',
@@ -73,3 +74,13 @@ export default function Toast(props: Props) {
     </Box>
   );
 }
+
+Toast.propTypes = {
+  color: PropTypes.oneOf(['darkGray', 'orange']),
+  icon: PropTypes.oneOf(['arrow-circle-forward']), // leaving open to additional icons in the future
+  text: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]).isRequired,
+  thumbnail: PropTypes.element,
+};

--- a/packages/gestalt/src/Tooltip/Tooltip.js
+++ b/packages/gestalt/src/Tooltip/Tooltip.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import Box from '../Box/Box';
+import PropTypes from 'prop-types';
 import Controller from '../FlyoutUtils/Controller';
 
 type Props = {|
@@ -41,3 +42,15 @@ export default function Tooltip(props: Props) {
     </Controller>
   );
 }
+
+Tooltip.propTypes = {
+  anchor: PropTypes.shape({
+    contains: PropTypes.func,
+    getBoundingClientRect: PropTypes.func,
+  }),
+  children: PropTypes.node,
+  idealDirection: PropTypes.oneOf(['up', 'right', 'down', 'left']),
+  onDismiss: PropTypes.func.isRequired,
+  positionRelativeToAnchor: PropTypes.bool,
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
+};


### PR DESCRIPTION
I noticed a few components were missing the same React Proptyping that every other component had so I added those in here.

This change also moves `<Text />` Flow types to a separate `Props` type declaration so it is easier to read.

Lastly, `<Label />` had a mismatch between its Flow types and React Proptypes so I changed the Proptype to match the Flow type