### PR TITLE
Use createHref from history to make routes and fix navigation in new tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Patch
 * Docs: Add live docs to TextField / TextArea (#116)
+* Internal: Fix navigation to allow opening in new tabs (#120)
 
 </details>
 

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -16,12 +16,12 @@ const components = Object.keys(routes);
 export default function Navigation(props: Props) {
   const { history } = props;
   const links = components.map(ns => {
-    const href = `/${ns}`;
+    const href = history.createHref({ pathname: `/${ns}` });
     const handleClick = ({ event }) => {
       if (event.defaultPrevented) return;
       if (isModifiedEvent(event) || !isLeftClickEvent(event)) return;
       event.preventDefault();
-      history.push(href);
+      history.push(`/${ns}`);
     };
     return (
       <Text bold leading="tall" color="darkGray" size="lg">

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -1,22 +1,24 @@
 // @flow
 import React from 'react';
-import { HashRouter as Router, Route } from 'react-router-dom';
+import { HashRouter, Route, Switch } from 'react-router-dom';
 import { render } from 'react-dom';
 import App from './components/App';
 import routes from './routes';
 import 'gestalt/dist/gestalt.css';
 
 render(
-  <Router>
+  <HashRouter>
     <App>
-      {Object.keys(routes).map(pathname => (
-        <Route
-          component={routes[pathname]}
-          path={`/${pathname}`}
-          key={pathname}
-        />
-      ))}
+      <Switch>
+        {Object.keys(routes).map(pathname => (
+          <Route
+            component={routes[pathname]}
+            path={`/${pathname}`}
+            key={pathname}
+          />
+        ))}
+      </Switch>
     </App>
-  </Router>,
+  </HashRouter>,
   document.getElementById('root')
 );


### PR DESCRIPTION
In order to fix routing in new tabs we need to use the `history.createHref` function because we chose not to use the `Link` components from `react-router`. The issue was that the href set on the `<a/>` tag did not have the `#` symbol since it was not aware it was inside of a `HashRouter` (which the `history` props knows).

See this for more info: https://github.com/ReactTraining/history/blob/9ff690785f02d5c2554b860ff1a39a6527d18aa1/modules/createHashHistory.js#L176

Solves issue #113 