### PR TITLE
Fix display name for Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Patch
 
+- Box: add displayName to Box to maintain current naming (#446)
+
 </details>
 
 ## 0.86.0 (January 3, 2019)

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -684,6 +684,10 @@ const Box = React.forwardRef(
   }
 );
 
+//  NOTE: This is needed in order to override the ForwardRef display name that is
+//  used in dev tools and in snapshot testing.
+Box.displayName = 'Box';
+
 export default Box;
 
 /*


### PR DESCRIPTION
Makes `<Box>` maintain its old display name in tests and dev tools
