### PR TITLE
Docs: Add links to remaining component propTables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 ### Patch
+- Docs: Update remaining prop tables to include links to examples (#XXX)
 
 - Docs: Improve Image description (#481)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Minor
 
 ### Patch
-- Docs: Update remaining prop tables to include links to examples (#XXX)
+- Docs: Update remaining prop tables to include links to examples (#487)
 
 - Docs: Improve Image description (#481)
 

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -38,21 +38,25 @@ card(
         type: 'string',
         description:
           'String that clients such as VoiceOver will read to describe the element. Always localize the label.',
+        href: 'accessibilityLabel',
       },
       {
         name: 'color',
         type: `"blue" | "gray" | "red" | "transparent" | "white"`,
         defaultValue: 'gray',
+        href: 'color',
       },
       {
         name: 'disabled',
         type: 'boolean',
         defaultValue: false,
+        href: 'combinations',
       },
       {
         name: 'inline',
         type: 'boolean',
         defaultValue: false,
+        href: 'widths',
       },
       {
         name: 'name',
@@ -67,6 +71,7 @@ card(
         type: `"sm" | "md" | "lg"`,
         defaultValue: 'md',
         description: 'sm: 36px, md: 40px, lg: 48px',
+        href: 'combinations',
       },
       {
         name: 'text',
@@ -77,6 +82,7 @@ card(
         name: 'type',
         type: `"submit" | "button"`,
         defaultValue: 'button',
+        href: 'types',
       },
     ]}
   />
@@ -98,6 +104,7 @@ card(
     are sized by the text within the button, whereas the default block buttons
     expand to the full width of their container. The default \`inline\` is false.
   `}
+    id="widths"
     name="Widths"
     defaultCode={`
 <Box margin={-2}>
@@ -117,6 +124,7 @@ card(
     description={`
     \`transparent\` and \`white\` are our secondary colors for \`Button\`. We should only show them on a dark gray background.
   `}
+    id="color"
     name="Colors: Dark Backgrounds"
     defaultCode={`
 <Box color="darkGray" maxWidth={320} shape="rounded" padding={4}>
@@ -145,6 +153,7 @@ card(
     There are 2 types of buttons: button and submit. Use the \`submit\` type when you do not
     need to specify an \`onClick\` handler. The default type is \`button\`.
   `}
+    id="types"
     name="Types"
     defaultCode={`
 <Box margin={-2}>
@@ -167,6 +176,7 @@ card(
 
     Be sure to internationalize your \`accessibilityLabel\`!
   `}
+    id="accessibilityLabel"
     name="Accessibility Label"
     defaultCode={`
 <Box margin={-2}>
@@ -183,6 +193,7 @@ card(
 
 card(
   <Combination
+    id="combinations"
     name="Combinations"
     color={['gray', 'red', 'blue']}
     disabled={[false, true]}

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -25,16 +25,19 @@ card(
         name: 'checked',
         type: 'boolean',
         defaultValue: false,
+        href: 'combinations',
       },
       {
         name: 'disabled',
         type: 'boolean',
         defaultValue: false,
+        href: 'combinations',
       },
       {
         name: 'hasError',
         type: 'boolean',
         defaultValue: false,
+        href: 'hasError',
       },
       {
         name: 'id',
@@ -48,6 +51,7 @@ card(
         description: `Indeterminism is
 purely presentational - the value of
 a checkbox and its indeterminism are independent.`,
+        href: 'combinations',
       },
       {
         name: 'name',
@@ -67,6 +71,7 @@ a checkbox and its indeterminism are independent.`,
         type: `"sm" | "md"`,
         defaultValue: 'md',
         description: `"sm" is 16px & "md" is 24px`,
+        href: 'combinations',
       },
     ]}
   />
@@ -155,6 +160,7 @@ class CheckboxExample extends React.Component {
 
 card(
   <Example
+    id="hasError"
     name="Example: Error state"
     defaultCode={`
 class CheckboxExample extends React.Component {
@@ -182,6 +188,7 @@ class CheckboxExample extends React.Component {
 
 card(
   <Combination
+    id="combinations"
     checked={[false, true]}
     disabled={[false, true]}
     indeterminate={[false, true]}

--- a/docs/src/Collage.doc.js
+++ b/docs/src/Collage.doc.js
@@ -30,24 +30,28 @@ card(
         type: 'number',
         description: 'Number of columns (2 - 4)',
         required: true,
+        href: 'columns',
       },
       {
         name: 'cover',
         type: 'boolean',
         description: 'Whether or not the first image is a cover image',
         defaultValue: false,
+        href: 'coverImage',
       },
       {
         name: 'gutter',
         type: 'number',
         description: 'The amount of vertical & horizontal space between images',
         defaultValue: 0,
+        href: 'gutter',
       },
       {
         name: 'height',
         type: 'number',
         description: 'Height of the collage',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'layoutKey',
@@ -57,6 +61,7 @@ card(
         If there are N layouts available, (layoutKey % N) will determine which layout is used.
         `,
         defaultValue: 0,
+        href: 'layoutKey',
       },
       {
         name: 'renderImage',
@@ -64,12 +69,14 @@ card(
           '({ width: number, height: number, index: number }) => React.Node',
         description: 'Render prop for the collage images',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'width',
         type: 'number',
         description: 'Width of the collage',
         required: true,
+        href: 'basicExample',
       },
     ]}
   />
@@ -77,6 +84,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     name="Basic example"
     defaultCode={`
 <Collage
@@ -143,6 +151,7 @@ card(
 
 card(
   <Example
+    id="columns"
     name="Different columns"
     description="2 - 4 columns"
     defaultCode={`
@@ -225,6 +234,7 @@ card(
 
 card(
   <Example
+    id="gutter"
     name="Gutter"
     defaultCode={`
 <Box color="gray" width={300} height={300}>
@@ -294,6 +304,7 @@ card(
 
 card(
   <Example
+    id="coverImage"
     name="Cover image"
     defaultCode={`
 <Box color="gray" width={300} height={300}>
@@ -429,6 +440,7 @@ card(
 
 card(
   <Example
+    id="layoutKey"
     name="Layout key"
     description="
       You can pick a layout using the layout key (layout key is 0 by default).

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -24,11 +24,13 @@ card(
         type: '?HTMLElement',
         required: true,
         description: 'Ref for the element that the Flyout will attach to',
+        href: 'anchor',
       },
       {
         name: 'idealDirection',
         type: `'up' | 'right' | 'down' | 'left'`,
         description: 'Preferred direction for the Flyout to open',
+        href: 'idealDirection',
       },
       {
         name: 'children',
@@ -38,6 +40,7 @@ card(
         name: 'onDismiss',
         type: '() => void',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'positionRelativeToAnchor',
@@ -45,6 +48,7 @@ card(
         defaultValue: true,
         description:
           'Depicts if the Flyout shares a relative root with the anchor element',
+        href: 'anchor',
       },
       {
         name: 'color',
@@ -52,18 +56,21 @@ card(
         defaultValue: 'white',
         description:
           'The background color of the Flyout; orange matches other default error messaging',
+        href: 'errorFlyout',
       },
       {
         name: 'shouldFocus',
         type: 'boolean',
         defaultValue: true,
         description: 'Focus on the flyout when opened',
+        href: 'errorFlyout',
       },
       {
         name: 'size',
         type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | number`,
         description: `xs: 185px, sm: 230px, md: 284px, lg: 320px, xl:375px`,
         defaultValue: 'sm',
+        href: 'basicExample',
       },
     ]}
   />
@@ -71,6 +78,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     name="Example"
     defaultCode={`
 class FlyoutExample extends React.Component {
@@ -124,6 +132,7 @@ class FlyoutExample extends React.Component {
 
 card(
   <Example
+    id="errorFlyout"
     name="Example: ErrorFlyout"
     description={`Flyout can also take on additional roles. Like [TextField](#TextField) and [TextArea](#TextArea), this component
 can be used to highlight errors on other types of form fields by setting the \`color\` to \`orange.\``}
@@ -174,6 +183,7 @@ class ErrorFlyoutExample extends React.Component {
 
 card(
   <Card
+    id="anchor"
     description={`
     The \`anchor\` ref you pass in should not include anything other than the trigger element itself. The Flyout
     calculates its position based on the bounding box of the \`anchor\`. To achieve this, we recommend setting a
@@ -189,6 +199,7 @@ card(
 
 card(
   <Card
+    id="idealDirection"
     description={`
     The \`Flyout\` component gives you the ability to _influence_ the preferred direction that it
     opens. This may be a useful property to specify if you have a page with many potential flyouts

--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -23,6 +23,7 @@ card(
         name: 'accessibilityLevel',
         type: '1 | 2 | 3 | 4 | 5 | 6',
         description: 'Allows you to override the default heading level',
+        href: 'levels',
       },
       {
         name: 'children',
@@ -32,6 +33,7 @@ card(
         name: 'color',
         type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
         defaultValue: 'darkGray',
+        href: 'colors',
       },
       {
         name: 'id',
@@ -41,6 +43,7 @@ card(
         name: 'overflow',
         type: '"normal" | "breakWord"',
         defaultValue: 'breakWord',
+        href: 'overflowTruncation',
       },
       {
         name: 'size',
@@ -48,11 +51,13 @@ card(
         description: `xs: 24px, sm: 36px, md: 48px, lg: 64px, xl: 96px`,
         responsive: true,
         defaultValue: 'md',
+        href: 'sizes',
       },
       {
         name: 'truncate',
         type: 'boolean',
         defaultValue: false,
+        href: 'overflowTruncation',
       },
     ]}
   />
@@ -60,6 +65,7 @@ card(
 
 card(
   <Example
+    id="sizes"
     name="Example: Sizes"
     defaultCode={`
 <Box>
@@ -92,6 +98,7 @@ card(
 
 card(
   <Example
+    id="colors"
     name="Example: Colors"
     defaultCode={`
 <Box>
@@ -121,6 +128,7 @@ card(
 
 card(
   <Example
+    id="overflowTruncation"
     name="Example: Overflow & truncation"
     defaultCode={`
 <Box maxWidth={240} marginTop={-2} marginBottom={-2}>
@@ -151,6 +159,7 @@ card(
 
 card(
   <Example
+    id="levels"
     description="
     For accessibility purposes, we allow you to override the heading level.
 

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -27,23 +27,27 @@ card(
         required: true,
         description:
           'String that clients such as VoiceOver will read to describe the element. Always localize the label.',
+        href: 'iconWithLabel',
       },
       {
         name: 'color',
         type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
         defaultValue: 'gray',
+        href: 'sizeColorCombinations',
       },
       {
         name: 'icon',
         type: Icon.icons.map(name => `'${name}'`).join(' | '),
         required: true,
         description: `This allows us to type check for a valid icon name based on the keys from the list of icons shown below.`,
+        href: 'iconCombinations',
       },
       {
         name: 'size',
         type: `number | string`,
         description: `Use a number for pixel sizes or a string for percentage based sizes`,
         defaultValue: 16,
+        href: 'sizeColorCombinations',
       },
       {
         name: 'inline',
@@ -67,6 +71,7 @@ card(
 
 card(
   <Example
+    id="iconWithLabel"
     description="Icon with a label"
     name="Example:"
     defaultCode={`
@@ -83,7 +88,7 @@ card(
 );
 
 card(
-  <Combination name="Icon Combinations" icon={Icon.icons}>
+  <Combination id="iconCombinations" name="Icon Combinations" icon={Icon.icons}>
     {props => (
       <Icon color="darkGray" accessibilityLabel="" size={32} {...props} />
     )}
@@ -92,6 +97,7 @@ card(
 
 card(
   <Combination
+    id="sizeColorCombinations"
     name="Size & Color Combinations"
     size={[16, 24, 32]}
     color={['gray', 'darkGray', 'red']}

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -24,12 +24,14 @@ card(
         type: 'boolean',
         description:
           'Use this property on elements that can expand to reveal additional information',
+        href: 'accessibility',
       },
       {
         name: 'accessibilityHaspopup',
         type: 'boolean',
         description:
           'Indicates that the element has a popup context menu or sub-level menu.',
+        href: 'accessibility',
       },
       {
         name: 'accessibilityLabel',
@@ -37,17 +39,20 @@ card(
         required: true,
         description:
           'String that clients such as VoiceOver will read to describe the element. Will also be used for hover text (title). Always localize the label.',
+        href: 'accessibility',
       },
       {
         name: 'bgColor',
         type:
           '"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white"',
         defaultValue: 'transparent',
+        href: 'backgroundColorCombinations',
       },
       {
         name: 'iconColor',
         type: `"blue" | "darkGray" | "gray" | "red" | "white"`,
         defaultValue: 'gray',
+        href: 'iconColorCombinations',
       },
       {
         name: 'icon',
@@ -61,6 +66,7 @@ card(
         type: `"xs" | "sm" | "md" | "lg" | "xl"`,
         description: `xs: 24px, sm: 32px, md: 40px, lg: 48px, xl: 56px`,
         defaultValue: 'md',
+        href: 'sizeCombinations',
       },
       {
         name: 'onClick',
@@ -87,6 +93,7 @@ card(
 
 card(
   <Example
+    id="accessibility"
     description={`
       We want to make sure every button on the page is unique when being read by screenreader.
       \`accessibilityExpanded\` allows us to specify that the associated content (i.e. Flyout) is open.
@@ -132,13 +139,18 @@ card(
 );
 
 card(
-  <Combination name="Size Combinations" size={['xs', 'sm', 'md', 'lg', 'xl']}>
+  <Combination
+    id="sizeCombinations"
+    name="Size Combinations"
+    size={['xs', 'sm', 'md', 'lg', 'xl']}
+  >
     {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
   </Combination>
 );
 
 card(
   <Combination
+    id="iconColorCombinations"
     name="Icon Color Combinations"
     iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
   >
@@ -148,6 +160,7 @@ card(
 
 card(
   <Combination
+    id="backgroundColorCombinations"
     name="Background Color Combinations"
     bgColor={[
       'transparent',

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -41,24 +41,28 @@ card(
         name: 'color',
         type: 'string',
         required: true,
+        href: 'placeholders',
       },
       {
         name: 'fit',
         type: `"cover" | "contain" | "none"`,
         defaultValue: 'none',
         description: `Doesn't work with srcSet or sizes.`,
+        href: 'fit',
       },
       {
         name: 'naturalHeight',
         type: 'number',
         required: true,
         description: 'Exact height of source image',
+        href: 'fit',
       },
       {
         name: 'naturalWidth',
         type: 'number',
         required: true,
         description: 'Exact width of source image',
+        href: 'fit',
       },
       {
         name: 'onError',
@@ -78,6 +82,7 @@ card(
         name: 'src',
         type: 'string',
         required: true,
+        href: 'placeholders',
       },
       {
         name: 'srcSet',
@@ -107,6 +112,7 @@ card(
 
 card(
   <Example
+    id="placeholders"
     description={`
     The color you pass into \`Image\` will be used to fill the placeholder that shows up
     as an image loads. The example shown has an empty \`src\` prop provided so it remains
@@ -155,6 +161,7 @@ card(
 
 card(
   <Example
+    id="fit"
     description={`
     In some cases, you may want to scale an image to fit into its container.
     To achieve that, you can set \`fit\` to either \`cover\` or \`contain\`, depending on the effect you wish to achieve.

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -30,20 +30,24 @@ card(
       {
         name: 'height',
         type: `number | string`,
+        href: 'basicExample',
       },
       {
         name: 'width',
         type: `number | string`,
+        href: 'basicExample',
       },
       {
         name: 'shape',
         type: `"circle" | "rounded" | "square"`,
         defaultValue: 'square',
+        href: 'shapeCombinations',
       },
       {
         name: 'wash',
         type: 'boolean',
         defaultValue: false,
+        href: 'wash',
       },
     ]}
   />
@@ -51,6 +55,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     name="Example"
     defaultCode={`
 <Mask height={70} shape="circle" width={70}>
@@ -82,6 +87,7 @@ card(
 
 card(
   <Example
+    id="wash"
     description="
     If you expect the masked content to be nearly white, you can apply a wash to emphasize the edge of the mask.
   "
@@ -102,6 +108,7 @@ card(
 
 card(
   <Combination
+    id="shapeCombinations"
     name="Shape Combinations"
     shape={['circle', 'rounded', 'square']}
   >

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -28,6 +28,7 @@ card(
         required: true,
         description:
           'String that clients such as VoiceOver will read to describe the close button. Always localize the label.',
+        href: 'accessibility',
       },
       {
         name: 'accessibilityModalLabel',
@@ -35,31 +36,37 @@ card(
         required: true,
         description:
           'String that clients such as VoiceOver will read to describe the modal. Always localize the label.',
+        href: 'accessibility',
       },
       {
         name: 'footer',
         type: 'React.Node',
+        href: 'sizesExample',
       },
       {
         name: 'heading',
         type: `string`,
         required: true,
+        href: 'sizesExample',
       },
       {
         name: 'onDismiss',
         type: '() => void',
         required: true,
+        href: 'sizesExample',
       },
       {
         name: 'role',
         type: `"alertdialog" | "dialog"`,
         defaultValue: 'dialog',
+        href: 'role',
       },
       {
         name: 'size',
         type: `"sm" | "md" | "lg"`,
         defaultValue: 'sm',
         description: `sm: 414px, md: 544px, lg: 804px`,
+        href: 'sizesExample',
       },
     ]}
   />
@@ -67,6 +74,7 @@ card(
 
 card(
   <Example
+    id="sizesExample"
     name="Sizes"
     description={`
       There are 3 different widths available for a \`Modal\`. Click on each button
@@ -230,6 +238,7 @@ class Example extends React.Component {
 
 card(
   <Example
+    id="role"
     name="Alert Dialogs"
     description={`
       The \`alertdialog\` role is used to notify the user of urgent information that demands the user's immediate attention.
@@ -507,6 +516,7 @@ class Example extends React.Component {
 
 card(
   <Card
+    id="accessibility"
     description={`
     We want to make sure every button on the page is unique when being read by screenreader.
 

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -27,26 +27,31 @@ card(
         name: 'active',
         type: 'boolean',
         defaultValue: false,
+        href: 'stateCombinations',
       },
       {
         name: 'bgColor',
         type: `"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white"`,
         defaultValue: 'transparent',
+        href: 'colorCombinations',
       },
       {
         name: 'focused',
         type: 'boolean',
         defaultValue: false,
+        href: 'stateCombinations',
       },
       {
         name: 'hovered',
         type: 'boolean',
         defaultValue: false,
+        href: 'stateCombinations',
       },
       {
         name: 'iconColor',
         type: `"blue" | "darkGray" | "gray" | "red" | "white"`,
         defaultValue: 'gray',
+        href: 'colorCombinations',
       },
       {
         name: 'icon',
@@ -60,6 +65,7 @@ card(
         type: `"xs" | "sm" | "md" | "lg" | "xl"`,
         description: `xs: 24px, sm: 32px, md: 40px, lg: 48px, xl: 56px`,
         defaultValue: 'md',
+        href: 'sizeCombinations',
       },
     ]}
   />
@@ -79,6 +85,7 @@ card(
 
 card(
   <Combination
+    id="stateCombinations"
     name="State Combinations"
     hovered={[false, true]}
     focused={[false, true]}
@@ -89,13 +96,18 @@ card(
 );
 
 card(
-  <Combination name="Size Combinations" size={['xs', 'sm', 'md', 'lg', 'xl']}>
+  <Combination
+    id="sizeCombinations"
+    name="Size Combinations"
+    size={['xs', 'sm', 'md', 'lg', 'xl']}
+  >
     {props => <Pog icon="heart" {...props} />}
   </Combination>
 );
 
 card(
   <Combination
+    id="colorCombinations"
     name="Color Combinations"
     iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
     bgColor={[

--- a/docs/src/SelectList.doc.js
+++ b/docs/src/SelectList.doc.js
@@ -25,11 +25,13 @@ card(
       {
         name: 'errorMessage',
         type: '?string',
+        href: 'exampleWithError',
       },
       {
         name: 'id',
         type: 'string',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'idealErrorDirection',
@@ -40,25 +42,30 @@ card(
       {
         name: 'name',
         type: '?string',
+        href: 'basicExample',
       },
       {
         name: 'onChange',
         type: '({ event: SyntheticInputEvent<>, value: string }) => void',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'options',
         type: 'Array<{ label: string, value: string }>',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'placeholder',
         type: '?string',
+        href: 'basicExample',
       },
       {
         name: 'value',
         type: '?string',
         description: 'Value that is selected.',
+        href: 'basicExample',
       },
     ]}
   />
@@ -66,6 +73,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     name="Example"
     description={`Make sure to attach a \`Label\` to every SelectList.`}
     defaultCode={`
@@ -124,6 +132,7 @@ class SelectListExample extends React.Component {
 
 card(
   <Example
+    id="exampleWithError"
     name="Example: With Error Message"
     description={`SelectList can display error messages if you'd like.
     To use our errors, simply pass in an \`errorMessage\` when there is an error present and we will

--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -24,25 +24,30 @@ card(
         name: 'disabled',
         type: 'boolean',
         defaultValue: false,
+        href: 'switchCombinations',
       },
       {
         name: 'id',
         type: 'string',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'name',
         type: 'string',
+        href: 'basicExample',
       },
       {
         name: 'onChange',
         type: '({ event: SyntheticInputEvent<>, value: boolean }) => void',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'switched',
         type: 'boolean',
         defaultValue: false,
+        href: 'switchCombinations',
       },
     ]}
   />
@@ -50,6 +55,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     description={`
     Whenever you are using a \`Switch\` component, you should use a [Label](#/Label) with it to make your component accessible.
   `}
@@ -87,6 +93,7 @@ class SwitchExample extends React.Component {
 
 card(
   <Combination
+    id="switchCombinations"
     disabled={[false, true]}
     switched={[false, true]}
     heading={false}

--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -22,15 +22,18 @@ card(
         name: 'disabled',
         type: 'boolean',
         defaultValue: 'false',
+        href: 'disabledExample',
       },
       {
         name: 'errorMessage',
         type: 'string',
+        href: 'errorMessageExample',
       },
       {
         name: 'id',
         type: 'string',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'idealErrorDirection',
@@ -52,6 +55,7 @@ card(
         type:
           '({ event: SyntheticInputEvent<HTMLTextAreaElement>, value: string }) => void',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'onFocus',
@@ -66,6 +70,7 @@ card(
       {
         name: 'placeholder',
         type: 'string',
+        href: 'basicExample',
       },
       {
         name: 'rows',
@@ -76,6 +81,7 @@ card(
       {
         name: 'value',
         type: 'string',
+        href: 'basicExample',
       },
     ]}
   />
@@ -83,6 +89,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     name="Example"
     description={`
     A \`TextArea\` will expand to fill the width of the parent container.
@@ -125,6 +132,7 @@ class Example extends React.Component {
 
 card(
   <Example
+    id="disabledExample"
     name="Example: Disabled"
     defaultCode={`
 class Example extends React.Component {
@@ -165,6 +173,7 @@ class Example extends React.Component {
 
 card(
   <Example
+    id="errorMessageExample"
     name="Example: Error message"
     description={`
     A TextArea can display its own error message.

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -23,15 +23,18 @@ card(
         name: 'disabled',
         type: 'boolean',
         defaultValue: 'false',
+        href: 'disabledExample',
       },
       {
         name: 'errorMessage',
         type: 'string',
+        href: 'errorMessageExample',
       },
       {
         name: 'id',
         type: 'string',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'idealErrorDirection',
@@ -53,6 +56,7 @@ card(
         type:
           '({ event: SyntheticInputEvent<HTMLInputElement>, value: string }) => void',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'onFocus',
@@ -67,15 +71,18 @@ card(
       {
         name: 'placeholder',
         type: 'string',
+        href: 'basicExample',
       },
       {
         name: 'type',
         type: `"date" | "email" | "number" | "password" | "text" | "url"`,
         defaultValue: 'text',
+        href: 'basicExample',
       },
       {
         name: 'value',
         type: 'string',
+        href: 'basicExample',
       },
     ]}
   />
@@ -83,6 +90,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     name="Example"
     description={`
     A \`TextField\` will expand to fill the width of the parent container.
@@ -124,6 +132,7 @@ class Example extends React.Component {
 
 card(
   <Example
+    id="disabledExample"
     name="Example: Disabled"
     defaultCode={`
 class Example extends React.Component {
@@ -162,6 +171,7 @@ class Example extends React.Component {
 
 card(
   <Example
+    id="errorMessageExample"
     name="Example: Error message"
     description={`
     A TextField can display its own error message.

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -26,23 +26,27 @@ card(
         name: 'color',
         type: `'darkGray' | 'orange'`,
         defaultValue: 'darkGray',
+        href: 'errorExample',
       },
       {
         name: 'icon',
         type: 'arrow-circle-forward',
         defaultValue: 'arrow-circle-forward',
         description: 'More icons can be added in the future.',
+        href: 'guideExample',
       },
       {
         name: 'thumbnail',
         type: 'React.Node',
         description: 'Image should fit nicely into a square',
+        href: 'confirmationExample',
       },
       {
         name: 'text',
         type: 'string | Array<string>',
         description:
           'Use string for guide toasts (one line of text) and Array<string> for confirmation toasts (two lines of text).',
+        href: 'confirmationExample',
       },
     ]}
   />
@@ -50,6 +54,7 @@ card(
 
 card(
   <Example
+    id="confirmationExample"
     name="Confirmation Toasts"
     description="You can use Toasts to confirm an action has occured. When you are using a Toast as a confirmation, you should
         always include a thumbnail and two lines of text."
@@ -109,6 +114,7 @@ class ToastExample extends React.Component {
 
 card(
   <Example
+    id="guideExample"
     name="Guide Toasts"
     description="You can also use Toasts to guide and educate your users. In this case, no thumbnail is needed. Simply provide
       your instructional text to the Toast component. The arrow icon indicating the Toast is a link will be automatically
@@ -162,6 +168,7 @@ class ToastExample extends React.Component {
 
 card(
   <Example
+    id="errorExample"
     description="
       You can use Toasts to indicate that something wrong occurred by setting the color to orange.
     "

--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -25,16 +25,19 @@ card(
       {
         name: 'fullHeight',
         type: 'boolean',
+        href: 'fullHeightWidthExample',
       },
       {
         name: 'fullWidth',
         type: 'boolean',
         defaultValue: true,
+        href: 'fullHeightWidthExample',
       },
       {
         name: 'mouseCursor',
         type: `"copy" | "grab" | "grabbing" | "move" | "noDrop" | "pointer" | "zoomIn" | "zoomOut"`,
         defaultValue: 'pointer',
+        href: 'basicExample',
       },
       {
         name: 'onMouseEnter',
@@ -49,11 +52,13 @@ card(
         type:
           '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> }) => void',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'shape',
         type: `"square" | "rounded" | "pill" | "circle" | "roundedTop" | "roundedBottom" | "roundedLeft" | "roundedRight"`,
         defaultValue: 'square',
+        href: 'basicExample',
       },
     ]}
   />
@@ -61,6 +66,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     description={`
     For a generic container to be clickable, use the Touchable component.
 
@@ -125,6 +131,7 @@ class TouchableExample extends React.Component {
 
 card(
   <Example
+    id="fullHeightWidthExample"
     description={`
     \`fullWidth\` and \`fullHeight\` are flags on \`Touchable\` controlling how it is sized relative to the parent container.
     If one is set to \`true\`, the \`Touchable\` component will expand to the full size of its parent in that direction.

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -25,48 +25,56 @@ card(
         type: 'string',
         description:
           'Accessibility label for the fullscreen maximize button if controls are shown',
+        href: 'videoControlsExample',
       },
       {
         name: 'accessibilityMinimizeLabel',
         type: 'string',
         description:
           'Accessibility label for the fullscreen minimize button if controls are shown',
+        href: 'videoControlsExample',
       },
       {
         name: 'accessibilityMuteLabel',
         type: 'string',
         description:
           'Accessibility label for the mute button if controls are shown',
+        href: 'videoControlsExample',
       },
       {
         name: 'accessibilityPauseLabel',
         type: 'string',
         description:
           'Accessibility label for the pause button if controls are shown',
+        href: 'videoControlsExample',
       },
       {
         name: 'accessibilityPlayLabel',
         type: 'string',
         description:
           'Accessibility label for the play button if controls are shown',
+        href: 'videoControlsExample',
       },
       {
         name: 'accessibilityUnmuteLabel',
         type: 'string',
         description:
           'Accessibility label for the unmute button if controls are shown',
+        href: 'videoControlsExample',
       },
       {
         name: 'aspectRatio',
         type: 'number',
         description: `Proportional relationship between width and height of the video, calculated as width / height.`,
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'captions',
         type: 'string',
         description: 'The URL of the captions track for the video (.vtt file)',
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'children',
@@ -78,11 +86,13 @@ card(
         name: 'controls',
         type: 'boolean',
         description: 'Show the video player controls',
+        href: 'videoControlsExample',
       },
       {
         name: 'loop',
         type: 'boolean',
         description: 'The video will start playing over again when finished',
+        href: 'nativeVideoAttributesExample',
       },
       {
         name: 'onDurationChange',
@@ -112,11 +122,13 @@ card(
         type: '({ event: SyntheticEvent<HTMLDivElement> }) => void',
         description:
           'Sent when playback of the media starts after having been paused',
+        href: 'videoUpdatesExample',
       },
       {
         name: 'onPause',
         type: '({ event: SyntheticEvent<HTMLDivElement> }) => void',
         description: 'Sent when playback is paused',
+        href: 'videoUpdatesExample',
       },
       {
         name: 'onReady',
@@ -140,6 +152,7 @@ card(
         type:
           '({ event: SyntheticEvent<HTMLDivElement>, volume: number }) => void',
         description: 'Sent when the audio volume changes',
+        href: 'videoUpdatesExample',
       },
       {
         name: 'playbackRate',
@@ -147,12 +160,14 @@ card(
         description:
           'Specifies the speed at which the video plays: 1 for normal',
         defaultValue: 1,
+        href: 'videoUpdatesExample',
       },
       {
         name: 'playing',
         type: 'boolean',
         description: 'Specifies whether the video should play or not',
         defaultValue: false,
+        href: 'nativeVideoAttributesExample',
       },
       {
         name: 'playsInline',
@@ -166,6 +181,7 @@ card(
         name: 'poster',
         type: 'string',
         description: 'The image to show while the video is downloading',
+        href: 'basicExample',
       },
       {
         name: 'preload',
@@ -181,6 +197,7 @@ card(
         description: `The URL of the video file to play. This can also be supplied as a list of video types to respective
           video source urls in fallback order for support on various browsers.`,
         required: true,
+        href: 'basicExample',
       },
       {
         name: 'volume',
@@ -188,6 +205,7 @@ card(
         description:
           'Specifies the volume of the video audio: 0 for muted, 1 for max',
         defaultValue: 1,
+        href: 'nativeVideoAttributesExample',
       },
     ]}
   />
@@ -195,6 +213,7 @@ card(
 
 card(
   <Example
+    id="basicExample"
     name="Video media basics"
     description={`
     The source url you pass into \`Video\` will be used to download and play the video file. While it is
@@ -241,6 +260,7 @@ card(
 
 card(
   <Example
+    id="nativeVideoAttributesExample"
     name="Native video attributes"
     description={`
     \`Video\` supports the native HTML video attributes such as \`autoPlay\`, \`loop\`, \`muted\`, and more.
@@ -261,6 +281,7 @@ card(
 
 card(
   <Example
+    id="videoControlsExample"
     name="Video controls"
     description={`
     \`Video\` components can show a control bar to users in order to allow them access to certain features
@@ -322,6 +343,7 @@ card(
 
 card(
   <Example
+    id="videoUpdatesExample"
     name="Video updates"
     description={`
     \`Video\` is robust enough to handle any updates, such as changing the source, volume, or speed.`}


### PR DESCRIPTION
Add links from the propTable to the relevant examples in component documentation.

- [X] Documentation
- [ ] Tests
- [ ] Experimental evidence (required for Masonry changes)
- [ ] Accessibility checkup
