### PR TITLE
Update publish script for Gestalt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
   </summary>
 
   ### Minor
+  * Heading / Text / SegmentedControl: Add `title` when `truncate` is set (#82)
 
   ### Patch
   * Docs: Masonry locally on port `3000` + update the `README` with the latest commands (#89)
+  * Internal: Fix publish script to work for new Gestalt directory structure (#94)
 
 </details>
 
@@ -19,7 +21,6 @@
 
 * Image: Don't show `alt` text when loading the image in FireFox. (#80)(#84)
 * Tabs: Update the background color to be transparent for unselected tabs (#79)
-* Heading / Text / SegmentedControl: Add `title` when `truncate` is set (#82)
 
 ### Patch
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,14 @@ Running Masonry's integration tests. This will leave lots of Firefox processes h
 
 ## Releasing
 
+If you haven’t already, you’ll first need to [create an npm account](https://www.npmjs.com/signup). Once you've done that
+you can setup your username and email in Yarn using `yarn login`.
+
 The following outlines our release process:
 
-* Checkout a new branch.
-* Bump package version in `packages/gestalt/package.json` & update `CHANGELOG.md`.
-* Open a pull request with the new version and land that in master.
-* Once the version is bumped in master, checkout that commit locally.
-* Publish the tag, npm package, and docs with: `./scripts/publish.js`.
-* Draft a release from the tag and update the release notes from the `CHANGELOG` at https://github.com/pinterest/gestalt/releases.
+1. Checkout a new branch.
+2. Bump package version in `packages/gestalt/package.json` & update `CHANGELOG.md`.
+3. Open a pull request with the new version and land that in master.
+4. Once the version is bumped in master, checkout that commit locally.
+5. Run the release script from the root directory of the project `./scripts/publish.js` to publish the tag, npm package, and docs.
+6. Draft a new release from the tag at https://github.com/pinterest/gestalt/releases.

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -11,9 +11,18 @@ const json = require(path.join(
   'package.json'
 ));
 const { version } = json;
-console.log('publishing version ', version);
+console.log(`Publishing version: ${version}`);
 
-shell.exec('yarn publish --registry=https://registry.npmjs.org');
+// Publish command to post to npm - must be run in the same directory as the gestalt package
+shell.cd(path.join(__dirname, '..', 'packages', 'gestalt'));
+shell.exec(
+  `yarn publish --registry=https://registry.npmjs.org --no-git-tag-version --new-version ${version}`
+);
+
+// Creates a new tag on GitHub for record keeping
 shell.exec(`git tag v${version}`);
 shell.exec(`git push upstream tags/v${version}`);
+
+// Script to publish the docs - must be run from the home directory
+shell.cd(path.join(__dirname, '..'));
 shell.exec('./scripts/ghpages.sh');


### PR DESCRIPTION
Updating the publish script to reflect changes after separation of Gestalt into its own package.

![screen shot 2018-03-20 at 5 24 44 pm](https://user-images.githubusercontent.com/7877010/37689677-a1d02f12-2c63-11e8-8e44-5163ed767e2e.png)
