### PR TITLE
[Flow] Fix Flow errors in docs directory (part 2)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,19 +1,9 @@
 [version]
 0.71.0
 
-[ignore]
-# Tracking https://github.com/facebook/flow/issues/4015
-<PROJECT_ROOT>/docs
-<PROJECT_ROOT>/test
-
-<PROJECT_ROOT>/node_modules/stylelint.*
-<PROJECT_ROOT>/node_modules/eslint-plugin-jsx-a11y/*
-
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment= \\(.\\|\n\\)*\\$FlowIssue
-esproposal.class_instance_fields=enable
-esproposal.class_static_fields=enable
 # necessary for webpack loader syntax.
 module.name_mapper='^.*\.css$' -> '<PROJECT_ROOT>/flow/stubs/CSSModuleStub.js'
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,11 @@
 [version]
 0.71.0
 
+[ignore]
+# Tracking https://github.com/facebook/flow/issues/4015
+<PROJECT_ROOT>/docs
+<PROJECT_ROOT>/test
+
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment= \\(.\\|\n\\)*\\$FlowIssue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Internal: Fix react router dependencies (#212)
 * Internal: Fix package.json dependency locations (#213)
 * Flow: Fix Flow errors in the `docs/` directory (#214)
+* Flow: Fix remaining errors in the `docs/` directory and enable Flow (#215)
 
 ### Patch
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "gestalt": ">0.0.0",
+    "gestalt": "^0.71.0",
     "highlight.js": "^9.12.0",
     "history": "^4.7.2",
     "marked": "^0.3.17",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "gestalt": "^0.71.0",
+    "gestalt": ">0.0.0",
     "highlight.js": "^9.12.0",
     "history": "^4.7.2",
     "marked": "^0.3.17",

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -416,8 +416,10 @@ card(
 );
 
 const toggleRTL = () => {
-  document.documentElement.dir =
-    document.documentElement.dir === 'rtl' ? '' : 'rtl';
+  if (document.documentElement) {
+    const isRTL = document.documentElement.dir === 'rtl';
+    document.documentElement.dir = isRTL ? 'ltr' : 'rtl';
+  }
 };
 
 card(

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -1,6 +1,5 @@
 // @flow
-import type { Node } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { Box, Text, Icon } from 'gestalt';
 
 type Props = {|
@@ -12,10 +11,10 @@ type Props = {|
     responsive?: boolean,
     type: string,
   |}>,
-  Component: { displayName: string, propTypes: any },
+  Component?: React.ComponentType<any>,
 |};
 
-const Th = ({ children }: {| children?: Node |}) => (
+const Th = ({ children }: {| children?: React.Node |}) => (
   <th style={{ borderBottom: '2px solid #EFEFEF' }}>
     <Box padding={2}>
       <Text bold size="sm" color="gray" overflow="normal">
@@ -33,7 +32,7 @@ const Td = ({
   color = 'darkGray',
 }: {
   border?: boolean,
-  children?: Node,
+  children?: React.Node,
   colspan?: number,
   shrink?: boolean,
   color?: 'darkGray' | 'gray',
@@ -61,7 +60,7 @@ const sortBy = (list, fn) => list.sort((a, b) => fn(a).localeCompare(fn(b)));
 export default function PropTable({ props: properties, Component }: Props) {
   const hasRequired = properties.some(prop => prop.required);
 
-  if (process.env.NODE_ENV === 'dev' && Component) {
+  if (process.env.NODE_ENV === 'development' && Component) {
     const { displayName, propTypes } = Component;
     const missingProps = Object.keys(propTypes || {}).reduce((acc, prop) => {
       if (!properties.find(p => p.name === prop)) {
@@ -72,7 +71,7 @@ export default function PropTable({ props: properties, Component }: Props) {
     if (missingProps.length > 0) {
       // eslint-disable-next-line no-console
       console.warn(
-        `${displayName} is missing ${
+        `${displayName || ''} is missing ${
           missingProps.length
         } PropTable definitions ${missingProps.join(', ')}`
       );


### PR DESCRIPTION
This change fixes all the remaining Flow relate errors with gestalt:

1. Finishes cleaning up the `docs` Flow errors
2. Removes all the Flow ignore folders as they are good to go now
3. Removes `esproposal.class_instance_fields=enable` and `esproposal.class_static_fields=enable` from the config as Flow already defaults to these [values](https://flow.org/en/docs/config/options/#toc-esproposal-class-instance-fields-enable-ignore-warn)
4. Fixes our `NODE_ENV` check in `PropTable` to the correct string