### PR TITLE
Remove faux virtualization (display none on non-visible components)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Minor
 * Avatar / GroupAvatar: make outline configurable(#173)
+* Masonry: Update non-virtualized Masonry to render all items regardless of the window
 * ExperimentalMasonry: remove component (#183)
 * Internal: Add flow-typed files for third party packages (#174)
 * Internal: Remove unused linter suppressions (#180)

--- a/packages/gestalt/src/Masonry/Masonry.js
+++ b/packages/gestalt/src/Masonry/Masonry.js
@@ -387,9 +387,6 @@ export default class Masonry<T> extends React.Component<Props<T>, State> {
           WebkitTransform: `translateX(${left}px) translateY(${top}px)`,
           width: layoutNumberToCssDimension(width),
           height: layoutNumberToCssDimension(height),
-          ...(virtualize || isVisible
-            ? {}
-            : { display: 'none', transition: 'none' }),
         }}
       >
         <Component data={itemData} itemIdx={idx} isMeasuring={false} />

--- a/packages/gestalt/src/Masonry/__integration__/virtualBoundsVisibility.ghost.js
+++ b/packages/gestalt/src/Masonry/__integration__/virtualBoundsVisibility.ghost.js
@@ -3,10 +3,7 @@
 import ghost from 'ghostjs';
 import selectors from './lib/selectors';
 
-const getFirstItemDisplay = async () => {
-  const gridItems = await ghost.findElements(selectors.gridItem);
-  return await gridItems[0].script(element => element.style.display);
-};
+const getFirstItem = async () => await ghost.findElements(selectors.gridItem);
 
 describe('Masonry > virtual bounds visibility', () => {
   it('Calculates correct virtual bounds when masonry is offset', async () => {
@@ -30,12 +27,12 @@ describe('Masonry > virtual bounds visibility', () => {
     // because we don't have DOM measurements yet. Scroll down a bit to trigger virtualization.
     await ghost.wait(async () => {
       await ghost.script(() => window.scrollTo(0, window.scrollY + 1));
-      return (await getFirstItemDisplay()) === 'none';
+      return (await getFirstItem()) === null;
     });
 
     await ghost.script(scrollToY => window.scrollTo(0, scrollToY), [
       VIRTUALIZED_TOP,
     ]);
-    await ghost.wait(async () => (await getFirstItemDisplay()) !== 'none');
+    await ghost.wait(async () => (await getFirstItem()) !== null);
   });
 });

--- a/packages/gestalt/src/Masonry/__integration__/virtualBoundsVisibilityWithScrollContainer.ghost.js
+++ b/packages/gestalt/src/Masonry/__integration__/virtualBoundsVisibilityWithScrollContainer.ghost.js
@@ -3,10 +3,7 @@
 import ghost from 'ghostjs';
 import selectors from './lib/selectors';
 
-const getFirstItemDisplay = async () => {
-  const gridItems = await ghost.findElements(selectors.gridItem);
-  return await gridItems[0].script(element => element.style.display);
-};
+const getFirstItem = async () => await ghost.findElements(selectors.gridItem);
 
 describe('Masonry > virtual bounds visibility /w scroll container', () => {
   it('Calculates correct virtual bounds when masonry is offset', async () => {
@@ -34,7 +31,7 @@ describe('Masonry > virtual bounds visibility /w scroll container', () => {
         },
         [selectors.scrollContainer]
       );
-      return (await getFirstItemDisplay()) === 'none';
+      return (await getFirstItem()) === null;
     });
 
     await ghost.script(
@@ -44,6 +41,6 @@ describe('Masonry > virtual bounds visibility /w scroll container', () => {
       },
       [VIRTUALIZED_TOP, selectors.scrollContainer]
     );
-    await ghost.wait(async () => (await getFirstItemDisplay()) !== 'none');
+    await ghost.wait(async () => (await getFirstItem()) !== null);
   });
 });

--- a/test/utils/renderConfig.js
+++ b/test/utils/renderConfig.js
@@ -16,7 +16,7 @@ const RenderConfig = {
   Masonry: {
     Component: MasonryExample,
     styles: classicGridServerStyles,
-    props: { initialPins: masonryPins },
+    props: { initialPins: masonryPins, virtualize: true },
   },
 };
 


### PR DESCRIPTION
## Remove faux virtualization
Today we use virtualization to enable a more performant scrolling experience for our masonry users. Unfortunately this does not translate into a good experience for bots. We have seen that virtualization severely limits the number of components a bot can crawl due to removing the components from the DOM. Masonry supports a non-virtualized grid but it stills attempts to hide the component by setting the style to `display: none`. This "faux-virtualization" also severely limits bot crawls and this PR proposes removing this functionality.

This PR will enabled bot crawls on masonry and deliver a truly non-virtual masonry.
