### PR TITLE
Adds aspectRatio to Video and hides fullscreen button for unsupported browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 * Sticky: Expand threshold options to take string values (#166)
 * Avatar: Fall back to default letter if image does not load (#156)
-
 * Video: Add new Video component to Gestalt (#150)
+* Video: Add `aspectRatio` prop to Video and hide fullscreen on unsupported browsers (#171)
 
 ### Patch
 

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -58,6 +58,13 @@ card(
           'Accessibility label for the unmute button if controls are shown',
       },
       {
+        name: 'aspectRatio',
+        type: 'number',
+        description: `Proportional relationship between width and height of the video, calculated as width / height.
+           Used to size the placeholder until the video is loaded. Default is equivalent to 16:9`,
+        defaultValue: 16 / 9,
+      },
+      {
         name: 'captions',
         type: 'string',
         description: 'The URL of the captions track for the video (.vtt file)',

--- a/packages/gestalt/src/Video/Video.js
+++ b/packages/gestalt/src/Video/Video.js
@@ -113,16 +113,6 @@ const isFullscreen = () =>
   // $FlowIssue - vendor prefix missing from Flow
   document.msFullscreenElement;
 
-const fullscreenEnabled = () =>
-  // $FlowIssue - vendor prefix missing from Flow
-  document.fullscreenEnabled ||
-  // $FlowIssue - vendor prefix missing from Flow
-  document.webkitFullscreenEnabled ||
-  // $FlowIssue - vendor prefix missing from Flow
-  document.mozFullScreenEnabled ||
-  // $FlowIssue - vendor prefix missing from Flow
-  document.msFullscreenEnabled;
-
 const addFullscreenEventListener = (handler: Function) => {
   document.addEventListener('fullscreenchange', handler);
   document.addEventListener('webkitfullscreenchange', handler);
@@ -276,12 +266,10 @@ export default class Video extends React.PureComponent<Props, State> {
 
   // Enter/exit fullscreen video player mode
   toggleFullscreen = () => {
-    if (fullscreenEnabled()) {
-      if (isFullscreen()) {
-        exitFullscreen();
-      } else if (this.player) {
-        requestFullscreen(this.player);
-      }
+    if (isFullscreen()) {
+      exitFullscreen();
+    } else if (this.player) {
+      requestFullscreen(this.player);
     }
   };
 

--- a/packages/gestalt/src/Video/Video.js
+++ b/packages/gestalt/src/Video/Video.js
@@ -28,6 +28,7 @@ type VideoNoControls = {|
 type Controls = VideoWithControls | VideoNoControls;
 
 type Props = {|
+  aspectRatio: number,
   captions: string,
   loop?: boolean,
   onDurationChange?: ({
@@ -144,6 +145,7 @@ export default class Video extends React.PureComponent<Props, State> {
     accessibilityPauseLabel: PropTypes.string,
     accessibilityPlayLabel: PropTypes.string,
     accessibilityUnmuteLabel: PropTypes.string,
+    aspectRatio: PropTypes.number,
     captions: PropTypes.string.isRequired,
     controls: PropTypes.bool,
     loop: PropTypes.bool,
@@ -171,6 +173,7 @@ export default class Video extends React.PureComponent<Props, State> {
   };
 
   static defaultProps = {
+    aspectRatio: 16 / 9,
     playing: false,
     preload: 'auto',
     volume: 1,
@@ -362,6 +365,7 @@ export default class Video extends React.PureComponent<Props, State> {
 
   render() {
     const {
+      aspectRatio,
       captions,
       loop,
       playing,
@@ -379,8 +383,8 @@ export default class Video extends React.PureComponent<Props, State> {
       // If video data is present, use the correct aspect ratio
       (this.video &&
         `${this.video.videoHeight / this.video.videoWidth * 100}%`) ||
-      // If the video metadata is missing, default to a standard 16:9 ratio
-      `${9 / 16 * 100}%`;
+      // If the video metadata is missing, default to the aspect ratio
+      `${1 / aspectRatio * 100}%`;
 
     return (
       <div

--- a/packages/gestalt/src/Video/VideoControls.js
+++ b/packages/gestalt/src/Video/VideoControls.js
@@ -27,6 +27,16 @@ type Props = {|
   volume: number,
 |};
 
+const fullscreenEnabled = () =>
+  // $FlowIssue - vendor prefix missing from Flow
+  document.fullscreenEnabled ||
+  // $FlowIssue - vendor prefix missing from Flow
+  document.webkitFullscreenEnabled ||
+  // $FlowIssue - vendor prefix missing from Flow
+  document.mozFullScreenEnabled ||
+  // $FlowIssue - vendor prefix missing from Flow
+  document.msFullscreenEnabled;
+
 const timeToString = (time?: number) => {
   const rounded = Math.floor(time || 0);
   const minutes = Math.floor(rounded / 60);
@@ -56,6 +66,8 @@ export default function VideoControls(props: Props) {
     volume,
   } = props;
   const muted = volume === 0;
+  const showFullscreenButton =
+    typeof document !== 'undefined' && !!fullscreenEnabled();
   return (
     <Box
       position="absolute"
@@ -108,20 +120,22 @@ export default function VideoControls(props: Props) {
           />
         </Touchable>
       </Box>
-      <Box padding={2}>
-        <Touchable onTouch={onFullscreenChange} fullWidth={false}>
-          <Icon
-            accessibilityLabel={
-              fullscreen
-                ? accessibilityMinimizeLabel
-                : accessibilityMaximizeLabel
-            }
-            color="white"
-            icon={fullscreen ? 'minimize' : 'maximize'}
-            size={20}
-          />
-        </Touchable>
-      </Box>
+      {showFullscreenButton && (
+        <Box padding={2}>
+          <Touchable onTouch={onFullscreenChange} fullWidth={false}>
+            <Icon
+              accessibilityLabel={
+                fullscreen
+                  ? accessibilityMinimizeLabel
+                  : accessibilityMaximizeLabel
+              }
+              color="white"
+              icon={fullscreen ? 'minimize' : 'maximize'}
+              size={20}
+            />
+          </Touchable>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/packages/gestalt/src/Video/__tests__/__snapshots__/VideoControls.test.js.snap
+++ b/packages/gestalt/src/Video/__tests__/__snapshots__/VideoControls.test.js.snap
@@ -155,36 +155,6 @@ exports[`VideoControls for double digit minutes 1`] = `
       </svg>
     </div>
   </div>
-  <div
-    className="box paddingX2 paddingY2"
-  >
-    <div
-      className="touchable pointer square"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      role="button"
-      tabIndex="0"
-    >
-      <svg
-        aria-hidden={null}
-        aria-label="Maximize"
-        className="icon white iconBlock"
-        height={20}
-        role="img"
-        viewBox="0 0 24 24"
-        width={20}
-      >
-        <title>
-          Maximize
-        </title>
-        <path
-          d="test-file-stub"
-        />
-      </svg>
-    </div>
-  </div>
 </div>
 `;
 
@@ -336,36 +306,6 @@ exports[`VideoControls for double digit seconds 1`] = `
       >
         <title>
           Unmute
-        </title>
-        <path
-          d="test-file-stub"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="box paddingX2 paddingY2"
-  >
-    <div
-      className="touchable pointer square"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      role="button"
-      tabIndex="0"
-    >
-      <svg
-        aria-hidden={null}
-        aria-label="Maximize"
-        className="icon white iconBlock"
-        height={20}
-        role="img"
-        viewBox="0 0 24 24"
-        width={20}
-      >
-        <title>
-          Maximize
         </title>
         <path
           d="test-file-stub"
@@ -531,36 +471,6 @@ exports[`VideoControls for single digit minutes 1`] = `
       </svg>
     </div>
   </div>
-  <div
-    className="box paddingX2 paddingY2"
-  >
-    <div
-      className="touchable pointer square"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      role="button"
-      tabIndex="0"
-    >
-      <svg
-        aria-hidden={null}
-        aria-label="Maximize"
-        className="icon white iconBlock"
-        height={20}
-        role="img"
-        viewBox="0 0 24 24"
-        width={20}
-      >
-        <title>
-          Maximize
-        </title>
-        <path
-          d="test-file-stub"
-        />
-      </svg>
-    </div>
-  </div>
 </div>
 `;
 
@@ -719,36 +629,6 @@ exports[`VideoControls for single digit seconds 1`] = `
       </svg>
     </div>
   </div>
-  <div
-    className="box paddingX2 paddingY2"
-  >
-    <div
-      className="touchable pointer square"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      role="button"
-      tabIndex="0"
-    >
-      <svg
-        aria-hidden={null}
-        aria-label="Maximize"
-        className="icon white iconBlock"
-        height={20}
-        role="img"
-        viewBox="0 0 24 24"
-        width={20}
-      >
-        <title>
-          Maximize
-        </title>
-        <path
-          d="test-file-stub"
-        />
-      </svg>
-    </div>
-  </div>
 </div>
 `;
 
@@ -900,36 +780,6 @@ exports[`VideoControls rounds for partial seconds 1`] = `
       >
         <title>
           Unmute
-        </title>
-        <path
-          d="test-file-stub"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="box paddingX2 paddingY2"
-  >
-    <div
-      className="touchable pointer square"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      role="button"
-      tabIndex="0"
-    >
-      <svg
-        aria-hidden={null}
-        aria-label="Maximize"
-        className="icon white iconBlock"
-        height={20}
-        role="img"
-        viewBox="0 0 24 24"
-        width={20}
-      >
-        <title>
-          Maximize
         </title>
         <path
           d="test-file-stub"


### PR DESCRIPTION
In the initial implementation, `aspectRatio` was hardcoded to 16:9 in the render because that is the industry standard widescreen size. Instead of doing this, we should open this option up to developers to all them to pass in a custom ratio for the placeholder, and only then default to the 16:9 number. This aspect ratio is really only used as a placeholder, similar to `Image` to hold the height while the video loads and we fully know the real width and height.

Also, the fullscreen toggle button should not be exposed if the browser document cannot support the fullscreen API. Instead of doing that check in the callback, we can move the check to the render of the button and hide if for unsupported browsers. One small not here, is this bad for SSR @chrislloyd since document does not exist on the server, thoughts?