### PR TITLE
Removed Masonry onFinishedRendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 - Box: Add ref forwarding (#431)
+- Masonry: Removed onFinishedRendering prop because better test alternatives could be used (#435)
 
 ### Patch
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -51,7 +51,6 @@ type Props<T> = {|
           from: number,
         }
       ) => void | boolean | {}),
-  onFinishedRendering?: () => void,
   scrollContainer?: () => HTMLElement,
   virtualBoundsTop?: number,
   virtualBoundsBottom?: number,
@@ -228,7 +227,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
   }
 
   componentDidUpdate(prevProps: Props<T>, prevState: State<T>) {
-    const { items, measurementStore, onFinishedRendering } = this.props;
+    const { items, measurementStore } = this.props;
 
     this.measureContainerAsync();
 
@@ -249,8 +248,6 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
           hasPendingMeasurements,
         });
       });
-    } else if (onFinishedRendering) {
-      onFinishedRendering();
     }
   }
 


### PR DESCRIPTION
About a week ago, I added a new prop to Masonry called `onFinishedRendering` to better help with integration tests. After talking with Chris and taking another run at tests, I've chosen to remove it. The DOM serves as a better source of truth to integration tests than an event system ever could.