### PR TITLE
margin top override

### DIFF
--- a/packages/gestalt/src/Letterbox.js
+++ b/packages/gestalt/src/Letterbox.js
@@ -19,6 +19,7 @@ type Props = {|
   contentAspectRatio: number,
   height: number,
   width: number,
+  marginTop?:number,
 |};
 
 export default function Letterbox({
@@ -26,6 +27,7 @@ export default function Letterbox({
   contentAspectRatio,
   height,
   width,
+  marginTop,
 }: Props) {
   const viewportAspectRatio = aspectRatio(width, height);
 
@@ -40,7 +42,7 @@ export default function Letterbox({
     contentHeight = height;
   }
 
-  const offsetTop = (contentHeight - height) / -2;
+  const offsetTop = marginTop || (contentHeight - height) / -2;
   const offsetLeft = (contentWidth - width) / -2;
 
   return (
@@ -59,4 +61,5 @@ Letterbox.propTypes = {
   contentAspectRatio: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
+  marginTop: PropTypes.number,
 };


### PR DESCRIPTION
- Add margin override to provide for additional flexibility.
Use case:
Currently, unauth pin pages at Pinterest uses the Letterbox to render images.
Example:
![Screen Shot 2019-06-05 at 11 35 15 AM](https://user-images.githubusercontent.com/12265142/58997037-8ca28b00-87af-11e9-8677-dd04bb691215.png)
Notice how the center of the image is centered(effects of using Letterbox with aspect ratio), which is undesired in this case.
I propose that by making this change, we will have the ability to shift images based on contents to provide better UX, providing the image below instead. 
Proposed result:
![Screen Shot 2019-06-05 at 11 35 22 AM](https://user-images.githubusercontent.com/12265142/58997068-be1b5680-87af-11e9-807a-43182a357d11.png)
