### PR TITLE
Masonry’s onFinishedRendering is called only when fetching has finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Minor
 
-- Icon: adding new icons (#425)
+- Masonry: onFinishedRendering is only called when fetching has finished (#426)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Minor
 
+- Icon: adding new icons (#425)
 - Masonry: onFinishedRendering is only called when fetching has finished (#426)
 
 ### Patch

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -111,6 +111,12 @@ card(
         description:
           'MasonryUniformRowLayout will make it so that each row is as tall as the tallest item in that row.',
       },
+      {
+        name: 'onFinishedRendering',
+        type: '() => void',
+        description:
+          'onFinishedRendering is a callback function that will be called when Masonry is finished with all measurements, fetches, and renders. This is useful because sometimes Masonry will re-render many times asyncronously as it measures and lays out items in batches and it can otherwise be difficult to tell when its finished without inspecting its internal state. Note that this method may be called immediately before `loadItems` is called which would cause further measurement/fetching.',
+      },
     ]}
   />
 );

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -229,6 +229,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
 
   componentDidUpdate(prevProps: Props<T>, prevState: State<T>) {
     const { items, measurementStore, onFinishedRendering } = this.props;
+    const { isFetching } = this.state;
 
     this.measureContainerAsync();
 
@@ -249,7 +250,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
           hasPendingMeasurements,
         });
       });
-    } else if (onFinishedRendering) {
+    } else if (onFinishedRendering && !isFetching) {
       onFinishedRendering();
     }
   }


### PR DESCRIPTION
I released a new Masonry prop, `onFinishedRendering`, last week. After adding, I realized it was being called twice on each load, and I traced it back to the `isFetching` flag being toggled. `onFinishedRendering` is now called only when `isFetching` which results in a more useful callback.