### PR TITLE
Bump gestalt to 0.90.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@
 
 ### Minor
 
-- Upgrade flow version to [0.84.0](https://github.com/facebook/flow/releases/tag/v0.85.0) (#479)
-- Layer: `children` prop is now required (#479)
-
 ### Patch
 
 </details>
+
+## 0.90.0 (February 19, 2019)
+
+### Minor
+
+- Upgrade flow version to [0.84.0](https://github.com/facebook/flow/releases/tag/v0.84.0) (#479)
+- Layer: `children` prop is now required (#479)
 
 ## 0.89.0 (February 15, 2019)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
This release includes flow upgrade #479

Breaking change:
- `Layer`: the `children` prop is now a required prop
