### PR TITLE
Exclude node_modules from babelification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 ### Minor
 
 - Button: Fix transparent button on blue background (#316)
-- Flyout: Add new prop `shouldFocus` to override focus on open behavior. _Has codemod_ (#325)
+- Flyout: Add new prop `shouldFocus` to override focus on open behavior. *Has codemod* (#325)
 - Icon: Add camera roll icon (#317)
 - Video: Make a11y label props required in Video component (#321)
 - Internal: Add in greenkeeper-lockfile for auto updates (#327)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Patch
 
+- Internal: Exclude node_modules from babelification (#382)
 - Internal: publish `README.md` (#367)
 - Internal: add `GH_TOKEN` to docker-compose file for greenkeeper (#378)
 - Internal: add greenkeeper env variables to docker-compose and buildkite files (#381)
@@ -42,7 +43,7 @@
 ### Minor
 
 - Button: Fix transparent button on blue background (#316)
-- Flyout: Add new prop `shouldFocus` to override focus on open behavior. *Has codemod* (#325)
+- Flyout: Add new prop `shouldFocus` to override focus on open behavior. _Has codemod_ (#325)
 - Icon: Add camera roll icon (#317)
 - Video: Make a11y label props required in Video component (#321)
 - Internal: Add in greenkeeper-lockfile for auto updates (#327)

--- a/packages/gestalt/rollup.config.js
+++ b/packages/gestalt/rollup.config.js
@@ -200,6 +200,7 @@ export default {
     babel({
       babelrc: false,
       presets: [['env', { modules: false }], 'stage-1', 'react'],
+      exclude: 'node_modules/**',
       plugins: ['external-helpers'],
     }),
     visualizer(),

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
+        exclude: /node_modules/,
       },
     ],
   },


### PR DESCRIPTION
When attempting to add `react-virtualized` in my Masonry9 branch, I ran into issues where the test package would explode. Turns out, it was trying to babelify all node_modules. This PR excludes node_modules in both the Gestalt package and test.

See exact problem and recommended solution here:
https://github.com/bvaughn/react-virtualized/issues/1112