### PR TITLE
 TextField / TextArea / SelectList: Fix issue with flyout when errorMessage is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Minor
 
+- TextField / TextArea: Fix issue with flyout when `errorMessage` is set (#350)
+- Icon: Add download svg (#341)
+- Masonry: Remove mention of server rendering (#342)
+
 ### Patch
 
 </details>
@@ -28,8 +32,6 @@
 - Icon: Add camera roll icon (#317)
 - Video: Make a11y label props required in Video component (#321)
 - Internal: Add in greenkeeper-lockfile for auto updates (#327)
-- Icon: Add download svg (#341)
-- Masonry: Remove mention of server rendering (#342)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Minor
 
-- TextField / TextArea: Fix issue with flyout when `errorMessage` is set (#350)
+- TextField / TextArea / SelectList: Fix issue with flyout when `errorMessage` is set (#350)
 - Icon: Add download svg (#341)
 - Masonry: Remove mention of server rendering (#342)
 

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -176,6 +176,7 @@ export default class SelectList extends React.Component<Props, State> {
               color="orange"
               idealDirection={idealErrorDirection}
               onDismiss={() => this.setState({ errorIsOpen: false })}
+              shouldFocus={false}
               size="sm"
             >
               <Box padding={3}>

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -175,6 +175,7 @@ export default class TextArea extends React.Component<Props, State> {
             color="orange"
             idealDirection={idealErrorDirection}
             onDismiss={() => this.setState({ errorIsOpen: false })}
+            shouldFocus={false}
             size="sm"
           >
             <Box padding={3}>

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -193,6 +193,7 @@ export default class TextField extends React.Component<Props, State> {
               color="orange"
               idealDirection={idealErrorDirection}
               onDismiss={() => this.setState({ errorIsOpen: false })}
+              shouldFocus={false}
               size="sm"
             >
               <Box padding={3}>


### PR DESCRIPTION
Introduced by #325

![textfield-errormessage-not-editable 2018-09-11 17_40_24](https://user-images.githubusercontent.com/127199/45395192-cc09c580-b5e9-11e8-84bb-2fad01e7aabb.gif)
