### PR TITLE
Change flow type of item in SegmentedControl to support React.Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Minor
 * Masonry: Makes Masonry React Async compatible (#227)
+* SegmentedControl: Change flow type of `items` to `React.Node` (#230)
 
 ### Patch
 

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -25,7 +25,7 @@ card(
     props={[
       {
         name: 'items',
-        type: 'Array<any>',
+        type: 'Array<React.Node>',
         required: true,
       },
       {
@@ -64,7 +64,6 @@ class ToastExample extends React.Component {
     super(props);
     this.state = {
       itemIndex: 0,
-      items: ['News', 'You', 'Messages']
     };
     this.handleItemChange = this.handleItemChange.bind(this);
   }
@@ -74,9 +73,22 @@ class ToastExample extends React.Component {
   };
 
   render() {
+    const items = [
+      'News',
+      'You',
+      'Messages',
+      <Box display="flex" justifyContent="center">
+        <Icon
+          icon="pin"
+          accessibilityLabel="Pin"
+          color={this.state.itemIndex === 3 ? 'darkGray' : 'gray'}
+        />
+      </Box>,
+    ];
+
     return (
       <SegmentedControl
-        items={this.state.items}
+        items={items}
         selectedItemIndex={this.state.itemIndex}
         onChange={this.handleItemChange}
       />

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -77,13 +77,11 @@ class ToastExample extends React.Component {
       'News',
       'You',
       'Messages',
-      <Box display="flex" justifyContent="center">
-        <Icon
-          icon="pin"
-          accessibilityLabel="Pin"
-          color={this.state.itemIndex === 3 ? 'darkGray' : 'gray'}
-        />
-      </Box>,
+      <Icon
+        icon="pin"
+        accessibilityLabel="Pin"
+        color={this.state.itemIndex === 3 ? 'darkGray' : 'gray'}
+      />,
     ];
 
     return (

--- a/packages/gestalt/src/SegmentedControl/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl/SegmentedControl.js
@@ -6,7 +6,7 @@ import Text from '../Text/Text';
 import styles from './SegmentedControl.css';
 
 type Props = {|
-  items: Array<string | React.Node>,
+  items: Array<React.Node>,
   onChange: ({ event: SyntheticMouseEvent<>, activeIndex: number }) => void,
   selectedItemIndex: number,
   size?: 'md' | 'lg',

--- a/packages/gestalt/src/SegmentedControl/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl/SegmentedControl.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import Box from '../Box/Box';
 import Text from '../Text/Text';
 import styles from './SegmentedControl.css';
 
@@ -46,7 +47,7 @@ export default function SegmentedControl(props: Props) {
                 {item}
               </Text>
             ) : (
-              <div>{item}</div>
+              <Box display="flex" justifyContent="center">{item}</Box>
             )}
           </button>
         );

--- a/packages/gestalt/src/SegmentedControl/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl/SegmentedControl.js
@@ -6,7 +6,7 @@ import Text from '../Text/Text';
 import styles from './SegmentedControl.css';
 
 type Props = {|
-  items: Array<string>,
+  items: Array<string | React.Node>,
   onChange: ({ event: SyntheticMouseEvent<>, activeIndex: number }) => void,
   selectedItemIndex: number,
   size?: 'md' | 'lg',
@@ -36,14 +36,18 @@ export default function SegmentedControl(props: Props) {
             onClick={e => onChange({ event: e, activeIndex: i })}
             role="tab"
           >
-            <Text
-              bold
-              color={isSelected ? 'darkGray' : 'gray'}
-              align="center"
-              size={size}
-            >
-              {item}
-            </Text>
+            {typeof item === 'string' ? (
+              <Text
+                bold
+                color={isSelected ? 'darkGray' : 'gray'}
+                align="center"
+                size={size}
+              >
+                {item}
+              </Text>
+            ) : (
+              <div>{item}</div>
+            )}
           </button>
         );
       })}

--- a/packages/gestalt/src/SegmentedControl/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl/SegmentedControl.js
@@ -47,7 +47,9 @@ export default function SegmentedControl(props: Props) {
                 {item}
               </Text>
             ) : (
-              <Box display="flex" justifyContent="center">{item}</Box>
+              <Box display="flex" justifyContent="center">
+                {item}
+              </Box>
             )}
           </button>
         );

--- a/packages/gestalt/src/SegmentedControl/__tests__/SegmentedControl.test.js
+++ b/packages/gestalt/src/SegmentedControl/__tests__/SegmentedControl.test.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
+import { shallow } from 'enzyme';
 import SegmentedControl from '../SegmentedControl';
 import Icon from '../../Icon/Icon';
 import Text from '../../Text/Text';
-import { shallow } from 'enzyme';
 
 test('SegmentedControl renders', () => {
   const tree = create(
@@ -24,8 +24,8 @@ test('SegmentedControl renders component items', () => {
         'News',
         'You',
         'Messages',
-        <Icon accessibilityLabel="" icon="pin" color="red" />,
-        <Icon accessibilityLabel="" icon="pin" color="red" />,
+        <Icon key="icon1" accessibilityLabel="" icon="pin" color="red" />,
+        <Icon key="icon2" accessibilityLabel="" icon="pin" color="red" />,
       ]}
       selectedItemIndex={0}
       onChange={() => {}}

--- a/packages/gestalt/src/SegmentedControl/__tests__/SegmentedControl.test.js
+++ b/packages/gestalt/src/SegmentedControl/__tests__/SegmentedControl.test.js
@@ -2,6 +2,9 @@
 import React from 'react';
 import { create } from 'react-test-renderer';
 import SegmentedControl from '../SegmentedControl';
+import Icon from '../../Icon/Icon';
+import Text from '../../Text/Text';
+import { shallow } from 'enzyme';
 
 test('SegmentedControl renders', () => {
   const tree = create(
@@ -12,4 +15,22 @@ test('SegmentedControl renders', () => {
     />
   ).toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+test('SegmentedControl renders component items', () => {
+  const wrapper = shallow(
+    <SegmentedControl
+      items={[
+        'News',
+        'You',
+        'Messages',
+        <Icon accessibilityLabel="" icon="pin" color="red" />,
+        <Icon accessibilityLabel="" icon="pin" color="red" />,
+      ]}
+      selectedItemIndex={0}
+      onChange={() => {}}
+    />
+  );
+  expect(wrapper.find(Text)).toHaveLength(3);
+  expect(wrapper.find(Icon)).toHaveLength(2);
 });

--- a/packages/gestalt/src/SegmentedControl/__tests__/SegmentedControl.test.js
+++ b/packages/gestalt/src/SegmentedControl/__tests__/SegmentedControl.test.js
@@ -1,36 +1,15 @@
 // @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
-import { shallow } from 'enzyme';
 import SegmentedControl from '../SegmentedControl';
-import Icon from '../../Icon/Icon';
-import Text from '../../Text/Text';
 
 test('SegmentedControl renders', () => {
   const tree = create(
     <SegmentedControl
-      items={['News', 'You', 'Messages']}
+      items={['News', 'You', 'Messages', <div key="dummy" />]}
       selectedItemIndex={0}
       onChange={() => {}}
     />
   ).toJSON();
   expect(tree).toMatchSnapshot();
-});
-
-test('SegmentedControl renders component items', () => {
-  const wrapper = shallow(
-    <SegmentedControl
-      items={[
-        'News',
-        'You',
-        'Messages',
-        <Icon key="icon1" accessibilityLabel="" icon="pin" color="red" />,
-        <Icon key="icon2" accessibilityLabel="" icon="pin" color="red" />,
-      ]}
-      selectedItemIndex={0}
-      onChange={() => {}}
-    />
-  );
-  expect(wrapper.find(Text)).toHaveLength(3);
-  expect(wrapper.find(Icon)).toHaveLength(2);
 });

--- a/packages/gestalt/src/SegmentedControl/__tests__/__snapshots__/SegmentedControl.test.js.snap
+++ b/packages/gestalt/src/SegmentedControl/__tests__/__snapshots__/SegmentedControl.test.js.snap
@@ -41,5 +41,17 @@ exports[`SegmentedControl renders 1`] = `
       Messages
     </div>
   </button>
+  <button
+    aria-selected={false}
+    className="item itemIsNotSelected"
+    onClick={[Function]}
+    role="tab"
+  >
+    <div
+      className="box justifyCenter xsDisplayFlex"
+    >
+      <div />
+    </div>
+  </button>
 </div>
 `;


### PR DESCRIPTION
Even with type `string`, we can still put components in the items array, and it just works.  
In this change, I split the string type and component types. 
![snip20180531_25](https://user-images.githubusercontent.com/8308723/40814501-80099eca-64f5-11e8-9111-6377c8061698.png)
