### PR TITLE
Add docs and export for Layer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 * Icon: reduce filesize of each icon with 40% + add new icons (#269)
 * Video: Add a gradient overlay on the control bar (#27)
+* Layer: Layer component is now exported for use and has documentation
 
 ### Patch
 

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -1,0 +1,82 @@
+// @flow
+import * as React from 'react';
+import PropTable from './components/PropTable.js';
+import Example from './components/Example.js';
+import PageHeader from './components/PageHeader.js';
+
+const cards = [];
+const card = c => cards.push(c);
+
+card(
+  <PageHeader
+    name="Layer"
+    description="Layers allow you to render children outside the DOM hierarchy of the parent. It's a wrapper around React createPortal that lets you use it as a component. This is particularly useful for places you might have needed to use z-index to overlay the screen before."
+  />
+);
+
+card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+    ]}
+  />
+);
+
+card(
+  <Example
+    description="
+    Child content will be rendered outside the DOM hierarchy for easy overlaying. Click to see an example.
+  "
+    name="Overlaying Content"
+    defaultCode={`
+class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleToggle = this._handleToggle.bind(this);
+    this.state = {
+      showLayer: false,
+    };
+  }
+
+  _handleToggle() {
+    this.setState(prevState => ({ showLayer: !prevState.showLayer }));
+  }
+
+  render() {
+    const { showLayer } = this.state;
+    return (
+      <Box marginLeft={-1} marginRight={-1}>
+        <Box padding={1}>
+          <Button
+            text="Show Layer"
+            onClick={this.handleToggle}
+          />
+          {showLayer && (
+            <Layer>
+              <Box color="darkWash" position="fixed" top left right bottom display="flex" alignItems="center" justifyContent="center">
+                <Box color="white" padding="3" display="flex" alignItems="center">
+                  <Text>Layer Content</Text>
+                  <Box marginStart={2}>
+                    <IconButton
+                      accessibilityLabel="Close"
+                      icon="cancel"
+                      onClick={this.handleToggle}
+                    />
+                  </Box>
+                </Box>
+              </Box>
+            </Layer>
+          )}
+        </Box>
+      </Box>
+    );
+  }
+}
+`}
+  />
+);
+
+export default cards;

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -57,7 +57,7 @@ class Example extends React.Component {
           {showLayer && (
             <Layer>
               <Box color="darkWash" position="fixed" top left right bottom display="flex" alignItems="center" justifyContent="center">
-                <Box color="white" padding="3" display="flex" alignItems="center">
+                <Box color="white" padding={3} display="flex" alignItems="center">
                   <Text>Layer Content</Text>
                   <Box marginStart={2}>
                     <IconButton

--- a/packages/gestalt/src/Layer.jsdom.test.js
+++ b/packages/gestalt/src/Layer.jsdom.test.js
@@ -1,0 +1,31 @@
+// @flow
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { shallow } from 'enzyme';
+import Layer from './Layer.js';
+
+jest.mock('react-dom', () => ({
+  createPortal: jest.fn(children => children),
+}));
+
+test('Layer appends itself to body on mount', () => {
+  const body = document.getElementsByTagName('body')[0];
+  const wrapper = shallow(<Layer>content</Layer>);
+  const element = wrapper.instance().el;
+  expect(body.contains(element)).toBeTruthy();
+});
+
+test('Layer removes itself from body on unmount', () => {
+  const body = document.getElementsByTagName('body')[0];
+  const wrapper = shallow(<Layer>content</Layer>);
+  const element = wrapper.instance().el;
+  wrapper.unmount();
+  expect(body.contains(element)).toBeFalsy();
+});
+
+test('Layer renders through createPortal', () => {
+  const wrapper = shallow(<Layer>content</Layer>);
+  const element = wrapper.instance().el;
+  expect(createPortal).toHaveBeenCalledWith('content', element);
+  expect(wrapper.text()).toBe('content');
+});

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -15,6 +15,7 @@ import Icon from './Icon.js';
 import IconButton from './IconButton.js';
 import Image from './Image.js';
 import Label from './Label.js';
+import Layer from './Layer.js';
 import Letterbox from './Letterbox.js';
 import Link from './Link.js';
 import Mask from './Mask.js';
@@ -58,6 +59,7 @@ export {
   IconButton,
   Image,
   Label,
+  Layer,
   Letterbox,
   Link,
   Mask,


### PR DESCRIPTION
This component looks ready for use, so I'm adding documentation here and adding it to the export. I'm going to try it out with our internal `Modal` usage first and after testing it out there will evaluate making gestalt `Modal` use `Layer` itself.