### PR TITLE
Add jsdom specific tests for VideoControls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Video: Makes `aspectRatio` a required prop for `Video` (#201)
 * Video: Pass events through to callback functions (#203)
 * Touchable: Add event targets to Flow typing for callbacks (#204)
+* Video: Add jsdom browser specific tests (#205)
 
 ### Patch
 * Internal: Add code coverage to PRs (#185)

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
           "\\.(svg)$": "<rootDir>/scripts/fileMock.js",
           "\\.(css)$": "identity-obj-proxy"
         },
+        "testPathIgnorePatterns": ["jsdom.test.js"],
         "setupTestFrameworkScriptFile": "<rootDir>scripts/setupJest.js"
       },
       {

--- a/packages/gestalt/src/Video/__tests__/VideoControls.jsdom.test.js
+++ b/packages/gestalt/src/Video/__tests__/VideoControls.jsdom.test.js
@@ -1,0 +1,82 @@
+// @flow
+import React from 'react';
+import { mount } from 'enzyme';
+import VideoControls from '../VideoControls';
+
+test('VideoControls handles play events', () => {
+  const mockOnPlay = jest.fn();
+  const wrapper = mount(
+    <VideoControls
+      accessibilityMaximizeLabel="Maximize"
+      accessibilityMinimizeLabel="Minimize"
+      accessibilityMuteLabel="Mute"
+      accessibilityPauseLabel="Pause"
+      accessibilityPlayLabel="Play"
+      accessibilityUnmuteLabel="Unmute"
+      currentTime={67.3}
+      duration={67.3}
+      fullscreen={false}
+      onFullscreenChange={() => {}}
+      onPause={() => {}}
+      onPlay={mockOnPlay}
+      onVolumeChange={() => {}}
+      playing={false}
+      seek={() => {}}
+      volume={0}
+    />
+  );
+  wrapper.find('Icon[icon="play"]').simulate('click');
+  expect(mockOnPlay).toBeCalled();
+});
+
+test('VideoControls handles pause events', () => {
+  const mockOnPause = jest.fn();
+  const wrapper = mount(
+    <VideoControls
+      accessibilityMaximizeLabel="Maximize"
+      accessibilityMinimizeLabel="Minimize"
+      accessibilityMuteLabel="Mute"
+      accessibilityPauseLabel="Pause"
+      accessibilityPlayLabel="Play"
+      accessibilityUnmuteLabel="Unmute"
+      currentTime={67.3}
+      duration={67.3}
+      fullscreen={false}
+      onFullscreenChange={() => {}}
+      onPause={mockOnPause}
+      onPlay={() => {}}
+      onVolumeChange={() => {}}
+      playing
+      seek={() => {}}
+      volume={0}
+    />
+  );
+  wrapper.find('Icon[icon="pause"]').simulate('click');
+  expect(mockOnPause).toBeCalled();
+});
+
+test('VideoControls handles volume events', () => {
+  const mockOnVolumeChange = jest.fn();
+  const wrapper = mount(
+    <VideoControls
+      accessibilityMaximizeLabel="Maximize"
+      accessibilityMinimizeLabel="Minimize"
+      accessibilityMuteLabel="Mute"
+      accessibilityPauseLabel="Pause"
+      accessibilityPlayLabel="Play"
+      accessibilityUnmuteLabel="Unmute"
+      currentTime={67.3}
+      duration={67.3}
+      fullscreen={false}
+      onFullscreenChange={() => {}}
+      onPause={() => {}}
+      onPlay={() => {}}
+      onVolumeChange={mockOnVolumeChange}
+      playing={false}
+      seek={() => {}}
+      volume={0}
+    />
+  );
+  wrapper.find('Icon[icon="mute"]').simulate('click');
+  expect(mockOnVolumeChange).toBeCalled();
+});


### PR DESCRIPTION
Sets up test files named `*.jsdom.test.js` to only be run in the jsdom environment. Regular `.test.js` files will still be run in both jsdom and node environments.