### PR TITLE
Fix OutsideEventBehavior capturing events too late

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@
 
 ### Patch
 
+* Modal: Fix issue with outside click error bubbling (#254)
+
 </details>
 
 ## 0.73.0 (Jun 8, 2018)
 
 ### Minor
+
 * Masonry: Makes Masonry React Async compatible (#227)
 * SegmentedControl: Change flow type of `items` to `React.Node` (#230)
 * Video: Add jsdom browser specific tests (#205)
@@ -25,6 +28,7 @@
 * Video: Move initial video setup calls to componentDidMount (#245)
 
 ### Patch
+
 * Internal: add better basic test coverage (#231)
 * Modal: Refactor internals and remove responsive behavior (#218)
 * Internal: update to jsdom only tests (#232)
@@ -40,6 +44,7 @@
 ## 0.72.0 (May 30, 2018)
 
 ### Minor
+
 * Video: Added new `onSeek` callback prop to `Video` component (#209)
 * Video: Added new `onReady` callback prop to `Video` component (#210)
 * Internal: Remove dead example code from docs (#211)
@@ -58,6 +63,7 @@
 ## 0.71.0 (May 23, 2018)
 
 ### Minor
+
 * Drop support for React 15 and bump React 16 version (#168)
 * Colors: Update blue color (#193)
 * Video: Fix background color for fullscreen video playback (#198)
@@ -69,6 +75,7 @@
 * Video: Add new `onEnded` prop for media end event (#207)
 
 ### Patch
+
 * Internal: Add code coverage to PRs (#185)
 * Internal: Internal: Convert ghostjs to puppeteer (#182)
 * Internal: Update Jest and use multi-project runner (#158)
@@ -85,6 +92,7 @@
 ## 0.70.0 (May 15, 2018)
 
 ### Minor
+
 * Avatar / GroupAvatar: make outline configurable(#173)
 * Masonry: Update non-virtualized Masonry to render all items regardless of the window
 * ExperimentalMasonry: remove component (#183)

--- a/packages/gestalt/src/behaviors/OutsideEventBehavior.js
+++ b/packages/gestalt/src/behaviors/OutsideEventBehavior.js
@@ -9,11 +9,15 @@ type Props = {|
 
 export default class OutsideEventBehavior extends React.Component<Props> {
   componentDidMount() {
-    document.addEventListener('click', this.handleClickEvent);
+    document.addEventListener('click', this.handleClickEvent, {
+      capture: true,
+    });
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.handleClickEvent);
+    document.removeEventListener('click', this.handleClickEvent, {
+      capture: true,
+    });
   }
 
   handleClickEvent = (event: MouseEvent) => {


### PR DESCRIPTION
Change OutsideEventBehavior to capture click early to prevent subcomponents re-rendering and the event.target being removed from the DOM.