### PR TITLE
Cleanup Link component Flow + React prop typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * TextArea: Makes TextArea React Async compatible (#222)
 * TextField: Makes TextField React Async compatible (#223)
 * ScrollContainer: Makes ScrollContainer React Async compatible (#224)
+* Link: Cleanup href and children prop typing (#226)
 
 ### Patch
 

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -32,11 +32,11 @@ card(
       },
       {
         name: 'onClick',
-        type: '({ event: SyntheticMouseEvent<> }) => void',
+        type: '({ event: SyntheticMouseEvent<HTMLAnchorElement> }) => void',
       },
       {
         name: 'target',
-        type: `"null" | "self" | "blank"`,
+        type: `null | "self" | "blank"`,
         defaultValue: 'null',
       },
     ]}

--- a/packages/gestalt/src/Link/Link.js
+++ b/packages/gestalt/src/Link/Link.js
@@ -6,9 +6,9 @@ import styles from './Link.css';
 
 type Props = {|
   children?: React.Node,
-  href: string,
+  href?: string,
   inline?: boolean,
-  onClick?: ({ event: SyntheticMouseEvent<> }) => void,
+  onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> }) => void,
   target?: null | 'self' | 'blank',
 |};
 
@@ -20,18 +20,23 @@ const TAB_KEY_CODE = 9;
 
 export default class Link extends React.Component<Props, State> {
   static propTypes = {
-    children: PropTypes.node.isRequired,
-    href: PropTypes.string.isRequired,
+    children: PropTypes.node,
+    href: PropTypes.string,
     inline: PropTypes.bool,
     onClick: PropTypes.func,
     target: PropTypes.oneOf([null, 'self', 'blank']),
   };
 
-  state: State = {
+  static defaultProps = {
+    inline: false,
+    target: null,
+  };
+
+  state = {
     enableFocusStyles: true,
   };
 
-  handleClick = (event: SyntheticMouseEvent<>) => {
+  handleClick = (event: SyntheticMouseEvent<HTMLAnchorElement>) => {
     const { href, onClick } = this.props;
     if (onClick && href) {
       onClick({ event });
@@ -45,7 +50,7 @@ export default class Link extends React.Component<Props, State> {
     }
   };
 
-  handleKeyUp = (event: SyntheticKeyboardEvent<>) => {
+  handleKeyUp = (event: SyntheticKeyboardEvent<HTMLAnchorElement>) => {
     const { href, target } = this.props;
     if (target === 'blank' && event.keyCode === TAB_KEY_CODE && href) {
       this.setState({ enableFocusStyles: true });
@@ -53,7 +58,7 @@ export default class Link extends React.Component<Props, State> {
   };
 
   render() {
-    const { children, inline = false, target = null, href } = this.props;
+    const { children, inline, target, href } = this.props;
     const rel = target === 'blank' ? 'noopener noreferrer' : null;
     const linkTarget = target ? `_${target}` : null;
 


### PR DESCRIPTION
There is a discrepancy between the Flow typing, the React proptyping, and the gestalt docs for this component. In my opinion, these should both be optional (similar to `Text`) so let's make it all consistent. This also moves the default props to the correct `static defaultProps` and adds and event target to the event handler.