### PR TITLE
Flyout: make IE11 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+* Flyout: make IE11 compatible (#138)
 
 ### Patch
 

--- a/packages/gestalt/src/FlyoutUtils/Contents.js
+++ b/packages/gestalt/src/FlyoutUtils/Contents.js
@@ -376,20 +376,24 @@ export default class Contents extends React.Component<Props, State> {
       width,
     } = props;
 
+    // Scroll not needed for relative elements
+    // We can't use window.scrollX / window.scrollY since it's not supported by IE11
+    const scrollX = positionRelativeToAnchor
+      ? 0
+      : window.pageXOffset ||
+        (document.documentElement && document.documentElement.scrollLeft) ||
+        0;
+    const scrollY = positionRelativeToAnchor
+      ? 0
+      : window.pageYOffset ||
+        (document.documentElement && document.documentElement.scrollTop) ||
+        0;
+
     const windowSize = {
       height: window.innerHeight,
       width: window.innerWidth,
-      // scroll not needed for relative elements
-      scrollY: positionRelativeToAnchor
-        ? 0
-        : window.pageYOffset ||
-          (document.documentElement && document.documentElement.scrollTop) ||
-          0,
-      scrollX: positionRelativeToAnchor
-        ? 0
-        : window.pageXOffset ||
-          (document.documentElement && document.documentElement.scrollLeft) ||
-          0,
+      scrollX,
+      scrollY,
     };
 
     const flyoutSize = {

--- a/packages/gestalt/src/FlyoutUtils/Contents.js
+++ b/packages/gestalt/src/FlyoutUtils/Contents.js
@@ -379,8 +379,17 @@ export default class Contents extends React.Component<Props, State> {
     const windowSize = {
       height: window.innerHeight,
       width: window.innerWidth,
-      scrollY: positionRelativeToAnchor ? 0 : window.scrollY, // scroll not needed for relative elements
-      scrollX: positionRelativeToAnchor ? 0 : window.scrollX,
+      // scroll not needed for relative elements
+      scrollY: positionRelativeToAnchor
+        ? 0
+        : window.pageYOffset ||
+          (document.documentElement && document.documentElement.scrollTop) ||
+          0,
+      scrollX: positionRelativeToAnchor
+        ? 0
+        : window.pageXOffset ||
+          (document.documentElement && document.documentElement.scrollLeft) ||
+          0,
     };
 
     const flyoutSize = {


### PR DESCRIPTION
IE11 doesn't support `scrollX` and `scrollY` on window which we used when `positionRelativeToAnchor` was set to `false`.

We're using the same patch as React & React Router + made it pass flow:
https://github.com/facebook/react/blob/5d3b12bb3bd6a092cf00ede07b8255a8399c2e58/src/vendor/core/dom/getUnboundedScrollPosition.js#L28
https://github.com/ReactTraining/react-router/pull/607

<img width="1133" alt="screen shot 2018-04-25 at 1 54 24 pm" src="https://user-images.githubusercontent.com/127199/39274272-48694450-4896-11e8-84df-c0a8c983ea32.png">

*Before*
<img width="1123" alt="screen shot 2018-04-25 at 2 40 15 pm" src="https://user-images.githubusercontent.com/127199/39274396-abfc7dc0-4896-11e8-90aa-52fa0f3e93ba.png">

*After*
<img width="1093" alt="screen shot 2018-04-25 at 2 40 29 pm" src="https://user-images.githubusercontent.com/127199/39274400-af229642-4896-11e8-99d6-fb7c83197804.png">

