### PR TITLE
Turn on all recommended react linters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:flowtype/recommended",
+    "plugin:react/recommended",
     "prettier",
     "prettier/flowtype",
     "prettier/react"
@@ -13,7 +14,7 @@
     "es6": true
   },
   "parser": "babel-eslint",
-  "plugins": ["flowtype", "jest", "jsx-a11y", "prettier"],
+  "plugins": ["flowtype", "jest", "jsx-a11y", "prettier", "react"],
   "rules": {
     "jsx-a11y/label-has-for": [
       "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Internal: Turn on eslint-plugin-import rules already being followed (#189)
 * Docs: Add live docs to Letterbox (#190)
 * Docs: Move CardPage rendering into the Route render prop (#191)
+* Internal: Turn on all react recommended linters (#192)
 
 </details>
 

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -15,69 +15,77 @@ type Props = {|
 
 const { Box, Text, Column } = gestalt;
 
-export default ({
+function Example({
   defaultCode,
   description = '',
   name,
   scope,
   direction = 'column',
-}: Props) => (
-  <Card name={name} description={description} stacked={direction === 'column'}>
-    <LiveProvider
-      code={defaultCode.trim()}
-      scope={{
-        ...gestalt,
-        ...scope,
-      }}
+}: Props) {
+  return (
+    <Card
+      name={name}
+      description={description}
+      stacked={direction === 'column'}
     >
-      <Box
-        display="flex"
-        direction={direction}
-        marginLeft={-2}
-        marginRight={-2}
+      <LiveProvider
+        code={defaultCode.trim()}
+        scope={{
+          ...gestalt,
+          ...scope,
+        }}
       >
-        <Column span={direction === 'column' ? 12 : 6}>
-          <Box
-            paddingX={2}
-            display="flex"
-            direction="column"
-            alignItems="stretch"
-            height="100%"
-          >
-            <Box paddingY={2}>
-              <Text size="sm" color="gray">
-                Preview
-              </Text>
-            </Box>
-
-            <Box flex="grow" position="relative">
-              <Box position="absolute" top bottom left right>
-                <Checkerboard />
+        <Box
+          display="flex"
+          direction={direction}
+          marginLeft={-2}
+          marginRight={-2}
+        >
+          <Column span={direction === 'column' ? 12 : 6}>
+            <Box
+              paddingX={2}
+              display="flex"
+              direction="column"
+              alignItems="stretch"
+              height="100%"
+            >
+              <Box paddingY={2}>
+                <Text size="sm" color="gray">
+                  Preview
+                </Text>
               </Box>
-              <Box position="relative" padding={4}>
-                <LivePreview />
+
+              <Box flex="grow" position="relative">
+                <Box position="absolute" top bottom left right>
+                  <Checkerboard />
+                </Box>
+                <Box position="relative" padding={4}>
+                  <LivePreview />
+                </Box>
               </Box>
             </Box>
-          </Box>
-        </Column>
+          </Column>
 
-        <Column span={direction === 'column' ? 12 : 6}>
-          <Box paddingX={2}>
-            <Box paddingY={2}>
-              <Text size="sm" color="gray">
-                Editor
-              </Text>
+          <Column span={direction === 'column' ? 12 : 6}>
+            <Box paddingX={2}>
+              <Box paddingY={2}>
+                <Text size="sm" color="gray">
+                  Editor
+                </Text>
+              </Box>
+              <LiveEditor />
             </Box>
-            <LiveEditor />
-          </Box>
-        </Column>
-      </Box>
+          </Column>
+        </Box>
 
-      <Box padding={2}>
-        <Text color="watermelon" leading="tall">
-          <LiveError />
-        </Text>
-      </Box>
-    </LiveProvider>
-  </Card>
-);
+        <Box padding={2}>
+          <Text color="watermelon" leading="tall">
+            <LiveError />
+          </Text>
+        </Box>
+      </LiveProvider>
+    </Card>
+  );
+}
+
+export default Example;


### PR DESCRIPTION
We already list [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) as a dependency for our package and subscribe to most of the rules. This change turns on the recommended config from that plugin and fixes the one error that arises from doing so. Our settings already turn off the 3 rules we do not follow so this change causes no other errors.