### PR TITLE
Fix release script for gh-pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Patch
 
+* Internal: Fix release script for gh-pages (#266)
+
 </details>
 
 ## 0.75.0 (Jun 27, 2018)

--- a/scripts/ghpages.sh
+++ b/scripts/ghpages.sh
@@ -15,7 +15,7 @@ repo=${1:-https://github.com/pinterest/gestalt.git}
 git checkout -b tmp-deploy
 (cd docs && NODE_ENV=production yarn build --output-public-path '/gestalt')
 git add -f docs/build
-git commit -m "Deployed to Github Pages"
+git commit -m "Deployed to Github Pages" --no-verify
 git subtree split --prefix docs/build -b tmp-gh-pages
 git push -f ${repo} tmp-gh-pages:gh-pages
 git checkout master


### PR DESCRIPTION
My change to add pre-commit linting broke the gh-pages release script because it tries to run on the compiled files and blocks completion of the release. This flag bypasses that check on a release commit for gh-pages - something I had to work around in the 0.75.0 release - with this fix that will no longer be an issue.