### PR TITLE
Fix Video autoplay on SSR on initial render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * TextArea: Makes TextArea React Async compatible (#222)
 * TextField: Makes TextField React Async compatible (#223)
 * ScrollContainer: Makes ScrollContainer React Async compatible (#224)
+* Video: Fix Video playback on SSR if playing is true on first mount (#225)
 
 ### Patch
 

--- a/packages/gestalt/src/Video/Video.js
+++ b/packages/gestalt/src/Video/Video.js
@@ -468,6 +468,7 @@ export default class Video extends React.PureComponent<Props, State> {
         style={{ paddingBottom, height: fullscreen ? '100%' : 0 }}
       >
         <video
+          autoPlay={playing}
           loop={loop}
           muted={volume === 0}
           playsInline={playsInline}

--- a/packages/gestalt/src/Video/__tests__/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/Video/__tests__/__snapshots__/Video.test.js.snap
@@ -11,6 +11,7 @@ exports[`Video with callbacks 1`] = `
   }
 >
   <video
+    autoPlay={false}
     className="video"
     loop={undefined}
     muted={false}
@@ -44,6 +45,7 @@ exports[`Video with media attributes 1`] = `
   }
 >
   <video
+    autoPlay={false}
     className="video"
     loop={true}
     muted={true}
@@ -77,6 +79,7 @@ exports[`Video with multiple sources 1`] = `
   }
 >
   <video
+    autoPlay={false}
     className="video"
     loop={undefined}
     muted={false}
@@ -118,6 +121,7 @@ exports[`Video with source 1`] = `
   }
 >
   <video
+    autoPlay={false}
     className="video"
     loop={undefined}
     muted={false}


### PR DESCRIPTION
The `playing` prop covers flipping the video back and forth between being played and being paused, but it breaks on SSR because the browser expects the user to interact with the DOM before the video can play. This means that if for example a user lands on Closeup of a video Pin and `playing` was defaulted to `true`, the video would not actually play until the user starts to click around and clicks play manually (which can lead to inconsistent state issues). By making the `autoPlay` attribute on `video` mirror the `playing` prop on `Video` we can achieve the effect we need of **all** video closeups playing from the get-go regardless of whether they are client navigated from a feed or via a URL.