### PR TITLE
Turn on sketchy number rule from Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -16,6 +16,7 @@ module.name_mapper='^.*\.css$' -> '<PROJECT_ROOT>/flow/stubs/CSSModuleStub.js'
 <PROJECT_ROOT>/flow-typed
 
 [lints]
+sketchy-number=error
 untyped-type-import=error
 untyped-import=error
 unclear-type=error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Internal: Bump flow version to 0.77.0 (#289)
 * Internal: Add flow typed definitions for node-fetch and filesize (#290)
 * Internal: Turn on all non-sketchy flow lint rules as errors (#292)
+* Internal: Turn on sketchy-number flow lint rules as an error (#293)
 
 ### Patch
 

--- a/packages/gestalt/src/Column.js
+++ b/packages/gestalt/src/Column.js
@@ -26,7 +26,11 @@ type ColumnProps =
 export default function Column(props: ColumnProps) {
   const { children } = props;
   const cs = classnames(
-    (props.xs || props.sm || props.md || props.lg) && styles.deprecatedColumn,
+    (props.xs !== undefined ||
+      props.sm !== undefined ||
+      props.md !== undefined ||
+      props.lg !== undefined) &&
+      styles.deprecatedColumn,
     props.xs && styles[`xsCol${props.xs}`],
     props.sm && styles[`smCol${props.sm}`],
     props.md && styles[`mdCol${props.md}`],

--- a/packages/gestalt/src/throttle.js
+++ b/packages/gestalt/src/throttle.js
@@ -9,11 +9,11 @@ export default function throttle(
   fn: (...args: *) => void,
   threshhold: number = 100
 ) {
-  let last: number;
-  let deferTimer: TimeoutID;
+  let last: number | void;
+  let deferTimer: TimeoutID | void;
   const throttled = (...args: *) => {
     const now = Date.now();
-    if (last && now - last < threshhold) {
+    if (last !== undefined && now - last < threshhold) {
       clearTimeout(deferTimer);
       deferTimer = setTimeout(() => {
         last = now;


### PR DESCRIPTION
Adds the new [sketchy-number](https://flow.org/en/docs/linting/rule-reference/#toc-sketchy-number) lint rule from Flow as an error and fixes all issues that arise from it.