### PR TITLE
Make <PropTable/> in docs link to <Example/>'s

### DIFF
--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -21,11 +21,13 @@ card(
         name: 'align',
         type: `"left" | "right" | "center" | "justify"`,
         defaultValue: 'left',
+        id: 'align',
       },
       {
         name: 'bold',
         type: 'boolean',
         defaultValue: false,
+        id: 'styles',
       },
       {
         name: 'children',
@@ -35,11 +37,13 @@ card(
         name: 'color',
         type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
         defaultValue: 'darkGray',
+        id: 'color',
       },
       {
         name: 'inline',
         type: 'boolean',
         defaultValue: false,
+        id: 'inline',
       },
       {
         name: 'leading',
@@ -50,17 +54,20 @@ card(
         name: 'italic',
         type: 'boolean',
         defaultValue: false,
+        id: 'styles',
       },
       {
         name: 'overflow',
         type: `"normal" | "breakWord"`,
         defaultValue: 'breakWord',
+        id: 'overflow',
       },
       {
         name: 'size',
         type: `"xs" | "sm" | "md" | "lg" | "xl"`,
         description: `xs: 12px, sm: 14px, md: 16px, lg: 18px, xl: 21px`,
         defaultValue: 'md',
+        id: 'size',
         responsive: true,
       },
       {
@@ -68,6 +75,7 @@ card(
         type: 'boolean',
         description:
           'Truncate the text to a single line. Add the title attribute if `<Text>` only contains text.',
+        id: 'overflow',
         defaultValue: false,
       },
     ]}
@@ -77,6 +85,7 @@ card(
 card(
   <Example
     description="You can apply the following to adjust the positioning of text within wrapper elements."
+    id="align"
     name="Alignment"
     defaultCode={`
 <Box maxWidth="8em">
@@ -94,6 +103,7 @@ card(
     description={`
     The Text component allows you to specifiy whether you want \`block\` or \`inline\` text.
   `}
+    id="inline"
     name="Block vs inline"
     defaultCode={`
 <Box>
@@ -113,6 +123,7 @@ card(
 card(
   <Example
     description="You can specify which color you want for your text."
+    id="color"
     name="Colors"
     defaultCode={`
 <Box>
@@ -139,6 +150,7 @@ card(
 card(
   <Example
     description="Gestalt provides utility options to deal with text overflow."
+    id="overflow"
     name="Overflow"
     defaultCode={`
 <Box maxWidth={240}>
@@ -174,6 +186,7 @@ card(
     description={`
     You can apply the following \`size\` options to define the size of the text.
   `}
+    id="size"
     name="Sizes"
     defaultCode={`
 <Box>
@@ -237,6 +250,7 @@ card(
     There are multiple styles such as bold and italic that we can
     attach to the Text component.
   "
+    id="styles"
     name="Styles"
     defaultCode={`
 <Box>

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -21,13 +21,13 @@ card(
         name: 'align',
         type: `"left" | "right" | "center" | "justify"`,
         defaultValue: 'left',
-        id: 'align',
+        href: 'align',
       },
       {
         name: 'bold',
         type: 'boolean',
         defaultValue: false,
-        id: 'styles',
+        href: 'styles',
       },
       {
         name: 'children',
@@ -37,13 +37,13 @@ card(
         name: 'color',
         type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
         defaultValue: 'darkGray',
-        id: 'color',
+        href: 'color',
       },
       {
         name: 'inline',
         type: 'boolean',
         defaultValue: false,
-        id: 'inline',
+        href: 'inline',
       },
       {
         name: 'leading',
@@ -54,20 +54,20 @@ card(
         name: 'italic',
         type: 'boolean',
         defaultValue: false,
-        id: 'styles',
+        href: 'styles',
       },
       {
         name: 'overflow',
         type: `"normal" | "breakWord"`,
         defaultValue: 'breakWord',
-        id: 'overflow',
+        href: 'overflow',
       },
       {
         name: 'size',
         type: `"xs" | "sm" | "md" | "lg" | "xl"`,
         description: `xs: 12px, sm: 14px, md: 16px, lg: 18px, xl: 21px`,
         defaultValue: 'md',
-        id: 'size',
+        href: 'size',
         responsive: true,
       },
       {
@@ -75,7 +75,7 @@ card(
         type: 'boolean',
         description:
           'Truncate the text to a single line. Add the title attribute if `<Text>` only contains text.',
-        id: 'overflow',
+        href: 'overflow',
         defaultValue: false,
       },
     ]}

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -21,7 +21,7 @@ export default function Card({
   stacked = false,
 }: Props) {
   return (
-    <Box {...(id ? { id } : {})}>
+    <Box id={id}>
       {heading && <Heading size="xs">{name}</Heading>}
       <Box
         marginLeft={-2}

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -7,6 +7,7 @@ type Props = {|
   children?: React.Node,
   description?: string,
   heading?: boolean,
+  id: ?string,
   name: string,
   stacked?: boolean,
 |};
@@ -15,11 +16,12 @@ export default function Card({
   children,
   description,
   heading = true,
+  id,
   name,
   stacked = false,
 }: Props) {
   return (
-    <Box>
+    <Box {...(id ? { id } : {})}>
       {heading && <Heading size="xs">{name}</Heading>}
       <Box
         marginLeft={-2}

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -8,6 +8,7 @@ import Checkerboard from './Checkerboard.js';
 type Props = {|
   defaultCode: string,
   description?: string,
+  id?: string,
   name: string,
   direction?: 'row' | 'column',
 |};
@@ -17,6 +18,7 @@ const { Box, Text, Column } = gestalt;
 function Example({
   defaultCode,
   description,
+  id,
   name,
   direction = 'column',
 }: Props) {
@@ -24,6 +26,7 @@ function Example({
     <Card
       name={name}
       description={description}
+      id={id}
       stacked={direction === 'column'}
     >
       <LiveProvider code={defaultCode.trim()} scope={gestalt}>

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -1,11 +1,12 @@
 // @flow
 import * as React from 'react';
-import { Box, Text, Icon } from 'gestalt';
+import { Box, Text, Icon, Link } from 'gestalt';
 
 type Props = {|
   props: Array<{|
     defaultValue?: any,
     description?: string,
+    id: ?string,
     name: string,
     required?: boolean,
     responsive?: boolean,
@@ -104,7 +105,15 @@ export default function PropTable({ props: properties, Component }: Props) {
             ).reduce(
               (
                 acc,
-                { required, name, responsive, type, defaultValue, description },
+                {
+                  required,
+                  name,
+                  responsive,
+                  type,
+                  defaultValue,
+                  description,
+                  id,
+                },
                 i
               ) => {
                 acc.push(
@@ -126,7 +135,22 @@ export default function PropTable({ props: properties, Component }: Props) {
                     <Td shrink border={!description}>
                       <Box>
                         <Text overflow="normal" bold leading="tall">
-                          <code>{name}</code>
+                          {id ? (
+                            <Link
+                              href={`#${id}`}
+                              onClick={({ event }) => {
+                                event.preventDefault();
+                                const elem = document.getElementById(id);
+                                if (elem) {
+                                  elem.scrollIntoView({ behavior: 'smooth' });
+                                }
+                              }}
+                            >
+                              <code>{name}</code>
+                            </Link>
+                          ) : (
+                            <code>{name}</code>
+                          )}
                         </Text>
                       </Box>
                       {responsive && (

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -6,7 +6,7 @@ type Props = {|
   props: Array<{|
     defaultValue?: any,
     description?: string,
-    id: ?string,
+    href: ?string,
     name: string,
     required?: boolean,
     responsive?: boolean,
@@ -106,13 +106,13 @@ export default function PropTable({ props: properties, Component }: Props) {
               (
                 acc,
                 {
-                  required,
-                  name,
-                  responsive,
-                  type,
                   defaultValue,
                   description,
-                  id,
+                  href,
+                  name,
+                  required,
+                  responsive,
+                  type,
                 },
                 i
               ) => {
@@ -135,14 +135,17 @@ export default function PropTable({ props: properties, Component }: Props) {
                     <Td shrink border={!description}>
                       <Box>
                         <Text overflow="normal" bold leading="tall">
-                          {id ? (
+                          {href ? (
                             <Link
-                              href={`#${id}`}
+                              href={`#${href}`}
                               onClick={({ event }) => {
                                 event.preventDefault();
-                                const elem = document.getElementById(id);
+                                const elem = document.getElementById(href);
                                 if (elem) {
-                                  elem.scrollIntoView({ behavior: 'smooth' });
+                                  elem.scrollIntoView({
+                                    behavior: 'smooth',
+                                    block: 'start',
+                                  });
                                 }
                               }}
                             >


### PR DESCRIPTION
I often find myself looking at the table of props for each component, then scrolling down to find an example usage for that prop.  This adds the ability to make the name of a prop a link which scrolls to the relevant example on the page.

This is a little hacky atm.  I tried just wrapping the name of the prop in a `<Link href="#someId"/>` but I end up getting navigated to `/#/someId` instead of scrolling to the element with associated id.

![scrollto](https://user-images.githubusercontent.com/10646092/51783896-d25e9100-20f5-11e9-8e69-8f1ffcb47c9c.gif)
