### PR TITLE
Removed unused “serverRender” prop from Masonry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 ### Minor
 
 ### Patch
+
 * Switch: Disallow width shrinking in flex layouts
+* Masonry: Removed the unused "serverRender" prop
 
 </details>
 
@@ -28,7 +30,6 @@
 * Internal: Fixed a subtle bug in throttle that would cause longer than intended delays
 * Masonry: Fixed a timing bug where Masonry's handleResize could be called after unmount
 * Masonry: Added a debounce method and moved over some Masonry methods to use it
-* Masonry: Removed the unused "serverRender" prop
 
 ## 0.64.0 (April 12, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Internal: Fixed a subtle bug in throttle that would cause longer than intended delays
 * Masonry: Fixed a timing bug where Masonry's handleResize could be called after unmount
 * Masonry: Added a debounce method and moved over some Masonry methods to use it
+* Masonry: Removed the unused "serverRender" prop
 
 ## 0.64.0 (April 12, 2018)
 

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -74,10 +74,6 @@ card(
         type: '() => HTMLElement',
       },
       {
-        name: 'serverRender',
-        type: 'boolean',
-      },
-      {
         name: 'virtualize',
         type: 'boolean',
         defaultValue: false,

--- a/packages/gestalt/src/ExperimentalMasonry/Masonry.js
+++ b/packages/gestalt/src/ExperimentalMasonry/Masonry.js
@@ -49,7 +49,6 @@ type Props<T> = {|
         }
       ) => void | boolean | {}),
   scrollContainer?: () => HTMLElement,
-  serverRender?: boolean,
   virtualize?: boolean,
 |};
 
@@ -126,12 +125,6 @@ export default class ExperimentalMasonry<T> extends React.Component<
     scrollContainer: PropTypes.func,
 
     /**
-     * Whether or not this instance is server rendered.
-     * TODO: If true, generate and output CSS for the initial server render.
-     */
-    serverRender: PropTypes.bool,
-
-    /**
      * Whether or not to use actual virtualization
      */
     virtualize: PropTypes.bool,
@@ -141,7 +134,6 @@ export default class ExperimentalMasonry<T> extends React.Component<
     columnWidth: 236,
     measurementStore: new MeasurementStore(),
     minCols: 3,
-    serverRender: false,
     layout: DefaultLayoutSymbol,
     loadItems: () => {},
     virtualize: false,

--- a/packages/gestalt/src/Masonry/Masonry.js
+++ b/packages/gestalt/src/Masonry/Masonry.js
@@ -50,7 +50,6 @@ type Props<T> = {|
         }
       ) => void | boolean | {}),
   scrollContainer?: () => HTMLElement,
-  serverRender?: boolean,
   virtualize?: boolean,
 |};
 
@@ -126,12 +125,6 @@ export default class Masonry<T> extends React.Component<Props<T>, State> {
     scrollContainer: PropTypes.func,
 
     /**
-     * Whether or not this instance is server rendered.
-     * TODO: If true, generate and output CSS for the initial server render.
-     */
-    serverRender: PropTypes.bool,
-
-    /**
      * Whether or not to use actual virtualization
      */
     virtualize: PropTypes.bool,
@@ -141,7 +134,6 @@ export default class Masonry<T> extends React.Component<Props<T>, State> {
     columnWidth: 236,
     measurementStore: new MeasurementStore(),
     minCols: 3,
-    serverRender: false,
     layout: DefaultLayoutSymbol,
     loadItems: () => {},
     virtualize: false,

--- a/test/containers/ExperimentalMasonryExample.js
+++ b/test/containers/ExperimentalMasonryExample.js
@@ -27,7 +27,6 @@ export default class MasonryExample extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      disableServerRender: false,
       expanded: false,
       hasScrollContainer: !!this.props.scrollContainer,
       items: props.initialPins,
@@ -168,7 +167,6 @@ export default class MasonryExample extends React.Component {
       }),
       () => {
         this.setState(prevState => ({
-          disableServerRender: true,
           mountGrid: !prevState.mountGrid,
         }));
       }
@@ -297,7 +295,6 @@ export default class MasonryExample extends React.Component {
             ref={ref => {
               this.gridRef = ref;
             }}
-            serverRender={!this.state.disableServerRender}
             virtualize={Boolean(this.props.virtualize)}
             {...dynamicGridProps}
           />

--- a/test/containers/MasonryExample.js
+++ b/test/containers/MasonryExample.js
@@ -27,7 +27,6 @@ export default class MasonryExample extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      disableServerRender: false,
       expanded: false,
       hasScrollContainer: !!this.props.scrollContainer,
       items: props.initialPins,
@@ -168,7 +167,6 @@ export default class MasonryExample extends React.Component {
       }),
       () => {
         this.setState(prevState => ({
-          disableServerRender: true,
           mountGrid: !prevState.mountGrid,
         }));
       }
@@ -297,7 +295,6 @@ export default class MasonryExample extends React.Component {
             ref={ref => {
               this.gridRef = ref;
             }}
-            serverRender={!this.state.disableServerRender}
             virtualize={Boolean(this.props.virtualize)}
             {...dynamicGridProps}
           />


### PR DESCRIPTION
More cleanup on Masonry. I found an unused prop.