### PR TITLE
New <List /> component for gestalt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Icon: add calendar icon to gestalt (#512)
 - Icon: add lightning bolt icon (#513)
 - Flow: upgrade version to [0.97.0](https://github.com/facebook/flow/releases/tag/v0.97.0) (#515)
+- List: create a new `List` component for gestalt (#516)
 
 ### Patch
 

--- a/docs/src/List.doc.js
+++ b/docs/src/List.doc.js
@@ -50,10 +50,11 @@ class ListExample extends React.Component {
   }
   render() {
     return (
-      <Box>
-        <Box ref={this.buttonRef}>
+      <Box display="inlineBlock">
+        <Box ref={this.anchorRef}>
           <IconButton
             accessibilityLabel="More options"
+            bgColor="gray"
             icon="ellipsis"
             onClick={this.handleClick}
           />
@@ -113,10 +114,11 @@ class ListExample extends React.Component {
   }
   render() {
     return (
-      <Box>
-        <Box ref={this.buttonRef}>
+      <Box display="inlineBlock">
+        <Box ref={this.anchorRef}>
           <IconButton
             accessibilityLabel="Invite user"
+            bgColor="gray"
             icon="add"
             onClick={this.handleClick}
           />
@@ -134,11 +136,11 @@ class ListExample extends React.Component {
                   children: (
                     <Box alignItems="center" display="flex" marginStart={-1} marginEnd={-1}>
                       <Box paddingX={1}>
-                        <Avatar name="chrislloyd" size="md" />
+                        <Avatar name="peterfarejowicz" size="md" />
                       </Box>
                       <Box paddingX={1}>
-                        <Text bold>Chris Lloyd</Text>
-                        <Text>joined 3 years ago</Text>
+                        <Text bold>Peter Farejowicz</Text>
+                        <Text>joined 2 years ago</Text>
                       </Box>
                     </Box>
                   ),
@@ -148,11 +150,11 @@ class ListExample extends React.Component {
                   children: (
                     <Box alignItems="center" display="flex" marginStart={-1} marginEnd={-1}>
                       <Box paddingX={1}>
-                        <Avatar name="peterfarejowicz" size="md" />
+                        <Avatar name="chrislloyd" size="md" />
                       </Box>
                       <Box paddingX={1}>
-                        <Text bold>Peter Farejowicz</Text>
-                        <Text>joined 2 years ago</Text>
+                        <Text bold>Chris Lloyd</Text>
+                        <Text>joined 3 years ago</Text>
                       </Box>
                     </Box>
                   ),

--- a/docs/src/List.doc.js
+++ b/docs/src/List.doc.js
@@ -1,0 +1,187 @@
+// @flow
+import * as React from 'react';
+import { List } from 'gestalt';
+import PropTable from './components/PropTable.js';
+import Example from './components/Example.js';
+import PageHeader from './components/PageHeader.js';
+
+const cards = [];
+const card = c => cards.push(c);
+
+card(
+  <PageHeader
+    name="List"
+    description="List is a media agnostic presentation component to help manage sequential related items."
+  />
+);
+
+card(
+  <PropTable
+    Component={List}
+    props={[
+      {
+        name: 'items',
+        type: `Array<{| children: React.Node, onClick: ({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> }) => void |}>`,
+        required: true,
+      },
+    ]}
+  />
+);
+
+card(
+  <Example
+    name="Example"
+    description="List is helpful when rendering a group of related items each with their own actions.
+    Consider the following example where we render different actions a user can take."
+    defaultCode={`
+class ListExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { open: false };
+    this.handleClick = this._handleClick.bind(this);
+    this.handleDismiss = this._handleDismiss.bind(this);
+    this.anchorRef = React.createRef();
+  }
+  _handleClick() {
+    this.setState((prevState) => ({ open: !prevState.open }));
+  }
+  _handleDismiss() {
+    this.setState(() => ({ open: false }));
+  }
+  render() {
+    return (
+      <Box>
+        <Box ref={this.buttonRef}>
+          <IconButton
+            accessibilityLabel="More options"
+            icon="ellipsis"
+            onClick={this.handleClick}
+          />
+        </Box>
+        {this.state.open && (
+          <Flyout
+            anchor={this.anchorRef.current}
+            idealDirection="down"
+            onDismiss={this.handleDismiss}
+            size="md"
+          >
+            <List
+              items={[
+                {
+                  children: 'Delete',
+                  onClick: () => {},
+                },
+                {
+                  children: 'Duplicate',
+                  onClick: () => {},
+                },
+                {
+                  children: 'Rename',
+                  onClick: () => {},
+                },
+              ]}
+            />
+          </Flyout>
+        )}
+      </Box>
+    );
+  }
+}
+`}
+  />
+);
+
+card(
+  <Example
+    name="Advanced use"
+    description="List items can also reach beyond plain text. For special cases, consider passing your
+    own special renderable items to the List item prop."
+    defaultCode={`
+class ListExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { open: false };
+    this.handleClick = this._handleClick.bind(this);
+    this.handleDismiss = this._handleDismiss.bind(this);
+    this.anchorRef = React.createRef();
+  }
+  _handleClick() {
+    this.setState((prevState) => ({ open: !prevState.open }));
+  }
+  _handleDismiss() {
+    this.setState(() => ({ open: false }));
+  }
+  render() {
+    return (
+      <Box>
+        <Box ref={this.buttonRef}>
+          <IconButton
+            accessibilityLabel="Invite user"
+            icon="add"
+            onClick={this.handleClick}
+          />
+        </Box>
+        {this.state.open && (
+          <Flyout
+            anchor={this.anchorRef.current}
+            idealDirection="down"
+            onDismiss={this.handleDismiss}
+            size="md"
+          >
+            <List
+              items={[
+                {
+                  children: (
+                    <Box alignItems="center" display="flex" marginStart={-1} marginEnd={-1}>
+                      <Box paddingX={1}>
+                        <Avatar name="chrislloyd" size="md" />
+                      </Box>
+                      <Box paddingX={1}>
+                        <Text bold>Chris Lloyd</Text>
+                        <Text>joined 3 years ago</Text>
+                      </Box>
+                    </Box>
+                  ),
+                  onClick: () => {},
+                },
+                {
+                  children: (
+                    <Box alignItems="center" display="flex" marginStart={-1} marginEnd={-1}>
+                      <Box paddingX={1}>
+                        <Avatar name="peterfarejowicz" size="md" />
+                      </Box>
+                      <Box paddingX={1}>
+                        <Text bold>Peter Farejowicz</Text>
+                        <Text>joined 2 years ago</Text>
+                      </Box>
+                    </Box>
+                  ),
+                  onClick: () => {},
+                },
+                {
+                  children: (
+                    <Box alignItems="center" display="flex" marginStart={-1} marginEnd={-1}>
+                      <Box paddingX={1}>
+                        <Avatar name="bensilbermann" size="md" />
+                      </Box>
+                      <Box paddingX={1}>
+                        <Text bold>Ben Silbermann</Text>
+                        <Text>joined a long time ago</Text>
+                      </Box>
+                    </Box>
+                  ),
+                  onClick: () => {},
+                },
+              ]}
+            />
+          </Flyout>
+        )}
+      </Box>
+    );
+  }
+}
+`}
+  />
+);
+
+export default cards;

--- a/packages/gestalt/src/List.js
+++ b/packages/gestalt/src/List.js
@@ -1,0 +1,28 @@
+// @flow
+
+import * as React from 'react';
+import Box from './Box.js';
+import ListItem from './ListItem.js';
+
+type Props = {|
+  items: Array<{|
+    onClick: ({
+      event:
+        | SyntheticMouseEvent<HTMLDivElement>
+        | SyntheticKeyboardEvent<HTMLDivElement>,
+    }) => void,
+    children: React.Node,
+  |}>,
+|};
+
+export default function List({ items }: Props) {
+  return (
+    <Box column={12} paddingY={4} role="list">
+      {items.map((item, index) => (
+        <ListItem key={index} onClick={item.onClick}>
+          {item.children}
+        </ListItem>
+      ))}
+    </Box>
+  );
+}

--- a/packages/gestalt/src/List.test.js
+++ b/packages/gestalt/src/List.test.js
@@ -1,0 +1,13 @@
+// @flow
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import List from './List.js';
+
+test('List renders', () => {
+  const component = renderer.create(
+    <List items={[{ onClick: () => {}, children: 'Item' }]} />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/ListItem.js
+++ b/packages/gestalt/src/ListItem.js
@@ -1,0 +1,51 @@
+// @flow
+
+import * as React from 'react';
+import Box from './Box.js';
+import Text from './Text.js';
+import Touchable from './Touchable.js';
+
+type Props = {|
+  children: React.Node,
+  onClick: ({
+    event:
+      | SyntheticMouseEvent<HTMLDivElement>
+      | SyntheticKeyboardEvent<HTMLDivElement>,
+  }) => void,
+|};
+
+type State = {|
+  hovered: boolean,
+|};
+
+export default class ListItem extends React.PureComponent<Props, State> {
+  state = {
+    hovered: false,
+  };
+
+  handleMouseEnter = () => {
+    this.setState({ hovered: true });
+  };
+
+  handleMouseLeave = () => {
+    this.setState({ hovered: false });
+  };
+
+  render() {
+    const { children, onClick } = this.props;
+    const { hovered } = this.state;
+    return (
+      <Box role="listitem" padding={1} color={hovered ? 'lightGray' : 'white'}>
+        <Touchable
+          onTouch={onClick}
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
+        >
+          <Box column={12} paddingX={3} paddingY={1}>
+            <Text bold>{children}</Text>
+          </Box>
+        </Touchable>
+      </Box>
+    );
+  }
+}

--- a/packages/gestalt/src/ListItem.test.js
+++ b/packages/gestalt/src/ListItem.test.js
@@ -1,0 +1,13 @@
+// @flow
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import ListItem from './ListItem.js';
+
+test('ListItem renders', () => {
+  const component = renderer.create(
+    <ListItem onClick={() => {}}>Item</ListItem>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/List.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/List.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`List renders 1`] = `
+<div
+  className="box paddingY4 xsCol12"
+  role="list"
+>
+  <div
+    className="box paddingX1 paddingY1 whiteBg"
+    role="listitem"
+  >
+    <div
+      className="touchable pointer square fullWidth"
+      onClick={[Function]}
+      onKeyPress={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      role="button"
+      tabIndex="0"
+    >
+      <div
+        className="box paddingX3 paddingY1 xsCol12"
+      >
+        <div
+          className="Text fontSize3 darkGray alignLeft breakWord fontStyleNormal fontWeightBold"
+        >
+          Item
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/gestalt/src/__snapshots__/ListItem.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ListItem.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListItem renders 1`] = `
+<div
+  className="box paddingX1 paddingY1 whiteBg"
+  role="listitem"
+>
+  <div
+    className="touchable pointer square fullWidth"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <div
+      className="box paddingX3 paddingY1 xsCol12"
+    >
+      <div
+        className="Text fontSize3 darkGray alignLeft breakWord fontStyleNormal fontWeightBold"
+      >
+        Item
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -20,6 +20,7 @@ import Label from './Label.js';
 import Layer from './Layer.js';
 import Letterbox from './Letterbox.js';
 import Link from './Link.js';
+import List from './List.js';
 import Mask from './Mask.js';
 import Masonry from './Masonry.js';
 import MasonryBeta from './MasonryBeta.js';
@@ -68,11 +69,12 @@ export {
   Layer,
   Letterbox,
   Link,
+  List,
   Mask,
   Masonry,
   MasonryBeta,
-  MasonryInfiniteBeta,
   MasonryDefaultLayout,
+  MasonryInfiniteBeta,
   MasonryUniformRowLayout,
   Modal,
   Pog,


### PR DESCRIPTION
## A new presentational component for gestalt

This change:
![image](https://user-images.githubusercontent.com/7877010/56707383-70e69800-66cd-11e9-8664-f1a2fbfc2896.png)

Inspiration (real world example):
![image](https://user-images.githubusercontent.com/7877010/56707289-14837880-66cd-11e9-8a29-19325797e195.png)

Example use case we could replace in product:
![image](https://user-images.githubusercontent.com/7877010/56707538-23b6f600-66ce-11e9-8adc-519277bc4e96.png)

Preview: https://deploy-preview-516--gestalt.netlify.com

- [x] Documentation
- [x] Tests
- [x] Accessibility checkup (verified tabbing works)
