### PR TITLE
Add delay prop to Spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - SegmentedControl: Update outer border radius to 8px from new design spec (#530)
 - Masonry: remove `MasonryBeta` and `MasonryInfiniteBeta` from source code (#531)
+- Spinner: add `delay` prop to optionally remove 300ms delay to appear (#533)
 
 ### Patch
 

--- a/docs/src/Spinner.doc.js
+++ b/docs/src/Spinner.doc.js
@@ -25,6 +25,14 @@ card(
         required: true,
         defaultValue: false,
       },
+      {
+        name: 'delay',
+        type: 'boolean',
+        required: false,
+        defaultValue: true,
+        description:
+          'Whether or not to render with a 300ms delay. The delay is for perceived performance so you should rarely need to remove it.',
+      },
     ]}
   />
 );

--- a/packages/gestalt/src/Spinner.css
+++ b/packages/gestalt/src/Spinner.css
@@ -12,10 +12,13 @@
 
 .icon {
   composes: block from "./Layout.css";
-  animation-delay: 0.3s;
   animation-duration: 1.2s;
   animation-iteration-count: infinite;
   animation-name: spin;
   animation-timing-function: linear;
+}
+
+.delay {
+  animation-delay: 0.3s;
   opacity: 0;
 }

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import Box from './Box.js';
 import Icon from './Icon.js';
 import styles from './Spinner.css';
@@ -9,13 +10,18 @@ const SIZE = 40;
 
 type Props = {|
   accessibilityLabel: string,
+  delay?: boolean,
   show: boolean,
 |};
 
-export default function Spinner({ accessibilityLabel, show }: Props) {
+export default function Spinner({
+  accessibilityLabel,
+  delay = true,
+  show,
+}: Props) {
   return show ? (
     <Box display="flex" justifyContent="around" overflow="hidden">
-      <div className={styles.icon}>
+      <div className={classnames(styles.icon, { [styles.delay]: delay })}>
         <Icon
           icon="knoop"
           accessibilityLabel={accessibilityLabel}
@@ -31,4 +37,5 @@ export default function Spinner({ accessibilityLabel, show }: Props) {
 Spinner.propTypes = {
   show: PropTypes.bool.isRequired,
   accessibilityLabel: PropTypes.string.isRequired,
+  delay: PropTypes.bool,
 };

--- a/packages/gestalt/src/Spinner.test.js
+++ b/packages/gestalt/src/Spinner.test.js
@@ -1,0 +1,24 @@
+// @flow
+import React from 'react';
+import { create } from 'react-test-renderer';
+import Spinner from './Spinner.js';
+
+const baseProps = {
+  accessibilityLabel: 'Test',
+  show: false, // default
+};
+
+test('Spinner does not render by default', () => {
+  const tree = create(<Spinner {...baseProps} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Spinner renders when passed show', () => {
+  const tree = create(<Spinner {...baseProps} show />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Spinner renders with no delay', () => {
+  const tree = create(<Spinner {...baseProps} show delay={false} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/Spinner.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Spinner.test.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spinner does not render by default 1`] = `<div />`;
+
+exports[`Spinner renders when passed show 1`] = `
+<div
+  className="box justifyAround overflowHidden xsDisplayFlex"
+>
+  <div
+    className="icon delay"
+  >
+    <svg
+      aria-hidden={null}
+      aria-label="Test"
+      className="icon gray iconBlock"
+      height={40}
+      role="img"
+      viewBox="0 0 24 24"
+      width={40}
+    >
+      <path
+        d="test-file-stub"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`Spinner renders with no delay 1`] = `
+<div
+  className="box justifyAround overflowHidden xsDisplayFlex"
+>
+  <div
+    className="icon"
+  >
+    <svg
+      aria-hidden={null}
+      aria-label="Test"
+      className="icon gray iconBlock"
+      height={40}
+      role="img"
+      viewBox="0 0 24 24"
+      width={40}
+    >
+      <path
+        d="test-file-stub"
+      />
+    </svg>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Sometimes we show a `<Spinner>` as part of an 'educational loading state' that has a minimum display time determined by the client. In these cases `<Spinner>`'s built in delay results in a distracting flickering as it appears 300ms after the rest of 'educational loading state' component renders. E.g.

![hf-spinner-issue](https://user-images.githubusercontent.com/1231913/58910498-8a1a3580-86ca-11e9-9310-79296804ea1d.gif)

This change provides a way to remove the 300ms delay to display from `<Spinner>` for use in these cases.

![gestalt-spinner-delay](https://user-images.githubusercontent.com/1231913/58907610-70292480-86c3-11e9-840e-22c86990301d.gif)

- [x] Documentation
- [x] Tests
- [ ] ~Experimental evidence (required for Masonry changes)~
- [ ] ~Accessibility checkup~

