### PR TITLE
Masonry: MasonryInfinite for infinite fetching

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -28,6 +28,8 @@ type Layout =
   | LegacyMasonryLayout
   | LegacyUniformRowLayout;
 
+export type MeasurementState = 'idle' | 'measuring';
+
 export type Props<T> = {|
   columnWidth?: number,
   comp: React.ComponentType<{
@@ -45,7 +47,7 @@ export type Props<T> = {|
     content: Position,
     viewport: Position
   ) => void,
-  onPendingMeasurementsUpdate?: (hasPendingMeasurements: boolean) => void,
+  onAutoMeasuringUpdate?: (state: MeasurementState) => void,
   layout?: Layout,
   // Support legacy loadItems usage.
   // TODO: Simplify non falsey flowtype.
@@ -310,7 +312,9 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     }));
 
     // need to make sure parent component has the correct pending measurement value
-    this.handleOnPendingMeasurementsUpdate(this.state.hasPendingMeasurements);
+    this.handleOnAutoMeasuringUpdate(
+      this.state.hasPendingMeasurements ? 'measuring' : 'idle'
+    );
   }
 
   componentDidUpdate(prevProps: Props<T>, prevState: State<T>) {
@@ -327,9 +331,9 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     );
 
     if (hasPendingMeasurements && !prevState.hasPendingMeasurements) {
-      this.handleOnPendingMeasurementsUpdate(true);
+      this.handleOnAutoMeasuringUpdate('measuring');
     } else if (!hasPendingMeasurements && prevState.hasPendingMeasurements) {
-      this.handleOnPendingMeasurementsUpdate(false);
+      this.handleOnAutoMeasuringUpdate('idle');
     }
     this.handleVirtualizationWindowUpdate();
 
@@ -452,9 +456,9 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     }
   };
 
-  handleOnPendingMeasurementsUpdate = (hasPendingMeasurements: boolean) => {
-    if (this.props.onPendingMeasurementsUpdate) {
-      this.props.onPendingMeasurementsUpdate(hasPendingMeasurements);
+  handleOnAutoMeasuringUpdate = (state: MeasurementState) => {
+    if (this.props.onAutoMeasuringUpdate) {
+      this.props.onAutoMeasuringUpdate(state);
     }
   };
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -49,8 +49,7 @@ export type Props<T> = {|
   minCols: number,
   // Content layer and Viewport layer is as defined in Collection.
   onLayerUpdate?: (contentLayer: Layer, viewportLayer: Layer) => void,
-  onPendingMeasurements?: () => void,
-  onNoPendingMeasurements?: () => void,
+  onPendingMeasurementsUpdate?: (hasPendingMeasurements: boolean) => void,
   layout?: Layout,
   // Support legacy loadItems usage.
   // TODO: Simplify non falsey flowtype.
@@ -89,10 +88,6 @@ const layoutNumberToCssDimension = n => (n !== Infinity ? n : undefined);
  * The name is kept for now to have an easier time seeing the diffs.
  */
 export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
-  static createMeasurementStore() {
-    return new MeasurementStore();
-  }
-
   /**
    * Delays resize handling in case the scroll container is still being resized.
    */
@@ -112,9 +107,8 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       return;
     }
 
-    const scrollTop = getScrollPos(scrollContainer);
     this.setState({
-      scrollTop,
+      scrollTop: getScrollPos(scrollContainer),
     });
 
     this.handleOnLayerUpdate();
@@ -239,7 +233,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     }));
 
     this.handleOnLayerUpdate();
-    this.handleOnPendingMeasurements();
+    this.handleOnPendingMeasurementsUpdate(true);
   }
 
   componentDidUpdate(prevProps: Props<T>, prevState: State<T>) {
@@ -256,9 +250,9 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     );
 
     if (hasPendingMeasurements && !prevState.hasPendingMeasurements) {
-      this.handleOnPendingMeasurements();
+      this.handleOnPendingMeasurementsUpdate(true);
     } else if (!hasPendingMeasurements && prevState.hasPendingMeasurements) {
-      this.handleOnNoPendingMeasurements();
+      this.handleOnPendingMeasurementsUpdate(false);
     }
     this.handleOnLayerUpdate();
 
@@ -369,14 +363,14 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
   };
 
   handleOnPendingMeasurements = () => {
-    if (this.props.onPendingMeasurements) {
-      this.props.onPendingMeasurements();
+    if (this.props.onPendingMeasurementsUpdate) {
+      this.props.onPendingMeasurementsUpdate(true);
     }
   };
 
-  handleOnNoPendingMeasurements = () => {
-    if (this.props.onNoPendingMeasurements) {
-      this.props.onNoPendingMeasurements();
+  handleOnPendingMeasurementsUpdate = (hasPendingMeasurements: boolean) => {
+    if (this.props.onPendingMeasurementsUpdate) {
+      this.props.onPendingMeasurementsUpdate(hasPendingMeasurements);
     }
   };
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -16,7 +16,7 @@ import {
   DefaultLayoutSymbol,
   UniformRowLayoutSymbol,
 } from './legacyLayoutSymbols.js';
-import defaultLayout from './defaultLayout.js';
+import defaultLayout, { type Position } from './defaultLayout.js';
 import uniformRowLayout from './uniformRowLayout.js';
 import fullWidthLayout from './fullWidthLayout.js';
 import LegacyMasonryLayout from './layouts/MasonryLayout.js';
@@ -28,13 +28,12 @@ type Layout =
   | LegacyMasonryLayout
   | LegacyUniformRowLayout;
 
-export type Layer = {
+export type Layer = {|
   top: number,
   left: number,
   width: number,
   height: number,
-};
-type Position = Layer;
+|};
 
 export type Props<T> = {|
   columnWidth?: number,
@@ -243,8 +242,8 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       width: this.gridWrapper ? this.gridWrapper.clientWidth : prevState.width,
     }));
 
-    this.handleOnLayerUpdate();
-    this.handleOnPendingMeasurementsUpdate(true);
+    // need to make sure parent component has the correct pending measurement value
+    this.handleOnPendingMeasurementsUpdate(this.state.hasPendingMeasurements);
   }
 
   componentDidUpdate(prevProps: Props<T>, prevState: State<T>) {
@@ -307,7 +306,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     // whenever we're receiving new props, determine whether any items need to be measured
     // TODO - we should treat items as immutable
     const hasPendingMeasurements = items.some(
-      item => !measurementStore.has(item)
+      item => item && !measurementStore.has(item)
     );
 
     // Shallow compare all items, if any change reflow the grid.
@@ -455,12 +454,6 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       };
 
       this.props.onLayerUpdate(contentLayer, viewportLayer);
-    }
-  };
-
-  handleOnPendingMeasurements = () => {
-    if (this.props.onPendingMeasurementsUpdate) {
-      this.props.onPendingMeasurementsUpdate(true);
     }
   };
 

--- a/packages/gestalt/src/MasonryInfinite.js
+++ b/packages/gestalt/src/MasonryInfinite.js
@@ -1,0 +1,142 @@
+// @flow
+import * as React from 'react';
+import FetchItems from './FetchItems.js';
+import MeasurementStore from './MeasurementStore.js';
+import Masonry, { type Props, type Layer } from './Masonry.js';
+
+type State<T> = {|
+  containerHeight: number,
+  hasPendingMeasurements: boolean,
+  isFetching: boolean,
+  items: Array<T>,
+  scrollTop: number,
+  scrollHeight: number,
+|};
+
+const hasNewItem = (i, items) => items[i] === undefined;
+const hasDifferentItem = (i, itemsA, itemsB) => itemsA[i] !== itemsB[i];
+const hasLessItems = (itemsA, itemsB) => itemsA.length < itemsB.length;
+
+/**
+ * This MasonryInfinite is backward compatible and serves to help with migrating
+ * to a Masrony that doesn't have the scrol fetch concerns
+ */
+export default class MasonryInfinite<T> extends React.Component<
+  Props<T>,
+  State<T>
+> {
+  static createMeasurementStore() {
+    return new MeasurementStore();
+  }
+
+  constructor(props: Props<T>) {
+    super(props);
+
+    this.state = {
+      containerHeight: 0,
+      hasPendingMeasurements: false,
+      isFetching: false,
+      // eslint-disable-next-line react/no-unused-state
+      items: props.items,
+      scrollTop: 0,
+      scrollHeight: 0,
+    };
+
+    this.gridRef = React.createRef();
+  }
+
+  /**
+   * Content layer and Viewport layer is as defined in Collection.
+   */
+  onLayerUpdate = (contentLayer: Layer, viewportLayer: Layer) => {
+    const { containerHeight, scrollTop, scrollHeight } = this.state;
+    if (
+      viewportLayer.height !== containerHeight ||
+      viewportLayer.top !== scrollTop ||
+      contentLayer.height !== scrollHeight
+    ) {
+      this.setState({
+        containerHeight: viewportLayer.height,
+        scrollTop: viewportLayer.top,
+        scrollHeight: contentLayer.height,
+      });
+    }
+  };
+
+  static getDerivedStateFromProps(props: Props<T>, state: State<T>) {
+    const { items } = props;
+
+    // Shallow compare all items, if any change reflow the grid.
+    // checks below are comparable to Masonry.getDerivedStateFromProps
+    for (let i = 0; i < items.length; i += 1) {
+      if (
+        hasNewItem(i, state.items) ||
+        hasDifferentItem(i, items, state.items) ||
+        hasLessItems(items, state.items)
+      ) {
+        return { isFetching: false };
+      }
+    }
+
+    // Return null to indicate no change to state.
+    return null;
+  }
+
+  fetchMore = () => {
+    const { loadItems } = this.props;
+    if (loadItems && typeof loadItems === 'function') {
+      this.setState(
+        {
+          isFetching: true,
+        },
+        () => loadItems({ from: this.props.items.length })
+      );
+    }
+  };
+
+  handlePendingMeasurements = () => {
+    if (!this.state.hasPendingMeasurements) {
+      this.setState({ hasPendingMeasurements: true });
+    }
+  };
+
+  handleNoPendingMeasurements = () => {
+    if (this.state.hasPendingMeasurements) {
+      this.setState({ hasPendingMeasurements: false });
+    }
+  };
+
+  reflow = () => {
+    if (this.gridRef.current) {
+      this.gridRef.current.reflow();
+    }
+  };
+
+  // $FlowFixMe - this is the right definition
+  gridRef: React.ElementRef<typeof Masonry<T>>;
+
+  render() {
+    return this.props.scrollContainer ? (
+      <React.Fragment>
+        <FetchItems
+          containerHeight={this.state.containerHeight}
+          fetchMore={this.fetchMore}
+          isFetching={
+            this.state.isFetching || this.state.hasPendingMeasurements
+          }
+          scrollHeight={this.state.scrollHeight}
+          scrollTop={this.state.scrollTop}
+        />
+        <Masonry
+          {...this.props}
+          onLayerUpdate={this.onLayerUpdate}
+          onPendingMeasurements={this.handlePendingMeasurements}
+          onNoPendingMeasurements={this.handleNoPendingMeasurements}
+          ref={this.gridRef}
+        />
+      </React.Fragment>
+    ) : (
+      <Masonry {...this.props} ref={this.gridRef} />
+    );
+  }
+}

--- a/packages/gestalt/src/MasonryInfinite.js
+++ b/packages/gestalt/src/MasonryInfinite.js
@@ -94,15 +94,9 @@ export default class MasonryInfinite<T> extends React.Component<
     }
   };
 
-  handlePendingMeasurements = () => {
-    if (!this.state.hasPendingMeasurements) {
-      this.setState({ hasPendingMeasurements: true });
-    }
-  };
-
-  handleNoPendingMeasurements = () => {
-    if (this.state.hasPendingMeasurements) {
-      this.setState({ hasPendingMeasurements: false });
+  handlePendingMeasurementsUpdate = (hasPendingMeasurements: boolean) => {
+    if (this.state.hasPendingMeasurements !== hasPendingMeasurements) {
+      this.setState({ hasPendingMeasurements });
     }
   };
 
@@ -130,8 +124,7 @@ export default class MasonryInfinite<T> extends React.Component<
         <Masonry
           {...this.props}
           onLayerUpdate={this.onLayerUpdate}
-          onPendingMeasurements={this.handlePendingMeasurements}
-          onNoPendingMeasurements={this.handleNoPendingMeasurements}
+          onPendingMeasurementsUpdate={this.handlePendingMeasurementsUpdate}
           ref={this.gridRef}
         />
       </React.Fragment>

--- a/packages/gestalt/src/MasonryInfinite.js
+++ b/packages/gestalt/src/MasonryInfinite.js
@@ -13,10 +13,6 @@ type State<T> = {|
   scrollHeight: number,
 |};
 
-const hasNewItem = (i, items) => items[i] === undefined;
-const hasDifferentItem = (i, itemsA, itemsB) => itemsA[i] !== itemsB[i];
-const hasLessItems = (itemsA, itemsB) => itemsA.length < itemsB.length;
-
 /**
  * This MasonryInfinite is backward compatible and serves to help with migrating
  * to a Masrony that doesn't have the scrol fetch concerns
@@ -66,16 +62,12 @@ export default class MasonryInfinite<T> extends React.Component<
   static getDerivedStateFromProps(props: Props<T>, state: State<T>) {
     const { items } = props;
 
-    // Shallow compare all items, if any change reflow the grid.
-    // checks below are comparable to Masonry.getDerivedStateFromProps
-    for (let i = 0; i < items.length; i += 1) {
-      if (
-        hasNewItem(i, state.items) ||
-        hasDifferentItem(i, items, state.items) ||
-        hasLessItems(items, state.items)
-      ) {
-        return { isFetching: false };
-      }
+    // assume immutable items
+    if (props.items !== state.items) {
+      return {
+        items,
+        isFetching: false,
+      };
     }
 
     // Return null to indicate no change to state.

--- a/packages/gestalt/src/MasonryInfinite.js
+++ b/packages/gestalt/src/MasonryInfinite.js
@@ -38,8 +38,6 @@ export default class MasonryInfinite<T> extends React.Component<
       scrollTop: 0,
       scrollHeight: 0,
     };
-
-    this.gridRef = React.createRef();
   }
 
   /**
@@ -75,6 +73,12 @@ export default class MasonryInfinite<T> extends React.Component<
     return null;
   }
 
+  setRef = (ref: React.ElementRef<*>) => {
+    if (ref) {
+      this.gridRef = ref;
+    }
+  };
+
   fetchMore = () => {
     const { loadItems } = this.props;
     if (loadItems && typeof loadItems === 'function') {
@@ -99,13 +103,12 @@ export default class MasonryInfinite<T> extends React.Component<
   };
 
   reflow = () => {
-    if (this.gridRef.current) {
-      this.gridRef.current.reflow();
+    if (this.gridRef) {
+      this.gridRef.reflow();
     }
   };
 
-  // $FlowFixMe - this is the right definition
-  gridRef: React.ElementRef<typeof Masonry<T>>;
+  gridRef: Masonry<T>;
 
   render() {
     return this.props.scrollContainer ? (
@@ -123,11 +126,11 @@ export default class MasonryInfinite<T> extends React.Component<
           {...this.props}
           onVirtualizationWindowUpdate={this.onVirtualizationWindowUpdate}
           onAutoMeasuringUpdate={this.handleOnAutoMeasuringUpdate}
-          ref={this.gridRef}
+          ref={this.setRef}
         />
       </React.Fragment>
     ) : (
-      <Masonry {...this.props} ref={this.gridRef} />
+      <Masonry {...this.props} ref={this.setRef} />
     );
   }
 }

--- a/packages/gestalt/src/MasonryInfinite.js
+++ b/packages/gestalt/src/MasonryInfinite.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import FetchItems from './FetchItems.js';
 import MeasurementStore from './MeasurementStore.js';
-import Masonry, { type Props } from './Masonry.js';
+import Masonry, { type Props, type MeasurementState } from './Masonry.js';
 import { type Position } from './defaultLayout.js';
 
 type State<T> = {|
@@ -87,9 +87,14 @@ export default class MasonryInfinite<T> extends React.Component<
     }
   };
 
-  handlePendingMeasurementsUpdate = (hasPendingMeasurements: boolean) => {
+  handleOnAutoMeasuringUpdate = (state: MeasurementState) => {
+    const hasPendingMeasurements = state === 'measuring';
     if (this.state.hasPendingMeasurements !== hasPendingMeasurements) {
       this.setState({ hasPendingMeasurements });
+    }
+
+    if (typeof this.props.onAutoMeasuringUpdate === 'function') {
+      this.props.onAutoMeasuringUpdate(state);
     }
   };
 
@@ -117,7 +122,7 @@ export default class MasonryInfinite<T> extends React.Component<
         <Masonry
           {...this.props}
           onVirtualizationWindowUpdate={this.onVirtualizationWindowUpdate}
-          onPendingMeasurementsUpdate={this.handlePendingMeasurementsUpdate}
+          onAutoMeasuringUpdate={this.handleOnAutoMeasuringUpdate}
           ref={this.gridRef}
         />
       </React.Fragment>

--- a/packages/gestalt/src/MasonryInfinite.js
+++ b/packages/gestalt/src/MasonryInfinite.js
@@ -2,7 +2,8 @@
 import * as React from 'react';
 import FetchItems from './FetchItems.js';
 import MeasurementStore from './MeasurementStore.js';
-import Masonry, { type Props, type Layer } from './Masonry.js';
+import Masonry, { type Props } from './Masonry.js';
+import { type Position } from './defaultLayout.js';
 
 type State<T> = {|
   containerHeight: number,
@@ -44,17 +45,17 @@ export default class MasonryInfinite<T> extends React.Component<
   /**
    * Content layer and Viewport layer is as defined in Collection.
    */
-  onLayerUpdate = (contentLayer: Layer, viewportLayer: Layer) => {
+  onVirtualizationWindowUpdate = (content: Position, viewport: Position) => {
     const { containerHeight, scrollTop, scrollHeight } = this.state;
     if (
-      viewportLayer.height !== containerHeight ||
-      viewportLayer.top !== scrollTop ||
-      contentLayer.height !== scrollHeight
+      viewport.height !== containerHeight ||
+      viewport.top !== scrollTop ||
+      content.height !== scrollHeight
     ) {
       this.setState({
-        containerHeight: viewportLayer.height,
-        scrollTop: viewportLayer.top,
-        scrollHeight: contentLayer.height,
+        containerHeight: viewport.height,
+        scrollTop: viewport.top,
+        scrollHeight: content.height,
       });
     }
   };
@@ -115,7 +116,7 @@ export default class MasonryInfinite<T> extends React.Component<
         />
         <Masonry
           {...this.props}
-          onLayerUpdate={this.onLayerUpdate}
+          onVirtualizationWindowUpdate={this.onVirtualizationWindowUpdate}
           onPendingMeasurementsUpdate={this.handlePendingMeasurementsUpdate}
           ref={this.gridRef}
         />

--- a/packages/gestalt/src/__integration__/loadMore.integration.js
+++ b/packages/gestalt/src/__integration__/loadMore.integration.js
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import selectors from './lib/selectors.js';
 
+jest.setTimeout(10000);
+
 const PIN_INSERTION_TIME = 500;
 
 describe('Masonry > Scrolls', () => {

--- a/packages/gestalt/src/__integration__/nullItems.integration.js
+++ b/packages/gestalt/src/__integration__/nullItems.integration.js
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import selectors from './lib/selectors.js';
 
+jest.setTimeout(10000);
+
 describe('Masonry > Null items', () => {
   it('Should not throw an error when null/undefined items are inserted', async () => {
     await page.setViewport({

--- a/packages/gestalt/src/__integration__/reflowItemPropChanges.integration.js
+++ b/packages/gestalt/src/__integration__/reflowItemPropChanges.integration.js
@@ -24,7 +24,7 @@ describe('Masonry > Item prop changes', () => {
       );
     }, masonryItemData);
 
-    page.waitFor(200);
+    await page.waitFor(200);
     const newItems = await page.$$(selectors.gridItem);
     assert.ok(newItems.length > 0);
 
@@ -50,7 +50,7 @@ describe('Masonry > Item prop changes', () => {
       );
     });
 
-    page.waitFor(200);
+    await page.waitFor(200);
     const newItems = await page.$$(selectors.gridItem);
     assert.ok(!newItems || newItems.length === 0);
   });

--- a/packages/gestalt/src/__integration__/reflowItemPropRemoval.integration.js
+++ b/packages/gestalt/src/__integration__/reflowItemPropRemoval.integration.js
@@ -25,7 +25,7 @@ describe('Masonry > Item prop removal', () => {
       );
     }, masonryItemData);
 
-    page.waitFor(200);
+    await page.waitFor(200);
     const newItems = await page.$$(selectors.gridItem);
     assert.ok(newItems.length === 3);
   });
@@ -40,7 +40,7 @@ describe('Masonry > Item prop removal', () => {
         })
       );
     });
-    page.waitFor(200);
+    await page.waitFor(200);
     const newItems = await page.$$(selectors.gridItem);
     assert.equal(newItems.length, 2);
   });

--- a/packages/gestalt/src/__integration__/scrollFetchOnload.integration.js
+++ b/packages/gestalt/src/__integration__/scrollFetchOnload.integration.js
@@ -11,7 +11,7 @@ describe('Masonry > ScrollFetch onload', () => {
     const initialFetchCount = await page.evaluate(
       () => window.TEST_FETCH_COUNTS
     );
-    assert.equal(initialFetchCount, null);
+    assert.equal(initialFetchCount, 1);
 
     // Fetches 1 time if the viewport is big enough
     await page.setViewport({
@@ -22,6 +22,6 @@ describe('Masonry > ScrollFetch onload', () => {
     const largerFetchCount = await page.evaluate(
       () => window.TEST_FETCH_COUNTS
     );
-    assert.ok(largerFetchCount >= 1);
+    assert.ok(largerFetchCount >= 2);
   });
 });

--- a/packages/gestalt/src/__integration__/serverRenderLayout.integration.js
+++ b/packages/gestalt/src/__integration__/serverRenderLayout.integration.js
@@ -75,6 +75,7 @@ describe('Masonry > Server Render Layout', () => {
       window.dispatchEvent(new CustomEvent('trigger-mount'));
     });
 
+    await page.waitFor(100);
     const gridItems = await page.$$(selectors.gridItem);
 
     const gridItem1Rect = await gridItems[0].boundingBox();

--- a/packages/gestalt/src/defaultLayout.js
+++ b/packages/gestalt/src/defaultLayout.js
@@ -1,7 +1,12 @@
 // @flow
 import type { Cache } from './Cache.js';
 
-type Position = { top: number, left: number, width: number, height: number };
+export type Position = {
+  top: number,
+  left: number,
+  width: number,
+  height: number,
+};
 
 const mindex = arr => {
   let idx = 0;

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -20,6 +20,7 @@ import Layer from './Layer.js';
 import Letterbox from './Letterbox.js';
 import Link from './Link.js';
 import Mask from './Mask.js';
+import MasonryInfinite from './MasonryInfinite.js';
 import Masonry from './Masonry.js';
 import MasonryDefaultLayout from './layouts/MasonryLayout.js';
 import MasonryUniformRowLayout from './layouts/UniformRowLayout.js';
@@ -65,7 +66,8 @@ export {
   Letterbox,
   Link,
   Mask,
-  Masonry,
+  MasonryInfinite as Masonry,
+  Masonry as MasonryBeta,
   MasonryDefaultLayout,
   MasonryUniformRowLayout,
   Modal,

--- a/test/containers/MasonryExample.js
+++ b/test/containers/MasonryExample.js
@@ -57,7 +57,7 @@ export default class MasonryExample extends React.Component {
       window.RESIZE_MEASUREMENT_DONE = false;
       setTimeout(() => {
         const checkIfMeasuring = () => {
-          if (!this.gridRef.state.hasPendingMeasurements) {
+          if (!this.gridRef.hasPendingMeasurements) {
             window.RESIZE_MEASUREMENT_DONE = true;
           } else {
             window.requestAnimationFrame(checkIfMeasuring);

--- a/test/containers/MasonryExample.js
+++ b/test/containers/MasonryExample.js
@@ -24,6 +24,8 @@ const getRandomNumberGenerator = seed => {
 };
 
 export default class MasonryExample extends React.Component {
+  autoMeasurementState = 'measuring'; // MeasurementState
+
   randomNumberSeed = 0;
 
   constructor(props) {
@@ -57,7 +59,7 @@ export default class MasonryExample extends React.Component {
       window.RESIZE_MEASUREMENT_DONE = false;
       setTimeout(() => {
         const checkIfMeasuring = () => {
-          if (!this.gridRef.hasPendingMeasurements) {
+          if (this.autoMeasurementState === 'idle') {
             window.RESIZE_MEASUREMENT_DONE = true;
           } else {
             window.requestAnimationFrame(checkIfMeasuring);
@@ -112,6 +114,10 @@ export default class MasonryExample extends React.Component {
 
   getScrollContainerRef = ref => {
     this.scrollContainer = ref;
+  };
+
+  handleAutoMeasuringUpdate = state => {
+    this.autoMeasurementState = state;
   };
 
   handleToggleScrollContainer = e => {
@@ -324,6 +330,7 @@ export default class MasonryExample extends React.Component {
             flexible={Boolean(this.props.flexible)}
             items={this.state.items}
             measurementStore={this.props.externalCache ? store : undefined}
+            onAutoMeasuringUpdate={this.handleAutoMeasuringUpdate}
             ref={ref => {
               this.gridRef = ref;
             }}


### PR DESCRIPTION
- Pulled fetching out from Masonry
- MasornyInfinite is exported as the old Masonry
  and should function the same
- export MasonryBeta as it can be used with custom
  fetching logic
- This provides a graceful migration path.
- Final migration will involve renaming
  MasonryBeta/MasonryInfinite/Masrony
- Existing Masonry integration will be testing MasonryInfinite to ensure
  compatibility