### PR TITLE
 Allow dangerouslySetSvgPath in IconButton

### DIFF
--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -38,7 +38,6 @@ card(
       {
         name: 'icon',
         type: Icon.icons.map(name => `'${name}'`).join(' | '),
-        required: true,
         description: `This allows us to type check for a valid icon name based on the keys from the list of icons shown below.`,
         href: 'iconCombinations',
       },

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -62,9 +62,13 @@ card(
       {
         name: 'icon',
         type: '$Keys<typeof icons>',
-        required: true,
         description: `This allows type checking for a valid icon name based on the keys from the list of icons in
         Icon.`,
+      },
+      {
+        name: 'dangerouslySetSvgPath',
+        type: `{ __path: string }`,
+        description: `When using this prop, make sure that the viewbox around the SVG path is 24x24`,
       },
       {
         name: 'size',

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -56,9 +56,13 @@ card(
       {
         name: 'icon',
         type: '$Keys<typeof icons>',
-        required: true,
         description: `This allows us to type check for a valid icon name based on the keys from the list of icons in
         Icon`,
+      },
+      {
+        name: 'dangerouslySetSvgPath',
+        type: `{ __path: string }`,
+        description: `When using this prop, make sure that the viewbox around the SVG path is 24x24`,
       },
       {
         name: 'size',

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -6,7 +6,7 @@ import styles from './Icon.css';
 import icons from './icons/index.js';
 import colors from './Colors.css';
 
-type IconProps = {
+type Props = {|
   accessibilityLabel: string,
   color?:
     | 'blue'
@@ -26,21 +26,11 @@ type IconProps = {
     | 'red'
     | 'watermelon'
     | 'white',
+  icon?: $Keys<typeof icons>,
+  dangerouslySetSvgPath?: { __path: string },
   inline?: boolean,
   size?: number | string,
-};
-
-type IconNoPath = {
-  icon: $Keys<typeof icons>,
-  dangerouslySetSvgPath?: null,
-};
-
-type PathNoIcon = {
-  icon?: null,
-  dangerouslySetSvgPath: { __path: string },
-};
-
-type Props = IconProps & (PathNoIcon | IconNoPath);
+|};
 
 const IconNames = Object.keys(icons);
 

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -16,9 +16,10 @@ type Props = {|
     | 'gray'
     | 'lightGray'
     | 'white',
+  dangerouslySetSvgPath?: { __path: string },
   disabled?: boolean,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white',
-  icon: $Keys<typeof icons>,
+  icon?: $Keys<typeof icons>,
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
@@ -41,8 +42,11 @@ export default class IconButton extends React.Component<Props, State> {
       'lightGray',
       'white',
     ]),
+    dangerouslySetSvgPath: PropTypes.shape({
+      __path: PropTypes.string,
+    }),
     disabled: PropTypes.bool,
-    icon: PropTypes.oneOf(Object.keys(icons)).isRequired,
+    icon: PropTypes.oneOf(Object.keys(icons)),
     iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'blue', 'white']),
     onClick: PropTypes.func,
     size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
@@ -72,6 +76,7 @@ export default class IconButton extends React.Component<Props, State> {
       accessibilityHaspopup,
       accessibilityLabel,
       bgColor,
+      dangerouslySetSvgPath,
       disabled,
       iconColor,
       icon,
@@ -103,6 +108,7 @@ export default class IconButton extends React.Component<Props, State> {
         <Pog
           active={!disabled && active}
           bgColor={bgColor}
+          dangerouslySetSvgPath={dangerouslySetSvgPath}
           focused={!disabled && focused}
           hovered={!disabled && hovered}
           iconColor={iconColor}

--- a/packages/gestalt/src/IconButton.test.js
+++ b/packages/gestalt/src/IconButton.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import IconButton from './IconButton.js';
 
-test('IconButton renders', () => {
+test('IconButton renders with icon', () => {
   const component = renderer.create(
     <IconButton accessibilityLabel="Pinterest" icon="pin" />
   );
@@ -14,6 +14,17 @@ test('IconButton renders', () => {
 test('IconButton renders with disabled state', () => {
   const component = renderer.create(
     <IconButton accessibilityLabel="Pinterest" icon="pin" disabled />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('IconButton renders with svg', () => {
+  const component = renderer.create(
+    <IconButton
+      accessibilityLabel="Pinterest"
+      dangerouslySetSvgPath={{ __path: 'M13.00,20.00' }}
+    />
   );
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -23,10 +23,11 @@ type Props = {|
     | 'gray'
     | 'lightGray'
     | 'white',
+  dangerouslySetSvgPath?: { __path: string },
   focused?: boolean,
   hovered?: boolean,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white',
-  icon: $Keys<typeof icons>,
+  icon?: $Keys<typeof icons>,
   size?: $Keys<typeof SIZE_NAME_TO_PIXEL>,
 |};
 
@@ -42,6 +43,7 @@ export default function Pog(props: Props) {
   const {
     active = false,
     bgColor = 'transparent',
+    dangerouslySetSvgPath,
     focused = false,
     hovered = false,
     iconColor = defaultIconButtonIconColors[bgColor],
@@ -74,6 +76,7 @@ export default function Pog(props: Props) {
         <Icon
           accessibilityLabel=""
           color={iconColor}
+          dangerouslySetSvgPath={dangerouslySetSvgPath}
           icon={icon}
           size={iconSize}
         />
@@ -91,9 +94,12 @@ Pog.propTypes = {
     'lightGray',
     'white',
   ]),
+  dangerouslySetSvgPath: PropTypes.shape({
+    __path: PropTypes.string,
+  }),
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'blue', 'white']),
-  icon: PropTypes.oneOf(Object.keys(icons)).isRequired,
+  icon: PropTypes.oneOf(Object.keys(icons)),
   size: PropTypes.oneOf(Object.keys(SIZE_NAME_TO_PIXEL)),
 };

--- a/packages/gestalt/src/Pog.test.js
+++ b/packages/gestalt/src/Pog.test.js
@@ -3,8 +3,15 @@ import React from 'react';
 import { create } from 'react-test-renderer';
 import Pog from './Pog.js';
 
-test('Pog renders', () => {
+test('Pog renders with icon', () => {
   const tree = create(<Pog icon="heart" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Pog renders with svg', () => {
+  const tree = create(
+    <Pog dangerouslySetSvgPath={{ __path: 'M13.00,20.00' }} />
+  ).toJSON();
   expect(tree).toMatchSnapshot();
 });
 

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -1,6 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IconButton renders 1`] = `
+exports[`IconButton renders with disabled state 1`] = `
+<button
+  aria-label="Pinterest"
+  className="button disabled"
+  disabled={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  type="button"
+>
+  <div
+    className="pog transparent"
+    style={
+      Object {
+        "height": 40,
+        "width": 40,
+      }
+    }
+  >
+    <div
+      className="box circle"
+    >
+      <svg
+        aria-hidden={true}
+        aria-label=""
+        className="icon gray iconBlock"
+        height={20}
+        role="img"
+        viewBox="0 0 24 24"
+        width={20}
+      >
+        <path
+          d="test-file-stub"
+        />
+      </svg>
+    </div>
+  </div>
+</button>
+`;
+
+exports[`IconButton renders with icon 1`] = `
 <button
   aria-label="Pinterest"
   className="button enabled"
@@ -43,11 +87,10 @@ exports[`IconButton renders 1`] = `
 </button>
 `;
 
-exports[`IconButton renders with disabled state 1`] = `
+exports[`IconButton renders with svg 1`] = `
 <button
   aria-label="Pinterest"
-  className="button disabled"
-  disabled={true}
+  className="button enabled"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -79,7 +122,7 @@ exports[`IconButton renders with disabled state 1`] = `
         width={20}
       >
         <path
-          d="test-file-stub"
+          d="M13.00,20.00"
         />
       </svg>
     </div>

--- a/packages/gestalt/src/__snapshots__/Pog.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pog.test.js.snap
@@ -90,7 +90,7 @@ exports[`Pog hovered renders 1`] = `
 </div>
 `;
 
-exports[`Pog renders 1`] = `
+exports[`Pog renders with icon 1`] = `
 <div
   className="pog transparent"
   style={
@@ -114,6 +114,36 @@ exports[`Pog renders 1`] = `
     >
       <path
         d="test-file-stub"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`Pog renders with svg 1`] = `
+<div
+  className="pog transparent"
+  style={
+    Object {
+      "height": 40,
+      "width": 40,
+    }
+  }
+>
+  <div
+    className="box circle"
+  >
+    <svg
+      aria-hidden={true}
+      aria-label=""
+      className="icon gray iconBlock"
+      height={20}
+      role="img"
+      viewBox="0 0 24 24"
+      width={20}
+    >
+      <path
+        d="M13.00,20.00"
       />
     </svg>
   </div>


### PR DESCRIPTION
Adding custom icons to gestalt seems to be the source of a great deal of friction.  This change allows you to use `dangerouslySetSvgPath` in `IconButton` (and `Pog`).  Previously we supported this for `Icon` but not `IconButton`.  

One downside of this implementation is that previously `Icon` had type checking that would require `icon` _or_ `dangerouslySetSvgPath` but not both. For this change, I was unable to arrive at a good solution, so made both `icon` and `dangerouslySetSvgPath` optional props in `IconButton`, `Pog` and `Icon`.  

 As a result, a user _could_ create one of the these components and fail to pass `icon` or `dangerouslySetSvgPath`.  In this case they would not receive a flow error (and we'd render an empty path in `Icon`).  However, this does not seem like a huge risk given displaying an icon or svg is the primary reason for using any of these components and the user is likely to immediately notice.

- [x] Documentation
- [x] Tests
- [ ] ~Experimental evidence (required for Masonry changes)~
- [ ] ~Accessibility checkup~
