### PR TITLE
Made the SearchField placeholder text color to contrast its background better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 * Internal: Turn on sketchy-number flow lint rules as an error (#293)
+* SearchField: Added darker placeholder color for WGAP AA compliance (#304)
 
 ### Patch
 

--- a/packages/gestalt/src/SearchField.css
+++ b/packages/gestalt/src/SearchField.css
@@ -17,7 +17,7 @@
 }
 
 .input::placeholder {
-  color: #8e8e8e;
+  color: #6c6c6c;
 }
 
 .input::-webkit-search-decoration,


### PR DESCRIPTION
We recently darkened the grays of Gestalt to create better contrast as a win for accessibility. Unfortunately, the background of SearchField is still too close to the placeholder text color to achieve a WCAG AA rating.

This PR darkens the placeholder color just for SearchField, something our designers have already approved.