### PR TITLE
BrowserRouter -> HashRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Patch
 
+* Internal: Convert `BrowserRouter` to `HashRouter` - fixes directly going to a component (#88)
+
 </details>
 
 ## 0.60.0 (March 13, 2018)

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { HashRouter as Router, Route } from 'react-router-dom';
 import { render } from 'react-dom';
 import App from './components/App';
 import routes from './routes';


### PR DESCRIPTION
I'm working with this awesome project but because it's using BrowserRouter every time I want to open the docs of a component on a different tab or when I refresh a page that is not the Home I get redirected to https://engineering.pinterest.com/.

Changing the BrowserRouter to  HashRouter will fix this problem.

Thanks for everything!