### PR TITLE
Add forgotten env variable to docker-compose file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Patch
 
 - Internal: publish `README.md` (#367)
+- Internal: add `GH_TOKEN` to docker-compose file for greenkeeper (#377)
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Patch
 
 - Internal: publish `README.md` (#367)
-- Internal: add `GH_TOKEN` to docker-compose file for greenkeeper (#377)
+- Internal: add `GH_TOKEN` to docker-compose file for greenkeeper (#378)
 
 </details>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,4 @@ services:
       - CI
       - CODECOV_TOKEN
       - DANGER_GITHUB_API_TOKEN
+      - GH_TOKEN


### PR DESCRIPTION
## Potential fix for the greenkeeper yarn file updates

I added `greenkeeper-lockfile` in #327 but it hasnt been able to successfully write to github because of a known hosts issue, I'm curious if its because I forgot to add the token name here to the docker file since I only listed it in the buildkite pipeline file.

- [ ] Documentation
I wonder if its possible forgetting to list the ENV variable in the `docker-compose` file made the greenkeeper commands on buildkite fail as such:
![image](https://user-images.githubusercontent.com/7877010/45991982-400d8a00-c03c-11e8-9f3e-6236aaa4204b.png)

