### PR TITLE
Update segmented control border radius to match new design spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- SegmentedControl: Update outer border radius to 8px from new design spec (#530)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/SegmentedControl.css
+++ b/packages/gestalt/src/SegmentedControl.css
@@ -3,7 +3,7 @@
   composes: lightGrayBg from "./Colors.css";
   composes: flex from "./Layout.css";
   composes: justifyBetween from "./Layout.css";
-  border-radius: 4px;
+  composes: rounded from "./Borders.css";
   padding: 2px;
   user-select: none;
 }
@@ -22,7 +22,7 @@
   composes: m0 from "./Whitespace.css";
   composes: noBorder from "./Borders.css";
   composes: pointer from "./Cursor.css";
-  border-radius: 3px;
+  border-radius: 6px;
   flex-basis: 0;
   flex-shrink: 1;
   padding: 4px 14px;


### PR DESCRIPTION
Design request to make the outer border radius 8px (which means 6px inner radius for the white selected state)

![image](https://user-images.githubusercontent.com/7877010/58588342-4d56c600-8214-11e9-9d88-81269efda422.png)

