### PR TITLE
Fix server swallowing video events on server render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * SegmentedControl: Change flow type of `items` to `React.Node` (#230)
 * Video: Add jsdom browser specific tests (#205)
 * Card: Make Card explicitely use box-sizing: content-box (#243)
+* Video: Move initial video setup calls to componentDidMount (#244)
 
 ### Patch
 * Internal: add better basic test coverage (#231)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * SegmentedControl: Change flow type of `items` to `React.Node` (#230)
 * Video: Add jsdom browser specific tests (#205)
 * Card: Make Card explicitely use box-sizing: content-box (#243)
-* Video: Move initial video setup calls to componentDidMount (#244)
+* Video: Move initial video setup calls to componentDidMount (#245)
 
 ### Patch
 * Internal: add better basic test coverage (#231)

--- a/packages/gestalt/src/Video/Video.js
+++ b/packages/gestalt/src/Video/Video.js
@@ -226,10 +226,20 @@ export default class Video extends React.PureComponent<Props, State> {
    */
 
   componentDidMount() {
+    const { playbackRate, playing, volume } = this.props;
     // Set up event listeners to catch backdoors in fullscreen
     // changes such as using the ESC key to exit
     if (typeof document !== 'undefined') {
       addFullscreenEventListener(this.handleFullscreenChange);
+    }
+    // Set the initial volume
+    this.setVolume(volume);
+    // Set the initial playback rate
+    this.setPlaybackRate(playbackRate);
+    // Simulate an autoplay effect if the component was mounted with
+    // playing set to true
+    if (playing) {
+      this.play();
     }
   }
 
@@ -339,14 +349,7 @@ export default class Video extends React.PureComponent<Props, State> {
 
   // Sent when enough data is available that the media can be played
   handleCanPlay = (event: SyntheticEvent<HTMLVideoElement>) => {
-    const { onReady, playbackRate, playing } = this.props;
-    // Simulate an autoplay effect if the component was mounted with
-    // playing set to true
-    if (playing) {
-      this.play();
-    }
-    // Set the initial playback rate when video is raedy to play
-    this.setPlaybackRate(playbackRate);
+    const { onReady } = this.props;
 
     if (onReady) {
       onReady({ event });

--- a/packages/gestalt/src/Video/Video.js
+++ b/packages/gestalt/src/Video/Video.js
@@ -232,12 +232,13 @@ export default class Video extends React.PureComponent<Props, State> {
     if (typeof document !== 'undefined') {
       addFullscreenEventListener(this.handleFullscreenChange);
     }
+    // Load the video to hydrate the DOM after a server render
+    this.load();
     // Set the initial volume
     this.setVolume(volume);
     // Set the initial playback rate
     this.setPlaybackRate(playbackRate);
-    // Simulate an autoplay effect if the component was mounted with
-    // playing set to true
+    // Simulate an autoplay effect if the component
     if (playing) {
       this.play();
     }


### PR DESCRIPTION
If server rendered, `onDurationChange` and `onCanPlay` were not being fired off by the native `video` element. By moving the initial setup calls like `setVolume` `setPlaybackRate` and `play` to `componentDidMount` we can make them mirror the other `componentDidUpdate` calls which do similar things since `componentDidMount` is not called on the server. This adds a `video.load()` call in that method as well in order to trigger those missing events on the client which are needed.