### PR TITLE
[Modal] Add an escape hatch size option to Modal for custom sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 - Icon: add some new text related icons (#496)
+- Modal: add a new sizing option to Modal to match Flyout (#499)
 
 ### Patch
 

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -63,7 +63,7 @@ card(
       },
       {
         name: 'size',
-        type: `"sm" | "md" | "lg"`,
+        type: `"sm" | "md" | "lg" | number`,
         defaultValue: 'sm',
         description: `sm: 414px, md: 544px, lg: 804px`,
         href: 'sizesExample',
@@ -77,8 +77,9 @@ card(
     id="sizesExample"
     name="Sizes"
     description={`
-      There are 3 different widths available for a \`Modal\`. Click on each button
-      to view a sample Modal of the specified size. All Modals have a max width of 100%.
+      There are 3 different pre-selected widths available for a \`Modal\`, as well as a last-resort
+      option to set a custom width. Click on each button to view a sample Modal of the specified size.
+      All Modals have a max width of 100%.
     `}
     defaultCode={`
 class Example extends React.Component {

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -18,7 +18,7 @@ type Props = {|
   heading: string,
   onDismiss: () => void,
   role?: 'alertdialog' | 'dialog',
-  size?: 'sm' | 'md' | 'lg',
+  size?: 'sm' | 'md' | 'lg' | number,
 |};
 
 const SIZE_WIDTH_MAP = {
@@ -38,14 +38,17 @@ const Backdrop = ({ children }: { children?: React.Node }) => (
 
 export default class Modal extends React.Component<Props> {
   static propTypes = {
-    children: PropTypes.node,
     accessibilityCloseLabel: PropTypes.string.isRequired,
+    accessibilityModalLabel: PropTypes.string.isRequired,
+    children: PropTypes.node,
     footer: PropTypes.node,
     heading: PropTypes.string.isRequired,
-    accessibilityModalLabel: PropTypes.string.isRequired,
     onDismiss: PropTypes.func,
     role: PropTypes.oneOf(['alertdialog', 'dialog']),
-    size: PropTypes.oneOf(['sm', 'md', 'lg']),
+    size: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.oneOf(['sm', 'md', 'lg']),
+    ]),
   };
 
   componentDidMount() {
@@ -80,7 +83,8 @@ export default class Modal extends React.Component<Props> {
       role = 'dialog',
       size = 'sm',
     } = this.props;
-    const width = SIZE_WIDTH_MAP[size];
+
+    const width = typeof size === 'string' ? SIZE_WIDTH_MAP[size] : size;
 
     return (
       <StopScrollBehavior>


### PR DESCRIPTION
Makes this component more closely align with what we do for Flyouts by allowing an back door custom sizing option https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Flyout.js#L14
