### PR TITLE
Made some throttle changes and added debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@
   </summary>
 
 ### Minor
+
 * Link: Remove duplicate CSS declaration (#118)
 
 ### Patch
+
 * Docs: Updated Masonry "comp" definition to be more descriptive
+* Fixed a subtle bug in throttle that would cause longer than intended delays
+* Fixed a timing bug where Masonry's handleResize could be called after unmount
+* Added a debounce method and moved over some Masonry methods to use it
+
   </details>
 
 </details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@
 ### Patch
 
 * Docs: Updated Masonry "comp" definition to be more descriptive
-* Fixed a subtle bug in throttle that would cause longer than intended delays
-* Fixed a timing bug where Masonry's handleResize could be called after unmount
-* Added a debounce method and moved over some Masonry methods to use it
+* Internal: Fixed a subtle bug in throttle that would cause longer than intended delays
+* Masonry: Fixed a timing bug where Masonry's handleResize could be called after unmount
+* Masonry: Added a debounce method and moved over some Masonry methods to use it
 
   </details>
 

--- a/packages/gestalt/src/debounce.js
+++ b/packages/gestalt/src/debounce.js
@@ -1,0 +1,29 @@
+/**
+ * debounce prevents a particular function from being called until after a given
+ * cooldown period (default 100ms). Every time the function is called, it resets
+ * the cooldown.
+ */
+
+// @flow
+export default function debounce(fn: () => void, threshhold: number = 100) {
+  let deferTimer: TimeoutID | null = null;
+
+  const debounced = (...args: any) => {
+    if (deferTimer) {
+      clearTimeout(deferTimer);
+    }
+
+    deferTimer = setTimeout(() => {
+      deferTimer = null;
+      fn(...args);
+    }, threshhold);
+  };
+
+  debounced.clearTimeout = () => {
+    if (deferTimer) {
+      clearTimeout(deferTimer);
+    }
+  };
+
+  return debounced;
+}

--- a/packages/gestalt/src/throttle.js
+++ b/packages/gestalt/src/throttle.js
@@ -1,18 +1,32 @@
+/**
+ * throttle limits the number of times a function can be called to a
+ * given threshhold (100ms by default). The function is always called
+ * on the leading and trailing edge.
+ */
+
 // @flow
 export default function throttle(fn: () => void, threshhold: number = 100) {
-  let last;
-  let deferTimer;
-  return (...args: any) => {
+  let last: number;
+  let deferTimer: TimeoutID;
+  const throttled = (...args: any) => {
     const now = Date.now();
-    if (last && now < last + threshhold) {
+    if (last && now - last < threshhold) {
       clearTimeout(deferTimer);
       deferTimer = setTimeout(() => {
         last = now;
         fn(...args);
-      }, threshhold);
+      }, threshhold - (now - last));
     } else {
       last = now;
       fn(...args);
     }
   };
+
+  throttled.clearTimeout = () => {
+    if (deferTimer) {
+      clearTimeout(deferTimer);
+    }
+  };
+
+  return throttled;
 }


### PR DESCRIPTION
This PR makes the following changes:
1. I added comments to throttle.
2. I fixed a tiny bug in throttle that was causing longer than intended delays on throttled calls. If a function is throttled to 5 seconds, the first call should happen immediately and another call at 4 seconds should be executed at the 5 second mark. Our throttle function was executing the first one immediately and then starting a new threshold timer at the 4 second mark, so the second call wasn't being executed until 9 seconds (4 + 5).
3. I fixed a subtle bug in Masonry where `handleResize` could be executed after unmount because its timeout wasn't being cleared. I did this by adding a `clearTimeout` method to the function returned by `throttle`.
4. I created `debounce` and switched a couple Masonry methods to use it. This simplifies Masonry code and removes a couple of class properties.