### PR TITLE
Internal: publish README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Patch
 
+- Internal: publish `README.md` (#367)
+
 </details>
 
 ## 0.81.0 (September 11, 2018)

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -21,6 +21,8 @@
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",
+    "postpack": "rm README.md",
+    "prepack": "cp ../../README.md .",
     "prepublish": "rollup -c rollup.config.js",
     "watch": "rollup -c rollup.config.js --watch"
   },

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -3,6 +3,7 @@
   "version": "0.81.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
+  "description": "A set of React UI components which enforce Pinterest’s design language",
   "main": "dist/gestalt.js",
   "jsnext:main": "dist/gestalt.es.js",
   "module": "dist/gestalt.es.js",


### PR DESCRIPTION
Adding the `README.md` when publishing the package so we no longer see:

![image](https://user-images.githubusercontent.com/127199/45795253-9d29ca00-bc4f-11e8-95a6-aca944eb772f.png)
https://yarnpkg.com/en/package/gestalt

![image](https://user-images.githubusercontent.com/127199/45795256-a7e45f00-bc4f-11e8-8f37-0de36ba3d6ed.png)
https://www.npmjs.com/package/gestalt