### PR TITLE
Masonry: update state so it matches when items prop is updated

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -129,6 +129,7 @@ function statesForRendering<T>(props: Props<T>, state: State<T>) {
   const { items } = state;
 
   // Full layout is possible
+  // $FlowFixMe https://github.com/facebook/flow/issues/6151
   const itemsToRender = items.filter(
     item => item && measurementStore.has(item)
   );
@@ -140,6 +141,7 @@ function statesForRendering<T>(props: Props<T>, state: State<T>) {
     ? Math.max(...renderPositions.map(pos => pos.top + pos.height))
     : 0;
 
+  // $FlowFixMe https://github.com/facebook/flow/issues/6151
   const itemsToMeasure = items
     .filter(item => item && !measurementStore.has(item))
     .slice(0, minCols);
@@ -381,6 +383,12 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       item => item && !measurementStore.has(item)
     );
 
+    const newState: State<T> = {
+      ...state,
+      hasPendingMeasurements,
+      items,
+    };
+
     // Shallow compare all items, if any change reflow the grid.
     for (let i = 0; i < items.length; i += 1) {
       // We've reached the end of our current props and everything matches.
@@ -389,6 +397,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
         return {
           hasPendingMeasurements,
           items,
+          ...statesForRendering(props, newState),
         };
       }
 
@@ -402,6 +411,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
         return {
           hasPendingMeasurements,
           items,
+          ...statesForRendering(props, newState),
         };
       }
     }
@@ -411,6 +421,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       return {
         hasPendingMeasurements,
         items,
+        ...statesForRendering(props, newState),
       };
     }
     if (hasPendingMeasurements !== state.hasPendingMeasurements) {
@@ -418,6 +429,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       return {
         hasPendingMeasurements,
         items,
+        ...statesForRendering(props, newState),
       };
     }
 
@@ -571,7 +583,6 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       renderPositions,
       width,
     } = this.state;
-
     let gridBody;
     if (width == null && hasPendingMeasurements) {
       // When hyrdating from a server render, we don't have the width of the grid

--- a/packages/gestalt/src/Masonry.jsdom.test.js
+++ b/packages/gestalt/src/Masonry.jsdom.test.js
@@ -1,0 +1,36 @@
+// @flow
+import React from 'react';
+import { mount } from 'enzyme';
+import { create } from 'react-test-renderer';
+import Masonry from './Masonry.js';
+
+type Item = { id: string };
+
+describe('Masonry', () => {
+  test('renders', () => {
+    const a: Item = { id: 'a' };
+    const b = { id: 'b' };
+    const items1 = [a, b];
+    const masonry = create(
+      <Masonry
+        comp={() => <div style={{ height: '100px', width: '200px' }} />}
+        items={items1}
+      />
+    ).toJSON();
+    expect(masonry).toMatchSnapshot();
+  });
+
+  test('renders with new items', () => {
+    const a: Item = { id: 'a' };
+    const b = { id: 'b' };
+    const items1 = [a, b];
+    const masonry = mount(<Masonry comp={() => <div />} items={items1} />);
+
+    const items2 = [a];
+    const comp2 = ({ data, itemIdx }: { data: Item, itemIdx: number }) => {
+      expect(itemIdx).toBeLessThan(1);
+      return <div>{data[itemIdx]}</div>;
+    };
+    masonry.setProps({ comp: comp2, items: items2 });
+  });
+});

--- a/packages/gestalt/src/__integration__/scrollFetchOnload.integration.js
+++ b/packages/gestalt/src/__integration__/scrollFetchOnload.integration.js
@@ -7,11 +7,10 @@ describe('Masonry > ScrollFetch onload', () => {
       height: 400,
     });
     await page.goto('http://localhost:3001/Masonry?manualFetch=1');
-
     const initialFetchCount = await page.evaluate(
       () => window.TEST_FETCH_COUNTS
     );
-    assert.equal(initialFetchCount, 1);
+    assert.equal(initialFetchCount, null);
 
     // Fetches 1 time if the viewport is big enough
     await page.setViewport({

--- a/packages/gestalt/src/__snapshots__/Masonry.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Masonry.jsdom.test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Masonry renders 1`] = `
+<div
+  className="Masonry"
+  style={
+    Object {
+      "height": 0,
+      "width": "100%",
+    }
+  }
+>
+  <div
+    className="static"
+    data-grid-item={true}
+    style={
+      Object {
+        "WebkitTransform": "translateX(0px) translateY(0px)",
+        "left": 0,
+        "top": 0,
+        "transform": "translateX(0px) translateY(0px)",
+        "width": 236,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": "100px",
+          "width": "200px",
+        }
+      }
+    />
+  </div>
+  <div
+    className="static"
+    data-grid-item={true}
+    style={
+      Object {
+        "WebkitTransform": "translateX(0px) translateY(0px)",
+        "left": 0,
+        "top": 0,
+        "transform": "translateX(0px) translateY(0px)",
+        "width": 236,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": "100px",
+          "width": "200px",
+        }
+      }
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
This PR fixes: #318 