### PR TITLE
Remove dead example code from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+* Internal: Remove dead example code from docs (#211)
 
 ### Patch
 

--- a/docs/src/Avatar.doc.js
+++ b/docs/src/Avatar.doc.js
@@ -1,7 +1,5 @@
 // @flow
 import * as React from 'react';
-import PropTypes from 'prop-types';
-import { Avatar, Box, Text } from 'gestalt';
 import keerthi from './avatars/keerthi.jpg';
 import shanice from './avatars/shanice.jpg';
 import PropTable from './components/PropTable';
@@ -51,33 +49,6 @@ card(
     heading={false}
   />
 );
-
-const sizes = ['sm', 'md', 'lg'];
-
-type AvatarExProps = {
-  size: 'sm' | 'md' | 'lg',
-  src: string,
-};
-
-function AvatarEx(props: AvatarExProps) {
-  const name = 'Keerthi';
-  const { size, src } = props;
-  return (
-    <Box padding={1}>
-      <Box marginBottom={1}>
-        <Text bold align="center">
-          {size}
-        </Text>
-      </Box>
-      <Avatar name={name} size={size} src={src} />
-    </Box>
-  );
-}
-
-AvatarEx.propTypes = {
-  size: PropTypes.oneOf(sizes),
-  src: PropTypes.string,
-};
 
 card(
   <Example

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -1,7 +1,5 @@
 // @flow
 import * as React from 'react';
-import PropTypes from 'prop-types';
-import { Box, Label, TextField } from 'gestalt';
 import Example from './components/Example';
 import PropTable from './components/PropTable';
 import PageHeader from './components/PageHeader';
@@ -75,40 +73,6 @@ card(
     heading={false}
   />
 );
-
-const TextFieldExample = (props: {
-  disabled?: boolean,
-  id: string,
-  type: *,
-  placeholder?: string,
-  label: string,
-  state?: Object,
-  type?: *,
-  value?: string,
-}) => (
-  <Box paddingY={2}>
-    <Box marginBottom={2}>
-      <Label htmlFor={props.id}>{props.label}</Label>
-    </Box>
-    <TextField
-      disabled={props.disabled}
-      id={props.id}
-      onChange={() => {}}
-      placeholder={props.placeholder || ''}
-      value={props.state ? props.state[props.id] : props.value}
-      type={props.type}
-    />
-  </Box>
-);
-
-TextFieldExample.propTypes = {
-  disabled: PropTypes.bool,
-  id: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  placeholder: PropTypes.string,
-  state: PropTypes.shape({}),
-  type: PropTypes.string,
-};
 
 card(
   <Example


### PR DESCRIPTION
These React example components are not being used in the docs so they can be removed.