### PR TITLE
TextArea: Add hasError prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Colors: Darken gray and darkGray so they're AA accessible at smaller sizes (#276)
 * Video: Add a gradient overlay on the control bar (#27)
 * Layer: Layer component is now exported for use and has documentation
-* TextArea: Add a hasError prop
+* TextArea: Add a hasError prop (#280)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Colors: Darken gray and darkGray so they're AA accessible at smaller sizes (#276)
 * Video: Add a gradient overlay on the control bar (#27)
 * Layer: Layer component is now exported for use and has documentation
+* TextArea: Add a hasError prop
 
 ### Patch
 

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -17,6 +17,7 @@ type State = {
 type Props = {|
   errorMessage?: string,
   disabled?: boolean,
+  hasError?: boolean,
   id: string,
   idealErrorDirection?: 'up' | 'right' | 'down' | 'left' /* default: right */,
   name?: string,
@@ -32,6 +33,7 @@ export default class TextArea extends React.Component<Props, State> {
   static propTypes = {
     disabled: PropTypes.bool,
     errorMessage: PropTypes.string,
+    hasError: PropTypes.bool,
     id: PropTypes.string.isRequired,
     idealErrorDirection: PropTypes.string,
     name: PropTypes.string,
@@ -45,6 +47,7 @@ export default class TextArea extends React.Component<Props, State> {
 
   static defaultProps = {
     disabled: false,
+    hasError: false,
     idealErrorDirection: 'right',
     rows: 3,
   };
@@ -108,6 +111,7 @@ export default class TextArea extends React.Component<Props, State> {
     const {
       disabled,
       errorMessage,
+      hasError,
       id,
       idealErrorDirection,
       name,
@@ -119,7 +123,7 @@ export default class TextArea extends React.Component<Props, State> {
     const classes = classnames(
       styles.textArea,
       disabled ? styles.disabled : styles.enabled,
-      errorMessage ? styles.errored : styles.normal
+      hasError || errorMessage ? styles.errored : styles.normal
     );
 
     return (
@@ -128,7 +132,7 @@ export default class TextArea extends React.Component<Props, State> {
           aria-describedby={
             errorMessage && this.state.focused ? `${id}-gestalt-error` : null
           }
-          aria-invalid={errorMessage ? 'true' : 'false'}
+          aria-invalid={errorMessage || hasError ? 'true' : 'false'}
           className={classes}
           disabled={disabled}
           id={id}

--- a/packages/gestalt/src/TextArea.test.js
+++ b/packages/gestalt/src/TextArea.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { create } from 'react-test-renderer';
 import { shallow } from 'enzyme';
 import TextArea from './TextArea.js';
+import Flyout from './Flyout.js';
 
 describe('TextArea', () => {
   it('Renders a Flyout if an error message is passed in', () => {
@@ -11,12 +12,12 @@ describe('TextArea', () => {
     );
     wrapper.instance().setState({ errorIsOpen: true });
     wrapper.simulate('focus');
-    expect(wrapper.find('Flyout')).toHaveLength(1);
+    expect(wrapper.find(Flyout)).toHaveLength(1);
   });
 
   it('Does not render a Flyout when errorMessage is null', () => {
     const wrapper = shallow(<TextArea id="test" onChange={jest.fn()} />);
-    expect(wrapper.find('Flyout')).toHaveLength(0);
+    expect(wrapper.find(Flyout)).toHaveLength(0);
   });
 
   it('TextArea normal', () => {
@@ -44,6 +45,20 @@ describe('TextArea', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('TextArea with hasError', () => {
+    const wrapper = shallow(
+      <TextArea
+        hasError
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />
+    );
+    expect(wrapper.find(Flyout)).toHaveLength(0);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
   it('TextArea with rows', () => {
     const tree = create(
       <TextArea id="test" onChange={jest.fn()} rows={5} />
@@ -60,10 +75,10 @@ describe('TextArea', () => {
         onBlur={jest.fn()}
       />
     );
-    expect(tree.find('Flyout')).toHaveLength(0);
+    expect(tree.find(Flyout)).toHaveLength(0);
     tree.setProps({
       errorMessage: 'error message',
     });
-    expect(tree.find('Flyout')).toHaveLength(1);
+    expect(tree.find(Flyout)).toHaveLength(1);
   });
 });

--- a/packages/gestalt/src/TextField.test.js
+++ b/packages/gestalt/src/TextField.test.js
@@ -45,6 +45,21 @@ describe('TextField', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('TextField with hasError', () => {
+    const wrapper = shallow(
+      <TextField
+        hasError
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find(Flyout)).toHaveLength(0);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
   it('TextField with name', () => {
     const tree = shallow(
       <TextField

--- a/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
@@ -18,6 +18,8 @@ exports[`TextArea TextArea normal 1`] = `
 
 exports[`TextArea TextArea with error 1`] = `"<span><textarea aria-invalid=\\"true\\" class=\\"textArea enabled errored\\" id=\\"test\\" rows=\\"3\\"></textarea></span>"`;
 
+exports[`TextArea TextArea with hasError 1`] = `"<span><textarea aria-invalid=\\"true\\" class=\\"textArea enabled errored\\" id=\\"test\\" rows=\\"3\\"></textarea></span>"`;
+
 exports[`TextArea TextArea with rows 1`] = `
 <span>
   <textarea

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -20,6 +20,8 @@ exports[`TextField TextField with autocomplete 1`] = `"<span><input type=\\"text
 
 exports[`TextField TextField with error 1`] = `"<span><input type=\\"text\\" aria-invalid=\\"true\\" class=\\"textField enabled errored\\" id=\\"test\\"/></span>"`;
 
+exports[`TextField TextField with hasError 1`] = `"<span><input type=\\"text\\" aria-invalid=\\"true\\" class=\\"textField enabled errored\\" id=\\"test\\"/></span>"`;
+
 exports[`TextField TextField with name 1`] = `"<span><input type=\\"text\\" aria-invalid=\\"false\\" class=\\"textField enabled normal\\" id=\\"email\\" name=\\"email\\"/></span>"`;
 
 exports[`TextField TextField with type number 1`] = `"<span><input type=\\"number\\" aria-invalid=\\"false\\" class=\\"textField enabled normal\\" id=\\"test\\" pattern=\\"\\\\d*\\"/></span>"`;


### PR DESCRIPTION
Add hasError prop to `TextArea` (identical to `TextField`)

I have a component which renders errors inline on TextFields (rather than in a flyout) using the hasError prop.  This component is adjacent to TextArea's which do not provide this functionality.  Updating to allow a homogenous UI

Before:
![textfieldandtextareaerrors](https://user-images.githubusercontent.com/10646092/42785554-ce0e685e-8907-11e8-84c1-8270673ffde6.png)

After:
![screen shot 2018-07-16 at 2 51 48 pm](https://user-images.githubusercontent.com/10646092/42785557-d599b66e-8907-11e8-912a-e7a5bc07aab0.png)
