### PR TITLE
Move 0.77 release up a commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,20 @@
 
 ### Minor
 
-* Collage: Add new Collage component to Gestalt (#291)
-
 ### Patch
 
 </details>
 
-## 0.77.0 (July 26, 2018)
+## 0.77.0 (July 30, 2018)
 
 ### Minor
 
 * Checkbox: Add error prop and styling (#287)
-* Masonry: Add configurable virtual bounds (#294)
 * Internal: Bump flow version to 0.77.0 (#289)
 * Internal: Add flow typed definitions for node-fetch and filesize (#290)
+* Collage: Add new Collage component to Gestalt (#291)
 * Internal: Turn on all non-sketchy flow lint rules as errors (#292)
+* Masonry: Add configurable virtual bounds (#294)
 
 ## 0.76.1 (July 17, 2018)
 


### PR DESCRIPTION
Gestalt 0.77 has not been released yet since #295 was committed, however, after that, #291 landed which includes the `Collage` component. This updates the Changelog appropriately so we can create a new commit to release off of.