### PR TITLE
Bump flow to 0.81.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.77.0
+0.81.0
 
 [ignore]
 # Tracking https://github.com/facebook/flow/issues/4015

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - SearchField: Add `autoComplete` prop for parity with `TextField` (#363)
 - Tabs: Add optional wrap prop (#361)
 - Checkbox: Add optional onClick prop (#364)
+- Flow: Bump to version `0.81.0` (#376)
 
 ### Patch
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-react": "^7.11.1",
     "filesize": "^3.6.1",
-    "flow-bin": "0.77.0",
+    "flow-bin": "0.81.0",
     "greenkeeper-lockfile": "^2.5.0",
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,9 +4246,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@0.77.0:
-  version "0.77.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.77.0.tgz#4e5c93929f289a0c28e08fb361a9734944a11297"
+flow-bin@0.81.0:
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.81.0.tgz#7f0a733dce1dad3cb1447c692639292dc3d60bf5"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Bumping Gestalt Flow version to `v0.81.0`

- [x] Documentation
Upgrading this package to match the version we are using internally. Seems to be no errors so its a smooth upgrade.

