### PR TITLE
Fixed flakey integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Patch
 
+- Internal: Fixed a test that started flaking out with React 16.6 (#410)
+
 </details>
 
 ## 0.83.0 (October 25, 2018)

--- a/packages/gestalt/src/__integration__/optimizedRemount.integration.js
+++ b/packages/gestalt/src/__integration__/optimizedRemount.integration.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import selectors from './lib/selectors.js';
 
 describe('Masonry > External cache', () => {
@@ -9,11 +8,16 @@ describe('Masonry > External cache', () => {
       'http://localhost:3001/MasonryInfinite?virtualize=1&externalCache=1',
     ],
   ])('should only mount visible items on remount - %s', async (name, url) => {
+    expect.assertions(3);
+
     await page.setViewport({
       width: 800,
       height: 800,
     });
     await page.goto(url);
+
+    // Wait for Masonry multi-stage rendering.
+    await page.waitFor(1000);
 
     const initialMountCount = await page.evaluate(
       () => window.ITEM_MOUNT_COUNT
@@ -35,9 +39,12 @@ describe('Masonry > External cache', () => {
       )
     );
 
+    // Wait for Masonry multi-stage rendering.
+    await page.waitFor(1000);
+
     // mount count should be increased
     let updatedMountCount = await page.evaluate(() => window.ITEM_MOUNT_COUNT);
-    assert.ok(updatedMountCount > initialMountCount);
+    expect(updatedMountCount).toBeGreaterThan(initialMountCount);
 
     // unmount/remount the grid
     const toggleMountTrigger = await page.$(selectors.toggleMount);
@@ -45,8 +52,11 @@ describe('Masonry > External cache', () => {
 
     // wait for grid to be unmounted
     updatedMountCount = await page.evaluate(() => window.ITEM_MOUNT_COUNT);
-    assert.equal(updatedMountCount, 0);
+    expect(updatedMountCount).toBe(0);
     await toggleMountTrigger.click();
+
+    // Wait for Masonry multi-stage rendering.
+    await page.waitFor(1000);
 
     // wait for grid to be remounted
     const updatedCount = await page.evaluate(() => window.ITEM_MOUNT_COUNT);


### PR DESCRIPTION
When we upgraded to React 16.6 with #406, it exposed an issue with our integration tests where Jest was terminating early without finishing all asserts. This diff fixes that by adding more `waitFor` to ensure Masonry fully renders and also a deterministic termination in the Jest test.