### PR TITLE
Turn on import/first linter rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,6 @@
     "react/no-array-index-key": 0,
     "react/require-default-props": 0,
     "import/extensions": 0,
-    "import/first": 0,
     "import/no-absolute-path": 0,
     "import/no-duplicates": 0,
     "import/no-extraneous-dependencies": 0,

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
+import { IconButton } from 'gestalt';
 import Example from './components/Example';
 import PropTable from './components/PropTable';
 import Combination from './components/Combination';
-import { IconButton } from 'gestalt';
 import PageHeader from './components/PageHeader';
 import CardPage from './components/CardPage';
 

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
-import PropTable from './components/PropTable';
 import { Box, Masonry, Image, Text, MasonryUniformRowLayout } from 'gestalt';
+import PropTable from './components/PropTable';
 import stock9 from './images/stock9.jpg';
 import stock10 from './images/stock10.jpg';
 import stock11 from './images/stock11.jpg';

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from 'react';
+import { Pog } from 'gestalt';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import Combination from './components/Combination';
-import { Pog } from 'gestalt';
 import PageHeader from './components/PageHeader';
 import CardPage from './components/CardPage';
 

--- a/docs/src/components/CardPage.js
+++ b/docs/src/components/CardPage.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
-import SearchContent from './SearchContent';
 import { Box } from 'gestalt';
+import SearchContent from './SearchContent';
 
 type Props = {|
   cards: Array<React.Node>,

--- a/docs/src/components/Combination.js
+++ b/docs/src/components/Combination.js
@@ -1,12 +1,11 @@
 // @flow
-import type { Node } from 'react';
-import React from 'react';
-import Checkerboard from './Checkerboard';
+import * as React from 'react';
 import { Box, Text } from 'gestalt';
+import Checkerboard from './Checkerboard';
 import Card from './Card';
 
 type Props = {
-  children: (Object, number) => Node,
+  children: (Object, number) => React.Node,
   description?: string,
   heading?: boolean,
   name?: string,

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 import { render } from 'react-dom';
+import 'gestalt/dist/gestalt.css';
 import App from './components/App';
 import routes from './routes';
-import 'gestalt/dist/gestalt.css';
 import './reset.css';
 
 render(

--- a/packages/gestalt/src/Card/Card.js
+++ b/packages/gestalt/src/Card/Card.js
@@ -1,8 +1,9 @@
 // @flow
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import Box from '../Box/Box';
 import classnames from 'classnames';
+import Box from '../Box/Box';
+
 import styles from './Card.css';
 
 type Props = {|

--- a/packages/gestalt/src/ErrorFlyout/ErrorFlyout.js
+++ b/packages/gestalt/src/ErrorFlyout/ErrorFlyout.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import Box from '../Box/Box';
 import Controller from '../FlyoutUtils/Controller';
-import PropTypes from 'prop-types';
 import Text from '../Text/Text';
 
 type Props = {|

--- a/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
+++ b/packages/gestalt/src/FlyoutUtils/__tests__/Controller.test.js
@@ -1,11 +1,10 @@
 // @flow
-/* eslint import/imports-first: 0 */
-jest.unmock('../Controller');
-
 import React from 'react';
 import { shallow } from 'enzyme';
 import Controller from '../Controller';
 import Contents from '../Contents';
+
+jest.unmock('../Controller');
 
 describe('Flyout', () => {
   it('does not render Contents when anchor is null', () => {

--- a/packages/gestalt/src/Masonry/Masonry.js
+++ b/packages/gestalt/src/Masonry/Masonry.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
-import debounce from '../debounce';
 import PropTypes from 'prop-types';
+import debounce from '../debounce';
 import FetchItems from '../ScrollFetch/FetchItems';
 import styles from './Masonry.css';
 import ScrollContainer from '../ScrollFetch/ScrollContainer';

--- a/packages/gestalt/src/Pulsar/Pulsar.js
+++ b/packages/gestalt/src/Pulsar/Pulsar.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
-import Box from '../Box/Box';
 import PropTypes from 'prop-types';
+import Box from '../Box/Box';
 import styles from './Pulsar.css';
 
 type Props = {

--- a/packages/gestalt/src/SelectList/SelectList.js
+++ b/packages/gestalt/src/SelectList/SelectList.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import Box from '../Box/Box';
 import classnames from 'classnames';
+import Box from '../Box/Box';
 import ErrorFlyout from '../ErrorFlyout/ErrorFlyout';
 import Icon from '../Icon/Icon';
 import styles from './SelectList.css';

--- a/packages/gestalt/src/Sticky/Sticky.js
+++ b/packages/gestalt/src/Sticky/Sticky.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import layout from '../Layout.css';
 import PropTypes from 'prop-types';
+import layout from '../Layout.css';
 
 type Threshold =
   | {| top: number | string |}

--- a/packages/gestalt/src/Toast/Toast.js
+++ b/packages/gestalt/src/Toast/Toast.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import Box from '../Box/Box';
 import Mask from '../Mask/Mask';
 import Text from '../Text/Text';
 import Icon from '../Icon/Icon';
-import PropTypes from 'prop-types';
 
 type Props = {|
   color?: 'darkGray' | 'orange',

--- a/packages/gestalt/src/Tooltip/Tooltip.js
+++ b/packages/gestalt/src/Tooltip/Tooltip.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
-import Box from '../Box/Box';
 import PropTypes from 'prop-types';
+import Box from '../Box/Box';
 import Controller from '../FlyoutUtils/Controller';
 
 type Props = {|

--- a/packages/gestalt/src/Video/Video.js
+++ b/packages/gestalt/src/Video/Video.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import VideoControls from './VideoControls';
 import PropTypes from 'prop-types';
+import VideoControls from './VideoControls';
 import styles from './Video.css';
 
 type VideoWithControls = {|

--- a/packages/gestalt/src/Video/VideoControls.js
+++ b/packages/gestalt/src/Video/VideoControls.js
@@ -1,12 +1,12 @@
 // @flow
 
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import Box from '../Box/Box';
 import Icon from '../Icon/Icon';
 import Text from '../Text/Text';
 import Touchable from '../Touchable/Touchable';
 import VideoPlayhead from './VideoPlayhead';
-import PropTypes from 'prop-types';
 
 type Props = {|
   accessibilityMaximizeLabel: string,

--- a/packages/gestalt/src/Video/VideoPlayhead.js
+++ b/packages/gestalt/src/Video/VideoPlayhead.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import Box from '../Box/Box';
 import PropTypes from 'prop-types';
+import Box from '../Box/Box';
 import styles from './Video.css';
 
 type Props = {|

--- a/scripts/boxperf.js
+++ b/scripts/boxperf.js
@@ -8,9 +8,9 @@ Usage:
     $ babel-node ./boxperf.js
 
 */
+import Benchmark from 'benchmark';
 import { Box as PublishedBox } from 'gestalt';
 import { Box as DevelopmentBox } from '../dist/gestalt.es.js';
-import Benchmark from 'benchmark';
 
 const emptyProps = {};
 const lotsOfProps = {

--- a/test/containers/A11YCheck.js
+++ b/test/containers/A11YCheck.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import IconA11Y from './Icon.a11y';
 import PropTypes from 'prop-types';
+import IconA11Y from './Icon.a11y';
 
 export default function A11YCheck(props) {
   const { component } = props;

--- a/test/containers/MasonryExample.js
+++ b/test/containers/MasonryExample.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Masonry } from 'gestalt';
-import Item from './ExampleGridItem';
 import PropTypes from 'prop-types';
+import Item from './ExampleGridItem';
 
 const store = Masonry.createMeasurementStore();
 

--- a/test/server.js
+++ b/test/server.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import RenderConfig from './utils/renderConfig';
 import { readFileSync } from 'fs';
+import RenderConfig from './utils/renderConfig';
 
 const express = require('express');
 

--- a/test/views/main.js
+++ b/test/views/main.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import RenderConfig from '../utils/renderConfig';
 import 'gestalt/dist/gestalt.css';
+import RenderConfig from '../utils/renderConfig';
 
 // Wait to mount until the test tells us to do so.
 function mount() {


### PR DESCRIPTION
We were previously disabling the `import/first` from `eslint-plugin-import` but we don't need to since its generally accepted best practice. This PR enables that one rule and fixes the lint errors.