### PR TITLE
A GroupAvatar for nobody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
     Click to see more.
   </summary>
 
-  ### Minor
+### Minor
+
+* Fixes GroupAvatar when there are no collaborators (#112)
+* Fix flyout positioning during resize (#111)
 
   ### Patch
 
@@ -15,8 +18,9 @@
 ## 0.63.0 (March 26, 2018)
 
 ### Minor
+
 * Masonry: Promotes ExperimentalMasonry to be Masonry. Complete re-write of
-measuring etc. (#101)
+  measuring etc. (#101)
 * Internal: Gestalt now is React 16.2.0 compatible. (#101)
 
 ## 0.62.1 (March 22, 2018)

--- a/packages/gestalt/src/GroupAvatar/GroupAvatar.js
+++ b/packages/gestalt/src/GroupAvatar/GroupAvatar.js
@@ -31,6 +31,7 @@ type Props = {|
 
 const avatarLayout = (n, size) => {
   switch (n) {
+    case 0:
     case 1:
       return [{ top: 0, left: 0, width: size, height: size }];
     case 2:
@@ -177,12 +178,25 @@ export default function GroupAvatar(props: Props) {
       <Collection
         layout={layout}
         Item={({ idx }) => {
-          const { name, src } = collaborators[idx];
-          const { width, height } = layout[idx];
           const fontSize =
-            collaborators.length === 1
+            collaborators.length <= 1
               ? DEFAULT_AVATAR_TEXT_SIZES[props.size] * 2
               : DEFAULT_AVATAR_TEXT_SIZES[props.size];
+
+          if (!collaborators[idx]) {
+            return (
+              <DefaultAvatar
+                name=" "
+                fontSize={fontSize}
+                textLayout="center"
+                height={layout[0].height}
+                size={size}
+              />
+            );
+          }
+
+          const { name, src } = collaborators[idx];
+          const { width, height } = layout[idx];
           if (!src) {
             return (
               <DefaultAvatar

--- a/packages/gestalt/src/GroupAvatar/__tests__/GroupAvatar.test.js
+++ b/packages/gestalt/src/GroupAvatar/__tests__/GroupAvatar.test.js
@@ -18,6 +18,11 @@ describe('DefaultAvatar', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders 0 avatars', () => {
+    const tree = create(<GroupAvatar collaborators={[]} size="md" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders 2 avatars', () => {
     const tree = create(
       <GroupAvatar

--- a/packages/gestalt/src/GroupAvatar/__tests__/__snapshots__/GroupAvatar.test.js.snap
+++ b/packages/gestalt/src/GroupAvatar/__tests__/__snapshots__/GroupAvatar.test.js.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DefaultAvatar renders 0 avatars 1`] = `
+<div
+  className="box circle overflowHidden whiteBg"
+  style={
+    Object {
+      "boxShadow": "0 0 0 2px #fff",
+      "height": 40,
+      "width": 40,
+      "willChange": "transform",
+    }
+  }
+>
+  <div
+    className="relative"
+    style={
+      Object {
+        "height": 40,
+        "width": 40,
+      }
+    }
+  >
+    <div
+      className="absolute"
+      style={
+        Object {
+          "height": 40,
+          "left": 0,
+          "top": 0,
+          "width": 40,
+        }
+      }
+    >
+      <div
+        aria-label=" "
+        className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
+        style={
+          Object {
+            "height": 40,
+          }
+        }
+      >
+        <div
+          className="Text fontSize3 white leadingShort alignLeft breakWord fontStyleNormal fontWeightBold"
+        >
+          <div
+            className="box"
+            style={
+              Object {
+                "fontSize": 22,
+                "lineHeight": "22px",
+              }
+            }
+          >
+             
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DefaultAvatar renders 2 avatars 1`] = `
 <div
   className="box circle overflowHidden whiteBg"


### PR DESCRIPTION
Fix GroupAvatar when there are zero collaborators present.

Looks like:
<img width="237" alt="image" src="https://user-images.githubusercontent.com/122602/38408425-707dace8-39b8-11e8-8326-2e8a1eba29c4.png">

Fixes #43
