### PR TITLE
Add support for nofollow prop in Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   measuring etc. (#46)
 * Sticky: Fallback to position relative in IE11 (#51)
 * SelectList: Hardcode 40px height for consistency (#57)
+* Link: Add `nollow` prop
 
 ### Patch
 

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -33,6 +33,11 @@ card(
         defaultValue: false,
       },
       {
+        name: 'nofollow',
+        type: 'boolean',
+        defaultValue: false,
+      },
+      {
         name: 'onClick',
         type: '({ event: SyntheticMouseEvent<> }) => void',
       },

--- a/packages/gestalt/src/Link/Link.js
+++ b/packages/gestalt/src/Link/Link.js
@@ -8,6 +8,7 @@ type Props = {|
   children?: any,
   href: string,
   inline?: boolean,
+  nofollow?: boolean,
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
   target?: null | 'self' | 'blank',
 |};
@@ -59,7 +60,7 @@ export default class Link extends React.Component<Props, State> {
       inline = false,
       nofollow = false,
       target = null,
-      href
+      href,
     } = this.props;
     const relAttributes = [];
     if (target === 'blank') {
@@ -68,7 +69,7 @@ export default class Link extends React.Component<Props, State> {
     if (nofollow) {
       relAttributes.push('nofollow');
     }
-    const rel = relAttributes.join(' ');
+    const rel = relAttributes.join(' ') || null;
     const linkTarget = target ? `_${target}` : null;
 
     return (

--- a/packages/gestalt/src/Link/Link.js
+++ b/packages/gestalt/src/Link/Link.js
@@ -23,6 +23,7 @@ export default class Link extends React.Component<Props, State> {
     children: PropTypes.node.isRequired,
     href: PropTypes.string.isRequired,
     inline: PropTypes.bool,
+    nofollow: PropTypes.bool,
     onClick: PropTypes.func,
     target: PropTypes.oneOf([null, 'self', 'blank']),
   };
@@ -53,8 +54,14 @@ export default class Link extends React.Component<Props, State> {
   };
 
   render() {
-    const { children, inline = false, nofollow = false, target = null, href } = this.props;
-    let relAttributes = [];
+    const {
+      children,
+      inline = false,
+      nofollow = false,
+      target = null,
+      href
+    } = this.props;
+    const relAttributes = [];
     if (target === 'blank') {
       relAttributes.push('noopener', 'noreferrer');
     }

--- a/packages/gestalt/src/Link/Link.js
+++ b/packages/gestalt/src/Link/Link.js
@@ -53,8 +53,15 @@ export default class Link extends React.Component<Props, State> {
   };
 
   render() {
-    const { children, inline = false, target = null, href } = this.props;
-    const rel = target === 'blank' ? 'noopener noreferrer' : null;
+    const { children, inline = false, nofollow = false, target = null, href } = this.props;
+    let relAttributes = [];
+    if (target === 'blank') {
+      relAttributes.push('noopener', 'noreferrer');
+    }
+    if (nofollow) {
+      relAttributes.push('nofollow');
+    }
+    const rel = relAttributes.join(' ');
     const linkTarget = target ? `_${target}` : null;
 
     return (

--- a/packages/gestalt/src/Link/__tests__/Link.test.js
+++ b/packages/gestalt/src/Link/__tests__/Link.test.js
@@ -44,3 +44,10 @@ it('with onClick', () =>
       Link
     </Link>
   ));
+
+it('with nofollow', () =>
+  snapshot(
+    <Link href="https://example.com" nofollow>
+      Link
+    </Link>
+  ));

--- a/packages/gestalt/src/Link/__tests__/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/Link/__tests__/__snapshots__/Link.test.js.snap
@@ -7,7 +7,7 @@ exports[`default 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel=""
+  rel={null}
   target={null}
 >
   Link
@@ -21,7 +21,7 @@ exports[`inline 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel=""
+  rel={null}
   target={null}
 >
   Link
@@ -35,7 +35,7 @@ exports[`regular 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel=""
+  rel={null}
   target={null}
 >
   Link
@@ -63,7 +63,7 @@ exports[`target null 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel=""
+  rel={null}
   target={null}
 >
   Link
@@ -77,7 +77,7 @@ exports[`target self 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel=""
+  rel={null}
   target="_self"
 >
   Link
@@ -105,7 +105,7 @@ exports[`with onClick 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel=""
+  rel={null}
   target={null}
 >
   Link

--- a/packages/gestalt/src/Link/__tests__/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/Link/__tests__/__snapshots__/Link.test.js.snap
@@ -7,7 +7,7 @@ exports[`default 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel={null}
+  rel=""
   target={null}
 >
   Link
@@ -21,7 +21,7 @@ exports[`inline 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel={null}
+  rel=""
   target={null}
 >
   Link
@@ -35,7 +35,7 @@ exports[`regular 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel={null}
+  rel=""
   target={null}
 >
   Link
@@ -63,7 +63,7 @@ exports[`target null 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel={null}
+  rel=""
   target={null}
 >
   Link
@@ -77,8 +77,22 @@ exports[`target self 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel={null}
+  rel=""
   target="_self"
+>
+  Link
+</a>
+`;
+
+exports[`with nofollow 1`] = `
+<a
+  className="link accessibleFocusStyle block"
+  href="https://example.com"
+  onClick={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  rel="nofollow"
+  target={null}
 >
   Link
 </a>
@@ -91,7 +105,7 @@ exports[`with onClick 1`] = `
   onClick={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
-  rel={null}
+  rel=""
   target={null}
 >
   Link


### PR DESCRIPTION
We'd like to be able to explicitly specify whether to include the rel=nofollow attribute to Gestalt links. This is important for SEO, so that we can avoid needless following of links by search bots.