### PR TITLE
Disabled IconButton states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- IconButton: Add new `disabled` prop and stylings to `IconButton` component (#517)
+
 ### Patch
 
 </details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Minor
 
-- IconButton: Add new `disabled` prop and stylings to `IconButton` component (#517)
+- IconButton: Add new `disabled` prop and stylings to `IconButton` component (#521)
 
 ### Patch
 

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -184,17 +184,11 @@ card(
     id="disabledCombinations"
     name="Disabled Combinations"
     description="Icon buttons can be disabled as well. Adding the disabled flag to any color combination will add a 50% opacity and remove interactivity"
-    disabled={[false, true]}
     iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
-    bgColor={[
-      'transparent',
-      'transparentDarkGray',
-      'white',
-      'lightGray',
-      'gray',
-    ]}
   >
-    {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
+    {props => (
+      <IconButton icon="heart" accessibilityLabel="" disabled {...props} />
+    )}
   </Combination>
 );
 

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -49,6 +49,11 @@ card(
         href: 'backgroundColorCombinations',
       },
       {
+        name: 'disabled',
+        type: 'boolean',
+        href: 'disabledCombinations',
+      },
+      {
         name: 'iconColor',
         type: `"blue" | "darkGray" | "gray" | "red" | "white"`,
         defaultValue: 'gray',
@@ -162,6 +167,25 @@ card(
   <Combination
     id="backgroundColorCombinations"
     name="Background Color Combinations"
+    bgColor={[
+      'transparent',
+      'transparentDarkGray',
+      'white',
+      'lightGray',
+      'gray',
+    ]}
+  >
+    {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="disabledCombinations"
+    name="Disabled Combinations"
+    description="Icon buttons can be disabled as well. Adding the disabled flag to any color combination will add a 50% opacity and remove interactivity"
+    disabled={[false, true]}
+    iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
     bgColor={[
       'transparent',
       'transparentDarkGray',

--- a/packages/gestalt/src/IconButton.css
+++ b/packages/gestalt/src/IconButton.css
@@ -6,8 +6,16 @@
   composes: block from "./Layout.css";
   composes: noBorder from "./Borders.css";
   composes: p0 from "./Whitespace.css";
-  composes: pointer from "./Cursor.css";
   background: transparent;
+}
+
+.enabled {
+  composes: pointer from "./Cursor.css";
+}
+
+.disabled {
+  cursor: default;
+  opacity: 0.5;
 }
 
 .button:focus {

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -101,10 +101,10 @@ export default class IconButton extends React.Component<Props, State> {
         type="button"
       >
         <Pog
-          active={disabled ? false : active}
+          active={!disabled && active}
           bgColor={bgColor}
-          focused={disabled ? false : focused}
-          hovered={disabled ? false : hovered}
+          focused={!disabled && focused}
+          hovered={!disabled && hovered}
           iconColor={iconColor}
           icon={icon}
           size={size}

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -101,10 +101,10 @@ export default class IconButton extends React.Component<Props, State> {
         type="button"
       >
         <Pog
-          active={active}
+          active={disabled ? false : active}
           bgColor={bgColor}
-          focused={focused}
-          hovered={hovered}
+          focused={disabled ? false : focused}
+          hovered={disabled ? false : hovered}
           iconColor={iconColor}
           icon={icon}
           size={size}

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import styles from './IconButton.css';
 import icons from './icons/index.js';
 import Pog from './Pog.js';
@@ -15,6 +16,7 @@ type Props = {|
     | 'gray'
     | 'lightGray'
     | 'white',
+  disabled?: boolean,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white',
   icon: $Keys<typeof icons>,
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
@@ -39,6 +41,7 @@ export default class IconButton extends React.Component<Props, State> {
       'lightGray',
       'white',
     ]),
+    disabled: PropTypes.bool,
     icon: PropTypes.oneOf(Object.keys(icons)).isRequired,
     iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'blue', 'white']),
     onClick: PropTypes.func,
@@ -69,6 +72,7 @@ export default class IconButton extends React.Component<Props, State> {
       accessibilityHaspopup,
       accessibilityLabel,
       bgColor,
+      disabled,
       iconColor,
       icon,
       size,
@@ -82,7 +86,11 @@ export default class IconButton extends React.Component<Props, State> {
         aria-expanded={accessibilityExpanded}
         aria-haspopup={accessibilityHaspopup}
         aria-label={accessibilityLabel}
-        className={styles.button}
+        className={classnames(
+          styles.button,
+          disabled ? styles.disabled : styles.enabled
+        )}
+        disabled={disabled}
         onBlur={this.handleBlur}
         onClick={event => onClick && onClick({ event })}
         onFocus={this.handleFocus}

--- a/packages/gestalt/src/IconButton.test.js
+++ b/packages/gestalt/src/IconButton.test.js
@@ -10,3 +10,11 @@ test('IconButton renders', () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('IconButton renders with disabled state', () => {
+  const component = renderer.create(
+    <IconButton accessibilityLabel="Pinterest" icon="pin" disabled />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -3,7 +3,51 @@
 exports[`IconButton renders 1`] = `
 <button
   aria-label="Pinterest"
-  className="button"
+  className="button enabled"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  type="button"
+>
+  <div
+    className="pog transparent"
+    style={
+      Object {
+        "height": 40,
+        "width": 40,
+      }
+    }
+  >
+    <div
+      className="box circle"
+    >
+      <svg
+        aria-hidden={true}
+        aria-label=""
+        className="icon gray iconBlock"
+        height={20}
+        role="img"
+        viewBox="0 0 24 24"
+        width={20}
+      >
+        <path
+          d="test-file-stub"
+        />
+      </svg>
+    </div>
+  </div>
+</button>
+`;
+
+exports[`IconButton renders with disabled state 1`] = `
+<button
+  aria-label="Pinterest"
+  className="button disabled"
+  disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}


### PR DESCRIPTION
Stop gap solution to introduce `disabled` prop to `<IconButton />` until we get a more cohesive unified solution to buttons.

![image](https://user-images.githubusercontent.com/7877010/57474902-13fbed80-7248-11e9-8a28-e83a2c079c87.png)

- [x] Documentation - added new examples
- [x] Tests - added new tests
