### PR TITLE
<SegmentedControl /> should have equal item widths by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- SegmentedControl: add optional `equalWidths` prop for forcing all items to have equal width (#473)
+
 ### Patch
 
 </details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Minor
 
-- SegmentedControl: add optional `equalWidths` prop for forcing all items to have equal width (#473)
+- SegmentedControl: items have equal width by default; add `responsive` prop which makes item width responsive to content width (#473)
 
 ### Patch
 

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -24,13 +24,6 @@ card(
   <PropTable
     props={[
       {
-        name: 'equalWidths',
-        type: 'boolean',
-        required: false,
-        description:
-          'By default, the width of an item is based on its content. This forces all items to have equal width.',
-      },
-      {
         name: 'items',
         type: 'Array<React.Node>',
         required: true,
@@ -39,6 +32,13 @@ card(
         name: 'onChange',
         type: '({ event: SyntheticMouseEvent<>, activeIndex: number }) => void',
         required: true,
+      },
+      {
+        name: 'responsive',
+        type: 'boolean',
+        required: false,
+        description:
+          'By default, items have equal widths. If this prop is true, the width of an item is based on its content.',
       },
       {
         name: 'selectedItemIndex',
@@ -130,10 +130,10 @@ class SegmentedControlExample extends React.Component {
     };
     return (
       <Box>
-        <h3>Responsive widths</h3>
-        <SegmentedControl {...props} />
         <h3>Equal widths</h3>
-        <SegmentedControl {...props} equalWidths />
+        <SegmentedControl {...props} />
+        <h3>Responsive widths</h3>
+        <SegmentedControl {...props} responsive />
       </Box>
     );
   }

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -106,7 +106,7 @@ class SegmentedControlExample extends React.Component {
 
 card(
   <Example
-    description="Segmented Controls can have equal widths"
+    description="Segmented Controls can have responsive widths where the width of an item is based on its content."
     name="Example"
     defaultCode={`
 class SegmentedControlExample extends React.Component {

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -59,7 +59,7 @@ card(
     "
     name="Example"
     defaultCode={`
-class ToastExample extends React.Component {
+class SegmentedControlExample extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -90,6 +90,44 @@ class ToastExample extends React.Component {
         selectedItemIndex={this.state.itemIndex}
         onChange={this.handleItemChange}
       />
+    );
+  }
+}
+    `}
+  />
+);
+
+card(
+  <Example
+    description="Segmented Controls can have equal widths"
+    name="Example"
+    defaultCode={`
+class SegmentedControlExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      itemIndex: 0,
+    };
+    this.handleItemChange = this.handleItemChange.bind(this);
+  }
+
+  handleItemChange({ activeIndex }) {
+    this.setState(prevState => ({ itemIndex: activeIndex }));
+  };
+
+  render() {
+    const props = {
+      items: ['Short', 'Really really really long title'],
+      selectedItemIndex: this.state.itemIndex,
+      onChange: this.handleItemChange,
+    };
+    return (
+      <Box>
+        <h3>Responsive widths</h3>
+        <SegmentedControl {...props} />
+        <h3>Equal widths</h3>
+        <SegmentedControl {...props} equalWidths />
+      </Box>
     );
   }
 }

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -24,6 +24,13 @@ card(
   <PropTable
     props={[
       {
+        name: 'equalWidths',
+        type: 'boolean',
+        required: false,
+        description:
+          'By default, the width of an item is based on its content. This forces all items to have equal width.',
+      },
+      {
         name: 'items',
         type: 'Array<React.Node>',
         required: true,

--- a/packages/gestalt-codemods/0.88.0-0.89.0/segmented-control-responsive-widths.js
+++ b/packages/gestalt-codemods/0.88.0-0.89.0/segmented-control-responsive-widths.js
@@ -1,0 +1,43 @@
+/**
+ * Converts
+ *  <SegmentedControl ... />
+ * to
+ *  <SegmentedControl ... responsive />
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return;
+    }
+    const specifier = decl.specifiers.find(
+      node => node.imported.name === 'SegmentedControl'
+    );
+    if (!specifier) {
+      return;
+    }
+    localIdentifierName = specifier.local.name;
+  });
+
+  return src
+    .find(j.JSXElement)
+    .forEach(path => {
+      const { node } = path;
+      if (
+        !localIdentifierName ||
+        node.openingElement.name.name !== localIdentifierName
+      ) {
+        return;
+      }
+      const attrs = node.openingElement.attributes;
+      attrs.push(j.jsxAttribute(j.jsxIdentifier('responsive')));
+
+      j(path).replaceWith(node);
+    })
+    .toSource();
+}

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -7,6 +7,7 @@ import Text from './Text.js';
 import styles from './SegmentedControl.css';
 
 type Props = {|
+  equalWidths?: boolean,
   items: Array<React.Node>,
   onChange: ({ event: SyntheticMouseEvent<>, activeIndex: number }) => void,
   selectedItemIndex: number,
@@ -14,7 +15,16 @@ type Props = {|
 |};
 
 export default function SegmentedControl(props: Props) {
-  const { items, onChange, selectedItemIndex, size = 'md' } = props;
+  const {
+    equalWidths,
+    items,
+    onChange,
+    selectedItemIndex,
+    size = 'md',
+  } = props;
+  const buttonStyle = equalWidths
+    ? { width: `${Math.floor(100 / Math.max(1, items.length))}%` }
+    : undefined;
   return (
     <div
       className={classnames(styles.SegmentedControl, {
@@ -37,6 +47,7 @@ export default function SegmentedControl(props: Props) {
             onClick={e => onChange({ event: e, activeIndex: i })}
             role="tab"
             type="button"
+            style={buttonStyle}
           >
             {typeof item === 'string' ? (
               <Text

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -7,24 +7,18 @@ import Text from './Text.js';
 import styles from './SegmentedControl.css';
 
 type Props = {|
-  equalWidths?: boolean,
   items: Array<React.Node>,
   onChange: ({ event: SyntheticMouseEvent<>, activeIndex: number }) => void,
+  responsive?: boolean,
   selectedItemIndex: number,
   size?: 'md' | 'lg',
 |};
 
 export default function SegmentedControl(props: Props) {
-  const {
-    equalWidths,
-    items,
-    onChange,
-    selectedItemIndex,
-    size = 'md',
-  } = props;
-  const buttonStyle = equalWidths
-    ? { width: `${Math.floor(100 / Math.max(1, items.length))}%` }
-    : undefined;
+  const { items, onChange, responsive, selectedItemIndex, size = 'md' } = props;
+  const buttonStyle = responsive
+    ? undefined
+    : { width: `${Math.floor(100 / Math.max(1, items.length))}%` };
   return (
     <div
       className={classnames(styles.SegmentedControl, {
@@ -73,5 +67,7 @@ export default function SegmentedControl(props: Props) {
 SegmentedControl.propTypes = {
   items: PropTypes.arrayOf(PropTypes.node).isRequired,
   onChange: PropTypes.func.isRequired,
+  responsive: PropTypes.bool,
   selectedItemIndex: PropTypes.number.isRequired,
+  size: PropTypes.oneOf(['md', 'lg']),
 };

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -16,9 +16,9 @@ type Props = {|
 
 export default function SegmentedControl(props: Props) {
   const { items, onChange, responsive, selectedItemIndex, size = 'md' } = props;
-  const buttonStyle = responsive
+  const buttonWidth = responsive
     ? undefined
-    : { width: `${Math.floor(100 / Math.max(1, items.length))}%` };
+    : `${Math.floor(100 / Math.max(1, items.length))}%`;
   return (
     <div
       className={classnames(styles.SegmentedControl, {
@@ -41,7 +41,7 @@ export default function SegmentedControl(props: Props) {
             onClick={e => onChange({ event: e, activeIndex: i })}
             role="tab"
             type="button"
-            style={buttonStyle}
+            style={{ width: buttonWidth }}
           >
             {typeof item === 'string' ? (
               <Text

--- a/packages/gestalt/src/SegmentedControl.test.js
+++ b/packages/gestalt/src/SegmentedControl.test.js
@@ -15,10 +15,10 @@ test('SegmentedControl renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('SegmentedControl with equal widths renders', () => {
+test('SegmentedControl with responsive widths renders', () => {
   const tree = create(
     <SegmentedControl
-      equalWidths
+      responsive
       items={['Short', 'Really really really long title']}
       selectedItemIndex={0}
       onChange={() => {}}

--- a/packages/gestalt/src/SegmentedControl.test.js
+++ b/packages/gestalt/src/SegmentedControl.test.js
@@ -15,6 +15,18 @@ test('SegmentedControl renders', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('SegmentedControl with equal widths renders', () => {
+  const tree = create(
+    <SegmentedControl
+      equalWidths
+      items={['Short', 'Really really really long title']}
+      selectedItemIndex={0}
+      onChange={() => {}}
+    />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('SegmentedControl handles click', () => {
   const mockOnChange = jest.fn();
   const wrapper = shallow(

--- a/packages/gestalt/src/__snapshots__/SegmentedControl.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SegmentedControl.test.js.snap
@@ -90,6 +90,11 @@ exports[`SegmentedControl with responsive widths renders 1`] = `
     className="item itemIsSelected"
     onClick={[Function]}
     role="tab"
+    style={
+      Object {
+        "width": undefined,
+      }
+    }
     type="button"
   >
     <div
@@ -103,6 +108,11 @@ exports[`SegmentedControl with responsive widths renders 1`] = `
     className="item itemIsNotSelected"
     onClick={[Function]}
     role="tab"
+    style={
+      Object {
+        "width": undefined,
+      }
+    }
     type="button"
   >
     <div

--- a/packages/gestalt/src/__snapshots__/SegmentedControl.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SegmentedControl.test.js.snap
@@ -59,3 +59,47 @@ exports[`SegmentedControl renders 1`] = `
   </button>
 </div>
 `;
+
+exports[`SegmentedControl with equal widths renders 1`] = `
+<div
+  className="SegmentedControl md"
+  role="tablist"
+>
+  <button
+    aria-selected={true}
+    className="item itemIsSelected"
+    onClick={[Function]}
+    role="tab"
+    style={
+      Object {
+        "width": "50%",
+      }
+    }
+    type="button"
+  >
+    <div
+      className="Text fontSize3 darkGray alignCenter breakWord fontStyleNormal fontWeightBold"
+    >
+      Short
+    </div>
+  </button>
+  <button
+    aria-selected={false}
+    className="item itemIsNotSelected"
+    onClick={[Function]}
+    role="tab"
+    style={
+      Object {
+        "width": "50%",
+      }
+    }
+    type="button"
+  >
+    <div
+      className="Text fontSize3 gray alignCenter breakWord fontStyleNormal fontWeightBold"
+    >
+      Really really really long title
+    </div>
+  </button>
+</div>
+`;

--- a/packages/gestalt/src/__snapshots__/SegmentedControl.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SegmentedControl.test.js.snap
@@ -10,6 +10,11 @@ exports[`SegmentedControl renders 1`] = `
     className="item itemIsSelected"
     onClick={[Function]}
     role="tab"
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
     type="button"
   >
     <div
@@ -23,6 +28,11 @@ exports[`SegmentedControl renders 1`] = `
     className="item itemIsNotSelected"
     onClick={[Function]}
     role="tab"
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
     type="button"
   >
     <div
@@ -36,6 +46,11 @@ exports[`SegmentedControl renders 1`] = `
     className="item itemIsNotSelected"
     onClick={[Function]}
     role="tab"
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
     type="button"
   >
     <div
@@ -49,6 +64,11 @@ exports[`SegmentedControl renders 1`] = `
     className="item itemIsNotSelected"
     onClick={[Function]}
     role="tab"
+    style={
+      Object {
+        "width": "25%",
+      }
+    }
     type="button"
   >
     <div
@@ -60,7 +80,7 @@ exports[`SegmentedControl renders 1`] = `
 </div>
 `;
 
-exports[`SegmentedControl with equal widths renders 1`] = `
+exports[`SegmentedControl with responsive widths renders 1`] = `
 <div
   className="SegmentedControl md"
   role="tablist"
@@ -70,11 +90,6 @@ exports[`SegmentedControl with equal widths renders 1`] = `
     className="item itemIsSelected"
     onClick={[Function]}
     role="tab"
-    style={
-      Object {
-        "width": "50%",
-      }
-    }
     type="button"
   >
     <div
@@ -88,11 +103,6 @@ exports[`SegmentedControl with equal widths renders 1`] = `
     className="item itemIsNotSelected"
     onClick={[Function]}
     role="tab"
-    style={
-      Object {
-        "width": "50%",
-      }
-    }
     type="button"
   >
     <div


### PR DESCRIPTION
Per the [design spec](https://design.pinadmin.com/pds/#segmented-controls), the width of each item in a segmented control should be the same, rather than based on what's inside of the segmented control item.

<img width="310" alt="screenshot 2019-01-30 22 45 25" src="https://user-images.githubusercontent.com/5341184/52035998-bcc7dd80-24e0-11e9-89d9-2f08c5438d9c.png">

~I added an optional prop `equalWidths`. If it's true, the segmented control items would have equal widths.~
**UPDATE**: Before this PR, the items in `<SegmentedControl>` have width responsive to their content. After this PR is merged, the items in `<SegmentedControl>` will have equal width by default and will be adhere the design spec. To use the old behavior, pass the optional prop `responsive`.

~I am including an example in the doc that shows the side-by-side comparison between responsive width (default) and the equal/fixed widths.~
**UPDATE**: I am including an example in the doc that shows the side-by-side comparison between the equal width (now the default) and the responsive width (the old default)
<img width="837" alt="screenshot 2019-01-30 22 32 19" src="https://user-images.githubusercontent.com/5341184/52036084-fd275b80-24e0-11e9-91be-973218ffda26.png">

## TODO
- [x] Documentation
- [x] Tests
- [x] Codemode
