### PR TITLE
Fix src check on Video to work for arrays and strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Internal: Turn on all react recommended linters (#192)
 * Internal: Merge jest-pupeteer eslint file into main one (#193)
 * Docs: Rewrite Column doc to remove scope prop from Example (#196)
+* Video: Fix broken equality check for Video `src` prop (#202)
 
 </details>
 

--- a/packages/gestalt/src/Video/__tests__/Video.test.js
+++ b/packages/gestalt/src/Video/__tests__/Video.test.js
@@ -68,19 +68,6 @@ test('Video with callbacks', () => {
 });
 
 describe('Video loading', () => {
-  it('Loads when string src changes to new string src', () => {
-    const wrapper = shallow(
-      <Video
-        aspectRatio={1}
-        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
-        src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
-      />
-    );
-    const spy = jest.spyOn(wrapper.instance(), 'load');
-    wrapper.setProps({ src: 'http://media.w3.org/2010/05/bunny/movie.mp4' });
-    expect(spy).toHaveBeenCalled();
-  });
-
   it('Does not load when string src does not change', () => {
     const wrapper = shallow(
       <Video
@@ -92,6 +79,37 @@ describe('Video loading', () => {
     const spy = jest.spyOn(wrapper.instance(), 'load');
     wrapper.setProps({ volume: 0 });
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('Does not load when array src does not change', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src={[
+          {
+            type: 'video/mp4',
+            src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+          },
+        ]}
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({ volume: 0 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('Loads when string src changes to new string src', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({ src: 'http://media.w3.org/2010/05/bunny/movie.mp4' });
+    expect(spy).toHaveBeenCalled();
   });
 
   it('Loads when string src changes to new array src', () => {
@@ -134,24 +152,6 @@ describe('Video loading', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('Does not load when array src does not change', () => {
-    const wrapper = shallow(
-      <Video
-        aspectRatio={1}
-        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
-        src={[
-          {
-            type: 'video/mp4',
-            src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
-          },
-        ]}
-      />
-    );
-    const spy = jest.spyOn(wrapper.instance(), 'load');
-    wrapper.setProps({ volume: 0 });
-    expect(spy).not.toHaveBeenCalled();
-  });
-
   it('Loads when array src changes to new array src', () => {
     const wrapper = shallow(
       <Video
@@ -171,6 +171,35 @@ describe('Video loading', () => {
         {
           type: 'video/mp4',
           src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+        },
+      ],
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Loads when array src changes to new length array src', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src={[
+          {
+            type: 'video/mp4',
+            src: 'https://media.w3.org/2010/05/sintel/trailer_hd.mp4',
+          },
+        ]}
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({
+      src: [
+        {
+          type: 'video/mp4',
+          src: 'https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4',
+        },
+        {
+          type: 'video/ogg',
+          src: 'https://archive.org/download/ElephantsDream/ed_hd.ogv',
         },
       ],
     });

--- a/packages/gestalt/src/Video/__tests__/Video.test.js
+++ b/packages/gestalt/src/Video/__tests__/Video.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
+import { shallow } from 'enzyme';
 import Video from '../Video';
 
 test('Video with source', () => {
@@ -64,4 +65,115 @@ test('Video with callbacks', () => {
     />
   ).toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+describe('Video loading', () => {
+  it('Loads when string src changes to new string src', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({ src: 'http://media.w3.org/2010/05/bunny/movie.mp4' });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Does not load when string src does not change', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({ volume: 0 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('Loads when string src changes to new array src', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({
+      src: [
+        {
+          type: 'video/mp4',
+          src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+        },
+      ],
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Loads when array src changes to new string src', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src={[
+          {
+            type: 'video/mp4',
+            src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+          },
+        ]}
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({
+      src: 'https://media.w3.org/2010/05/sintel/trailer_hd.mp4',
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Does not load when array src does not change', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src={[
+          {
+            type: 'video/mp4',
+            src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+          },
+        ]}
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({ volume: 0 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('Loads when array src changes to new array src', () => {
+    const wrapper = shallow(
+      <Video
+        aspectRatio={1}
+        captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+        src={[
+          {
+            type: 'video/mp4',
+            src: 'https://media.w3.org/2010/05/sintel/trailer_hd.mp4',
+          },
+        ]}
+      />
+    );
+    const spy = jest.spyOn(wrapper.instance(), 'load');
+    wrapper.setProps({
+      src: [
+        {
+          type: 'video/mp4',
+          src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+        },
+      ],
+    });
+    expect(spy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Since the `src` prop on `Video` can be either an array or a string, the shallow `===` check does not work. We need to do a deep comparison of the array contents to verify if the video should indeed be loaded.

This fixes the issue where the video was replaying from the start on interactions.