### PR TITLE
Toast: Make icon prop nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+* Toast: Make icon prop nullable (#286)
 
 ### Patch
 

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -8,7 +8,7 @@ import Icon from './Icon.js';
 
 type Props = {|
   color?: 'darkGray' | 'orange',
-  icon?: 'arrow-circle-forward', // leaving open to additional icons in the future
+  icon?: ?'arrow-circle-forward', // leaving open to additional icons in the future
   text: string | Array<string>,
   thumbnail?: React.Element<any>,
 |};


### PR DESCRIPTION
Accommodate code like `const iconName = href && !imageUrl ? 'arrow-circle-forward' : null;` by allowing icon to be null.