### PR TITLE
Collage should not create a new item component in every re-render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Internal: Bump all eslint and stylelint packages (#400)
 - Icon: add new icons for text alignment
+- Collage: Use `Item` prop instead of `renderImage` (#402)
 
 ### Patch
 

--- a/docs/src/Collage.doc.js
+++ b/docs/src/Collage.doc.js
@@ -50,6 +50,15 @@ card(
         required: true,
       },
       {
+        name: 'Item',
+        type: 'React.ComponentType',
+        description: `
+        A React component (or functional component) that renders the item displayed in the collage.
+        This component is passed props: \`width : number\`, \`height: number\`, \`idx: number\`
+        `,
+        required: true,
+      },
+      {
         name: 'layoutKey',
         type: 'number',
         description: `
@@ -57,13 +66,6 @@ card(
         If there are N layouts available, (layoutKey % N) will determine which layout is used.
         `,
         defaultValue: 0,
-      },
-      {
-        name: 'renderImage',
-        type:
-          '({ width: number, height: number, index: number }) => React.Node',
-        description: 'Render prop for the collage images',
-        required: true,
       },
       {
         name: 'width',
@@ -83,7 +85,7 @@ card(
   columns={3}
   height={300}
   width={300}
-  renderImage={({ index, width, height }) => {
+  Item={({ idx, width, height }) => {
     const images = [
       {
         color: 'rgb(111, 91, 77)',
@@ -122,7 +124,7 @@ card(
         src: '${stock6}',
       },
     ];
-    const image = images[index];
+    const image = images[idx];
     return (
       <Mask wash width={width} height={height}>
         <Image
@@ -154,7 +156,7 @@ card(
         columns={columns}
         height={150}
         width={150}
-        renderImage={({ index, width, height }) => {
+        Item={({ idx, width, height }) => {
           const images = [
             {
               color: 'rgb(111, 91, 77)',
@@ -193,7 +195,7 @@ card(
               src: '${stock6}',
             },
           ];
-          const image = images[index];
+          const image = images[idx];
           return (
             <Mask wash width={width} height={height}>
               {image ? (
@@ -233,7 +235,7 @@ card(
     gutter={8}
     height={300}
     width={300}
-    renderImage={({ index, width, height }) => {
+    Item={({ idx, width, height }) => {
       const images = [
         {
           color: 'rgb(111, 91, 77)',
@@ -272,7 +274,7 @@ card(
           src: '${stock6}',
         },
       ];
-      const image = images[index];
+      const image = images[idx];
       return (
         <Mask wash width={width} height={height}>
           <Image
@@ -302,7 +304,7 @@ card(
     cover
     height={300}
     gutter={8}
-    renderImage={({ index, width, height }) => {
+    Item={({ idx, width, height }) => {
       const coverImage = {
         color: '#000',
         naturalHeight: 806,
@@ -323,7 +325,7 @@ card(
           src: '${stock2}',
         },
       ];
-      const image = index === 0 ? coverImage : nonCoverImages[index - 1];
+      const image = idx === 0 ? coverImage : nonCoverImages[idx - 1];
       return (
         <Mask width={width} height={height}>
           <Image
@@ -358,7 +360,7 @@ card(
         cover
         height={150}
         width={150}
-        renderImage={({ index, width, height }) => {
+        Item={({ idx, width, height }) => {
           const images = [
             {
               color: 'rgb(111, 91, 77)',
@@ -397,7 +399,7 @@ card(
               src: '${stock6}',
             },
           ];
-          const image = images[index];
+          const image = images[idx];
           return (
             <Mask wash width={width} height={height}>
               {image ? (
@@ -445,7 +447,7 @@ card(
         height={150}
         width={150}
         layoutKey={layoutKey}
-        renderImage={({ index, width, height }) => {
+        Item={({ idx, width, height }) => {
           const images = [
             {
               color: 'rgb(111, 91, 77)',
@@ -484,7 +486,7 @@ card(
               src: '${stock6}',
             },
           ];
-          const image = images[index];
+          const image = images[idx];
           return (
             <Mask wash width={width} height={height}>
               <Image

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -141,8 +141,15 @@ type Props = {|
   cover?: boolean,
   gutter?: number,
   height: number,
+  Item?: React.ComponentType<{|
+    // TODO: make `Item` required when we deprecate `renderImage`
+    width: number,
+    height: number,
+    idx: number,
+  |}>,
   layoutKey?: number,
-  renderImage: ({|
+  renderImage?: ({|
+    // TODO: deprecate `renderImage` in favor of `Item`
     width: number,
     height: number,
     index: number,
@@ -155,13 +162,16 @@ export default function Collage({
   cover,
   gutter,
   height,
+  Item,
   layoutKey,
-  renderImage,
+  renderImage, // TODO: deprecate in favor of `Item`
   width,
 }: Props) {
   return (
     <Collection
-      Item={renderImage}
+      Item={
+        Item || (({ idx: index, ...rest }) => renderImage({ index, ...rest }))
+      }
       layout={getCollageLayout({
         columns,
         cover: !!cover,
@@ -179,7 +189,8 @@ Collage.propTypes = {
   cover: PropTypes.bool,
   gutter: PropTypes.number,
   height: PropTypes.number.isRequired,
+  Item: PropTypes.func,
   layoutKey: PropTypes.number,
-  renderImage: PropTypes.func.isRequired,
+  renderImage: PropTypes.func,
   width: PropTypes.number.isRequired,
 };

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -150,34 +150,26 @@ type Props = {|
   width: number,
 |};
 
-export default function Collage(props: Props) {
-  const {
-    columns,
-    cover,
-    gutter,
-    height,
-    layoutKey,
-    renderImage,
-    width,
-  } = props;
-  const positions = getCollageLayout({
-    columns,
-    cover: !!cover,
-    width,
-    height,
-    gutter: gutter || 0,
-    layoutKey: layoutKey || 0,
-  });
+export default function Collage({
+  columns,
+  cover,
+  gutter,
+  height,
+  layoutKey,
+  renderImage,
+  width,
+}: Props) {
   return (
     <Collection
-      Item={({ idx: index }) =>
-        renderImage({
-          index,
-          width: positions[index].width,
-          height: positions[index].height,
-        })
-      }
-      layout={positions}
+      Item={renderImage}
+      layout={getCollageLayout({
+        columns,
+        cover: !!cover,
+        width,
+        height,
+        gutter: gutter || 0,
+        layoutKey: layoutKey || 0,
+      })}
     />
   );
 }

--- a/packages/gestalt/src/Collage.test.js
+++ b/packages/gestalt/src/Collage.test.js
@@ -6,12 +6,12 @@ import Collage from './Collage.js';
 type CollageImageProps = {
   width: number,
   height: number,
-  index: number,
+  idx: number,
 };
 
 describe('<Collage />', () => {
-  function CollageImage({ width, height, index }: CollageImageProps) {
-    return <div style={{ width, height }}>{index}</div>;
+  function CollageImage({ width, height, idx }: CollageImageProps) {
+    return <div style={{ width, height }}>{idx}</div>;
   }
 
   const collageProps = {
@@ -19,7 +19,7 @@ describe('<Collage />', () => {
     gutter: 2,
     height: 200,
     width: 300,
-    renderImage: CollageImage,
+    Item: CollageImage,
   };
 
   it('should match the snapshot', () => {

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -44,7 +44,11 @@ import PropTypes from 'prop-types';
 import layoutStyles from './Layout.css';
 
 type Props = {|
-  Item: ({ index: number, width: number, height: number }) => React.Node,
+  Item: React.ComponentType<{|
+    idx: number,
+    width: number,
+    height: number,
+  |}>,
   layout: Array<{|
     top: number,
     left: number,
@@ -59,8 +63,7 @@ type Props = {|
 
 export default class Collection extends React.PureComponent<Props, void> {
   static propTypes = {
-    // eslint-disable-next-line react/forbid-prop-types
-    Item: PropTypes.any,
+    Item: PropTypes.any, // eslint-disable-line react/forbid-prop-types
     layout: PropTypes.arrayOf(
       PropTypes.exact({
         top: PropTypes.number.isRequired,
@@ -93,23 +96,23 @@ export default class Collection extends React.PureComponent<Props, void> {
 
     // Calculates which items from the item layer to render in the viewport
     // layer.
-    const items = layout.reduce((acc, position, index) => {
+    const items = layout.reduce((acc, position, idx) => {
       if (
         position.top + position.height > viewportTop &&
         position.top < viewportHeight + viewportTop &&
         position.left < viewportWidth + viewportLeft &&
         position.left + position.width > viewportLeft
       ) {
-        acc.push({ index, ...position });
+        acc.push({ idx, ...position });
       }
       return acc;
     }, []);
 
     return (
       <div className={layoutStyles.relative} style={{ width, height }}>
-        {items.map(({ index, ...style }) => (
-          <div key={index} className={layoutStyles.absolute} style={style}>
-            <Item index={index} width={style.width} height={style.height} />
+        {items.map(({ idx, ...style }) => (
+          <div key={idx} className={layoutStyles.absolute} style={style}>
+            <Item idx={idx} width={style.width} height={style.height} />
           </div>
         ))}
       </div>

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -44,7 +44,7 @@ import PropTypes from 'prop-types';
 import layoutStyles from './Layout.css';
 
 type Props = {|
-  Item: ({ idx: number }) => React.Node,
+  Item: ({ index: number, width: number, height: number }) => React.Node,
   layout: Array<{|
     top: number,
     left: number,
@@ -93,23 +93,23 @@ export default class Collection extends React.PureComponent<Props, void> {
 
     // Calculates which items from the item layer to render in the viewport
     // layer.
-    const items = layout.reduce((acc, position, idx) => {
+    const items = layout.reduce((acc, position, index) => {
       if (
         position.top + position.height > viewportTop &&
         position.top < viewportHeight + viewportTop &&
         position.left < viewportWidth + viewportLeft &&
         position.left + position.width > viewportLeft
       ) {
-        acc.push({ idx, ...position });
+        acc.push({ index, ...position });
       }
       return acc;
     }, []);
 
     return (
       <div className={layoutStyles.relative} style={{ width, height }}>
-        {items.map(({ idx, ...style }) => (
-          <div key={idx} className={layoutStyles.absolute} style={style}>
-            <Item idx={idx} />
+        {items.map(({ index, ...style }) => (
+          <div key={index} className={layoutStyles.absolute} style={style}>
+            <Item index={index} width={style.width} height={style.height} />
           </div>
         ))}
       </div>

--- a/packages/gestalt/src/Collection.test.js
+++ b/packages/gestalt/src/Collection.test.js
@@ -6,7 +6,7 @@ import Collection from './Collection.js';
 test('Collection with default viewport', () => {
   const tree = create(
     <Collection
-      Item={({ idx }) => <div>{idx}</div>}
+      Item={({ index }) => <div>{index}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
@@ -19,7 +19,7 @@ test('Collection with default viewport', () => {
 test('Collection with limited viewport', () => {
   const tree = create(
     <Collection
-      Item={({ idx }) => <div>{idx}</div>}
+      Item={({ index }) => <div>{index}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
@@ -36,7 +36,7 @@ test('Collection with limited viewport', () => {
 test('Collection with limited viewport and a few items', () => {
   const tree = create(
     <Collection
-      Item={({ idx }) => <div>{idx}</div>}
+      Item={({ index }) => <div>{index}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 0, left: 100, width: 100, height: 100 },

--- a/packages/gestalt/src/Collection.test.js
+++ b/packages/gestalt/src/Collection.test.js
@@ -6,7 +6,7 @@ import Collection from './Collection.js';
 test('Collection with default viewport', () => {
   const tree = create(
     <Collection
-      Item={({ index }) => <div>{index}</div>}
+      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
@@ -19,7 +19,7 @@ test('Collection with default viewport', () => {
 test('Collection with limited viewport', () => {
   const tree = create(
     <Collection
-      Item={({ index }) => <div>{index}</div>}
+      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
@@ -36,7 +36,7 @@ test('Collection with limited viewport', () => {
 test('Collection with limited viewport and a few items', () => {
   const tree = create(
     <Collection
-      Item={({ index }) => <div>{index}</div>}
+      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 0, left: 100, width: 100, height: 100 },


### PR DESCRIPTION
Collage items get unmounted and mounted again on every re-render because a new item component is created on every re-render. This should fix it.