### PR TITLE
Updated Masonry docs’ “comp” definition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@
     Changes that have landed in master but are not yet released.
     Click to see more.
   </summary>
-</details>
+
+### Minor
+
+* Docs: Updated Masonry "comp" definition to be more descriptive
+  </details>
 
 ## 0.64.0 (April 12, 2018)
 
 ### Minor
+
 * Icon: 4 new icons related to analytic stats (#105)
 * GroupAvatar: Fix when there are no collaborators (#112)
 * Flyout: Fix positioning during resize (#111)
@@ -18,6 +23,7 @@
 * Icon: 1 icon (circle-arrow-down) for search (#119)
 
 ### Patch
+
 * Docs: Add live docs to TextField / TextArea (#116)
 * Internal: Fix navigation to allow opening in new tabs (#120)
 

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -31,10 +31,10 @@ card(
       },
       {
         name: 'comp',
-        type: '() => void',
+        type: 'React.ComponentType',
         required: true,
         description:
-          'A function or React component that renders the item you would like displayed in the grid.',
+          'A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: `data: T`, `itemIdx: number`, and `isMeasuring: boolean`.',
       },
       {
         name: 'flexible',


### PR DESCRIPTION
I noticed the Masonry docs for the "comp" param were a little misleading, so I provided additional information.