### PR TITLE
React 16.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+* Drop support for React 15 and bump React 16 version (#168)
+
 ### Patch
 * Internal: Add code coverage to PRs (#185)
 * Internal: Internal: Convert ghostjs to puppeteer (#182)

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,8 +14,8 @@
     "gestalt": ">0.0.0",
     "highlight.js": "^9.12.0",
     "marked": "^0.3.17",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "react-live": "^1.10.1",
     "react-router-dom": "^4.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node-fetch": "^2.1.2",
     "prettier": "1.10.2",
     "puppeteer": "^1.4.0",
-    "react-test-renderer": "^16.2.0",
+    "react-test-renderer": "^16.3.2",
     "stylelint": "^8.0.0",
     "stylelint-config-prettier": "^2.1.0",
     "stylelint-config-standard": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "resolutions": {
     "jest": "^22.4.3"
   },
+  "dependencies": {
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
+  },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",
@@ -22,9 +26,8 @@
     "codecov": "^3.0.2",
     "concurrently": "^3.5.1",
     "danger": "^3.1.7",
+    "enzyme-adapter-react-16": "^1.1.1",
     "enzyme": "^3.3.0",
-    "enzyme-adapter-react-16": "^1.0.5",
-    "eslint": "^4.17.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-postcss": "^2.0.2",
     "eslint-config-prettier": "^2.1.1",
@@ -34,20 +37,21 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^7.4.0",
+    "eslint": "^4.17.0",
     "filesize": "^3.6.1",
     "flow-bin": "0.71.0",
     "gzip-size": "^4.1.0",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^22.4.3",
     "jest-puppeteer": "^3.0.1",
+    "jest": "^22.4.3",
     "node-fetch": "^2.1.2",
     "prettier": "1.10.2",
     "puppeteer": "^1.4.0",
     "react-test-renderer": "^16.3.2",
-    "stylelint": "^8.0.0",
     "stylelint-config-prettier": "^2.1.0",
     "stylelint-config-standard": "^18.0.0",
-    "stylelint-order": "^0.8.0"
+    "stylelint-order": "^0.8.0",
+    "stylelint": "^8.0.0"
   },
   "scripts": {
     "build": "cd packages/gestalt && yarn build",

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -16,8 +16,8 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^15.4.1 || ^16.2.0",
-    "react-dom": "^15.4.1 || ^16.2.0"
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",

--- a/test/package.json
+++ b/test/package.json
@@ -18,13 +18,13 @@
     "mocha": "^3.2.0",
     "open-browser-webpack-plugin": "0.0.2",
     "raw-loader": "^0.5.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react-dom": "^16.3.2",
     "react-hot-loader": "^1.3.0",
+    "react": "^16.3.2",
     "shelljs": "^0.7.7",
     "style-loader": "^0.13.0",
-    "webpack": "^3.11.0",
-    "webpack-dev-server": "^1.14.0"
+    "webpack-dev-server": "^1.14.0",
+    "webpack": "^3.11.0"
   },
   "scripts": {
     "start": "yarn start:webpack-server | yarn start:node-server",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2960,7 +2960,7 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-adapter-react-16@^1.0.5:
+enzyme-adapter-react-16@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7799,9 +7799,9 @@ react-dev-utils@^5.0.0:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -7822,6 +7822,10 @@ react-hot-loader@^1.3.0:
   dependencies:
     react-hot-api "^0.4.5"
     source-map "^0.4.4"
+
+react-is@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
 
 react-live@^1.10.1:
   version "1.10.1"
@@ -7910,7 +7914,7 @@ react-scripts@1.1.1:
   optionalDependencies:
     fsevents "^1.1.3"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
+react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:
@@ -7918,9 +7922,18 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react-test-renderer@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.2"
+
+react@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
This updates Gestalt to use 16.3.2 and also drops support for React 15 so we can start working with new-style context, portals etc.