### PR TITLE
Add the size prop to Spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Spinner: Add `size` prop which can be passed `sm` or `md` as a value (#553)
+
 ### Patch
 
 </details>

--- a/docs/src/Spinner.doc.js
+++ b/docs/src/Spinner.doc.js
@@ -35,8 +35,8 @@ card(
       },
       {
         name: 'size',
-        type: `"xs" | "sm" | "md" | "lg" | "xl"`,
-        description: `xs: 24px, sm: 32px, md: 40px, lg: 48px, xl: 56px`,
+        type: `"sm" | "md"`,
+        description: `sm: 32px, md: 40px`,
         defaultValue: 'md',
       },
     ]}

--- a/docs/src/Spinner.doc.js
+++ b/docs/src/Spinner.doc.js
@@ -33,6 +33,12 @@ card(
         description:
           'Whether or not to render with a 300ms delay. The delay is for perceived performance so you should rarely need to remove it.',
       },
+      {
+        name: 'size',
+        type: `"xs" | "sm" | "md" | "lg" | "xl"`,
+        description: `xs: 24px, sm: 32px, md: 40px, lg: 48px, xl: 56px`,
+        defaultValue: 'md',
+      },
     ]}
   />
 );

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -27,14 +27,13 @@ export default function Spinner({
   show,
   size = 'md',
 }: Props) {
-  const iconSize = SIZE_NAME_TO_PIXEL[size];
   return show ? (
     <Box display="flex" justifyContent="around" overflow="hidden">
       <div className={classnames(styles.icon, { [styles.delay]: delay })}>
         <Icon
           icon="knoop"
           accessibilityLabel={accessibilityLabel}
-          size={iconSize}
+          size={SIZE_NAME_TO_PIXEL[size]}
         />
       </div>
     </Box>

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -6,26 +6,35 @@ import Box from './Box.js';
 import Icon from './Icon.js';
 import styles from './Spinner.css';
 
-const SIZE = 40;
+const SIZE_NAME_TO_PIXEL = {
+  xs: 24,
+  sm: 32,
+  md: 40,
+  lg: 48,
+  xl: 56,
+};
 
 type Props = {|
   accessibilityLabel: string,
   delay?: boolean,
   show: boolean,
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
 export default function Spinner({
   accessibilityLabel,
   delay = true,
   show,
+  size = 'md',
 }: Props) {
+  const iconSize = SIZE_NAME_TO_PIXEL[size];
   return show ? (
     <Box display="flex" justifyContent="around" overflow="hidden">
       <div className={classnames(styles.icon, { [styles.delay]: delay })}>
         <Icon
           icon="knoop"
           accessibilityLabel={accessibilityLabel}
-          size={SIZE}
+          size={iconSize}
         />
       </div>
     </Box>
@@ -38,4 +47,5 @@ Spinner.propTypes = {
   show: PropTypes.bool.isRequired,
   accessibilityLabel: PropTypes.string.isRequired,
   delay: PropTypes.bool,
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 };

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -7,18 +7,15 @@ import Icon from './Icon.js';
 import styles from './Spinner.css';
 
 const SIZE_NAME_TO_PIXEL = {
-  xs: 24,
   sm: 32,
   md: 40,
-  lg: 48,
-  xl: 56,
 };
 
 type Props = {|
   accessibilityLabel: string,
   delay?: boolean,
   show: boolean,
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
+  size?: 'sm' | 'md',
 |};
 
 export default function Spinner({
@@ -46,5 +43,5 @@ Spinner.propTypes = {
   show: PropTypes.bool.isRequired,
   accessibilityLabel: PropTypes.string.isRequired,
   delay: PropTypes.bool,
-  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
+  size: PropTypes.oneOf(['sm', 'md']),
 };

--- a/packages/gestalt/src/Spinner.test.js
+++ b/packages/gestalt/src/Spinner.test.js
@@ -23,8 +23,8 @@ test('Spinner renders with no delay', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Spinner renders with large size', () => {
-  const tree = create(<Spinner {...baseProps} show size="lg" />).toJSON();
+test('Spinner renders with medium size', () => {
+  const tree = create(<Spinner {...baseProps} show size="md" />).toJSON();
   expect(tree).toMatchSnapshot();
 });
 

--- a/packages/gestalt/src/Spinner.test.js
+++ b/packages/gestalt/src/Spinner.test.js
@@ -22,3 +22,13 @@ test('Spinner renders with no delay', () => {
   const tree = create(<Spinner {...baseProps} show delay={false} />).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Spinner renders with large size', () => {
+  const tree = create(<Spinner {...baseProps} show size="lg" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Spinner renders with small size', () => {
+  const tree = create(<Spinner {...baseProps} show size="sm" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/Spinner.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Spinner.test.js.snap
@@ -26,6 +26,30 @@ exports[`Spinner renders when passed show 1`] = `
 </div>
 `;
 
+exports[`Spinner renders with large size 1`] = `
+<div
+  className="box justifyAround overflowHidden xsDisplayFlex"
+>
+  <div
+    className="icon delay"
+  >
+    <svg
+      aria-hidden={null}
+      aria-label="Test"
+      className="icon gray iconBlock"
+      height={48}
+      role="img"
+      viewBox="0 0 24 24"
+      width={48}
+    >
+      <path
+        d="test-file-stub"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
 exports[`Spinner renders with no delay 1`] = `
 <div
   className="box justifyAround overflowHidden xsDisplayFlex"
@@ -41,6 +65,30 @@ exports[`Spinner renders with no delay 1`] = `
       role="img"
       viewBox="0 0 24 24"
       width={40}
+    >
+      <path
+        d="test-file-stub"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`Spinner renders with small size 1`] = `
+<div
+  className="box justifyAround overflowHidden xsDisplayFlex"
+>
+  <div
+    className="icon delay"
+  >
+    <svg
+      aria-hidden={null}
+      aria-label="Test"
+      className="icon gray iconBlock"
+      height={32}
+      role="img"
+      viewBox="0 0 24 24"
+      width={32}
     >
       <path
         d="test-file-stub"

--- a/packages/gestalt/src/__snapshots__/Spinner.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Spinner.test.js.snap
@@ -26,7 +26,7 @@ exports[`Spinner renders when passed show 1`] = `
 </div>
 `;
 
-exports[`Spinner renders with large size 1`] = `
+exports[`Spinner renders with medium size 1`] = `
 <div
   className="box justifyAround overflowHidden xsDisplayFlex"
 >
@@ -37,10 +37,10 @@ exports[`Spinner renders with large size 1`] = `
       aria-hidden={null}
       aria-label="Test"
       className="icon gray iconBlock"
-      height={48}
+      height={40}
       role="img"
       viewBox="0 0 24 24"
-      width={48}
+      width={40}
     >
       <path
         d="test-file-stub"


### PR DESCRIPTION
Add the `size` prop for the Spinner. The value of `size` can be the following: `"xs" | "sm" | "md" | "lg" | "xl"`.

`size="sm"`
<img width="1040" alt="Screen Shot 2019-07-26 at 1 10 33 PM" src="https://user-images.githubusercontent.com/848328/61979785-ad19e500-afa9-11e9-8514-01f479cf6ea2.png">

No `size` prop present (size defaults to `"md"`)
<img width="1032" alt="Screen Shot 2019-07-26 at 1 10 57 PM" src="https://user-images.githubusercontent.com/848328/61979797-b2772f80-afa9-11e9-99b7-55dae3ffba1d.png">

