### PR TITLE
Add eslint-plugin-eslint-comments with recommended settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,10 @@
 {
   "extends": [
     "airbnb",
+    "plugin:eslint-comments/recommended",
+    "plugin:flowtype/recommended",
     "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
-    "plugin:flowtype/recommended",
     "plugin:react/recommended",
     "prettier",
     "prettier/flowtype",
@@ -14,7 +15,14 @@
     "es6": true
   },
   "parser": "babel-eslint",
-  "plugins": ["flowtype", "jest", "jsx-a11y", "prettier", "react"],
+  "plugins": [
+    "eslint-comments",
+    "flowtype",
+    "jest",
+    "jsx-a11y",
+    "prettier",
+    "react"
+  ],
   "rules": {
     "jsx-a11y/label-has-for": [
       "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 * Drop support for React 15 and bump React 16 version (#168)
 * Video: Fix background color for fullscreen video playback (#198)
+* Internal: Add eslint-plugin-eslint-comments with recommended settings (#200)
 
 ### Patch
 * Internal: Add code coverage to PRs (#185)

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable no-console */
 import { danger, markdown, warn } from 'danger';
 import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
@@ -77,6 +76,7 @@ ${rows.join('\n')}
   `);
 };
 
+/* eslint-disable no-console */
 const baseCommit = danger.github.pr.base.sha;
 // const currentCommit = danger.github.pr.head.sha;
 // Yen - fetching via API because i didn't see a way to get the build number for a commit via buildkite-agent
@@ -133,3 +133,4 @@ getBuildNumber(baseCommit)
   .catch(e => {
     console.error(`Error performing bundle size comparison: ${e.toString()}`);
   });
+/* eslint-enable no-console */

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-postcss": "^2.0.2",
     "eslint-config-prettier": "^2.1.1",
+    "eslint-plugin-eslint-comments": "^2.0.2",
     "eslint-plugin-flowtype": "^2.34.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jest": "^21.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3172,6 +3172,13 @@ eslint-module-utils@^2.1.1, eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-eslint-comments@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-2.0.2.tgz#006e1c834beffe6ff3014e84a3ae69acfa539a28"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^3.3.7"
+
 eslint-plugin-flowtype@2.39.1:
   version "2.39.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.39.1.tgz#b5624622a0388bcd969f4351131232dcb9649cd5"
@@ -4590,6 +4597,10 @@ ignore-walk@^3.0.1:
 ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
+ignore@^3.3.7:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
 import-lazy@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Adds the [eslint-comments](https://github.com/mysticatea/eslint-plugin-eslint-comments) linter as a new plugin for gestalt. This only raised one error in our repo which was fixed by adding an `enable` comment in the file.