### PR TITLE
Remove the white background of the outer box of SearchField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+- SearchField: Remove the white background color of the outer box to make its corners looks correct on backgrounds with colors different than white (#552)
 
 ### Patch
 

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -107,7 +107,6 @@ export default class SearchField extends React.Component<Props, State> {
         onMouseLeave={this.handleMouseLeave}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
-        color="white"
       >
         <Box
           dangerouslySetInlineStyle={{


### PR DESCRIPTION
## Remove the white background color of SeachField

- Remove the white background color of SeachField to make it can be used on background which has color other than white without the weird white sharp corner.

Before:
<img width="400" alt="Screen Shot 2019-07-29 at 11 50 57 AM" src="https://user-images.githubusercontent.com/23090573/62074562-e9db1b80-b1f7-11e9-8df2-f6f45f5656c6.png">
<img width="400" alt="Screen Shot 2019-07-29 at 11 50 50 AM" src="https://user-images.githubusercontent.com/23090573/62074532-dc259600-b1f7-11e9-9984-def18539b426.png">
After:
<img width="400" alt="Screen Shot 2019-07-29 at 11 51 14 AM" src="https://user-images.githubusercontent.com/23090573/62074594-f8293780-b1f7-11e9-8b27-197372b8e6af.png">
<img width="400" alt="Screen Shot 2019-07-29 at 11 51 18 AM" src="https://user-images.githubusercontent.com/23090573/62074593-f8293780-b1f7-11e9-9779-f5ec360bdadf.png">
