### PR TITLE
Image: Don't show  text when loading the image in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+* Image: Don't show `alt` text when loading the image in FireFox. (#80)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/Image/Image.css
+++ b/packages/gestalt/src/Image/Image.css
@@ -4,6 +4,15 @@
   composes: absolute from "../Layout.css";
 }
 
+/*
+    Disables alt text showing when loading an image in firefox
+    https://stackoverflow.com/questions/12667926
+*/
+
+img[alt] {
+  color: transparent;
+}
+
 .scaled-img {
   composes: relative from "../Layout.css";
   background-position: center center;


### PR DESCRIPTION
Before:
<img width="283" alt="screen shot 2018-03-13 at 9 57 14 pm" src="https://user-images.githubusercontent.com/127199/37384054-b97feecc-2709-11e8-9b32-b25b1c8769b3.png">

After:
<img width="369" alt="screen shot 2018-03-13 at 9 56 57 pm" src="https://user-images.githubusercontent.com/127199/37384058-bb6b6950-2709-11e8-8cd8-85657adf1d1b.png">
