### PR TITLE
[DO NOT MERGE] Attempting to add react-virtualized

### DIFF
--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -14,7 +14,8 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "react-virtualized": "^9.20.1"
   },
   "peerDependencies": {
     "react": "^16.3.2",

--- a/packages/gestalt/rollup.config.js
+++ b/packages/gestalt/rollup.config.js
@@ -180,6 +180,7 @@ export default {
     'classnames/bind',
     'classnames',
     'react-dom',
+    'react-virtualized',
   ],
   plugins: [
     progress(),
@@ -200,6 +201,7 @@ export default {
     babel({
       babelrc: false,
       presets: [['env', { modules: false }], 'stage-1', 'react'],
+      exclude: 'node_modules/**',
       plugins: ['external-helpers'],
     }),
     visualizer(),

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -45,6 +45,12 @@ import Tooltip from './Tooltip.js';
 import Touchable from './Touchable.js';
 import Video from './Video.js';
 
+// Importing react-virtualized here, not because I need it, but because I need
+// help resolving a failure on build.
+//
+// eslint-disable-next-line no-unused-vars,import/order
+import * as rv from 'react-virtualized';
+
 export {
   Avatar,
   Box,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,6 +2093,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.3:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
@@ -3093,6 +3097,10 @@ dom-converter@~0.1:
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
+
+"dom-helpers@^2.4.0 || ^3.0.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-iterator@^1.0.0:
   version "1.0.0"
@@ -6027,6 +6035,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.11.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -6554,6 +6566,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -8830,6 +8848,10 @@ react-is@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
 react-live@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/react-live/-/react-live-1.10.1.tgz#3736be3e8281e455b3cca781506813c55abed011"
@@ -8926,6 +8948,17 @@ react-test-renderer@^16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
     react-is "^16.3.2"
+
+react-virtualized@^9.20.1:
+  version "9.20.1"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.20.1.tgz#02dc08fe9070386b8c48e2ac56bce7af0208d22d"
+  dependencies:
+    babel-runtime "^6.26.0"
+    classnames "^2.2.3"
+    dom-helpers "^2.4.0 || ^3.0.0"
+    loose-envify "^1.3.0"
+    prop-types "^15.6.0"
+    react-lifecycles-compat "^3.0.4"
 
 react@^16.3.2:
   version "16.3.2"


### PR DESCRIPTION
I'm putting this PR together to illustrate an error I'm encountering when trying to add an external dependency, react-virtualized, to Gestalt. The trouble has to do with babel and its runtime helpers interacting poorly with either rollup, the split yarn workspaces structure, or both. I'm not sure how to proceed, so this PR is intended to share for the purpose of getting advice.