### PR TITLE
Bump gestalt version to 0.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 0.83.0 (October 25, 2018)
+
+### Minor
+
 - Internal: Bump version of React and related packages (#406)
 - Internal: Bump all eslint and stylelint packages (#400)
 - Icon: add new icons for text alignment
 - Tooltip: Merge abilities into Flyout for future deprecation (#403)
 - IconButton: Add new bgColor option "gray" (#405)
-
-### Patch
-
-</details>
 
 ## 0.82.0 (October 12, 2018)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## Bumping gestalt version to `0.83.0`

This migrates gestalt to `React 16.6`