### PR TITLE
Make Modal heading an overloaded prop to accept react elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Icon: add some new text related icons (#496)
 - Modal: add a new sizing option to Modal to match Flyout (#499)
+- Modal: add the ability to set a custom header beyond text (#500)
 
 ### Patch
 

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -45,9 +45,9 @@ card(
       },
       {
         name: 'heading',
-        type: `string`,
+        type: `React.Node`,
         required: true,
-        href: 'sizesExample',
+        href: 'heading',
       },
       {
         name: 'onDismiss',
@@ -215,6 +215,92 @@ class Example extends React.Component {
               accessibilityCloseLabel="close"
               accessibilityModalLabel="View default padding and styling"
               heading="Heading"
+              onDismiss={this.handleToggleModal}
+              footer={
+                <Box color="gray">
+                  <Heading size="sm">Footer</Heading>
+                </Box>
+              }
+              size="md"
+            >
+              <Box color="gray" height={400}>
+                <Heading size="sm">Children</Heading>
+              </Box>
+            </Modal>
+          )}
+        </Box>
+      </Box>
+    );
+  }
+}
+`}
+  />
+);
+
+card(
+  <Example
+    id="heading"
+    name="Custom heading"
+    description="
+      If you need more control over the Modal heading besides a wrapped and centered text element,
+      you can pass a custom React node as the heading prop and the Modal will render that instead.
+    "
+    defaultCode={`
+class HeadingExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleToggleModal = this._handleToggleModal.bind(this);
+    this.handleChangeTab = this._handleChangeTab.bind(this);
+    this.state = {
+      showModal: false,
+      activeTabIndex: 0,
+    };
+  }
+
+  _handleToggleModal() {
+    this.setState(prevState => ({ showModal: !prevState.showModal }));
+  }
+
+  _handleChangeTab({ activeTabIndex, event }) {
+    event.preventDefault();
+    this.setState({ activeTabIndex });
+  }
+
+  render() {
+    const { showModal } = this.state;
+    return (
+      <Box marginLeft={-1} marginRight={-1}>
+        <Box padding={1}>
+          <Button
+            text="View heading"
+            onClick={this.handleToggleModal}
+          />
+          {showModal && (
+            <Modal
+              accessibilityCloseLabel="close"
+              accessibilityModalLabel="View custom modal heading"
+              heading={
+                <Box padding={2}>
+                  <Tabs
+                    tabs={[
+                      {
+                        text: "Boards",
+                        href: "#"
+                      },
+                      {
+                        text: "Pins",
+                        href: "#"
+                      },
+                      {
+                        text: "Topics",
+                        href: "#"
+                      }
+                    ]}
+                    activeTabIndex={this.state.activeTabIndex}
+                    onChange={this.handleChangeTab}
+                  />
+                </Box>
+              }
               onDismiss={this.handleToggleModal}
               footer={
                 <Box color="gray">

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -45,7 +45,7 @@ card(
       },
       {
         name: 'heading',
-        type: `React.Node`,
+        type: `string | React.Node`,
         required: true,
         href: 'heading',
       },

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -42,7 +42,7 @@ function Header({
   heading,
   role,
 }: {
-  heading: React.Node,
+  heading: string | React.Node,
   role?: 'alertdialog' | 'dialog',
 }) {
   if (typeof heading !== 'string') {

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -15,7 +15,7 @@ type Props = {|
   accessibilityModalLabel: string,
   children?: React.Node,
   footer?: React.Node,
-  heading: React.Node,
+  heading: string | React.Node,
   onDismiss: () => void,
   role?: 'alertdialog' | 'dialog',
   size?: 'sm' | 'md' | 'lg' | number,
@@ -81,7 +81,7 @@ export default class Modal extends React.Component<Props> {
     accessibilityModalLabel: PropTypes.string.isRequired,
     children: PropTypes.node,
     footer: PropTypes.node,
-    heading: PropTypes.node.isRequired,
+    heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
     onDismiss: PropTypes.func,
     role: PropTypes.oneOf(['alertdialog', 'dialog']),
     size: PropTypes.oneOfType([

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -15,7 +15,7 @@ type Props = {|
   accessibilityModalLabel: string,
   children?: React.Node,
   footer?: React.Node,
-  heading: string,
+  heading: React.Node,
   onDismiss: () => void,
   role?: 'alertdialog' | 'dialog',
   size?: 'sm' | 'md' | 'lg' | number,
@@ -29,12 +29,51 @@ const SIZE_WIDTH_MAP = {
 
 const ESCAPE_KEY_CODE = 27;
 
-const Backdrop = ({ children }: { children?: React.Node }) => (
-  <React.Fragment>
-    <div className={styles.Backdrop} />
-    {children}
-  </React.Fragment>
-);
+function Backdrop({ children }: { children?: React.Node }) {
+  return (
+    <React.Fragment>
+      <div className={styles.Backdrop} />
+      {children}
+    </React.Fragment>
+  );
+}
+
+function Header({
+  heading,
+  role,
+}: {
+  heading: React.Node,
+  role?: 'alertdialog' | 'dialog',
+}) {
+  if (typeof heading !== 'string') {
+    return heading;
+  }
+
+  if (role === 'dialog') {
+    return (
+      <Box
+        dangerouslySetInlineStyle={{
+          __style: { paddingLeft: 50, paddingRight: 50 },
+        }}
+        display="flex"
+        justifyContent="center"
+        paddingY={5}
+      >
+        <Heading size="xs" accessibilityLevel={1}>
+          {heading}
+        </Heading>
+      </Box>
+    );
+  }
+
+  return (
+    <Box display="flex" padding={4}>
+      <Heading size="sm" accessibilityLevel={1}>
+        {heading}
+      </Heading>
+    </Box>
+  );
+}
 
 export default class Modal extends React.Component<Props> {
   static propTypes = {
@@ -42,7 +81,7 @@ export default class Modal extends React.Component<Props> {
     accessibilityModalLabel: PropTypes.string.isRequired,
     children: PropTypes.node,
     footer: PropTypes.node,
-    heading: PropTypes.string.isRequired,
+    heading: PropTypes.node.isRequired,
     onDismiss: PropTypes.func,
     role: PropTypes.oneOf(['alertdialog', 'dialog']),
     size: PropTypes.oneOfType([
@@ -105,36 +144,19 @@ export default class Modal extends React.Component<Props> {
                     width="100%"
                   >
                     <Box fit>
-                      {role === 'dialog' ? (
-                        <Box
-                          dangerouslySetInlineStyle={{
-                            __style: { paddingLeft: 50, paddingRight: 50 },
-                          }}
-                          display="flex"
-                          justifyContent="center"
-                          paddingY={5}
-                        >
-                          <Heading size="xs" accessibilityLevel={1}>
-                            {heading}
-                          </Heading>
-                        </Box>
-                      ) : (
-                        <Box display="flex" padding={4}>
-                          <Heading size="sm" accessibilityLevel={1}>
-                            {heading}
-                          </Heading>
-                        </Box>
-                      )}
+                      <Header heading={heading} role={role} />
                       {role === 'dialog' && (
-                        <Box padding={2} position="absolute" top right>
-                          <IconButton
-                            accessibilityLabel={accessibilityCloseLabel}
-                            icon="cancel"
-                            onClick={this.handleCloseClick}
-                          />
-                        </Box>
+                        <React.Fragment>
+                          <Box padding={2} position="absolute" top right>
+                            <IconButton
+                              accessibilityLabel={accessibilityCloseLabel}
+                              icon="cancel"
+                              onClick={this.handleCloseClick}
+                            />
+                          </Box>
+                          <Divider />
+                        </React.Fragment>
                       )}
-                      {role === 'dialog' && <Divider />}
                     </Box>
                     <Box flex="grow" overflow="auto" position="relative">
                       {children}


### PR DESCRIPTION
This opens the Modal `heading` prop up for more extensibility similar to the `footer` prop
