### PR TITLE
Fix Image docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Patch
 
+* Docs: Fix "fit" labels in Image docs example (#259)
 * Internal: Set up pre-commit hooks for linting and testing (#258)
 
 </details>

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -182,7 +182,7 @@ card(
     defaultCode={`
 <Box display="flex" direction="row" wrap>
   <Box>
-    <h3>Tall content: cover vs contain</h3>
+    <h3>Square content: contain vs cover</h3>
     <Box display="flex" direction="row" justifyContent="around">
       <Box
         color="darkGray"
@@ -192,7 +192,7 @@ card(
         marginRight={4}
       >
         <Image
-          alt="tall"
+          alt="square"
           color="#000"
           fit="contain"
           naturalHeight={1}
@@ -208,7 +208,7 @@ card(
         marginRight={4}
       >
         <Image
-          alt="tall"
+          alt="square"
           color="#000"
           fit="cover"
           naturalHeight={1}
@@ -219,7 +219,7 @@ card(
     </Box>
   </Box>
   <Box>
-    <h3>Wide content: cover vs contain</h3>
+    <h3>Wide content: contain vs cover</h3>
     <Box display="flex" direction="row" justifyContent="around">
       <Box
         color="darkGray"
@@ -229,7 +229,7 @@ card(
         marginRight={4}
       >
         <Image
-          alt="tall"
+          alt="wide"
           color="#000"
           fit="contain"
           naturalHeight={1}
@@ -245,7 +245,7 @@ card(
         marginRight={4}
       >
         <Image
-          alt="tall"
+          alt="wide"
           color="#000"
           fit="cover"
           naturalHeight={1}
@@ -256,7 +256,7 @@ card(
     </Box>
   </Box>
   <Box>
-    <h3>Square content: cover vs contain</h3>
+    <h3>Tall content: contain vs cover</h3>
     <Box display="flex" direction="row" justifyContent="around">
       <Box
         color="darkGray"


### PR DESCRIPTION
Fix labels for *Square*, *Wide*, and *Tall* fits and corresponding *contain vs cover* label in Image docs example

**Before**
![image](https://user-images.githubusercontent.com/9427813/41626148-2ea8fc4e-73d0-11e8-9b7a-e68dad1f28fb.png)

**After**
![image](https://user-images.githubusercontent.com/9427813/41626083-f25efbda-73cf-11e8-81e5-fb6605bac950.png)
