### PR TITLE
Updated Avatar to avoid Edge’s lack of support for SVG dominantBaseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Avatar: Fixed a bug in MS Edge where text was not vertically centered (#492)
+
 ### Patch
 
 </details>
@@ -16,7 +18,7 @@
 
 ### Minor
 
-- Flyout: Apply the box shadow to Flyout at all times  (#488)
+- Flyout: Apply the box shadow to Flyout at all times (#488)
 
 ### Patch
 

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -35,7 +35,7 @@ const DefaultAvatar = ({ name }: { name: string }) => {
           <text
             fontSize="50px"
             fill="#fff"
-            dominantBaseline="central"
+            dy="0.35em"
             textAnchor="middle"
             className={[
               typography.antialiased,

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -37,7 +37,7 @@ exports[`Avatar renders an outline 1`] = `
         </title>
         <text
           className="antialiased sansSerif leadingSmall fontWeightBold"
-          dominantBaseline="central"
+          dy="0.35em"
           fill="#fff"
           fontSize="50px"
           textAnchor="middle"
@@ -86,7 +86,7 @@ exports[`Avatar renders multi-byte character initials 1`] = `
         </title>
         <text
           className="antialiased sansSerif leadingSmall fontWeightBold"
-          dominantBaseline="central"
+          dy="0.35em"
           fill="#fff"
           fontSize="50px"
           textAnchor="middle"
@@ -475,7 +475,7 @@ exports[`Avatar renders the verified icon 1`] = `
         </title>
         <text
           className="antialiased sansSerif leadingSmall fontWeightBold"
-          dominantBaseline="central"
+          dy="0.35em"
           fill="#fff"
           fontSize="50px"
           textAnchor="middle"


### PR DESCRIPTION
We were getting reports of a bug (BUG-90851 internally) where the Avatar component was being displayed incorrectly on Edge when there was no image available (and thus the first initial was displayed). MS Edge doesn't support dominantBaseline in SVGs, so the text was being pinned to the top of the container.

![_thumb_207693](https://user-images.githubusercontent.com/967591/53841166-f614c280-3f50-11e9-8a0b-928c3939737c.png)

This PR fixes the issue by repositioning the text based on line height. It appears to look good on all Avatar sizes.