### PR TITLE
Bump gestalt from 0.85 to 0.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,16 @@
 
 ### Minor
 
-- Icon: adding new icons for editing. (#440)
-- Icon: adding canonical pin icon.
+### Patch
+
+</details>
+
+## 0.86.0 (January 3, 2019)
+
+### Minor
+
+- Icon: adding new icons for editing (#440)
+- Icon: adding canonical pin icon (#438)
 - Box: Add ref forwarding (#431)
 - Masonry: Removed onFinishedRendering prop because better test alternatives could be used (#435)
 - Internal: Removes integration tests (#439)
@@ -19,8 +27,6 @@
 
 - Internal: Migrated `postcss-cssnext` to `postcss-stage-env` and removed `color()` function (#432)
 - Docs: Update `Link` docs to indicate `href` is required (#437)
-
-</details>
 
 ## 0.85.0 (December 10, 2018)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
Deploying the backlog of features that landed in gestalt over holiday break
