### PR TITLE
Fix indentation on gestalt doc example code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Internal: Fix package.json dependency locations (#213)
 * Flow: Fix Flow errors in the `docs/` directory (#214)
 * Flow: Fix remaining errors in the `docs/` directory and enable Flow (#215)
+* Docs: Fix indentation on gestalt docs code examples (#219)
 
 ### Patch
 

--- a/docs/src/Avatar.doc.js
+++ b/docs/src/Avatar.doc.js
@@ -57,9 +57,9 @@ card(
     name="Fixed Sizes"
     defaultCode={`
 <Avatar
-size="md"
-src="${keerthi}"
-name="Keerthi"
+  size="md"
+  src="${keerthi}"
+  name="Keerthi"
 />
 `}
   />
@@ -77,15 +77,15 @@ card(
     name="Container Based Sizes"
     defaultCode={`
 <Box display="flex" direction="row">
-<Box width={40}>
-  <Avatar name="Julia" />
-</Box>
-<Box column={2}>
-  <Avatar name="Julia" />
-</Box>
-<Box column={4}>
-  <Avatar name="Keerthi" src="${keerthi}" />
-</Box>
+  <Box width={40}>
+    <Avatar name="Julia" />
+  </Box>
+  <Box column={2}>
+    <Avatar name="Julia" />
+  </Box>
+  <Box column={4}>
+    <Avatar name="Keerthi" src="${keerthi}" />
+  </Box>
 </Box>
   `}
   />
@@ -100,8 +100,8 @@ card(
     name="Without an image"
     defaultCode={`
 <Avatar
-name="Keerthi"
-size="lg"
+  name="Keerthi"
+  size="lg"
 />
   `}
   />
@@ -115,10 +115,10 @@ card(
     name="Verified"
     defaultCode={`
 <Avatar
-name="Shanice"
-size="lg"
-src="${shanice}"
-verified
+  name="Shanice"
+  size="lg"
+  src="${shanice}"
+  verified
 />
   `}
   />

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -230,18 +230,19 @@ card(
     name="Example: Media object"
     defaultCode={`
 <Box
-alignItems="center"
-direction="row"
-display="flex"
-marginStart={-1}
-marginEnd={-1}>
-<Box paddingX={1}>
-  <Avatar name="chrislloyd" size="md" />
-</Box>
-<Box paddingX={1}>
-  <Text bold>Chris Lloyd</Text>
-  <Text>joined 2 years ago</Text>
-</Box>
+  alignItems="center"
+  direction="row"
+  display="flex"
+  marginStart={-1}
+  marginEnd={-1}
+>
+  <Box paddingX={1}>
+    <Avatar name="chrislloyd" size="md" />
+  </Box>
+  <Box paddingX={1}>
+    <Text bold>Chris Lloyd</Text>
+    <Text>joined 2 years ago</Text>
+  </Box>
 </Box>
 `}
   />
@@ -255,21 +256,22 @@ card(
     name="Example: Double-sided media object"
     defaultCode={`
 <Box
-alignItems="center"
-direction="row"
-display="flex"
-marginStart={-1}
-marginEnd={-1}>
-<Box paddingX={1}>
-  <Avatar name="chrislloyd" size="md" />
-</Box>
-<Box paddingX={1}  flex="grow">
-  <Text bold>Chris Lloyd</Text>
-  <Text>joined 2 years ago</Text>
-</Box>
-<Box paddingX={1}>
-  <Button text="Follow" size="sm" color="red" />
-</Box>
+  alignItems="center"
+  direction="row"
+  display="flex"
+  marginStart={-1}
+  marginEnd={-1}
+>
+  <Box paddingX={1}>
+    <Avatar name="chrislloyd" size="md" />
+  </Box>
+  <Box paddingX={1}  flex="grow">
+    <Text bold>Chris Lloyd</Text>
+    <Text>joined 2 years ago</Text>
+  </Box>
+  <Box paddingX={1}>
+    <Button text="Follow" size="sm" color="red" />
+  </Box>
 </Box>
 `}
   />
@@ -453,18 +455,18 @@ card(
     name="Example: Absolute positioning"
     defaultCode={`
 <Box position="relative" color="white" height={200}>
-<Box position="absolute" top left padding={1}>
-  Top, left
-</Box>
-<Box position="absolute" top right padding={1}>
-  Top, right
-</Box>
-<Box position="absolute" bottom left padding={1}>
-  Bottom, left
-</Box>
-<Box position="absolute" bottom right padding={1}>
-  Bottom, right
-</Box>
+  <Box position="absolute" top left padding={1}>
+    Top, left
+  </Box>
+  <Box position="absolute" top right padding={1}>
+    Top, right
+  </Box>
+  <Box position="absolute" bottom left padding={1}>
+    Bottom, left
+  </Box>
+  <Box position="absolute" bottom right padding={1}>
+    Bottom, right
+  </Box>
 </Box>
 `}
   />

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -101,12 +101,12 @@ card(
     name="Widths"
     defaultCode={`
 <Box margin={-2}>
-<Box padding={2}>
-  <Button text="inline button" inline />
-</Box>
-<Box padding={2}>
-  <Button text="default full width button" />
-</Box>
+  <Box padding={2}>
+    <Button text="inline button" inline />
+  </Box>
+  <Box padding={2}>
+    <Button text="default full width button" />
+  </Box>
 </Box>
 `}
   />
@@ -120,25 +120,20 @@ card(
     name="Colors: Dark Backgrounds"
     defaultCode={`
 <Box color="darkGray" maxWidth={320} shape="rounded" padding={4}>
-<Box marginBottom={4}>
-  <Text color="white">
-    Explore today’s trending ideas, curated finds, and personalized
-    picks.
-  </Text>
-</Box>
-<Box
-  display="flex"
-  direction="row"
-  marginLeft={-2}
-  marginRight={-2}
->
-  <Box display="flex" direction="row" column={6} paddingX={2}>
-    <Button color="transparent" text="Later" />
+  <Box marginBottom={4}>
+    <Text color="white">
+      Explore today’s trending ideas, curated finds, and personalized
+      picks.
+    </Text>
   </Box>
-  <Box column={6} paddingX={2}>
-    <Button color="white" text="Learn more" />
+  <Box display="flex" direction="row" marginLeft={-2} marginRight={-2}>
+    <Box display="flex" direction="row" column={6} paddingX={2}>
+      <Button color="transparent" text="Later" />
+    </Box>
+    <Box column={6} paddingX={2}>
+      <Button color="white" text="Learn more" />
+    </Box>
   </Box>
-</Box>
 </Box>
 `}
   />
@@ -153,12 +148,12 @@ card(
     name="Types"
     defaultCode={`
 <Box margin={-2}>
-<Box padding={2}>
-  <Button onClick={() => {}} text="Clear" type="button" />
-</Box>
-<Box padding={2}>
-  <Button color="red" text="Submit" type="submit" />
-</Box>
+  <Box padding={2}>
+    <Button onClick={() => {}} text="Clear" type="button" />
+  </Box>
+  <Box padding={2}>
+    <Button color="red" text="Submit" type="submit" />
+  </Box>
 </Box>
 `}
   />
@@ -175,12 +170,12 @@ card(
     name="Accessibility Label"
     defaultCode={`
 <Box margin={-2}>
-<Box padding={2}>
-  <Button accessibilityLabel="Add James" text="Add" />
-</Box>
-<Box padding={2}>
-  <Button accessibilityLabel="Add Irene" text="Add" />
-</Box>
+  <Box padding={2}>
+    <Button accessibilityLabel="Add James" text="Add" />
+  </Box>
+  <Box padding={2}>
+    <Button accessibilityLabel="Add Irene" text="Add" />
+  </Box>
 </Box>
 `}
   />

--- a/docs/src/Card.doc.js
+++ b/docs/src/Card.doc.js
@@ -53,46 +53,46 @@ card(
     name="Example"
     defaultCode={`
 class CardExample extends React.Component {
-constructor(props) {
-  super(props);
-  this.state = { hovered: false };
-  this.handleMouseEnter = this._handleMouseEnter.bind(this);
-  this.handleMouseLeave = this._handleMouseLeave.bind(this);
-}
-_handleMouseEnter() {
-  this.setState(() => ({ hovered: true }));
-}
-_handleMouseLeave() {
-  this.setState(() => ({ hovered: false }));
-}
-render() {
-  return (
-    <Box maxWidth={236} padding={2} column={12}>
-      <Card
-        image={
-          <Avatar
-            name="James Jones"
-            src="${james}"
+  constructor(props) {
+    super(props);
+    this.state = { hovered: false };
+    this.handleMouseEnter = this._handleMouseEnter.bind(this);
+    this.handleMouseLeave = this._handleMouseLeave.bind(this);
+  }
+  _handleMouseEnter() {
+    this.setState(() => ({ hovered: true }));
+  }
+  _handleMouseLeave() {
+    this.setState(() => ({ hovered: false }));
+  }
+  render() {
+    return (
+      <Box maxWidth={236} padding={2} column={12}>
+        <Card
+          image={
+            <Avatar
+              name="James Jones"
+              src="${james}"
+            />
+          }
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}>
+          <Text align="center" bold size="xl">
+            <Link href="https://pinterest.com">
+              <Box paddingX={3} paddingY={2}>
+                James Jones
+              </Box>
+            </Link>
+          </Text>
+          <Button
+            accessibilityLabel="Follow James Jones"
+            color="red"
+            text="Follow"
           />
-        }
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}>
-        <Text align="center" bold size="xl">
-          <Link href="https://pinterest.com">
-            <Box paddingX={3} paddingY={2}>
-              James Jones
-            </Box>
-          </Link>
-        </Text>
-        <Button
-          accessibilityLabel="Follow James Jones"
-          color="red"
-          text="Follow"
-        />
-      </Card>
-    </Box>
-  );
-}
+        </Card>
+      </Box>
+    );
+  }
 }
 `}
   />

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -71,35 +71,31 @@ card(
     name="Example: Accessibility"
     defaultCode={`
 class CheckboxExample extends React.Component {
-constructor(props) {
-  super(props);
-  this.state = { checked: true };
-  this.handleChecked = this._handleChecked.bind(this);
-}
-_handleChecked({ checked }) {
-  this.setState({ checked });
-}
-render() {
-  return (
-    <Box
-      alignItems="center"
-      direction="row"
-      display="flex"
-    >
-      <Checkbox
-        checked={this.state.checked}
-        id="usa"
-        name="usa"
-        onChange={this.handleChecked}
-      />
-      <Label htmlFor="usa">
-        <Box paddingX={2}>
-          <Text>United States of America</Text>
-        </Box>
-      </Label>
-    </Box>
-  );
-}
+  constructor(props) {
+    super(props);
+    this.state = { checked: true };
+    this.handleChecked = this._handleChecked.bind(this);
+  }
+  _handleChecked({ checked }) {
+    this.setState({ checked });
+  }
+  render() {
+    return (
+      <Box alignItems="center" direction="row" display="flex">
+        <Checkbox
+          checked={this.state.checked}
+          id="usa"
+          name="usa"
+          onChange={this.handleChecked}
+        />
+        <Label htmlFor="usa">
+          <Box paddingX={2}>
+            <Text>United States of America</Text>
+          </Box>
+        </Label>
+      </Box>
+    );
+  }
 }
 `}
   />
@@ -113,40 +109,36 @@ card(
     name="Example: Labeled stack"
     defaultCode={`
 class CheckboxExample extends React.Component {
-render() {
-  const CheckboxWithLabel = ({ id, label }) => (
-    <Box
-      alignItems="center"
-      direction="row"
-      display="flex"
-    >
-      <Checkbox
-        checked
-        id={id}
-        onChange={() => {}}
-      />
-      <Label htmlFor={id}>
-        <Box paddingX={2}>
-          <Text>{label}</Text>
-        </Box>
-      </Label>
-    </Box>
-  );
+  render() {
+    const CheckboxWithLabel = ({ id, label }) => (
+      <Box alignItems="center" direction="row" display="flex">
+        <Checkbox
+          checked
+          id={id}
+          onChange={() => {}}
+        />
+        <Label htmlFor={id}>
+          <Box paddingX={2}>
+            <Text>{label}</Text>
+          </Box>
+        </Label>
+      </Box>
+    );
 
-  return (
+    return (
       <Box display="flex" direction="column" justifyContent="around" marginTop={-1} marginBottom={-1}>
-          <Box paddingY={1}>
-        <CheckboxWithLabel label="Email" id="email" />
-          </Box>
-          <Box paddingY={1}>
-              <CheckboxWithLabel label="Mobile push" id="push" />
-          </Box>
-          <Box paddingY={1}>
-        <CheckboxWithLabel label="Carrier pidgeon" id="pidgeon" />
+        <Box paddingY={1}>
+          <CheckboxWithLabel label="Email" id="email" />
+        </Box>
+        <Box paddingY={1}>
+          <CheckboxWithLabel label="Mobile push" id="push" />
+        </Box>
+        <Box paddingY={1}>
+          <CheckboxWithLabel label="Carrier pidgeon" id="pidgeon" />
+        </Box>
       </Box>
-      </Box>
-  );
-}
+    );
+  }
 }
 `}
   />

--- a/docs/src/Container.doc.js
+++ b/docs/src/Container.doc.js
@@ -33,11 +33,11 @@ card(
     name="Responsive content"
     defaultCode={`
 <Box color="gray" padding={3}>
-<Container>
-  <Box color="white" padding={3}>
-    <Text>Centered content</Text>
-  </Box>
-</Container>
+  <Container>
+    <Box color="white" padding={3}>
+      <Text>Centered content</Text>
+    </Box>
+  </Container>
 </Box>
 `}
   />

--- a/docs/src/Divider.doc.js
+++ b/docs/src/Divider.doc.js
@@ -24,13 +24,13 @@ card(
     name="Example"
     defaultCode={`
 <Box color="white">
-<Box padding={2}>
-  <Text>Some content</Text>
-</Box>
-<Divider />
-<Box padding={2}>
-  <Text>Other content</Text>
-</Box>
+  <Box padding={2}>
+    <Text>Some content</Text>
+  </Box>
+  <Divider />
+  <Box padding={2}>
+    <Text>Other content</Text>
+  </Box>
 </Box>
 `}
   />

--- a/docs/src/ErrorFlyout.doc.js
+++ b/docs/src/ErrorFlyout.doc.js
@@ -70,43 +70,41 @@ card(
     name="Example"
     defaultCode={`
 class ErrorFlyoutExample extends React.Component {
-constructor(props) {
-  super(props);
-  this.state = { open: false };
-  this.handleClick = this._handleClick.bind(this);
-  this.handleDismiss = this._handleDismiss.bind(this);
-}
-
-_handleClick() {
-  this.setState(() => ({ open: !this.state.open }));
-}
-_handleDismiss() {
-  this.setState(() => ({ open: false }));
-}
-
-render() {
-  return (
-    <Box>
-      <div
-        style={{ display: "inline-block" }}
-        ref={c => {
-          this.anchor = c;
-        }}
-      >
-        <Button onClick={this.handleClick} text="Remove" />
-      </div>
-      {this.state.open && (
-        <ErrorFlyout
-          anchor={this.anchor}
-          idealDirection="down"
-          message="Oops! This item is out of stock."
-          onDismiss={this.handleDismiss}
-          size="sm"
-        />
-      )}
-    </Box>
-  );
-}
+  constructor(props) {
+    super(props);
+    this.state = { open: false };
+    this.handleClick = this._handleClick.bind(this);
+    this.handleDismiss = this._handleDismiss.bind(this);
+  }
+  _handleClick() {
+    this.setState(() => ({ open: !this.state.open }));
+  }
+  _handleDismiss() {
+    this.setState(() => ({ open: false }));
+  }
+  render() {
+    return (
+      <Box>
+        <div
+          style={{ display: "inline-block" }}
+          ref={c => {
+            this.anchor = c;
+          }}
+        >
+          <Button onClick={this.handleClick} text="Remove" />
+        </div>
+        {this.state.open && (
+          <ErrorFlyout
+            anchor={this.anchor}
+            idealDirection="down"
+            message="Oops! This item is out of stock."
+            onDismiss={this.handleDismiss}
+            size="sm"
+          />
+        )}
+      </Box>
+    );
+  }
 }
 `}
   />

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -58,9 +58,6 @@ card(
 
 card(
   <Example
-    description="
-
-  "
     name="Example"
     defaultCode={`
 class FlyoutExample extends React.Component {
@@ -70,14 +67,12 @@ class FlyoutExample extends React.Component {
     this.handleClick = this._handleClick.bind(this);
     this.handleDismiss = this._handleDismiss.bind(this);
   }
-
   _handleClick() {
     this.setState(() => ({ open: !this.state.open }));
   }
   _handleDismiss() {
     this.setState(() => ({ open: false }));
   }
-
   render() {
     return (
       <Box>

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -62,19 +62,19 @@ card(
     name="Example"
     defaultCode={`
 <Box width={108}>
-<GroupAvatar
-  collaborators={[
-    {
-      name: 'Keerthi',
-      src: '${keerthi}',
-    },
-    {
-      name: 'Shanice',
-      src: '${shanice}',
-    },
-  ]}
-  size="lg"
-/>
+  <GroupAvatar
+    collaborators={[
+      {
+        name: 'Keerthi',
+        src: '${keerthi}',
+      },
+      {
+        name: 'Shanice',
+        src: '${shanice}',
+      },
+    ]}
+    size="lg"
+  />
 </Box>
 `}
   />

--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -63,28 +63,28 @@ card(
     name="Example: Sizes"
     defaultCode={`
 <Box>
-<Heading size="xs">Heading extra small</Heading>
-<span lang="ja">
-  <Heading size="xs">こんにちは</Heading>
-</span>
-<Heading size="sm">Heading small</Heading>
-<span lang="ja">
-  <Heading size="sm">こんにちは</Heading>
-</span>
-<span>
-  <Heading size="md">Heading medium</Heading>
-</span>{' '}
-<span lang="ja">
-  <Heading size="md">こんにちは</Heading>
-</span>
-<Heading size="lg">Heading large</Heading>
-<span lang="ja">
-  <Heading size="lg">こんにちは</Heading>
-</span>
-<Heading size="xl">Heading extra large</Heading>
-<span lang="ja">
-  <Heading size="xl">こんにちは</Heading>
-</span>
+  <Heading size="xs">Heading extra small</Heading>
+  <span lang="ja">
+    <Heading size="xs">こんにちは</Heading>
+  </span>
+  <Heading size="sm">Heading small</Heading>
+  <span lang="ja">
+    <Heading size="sm">こんにちは</Heading>
+  </span>
+  <span>
+    <Heading size="md">Heading medium</Heading>
+  </span>{' '}
+  <span lang="ja">
+    <Heading size="md">こんにちは</Heading>
+  </span>
+  <Heading size="lg">Heading large</Heading>
+  <span lang="ja">
+    <Heading size="lg">こんにちは</Heading>
+  </span>
+  <Heading size="xl">Heading extra large</Heading>
+  <span lang="ja">
+    <Heading size="xl">こんにちは</Heading>
+  </span>
 </Box>
 `}
   />
@@ -95,24 +95,25 @@ card(
     name="Example: Colors"
     defaultCode={`
 <Box>
-<Box margin={-1}>
-  <Box color="gray" padding={1}>
-    <Heading color="white" size="md">
-      White
-    </Heading>
+  <Box margin={-1}>
+    <Box color="gray" padding={1}>
+      <Heading color="white" size="md">
+        White
+      </Heading>
+    </Box>
   </Box>
-</Box>
-
-<Heading size="md">Dark gray (default)</Heading>
-<Heading color="gray" size="md">
-  Gray
-</Heading>
-<Heading color="blue" size="md">
-  Blue
-</Heading>
-<Heading color="red" size="md">
-  Red
-</Heading>
+  <Heading size="md">
+    Dark gray (default)
+  </Heading>
+  <Heading color="gray" size="md">
+    Gray
+  </Heading>
+  <Heading color="blue" size="md">
+    Blue
+  </Heading>
+  <Heading color="red" size="md">
+    Red
+  </Heading>
 </Box>
 `}
   />
@@ -123,26 +124,26 @@ card(
     name="Example: Overflow & truncation"
     defaultCode={`
 <Box maxWidth={240} marginTop={-2} marginBottom={-2}>
-<Box paddingY={2}>
-  <Heading size="xs">
-    This is a long and Supercalifragilisticexpialidocious sentence.
-    次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
-  </Heading>
-</Box>
+  <Box paddingY={2}>
+    <Heading size="xs">
+      This is a long and Supercalifragilisticexpialidocious sentence.
+      次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
+    </Heading>
+  </Box>
 
-<Box paddingY={2}>
-  <Heading size="xs" truncate>
-    This is a long and Supercalifragilisticexpialidocious sentence.
-    次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
-  </Heading>
-</Box>
+  <Box paddingY={2}>
+    <Heading size="xs" truncate>
+      This is a long and Supercalifragilisticexpialidocious sentence.
+      次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
+    </Heading>
+  </Box>
 
-<Box paddingY={2}>
-  <Heading size="xs" overflow="normal">
-    This is a long and Supercalifragilisticexpialidocious sentence.
-    次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
-  </Heading>
-</Box>
+  <Box paddingY={2}>
+    <Heading size="xs" overflow="normal">
+      This is a long and Supercalifragilisticexpialidocious sentence.
+      次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
+    </Heading>
+  </Box>
 </Box>
 `}
   />
@@ -158,12 +159,12 @@ card(
     name="Example: Levels"
     defaultCode={`
 <Box>
-<Heading size="sm" accessibilityLevel={2}>
-  Small heading level 2
-</Heading>
-<Heading size="xs" accessibilityLevel={3}>
-  Extra small heading level 3
-</Heading>
+  <Heading size="sm" accessibilityLevel={2}>
+    Small heading level 2
+  </Heading>
+  <Heading size="xs" accessibilityLevel={3}>
+    Extra small heading level 3
+  </Heading>
 </Box>
 `}
   />

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -61,18 +61,16 @@ card(
 
 card(
   <Example
-    description="
-    Icon with a label.
-  "
+    description="Icon with a label."
     name="Example:"
     defaultCode={`
 <Box alignItems="center" display="flex">
-<Box marginRight={1} padding={1}>
-  <Icon icon="pin" accessibilityLabel="Pin" color="darkGray" />
-</Box>
-<Text align="center" bold color="darkGray">
-  Pinterest
-</Text>
+  <Box marginRight={1} padding={1}>
+    <Icon icon="pin" accessibilityLabel="Pin" color="darkGray" />
+  </Box>
+  <Text align="center" bold color="darkGray">
+    Pinterest
+  </Text>
 </Box>
 `}
   />

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -74,11 +74,11 @@ card(
     name="Example"
     defaultCode={`
 <IconButton
-accessibilityLabel="Love"
-bgColor="white"
-icon="heart"
-iconColor="red"
-onClick={() => { console.log('❤️')}}
+  accessibilityLabel="Love"
+  bgColor="white"
+  icon="heart"
+  iconColor="red"
+  onClick={() => { console.log('❤️')}}
 />
 `}
   />

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -115,13 +115,13 @@ card(
     name="Placeholders"
     defaultCode={`
 <Column span={6}>
-<Image
-  alt="example.com"
-  color="rgb(111, 91, 77)"
-  naturalHeight={564}
-  naturalWidth={564}
-  src="${stock1}"
-/>
+  <Image
+    alt="example.com"
+    color="rgb(111, 91, 77)"
+    naturalHeight={564}
+    naturalWidth={564}
+    src="${stock1}"
+  />
 </Column>
 `}
   />
@@ -135,19 +135,19 @@ card(
     name="Overlay"
     defaultCode={`
 <Box column={6} paddingX={2}>
-<Image
-  alt="Tropic greens: The taste of Petrol and Porcelain | Interior design, Vintage Sets and Unique Pieces agave"
-  color="rgb(231, 186, 176)"
-  naturalHeight={751}
-  naturalWidth={564}
-  src="${stock2}"
->
-  <Box padding={3}>
-    <Text color="white">
-      Tropic greens: The taste of Petrol and Porcelain
-    </Text>
-  </Box>
-</Image>
+  <Image
+    alt="Tropic greens: The taste of Petrol and Porcelain | Interior design, Vintage Sets and Unique Pieces agave"
+    color="rgb(231, 186, 176)"
+    naturalHeight={751}
+    naturalWidth={564}
+    src="${stock2}"
+  >
+    <Box padding={3}>
+      <Text color="white">
+        Tropic greens: The taste of Petrol and Porcelain
+      </Text>
+    </Box>
+  </Image>
 </Box>
 `}
   />
@@ -181,117 +181,117 @@ card(
     name="Fit"
     defaultCode={`
 <Box display="flex" direction="row" wrap>
-<Box>
-  <h3>Tall content: cover vs contain</h3>
-  <Box display="flex" direction="row" justifyContent="around">
-    <Box
-      color="darkGray"
-      height={200}
-      width={200}
-      marginLeft={4}
-      marginRight={4}
-    >
-      <Image
-        alt="tall"
-        color="#000"
-        fit="contain"
-        naturalHeight={1}
-        naturalWidth={1}
-        src="${stock3}"
-      />
-    </Box>
-    <Box
-      color="darkGray"
-      height={200}
-      width={200}
-      marginLeft={4}
-      marginRight={4}
-    >
-      <Image
-        alt="tall"
-        color="#000"
-        fit="cover"
-        naturalHeight={1}
-        naturalWidth={1}
-        src="${stock3}"
-      />
-    </Box>
-  </Box>
-</Box>
-<Box>
-  <h3>Wide content: cover vs contain</h3>
-  <Box display="flex" direction="row" justifyContent="around">
-    <Box
-      color="darkGray"
-      height={200}
-      width={200}
-      marginLeft={4}
-      marginRight={4}
-    >
-      <Image
-        alt="tall"
-        color="#000"
-        fit="contain"
-        naturalHeight={1}
-        naturalWidth={1}
-        src="${stock4}"
-      />
-    </Box>
-    <Box
-      color="darkGray"
-      height={200}
-      width={200}
-      marginLeft={4}
-      marginRight={4}
-    >
-      <Image
-        alt="tall"
-        color="#000"
-        fit="cover"
-        naturalHeight={1}
-        naturalWidth={1}
-        src="${stock4}"
-      />
+  <Box>
+    <h3>Tall content: cover vs contain</h3>
+    <Box display="flex" direction="row" justifyContent="around">
+      <Box
+        color="darkGray"
+        height={200}
+        width={200}
+        marginLeft={4}
+        marginRight={4}
+      >
+        <Image
+          alt="tall"
+          color="#000"
+          fit="contain"
+          naturalHeight={1}
+          naturalWidth={1}
+          src="${stock3}"
+        />
+      </Box>
+      <Box
+        color="darkGray"
+        height={200}
+        width={200}
+        marginLeft={4}
+        marginRight={4}
+      >
+        <Image
+          alt="tall"
+          color="#000"
+          fit="cover"
+          naturalHeight={1}
+          naturalWidth={1}
+          src="${stock3}"
+        />
+      </Box>
     </Box>
   </Box>
-</Box>
-<Box>
-  <h3>Square content: cover vs contain</h3>
-  <Box display="flex" direction="row" justifyContent="around">
-    <Box
-      color="darkGray"
-      height={200}
-      width={200}
-      marginLeft={4}
-      marginRight={4}
-    >
-      <Image
-        alt="tall"
-        color="#000"
-        fit="contain"
-        naturalHeight={1}
-        naturalWidth={1}
-        src="${stock5}"
-      />
-    </Box>
-    <Box
-      color="darkGray"
-      height={200}
-      width={200}
-      marginLeft={4}
-      marginRight={4}
-    >
-      <Image
-        alt="tall"
-        color="#000"
-        fit="cover"
-        naturalHeight={1}
-        naturalWidth={1}
-        src="${stock5}"
-      />
+  <Box>
+    <h3>Wide content: cover vs contain</h3>
+    <Box display="flex" direction="row" justifyContent="around">
+      <Box
+        color="darkGray"
+        height={200}
+        width={200}
+        marginLeft={4}
+        marginRight={4}
+      >
+        <Image
+          alt="tall"
+          color="#000"
+          fit="contain"
+          naturalHeight={1}
+          naturalWidth={1}
+          src="${stock4}"
+        />
+      </Box>
+      <Box
+        color="darkGray"
+        height={200}
+        width={200}
+        marginLeft={4}
+        marginRight={4}
+      >
+        <Image
+          alt="tall"
+          color="#000"
+          fit="cover"
+          naturalHeight={1}
+          naturalWidth={1}
+          src="${stock4}"
+        />
+      </Box>
     </Box>
   </Box>
-</Box>
+  <Box>
+    <h3>Square content: cover vs contain</h3>
+    <Box display="flex" direction="row" justifyContent="around">
+      <Box
+        color="darkGray"
+        height={200}
+        width={200}
+        marginLeft={4}
+        marginRight={4}
+      >
+        <Image
+          alt="tall"
+          color="#000"
+          fit="contain"
+          naturalHeight={1}
+          naturalWidth={1}
+          src="${stock5}"
+        />
+      </Box>
+      <Box
+        color="darkGray"
+        height={200}
+        width={200}
+        marginLeft={4}
+        marginRight={4}
+      >
+        <Image
+          alt="tall"
+          color="#000"
+          fit="cover"
+          naturalHeight={1}
+          naturalWidth={1}
+          src="${stock5}"
+        />
+      </Box>
+    </Box>
+  </Box>
 </Box>
 `}
   />

--- a/docs/src/Label.doc.js
+++ b/docs/src/Label.doc.js
@@ -39,29 +39,28 @@ card(
     name="Example"
     defaultCode={`
 class LabelExample extends React.Component {
-constructor(props) {
-  super(props);
-  this.state = { switched: false };
-}
+  constructor(props) {
+    super(props);
+    this.state = { switched: false };
+  }
 
-render() {
-  return (
-    <Box>
-      <Box paddingY={1}>
-        <Label htmlFor="switchExample">
-          <Text>Live example</Text>
-        </Label>
+  render() {
+    return (
+      <Box>
+        <Box paddingY={1}>
+          <Label htmlFor="switchExample">
+            <Text>Live example</Text>
+          </Label>
+        </Box>
+        <Switch
+          onChange={() => this.setState({ switched: !this.state.switched })}
+          id="switchExample"
+          switched={this.state.switched}
+        />
       </Box>
-      <Switch
-        onChange={() => this.setState({ switched: !this.state.switched })}
-        id="switchExample"
-        switched={this.state.switched}
-      />
-    </Box>
-  );
+    );
+  }
 }
-}
-
 `}
   />
 );

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -51,20 +51,20 @@ card(
     name="Example"
     defaultCode={`
 <Box>
-<Link href="https://pinterest.com">
-  <Box padding={2}>
-    <Text bold>Pinterest.com</Text>
+  <Link href="https://pinterest.com">
+    <Box padding={2}>
+      <Text bold>Pinterest.com</Text>
+    </Box>
+  </Link>
+  <Box color="darkGray">
+    <Text color="white" bold>
+      <Link href="https://pinterest.com">
+        <Box padding={2}>
+          Pinterest.com
+        </Box>
+      </Link>
+    </Text>
   </Box>
-</Link>
-<Box color="darkGray">
-  <Text color="white" bold>
-    <Link href="https://pinterest.com">
-      <Box padding={2}>
-        Pinterest.com
-      </Box>
-    </Link>
-  </Text>
-</Box>
 </Box>
 `}
   />
@@ -78,11 +78,11 @@ card(
     name="Example: optional href"
     defaultCode={`
 <Link>
-<Box padding={2}>
-  <a href="https://pinterest.com" style={{ textDecoration: 'none' }}>
-    <Text bold>Pinterest.com</Text>
-  </a>
-</Box>
+  <Box padding={2}>
+    <a href="https://pinterest.com" style={{ textDecoration: 'none' }}>
+      <Text bold>Pinterest.com</Text>
+    </a>
+  </Box>
 </Link>
 `}
   />
@@ -96,33 +96,33 @@ card(
     name="Accessibility"
     defaultCode={`
 <Box>
-<Heading size="sm">
-  Bad ❌
-</Heading>
-<Text>
-  For more information,{' '}
-  <Text inline bold>
-    <Link inline href="https://pinterest.com">
-      click here
-    </Link>
-  </Text>.
-</Text>
-<Box paddingY={4}>
   <Heading size="sm">
-    Good ✅
+    Bad ❌
   </Heading>
   <Text>
-    Visit
-    {' '}
+    For more information,{' '}
     <Text inline bold>
       <Link inline href="https://pinterest.com">
-        Pinterest.com
+        click here
       </Link>
-    </Text>
-    {' '}
-    for more information.
+    </Text>.
   </Text>
-</Box>
+  <Box paddingY={4}>
+    <Heading size="sm">
+      Good ✅
+    </Heading>
+    <Text>
+      Visit
+      {' '}
+      <Text inline bold>
+        <Link inline href="https://pinterest.com">
+          Pinterest.com
+        </Link>
+      </Text>
+      {' '}
+      for more information.
+    </Text>
+  </Box>
 </Box>
 `}
   />

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -54,7 +54,7 @@ card(
     name="Example"
     defaultCode={`
 <Mask height={70} shape="circle" width={70}>
-<div style={{ backgroundColor: '#0fa573', width: 70, height: 70 }} />
+  <div style={{ backgroundColor: '#0fa573', width: 70, height: 70 }} />
 </Mask>
 `}
   />
@@ -68,13 +68,13 @@ card(
     name="Example: Masking other content"
     defaultCode={`
 <Box maxWidth={300}>
-<Mask shape="circle">
-  <img
-    alt="weakendclub.com"
-    src="${stock7}"
-    style={{ maxWidth: '100%', display: 'block' }}
-  />
-</Mask>
+  <Mask shape="circle">
+    <img
+      alt="weakendclub.com"
+      src="${stock7}"
+      style={{ maxWidth: '100%', display: 'block' }}
+    />
+  </Mask>
 </Box>
 `}
   />
@@ -88,13 +88,13 @@ card(
     name="Example: Adding a wash"
     defaultCode={`
 <Box maxWidth={300}>
-<Mask shape="rounded" wash>
-  <img
-    alt="subliming.tumblr.com"
-    src="${stock8}"
-    style={{ maxWidth: '100%', display: 'block' }}
-  />
-</Mask>
+  <Mask shape="rounded" wash>
+    <img
+      alt="subliming.tumblr.com"
+      src="${stock8}"
+      style={{ maxWidth: '100%', display: 'block' }}
+    />
+  </Mask>
 </Box>
 `}
   />

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -70,8 +70,8 @@ card(
     name="Example"
     defaultCode={`
 <Pog
-icon="heart"
-iconColor="red"
+  icon="heart"
+  iconColor="red"
 />
 `}
   />

--- a/docs/src/Pulsar.doc.js
+++ b/docs/src/Pulsar.doc.js
@@ -42,29 +42,29 @@ card(
     name="Example"
     defaultCode={`
 class PulsarExample extends React.Component {
-constructor(props) {
-  super(props);
-  this.state = {
-    isPulsing: true
-  };
-}
+  constructor(props) {
+    super(props);
+    this.state = {
+      isPulsing: true
+    };
+  }
 
-render() {
-  const text = this.state.isPulsing ? 'Click to pause' : 'Click to show';
-  return (
-    <Box display="flex" direction="column">
-      <Box marginBottom={4}>
-        <Button
-          text={text}
-          onClick={() => this.setState({ isPulsing: !this.state.isPulsing })}
-          inline
-          size="md"
-        />
+  render() {
+    const text = this.state.isPulsing ? 'Click to pause' : 'Click to show';
+    return (
+      <Box display="flex" direction="column">
+        <Box marginBottom={4}>
+          <Button
+            text={text}
+            onClick={() => this.setState({ isPulsing: !this.state.isPulsing })}
+            inline
+            size="md"
+          />
+        </Box>
+        <Pulsar paused={!this.state.isPulsing} />
       </Box>
-      <Pulsar paused={!this.state.isPulsing} />
-    </Box>
-  );
-}
+    );
+  }
 }
 `}
   />

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -71,14 +71,14 @@ card(
     name="Example: Accessibility"
     defaultCode={`
 <Box alignItems="center" display="flex" direction="row">
-<RadioButton id="usa" checked onChange={() => {}} value="usa" />
-<Box flex="grow">
-  <Label htmlFor="usa">
-    <Box paddingX={2}>
-      <Text bold>U.S.A.</Text>
-    </Box>
-  </Label>
-</Box>
+  <RadioButton id="usa" checked onChange={() => {}} value="usa" />
+  <Box flex="grow">
+    <Label htmlFor="usa">
+      <Box paddingX={2}>
+        <Text bold>U.S.A.</Text>
+      </Box>
+    </Label>
+  </Box>
 </Box>
 `}
   />
@@ -92,64 +92,64 @@ card(
     name="Example: Group"
     defaultCode={`
 class RadioButtonExample extends React.Component {
-constructor(props) {
-  super(props);
-  this.state = { gender: undefined };
-}
-render() {
-  return (
-    <Box role="list" display="flex" direction="column">
-      <Box alignItems="center" paddingY={1} display="flex" direction="row">
-        <RadioButton
-          checked={this.state.gender === 'male'}
-          id="genderMale"
-          name="gender"
-          onChange={() => this.setState({ gender: 'male' })}
-          value="male"
-        />
-        <Box flex="grow">
-          <Label htmlFor="genderMale">
-            <Box paddingX={2}>
-              <Text>Male</Text>
-            </Box>
-          </Label>
+  constructor(props) {
+    super(props);
+    this.state = { gender: undefined };
+  }
+  render() {
+    return (
+      <Box role="list" display="flex" direction="column">
+        <Box alignItems="center" paddingY={1} display="flex" direction="row">
+          <RadioButton
+            checked={this.state.gender === 'male'}
+            id="genderMale"
+            name="gender"
+            onChange={() => this.setState({ gender: 'male' })}
+            value="male"
+          />
+          <Box flex="grow">
+            <Label htmlFor="genderMale">
+              <Box paddingX={2}>
+                <Text>Male</Text>
+              </Box>
+            </Label>
+          </Box>
+        </Box>
+        <Box alignItems="center" paddingY={1} display="flex" direction="row">
+          <RadioButton
+            checked={this.state.gender === 'female'}
+            id="genderFemale"
+            name="gender"
+            onChange={() => this.setState({ gender: 'female' })}
+            value="female"
+          />
+          <Box flex="grow">
+            <Label htmlFor="genderFemale">
+              <Box paddingX={2}>
+                <Text>Female</Text>
+              </Box>
+            </Label>
+          </Box>
+        </Box>
+        <Box alignItems="center" paddingY={1} display="flex" direction="row">
+          <RadioButton
+            checked={this.state.gender === 'other'}
+            id="genderOther"
+            name="gender"
+            onChange={() => this.setState({ gender: 'other' })}
+            value="other"
+          />
+          <Box flex="grow">
+            <Label htmlFor="genderOther">
+              <Box paddingX={2}>
+                <Text>Other</Text>
+              </Box>
+            </Label>
+          </Box>
         </Box>
       </Box>
-      <Box alignItems="center" paddingY={1} display="flex" direction="row">
-        <RadioButton
-          checked={this.state.gender === 'female'}
-          id="genderFemale"
-          name="gender"
-          onChange={() => this.setState({ gender: 'female' })}
-          value="female"
-        />
-        <Box flex="grow">
-          <Label htmlFor="genderFemale">
-            <Box paddingX={2}>
-              <Text>Female</Text>
-            </Box>
-          </Label>
-        </Box>
-      </Box>
-      <Box alignItems="center" paddingY={1} display="flex" direction="row">
-        <RadioButton
-          checked={this.state.gender === 'other'}
-          id="genderOther"
-          name="gender"
-          onChange={() => this.setState({ gender: 'other' })}
-          value="other"
-        />
-        <Box flex="grow">
-          <Label htmlFor="genderOther">
-            <Box paddingX={2}>
-              <Text>Other</Text>
-            </Box>
-          </Label>
-        </Box>
-      </Box>
-    </Box>
-  );
-}
+    );
+  }
 }
 `}
   />

--- a/docs/src/Sticky.doc.js
+++ b/docs/src/Sticky.doc.js
@@ -51,31 +51,31 @@ card(
     name="Example: Sticky top"
     defaultCode={`
 <Box color="white" height={200} overflow="scroll">
-<Box height={500} marginTop={10}>
-  <Box>
-    <Sticky top={0}>
-      <Box alignItems="center" color="lightGray" display="flex" height={40}>
-        <Text>This should stick</Text>
+  <Box height={500} marginTop={10}>
+    <Box>
+      <Sticky top={0}>
+        <Box alignItems="center" color="lightGray" display="flex" height={40}>
+          <Text>This should stick</Text>
+        </Box>
+      </Sticky>
+      <Box marginTop={10} position="relative">
+        <Text>Scroll</Text>
+        <Text>Keep scrolling</Text>
+        <Text>Scroll more</Text>
       </Box>
-    </Sticky>
-    <Box marginTop={10} position="relative">
-      <Text>Scroll</Text>
-      <Text>Keep scrolling</Text>
-      <Text>Scroll more</Text>
+    </Box>
+    <Box>
+      <Sticky top={0} dangerouslySetZIndex={{ __zIndex: 3 }}>
+      <Box alignItems="center" color="lightGray" display="flex" height={40} position="relative" dangerouslySetInlineStyle={{ __style: { zIndex: 2 } }}>
+          <Text>This should also stick</Text>
+        </Box>
+      </Sticky>
+      <Box marginTop={10}>
+        <Text>Still scrolling</Text>
+        <Text>Tadaaaaa</Text>
+      </Box>
     </Box>
   </Box>
-  <Box>
-    <Sticky top={0} dangerouslySetZIndex={{ __zIndex: 3 }}>
-    <Box alignItems="center" color="lightGray" display="flex" height={40} position="relative" dangerouslySetInlineStyle={{ __style: { zIndex: 2 } }}>
-        <Text>This should also stick</Text>
-      </Box>
-    </Sticky>
-    <Box marginTop={10}>
-      <Text>Still scrolling</Text>
-      <Text>Tadaaaaa</Text>
-    </Box>
-  </Box>
-</Box>
 </Box>
 `}
   />

--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -56,30 +56,30 @@ card(
     name="Example: Using a label"
     defaultCode={`
 class SwitchExample extends React.Component {
-constructor(props) {
-  super(props);
-  this.state = { switched: false };
-  this.handleChange = this._handleChange.bind(this);
-}
-_handleChange() {
-  this.setState({ switched: !this.state.switched });
-}
-render() {
-  return (
-    <Box display="flex" direction="row" alignItems="center">
-      <Box paddingX={2} flex="grow">
-        <Label htmlFor="emailNotifications">
-          <Text>Airplane mode</Text>
-        </Label>
+  constructor(props) {
+    super(props);
+    this.state = { switched: false };
+    this.handleChange = this._handleChange.bind(this);
+  }
+  _handleChange() {
+    this.setState({ switched: !this.state.switched });
+  }
+  render() {
+    return (
+      <Box display="flex" direction="row" alignItems="center">
+        <Box paddingX={2} flex="grow">
+          <Label htmlFor="emailNotifications">
+            <Text>Airplane mode</Text>
+          </Label>
+        </Box>
+        <Switch
+          onChange={this.handleChange}
+          id="emailNotifications"
+          switched={this.state.switched}
+        />
       </Box>
-      <Switch
-        onChange={this.handleChange}
-        id="emailNotifications"
-        switched={this.state.switched}
-      />
-    </Box>
-  );
-}
+    );
+  }
 }
 `}
   />

--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -51,7 +51,6 @@ class TabExample extends React.Component {
     };
     this.handleChange = this._handleChange.bind(this);
   }
-
   _handleChange({ activeTabIndex, event }) {
     event.preventDefault();
     this.setState({

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -71,17 +71,16 @@ card(
 
 card(
   <Example
-    description="
-    You can apply the following to adjust the positioning of text within wrapper elements.
-  "
+    description="You can apply the following to adjust the positioning of text within wrapper elements."
     name="Alignment"
     defaultCode={`
 <Box maxWidth="8em">
-<Text align="left">Left (default)</Text>
-<Text align="right">Right</Text>
-<Text align="center">Center</Text>
-<Text align="justify">Justify</Text>
-</Box>`}
+  <Text align="left">Left (default)</Text>
+  <Text align="right">Right</Text>
+  <Text align="center">Center</Text>
+  <Text align="justify">Justify</Text>
+</Box>
+`}
   />
 );
 
@@ -93,77 +92,76 @@ card(
     name="Block vs inline"
     defaultCode={`
 <Box>
-<Box marginBottom={2}>
-  <Text>Some content in a default block element. (default)</Text>
+  <Box marginBottom={2}>
+    <Text>Some content in a default block element. (default)</Text>
+  </Box>
+  <Box marginBottom={2}>
+    <Text inline>Inline text with the inline prop.</Text>
+    {' '}
+    <Text inline>More inline text.</Text>
+  </Box>
 </Box>
-<Box marginBottom={2}>
-  <Text inline>Inline text with the inline prop.</Text>
-  {' '}
-  <Text inline>More inline text.</Text>
-</Box>
-</Box>`}
+`}
   />
 );
 
 card(
   <Example
-    description="
-    You can specify which color you want for your text.
-  "
+    description="You can specify which color you want for your text."
     name="Colors"
     defaultCode={`
 <Box>
-<Box color="darkGray" marginBottom={2}>
-  <Text color="white">White</Text>
+  <Box color="darkGray" marginBottom={2}>
+    <Text color="white">White</Text>
+  </Box>
+  <Box marginBottom={2}>
+    <Text color="gray">Gray</Text>
+  </Box>
+  <Box marginBottom={2}>
+    <Text color="darkGray">Dark Gray (default)</Text>
+  </Box>
+  <Box marginBottom={2}>
+    <Text color="blue">Blue</Text>
+  </Box>
+  <Box marginBottom={2}>
+    <Text color="red">Red</Text>
+  </Box>
 </Box>
-<Box marginBottom={2}>
-  <Text color="gray">Gray</Text>
-</Box>
-<Box marginBottom={2}>
-  <Text color="darkGray">Dark Gray (default)</Text>
-</Box>
-<Box marginBottom={2}>
-  <Text color="blue">Blue</Text>
-</Box>
-<Box marginBottom={2}>
-  <Text color="red">Red</Text>
-</Box>
-</Box>`}
+`}
   />
 );
 
 card(
   <Example
-    description="
-    Gestalt provides utility options to deal with text overflow.
-  "
+    description="Gestalt provides utility options to deal with text overflow."
     name="Overflow"
     defaultCode={`
 <Box maxWidth={240}>
-<Box marginBottom={2}>
-  <Text bold>normal:</Text>
-  <Text overflow="normal" leading="tall">
-    This is a long and Supercalifragilisticexpialidocious sentence.
-    次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉&#39;
-  </Text>
+  <Box marginBottom={2}>
+    <Text bold>normal:</Text>
+    <Text overflow="normal" leading="tall">
+      This is a long and Supercalifragilisticexpialidocious sentence.
+      次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉&#39;
+    </Text>
+  </Box>
+  <Box marginBottom={2}>
+    <Text bold>breakWord:</Text>
+    <Text leading="tall">
+      This is a long and Supercalifragilisticexpialidocious sentence.
+      次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
+      ｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗ&#39;
+    </Text>
+  </Box>
+  <Box marginBottom={2}>
+    <Text bold>truncate:</Text>
+    <Text truncate leading="tall">
+      This is a long and Supercalifragilisticexpialidocious sentence.
+      次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
+      ｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗ&#39;
+    </Text>
+  </Box>
 </Box>
-<Box marginBottom={2}>
-  <Text bold>breakWord:</Text>
-  <Text leading="tall">
-    This is a long and Supercalifragilisticexpialidocious sentence.
-    次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
-    ｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗ&#39;
-  </Text>
-</Box>
-<Box marginBottom={2}>
-  <Text bold>truncate:</Text>
-  <Text truncate leading="tall">
-    This is a long and Supercalifragilisticexpialidocious sentence.
-    次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
-    ｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗ&#39;
-  </Text>
-</Box>
-</Box>`}
+`}
   />
 );
 card(
@@ -174,57 +172,58 @@ card(
     name="Sizes"
     defaultCode={`
 <Box>
-<Box marginBottom={2}>
-  <Text inline size="xs">
-    {'Extra small'}
-  </Text>{' '}
-  <span lang="ja">
+  <Box marginBottom={2}>
     <Text inline size="xs">
-      こんにちは
-    </Text>
-  </span>
-</Box>
-<Box marginBottom={2}>
-  <Text inline size="sm">
-    {'Small'}
-  </Text>{' '}
-  <span lang="ja">
+      {'Extra small'}
+    </Text>{' '}
+    <span lang="ja">
+      <Text inline size="xs">
+        こんにちは
+      </Text>
+    </span>
+  </Box>
+  <Box marginBottom={2}>
     <Text inline size="sm">
-      こんにちは
-    </Text>
-  </span>
-</Box>
-<Box marginBottom={2}>
-  <Text inline size="md">
-    {'Medium (default size)'}
-  </Text>{' '}
-  <span lang="ja">
+      {'Small'}
+    </Text>{' '}
+    <span lang="ja">
+      <Text inline size="sm">
+        こんにちは
+      </Text>
+    </span>
+  </Box>
+  <Box marginBottom={2}>
     <Text inline size="md">
-      こんにちは
-    </Text>
-  </span>
-</Box>
-<Box marginBottom={2}>
-  <Text inline size="lg">
-    {'Large'}
-  </Text>{' '}
-  <span lang="ja">
+      {'Medium (default size)'}
+    </Text>{' '}
+    <span lang="ja">
+      <Text inline size="md">
+        こんにちは
+      </Text>
+    </span>
+  </Box>
+  <Box marginBottom={2}>
     <Text inline size="lg">
-      こんにちは
-    </Text>
-  </span>
-</Box>
-<Box marginBottom={2}>
-  <Text inline size="xl">
-    {'Extra Large'}
-  </Text>{' '}
-  <span lang="ja">
+      {'Large'}
+    </Text>{' '}
+    <span lang="ja">
+      <Text inline size="lg">
+        こんにちは
+      </Text>
+    </span>
+  </Box>
+  <Box marginBottom={2}>
     <Text inline size="xl">
-      こんにちは
-    </Text>
-  </span>
+      {'Extra Large'}
+    </Text>{' '}
+    <span lang="ja">
+      <Text inline size="xl">
+        こんにちは
+      </Text>
+    </span>
+  </Box>
 </Box>
-</Box>`}
+`}
   />
 );
 card(
@@ -236,13 +235,14 @@ card(
     name="Styles"
     defaultCode={`
 <Box>
-<Box marginBottom={2}>
-  <Text bold>Bold</Text>
+  <Box marginBottom={2}>
+    <Text bold>Bold</Text>
+  </Box>
+  <Box marginBottom={2}>
+    <Text italic>Italic</Text>
+  </Box>
 </Box>
-<Box marginBottom={2}>
-  <Text italic>Italic</Text>
-</Box>
-</Box>`}
+`}
   />
 );
 

--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -93,7 +93,6 @@ class Example extends React.Component {
       value
     });
   }
-
   render() {
     return (
       <Box>
@@ -133,7 +132,6 @@ class Example extends React.Component {
       value
     });
   }
-
   render() {
     return (
       <Box>
@@ -173,11 +171,8 @@ class Example extends React.Component {
     };
   }
   _handleChange({ value }) {
-    this.setState({
-      value
-    });
+    this.setState({ value });
   }
-
   render() {
     return (
       <Box>

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -89,11 +89,8 @@ class Example extends React.Component {
     };
   }
   _handleChange({ value }) {
-    this.setState({
-      value
-    });
+    this.setState({ value });
   }
-
   render() {
     return (
       <Box>
@@ -130,11 +127,8 @@ class Example extends React.Component {
     };
   }
   _handleChange({ value }) {
-    this.setState({
-      value
-    });
+    this.setState({ value });
   }
-
   render() {
     return (
       <Box>
@@ -174,11 +168,8 @@ class Example extends React.Component {
     };
   }
   _handleChange({ value }) {
-    this.setState({
-      value
-    });
+    this.setState({ value });
   }
-
   render() {
     return (
       <Box>

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -67,40 +67,40 @@ class ToastExample extends React.Component {
   };
   render() {
     return (
-      <div>
-      <Button
-        inline
-        text={ this.state.showConfirmationToast ? 'Close toast' : 'Show confirmation toast' }
-        onClick={this.handleConfirmationClick}
-        size='md'
-      />
-      <Box
-        fit
-        dangerouslySetInlineStyle={{
-          __style: {
-            bottom: 50,
-            left: '50%',
-            transform: 'translateX(-50%)',
-          },
-        }}
-        paddingX={1}
-        position='fixed'
-      >
-        {this.state.showConfirmationToast ? (
-            <Toast
-              text={['Saved to', 'Home decor']}
-              thumbnail={
-                <Image
-                  alt='Saved to home decor board'
-                  naturalHeight={564}
-                  naturalWidth={564}
-                  src='${stock1}'
-                />
-              }
-            />
-        ) : null}
+      <Box>
+        <Button
+          inline
+          text={ this.state.showConfirmationToast ? 'Close toast' : 'Show confirmation toast' }
+          onClick={this.handleConfirmationClick}
+          size='md'
+        />
+        <Box
+          fit
+          dangerouslySetInlineStyle={{
+            __style: {
+              bottom: 50,
+              left: '50%',
+              transform: 'translateX(-50%)',
+            },
+          }}
+          paddingX={1}
+          position='fixed'
+        >
+          {this.state.showConfirmationToast ? (
+              <Toast
+                text={['Saved to', 'Home decor']}
+                thumbnail={
+                  <Image
+                    alt='Saved to home decor board'
+                    naturalHeight={564}
+                    naturalWidth={564}
+                    src='${stock1}'
+                  />
+                }
+              />
+          ) : null}
+        </Box>
       </Box>
-      </div>
     );
   }
 }`}
@@ -127,33 +127,33 @@ class ToastExample extends React.Component {
   };
   render() {
     return (
-      <div>
-      <Button
-        inline
-        text={ this.state.showGuideToast ? 'Close toast' : 'Show guide toast' }
-        onClick={this.handleGuideClick}
-        size='md'
-      />
-      <Box
-        fit
-        dangerouslySetInlineStyle={{
-          __style: {
-            bottom: 150,
-            left: '50%',
-            transform: 'translateX(-50%)',
-          },
-        }}
-        paddingX={1}
-        position='fixed'
-      >
-        {this.state.showGuideToast ? (
-          <Toast
-            icon='arrow-circle-forward'
-            text='Same great profile, just a new look. Learn more?'
-          />
-        ) : null}
+      <Box>
+        <Button
+          inline
+          text={ this.state.showGuideToast ? 'Close toast' : 'Show guide toast' }
+          onClick={this.handleGuideClick}
+          size='md'
+        />
+        <Box
+          fit
+          dangerouslySetInlineStyle={{
+            __style: {
+              bottom: 150,
+              left: '50%',
+              transform: 'translateX(-50%)',
+            },
+          }}
+          paddingX={1}
+          position='fixed'
+        >
+          {this.state.showGuideToast ? (
+            <Toast
+              icon='arrow-circle-forward'
+              text='Same great profile, just a new look. Learn more?'
+            />
+          ) : null}
+        </Box>
       </Box>
-      </div>
     );
   }
 }`}
@@ -180,30 +180,30 @@ class ToastExample extends React.Component {
   };
   render() {
     return (
-      <div>
-      <Button
-        inline
-        text={ this.state.showErrorToast ? 'Close toast' : 'Show error toast' }
-        onClick={this.handleErrorClick}
-        size='md'
-      />
-      <Box
-        fit
-        dangerouslySetInlineStyle={{
-          __style: {
-            bottom: 250,
-            left: '50%',
-            transform: 'translateX(-50%)',
-          },
-        }}
-        paddingX={1}
-        position='fixed'
-      >
-        {this.state.showErrorToast ? (
-          <Toast color='orange' text="Oops, we couldn't find that!" />
-        ) : null}
+      <Box>
+        <Button
+          inline
+          text={ this.state.showErrorToast ? 'Close toast' : 'Show error toast' }
+          onClick={this.handleErrorClick}
+          size='md'
+        />
+        <Box
+          fit
+          dangerouslySetInlineStyle={{
+            __style: {
+              bottom: 250,
+              left: '50%',
+              transform: 'translateX(-50%)',
+            },
+          }}
+          paddingX={1}
+          position='fixed'
+        >
+          {this.state.showErrorToast ? (
+            <Toast color='orange' text="Oops, we couldn't find that!" />
+          ) : null}
+        </Box>
       </Box>
-      </div>
     );
   }
 }`}

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -72,14 +72,12 @@ class TooltipExample extends React.Component {
     this.handleClick = this._handleClick.bind(this);
     this.handleDismiss = this._handleDismiss.bind(this);
   }
-
   _handleClick() {
     this.setState(() => ({ open: !this.state.open }));
   }
   _handleDismiss() {
     this.setState(() => ({ open: false }));
   }
-
   render() {
     return (
       <Box>

--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -69,55 +69,55 @@ card(
     name="Example"
     defaultCode={`
 class TouchableExample extends React.Component {
-constructor(props) {
-  super(props);
-  this.state = { clicks: 0 };
-  this.handleTouch = this._handleTouch.bind(this);
-  this.handleLinkClick = this._handleLinkClick.bind(this);
-}
-_handleTouch() {
-  this.setState({
-    clicks: this.state.clicks + 1,
-  });
-};
-_handleLinkClick({ event }) {
-  event.stopPropagation();
-};
-render() {
-  return (
-    <Box padding={2} width={150}>
-    <Touchable
-      mouseCursor="zoomIn"
-      onTouch={this.handleTouch}
-      shape="rounded"
-    >
-      <Mask shape="rounded">
-        <Image
-          alt="Antelope Canyon"
-          naturalHeight={1}
-          naturalWidth={1}
-          src="${stock14}"
-        />
-      </Mask>
-      <Box paddingY={2}>
-        <Link
-          href="https://en.wikipedia.org/wiki/Antelope_Canyon"
-          onClick={this.handleLinkClick}
+  constructor(props) {
+    super(props);
+    this.state = { clicks: 0 };
+    this.handleTouch = this._handleTouch.bind(this);
+    this.handleLinkClick = this._handleLinkClick.bind(this);
+  }
+  _handleTouch() {
+    this.setState({
+      clicks: this.state.clicks + 1,
+    });
+  };
+  _handleLinkClick({ event }) {
+    event.stopPropagation();
+  };
+  render() {
+    return (
+      <Box padding={2} width={150}>
+        <Touchable
+          mouseCursor="zoomIn"
+          onTouch={this.handleTouch}
+          shape="rounded"
         >
-          <Text align="center">Wiki Link</Text>
-        </Link>
+          <Mask shape="rounded">
+            <Image
+              alt="Antelope Canyon"
+              naturalHeight={1}
+              naturalWidth={1}
+              src="${stock14}"
+            />
+          </Mask>
+          <Box paddingY={2}>
+            <Link
+              href="https://en.wikipedia.org/wiki/Antelope_Canyon"
+              onClick={this.handleLinkClick}
+            >
+              <Text align="center">Wiki Link</Text>
+            </Link>
+          </Box>
+        </Touchable>
+        <Box paddingY={2}>
+          <Text color="gray" align="center">
+            Clicked{' '}
+            {this.state.clicks}{' '}
+            {this.state.clicks === 1 ? 'time' : 'times'}
+          </Text>
+        </Box>
       </Box>
-    </Touchable>
-    <Box paddingY={2}>
-      <Text color="gray" align="center">
-        Clicked{' '}
-        {this.state.clicks}{' '}
-        {this.state.clicks === 1 ? 'time' : 'times'}
-      </Text>
-    </Box>
-  </Box>
-  );
-}
+    );
+  }
 }
 `}
   />
@@ -132,24 +132,24 @@ card(
     name="Full width and full height"
     defaultCode={`
 <Box color="white" display="flex" width={500} height={250}>
-<Box column={6}>
-  <Touchable fullHeight>
-    <Box height="100%" color="lightGray">
-      <Text align="center">
-        Full parent height
-      </Text>
-    </Box>
-  </Touchable>
-</Box>
-<Box column={6}>
-  <Touchable>
-    <Box height="100%" color="lightGray">
-      <Text align="center">
-        Child height only
-      </Text>
-    </Box>
-  </Touchable>
-</Box>
+  <Box column={6}>
+    <Touchable fullHeight>
+      <Box height="100%" color="lightGray">
+        <Text align="center">
+          Full parent height
+        </Text>
+      </Box>
+    </Touchable>
+  </Box>
+  <Box column={6}>
+    <Touchable>
+      <Box height="100%" color="lightGray">
+        <Text align="center">
+          Child height only
+        </Text>
+      </Box>
+    </Touchable>
+  </Box>
 </Box>
 `}
   />


### PR DESCRIPTION
Currently the indentation on the code examples in the gestalt docs is off. Examples in the preview look like this:
<img width="1237" alt="screen shot 2018-05-29 at 9 15 09 am" src="https://user-images.githubusercontent.com/7877010/40671494-e5a2e11e-6320-11e8-8651-c5ff0af4db83.png">
This change fixes all these collapsed indentations in the docs.