### PR TITLE
Fix background color for fullscreen video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
   </summary>
 
 ### Minor
-
 * Drop support for React 15 and bump React 16 version (#168)
+* Video: Fix background color for fullscreen video playback (#198)
 
 ### Patch
 * Internal: Add code coverage to PRs (#185)

--- a/packages/gestalt/src/Video/Video.css
+++ b/packages/gestalt/src/Video/Video.css
@@ -8,6 +8,7 @@
 .player {
   composes: relative from "../Layout.css";
   composes: xsCol12 from "../Column.css";
+  background-color: #000;
 }
 
 .playhead {


### PR DESCRIPTION
Previously in fullscreen, the `Video` background would look like this:
![screen shot 2018-05-18 at 1 28 21 pm](https://user-images.githubusercontent.com/7877010/40257276-7722a8cc-5aa2-11e8-92b2-d002168d2b5e.png)
With this change, the background is black so that the controls show:
<img width="1720" alt="screen shot 2018-05-18 at 1 28 35 pm" src="https://user-images.githubusercontent.com/7877010/40257288-8275f634-5aa2-11e8-83d4-71cf0ea5578d.png">
