### PR TITLE
Patch release gestalt 0.86.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Patch
 
-- Box: add displayName to Box to maintain current naming (#446)
-
 </details>
+
+## 0.86.1 (January 3, 2019)
+
+### Patch
+
+- Box: add displayName to Box to maintain current naming in snapshots (#446)
 
 ## 0.86.0 (January 3, 2019)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
Patch release to fix the naming issue in tests to reduce churn
