### PR TITLE
Add eslint-plugin-jest with recommended settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
   ],
   "env": {
     "browser": true,
-    "es6": true,
+    "es6": true
   },
   "parser": "babel-eslint",
   "plugins": ["flowtype", "jest", "jsx-a11y", "prettier"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,6 @@
   "env": {
     "browser": true,
     "es6": true,
-    "jest/globals": true,
   },
   "parser": "babel-eslint",
   "plugins": ["flowtype", "jest", "jsx-a11y", "prettier"],
@@ -38,5 +37,13 @@
     "import/no-named-as-default-member": 0,
     "import/no-unresolved": 0,
     "import/no-webpack-loader-syntax": 0
-  }
+  },
+  "overrides": [
+    {
+      "files": [ "**/*.test.js" ],
+      "env": {
+        "jest": true,
+      }
+    }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": [
     "airbnb",
+    "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:flowtype/recommended",
     "prettier",
@@ -9,10 +10,11 @@
   ],
   "env": {
     "browser": true,
-    "es6": true
+    "es6": true,
+    "jest/globals": true,
   },
   "parser": "babel-eslint",
-  "plugins": ["flowtype", "jsx-a11y", "prettier"],
+  "plugins": ["flowtype", "jest", "jsx-a11y", "prettier"],
   "rules": {
     "jsx-a11y/label-has-for": [
       "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 * Avatar / GroupAvatar: make outline configurable(#173)
 * Internal: Add flow-typed files for third party packages (#174)
+* Internal: Add eslint-plugin-jest and use recommended settings (#181)
 
 ### Patch
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-config-prettier": "^2.1.1",
     "eslint-plugin-flowtype": "^2.34.0",
     "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jest": "^21.15.1",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.1.1",
     "eslint-plugin-react": "^7.4.0",

--- a/packages/gestalt/src/Flyout/__tests__/Flyout.test.js
+++ b/packages/gestalt/src/Flyout/__tests__/Flyout.test.js
@@ -15,6 +15,6 @@ describe('Display checks', () => {
       />
     );
     wrapper.instance();
-    expect(wrapper.find('Controller').length).toEqual(1);
+    expect(wrapper.find('Controller')).toHaveLength(1);
   });
 });

--- a/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
+++ b/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
@@ -12,6 +12,6 @@ describe('Flyout', () => {
     const wrapper = shallow(
       <Controller anchor={null} bgColor="white" onDismiss={() => null} />
     );
-    expect(wrapper.find(Contents).length).toEqual(0);
+    expect(wrapper.find(Contents)).toHaveLength(0);
   });
 });

--- a/packages/gestalt/src/Sticky/__tests__/Sticky.test.js
+++ b/packages/gestalt/src/Sticky/__tests__/Sticky.test.js
@@ -8,7 +8,7 @@ test('Sticky renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Sticky correctly sets thresholds', () => {
+test('Sticky correctly sets thresholds for number values', () => {
   const tree = create(
     <Sticky bottom={1} left={2} right={3} top={4}>
       Sticky
@@ -17,7 +17,7 @@ test('Sticky correctly sets thresholds', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Sticky correctly sets thresholds', () => {
+test('Sticky correctly sets thresholds for string values', () => {
   const tree = create(
     <Sticky bottom="50%" left="25%" right="25%" top="50%">
       Sticky

--- a/packages/gestalt/src/Sticky/__tests__/__snapshots__/Sticky.test.js.snap
+++ b/packages/gestalt/src/Sticky/__tests__/__snapshots__/Sticky.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sticky correctly sets thresholds 1`] = `
+exports[`Sticky correctly sets thresholds for number values 1`] = `
 <div
   className="sticky"
   style={
@@ -17,7 +17,7 @@ exports[`Sticky correctly sets thresholds 1`] = `
 </div>
 `;
 
-exports[`Sticky correctly sets thresholds 2`] = `
+exports[`Sticky correctly sets thresholds for string values 1`] = `
 <div
   className="sticky"
   style={

--- a/packages/gestalt/src/TextArea/__tests__/TextArea.test.js
+++ b/packages/gestalt/src/TextArea/__tests__/TextArea.test.js
@@ -11,12 +11,12 @@ describe('TextArea', () => {
     );
     wrapper.instance().setState({ errorIsOpen: true });
     wrapper.simulate('focus');
-    expect(wrapper.find('ErrorFlyout').length).toEqual(1);
+    expect(wrapper.find('ErrorFlyout')).toHaveLength(1);
   });
 
   it('Does not render an ErrorFlyout when errorMessage is null', () => {
     const wrapper = shallow(<TextArea id="test" onChange={jest.fn()} />);
-    expect(wrapper.find('ErrorFlyout').length).toEqual(0);
+    expect(wrapper.find('ErrorFlyout')).toHaveLength(0);
   });
 
   it('TextArea normal', () => {
@@ -60,10 +60,10 @@ describe('TextArea', () => {
         onBlur={jest.fn()}
       />
     );
-    expect(tree.find('ErrorFlyout').length).toEqual(0);
+    expect(tree.find('ErrorFlyout')).toHaveLength(0);
     tree.setProps({
       errorMessage: 'error message',
     });
-    expect(tree.find('ErrorFlyout').length).toEqual(1);
+    expect(tree.find('ErrorFlyout')).toHaveLength(1);
   });
 });

--- a/packages/gestalt/src/TextField/__tests__/TextField.test.js
+++ b/packages/gestalt/src/TextField/__tests__/TextField.test.js
@@ -12,12 +12,12 @@ describe('TextField', () => {
     );
     wrapper.instance().setState({ errorIsOpen: true });
     wrapper.simulate('focus');
-    expect(wrapper.find(ErrorFlyout).length).toEqual(1);
+    expect(wrapper.find(ErrorFlyout)).toHaveLength(1);
   });
 
   it('Does not render an ErrorFlyout when errorMessage is null', () => {
     const wrapper = shallow(<TextField id="test" onChange={jest.fn()} />);
-    expect(wrapper.find(ErrorFlyout).length).toEqual(0);
+    expect(wrapper.find(ErrorFlyout)).toHaveLength(0);
   });
 
   it('TextField normal', () => {
@@ -80,11 +80,11 @@ describe('TextField', () => {
         onBlur={jest.fn()}
       />
     );
-    expect(tree.find(ErrorFlyout).length).toEqual(0);
+    expect(tree.find(ErrorFlyout)).toHaveLength(0);
     tree.setProps({
       errorMessage: 'error message',
     });
-    expect(tree.find(ErrorFlyout).length).toEqual(1);
+    expect(tree.find(ErrorFlyout)).toHaveLength(1);
   });
 
   it('TextField with type number', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3129,6 +3129,10 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
+eslint-plugin-jest@^21.15.1:
+  version "21.15.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.1.tgz#662a3f0888002878f0f388efd09c190a95c33d82"
+
 eslint-plugin-jsx-a11y@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz#5c96bb5186ca14e94db1095ff59b3e2bd94069b1"


### PR DESCRIPTION
Adds the [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) to gestalt and turns on the recommended settings. Puts the jest globals into the environment and fixes any errors from these settings.