### PR TITLE
Add in env variables for git email and username for greenkeeper

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,8 @@ steps:
     timeout_in_minutes: 10
     env:
       - GH_TOKEN
+      - GK_LOCK_COMMIT_EMAIL
+      - GK_LOCK_COMMIT_NAME
     agents:
       queue: elastic
     plugins:
@@ -97,6 +99,8 @@ steps:
     timeout_in_minutes: 10
     env:
       - GH_TOKEN
+      - GK_LOCK_COMMIT_EMAIL
+      - GK_LOCK_COMMIT_NAME
     agents:
       queue: elastic
     plugins:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Internal: publish `README.md` (#367)
 - Internal: add `GH_TOKEN` to docker-compose file for greenkeeper (#378)
+- Internal: add greenkeeper env variables to docker-compose and buildkite files (#381)
 
 </details>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,5 @@ services:
       - CODECOV_TOKEN
       - DANGER_GITHUB_API_TOKEN
       - GH_TOKEN
+      - GK_LOCK_COMMIT_EMAIL
+      - GK_LOCK_COMMIT_NAME


### PR DESCRIPTION
## Greenkeeper lockfile env variables

![image](https://user-images.githubusercontent.com/7877010/46058506-4e2cda80-c110-11e8-89cf-79fdee3c72bf.png)

Greenkeeper lockfile updating is still failing and the best result I could find online is this https://github.com/greenkeeperio/greenkeeper-lockfile/issues/206 I am following the suggestion to expose and set these variables (even though they should be defaulted) in the hopes it finally works.
