### PR TITLE
Gestalt 0.76.1 dot release for Masonry fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Patch
 
-* Masonry: Fix React prop typing for `layout` (#284)
-
 </details>
+
+## 0.76.1 (July 17, 2018)
+
+### Patch
+
+* Masonry: Fix React prop typing for `layout` (#284)
 
 ## 0.76.0 (July 17, 2018)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "0.76.0",
+  "version": "0.76.1",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "main": "dist/gestalt.js",


### PR DESCRIPTION
Fixing the react prop type checking for `Masonry` in this dot release