### PR TITLE
Fix tooltips when used inside a segmented control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@
   </summary>
 
 ### Minor
-  - Icon: Update send icon (#549)
-  - Icon: Add new lightning icon (#547)
 
 - Enzyme: Upgrade to the latest `v3.10.0` version and pull in Flow library changes (#543)
 - Eslint: Bump all related packages/plugins to current latest version (#544)
 - Button: add new `textColor` prop to allow overriding of text color for buttons (#545)
+- Icon: Add new lightning icon (#547)
+- Icon: Update send icon (#549)
+- SegmentedControl: Fixup some extra CSS that was messing with Tooltips (#550)
 
 ### Patch
 

--- a/packages/gestalt/src/SegmentedControl.css
+++ b/packages/gestalt/src/SegmentedControl.css
@@ -28,10 +28,6 @@
   padding: 4px 14px;
 }
 
-.item:focus {
-  position: relative;
-}
-
 .itemIsNotSelected {
   background: transparent;
 }


### PR DESCRIPTION
Previously when using `Tooltip` inside of a `SegmentedControl` clicking on the buttons would cause the flyout to go bonkers because of this little bit of CSS that changes the position attribute.

Removing it seems to fix the issue and it looks like nothing needed the position relative when focused

Before:
![image](https://user-images.githubusercontent.com/7877010/61673311-cff38300-aca3-11e9-8d52-61e703dbdd57.png)
After:
![image](https://user-images.githubusercontent.com/7877010/61673323-dd107200-aca3-11e9-828b-64a857d1bcaf.png)

