### PR TITLE
Using Link from React Router

### DIFF
--- a/docs/src/components/AtomDark.css
+++ b/docs/src/components/AtomDark.css
@@ -149,3 +149,8 @@ pre.prism-code {
 .token.entity {
   cursor: help;
 }
+
+a {
+  text-decoration: none;
+  color: inherit;
+}

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import { Text, Box, SelectList, Link, Icon, Heading } from 'gestalt';
+import { Link as RouterLink } from 'react-router-dom';
 import routes from '../routes';
 
 type Props = {|
@@ -16,18 +17,12 @@ const components = Object.keys(routes);
 export default function Navigation(props: Props) {
   const { history } = props;
   const links = components.map(ns => {
-    const href = `/${ns}`;
-    const handleClick = ({ event }) => {
-      if (event.defaultPrevented) return;
-      if (isModifiedEvent(event) || !isLeftClickEvent(event)) return;
-      event.preventDefault();
-      history.push(href);
-    };
+    const href = `${ns}`;
     return (
       <Text bold leading="tall" color="darkGray" size="lg">
-        <Link href={href} onClick={handleClick}>
-          {ns}
-        </Link>
+        <RouterLink to={href}>
+          <Link>{ns}</Link>
+        </RouterLink>
       </Text>
     );
   });


### PR DESCRIPTION
If we want to use the HashRouter we gotta use the Link from React Router in the navigation else when we open the links on a new tab they won't work.

I also added some css to remove the underline on the links. I put it on the only css file I found.