### PR TITLE
Show tooltips only on hover (not focus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Tooltip: remove focus from revealing Tooltip (#506)
+
 ### Patch
 
 </details>

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -10,9 +10,9 @@ const card = c => cards.push(c);
 card(
   <PageHeader
     name="Tooltip"
-    description="The Tooltip component allows you to wrap a child with a help tooltip when focused
-    or hovered. Tooltips are about way finding, not feature adoption, education, or promotion. They
-    should only include short descriptive text and are co-located with the element they describe."
+    description="The Tooltip component allows you to wrap a child with a help tooltip when hovered.
+    Tooltips are about way finding, not feature adoption, education, or promotion. They should
+    only include short descriptive text and are co-located with the element they describe."
   />
 );
 
@@ -23,7 +23,7 @@ card(
         name: 'children',
         type: 'React.Node',
         required: true,
-        description: 'The element to wrap with a tooltip on hover or focus.',
+        description: 'The element to wrap with a tooltip on hover.',
       },
       {
         name: 'inline',
@@ -98,7 +98,7 @@ card(
     name="Accessibility"
     description={`
       If more information is needed to describe an IconButton, you can wrap it in a Tooltip
-      in order to reveal more help text on hover or focus.
+      in order to reveal more help text on hover.
 
       Screenreaders will pick up on the accessibilityLabel supplied to the child, in this case
       IconButton, while the Tooltip just provides a more visible on screen description.

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -14,21 +14,15 @@ type Props = {|
 |};
 
 type State = {|
-  focused: boolean,
   hovered: boolean,
 |};
 
 export default class Tooltip extends React.Component<Props, State> {
   state = {
-    focused: false,
     hovered: false,
   };
 
   childRef = React.createRef();
-
-  handleBlur = () => this.setState({ focused: false });
-
-  handleFocus = () => this.setState({ focused: true });
 
   handleMouseEnter = () => this.setState({ hovered: true });
 
@@ -36,21 +30,19 @@ export default class Tooltip extends React.Component<Props, State> {
 
   render() {
     const { children, inline, text } = this.props;
-    const { focused, hovered } = this.state;
+    const { hovered } = this.state;
     const { current: anchor } = this.childRef;
 
     return (
       <Box display={inline ? 'inlineBlock' : 'block'}>
         <Box
-          onBlur={this.handleBlur}
-          onFocus={this.handleFocus}
           onMouseEnter={this.handleMouseEnter}
           onMouseLeave={this.handleMouseLeave}
           ref={this.childRef}
         >
           {children}
         </Box>
-        {(hovered || focused) &&
+        {hovered &&
           !!anchor && (
             <Controller
               anchor={anchor}

--- a/packages/gestalt/src/__snapshots__/Tooltip.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tooltip.jsdom.test.js.snap
@@ -6,8 +6,6 @@ exports[`Tooltip renders 1`] = `
 >
   <div
     className="box"
-    onBlur={[Function]}
-    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >


### PR DESCRIPTION
Removing the focus behaviors of tooltips
