### PR TITLE
Button- Make the border radius 8px regardless of button width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - SegmentedControl: Update outer border radius to 8px from new design spec (#530)
 - Masonry: remove `MasonryBeta` and `MasonryInfiniteBeta` from source code (#531)
 - Spinner: add `delay` prop to optionally remove 300ms delay to appear (#533)
-- Undo Button border radii changes for full width buttons.  Conform all to 8px (#534)
+- Button: Undo Button border radii changes for full width buttons.  Conform all to 8px (#534)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - SegmentedControl: Update outer border radius to 8px from new design spec (#530)
 - Masonry: remove `MasonryBeta` and `MasonryInfiniteBeta` from source code (#531)
 - Spinner: add `delay` prop to optionally remove 300ms delay to appear (#533)
+- Undo Button border radii changes for full width buttons.  Conform all to 8px (#534)
 
 ### Patch
 

--- a/packages/gestalt/src/Borders.css
+++ b/packages/gestalt/src/Borders.css
@@ -56,14 +56,6 @@ html[dir="rtl"] .borderLeft {
   border-radius: var(--border-radius) var(--border-radius) 0 0;
 }
 
-.radiusLarge {
-  border-radius: 12px;
-}
-
-.radiusSmall {
-  border-radius: var(--border-radius);
-}
-
 html:not([dir="rtl"]) .roundedRight {
   border-radius: 0 var(--border-radius) var(--border-radius) 0;
 }

--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -8,6 +8,7 @@
 
 .button {
   composes: borderBox from "./Layout.css";
+  border-radius: 8px;
 }
 
 .solid {

--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -8,7 +8,7 @@
 
 .button {
   composes: borderBox from "./Layout.css";
-  border-radius: 8px;
+  composes: rounded from "./Borders.css";
 }
 
 .solid {

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import borderStyles from './Borders.css';
 import styles from './Button.css';
 import Text from './Text.js';
 
@@ -53,8 +52,6 @@ export default function Button(props: Props) {
     [styles.enabled]: !disabled,
     [styles.inline]: inline,
     [styles.block]: !inline,
-    [borderStyles.radiusLarge]: !inline,
-    [borderStyles.radiusSmall]: inline,
   });
 
   /* eslint-disable react/button-has-type */

--- a/packages/gestalt/src/Button.test.js
+++ b/packages/gestalt/src/Button.test.js
@@ -17,11 +17,3 @@ test('Button handles click', () => {
   wrapper.find('button').simulate('click');
   expect(mockOnClick).toBeCalled();
 });
-
-test('Inline Button border radius', () => {
-  const mockOnClick = jest.fn();
-  const tree = create(
-    <Button inline text="Text" onClick={mockOnClick} />
-  ).toJSON();
-  expect(tree).toMatchSnapshot();
-});

--- a/packages/gestalt/src/__snapshots__/Button.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Button.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Button color="transparent" /> 1`] = `
 <button
-  className="button md transparent enabled block radiusLarge"
+  className="button md transparent enabled block"
   disabled={false}
   onClick={[Function]}
   type="button"
@@ -11,21 +11,6 @@ exports[`<Button color="transparent" /> 1`] = `
     className="Text fontSize3 white alignCenter fontStyleNormal fontWeightBold"
   >
     Hello World
-  </div>
-</button>
-`;
-
-exports[`Inline Button border radius 1`] = `
-<button
-  className="button md solid gray enabled inline radiusSmall"
-  disabled={false}
-  onClick={[Function]}
-  type="button"
->
-  <div
-    className="Text fontSize3 darkGray alignCenter fontStyleNormal fontWeightBold"
-  >
-    Text
   </div>
 </button>
 `;


### PR DESCRIPTION
Design has abandoned their spec where inline and full width buttons have different border radii and height.  Removing logic for changing button border radius depending on the inline prop.  All buttons will now have a border radius of 8px

