### PR TITLE
Container-based sizing for GroupAvatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@
     Click to see more.
   </summary>
 
+### Major
+* GroupAvatar: `size` prop is now optional. (#244)
+
 ### Minor
 * Masonry: Makes Masonry React Async compatible (#227)
 * SegmentedControl: Change flow type of `items` to `React.Node` (#230)
 * Video: Add jsdom browser specific tests (#205)
 * Card: Make Card explicitely use box-sizing: content-box (#243)
+* GroupAvatar: Text sizes have shrunk to be consistent with Avatar. (#244)
 
 ### Patch
 * Internal: add better basic test coverage (#231)

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -81,32 +81,6 @@ card(
 );
 
 card(
-  <Example
-    description={`
-    GroupAvatars that are not given a \`size\` prop will be expand to fit to the width of their
-    parent container. A common use case is to achieve column-based sizing.
-
-    Resize the browser to see these GroupAvatar change to match the width of the \`Column\` they
-    have been placed in.
-  `}
-    name="Container Based Sizes"
-    defaultCode={`
-<Box display="flex" direction="row">
-  <Box column={2} padding={2}>
-    <GroupAvatar collaborators={[{ name: 'Julia' }]} />
-  </Box>
-  <Box column={2} padding={2}>
-    <GroupAvatar collaborators={[{ name: 'James', src: "${james}" }, { name: 'Julia' }]} />
-  </Box>
-  <Box column={3} padding={2}>
-    <GroupAvatar collaborators={[{ name: 'Keerthi', src: "${keerthi}" }, { name: 'Shanice', src: "${shanice}" }, { name: 'Julia' }]} />
-  </Box>
-</Box>
-  `}
-  />
-);
-
-card(
   <Combination name="Size Combinations: 1 Person" size={['sm', 'md', 'lg']}>
     {props => <GroupAvatar collaborators={[user1]} {...props} />}
   </Combination>
@@ -154,6 +128,32 @@ card(
       />
     )}
   </Combination>
+);
+
+card(
+  <Example
+    description={`
+    GroupAvatars that are not given a \`size\` prop will be expand to fit to the width of their
+    parent container. A common use case is to achieve column-based sizing.
+
+    Resize the browser to see these GroupAvatar change to match the width of the \`Column\` they
+    have been placed in.
+  `}
+    name="Container Based Sizes"
+    defaultCode={`
+<Box display="flex" direction="row">
+  <Box column={2} padding={2}>
+    <GroupAvatar collaborators={[{ name: 'Julia' }]} />
+  </Box>
+  <Box column={2} padding={2}>
+    <GroupAvatar collaborators={[{ name: 'James', src: "${james}" }, { name: 'Julia' }]} />
+  </Box>
+  <Box column={3} padding={2}>
+    <GroupAvatar collaborators={[{ name: 'Keerthi', src: "${keerthi}" }, { name: 'Shanice', src: "${shanice}" }, { name: 'Julia' }]} />
+  </Box>
+</Box>
+  `}
+  />
 );
 
 export default cards;

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -37,8 +37,8 @@ card(
       {
         name: 'size',
         type: `"sm" | "md" | "lg"`,
-        description: 'sm: 24px, md: 40px, lg: 72px',
-        required: true,
+        description:
+          'sm: 24px, md: 40px, lg: 72px. If size is undefined, Avatar will fill 100% of the parent container width',
       },
     ]}
   />
@@ -77,6 +77,32 @@ card(
   />
 </Box>
 `}
+  />
+);
+
+card(
+  <Example
+    description={`
+    GroupAvatars that are not given a \`size\` prop will be expand to fit to the width of their
+    parent container. A common use case is to achieve column-based sizing.
+
+    Resize the browser to see these GroupAvatar change to match the width of the \`Column\` they
+    have been placed in.
+  `}
+    name="Container Based Sizes"
+    defaultCode={`
+<Box display="flex" direction="row">
+  <Box column={2} padding={2}>
+    <GroupAvatar collaborators={[{ name: 'Julia' }]} />
+  </Box>
+  <Box column={2} padding={2}>
+    <GroupAvatar collaborators={[{ name: 'James', src: "${james}" }, { name: 'Julia' }]} />
+  </Box>
+  <Box column={3} padding={2}>
+    <GroupAvatar collaborators={[{ name: 'Keerthi', src: "${keerthi}" }, { name: 'Shanice', src: "${shanice}" }, { name: 'Julia' }]} />
+  </Box>
+</Box>
+  `}
   />
 );
 

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -133,13 +133,13 @@ card(
 card(
   <Example
     description={`
-    GroupAvatars that are not given a \`size\` prop will be expand to fit to the width of their
+    GroupAvatars that are not given a \`size\` prop will expand to fit to the width of their
     parent container. A common use case is to achieve column-based sizing.
 
     Resize the browser to see these GroupAvatar change to match the width of the \`Column\` they
     have been placed in.
   `}
-    name="Container Based Sizes"
+    name="Container-based Sizes"
     defaultCode={`
 <Box display="flex" direction="row">
   <Box column={2} padding={2}>

--- a/packages/gestalt/src/GroupAvatar/GroupAvatar.js
+++ b/packages/gestalt/src/GroupAvatar/GroupAvatar.js
@@ -110,7 +110,7 @@ const DefaultAvatar = (props: {|
           typography.fontWeightBold,
         ].join(' ')}
       >
-        {[...name][0].toUpperCase()}
+        {name ? [...name][0].toUpperCase() : ''}
       </text>
     </svg>
   );
@@ -190,37 +190,39 @@ export default function GroupAvatar(props: Props) {
       }}
     >
       <Box dangerouslySetInlineStyle={{ __style: { paddingBottom: '100%' } }} />
-      {zip(positions, collaborators).map(([position, collaborator], idx) => {
-        const { width, height, top, left, textLayout } = position;
-        const { name, src } = collaborator;
-        return (
-          <Box
-            key={idx}
-            position="absolute"
-            width={width}
-            height={height}
-            dangerouslySetInlineStyle={{ __style: { top, left } }}
-          >
-            {src ? (
-              <Image
-                alt={name}
-                color="#EFEFEF"
-                src={src}
-                naturalWidth={1}
-                naturalHeight={1}
-                fit="cover"
-              />
-            ) : (
-              <DefaultAvatar
-                name={name}
-                textLayout={textLayout}
-                size={height}
-              />
-            )}
-            <div className={styles.wash} />
-          </Box>
-        );
-      })}
+      {zip(positions, collaborators).map(
+        ([position, collaborator = { name: '', src: undefined }], idx) => {
+          const { width, height, top, left, textLayout } = position;
+          const { name, src } = collaborator;
+          return (
+            <Box
+              key={idx}
+              position="absolute"
+              width={width}
+              height={height}
+              dangerouslySetInlineStyle={{ __style: { top, left } }}
+            >
+              {src ? (
+                <Image
+                  alt={name}
+                  color="#EFEFEF"
+                  src={src}
+                  naturalWidth={1}
+                  naturalHeight={1}
+                  fit="cover"
+                />
+              ) : (
+                <DefaultAvatar
+                  name={name}
+                  textLayout={textLayout}
+                  size={height}
+                />
+              )}
+              <div className={styles.wash} />
+            </Box>
+          );
+        }
+      )}
     </Box>
   );
 }

--- a/packages/gestalt/src/GroupAvatar/__tests__/GroupAvatar.test.js
+++ b/packages/gestalt/src/GroupAvatar/__tests__/GroupAvatar.test.js
@@ -102,4 +102,16 @@ describe('GroupAvatar', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders with container-based sizing', () => {
+    const tree = create(
+      <GroupAvatar
+        collaborators={[
+          { name: 'Jane Smith', src: 'foo.png' },
+          { name: 'Jane Smith', src: 'foo.png' },
+        ]}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/gestalt/src/GroupAvatar/__tests__/__snapshots__/GroupAvatar.test.js.snap
+++ b/packages/gestalt/src/GroupAvatar/__tests__/__snapshots__/GroupAvatar.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`GroupAvatar renders an outline 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "boxShadow": "0 0 0 2px #fff",
@@ -13,93 +13,71 @@ exports[`GroupAvatar renders an outline 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
-        "width": 40,
+        "left": 0,
+        "top": 0,
+        "width": "calc(50% - 1px)",
       }
     }
   >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 19,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 40,
-            "width": 19,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    />
     <div
-      className="absolute"
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": 40,
+        "left": "calc(50% + 1px)",
+        "top": 0,
+        "width": "calc(50% - 1px)",
+      }
+    }
+  >
+    <div
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 40,
-          "left": 21,
-          "top": 0,
-          "width": 19,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 40,
-            "width": 19,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    />
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;
 
 exports[`GroupAvatar renders avatars for 0 people 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "height": 40,
@@ -109,58 +87,64 @@ exports[`GroupAvatar renders avatars for 0 people 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
+        "left": 0,
+        "top": 0,
         "width": 40,
       }
     }
   >
     <div
-      className="absolute"
+      aria-label=""
+      className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 40,
+          "height": "100%",
         }
       }
     >
-      <div
-        aria-label=" "
-        className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
-        style={
-          Object {
-            "height": 40,
-          }
-        }
+      <svg
+        preserveAspectRatio="xMidYMid meet"
+        version="1.1"
+        viewBox="-50 -50 100 100"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <div
-          className="Text fontSize3 white leadingShort alignLeft breakWord fontStyleNormal fontWeightBold"
+        <title>
+          
+        </title>
+        <text
+          className="antialiased sansSerif leadingSmall fontWeightBold"
+          dominantBaseline="central"
+          fill="#fff"
+          fontSize="50px"
+          textAnchor="middle"
         >
-          <div
-            className="box"
-            style={
-              Object {
-                "fontSize": 22,
-                "lineHeight": "22px",
-              }
-            }
-          >
-             
-          </div>
-        </div>
-      </div>
+          
+        </text>
+      </svg>
     </div>
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;
 
 exports[`GroupAvatar renders avatars for 1 person 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "height": 40,
@@ -170,57 +154,45 @@ exports[`GroupAvatar renders avatars for 1 person 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
+        "left": 0,
+        "top": 0,
         "width": 40,
       }
     }
   >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 40,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 40,
-            "width": 40,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    />
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;
 
 exports[`GroupAvatar renders avatars for 2 people 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "height": 40,
@@ -230,93 +202,71 @@ exports[`GroupAvatar renders avatars for 2 people 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
-        "width": 40,
+        "left": 0,
+        "top": 0,
+        "width": "calc(50% - 1px)",
       }
     }
   >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 19,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 40,
-            "width": 19,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    />
     <div
-      className="absolute"
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": 40,
+        "left": "calc(50% + 1px)",
+        "top": 0,
+        "width": "calc(50% - 1px)",
+      }
+    }
+  >
+    <div
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 40,
-          "left": 21,
-          "top": 0,
-          "width": 19,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 40,
-            "width": 19,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    />
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;
 
 exports[`GroupAvatar renders avatars for 3 people 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "height": 40,
@@ -326,129 +276,97 @@ exports[`GroupAvatar renders avatars for 3 people 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
-        "width": 41,
+        "left": 0,
+        "top": 0,
+        "width": "calc(50% - 1px)",
       }
     }
   >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 19,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 40,
-            "width": 19,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    />
     <div
-      className="absolute"
-      style={
-        Object {
-          "height": 19,
-          "left": 21,
-          "top": 0,
-          "width": 20,
-        }
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": "calc(50% - 1px)",
+        "left": "calc(50% + 1px)",
+        "top": 0,
+        "width": "calc(50%)",
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 19,
-            "width": 20,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    }
+  >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 19,
-          "left": 21,
-          "top": 21,
-          "width": 20,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 19,
-            "width": 20,
-          }
+    />
+    <div
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": "calc(50% - 1px)",
+        "left": "calc(50% + 1px)",
+        "top": "calc(50% + 1px)",
+        "width": "calc(50%)",
+      }
+    }
+  >
+    <div
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
+      style={
+        Object {
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+      }
+    />
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;
 
 exports[`GroupAvatar renders avatars for more than 3 AVATAR_SIZES 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "height": 40,
@@ -458,129 +376,97 @@ exports[`GroupAvatar renders avatars for more than 3 AVATAR_SIZES 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
-        "width": 41,
+        "left": 0,
+        "top": 0,
+        "width": "calc(50% - 1px)",
       }
     }
   >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 19,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 40,
-            "width": 19,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    />
     <div
-      className="absolute"
-      style={
-        Object {
-          "height": 19,
-          "left": 21,
-          "top": 0,
-          "width": 20,
-        }
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": "calc(50% - 1px)",
+        "left": "calc(50% + 1px)",
+        "top": 0,
+        "width": "calc(50%)",
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 19,
-            "width": 20,
-          }
-        }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+    }
+  >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
       style={
         Object {
-          "height": 19,
-          "left": 21,
-          "top": 21,
-          "width": 20,
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
       }
-    >
-      <div
-        className="box relative"
-        style={
-          Object {
-            "height": 19,
-            "width": 20,
-          }
+    />
+    <div
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": "calc(50% - 1px)",
+        "left": "calc(50% + 1px)",
+        "top": "calc(50% + 1px)",
+        "width": "calc(50%)",
+      }
+    }
+  >
+    <div
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
+      style={
+        Object {
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
         }
-      >
-        <div
-          aria-label="Jane Smith"
-          className="cover"
-          role="img"
-          style={
-            Object {
-              "backgroundColor": "#EFEFEF",
-              "backgroundImage": "url('foo.png')",
-            }
-          }
-        />
-        <div
-          className="wash"
-        />
-      </div>
-    </div>
+      }
+    />
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;
 
 exports[`GroupAvatar renders multi-byte character initials 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "height": 40,
@@ -590,58 +476,64 @@ exports[`GroupAvatar renders multi-byte character initials 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
+        "left": 0,
+        "top": 0,
         "width": 40,
       }
     }
   >
     <div
-      className="absolute"
+      aria-label="💩 astral"
+      className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 40,
+          "height": "100%",
         }
       }
     >
-      <div
-        aria-label="💩 astral"
-        className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
-        style={
-          Object {
-            "height": 40,
-          }
-        }
+      <svg
+        preserveAspectRatio="xMidYMid meet"
+        version="1.1"
+        viewBox="-50 -50 100 100"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <div
-          className="Text fontSize3 white leadingShort alignLeft breakWord fontStyleNormal fontWeightBold"
+        <title>
+          💩 astral
+        </title>
+        <text
+          className="antialiased sansSerif leadingSmall fontWeightBold"
+          dominantBaseline="central"
+          fill="#fff"
+          fontSize="50px"
+          textAnchor="middle"
         >
-          <div
-            className="box"
-            style={
-              Object {
-                "fontSize": 22,
-                "lineHeight": "22px",
-              }
-            }
-          >
-            💩
-          </div>
-        </div>
-      </div>
+          💩
+        </text>
+      </svg>
     </div>
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;
 
 exports[`GroupAvatar renders single-byte character initials for 1 person 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "height": 40,
@@ -651,58 +543,64 @@ exports[`GroupAvatar renders single-byte character initials for 1 person 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
+        "left": 0,
+        "top": 0,
         "width": 40,
       }
     }
   >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 40,
+          "height": "100%",
         }
       }
     >
-      <div
-        aria-label="Jane Smith"
-        className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
-        style={
-          Object {
-            "height": 40,
-          }
-        }
+      <svg
+        preserveAspectRatio="xMidYMid meet"
+        version="1.1"
+        viewBox="-50 -50 100 100"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <div
-          className="Text fontSize3 white leadingShort alignLeft breakWord fontStyleNormal fontWeightBold"
+        <title>
+          Jane Smith
+        </title>
+        <text
+          className="antialiased sansSerif leadingSmall fontWeightBold"
+          dominantBaseline="central"
+          fill="#fff"
+          fontSize="50px"
+          textAnchor="middle"
         >
-          <div
-            className="box"
-            style={
-              Object {
-                "fontSize": 22,
-                "lineHeight": "22px",
-              }
-            }
-          >
-            J
-          </div>
-        </div>
-      </div>
+          J
+        </text>
+      </svg>
     </div>
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;
 
 exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
 <div
-  className="box circle overflowHidden whiteBg"
+  className="box circle overflowHidden relative whiteBg"
   style={
     Object {
       "height": 40,
@@ -712,127 +610,225 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
   }
 >
   <div
-    className="relative"
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
     style={
       Object {
         "height": 40,
-        "width": 41,
+        "left": 0,
+        "top": 0,
+        "width": "calc(50% - 1px)",
       }
     }
   >
     <div
-      className="absolute"
+      aria-label="Jane Smith"
+      className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
       style={
         Object {
-          "height": 40,
-          "left": 0,
-          "top": 0,
-          "width": 19,
+          "height": "100%",
         }
       }
     >
-      <div
-        aria-label="Jane Smith"
-        className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
-        style={
-          Object {
-            "height": 40,
-          }
-        }
+      <svg
+        preserveAspectRatio="xMidYMid meet"
+        version="1.1"
+        viewBox="-50 -50 100 100"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <div
-          className="Text fontSize3 white leadingShort alignLeft breakWord fontStyleNormal fontWeightBold"
+        <title>
+          Jane Smith
+        </title>
+        <text
+          className="antialiased sansSerif leadingSmall fontWeightBold"
+          dominantBaseline="central"
+          fill="#fff"
+          fontSize="50px"
+          textAnchor="middle"
         >
-          <div
-            className="box"
-            style={
-              Object {
-                "fontSize": 11,
-                "lineHeight": "11px",
-              }
-            }
-          >
-            J
-          </div>
-        </div>
-      </div>
+          J
+        </text>
+      </svg>
     </div>
     <div
-      className="absolute"
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": "calc(50% - 1px)",
+        "left": "calc(50% + 1px)",
+        "top": 0,
+        "width": "calc(50%)",
+      }
+    }
+  >
+    <div
+      aria-label="Jane Smith"
+      className="box grayBg itemsStart xsDisplayFlex"
       style={
         Object {
-          "height": 19,
-          "left": 21,
-          "top": 0,
-          "width": 20,
+          "height": "100%",
+          "paddingRight": "calc(0.7071067811865475 * (calc(50% - 1px)) / 2)",
+          "paddingTop": "calc(0.7071067811865475 * (calc(50% - 1px)) / 2)",
         }
       }
     >
-      <div
-        aria-label="Jane Smith"
-        className="box grayBg itemsEnd xsDisplayFlex"
-        style={
-          Object {
-            "height": 19,
-            "padding": 3,
-          }
-        }
+      <svg
+        preserveAspectRatio="xMidYMid meet"
+        version="1.1"
+        viewBox="-50 -50 100 100"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <div
-          className="Text fontSize3 white leadingShort alignLeft breakWord fontStyleNormal fontWeightBold"
+        <title>
+          Jane Smith
+        </title>
+        <text
+          className="antialiased sansSerif leadingSmall fontWeightBold"
+          dominantBaseline="central"
+          fill="#fff"
+          fontSize="50px"
+          textAnchor="middle"
         >
-          <div
-            className="box"
-            style={
-              Object {
-                "fontSize": 11,
-                "lineHeight": "11px",
-              }
-            }
-          >
-            J
-          </div>
-        </div>
-      </div>
+          J
+        </text>
+      </svg>
     </div>
     <div
-      className="absolute"
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": "calc(50% - 1px)",
+        "left": "calc(50% + 1px)",
+        "top": "calc(50% + 1px)",
+        "width": "calc(50%)",
+      }
+    }
+  >
+    <div
+      aria-label="Jane Smith"
+      className="box grayBg itemsEnd xsDisplayFlex"
       style={
         Object {
-          "height": 19,
-          "left": 21,
-          "top": 21,
-          "width": 20,
+          "height": "100%",
+          "paddingBottom": "calc(0.7071067811865475 * (calc(50% - 1px)) / 2)",
+          "paddingRight": "calc(0.7071067811865475 * (calc(50% - 1px)) / 2)",
         }
       }
     >
-      <div
-        aria-label="Jane Smith"
-        className="box grayBg itemsStart xsDisplayFlex"
-        style={
-          Object {
-            "height": 19,
-            "padding": 3,
-          }
-        }
+      <svg
+        preserveAspectRatio="xMidYMid meet"
+        version="1.1"
+        viewBox="-50 -50 100 100"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <div
-          className="Text fontSize3 white leadingShort alignLeft breakWord fontStyleNormal fontWeightBold"
+        <title>
+          Jane Smith
+        </title>
+        <text
+          className="antialiased sansSerif leadingSmall fontWeightBold"
+          dominantBaseline="central"
+          fill="#fff"
+          fontSize="50px"
+          textAnchor="middle"
         >
-          <div
-            className="box"
-            style={
-              Object {
-                "fontSize": 11,
-                "lineHeight": "11px",
-              }
-            }
-          >
-            J
-          </div>
-        </div>
-      </div>
+          J
+        </text>
+      </svg>
     </div>
+    <div
+      className="wash"
+    />
+  </div>
+</div>
+`;
+
+exports[`GroupAvatar renders with container-based sizing 1`] = `
+<div
+  className="box circle overflowHidden relative whiteBg"
+  style={
+    Object {
+      "height": "",
+      "width": "100%",
+      "willChange": "transform",
+    }
+  }
+>
+  <div
+    className="box"
+    style={
+      Object {
+        "paddingBottom": "100%",
+      }
+    }
+  />
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": "100%",
+        "left": 0,
+        "top": 0,
+        "width": "calc(50% - 1px)",
+      }
+    }
+  >
+    <div
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
+      style={
+        Object {
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
+        }
+      }
+    />
+    <div
+      className="wash"
+    />
+  </div>
+  <div
+    className="absolute box"
+    style={
+      Object {
+        "height": "100%",
+        "left": "calc(50% + 1px)",
+        "top": 0,
+        "width": "calc(50% - 1px)",
+      }
+    }
+  >
+    <div
+      aria-label="Jane Smith"
+      className="cover"
+      role="img"
+      style={
+        Object {
+          "backgroundColor": "#EFEFEF",
+          "backgroundImage": "url('foo.png')",
+        }
+      }
+    />
+    <div
+      className="wash"
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
This makes the `size` prop optional on Group Avatar.

I also updated the text sizing to be consistent with the single-collaborator Avatar case.

Before:
![screen shot 2018-06-05 at 5 31 30 pm](https://user-images.githubusercontent.com/5060341/41009516-607c774a-68e6-11e8-99b1-c8d5f02d8053.png)

After: 
![screen shot 2018-06-05 at 5 31 37 pm](https://user-images.githubusercontent.com/5060341/41009519-63b4e154-68e6-11e8-9dae-1aaea8d8312f.png)

Avatar: 
![screen shot 2018-06-05 at 5 32 21 pm](https://user-images.githubusercontent.com/5060341/41009531-70e23660-68e6-11e8-8949-41c0ac2c080b.png)

(The text sizing difference is more obvious if you open the docs from the different versions in 2 tabs and quickly toggle between them.)
