### PR TITLE
Disallow flex shrinking for Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 ### Patch
+* Switch: Disallow width shrinking in flex layouts
 
 </details>
 

--- a/packages/gestalt/src/Switch/Switch.css
+++ b/packages/gestalt/src/Switch/Switch.css
@@ -11,6 +11,7 @@
   border-radius: calc(var(--height) * 2);
   border-style: solid;
   border-width: var(--border);
+  flex-shrink: 0;
   height: var(--height);
   transition: background-color 250ms cubic-bezier(0.25, 0.375, 0.1, 0.975),
     border-color 250ms cubic-bezier(0.25, 0.375, 0.1, 0.975);


### PR DESCRIPTION
**Before**
<img width="229" alt="screen shot 2018-04-17 at 2 11 22 pm" src="https://user-images.githubusercontent.com/3934294/38897966-42dce9ae-4249-11e8-9c2c-dcabe2cdd9d4.png">

**After**
<img width="230" alt="screen shot 2018-04-17 at 2 11 29 pm" src="https://user-images.githubusercontent.com/3934294/38897968-42f37dae-4249-11e8-9219-00781b0008ae.png">

Note: I edited the DOM text to force the shrink issue...it doesn't normally sound that dumb...