### PR TITLE
Add new icons for text alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 - Internal: Bump all eslint and stylelint packages (#400)
+- Icon: add new icons for text alignment
 
 ### Patch
 

--- a/packages/gestalt/src/icons/index.js
+++ b/packages/gestalt/src/icons/index.js
@@ -78,6 +78,9 @@ import sound from './sound.svg';
 import speech from './speech.svg';
 import speechEllipsis from './speech-ellipsis.svg';
 import tag from './tag.svg';
+import textAlignCenter from './text-align-center.svg';
+import textAlignLeft from './text-align-left.svg';
+import textAlignRight from './text-align-right.svg';
 import twitter from './twitter.svg';
 import viewTypeDefault from './view-type-default.svg';
 import viewTypeDense from './view-type-dense.svg';
@@ -163,6 +166,9 @@ export default {
   speech,
   'speech-ellipsis': speechEllipsis,
   tag,
+  'text-align-left': textAlignLeft,
+  'text-align-center': textAlignCenter,
+  'text-align-right': textAlignRight,
   twitter,
   'view-type-default': viewTypeDefault,
   'view-type-dense': viewTypeDense,

--- a/packages/gestalt/src/icons/text-align-center.svg
+++ b/packages/gestalt/src/icons/text-align-center.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 4.5h24v-3H0v3zm3 6h18V7.499H3V10.5zm-3 6h24v-3H0v3zm3 6h18v-3H3v3z" fill="#B5B5B5" fill-rule="evenodd"/></svg>

--- a/packages/gestalt/src/icons/text-align-left.svg
+++ b/packages/gestalt/src/icons/text-align-left.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 4.5h24v-3H0v3zm0 6h18V7.499H0V10.5zm0 6h24v-3H0v3zm0 6h18v-3H0v3z" fill="#B5B5B5" fill-rule="evenodd"/></svg>

--- a/packages/gestalt/src/icons/text-align-right.svg
+++ b/packages/gestalt/src/icons/text-align-right.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M24 4.5H0v-3h24v3zm0 6H6v-3h18v3zm0 6H0v-3h24v3zm0 6H6v-3h18v3z" fill="#B5B5B5" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
New icons added:

```
text-align-center: packages/gestalt/src/icons/text-align-center.svg
text-align-left: packages/gestalt/src/icons/text-align-left.svg
text-align-right: packages/gestalt/src/icons/text-align-right.svg
```