### PR TITLE
Add flyout shadow regardless of focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### Minor
 
-### Patch
-- Docs: Update remaining prop tables to include links to examples (#487)
+- Flyout: Apply the box shadow to Flyout at all times  (#488)
 
+### Patch
+
+- Docs: Update remaining prop tables to include links to examples (#487)
 - Docs: Improve Image description (#481)
 
 </details>

--- a/packages/gestalt/src/Contents.css
+++ b/packages/gestalt/src/Contents.css
@@ -8,9 +8,6 @@
   composes: borderBox from "./Layout.css";
   composes: rounded from "./Borders.css";
   border: 1px solid currentColor;
-}
-
-.contents:focus {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.18);
   outline: none;
 }


### PR DESCRIPTION
Spoke to @collino and we are going to keep the shadow on the flyout at all times regardless of focus.
![image](https://user-images.githubusercontent.com/7877010/53522431-337bda80-3a8f-11e9-9dea-314053609803.png)

