### PR TITLE
Merge ErrorFlyout abilities into Flyout

### DIFF
--- a/docs/src/ErrorFlyout.doc.js
+++ b/docs/src/ErrorFlyout.doc.js
@@ -1,9 +1,6 @@
 // @flow
 import React from 'react';
-import PropTable from './components/PropTable';
-import Example from './components/Example';
 import PageHeader from './components/PageHeader';
-import Card from './components/Card';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -11,134 +8,8 @@ const card = c => cards.push(c);
 card(
   <PageHeader
     name="ErrorFlyout"
-    description="[TextField](#TextField) and [TextArea](#TextArea) already have errors built into them. This component
-is only for use with errors on other types of form fields."
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'anchor',
-        type: '?any',
-        required: true,
-        description: 'Ref for the element that the ErrorFlyout will attach to',
-      },
-      {
-        name: 'id',
-        type: 'string',
-      },
-      {
-        name: 'idealDirection',
-        type: `"up" | "right" | "down" | "left"`,
-        description: 'Preferred direction for the ErrorFlyout to open',
-      },
-      {
-        name: 'message',
-        type: 'string',
-        required: true,
-        description: 'Error message to be displayed',
-      },
-      {
-        name: 'onDismiss',
-        type: '() => void',
-        required: true,
-      },
-      {
-        name: 'positionRelativeToAnchor',
-        type: 'boolean',
-        defaultValue: true,
-        description:
-          'Depicts if the ErrorFlyout shares a relative root with the anchor element',
-      },
-      {
-        name: 'size',
-        type: `"xs" | "sm" | "md"`,
-        description: `xs: 185px, sm: 230px, md: 284px`,
-        defaultValue: 'sm',
-      },
-    ]}
-  />
-);
-
-card(
-  <Example
-    description="
-
-  "
-    name="Example"
-    defaultCode={`
-class ErrorFlyoutExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false };
-    this.handleClick = this._handleClick.bind(this);
-    this.handleDismiss = this._handleDismiss.bind(this);
-  }
-  _handleClick() {
-    this.setState(() => ({ open: !this.state.open }));
-  }
-  _handleDismiss() {
-    this.setState(() => ({ open: false }));
-  }
-  render() {
-    return (
-      <Box>
-        <div
-          style={{ display: "inline-block" }}
-          ref={c => {
-            this.anchor = c;
-          }}
-        >
-          <Button onClick={this.handleClick} text="Remove" />
-        </div>
-        {this.state.open && (
-          <ErrorFlyout
-            anchor={this.anchor}
-            idealDirection="down"
-            message="Oops! This item is out of stock."
-            onDismiss={this.handleDismiss}
-            size="sm"
-          />
-        )}
-      </Box>
-    );
-  }
-}
-`}
-  />
-);
-
-card(
-  <Card
-    description={`
-    The \`anchor\` ref you pass in should not include anything other than the trigger element itself. The Flyout
-    calculates its' position based on the bounding box of the \`anchor\`. To achieve this, we recommend setting a
-    ref directly on the component itself or adding \`display: inline-block\` to the parent container with the ref.
-
-    If you put the \`ErrorFlyout\` in a portal or provider or it no longer shares
-    a relative root with the \`anchor\`, you must set \`positionRelativeToAnchor=false\` in order for it to be
-    positioned correctly relative to the body.
-  `}
-    name="anchor"
-  />
-);
-
-card(
-  <Card
-    description={`
-    The \`ErrorFlyout\` component gives you the ability to _influence_ the preferred direction that it
-    opens. This may be a useful property to specify if you have a page with many potential Errors
-    and you want the behavior to look uniform.
-
-    If an \`idealDirection\` is provided, the ErrorFlyout will attempt to open in the direction specified.
-    It is important to note that the direction you specifiy can be over-ruled if there is not enough space
-    within the viewport in that specific direction and there is enough space in another direction. If no
-    \`idealDirection\` is provided, the ErrorFlyout will open in the direction where there is the
-    most space available within the viewport.
-  `}
-    name="Ideal Direction Preference"
+    description={`WARNING: This component is deprecated and will be removed in the next release.
+      Please use \`<Flyout />\` with a \`role\` set to \`alertdialog\` instead.`}
   />
 );
 

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -47,6 +47,13 @@ card(
           'Depicts if the Flyout shares a relative root with the anchor element',
       },
       {
+        name: 'role',
+        type: `"alertdialog" | "dialog"`,
+        defaultValue: 'dialog',
+        description:
+          'The render style for this Flyout: alertdialog changes the colors to match other errors',
+      },
+      {
         name: 'size',
         type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | number`,
         description: `xs: 185px, sm: 230px, md: 284px, lg: 320px, xl:375px`,
@@ -93,7 +100,6 @@ class FlyoutExample extends React.Component {
           <Flyout
             anchor={this.anchor}
             idealDirection="up"
-            message="Oops! This item is out of stock."
             onDismiss={this.handleDismiss}
             size="md"
           >
@@ -111,7 +117,59 @@ class FlyoutExample extends React.Component {
   }
 }
 `}
-    direction="row"
+  />
+);
+
+card(
+  <Example
+    name="Example: ErrorFlyout"
+    description={`Flyout can also take on additional roles. Like [TextField](#TextField) and [TextArea](#TextArea), this component
+can be used to highlight errors on other types of form fields by setting the \`role\` to \`alertdialog.\``}
+    defaultCode={`
+class ErrorFlyoutExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { open: false };
+    this.handleClick = this._handleClick.bind(this);
+    this.handleDismiss = this._handleDismiss.bind(this);
+  }
+  _handleClick() {
+    this.setState(() => ({ open: !this.state.open }));
+  }
+  _handleDismiss() {
+    this.setState(() => ({ open: false }));
+  }
+  render() {
+    return (
+      <Box>
+        <div
+          style={{ display: "inline-block" }}
+          ref={c => {
+            this.anchor = c;
+          }}
+        >
+          <Button onClick={this.handleClick} text="Remove" />
+        </div>
+        {this.state.open &&
+          <Flyout
+            anchor={this.anchor}
+            idealDirection="up"
+            onDismiss={this.handleDismiss}
+            role="alertdialog"
+            size="md"
+          >
+            <Box padding={3}>
+              <Text bold color="white">
+                Oops! This item is out of stock.
+              </Text>
+            </Box>
+          </Flyout>
+        }
+      </Box>
+    );
+  }
+}
+`}
   />
 );
 

--- a/packages/gestalt/src/Flyout/Flyout.js
+++ b/packages/gestalt/src/Flyout/Flyout.js
@@ -5,43 +5,50 @@ import Controller from '../FlyoutUtils/Controller';
 
 type Props = {|
   anchor: ?any,
-  children?: any,
+  children?: React.Node,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
   positionRelativeToAnchor?: boolean,
+  role?: 'alertdialog' | 'dialog',
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number,
 |};
 
-export default class Flyout extends React.PureComponent<Props> {
-  render() {
-    const {
-      anchor,
-      children,
-      idealDirection,
-      positionRelativeToAnchor = true,
-      onDismiss,
-      size,
-    } = this.props;
+export default function Flyout(props: Props) {
+  const {
+    anchor,
+    children,
+    idealDirection,
+    onDismiss,
+    positionRelativeToAnchor = true,
+    role,
+    size,
+  } = props;
 
-    if (!anchor) {
-      return null;
-    }
-
-    return (
-      <Controller
-        anchor={anchor}
-        bgColor="white"
-        idealDirection={idealDirection}
-        onDismiss={onDismiss}
-        positionRelativeToAnchor={positionRelativeToAnchor}
-        shouldFocus
-        size={size}
-      >
-        {children}
-      </Controller>
-    );
+  if (!anchor) {
+    return null;
   }
+
+  const bgColor = role === 'alertdialog' ? 'orange' : 'white';
+
+  return (
+    <Controller
+      anchor={anchor}
+      bgColor={bgColor}
+      idealDirection={idealDirection}
+      onDismiss={onDismiss}
+      positionRelativeToAnchor={positionRelativeToAnchor}
+      shouldFocus={role === 'dialog'}
+      size={size}
+    >
+      {children}
+    </Controller>
+  );
 }
+
+Flyout.defaultProps = {
+  role: 'dialog',
+  positionRelativeToAnchor: true,
+};
 
 Flyout.propTypes = {
   anchor: PropTypes.shape({
@@ -52,6 +59,7 @@ Flyout.propTypes = {
   idealDirection: PropTypes.oneOf(['up', 'right', 'down', 'left']),
   onDismiss: PropTypes.func.isRequired,
   positionRelativeToAnchor: PropTypes.bool,
+  role: PropTypes.oneOf(['alertdialog', 'dialog']),
   size: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']), // default: sm

--- a/packages/gestalt/src/Flyout/__tests__/Flyout.jsdom.test.js
+++ b/packages/gestalt/src/Flyout/__tests__/Flyout.jsdom.test.js
@@ -17,6 +17,21 @@ test('Flyout renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Flyout renders as error', () => {
+  const element = document.createElement('div');
+  const component = create(
+    <Flyout
+      anchor={element}
+      idealDirection="down"
+      onDismiss={jest.fn()}
+      role="alertdialog"
+      size="sm"
+    />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Flyout does not render when the anchor is null', () => {
   const tree = create(<Flyout anchor={null} onDismiss={() => {}} />).toJSON();
   expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/Flyout/__tests__/__snapshots__/Flyout.jsdom.test.js.snap
+++ b/packages/gestalt/src/Flyout/__tests__/__snapshots__/Flyout.jsdom.test.js.snap
@@ -9,3 +9,11 @@ exports[`Flyout renders 1`] = `
   <div />
 </div>
 `;
+
+exports[`Flyout renders as error 1`] = `
+<div
+  className="box"
+>
+  <div />
+</div>
+`;


### PR DESCRIPTION
Since `ErrorFlyout` is just a type of `Flyout` it makes sense to merge these as @chrislloyd pointed out.
Migration plan:
1. This PR - merge ErrorFlyout abilities into Flyout. The main differences are the background, the `shouldFocus` prop, and the `children`. I chose to handle this by implementing a `role` prop with options similar to `Modal` (`alertdialog` and `dialog`). @chrislloyd is this ok or should we just switch to `type = 'error' | 'dialog'`?
2. Cut a release with this change and convert all `<ErrorFlyout />` uses to `<Flyout role="alertdialog">`. At this stage we should convert the `message` prop from `ErrorFlyout` to a child that looks like
```
      <Box padding={3}>
        <Text bold color="white">
          <span id={id}>{message}</span>
        </Text>
      </Box>
```
Does this look good, or should we update the Flow typing such that `role = 'alertdialog'` automatically adds this snippet for children and expects a `message` prop as well @chrislloyd ?
3. Cut another release where we remove the exported `ErrorFlyout` once and for all