### PR TITLE
Make Card explicitely use box-sizing: content-box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Masonry: Makes Masonry React Async compatible (#227)
 * SegmentedControl: Change flow type of `items` to `React.Node` (#230)
 * Video: Add jsdom browser specific tests (#205)
+* Card: Make Card explicitely use box-sizing: content-box (#243)
 
 ### Patch
 * Internal: add better basic test coverage (#231)

--- a/packages/gestalt/src/Card/Card.css
+++ b/packages/gestalt/src/Card/Card.css
@@ -1,7 +1,7 @@
 .card {
   composes: absolute from "../Layout.css";
   composes: rounded from "../Borders.css";
-  composes: top0 right0 bottom0 left0 from "../Layout.css";
+  composes: top0 right0 bottom0 left0 contentBox from "../Layout.css";
   background: rgba(0, 0, 0, 0.064);
   height: 100%;
   opacity: 0;

--- a/packages/gestalt/src/Layout.css
+++ b/packages/gestalt/src/Layout.css
@@ -103,6 +103,10 @@
   box-sizing: border-box;
 }
 
+.contentBox {
+  box-sizing: content-box;
+}
+
 .flex {
   display: flex;
 }


### PR DESCRIPTION
Fixes https://github.com/pinterest/gestalt/issues/234

Card implicitly uses content-box, but breaks if someone is using * { box-sizing: border-box } for all elements. 

Note: We use content-box to transform: scale with pixels rather than a multiple.