### PR TITLE
Update TextField to take new-password as a prop value for autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 - Tooltip: remove focus from revealing Tooltip (#506)
+- TextField: Add autocomplete prop value to TextField (#508)
 
 ### Patch
 

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -17,7 +17,7 @@ card(
     props={[
       {
         name: 'autoComplete',
-        type: `"current-password" | "on" | "off" | "username"`,
+        type: `"current-password" | "new-password" | "on" | "off" | "username"`,
       },
       {
         name: 'disabled',

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -8,7 +8,12 @@ import FormErrorMessage from './FormErrorMessage.js';
 import styles from './TextField.css';
 
 type Props = {|
-  autoComplete?: 'current-password' | 'on' | 'off' | 'username',
+  autoComplete?:
+    | 'current-password'
+    | 'new-password'
+    | 'on'
+    | 'off'
+    | 'username',
   disabled?: boolean,
   errorMessage?: string,
   hasError?: boolean,
@@ -43,6 +48,7 @@ export default class TextField extends React.Component<Props, State> {
   static propTypes = {
     autoComplete: PropTypes.oneOf([
       'current-password',
+      'new-password',
       'on',
       'off',
       'username',


### PR DESCRIPTION
Add `new-password` prop value for `autocomplete` on TextFields to make it possible for browsers to suggest strong passwords.
