### PR TITLE
Updated tabs key to be a composite of index and href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Tabs: (Update to #368) Use composite of index and href for tab keys (#419)
+
 ### Patch
 
 - Internal: Fixed a test that started flaking out with React 16.6 (#410)

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -76,7 +76,7 @@ export default class Tabs extends React.Component<Props, State> {
               aria-selected={isActive}
               className={cs}
               href={href}
-              key={href}
+              key={`${i}${href}`}
               onClick={(e: SyntheticMouseEvent<>) => this.handleTabClick(i, e)}
               onFocus={() => this.handleTabFocus(i)}
               onBlur={this.handleTabBlur}


### PR DESCRIPTION
PR #368 changed tab keys to use only `href`. This is technically correct, but didn't work out in practice. In a perfect world, `href` would either be required and tabs would use A tags, or `href` would be removed and tabs would use buttons. In the meantime, we're using tabs in both ways all over and using `href` as the key resulted in a lot of key collisions where key was `""`.