### PR TITLE
Fix the legacy MasonryUniformRowLayout not working issue

### DIFF
--- a/packages/gestalt/src/Masonry/Masonry.js
+++ b/packages/gestalt/src/Masonry/Masonry.js
@@ -427,7 +427,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       });
     } else if (
       this.props.layout === UniformRowLayoutSymbol ||
-      this.props.layout instanceof LegacyUniformRowLayout
+      this.props.layout === LegacyUniformRowLayout
     ) {
       layout = uniformRowLayout({
         cache: measurementStore,


### PR DESCRIPTION
`this.props.layout` is actually the class `MasonryUniformRowLayout`, instead of an instance.
