### PR TITLE
Rename prop 'shape' to 'corners'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Minor
 
 * Internal: Turn on sketchy-number flow lint rules as an error (#293)
+* Rename prop 'shape' for components Box, Mask and Touchable (#301)
+* Update the documentation of Box, Mask and Touchable components (#301)
 
 ### Patch
 

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -206,7 +206,7 @@ card(
         defaultValue: 'static',
       },
       {
-        name: 'shape',
+        name: 'corners',
         type: `"square" | "rounded" | "pill" | "circle" | "roundedTop" | "roundedBottom" | "roundedLeft" | "roundedRight"`,
         defaultValue: 'square',
       },
@@ -512,14 +512,14 @@ card(
       'darkWash',
     ]}
   >
-    {props => <Box width={60} height={60} shape="circle" {...props} />}
+    {props => <Box width={60} height={60} corners="circle" {...props} />}
   </Combination>
 );
 
 card(
   <Combination
-    name="Shapes"
-    shape={[
+    name="Corners"
+    corners={[
       'square',
       'rounded',
       'pill',
@@ -533,7 +533,7 @@ card(
     {props => (
       <Box
         color="gray"
-        width={props.shape === 'pill' ? 120 : 60}
+        width={props.corners === 'pill' ? 120 : 60}
         height={60}
         {...props}
       />

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -119,7 +119,7 @@ card(
   `}
     name="Colors: Dark Backgrounds"
     defaultCode={`
-<Box color="darkGray" maxWidth={320} shape="rounded" padding={4}>
+<Box color="darkGray" maxWidth={320} corners="rounded" padding={4}>
   <Box marginBottom={4}>
     <Text color="white">
       Explore today’s trending ideas, curated finds, and personalized

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -36,7 +36,7 @@ card(
         type: `number | string`,
       },
       {
-        name: 'shape',
+        name: 'corners',
         type: `"circle" | "rounded" | "square"`,
         defaultValue: 'square',
       },
@@ -53,7 +53,7 @@ card(
   <Example
     name="Example"
     defaultCode={`
-<Mask height={70} shape="circle" width={70}>
+<Mask height={70} corners="circle" width={70}>
   <div style={{ backgroundColor: '#0fa573', width: 70, height: 70 }} />
 </Mask>
 `}
@@ -68,7 +68,7 @@ card(
     name="Example: Masking other content"
     defaultCode={`
 <Box maxWidth={300}>
-  <Mask shape="circle">
+  <Mask corners="circle">
     <img
       alt="weakendclub.com"
       src="${stock7}"
@@ -88,7 +88,7 @@ card(
     name="Example: Adding a wash"
     defaultCode={`
 <Box maxWidth={300}>
-  <Mask shape="rounded" wash>
+  <Mask corners="rounded" wash>
     <img
       alt="subliming.tumblr.com"
       src="${stock8}"
@@ -102,8 +102,8 @@ card(
 
 card(
   <Combination
-    name="Shape Combinations"
-    shape={['circle', 'rounded', 'square']}
+    name="Corners Combinations"
+    corners={['circle', 'rounded', 'square']}
   >
     {props => (
       <Mask height={70} width={70} {...props}>

--- a/docs/src/Pulsar.doc.js
+++ b/docs/src/Pulsar.doc.js
@@ -106,7 +106,7 @@ class TooltipExample extends React.Component {
             top: 10,
             left: 10,
             pointerEvents: "none", }}>
-            <Touchable onTouch={({ event }) => this.handleClick(event)} shape="circle" fullWidth={false}>
+            <Touchable onTouch={({ event }) => this.handleClick(event)} corners="circle" fullWidth={false}>
               <Pulsar paused={this.state.open} />
             </Touchable>
           </div>

--- a/docs/src/SearchField.doc.js
+++ b/docs/src/SearchField.doc.js
@@ -76,7 +76,7 @@ card(
 
     render() {
       return (
-        <Box color="white" shape="rounded" padding={3} display="flex" direction="row" alignItems="center">
+        <Box color="white" corners="rounded" padding={3} display="flex" direction="row" alignItems="center">
           <Box padding={3}>
             <Icon
               icon="pinterest"

--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -51,7 +51,7 @@ card(
         required: true,
       },
       {
-        name: 'shape',
+        name: 'corners',
         type: `"square" | "rounded" | "pill" | "circle" | "roundedTop" | "roundedBottom" | "roundedLeft" | "roundedRight"`,
         defaultValue: 'square',
       },
@@ -89,9 +89,9 @@ class TouchableExample extends React.Component {
         <Touchable
           mouseCursor="zoomIn"
           onTouch={this.handleTouch}
-          shape="rounded"
+          corners="rounded"
         >
-          <Mask shape="rounded">
+          <Mask corners="rounded">
             <Image
               alt="Antelope Canyon"
               naturalHeight={1}

--- a/packages/gestalt-codemods/0.77.0-0.78.0/replace-prop-shape-to-corners.js
+++ b/packages/gestalt-codemods/0.77.0-0.78.0/replace-prop-shape-to-corners.js
@@ -1,0 +1,49 @@
+/*
+* Rename prop 'shape' to 'corners' for Box, Square, Mask and Touchable components
+* Ex
+* <Box shape="circle"/>
+* to
+* <Box corners="circle"/>
+*
+* */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  const components = ['Box', 'Square', 'Mask', 'Touchable'];
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+
+    const specifier = decl.specifiers.find(node =>
+      components.includes(node.local.name)
+    );
+    if (!specifier) {
+      return;
+    }
+    localIdentifierName = specifier.local.name;
+  });
+
+  return src
+    .find(j.JSXElement)
+    .forEach(path => {
+      const { node } = path;
+      if (node.openingElement.name.name !== localIdentifierName) {
+        return;
+      }
+
+      node.openingElement.attributes = node.openingElement.attributes.map(
+        attr => {
+          if (attr.name && attr.name.name && attr.name.name === 'shape') {
+            const attribute = attr;
+            attribute.name.name = 'corners';
+            return attribute;
+          }
+          return attr;
+        }
+      );
+      j(path).replaceWith(node);
+    })
+    .toSource();
+}

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -22,7 +22,7 @@ const Square = (props: *) => (
 const DefaultAvatar = ({ name }: { name: string }) => {
   const firstInitial = name ? [...name][0].toUpperCase() : '';
   return (
-    <Square color="gray" shape="circle">
+    <Square color="gray" corners="circle">
       {firstInitial && (
         <svg
           width="100%"
@@ -103,10 +103,10 @@ export default class Avatar extends React.PureComponent<AvatarProps, State> {
         width={width}
         height={height}
         position="relative"
-        shape="circle"
+        corners="circle"
       >
         {src && isImageLoaded ? (
-          <Mask shape="circle" wash>
+          <Mask corners="circle" wash>
             <Image
               alt={name}
               color="#EFEFEF"
@@ -137,7 +137,7 @@ export default class Avatar extends React.PureComponent<AvatarProps, State> {
               color="white"
               width="100%"
               height="100%"
-              shape="circle"
+              corners="circle"
               dangerouslySetInlineStyle={{
                 __style: {
                   boxShadow: '0 0 0 2px #fff',

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -201,7 +201,7 @@ type PropType = {
 
   position?: 'static' | 'absolute' | 'relative' | 'fixed',
   right?: boolean,
-  shape?:
+  corners?:
     | 'square'
     | 'rounded'
     | 'pill'
@@ -605,7 +605,7 @@ const propToFn = {
     // default: static
   }),
   right: toggle(layout.right0),
-  shape: mapping({
+  corners: mapping({
     circle: borders.circle,
     pill: borders.pill,
     rounded: borders.rounded,
@@ -960,7 +960,7 @@ Box.propTypes = {
 
   position: PropTypes.oneOf(['static', 'absolute', 'relative', 'fixed']),
   right: PropTypes.bool,
-  shape: PropTypes.oneOf([
+  corners: PropTypes.oneOf([
     'square',
     'rounded',
     'pill',

--- a/packages/gestalt/src/GroupAvatar.js
+++ b/packages/gestalt/src/GroupAvatar.js
@@ -176,7 +176,7 @@ export default function GroupAvatar(props: Props) {
     <Box
       color="white"
       overflow="hidden"
-      shape="circle"
+      corners="circle"
       width={avatarWidth}
       height={avatarHeight}
       position="relative"

--- a/packages/gestalt/src/Mask.js
+++ b/packages/gestalt/src/Mask.js
@@ -7,15 +7,15 @@ import styles from './Mask.css';
 type Props = {|
   children?: React.Node,
   height?: number | string,
-  shape?: 'circle' | 'rounded' | 'square',
+  corners?: 'circle' | 'rounded' | 'square',
   width?: number | string,
   wash?: boolean,
 |};
 
 export default function Mask(props: Props) {
-  const { children, shape = 'square', width, height, wash = false } = props;
+  const { children, corners = 'square', width, height, wash = false } = props;
   return (
-    <div className={cx(styles.Mask, styles[shape])} style={{ width, height }}>
+    <div className={cx(styles.Mask, styles[corners])} style={{ width, height }}>
       {children}
       {wash && <div className={styles.wash} />}
     </div>
@@ -25,7 +25,7 @@ export default function Mask(props: Props) {
 Mask.propTypes = {
   children: PropTypes.node,
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  shape: PropTypes.oneOf(['circle', 'rounded', 'square']),
+  corners: PropTypes.oneOf(['circle', 'rounded', 'square']),
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   wash: PropTypes.bool,
 };

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -57,7 +57,7 @@ export default function Pog(props: Props) {
 
   return (
     <div className={classes} style={inlineStyle}>
-      <Box shape="circle">
+      <Box corners="circle">
         {/*
           We're explicitly setting an empty string as a label on the Icon since we
           already have an aria-label on the button container.

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -23,7 +23,7 @@ export default function Toast(props: Props) {
       <Box xs={{ display: 'flex' }}>
         <Box xs={{ display: 'flexColumn' }} flex="none" justifyContent="center">
           {thumbnail ? (
-            <Mask shape="rounded" height={48} width={48}>
+            <Mask corners="rounded" height={48} width={48}>
               {thumbnail}
             </Mask>
           ) : null}
@@ -68,7 +68,7 @@ export default function Toast(props: Props) {
 
   return (
     <Box marginBottom={3} paddingX={4} maxWidth={376} width="100vw">
-      <Box color={color} fit paddingX={8} paddingY={5} shape="pill">
+      <Box color={color} fit paddingX={8} paddingY={5} corners="pill">
         {contents}
       </Box>
     </Box>

--- a/packages/gestalt/src/Touchable.js
+++ b/packages/gestalt/src/Touchable.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './Touchable.css';
 
-type Shape =
+type Corners =
   | 'square'
   | 'rounded'
   | 'pill'
@@ -36,7 +36,7 @@ type Props = {|
       | SyntheticMouseEvent<HTMLDivElement>
       | SyntheticKeyboardEvent<HTMLDivElement>,
   }) => void,
-  shape?: Shape,
+  corners?: Corners,
 |};
 
 const SPACE_CHAR_CODE = 32;
@@ -65,13 +65,13 @@ export default class Touchable extends React.Component<Props> {
       onMouseEnter,
       onMouseLeave,
       onTouch,
-      shape = 'square',
+      corners = 'square',
     } = this.props;
 
     const classes = classnames(
       styles.touchable,
       styles[mouseCursor],
-      styles[shape],
+      styles[corners],
       {
         [styles.fullHeight]: fullHeight,
         [styles.fullWidth]: fullWidth,
@@ -111,7 +111,7 @@ Touchable.propTypes = {
   onTouch: PropTypes.func,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
-  shape: PropTypes.oneOf([
+  corners: PropTypes.oneOf([
     'square',
     'rounded',
     'pill',

--- a/packages/gestalt/src/VideoPlayhead.js
+++ b/packages/gestalt/src/VideoPlayhead.js
@@ -91,19 +91,19 @@ export default class VideoPlayhead extends React.PureComponent<Props, State> {
             right
             position="absolute"
             color="lightGray"
-            shape="rounded"
+            corners="rounded"
             height={4}
           >
-            <Box color="white" shape="rounded" height="100%" width={width} />
+            <Box color="white" corners="rounded" height="100%" width={width} />
           </Box>
           <Box
             position="absolute"
-            shape="rounded"
+            corners="rounded"
             height={4}
             dangerouslySetInlineStyle={{ __style: { left: width } }}
           >
             <Box
-              shape="circle"
+              corners="circle"
               width={16}
               height={16}
               color="white"

--- a/packages/gestalt/src/touchable.test.js
+++ b/packages/gestalt/src/touchable.test.js
@@ -22,7 +22,7 @@ test('Touchable sets correct mouse cursor', () => {
 
 test('Touchable sets correct shape', () => {
   const tree = create(
-    <Touchable onTouch={() => {}} shape="circle">
+    <Touchable onTouch={() => {}} corners="circle">
       Touchable
     </Touchable>
   ).toJSON();


### PR DESCRIPTION
Rename prop 'shape' to 'corners' for components Box, Mask, and Touchable (including dependent components Avatar, GroupAvatar, Pog, Toast, VideoPlayhead). Also updates the docs