### PR TITLE
[Box] Allow `justifyContent` and `alignContent` props to be passed `evenly` as a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Box: Allow `justifyContent` and `alignContent` props to be passed `evenly` as a value (#557)
+
 ### Patch
 
 </details>

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -82,7 +82,7 @@ card(
       },
       {
         name: 'alignContent',
-        type: `"start" | "end" | "center" | "between" | "around" | "stretch"`,
+        type: `"start" | "end" | "center" | "between" | "around" | "evenly" | "stretch"`,
         defaultValue: 'stretch',
         description:
           "Aligns a flex container's lines within when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.",
@@ -117,7 +117,7 @@ card(
       },
       {
         name: 'justifyContent',
-        type: `"start" | "end" | "center" | "between" | "around"`,
+        type: `"start" | "end" | "center" | "between" | "around" | "evenly"`,
         defaultValue: 'start',
         description:
           'Defines the alignment along the main axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.',

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -119,7 +119,14 @@ type PropType = {
   lgColumn?: Column,
   lgDirection?: Direction,
 
-  alignContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'stretch',
+  alignContent?:
+    | 'start'
+    | 'end'
+    | 'center'
+    | 'between'
+    | 'around'
+    | 'evenly'
+    | 'stretch',
   alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch',
   alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch',
   bottom?: boolean,
@@ -148,7 +155,7 @@ type PropType = {
   fit?: boolean,
   flex?: 'grow' | 'shrink' | 'none',
   height?: number | string,
-  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around',
+  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly',
   left?: boolean,
 
   marginStart?: Margin,
@@ -454,6 +461,7 @@ const propToFn = {
     center: layout.contentCenter,
     between: layout.contentBetween,
     around: layout.contentAround,
+    evenly: layout.contentEvenly,
     // default: stretch
   }),
   alignItems: mapping({
@@ -507,6 +515,7 @@ const propToFn = {
     center: layout.justifyCenter,
     between: layout.justifyBetween,
     around: layout.justifyAround,
+    evenly: layout.justifyEvenly,
     // default: start
   }),
   left: toggle(layout.left0),
@@ -879,6 +888,7 @@ Box.propTypes = {
     'center',
     'between',
     'around',
+    'evenly',
     'stretch',
   ]),
   alignItems: PropTypes.oneOf([
@@ -930,6 +940,7 @@ Box.propTypes = {
     'center',
     'between',
     'around',
+    'evenly',
   ]),
   left: PropTypes.bool,
 

--- a/packages/gestalt/src/Layout.css
+++ b/packages/gestalt/src/Layout.css
@@ -197,6 +197,10 @@
   justify-content: space-around;
 }
 
+.justifyEvenly {
+  justify-content: space-evenly;
+}
+
 .contentStart {
   align-content: flex-start;
 }
@@ -215,6 +219,10 @@
 
 .contentAround {
   align-content: space-around;
+}
+
+.contentEvenly {
+  align-content: space-evenly;
 }
 
 .contentStretch {


### PR DESCRIPTION
Enable the use of `space-evenly` with `justify-content` and `align-content` on `Box`.

Support looks reasonable:

https://caniuse.com/#search=space-evenly