### PR TITLE
Add eslint plugin for Jest, add Flow to all test files, and fix test errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": [
     "airbnb",
+    "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:flowtype/recommended",
     "prettier",
@@ -9,10 +10,11 @@
   ],
   "env": {
     "browser": true,
-    "es6": true
+    "es6": true,
+    "jest/globals": true
   },
   "parser": "babel-eslint",
-  "plugins": ["flowtype", "jsx-a11y", "prettier"],
+  "plugins": ["flowtype", "jest", "jsx-a11y", "prettier"],
   "rules": {
     "jsx-a11y/label-has-for": [
       "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 * Avatar / GroupAvatar: make outline configurable(#173)
 * Internal: Add flow-typed files for third party packages (#174)
+* Internal: Add eslint plugin for Jest and add Flow to all test files (#176)
 
 ### Patch
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-config-prettier": "^2.1.1",
     "eslint-plugin-flowtype": "^2.34.0",
     "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jest": "^21.15.1",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^7.4.0",

--- a/packages/gestalt/src/Avatar/__tests__/Avatar.test.js
+++ b/packages/gestalt/src/Avatar/__tests__/Avatar.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Avatar from '../Avatar';

--- a/packages/gestalt/src/Box/Box.test.js
+++ b/packages/gestalt/src/Box/Box.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Box from './Box';

--- a/packages/gestalt/src/Box/style.test.js
+++ b/packages/gestalt/src/Box/style.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import {
   concat,
   fromClassName,

--- a/packages/gestalt/src/Button/Button.test.js
+++ b/packages/gestalt/src/Button/Button.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Button from './Button';

--- a/packages/gestalt/src/Card/__tests__/Card.test.js
+++ b/packages/gestalt/src/Card/__tests__/Card.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Card from '../Card';

--- a/packages/gestalt/src/Checkbox/Checkbox.test.js
+++ b/packages/gestalt/src/Checkbox/Checkbox.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Checkbox from './Checkbox';

--- a/packages/gestalt/src/Collection/Collection.test.js
+++ b/packages/gestalt/src/Collection/Collection.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Collection from './Collection';

--- a/packages/gestalt/src/Column/__tests__/Column.test.js
+++ b/packages/gestalt/src/Column/__tests__/Column.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Column from '../Column';

--- a/packages/gestalt/src/ExperimentalMasonry/defaultLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/defaultLayout.test.js
@@ -5,6 +5,15 @@ const stubCache = (measurements = {}) => ({
   get(item) {
     return measurements[item];
   },
+  has(item) {
+    return !!measurements[item];
+  },
+  set(item, value) {
+    measurements[item] = value;
+  },
+  reset() {
+    measurements = {};
+  },
 });
 
 test('empty', () => {

--- a/packages/gestalt/src/ExperimentalMasonry/defaultLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/defaultLayout.test.js
@@ -1,13 +1,23 @@
 // @flow
 import defaultLayout from './defaultLayout';
-import MeasurementStore from './MeasurementStore';
 
 const stubCache = (measurements: Object = {}) => {
-  const measurementStore = new MeasurementStore();
-  Object.keys(measurements).map(key =>
-    measurementStore.set(key, measurements[key])
-  );
-  return measurementStore;
+  let cache = measurements;
+
+  return {
+    get(item) {
+      return cache[item];
+    },
+    has(item) {
+      return !!cache[item];
+    },
+    set(item, value) {
+      cache[item] = value;
+    },
+    reset() {
+      cache = {};
+    },
+  };
 };
 
 test('empty', () => {

--- a/packages/gestalt/src/ExperimentalMasonry/defaultLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/defaultLayout.test.js
@@ -1,20 +1,14 @@
 // @flow
 import defaultLayout from './defaultLayout';
+import MeasurementStore from './MeasurementStore';
 
-const stubCache = (measurements = {}) => ({
-  get(item) {
-    return measurements[item];
-  },
-  has(item) {
-    return !!measurements[item];
-  },
-  set(item, value) {
-    measurements[item] = value;
-  },
-  reset() {
-    measurements = {};
-  },
-});
+const stubCache = (measurements: Object = {}) => {
+  const measurementStore = new MeasurementStore();
+  Object.keys(measurements).map(key =>
+    measurementStore.set(key, measurements[key])
+  );
+  return measurementStore;
+};
 
 test('empty', () => {
   const layout = defaultLayout({

--- a/packages/gestalt/src/ExperimentalMasonry/defaultLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/defaultLayout.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import defaultLayout from './defaultLayout';
 
 const stubCache = (measurements = {}) => ({

--- a/packages/gestalt/src/ExperimentalMasonry/fullWidthLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/fullWidthLayout.test.js
@@ -1,20 +1,14 @@
 // @flow
 import fullWidthLayout from './fullWidthLayout';
+import MeasurementStore from './MeasurementStore';
 
-const stubCache = (measurements = {}) => ({
-  get(item) {
-    return measurements[item];
-  },
-  has(item) {
-    return !!measurements[item];
-  },
-  set(item, value) {
-    measurements[item] = value;
-  },
-  reset() {
-    measurements = {};
-  },
-});
+const stubCache = (measurements: Object = {}) => {
+  const measurementStore = new MeasurementStore();
+  Object.keys(measurements).map(key =>
+    measurementStore.set(key, measurements[key])
+  );
+  return measurementStore;
+};
 
 test('empty', () => {
   const layout = fullWidthLayout({

--- a/packages/gestalt/src/ExperimentalMasonry/fullWidthLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/fullWidthLayout.test.js
@@ -5,6 +5,15 @@ const stubCache = (measurements = {}) => ({
   get(item) {
     return measurements[item];
   },
+  has(item) {
+    return !!measurements[item];
+  },
+  set(item, value) {
+    measurements[item] = value;
+  },
+  reset() {
+    measurements = {};
+  },
 });
 
 test('empty', () => {

--- a/packages/gestalt/src/ExperimentalMasonry/fullWidthLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/fullWidthLayout.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import fullWidthLayout from './fullWidthLayout';
 
 const stubCache = (measurements = {}) => ({

--- a/packages/gestalt/src/ExperimentalMasonry/fullWidthLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/fullWidthLayout.test.js
@@ -1,13 +1,23 @@
 // @flow
 import fullWidthLayout from './fullWidthLayout';
-import MeasurementStore from './MeasurementStore';
 
 const stubCache = (measurements: Object = {}) => {
-  const measurementStore = new MeasurementStore();
-  Object.keys(measurements).map(key =>
-    measurementStore.set(key, measurements[key])
-  );
-  return measurementStore;
+  let cache = measurements;
+
+  return {
+    get(item) {
+      return cache[item];
+    },
+    has(item) {
+      return !!cache[item];
+    },
+    set(item, value) {
+      cache[item] = value;
+    },
+    reset() {
+      cache = {};
+    },
+  };
 };
 
 test('empty', () => {

--- a/packages/gestalt/src/ExperimentalMasonry/uniformRowLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/uniformRowLayout.test.js
@@ -5,6 +5,15 @@ const stubCache = (measurements = {}) => ({
   get(item) {
     return measurements[item];
   },
+  has(item) {
+    return !!measurements[item];
+  },
+  set(item, value) {
+    measurements[item] = value;
+  },
+  reset() {
+    measurements = {};
+  },
 });
 
 test('empty', () => {

--- a/packages/gestalt/src/ExperimentalMasonry/uniformRowLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/uniformRowLayout.test.js
@@ -1,13 +1,23 @@
 // @flow
 import uniformRowLayout from './uniformRowLayout';
-import MeasurementStore from './MeasurementStore';
 
 const stubCache = (measurements: Object = {}) => {
-  const measurementStore = new MeasurementStore();
-  Object.keys(measurements).map(key =>
-    measurementStore.set(key, measurements[key])
-  );
-  return measurementStore;
+  let cache = measurements;
+
+  return {
+    get(item) {
+      return cache[item];
+    },
+    has(item) {
+      return !!cache[item];
+    },
+    set(item, value) {
+      cache[item] = value;
+    },
+    reset() {
+      cache = {};
+    },
+  };
 };
 
 test('empty', () => {

--- a/packages/gestalt/src/ExperimentalMasonry/uniformRowLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/uniformRowLayout.test.js
@@ -1,20 +1,14 @@
 // @flow
 import uniformRowLayout from './uniformRowLayout';
+import MeasurementStore from './MeasurementStore';
 
-const stubCache = (measurements = {}) => ({
-  get(item) {
-    return measurements[item];
-  },
-  has(item) {
-    return !!measurements[item];
-  },
-  set(item, value) {
-    measurements[item] = value;
-  },
-  reset() {
-    measurements = {};
-  },
-});
+const stubCache = (measurements: Object = {}) => {
+  const measurementStore = new MeasurementStore();
+  Object.keys(measurements).map(key =>
+    measurementStore.set(key, measurements[key])
+  );
+  return measurementStore;
+};
 
 test('empty', () => {
   const layout = uniformRowLayout({

--- a/packages/gestalt/src/ExperimentalMasonry/uniformRowLayout.test.js
+++ b/packages/gestalt/src/ExperimentalMasonry/uniformRowLayout.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import uniformRowLayout from './uniformRowLayout';
 
 const stubCache = (measurements = {}) => ({

--- a/packages/gestalt/src/Flyout/__tests__/Flyout.test.js
+++ b/packages/gestalt/src/Flyout/__tests__/Flyout.test.js
@@ -8,7 +8,6 @@ describe('Display checks', () => {
     const wrapper = shallow(
       <Flyout
         anchor={<button onClick={() => null}> test </button>}
-        accessibilityCloseLabel="close"
         idealDirection="down"
         onDismiss={jest.fn()}
         size="sm"

--- a/packages/gestalt/src/Flyout/__tests__/Flyout.test.js
+++ b/packages/gestalt/src/Flyout/__tests__/Flyout.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { shallow } from 'enzyme';
 import Flyout from '../Flyout';

--- a/packages/gestalt/src/Flyout/__tests__/Flyout.test.js
+++ b/packages/gestalt/src/Flyout/__tests__/Flyout.test.js
@@ -15,6 +15,6 @@ describe('Display checks', () => {
       />
     );
     wrapper.instance();
-    expect(wrapper.find('Controller').length).toEqual(1);
+    expect(wrapper.find('Controller')).toHaveLength(1);
   });
 });

--- a/packages/gestalt/src/FlyoutUtils/Controller.js
+++ b/packages/gestalt/src/FlyoutUtils/Controller.js
@@ -5,7 +5,7 @@ import Box from '../Box/Box';
 import Contents from './Contents';
 
 type Props = {|
-  anchor?: HTMLElement,
+  anchor: ?HTMLElement,
   bgColor: 'darkGray' | 'white' | 'orange',
   children?: any,
   idealDirection?: 'up' | 'right' | 'down' | 'left',

--- a/packages/gestalt/src/FlyoutUtils/__tests__/Contents.test.js
+++ b/packages/gestalt/src/FlyoutUtils/__tests__/Contents.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import {
   getMainDir,
   getSubDir,

--- a/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
+++ b/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
@@ -10,7 +10,12 @@ import Contents from '../Contents';
 describe('Flyout', () => {
   it('does not render Contents when anchor is null', () => {
     const wrapper = shallow(
-      <Controller anchor={null} bgColor="white" onDismiss={() => null} />
+      <Controller
+        anchor={null}
+        positionRelativeToAnchor
+        bgColor="white"
+        onDismiss={() => {}}
+      />
     );
     expect(wrapper.find(Contents)).toHaveLength(0);
   });

--- a/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
+++ b/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 /* eslint import/imports-first: 0 */
 jest.unmock('../Controller');
 

--- a/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
+++ b/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
@@ -12,6 +12,6 @@ describe('Flyout', () => {
     const wrapper = shallow(
       <Controller anchor={null} bgColor="white" onDismiss={() => null} />
     );
-    expect(wrapper.find(Contents).length).toEqual(0);
+    expect(wrapper.find(Contents)).toHaveLength(0);
   });
 });

--- a/packages/gestalt/src/GroupAvatar/__tests__/GroupAvatar.test.js
+++ b/packages/gestalt/src/GroupAvatar/__tests__/GroupAvatar.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import GroupAvatar from '../GroupAvatar';

--- a/packages/gestalt/src/Heading/__tests__/Heading.test.js
+++ b/packages/gestalt/src/Heading/__tests__/Heading.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Heading from '../Heading';

--- a/packages/gestalt/src/Icon/Icon.js
+++ b/packages/gestalt/src/Icon/Icon.js
@@ -6,7 +6,19 @@ import styles from './Icon.css';
 import icons from './icons';
 import colors from '../Colors.css';
 
-type IconProps = {
+type IconNoPath = {|
+  icon: $Keys<typeof icons>,
+  dangerouslySetSvgPath?: null,
+|};
+
+type PathNoIcon = {|
+  icon?: null,
+  dangerouslySetSvgPath: { __path: string },
+|};
+
+type Path = PathNoIcon | IconNoPath;
+
+type Props = {|
   accessibilityLabel: string,
   color?:
     | 'blue'
@@ -28,19 +40,8 @@ type IconProps = {
     | 'white',
   inline?: boolean,
   size?: number | string,
-};
-
-type IconNoPath = {
-  icon: $Keys<typeof icons>,
-  dangerouslySetSvgPath?: null,
-};
-
-type PathNoIcon = {
-  icon?: null,
-  dangerouslySetSvgPath: { __path: string },
-};
-
-type Props = IconProps & (PathNoIcon | IconNoPath);
+  ...Path,
+|};
 
 const IconNames = Object.keys(icons);
 
@@ -64,8 +65,6 @@ export default function Icon(props: Props) {
   } else if (dangerouslySetSvgPath) {
     /* eslint-disable-next-line no-underscore-dangle */
     path = dangerouslySetSvgPath.__path;
-  } else {
-    path = '';
   }
 
   const ariaHidden = accessibilityLabel === '' ? true : null;

--- a/packages/gestalt/src/Icon/__integration__/Icon.test.js
+++ b/packages/gestalt/src/Icon/__integration__/Icon.test.js
@@ -22,8 +22,3 @@ test('Icon uses the dangerouslySetSvgPath prop when icon path is not specified',
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
-
-test('Icon renders blank when neither icon nor dangerouslySetSvgPath are passed to it', () => {
-  const tree = create(<Icon accessibilityLabel="Line" />).toJSON();
-  expect(tree).toMatchSnapshot();
-});

--- a/packages/gestalt/src/Icon/__integration__/Icon.test.js
+++ b/packages/gestalt/src/Icon/__integration__/Icon.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Icon from '../Icon';

--- a/packages/gestalt/src/Icon/__integration__/__snapshots__/Icon.test.js.snap
+++ b/packages/gestalt/src/Icon/__integration__/__snapshots__/Icon.test.js.snap
@@ -38,25 +38,6 @@ exports[`Icon renders 1`] = `
 </svg>
 `;
 
-exports[`Icon renders blank when neither icon nor dangerouslySetSvgPath are passed to it 1`] = `
-<svg
-  aria-hidden={null}
-  aria-label="Line"
-  className="icon gray iconBlock"
-  height={16}
-  role="img"
-  viewBox="0 0 24 24"
-  width={16}
->
-  <title>
-    Line
-  </title>
-  <path
-    d=""
-  />
-</svg>
-`;
-
 exports[`Icon uses the dangerouslySetSvgPath prop when icon path is not specified 1`] = `
 <svg
   aria-hidden={null}

--- a/packages/gestalt/src/Image/__tests__/Image.test.js
+++ b/packages/gestalt/src/Image/__tests__/Image.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Image from '../Image';

--- a/packages/gestalt/src/Letterbox/__tests__/Letterbox.test.js
+++ b/packages/gestalt/src/Letterbox/__tests__/Letterbox.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Letterbox from '../Letterbox';

--- a/packages/gestalt/src/Link/__tests__/Link.test.js
+++ b/packages/gestalt/src/Link/__tests__/Link.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Link from '../Link';

--- a/packages/gestalt/src/Link/__tests__/Link.test.js
+++ b/packages/gestalt/src/Link/__tests__/Link.test.js
@@ -40,7 +40,7 @@ it('target blank', () =>
 
 it('with onClick', () =>
   snapshot(
-    <Link href="https://example.com" onClick={() => 'hey'}>
+    <Link href="https://example.com" onClick={() => {}}>
       Link
     </Link>
   ));

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -5,6 +5,15 @@ const stubCache = (measurements = {}) => ({
   get(item) {
     return measurements[item];
   },
+  has(item) {
+    return !!measurements[item];
+  },
+  set(item, value) {
+    measurements[item] = value;
+  },
+  reset() {
+    measurements = {};
+  },
 });
 
 test('empty', () => {

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -1,13 +1,23 @@
 // @flow
 import defaultLayout from './defaultLayout';
-import MeasurementStore from './MeasurementStore';
 
 const stubCache = (measurements: Object = {}) => {
-  const measurementStore = new MeasurementStore();
-  Object.keys(measurements).map(key =>
-    measurementStore.set(key, measurements[key])
-  );
-  return measurementStore;
+  let cache = measurements;
+
+  return {
+    get(item) {
+      return cache[item];
+    },
+    has(item) {
+      return !!cache[item];
+    },
+    set(item, value) {
+      cache[item] = value;
+    },
+    reset() {
+      cache = {};
+    },
+  };
 };
 
 test('empty', () => {

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -1,20 +1,14 @@
 // @flow
 import defaultLayout from './defaultLayout';
+import MeasurementStore from './MeasurementStore';
 
-const stubCache = (measurements = {}) => ({
-  get(item) {
-    return measurements[item];
-  },
-  has(item) {
-    return !!measurements[item];
-  },
-  set(item, value) {
-    measurements[item] = value;
-  },
-  reset() {
-    measurements = {};
-  },
-});
+const stubCache = (measurements: Object = {}) => {
+  const measurementStore = new MeasurementStore();
+  Object.keys(measurements).map(key =>
+    measurementStore.set(key, measurements[key])
+  );
+  return measurementStore;
+};
 
 test('empty', () => {
   const layout = defaultLayout({

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import defaultLayout from './defaultLayout';
 
 const stubCache = (measurements = {}) => ({

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.js
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.js
@@ -1,20 +1,14 @@
 // @flow
 import fullWidthLayout from './fullWidthLayout';
+import MeasurementStore from './MeasurementStore';
 
-const stubCache = (measurements = {}) => ({
-  get(item) {
-    return measurements[item];
-  },
-  has(item) {
-    return !!measurements[item];
-  },
-  set(item, value) {
-    measurements[item] = value;
-  },
-  reset() {
-    measurements = {};
-  },
-});
+const stubCache = (measurements: Object = {}) => {
+  const measurementStore = new MeasurementStore();
+  Object.keys(measurements).map(key =>
+    measurementStore.set(key, measurements[key])
+  );
+  return measurementStore;
+};
 
 test('empty', () => {
   const layout = fullWidthLayout({

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.js
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.js
@@ -5,6 +5,15 @@ const stubCache = (measurements = {}) => ({
   get(item) {
     return measurements[item];
   },
+  has(item) {
+    return !!measurements[item];
+  },
+  set(item, value) {
+    measurements[item] = value;
+  },
+  reset() {
+    measurements = {};
+  },
 });
 
 test('empty', () => {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.js
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import fullWidthLayout from './fullWidthLayout';
 
 const stubCache = (measurements = {}) => ({

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.js
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.js
@@ -1,13 +1,23 @@
 // @flow
 import fullWidthLayout from './fullWidthLayout';
-import MeasurementStore from './MeasurementStore';
 
 const stubCache = (measurements: Object = {}) => {
-  const measurementStore = new MeasurementStore();
-  Object.keys(measurements).map(key =>
-    measurementStore.set(key, measurements[key])
-  );
-  return measurementStore;
+  let cache = measurements;
+
+  return {
+    get(item) {
+      return cache[item];
+    },
+    has(item) {
+      return !!cache[item];
+    },
+    set(item, value) {
+      cache[item] = value;
+    },
+    reset() {
+      cache = {};
+    },
+  };
 };
 
 test('empty', () => {

--- a/packages/gestalt/src/Masonry/uniformRowLayout.test.js
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.test.js
@@ -5,6 +5,15 @@ const stubCache = (measurements = {}) => ({
   get(item) {
     return measurements[item];
   },
+  has(item) {
+    return !!measurements[item];
+  },
+  set(item, value) {
+    measurements[item] = value;
+  },
+  reset() {
+    measurements = {};
+  },
 });
 
 test('empty', () => {

--- a/packages/gestalt/src/Masonry/uniformRowLayout.test.js
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.test.js
@@ -1,13 +1,23 @@
 // @flow
 import uniformRowLayout from './uniformRowLayout';
-import MeasurementStore from './MeasurementStore';
 
 const stubCache = (measurements: Object = {}) => {
-  const measurementStore = new MeasurementStore();
-  Object.keys(measurements).map(key =>
-    measurementStore.set(key, measurements[key])
-  );
-  return measurementStore;
+  let cache = measurements;
+
+  return {
+    get(item) {
+      return cache[item];
+    },
+    has(item) {
+      return !!cache[item];
+    },
+    set(item, value) {
+      cache[item] = value;
+    },
+    reset() {
+      cache = {};
+    },
+  };
 };
 
 test('empty', () => {

--- a/packages/gestalt/src/Masonry/uniformRowLayout.test.js
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.test.js
@@ -1,20 +1,14 @@
 // @flow
 import uniformRowLayout from './uniformRowLayout';
+import MeasurementStore from './MeasurementStore';
 
-const stubCache = (measurements = {}) => ({
-  get(item) {
-    return measurements[item];
-  },
-  has(item) {
-    return !!measurements[item];
-  },
-  set(item, value) {
-    measurements[item] = value;
-  },
-  reset() {
-    measurements = {};
-  },
-});
+const stubCache = (measurements: Object = {}) => {
+  const measurementStore = new MeasurementStore();
+  Object.keys(measurements).map(key =>
+    measurementStore.set(key, measurements[key])
+  );
+  return measurementStore;
+};
 
 test('empty', () => {
   const layout = uniformRowLayout({

--- a/packages/gestalt/src/Masonry/uniformRowLayout.test.js
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import uniformRowLayout from './uniformRowLayout';
 
 const stubCache = (measurements = {}) => ({

--- a/packages/gestalt/src/Pog/__tests__/Pog.test.js
+++ b/packages/gestalt/src/Pog/__tests__/Pog.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Pog from '../Pog';

--- a/packages/gestalt/src/RadioButton/RadioButton.test.js
+++ b/packages/gestalt/src/RadioButton/RadioButton.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import RadioButton from './RadioButton';

--- a/packages/gestalt/src/SegmentedControl/__tests__/SegmentedControl.test.js
+++ b/packages/gestalt/src/SegmentedControl/__tests__/SegmentedControl.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import SegmentedControl from '../SegmentedControl';

--- a/packages/gestalt/src/Sticky/__tests__/Sticky.test.js
+++ b/packages/gestalt/src/Sticky/__tests__/Sticky.test.js
@@ -8,7 +8,7 @@ test('Sticky renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Sticky correctly sets thresholds', () => {
+test('Sticky correctly sets thresholds for number values', () => {
   const tree = create(
     <Sticky bottom={1} left={2} right={3} top={4}>
       Sticky
@@ -17,7 +17,7 @@ test('Sticky correctly sets thresholds', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Sticky correctly sets thresholds', () => {
+test('Sticky correctly sets thresholds for string values', () => {
   const tree = create(
     <Sticky bottom="50%" left="25%" right="25%" top="50%">
       Sticky

--- a/packages/gestalt/src/Sticky/__tests__/Sticky.test.js
+++ b/packages/gestalt/src/Sticky/__tests__/Sticky.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Sticky from '../Sticky';

--- a/packages/gestalt/src/Sticky/__tests__/__snapshots__/Sticky.test.js.snap
+++ b/packages/gestalt/src/Sticky/__tests__/__snapshots__/Sticky.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sticky correctly sets thresholds 1`] = `
+exports[`Sticky correctly sets thresholds for number values 1`] = `
 <div
   className="sticky"
   style={
@@ -17,7 +17,7 @@ exports[`Sticky correctly sets thresholds 1`] = `
 </div>
 `;
 
-exports[`Sticky correctly sets thresholds 2`] = `
+exports[`Sticky correctly sets thresholds for string values 1`] = `
 <div
   className="sticky"
   style={

--- a/packages/gestalt/src/Switch/Switch.test.js
+++ b/packages/gestalt/src/Switch/Switch.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Switch from './Switch';

--- a/packages/gestalt/src/Tabs/__tests__/Tabs.test.js
+++ b/packages/gestalt/src/Tabs/__tests__/Tabs.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Tabs from '../Tabs';

--- a/packages/gestalt/src/Text/Text.test.js
+++ b/packages/gestalt/src/Text/Text.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Text from './Text';

--- a/packages/gestalt/src/TextArea/__tests__/TextArea.test.js
+++ b/packages/gestalt/src/TextArea/__tests__/TextArea.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import { shallow } from 'enzyme';

--- a/packages/gestalt/src/TextArea/__tests__/TextArea.test.js
+++ b/packages/gestalt/src/TextArea/__tests__/TextArea.test.js
@@ -11,12 +11,12 @@ describe('TextArea', () => {
     );
     wrapper.instance().setState({ errorIsOpen: true });
     wrapper.simulate('focus');
-    expect(wrapper.find('ErrorFlyout').length).toEqual(1);
+    expect(wrapper.find('ErrorFlyout')).toHaveLength(1);
   });
 
   it('Does not render an ErrorFlyout when errorMessage is null', () => {
     const wrapper = shallow(<TextArea id="test" onChange={jest.fn()} />);
-    expect(wrapper.find('ErrorFlyout').length).toEqual(0);
+    expect(wrapper.find('ErrorFlyout')).toHaveLength(0);
   });
 
   it('TextArea normal', () => {
@@ -60,10 +60,10 @@ describe('TextArea', () => {
         onBlur={jest.fn()}
       />
     );
-    expect(tree.find('ErrorFlyout').length).toEqual(0);
+    expect(tree.find('ErrorFlyout')).toHaveLength(0);
     tree.setProps({
       errorMessage: 'error message',
     });
-    expect(tree.find('ErrorFlyout').length).toEqual(1);
+    expect(tree.find('ErrorFlyout')).toHaveLength(1);
   });
 });

--- a/packages/gestalt/src/TextField/__tests__/TextField.test.js
+++ b/packages/gestalt/src/TextField/__tests__/TextField.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import { shallow } from 'enzyme';

--- a/packages/gestalt/src/TextField/__tests__/TextField.test.js
+++ b/packages/gestalt/src/TextField/__tests__/TextField.test.js
@@ -12,12 +12,12 @@ describe('TextField', () => {
     );
     wrapper.instance().setState({ errorIsOpen: true });
     wrapper.simulate('focus');
-    expect(wrapper.find(ErrorFlyout).length).toEqual(1);
+    expect(wrapper.find(ErrorFlyout)).toHaveLength(1);
   });
 
   it('Does not render an ErrorFlyout when errorMessage is null', () => {
     const wrapper = shallow(<TextField id="test" onChange={jest.fn()} />);
-    expect(wrapper.find(ErrorFlyout).length).toEqual(0);
+    expect(wrapper.find(ErrorFlyout)).toHaveLength(0);
   });
 
   it('TextField normal', () => {
@@ -80,11 +80,11 @@ describe('TextField', () => {
         onBlur={jest.fn()}
       />
     );
-    expect(tree.find(ErrorFlyout).length).toEqual(0);
+    expect(tree.find(ErrorFlyout)).toHaveLength(0);
     tree.setProps({
       errorMessage: 'error message',
     });
-    expect(tree.find(ErrorFlyout).length).toEqual(1);
+    expect(tree.find(ErrorFlyout)).toHaveLength(1);
   });
 
   it('TextField with type number', () => {

--- a/packages/gestalt/src/TextField/__tests__/TextField.test.js
+++ b/packages/gestalt/src/TextField/__tests__/TextField.test.js
@@ -61,7 +61,7 @@ describe('TextField', () => {
   it('TextField with autocomplete', () => {
     const tree = shallow(
       <TextField
-        autocomplete="on"
+        autoComplete="on"
         id="email"
         onChange={jest.fn()}
         onFocus={jest.fn()}

--- a/packages/gestalt/src/TextField/__tests__/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/TextField/__tests__/__snapshots__/TextField.test.js.snap
@@ -21,7 +21,7 @@ exports[`TextField TextField normal 1`] = `
 </span>
 `;
 
-exports[`TextField TextField with autocomplete 1`] = `"<span><input type=\\"text\\" aria-invalid=\\"false\\" class=\\"textField enabled normal\\" id=\\"email\\"/></span>"`;
+exports[`TextField TextField with autocomplete 1`] = `"<span><input type=\\"text\\" aria-invalid=\\"false\\" autoComplete=\\"on\\" class=\\"textField enabled normal\\" id=\\"email\\"/></span>"`;
 
 exports[`TextField TextField with error 1`] = `"<span><input type=\\"text\\" aria-invalid=\\"true\\" class=\\"textField enabled errored\\" id=\\"test\\"/></span>"`;
 

--- a/packages/gestalt/src/Toast/__tests__/Toast.test.js
+++ b/packages/gestalt/src/Toast/__tests__/Toast.test.js
@@ -6,7 +6,6 @@ import Toast from '../Toast';
 test('Confirmation Toast', () => {
   const tree = create(
     <Toast
-      href="https://www.pinterest.com/pinterest/home-decor/"
       text={['Saved to', 'Home decor']}
       thumbnail={
         <img
@@ -21,10 +20,7 @@ test('Confirmation Toast', () => {
 
 test('Guide Toast', () => {
   const tree = create(
-    <Toast
-      href="http://www.pinterest.com"
-      text="Same great profile, slightly new look. Learn more?"
-    />
+    <Toast text="Same great profile, slightly new look. Learn more?" />
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/packages/gestalt/src/Toast/__tests__/Toast.test.js
+++ b/packages/gestalt/src/Toast/__tests__/Toast.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Toast from '../Toast';

--- a/packages/gestalt/src/Touchable/__tests__/touchable.test.js
+++ b/packages/gestalt/src/Touchable/__tests__/touchable.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Touchable from '../Touchable';

--- a/packages/gestalt/src/Video/__tests__/Video.test.js
+++ b/packages/gestalt/src/Video/__tests__/Video.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Video from '../Video';

--- a/packages/gestalt/src/Video/__tests__/VideoControls.test.js
+++ b/packages/gestalt/src/Video/__tests__/VideoControls.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import VideoControls from '../VideoControls';

--- a/packages/gestalt/src/Video/__tests__/VideoPlayhead.test.js
+++ b/packages/gestalt/src/Video/__tests__/VideoPlayhead.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+// @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import VideoPlayhead from '../VideoPlayhead';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3129,6 +3129,10 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
+eslint-plugin-jest@^21.15.1:
+  version "21.15.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.1.tgz#662a3f0888002878f0f388efd09c190a95c33d82"
+
 eslint-plugin-jsx-a11y@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz#5c96bb5186ca14e94db1095ff59b3e2bd94069b1"


### PR DESCRIPTION
Adds the [eslint-jest-plugin](https://github.com/jest-community/eslint-plugin-jest) and sets up the recommended setting for the linter. Converts the eslint env comment to a global in the eslint config. Adds Flow to all test files using the new flow-typed library. Fixes all linter and Flow errors from the tests.