### PR TITLE
Move CardPage rendering into the Routes

### DIFF
--- a/docs/src/Avatar.doc.js
+++ b/docs/src/Avatar.doc.js
@@ -7,7 +7,6 @@ import shanice from './avatars/shanice.jpg';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -155,4 +154,4 @@ verified
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -6,7 +6,6 @@ import Example from './components/Example';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -524,4 +523,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -5,7 +5,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -206,4 +205,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Card.doc.js
+++ b/docs/src/Card.doc.js
@@ -4,7 +4,6 @@ import james from './avatars/james.jpg';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -100,4 +99,4 @@ render() {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -5,7 +5,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -168,4 +167,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Column.doc.js
+++ b/docs/src/Column.doc.js
@@ -4,7 +4,6 @@ import { Box, Text } from 'gestalt';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -207,4 +206,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Container.doc.js
+++ b/docs/src/Container.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -45,4 +44,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Divider.doc.js
+++ b/docs/src/Divider.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import Example from './components/Example';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -37,4 +36,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/ErrorFlyout.doc.js
+++ b/docs/src/ErrorFlyout.doc.js
@@ -4,7 +4,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -146,4 +145,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -4,7 +4,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -170,4 +169,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -8,7 +8,6 @@ import shanice from './avatars/shanice.jpg';
 import Example from './components/Example';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -132,4 +131,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -170,4 +169,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -5,7 +5,6 @@ import Example from './components/Example';
 import PropTable from './components/PropTable';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -100,4 +99,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -5,7 +5,6 @@ import Example from './components/Example';
 import PropTable from './components/PropTable';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -160,4 +159,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -9,7 +9,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -299,4 +298,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Label.doc.js
+++ b/docs/src/Label.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -68,4 +67,4 @@ render() {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Letterbox.doc.js
+++ b/docs/src/Letterbox.doc.js
@@ -7,7 +7,6 @@ import stock5 from './images/stock5.jpg';
 import stock6 from './images/stock6.jpg';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -152,4 +151,4 @@ card(
   </Box>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -130,4 +129,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -7,7 +7,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -115,4 +114,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -9,7 +9,6 @@ import stock12 from './images/stock12.jpg';
 import stock13 from './images/stock13.jpg';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -321,4 +320,4 @@ card(
   </Box>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -19,7 +19,6 @@ import PropTable from './components/PropTable';
 import StateRecorder from './components/StateRecorder';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -611,4 +610,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -5,7 +5,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -106,4 +105,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Pulsar.doc.js
+++ b/docs/src/Pulsar.doc.js
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -138,4 +137,4 @@ class TooltipExample extends React.Component {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -5,7 +5,6 @@ import Example from './components/Example';
 import PropTable from './components/PropTable';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -175,4 +174,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/SearchField.doc.js
+++ b/docs/src/SearchField.doc.js
@@ -4,7 +4,6 @@ import * as React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -114,4 +113,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -89,4 +88,4 @@ class ToastExample extends React.Component {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/SelectList.doc.js
+++ b/docs/src/SelectList.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import Example from './components/Example';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -185,4 +184,4 @@ class SelectListExample extends React.Component {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Spinner.doc.js
+++ b/docs/src/Spinner.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import Example from './components/Example';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -75,4 +74,4 @@ class SpinnerExample extends React.Component {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Sticky.doc.js
+++ b/docs/src/Sticky.doc.js
@@ -3,7 +3,6 @@ import React from 'react';
 import Example from './components/Example';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -82,4 +81,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -5,7 +5,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import Combination from './components/Combination';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -99,4 +98,4 @@ card(
   </Combination>
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -4,7 +4,6 @@ import { Tabs } from 'gestalt';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -87,4 +86,4 @@ class TabExample extends React.Component {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -248,4 +247,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -4,7 +4,6 @@ import Example from './components/Example';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -229,4 +228,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -6,7 +6,6 @@ import Example from './components/Example';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -266,4 +265,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 import Example from './components/Example';
 import stock1 from './images/stock1.jpg';
 
@@ -212,4 +211,4 @@ class ToastExample extends React.Component {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -4,7 +4,6 @@ import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
 import Card from './components/Card';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -161,4 +160,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 import stock14 from './images/stock14.jpg';
 
 const cards = [];
@@ -157,4 +156,4 @@ card(
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTable from './components/PropTable';
 import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import CardPage from './components/CardPage';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -387,4 +386,4 @@ class Example extends React.Component {
   />
 );
 
-export default () => <CardPage cards={cards} />;
+export default cards;

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -4,6 +4,7 @@ import { HashRouter, Route, Switch } from 'react-router-dom';
 import { render } from 'react-dom';
 import 'gestalt/dist/gestalt.css';
 import App from './components/App';
+import CardPage from './components/CardPage';
 import routes from './routes';
 import './reset.css';
 
@@ -13,9 +14,9 @@ render(
       <Switch>
         {Object.keys(routes).map(pathname => (
           <Route
-            component={routes[pathname]}
             path={`/${pathname}`}
             key={pathname}
+            render={() => <CardPage cards={routes[pathname]} />}
           />
         ))}
       </Switch>


### PR DESCRIPTION
Noticed we had a lot of duplicated code in all of our doc pages that could be removed by switching from the react-router [`component`](https://reacttraining.com/react-router/web/api/Route/component) prop to the [`render`](https://reacttraining.com/react-router/web/api/Route/render-func) prop