### PR TITLE
Add flow typing to Box transform functors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+* Internal: Add flow types to `Box` transform functors (#299)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -32,14 +32,12 @@ import {
   toProps,
 } from './style.js';
 import {
-  // flowlint untyped-import:off
   union,
   bind,
   range,
   toggle,
   mapping,
   rangeWithoutZero,
-  // flowlint untyped-import:error
 } from './transforms.js';
 
 /*

--- a/packages/gestalt/src/style.js
+++ b/packages/gestalt/src/style.js
@@ -20,7 +20,7 @@ type InlineStyle = { [key: string]: string | number | void };
 
 // TODO: This type should be opaque, however the Babel parser doesn't support
 //       the opaque syntax yet.
-type Style = {|
+export type Style = {|
   className: Set<string>,
   inlineStyle: InlineStyle,
 |};

--- a/packages/gestalt/src/transforms.js
+++ b/packages/gestalt/src/transforms.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { concat, fromClassName, identity, mapClassName } from './style.js';
 
 /*
@@ -28,14 +30,14 @@ export const mapping = map => val =>
 //
 //     <Box padding={1} />
 //
-export const range = scale => n =>
+export const range = (scale: string) => (n: number) =>
   fromClassName(`${scale}${n < 0 ? `N${Math.abs(n)}` : n}`);
 
 // Like `range`, maps a range of integers to a range of classnames, excluding
 // zero values.
 //
 //     <Box padding={0} />
-export const rangeWithoutZero = scale => n =>
+export const rangeWithoutZero = (scale: string) => (n: number) =>
   n === 0 ? identity() : range(scale)(n);
 
 // Binds a string classname to the value in an object. Useful when interacting

--- a/packages/gestalt/src/transforms.js
+++ b/packages/gestalt/src/transforms.js
@@ -22,7 +22,7 @@ type Functor = (n: number) => Style;
 //
 //     <Box top />
 //
-export const toggle = (...classNames: Array<string>) => (val: mixed) =>
+export const toggle = (...classNames: Array<string>) => (val?: boolean) =>
   val ? fromClassName(...classNames) : identity();
 
 // Maps string values to classes

--- a/packages/gestalt/src/transforms.js
+++ b/packages/gestalt/src/transforms.js
@@ -1,6 +1,12 @@
 // @flow
 
-import { concat, fromClassName, identity, mapClassName } from './style.js';
+import {
+  concat,
+  fromClassName,
+  identity,
+  mapClassName,
+  type Style,
+} from './style.js';
 
 /*
 
@@ -10,18 +16,20 @@ These are a collection of a few functors that take values and returns Style's. O
 
 */
 
+type Functor = (n: number) => Style;
+
 // Adds a classname when a property is present.
 //
 //     <Box top />
 //
-export const toggle = (...classNames) => val =>
+export const toggle = (...classNames: Array<string>) => (val: mixed) =>
   val ? fromClassName(...classNames) : identity();
 
 // Maps string values to classes
 //
 //     <Box alignItems="center" />
 //
-export const mapping = map => val =>
+export const mapping = (map: { [key: string]: string }) => (val: string) =>
   Object.prototype.hasOwnProperty.call(map, val)
     ? fromClassName(map[val])
     : identity();
@@ -43,9 +51,11 @@ export const rangeWithoutZero = (scale: string) => (n: number) =>
 // Binds a string classname to the value in an object. Useful when interacting
 // with ranges that need to come dynamically from a style object. This is
 // similar to the NPM package 'classnames/bind'.
-export const bind = (fn, scope) => val =>
-  mapClassName(name => scope[name])(fn(val));
+export const bind = (fn: Functor, scope: { [key: string]: string }) => (
+  val: number
+) => mapClassName(name => scope[name])(fn(val));
 
 // This takes a series of the previously defined functors, runs them all
 // against a value and returns the set of their classnames.
-export const union = (...fns) => val => concat(fns.map(fn => fn(val)));
+export const union = (...fns: Array<Functor>) => (val: number) =>
+  concat(fns.map(fn => fn(val)));


### PR DESCRIPTION
Adds proper flow typings to the `transforms.js` file based on the usage which allows us to remove the flow lint disable in `Box.js`