### PR TITLE
Remove unused linter suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 * Avatar / GroupAvatar: make outline configurable(#173)
 * Internal: Add flow-typed files for third party packages (#174)
+* Internal: Remove unused linter suppressions (#180)
 
 ### Patch
 

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/prop-types */
 import React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';

--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/prop-types */
 import React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';

--- a/packages/gestalt/src/Box/Box.js
+++ b/packages/gestalt/src/Box/Box.js
@@ -1,6 +1,4 @@
 // @flow
-/* eslint-disable react/no-unused-prop-types */
-/* eslint-disable no-underscore-dangle */
 
 /*
 
@@ -611,6 +609,7 @@ const propToFn = {
   width: width => fromInlineStyle({ width }),
   wrap: toggle(layout.flexWrap),
   dangerouslySetInlineStyle: value =>
+    /* eslint-disable-next-line no-underscore-dangle */
     value && value.__style ? fromInlineStyle(value.__style) : identity(),
 };
 

--- a/packages/gestalt/src/Button/Button.js
+++ b/packages/gestalt/src/Button/Button.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/no-unused-prop-types */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/IconButton/IconButton.js
+++ b/packages/gestalt/src/IconButton/IconButton.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/no-unused-prop-types */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styles from './IconButton.css';

--- a/packages/gestalt/src/Touchable/Touchable.js
+++ b/packages/gestalt/src/Touchable/Touchable.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';


### PR DESCRIPTION
Noticed that removing these linter suppressions still appeases the linter so they are no longer needed.