### PR TITLE
Fix Video sizing with required aspectRatio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Video: Fix background color for fullscreen video playback (#198)
 * Internal: Refactor Modal docs to kill StateRecorder (#199)
 * Internal: Add eslint-plugin-eslint-comments with recommended settings (#200)
+* Video: Makes `aspectRatio` a required prop for `Video` (#201)
 
 ### Patch
 * Internal: Add code coverage to PRs (#185)

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -178,6 +178,7 @@ card(
   `}
     defaultCode={`
 <Video
+  aspectRatio={853 / 480}
   captions=""
   poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
   src="http://media.w3.org/2010/05/bunny/movie.mp4"
@@ -195,6 +196,7 @@ card(
   `}
     defaultCode={`
 <Video
+  aspectRatio={426 / 240}
   captions=""
   playing
   volume={0}
@@ -222,6 +224,7 @@ card(
   `}
     defaultCode={`
 <Video
+  aspectRatio={1920 / 1080}
   captions=""
   loop
   playing
@@ -247,6 +250,7 @@ card(
   accessibilityPauseLabel="Pause"
   accessibilityPlayLabel="Play"
   accessibilityUnmuteLabel="Unmute"
+  aspectRatio={853 / 480}
   captions=""
   controls
   src="http://media.w3.org/2010/05/bunny/movie.mp4"
@@ -367,6 +371,7 @@ class Example extends React.Component {
           accessibilityPauseLabel="Pause"
           accessibilityPlayLabel="Play"
           accessibilityUnmuteLabel="Unmute"
+          aspectRatio={853 / 480}
           captions=""
           controls
           onPlay={this.handlePlay}

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -59,9 +59,8 @@ card(
       {
         name: 'aspectRatio',
         type: 'number',
-        description: `Proportional relationship between width and height of the video, calculated as width / height.
-           Used to size the placeholder until the video is loaded. Default is equivalent to 16:9`,
-        defaultValue: 16 / 9,
+        description: `Proportional relationship between width and height of the video, calculated as width / height.`,
+        required: true,
       },
       {
         name: 'captions',

--- a/packages/gestalt/src/Video/Video.js
+++ b/packages/gestalt/src/Video/Video.js
@@ -131,7 +131,7 @@ export default class Video extends React.PureComponent<Props, State> {
     accessibilityPauseLabel: PropTypes.string,
     accessibilityPlayLabel: PropTypes.string,
     accessibilityUnmuteLabel: PropTypes.string,
-    aspectRatio: PropTypes.number,
+    aspectRatio: PropTypes.number.isRequired,
     captions: PropTypes.string.isRequired,
     controls: PropTypes.bool,
     loop: PropTypes.bool,
@@ -161,7 +161,6 @@ export default class Video extends React.PureComponent<Props, State> {
   };
 
   static defaultProps = {
-    aspectRatio: 16 / 9,
     playbackRate: 1,
     playing: false,
     preload: 'auto',
@@ -390,14 +389,7 @@ export default class Video extends React.PureComponent<Props, State> {
     } = this.props;
     const { currentTime, duration, fullscreen } = this.state;
 
-    const paddingBottom =
-      // In full screen the padding bottom is 0 to fit the screen
-      (fullscreen && '0') ||
-      // If video data is present, use the correct aspect ratio
-      (this.video &&
-        `${this.video.videoHeight / this.video.videoWidth * 100}%`) ||
-      // If the video metadata is missing, default to the aspect ratio
-      `${1 / aspectRatio * 100}%`;
+    const paddingBottom = (fullscreen && '0') || `${1 / aspectRatio * 100}%`;
 
     return (
       <div

--- a/packages/gestalt/src/Video/__tests__/Video.test.js
+++ b/packages/gestalt/src/Video/__tests__/Video.test.js
@@ -6,6 +6,7 @@ import Video from '../Video';
 test('Video with source', () => {
   const tree = create(
     <Video
+      aspectRatio={1}
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
       src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
     />
@@ -16,6 +17,7 @@ test('Video with source', () => {
 test('Video with multiple sources', () => {
   const tree = create(
     <Video
+      aspectRatio={1}
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
       src={[
         {
@@ -35,6 +37,7 @@ test('Video with multiple sources', () => {
 test('Video with media attributes', () => {
   const tree = create(
     <Video
+      aspectRatio={1}
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
       loop
       volume={0}
@@ -48,6 +51,7 @@ test('Video with media attributes', () => {
 test('Video with callbacks', () => {
   const tree = create(
     <Video
+      aspectRatio={1}
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
       onDurationChange={() => {}}
       onFullscreenChange={() => {}}

--- a/packages/gestalt/src/Video/__tests__/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/Video/__tests__/__snapshots__/Video.test.js.snap
@@ -6,7 +6,7 @@ exports[`Video with callbacks 1`] = `
   style={
     Object {
       "height": 0,
-      "paddingBottom": "56.25%",
+      "paddingBottom": "100%",
     }
   }
 >
@@ -37,7 +37,7 @@ exports[`Video with media attributes 1`] = `
   style={
     Object {
       "height": 0,
-      "paddingBottom": "56.25%",
+      "paddingBottom": "100%",
     }
   }
 >
@@ -68,7 +68,7 @@ exports[`Video with multiple sources 1`] = `
   style={
     Object {
       "height": 0,
-      "paddingBottom": "56.25%",
+      "paddingBottom": "100%",
     }
   }
 >
@@ -107,7 +107,7 @@ exports[`Video with source 1`] = `
   style={
     Object {
       "height": 0,
-      "paddingBottom": "56.25%",
+      "paddingBottom": "100%",
     }
   }
 >


### PR DESCRIPTION
Setting `paddingBottom` using the DOM element was causing weird glitches with math operations that set the value to `NaN%`. This change makes the `aspectRatio` required and not defaulted.

@chrislloyd I'm only introducing the required `aspectRatio` here instead of `aspectRatio`, `width`, and `height` so we can keep the resizing fluid for now.