### PR TITLE
Bump flow version to 0.77.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.75.0
+0.77.0
 
 [ignore]
 # Tracking https://github.com/facebook/flow/issues/4015

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+* Internal: Bump flow version to 0.77.0 (#289)
+
 ### Patch
 
 </details>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-react": "^7.10.0",
     "filesize": "^3.6.1",
-    "flow-bin": "0.75.0",
+    "flow-bin": "0.77.0",
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,9 +4000,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.75.0.tgz#b96d1ee99d3b446a3226be66b4013224ce9df260"
+flow-bin@^0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.77.0.tgz#4e5c93929f289a0c28e08fb361a9734944a11297"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
No new errors arising from the bump to version 0.77.0