### PR TITLE
Fix react router dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+* Internal: Fix react router dependencies (#212)
 
 ### Patch
 

--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -1,16 +1,12 @@
 // @flow
-import type { Node } from 'react';
-import React from 'react';
-import { withRouter } from 'react-router-dom';
+import * as React from 'react';
 import { Box, Column, Divider } from 'gestalt';
 import Header from './Header';
 import Navigation from './Navigation';
 
 type Props = {|
-  children?: Node,
+  children?: React.Node,
 |};
-
-const NavigationWithRouter = withRouter(Navigation);
 
 export default function App(props: Props) {
   const { children } = props;
@@ -20,7 +16,7 @@ export default function App(props: Props) {
 
       <Box mdDisplay="flex" direction="row">
         <Column span={12} mdSpan={2}>
-          <NavigationWithRouter />
+          <Navigation />
         </Column>
         <Divider />
         <Column span={12} mdSpan={8}>

--- a/docs/src/components/Link.js
+++ b/docs/src/components/Link.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { Link as GestaltLink } from 'gestalt';
 import { createLocation } from 'history';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 
 type Props = {|
   history: *,


### PR DESCRIPTION
`App` does not need `withRouter` anymore because `Navigation` does not use it. Likewise, `Link` was the only package using `react-router` instead of `react-router-dom` so we can switch those out since the import is the same.