### PR TITLE
Fix the React prop typing for Masonry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@
     Click to see more.
   </summary>
 
-  ### Minor
+### Minor
 
-  ### Patch
+### Patch
+
+* Masonry: Fix React prop typing for `layout` (#284)
+
 </details>
 
 ## 0.76.0 (July 17, 2018)
 
 ### Minor
+
 * Icon: reduce filesize of each icon with 40% + add new icons (#269)
 * Colors: Darken gray and darkGray so they're AA accessible at smaller sizes (#276)
 * Video: Add a gradient overlay on the control bar (#27)

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -141,8 +141,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     layout: PropTypes.oneOfType([
       PropTypes.instanceOf(LegacyMasonryLayout),
       PropTypes.instanceOf(LegacyUniformRowLayout),
-      PropTypes.instanceOf(DefaultLayoutSymbol),
-      PropTypes.instanceOf(UniformRowLayoutSymbol),
+      PropTypes.symbol,
     ]),
 
     /**


### PR DESCRIPTION
These two cannot use the `instanceof` prop type checker because they are `Symbol`s
https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/legacyLayoutSymbols.js

We need to use the `PropTypes.symbol` to capture the other two
https://reactjs.org/docs/typechecking-with-proptypes.html