### PR TITLE
Add codecov badge to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Button/Icon: Add additional tests for 100% coverage (#237)
 * Flyout/SegmentedControl: Add additional tests for 100% coverage (#238)
 * Touchable: Add additional tests for 100% coverage (#239)
+* Internal: Add Codecov badge to README (#241)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build status](https://badge.buildkite.com/2c6b6e9f79054095354cc061876e4885f4b9212e1dbebda270.svg?branch=master)](https://buildkite.com/pinterest/gestalt)
 [![NPM Version](https://img.shields.io/npm/v/gestalt.svg)](https://www.npmjs.com/package/gestalt)
+[![Coverage status](https://codecov.io/gh/pinterest/gestalt/branch/master/graph/badge.svg)](https://codecov.io/github/pinterest/gestalt)
 
 Gestalt is a set of React UI components that enforces Pinterest’s design language. We use it to streamline communication between designers and developers by enforcing a bunch of fundamental UI components. This common set of components helps raise the bar for UX & accessibility across Pinterest.
 


### PR DESCRIPTION
Adds the code coverage badge to the top of the README.md file
![image](https://user-images.githubusercontent.com/7877010/40950025-bf95c040-6825-11e8-8e01-e5debfaf8f1a.png)
