### PR TITLE
Add disabled state to IconButton to match Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- IconButton: Add new `disabled` prop and stylings to `IconButton` component (#413)
+
 ### Patch
 
 - Internal: Fixed a test that started flaking out with React 16.6 (#410)

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -44,6 +44,10 @@ card(
         defaultValue: 'transparent',
       },
       {
+        name: 'disabled',
+        type: 'boolean',
+      },
+      {
         name: 'iconColor',
         type: `"blue" | "darkGray" | "gray" | "red" | "white"`,
         defaultValue: 'gray',
@@ -76,6 +80,23 @@ card(
 <IconButton
   accessibilityLabel="Love"
   bgColor="white"
+  icon="heart"
+  iconColor="red"
+  onClick={() => { console.log('❤️')}}
+/>
+`}
+  />
+);
+
+card(
+  <Example
+    name="Disabled"
+    description={`Just like any button component, \`IconButton\` can render in a disabled state`}
+    defaultCode={`
+<IconButton
+  accessibilityLabel="Love"
+  bgColor="white"
+  disabled={true}
   icon="heart"
   iconColor="red"
   onClick={() => { console.log('❤️')}}

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -96,7 +96,7 @@ card(
 <IconButton
   accessibilityLabel="Love"
   bgColor="white"
-  disabled={true}
+  disabled
   icon="heart"
   iconColor="red"
   onClick={() => { console.log('❤️')}}

--- a/packages/gestalt/src/IconButton.css
+++ b/packages/gestalt/src/IconButton.css
@@ -6,8 +6,15 @@
   composes: block from "./Layout.css";
   composes: noBorder from "./Borders.css";
   composes: p0 from "./Whitespace.css";
-  composes: pointer from "./Cursor.css";
   background: transparent;
+}
+
+.enabled {
+  composes: pointer from "./Cursor.css";
+}
+
+.disabled {
+  cursor: default;
 }
 
 .button:focus {

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import styles from './IconButton.css';
 import icons from './icons/index.js';
 import Pog from './Pog.js';
@@ -10,6 +11,7 @@ type Props = {|
   accessibilityHaspopup?: boolean,
   accessibilityLabel: string,
   bgColor?: 'transparent' | 'gray' | 'lightGray' | 'white',
+  disabled?: boolean,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white',
   icon: $Keys<typeof icons>,
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
@@ -28,13 +30,14 @@ export default class IconButton extends React.Component<Props, State> {
     accessibilityHaspopup: PropTypes.bool,
     accessibilityLabel: PropTypes.string.isRequired,
     bgColor: PropTypes.oneOf(['transparent', 'gray', 'lightGray', 'white']),
+    disabled: PropTypes.bool,
     icon: PropTypes.oneOf(Object.keys(icons)).isRequired,
     iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'blue', 'white']),
     onClick: PropTypes.func,
     size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
   };
 
-  state: State = {
+  state = {
     active: false,
     focused: false,
     hovered: false,
@@ -42,28 +45,15 @@ export default class IconButton extends React.Component<Props, State> {
 
   handleBlur = () => this.setState({ focused: false });
 
-  handleFocus = () => {
-    this.setState({ focused: true });
-  };
+  handleFocus = () => this.setState({ focused: true });
 
-  handleMouseDown = () => {
-    this.setState({ active: true });
-  };
+  handleMouseDown = () => this.setState({ active: true });
 
-  handleMouseEnter = () => {
-    this.setState({ hovered: true });
-  };
+  handleMouseEnter = () => this.setState({ hovered: true });
 
-  handleMouseLeave = () => {
-    this.setState({
-      active: false,
-      hovered: false,
-    });
-  };
+  handleMouseLeave = () => this.setState({ active: false, hovered: false });
 
-  handleMouseUp = () => {
-    this.setState({ active: false });
-  };
+  handleMouseUp = () => this.setState({ active: false });
 
   render() {
     const {
@@ -71,6 +61,7 @@ export default class IconButton extends React.Component<Props, State> {
       accessibilityHaspopup,
       accessibilityLabel,
       bgColor,
+      disabled,
       iconColor,
       icon,
       size,
@@ -79,12 +70,18 @@ export default class IconButton extends React.Component<Props, State> {
 
     const { active, focused, hovered } = this.state;
 
+    const classes = classnames(styles.button, {
+      [styles.disabled]: disabled,
+      [styles.enabled]: !disabled,
+    });
+
     return (
       <button
         aria-expanded={accessibilityExpanded}
         aria-haspopup={accessibilityHaspopup}
         aria-label={accessibilityLabel}
-        className={styles.button}
+        className={classes}
+        disabled={disabled}
         onBlur={this.handleBlur}
         onClick={event => onClick && onClick({ event })}
         onFocus={this.handleFocus}
@@ -95,11 +92,11 @@ export default class IconButton extends React.Component<Props, State> {
         type="button"
       >
         <Pog
-          active={active}
-          bgColor={bgColor}
-          focused={focused}
-          hovered={hovered}
-          iconColor={iconColor}
+          active={disabled ? false : active}
+          bgColor={disabled ? 'lightGray' : bgColor}
+          focused={disabled ? false : focused}
+          hovered={disabled ? false : hovered}
+          iconColor={disabled ? 'gray' : iconColor}
           icon={icon}
           size={size}
         />

--- a/packages/gestalt/src/IconButton.test.js
+++ b/packages/gestalt/src/IconButton.test.js
@@ -10,3 +10,11 @@ test('IconButton renders', () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('IconButton renders with disabled state', () => {
+  const component = renderer.create(
+    <IconButton accessibilityLabel="Pinterest" icon="pin" disabled />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`IconButton renders 1`] = `
 <button
   aria-label="Pinterest"
-  className="button"
+  className="button enabled"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -15,6 +15,53 @@ exports[`IconButton renders 1`] = `
 >
   <div
     className="pog transparent"
+    style={
+      Object {
+        "height": 40,
+        "width": 40,
+      }
+    }
+  >
+    <div
+      className="box circle"
+    >
+      <svg
+        aria-hidden={true}
+        aria-label=""
+        className="icon gray iconBlock"
+        height={20}
+        role="img"
+        viewBox="0 0 24 24"
+        width={20}
+      >
+        <title>
+          
+        </title>
+        <path
+          d="test-file-stub"
+        />
+      </svg>
+    </div>
+  </div>
+</button>
+`;
+
+exports[`IconButton renders with disabled state 1`] = `
+<button
+  aria-label="Pinterest"
+  className="button disabled"
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  type="button"
+>
+  <div
+    className="pog lightGray"
     style={
       Object {
         "height": 40,


### PR DESCRIPTION
Adds a new `disabled` prop on `IconButton` to match the stylings and ability of regular `Button`
![image](https://user-images.githubusercontent.com/7877010/47699956-dd2a8800-dbd1-11e8-955d-0ef303ccacb5.png)

