### PR TITLE
Button / SearchField / SegmentedControl / SelectList / Tabs / TextField: consistent sizing + improve Windows compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+* Button / SearchField / SegmentedControl / SelectList / Tabs / TextField: consistent sizing + improve Windows compatibility (#148)
 
 ### Patch
 

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -44,7 +44,7 @@ card(
         name: 'size',
         type: '"md" | "lg"',
         required: false,
-        description: 'Size of the Segemented control.',
+        description: 'md: 40px, lg: 48px',
         defaultValue: 'md',
       },
     ]}
@@ -64,7 +64,7 @@ card(
 class ToastExample extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { 
+    this.state = {
       itemIndex: 0,
       items: ['News', 'You', 'Messages']
     };
@@ -74,7 +74,7 @@ class ToastExample extends React.Component {
   handleItemChange({ activeIndex }) {
     this.setState(prevState => ({ itemIndex: activeIndex }));
   };
-  
+
   render() {
     return (
       <SegmentedControl

--- a/packages/gestalt/src/Button/Button.css
+++ b/packages/gestalt/src/Button/Button.css
@@ -21,15 +21,18 @@
 }
 
 .sm {
-  padding: 10px 14px;
+  composes: small from "../Layout.css";
+  padding: 8px 14px;
 }
 
 .md {
-  padding: 11px 14px;
+  composes: medium from "../Layout.css";
+  padding: 10px 14px;
 }
 
 .lg {
-  padding: 14px;
+  composes: large from "../Layout.css";
+  padding: 12px 14px;
 }
 
 .block {

--- a/packages/gestalt/src/Layout.css
+++ b/packages/gestalt/src/Layout.css
@@ -83,6 +83,20 @@
   left: 0;
 }
 
+/* size */
+
+.small {
+  min-height: 36px;
+}
+
+.medium {
+  min-height: 40px;
+}
+
+.large {
+  min-height: 48px;
+}
+
 /* box model */
 
 .borderBox {

--- a/packages/gestalt/src/SearchField/SearchField.css
+++ b/packages/gestalt/src/SearchField/SearchField.css
@@ -1,15 +1,15 @@
 .input {
   composes: accessibilityOutline from "../Focus.css";
   composes: border from "../Borders.css";
-  composes: borderBox from "../Layout.css";
+  composes: borderBox medium from "../Layout.css";
   composes: darkGray from "../Colors.css";
   composes: Text fontSize3 from "../Text/Text.css";
-  composes: leadingShort fontWeightBold from "../Typography.css";
+  composes: fontWeightBold from "../Typography.css";
   composes: lightGrayBg from "../Colors.css";
   composes: xsCol12 from "../Column.css";
   appearance: none;
   border-radius: 4px;
-  padding: 10px calc(16px + (2 * 8px)) 10px calc(16px + (2 * 16px));
+  padding: 8px calc(16px + (2 * 8px)) 8px calc(16px + (2 * 16px));
 }
 
 .input::-ms-clear {

--- a/packages/gestalt/src/SegmentedControl/SegmentedControl.css
+++ b/packages/gestalt/src/SegmentedControl/SegmentedControl.css
@@ -1,10 +1,19 @@
 .SegmentedControl {
+  composes: borderBox from '../Layout.css';
   composes: lightGrayBg from "../Colors.css";
   composes: flex from "../Layout.css";
   composes: justifyBetween from "../Layout.css";
   border-radius: 4px;
   padding: 2px;
   user-select: none;
+}
+
+.md {
+  composes: medium from "../Layout.css";
+}
+
+.lg {
+  composes: large from "../Layout.css";
 }
 
 .item {
@@ -16,14 +25,7 @@
   border-radius: 3px;
   flex-basis: 0;
   flex-shrink: 1;
-}
-
-.md {
-  padding: 9px 14px;
-}
-
-.lg {
-  padding: 12px 14px;
+  padding: 4px 14px;
 }
 
 .item:focus {

--- a/packages/gestalt/src/SegmentedControl/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl/SegmentedControl.js
@@ -15,12 +15,16 @@ type Props = {|
 export default function SegmentedControl(props: Props) {
   const { items, onChange, selectedItemIndex, size = 'md' } = props;
   return (
-    <div className={styles.SegmentedControl} role="tablist">
+    <div
+      className={classnames(styles.SegmentedControl, {
+        [styles.md]: size === 'md',
+        [styles.lg]: size === 'lg',
+      })}
+      role="tablist"
+    >
       {items.map((item, i) => {
         const isSelected = i === selectedItemIndex;
         const cs = classnames(styles.item, {
-          [styles.md]: size === 'md',
-          [styles.lg]: size === 'lg',
           [styles.itemIsNotSelected]: !isSelected,
           [styles.itemIsSelected]: isSelected,
         });

--- a/packages/gestalt/src/SelectList/SelectList.css
+++ b/packages/gestalt/src/SelectList/SelectList.css
@@ -1,17 +1,15 @@
 .select {
   composes: accessibilityOutline from "../Focus.css";
   composes: Text fontSize3 from "../Text/Text.css";
-  composes: leadingShort from "../Typography.css";
   composes: darkGray from "../Colors.css";
   composes: pointer from "../Cursor.css";
-  composes: relative from "../Layout.css";
+  composes: relative medium from "../Layout.css";
   composes: transparentBg from "../Colors.css";
   composes: xsCol12 from "../Column.css";
   appearance: none;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
-  height: 40px;
   padding: 0 35px 0 14px; /* right padding prevents it from running into arrow */
 }
 

--- a/packages/gestalt/src/Tabs/Tabs.css
+++ b/packages/gestalt/src/Tabs/Tabs.css
@@ -5,11 +5,12 @@
 
 .tab {
   composes: accessibilityOutline from "../Focus.css";
-  composes: flex flexColumn itemCenter from "../Layout.css";
+  composes: borderBox medium from '../Layout.css';
+  composes: flex flexColumn itemCenter justifyCenter from "../Layout.css";
   composes: noBorder pill from "../Borders.css";
   composes: m0 from "../Whitespace.css";
   composes: pointer from "../Cursor.css";
-  padding: 11px 16px;
+  padding: 8px 16px;
   text-decoration: none;
 }
 

--- a/packages/gestalt/src/TextField/TextField.css
+++ b/packages/gestalt/src/TextField/TextField.css
@@ -1,15 +1,13 @@
 .textField {
   composes: accessibilityOutline from "../Focus.css";
-  composes: borderBox from "../Layout.css";
+  composes: borderBox medium from "../Layout.css";
   composes: Text fontSize3 from "../Text/Text.css";
-  composes: leadingShort from "../Typography.css";
   composes: xsCol12 from "../Column.css";
   appearance: none;
   border-radius: 4px;
   border-style: solid;
   border-width: 1px;
-  max-height: 40px;
-  padding: 10px 14px;
+  padding: 8px 14px;
 }
 
 .textField::placeholder {


### PR DESCRIPTION
Currently some of our components render their medium size at `41px` instead of `40px` which makes them look slightly off next to other components.

![image](https://user-images.githubusercontent.com/127199/39454023-c6016352-4c8d-11e8-9c09-a0ccc306e29d.png)

We also fixed an issue in Windows where the text inside of TextField and SearchField was cut off (we shouldn't set the line-height there)

Before:
![screen shot 2018-04-30 at 3 31 15 pm](https://user-images.githubusercontent.com/127199/39454045-e7df1834-4c8d-11e8-9ea6-cada35a9eca8.png)
After:
![screen shot 2018-04-30 at 3 31 28 pm](https://user-images.githubusercontent.com/127199/39454047-ea3b7276-4c8d-11e8-8903-d373fb2d4755.png)
