### PR TITLE
Turn on linter rules already being followed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,13 +29,8 @@
     "react/no-array-index-key": 0,
     "react/require-default-props": 0,
     "import/extensions": 0,
-    "import/no-absolute-path": 0,
-    "import/no-duplicates": 0,
     "import/no-extraneous-dependencies": 0,
-    "import/no-named-as-default": 0,
-    "import/no-named-as-default-member": 0,
     "import/no-unresolved": 0,
-    "import/no-webpack-loader-syntax": 0
   },
   "overrides": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Patch
 * Internal: Add code coverage to PRs (#185)
 * Internal: Update Jest and use multi-project runner (#158)
+* Internal: Turn on eslint-plugin-import rules already being followed (#189)
 
 </details>
 


### PR DESCRIPTION
This change turns on the following rules that are already being followed:

- [import/no-absolute-path](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md)
- [import/no-duplicates](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)
- [import/no-named-as-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md)
- [import/no-named-as-default-member](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md)
- [import/no-webpack-loader-syntax](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)