### PR TITLE
Update componentWillReceiveProps to UNSAFE_componentWillReceiveProps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,13 +26,6 @@
     "import"
   ],
   "rules": {
-    "camelcase": [
-      "error",
-      {"allow": [
-          "UNSAFE_componentWillReceiveProps"
-        ]
-      }
-    ],
     "jsx-a11y/label-has-for": [
       "error",
       { "components": ["label"], "allowChildren": true }

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,13 @@
     "import"
   ],
   "rules": {
+    "camelcase": [
+      "error",
+      {"allow": [
+          "UNSAFE_componentWillReceiveProps"
+        ]
+      }
+    ],
     "jsx-a11y/label-has-for": [
       "error",
       { "components": ["label"], "allowChildren": true }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 - Icon: Replace existing filter icon (#565)
+- Contents/Controller: Replace componentWillReceiveProps with UNSAFE_componentWillReceiveProps
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Minor
 
 - Icon: Replace existing filter icon (#565)
-- Contents/Controller: Replace componentWillReceiveProps with UNSAFE_componentWillReceiveProps
+- Contents/Controller: Replace componentWillReceiveProps with UNSAFE_componentWillReceiveProps (#566)
 
 ### Patch
 

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -386,7 +386,7 @@ export default class Contents extends React.Component<Props, State> {
     window.addEventListener('keydown', this.props.onKeyDown);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     this.setFlyoutPosition(nextProps);
   }
 

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -470,7 +470,6 @@ export default class Contents extends React.Component<Props, State> {
     });
   };
 
-  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     this.setFlyoutPosition(nextProps);
   }

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -386,10 +386,6 @@ export default class Contents extends React.Component<Props, State> {
     window.addEventListener('keydown', this.props.onKeyDown);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    this.setFlyoutPosition(nextProps);
-  }
-
   componentWillUnmount() {
     window.removeEventListener('resize', this.props.onResize);
     window.removeEventListener('keydown', this.props.onKeyDown);
@@ -473,6 +469,10 @@ export default class Contents extends React.Component<Props, State> {
       mainDir,
     });
   };
+
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
+    this.setFlyoutPosition(nextProps);
+  }
 
   render() {
     const { bgColor, caret, children, width } = this.props;

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -470,6 +470,7 @@ export default class Contents extends React.Component<Props, State> {
     });
   };
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     this.setFlyoutPosition(nextProps);
   }

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -69,10 +69,6 @@ export default class Controller extends React.Component<Props, State> {
     this.updateTriggerRect(this.props);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    this.updateTriggerRect(nextProps);
-  }
-
   handleKeyDown = (event: { keyCode: number }) => {
     const { onDismiss } = this.props;
     if (event.keyCode === ESCAPE_KEY_CODE) {
@@ -111,6 +107,10 @@ export default class Controller extends React.Component<Props, State> {
 
     this.setState({ relativeOffset, triggerBoundingRect });
   };
+
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
+    this.updateTriggerRect(nextProps);
+  }
 
   render() {
     const {

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -69,7 +69,7 @@ export default class Controller extends React.Component<Props, State> {
     this.updateTriggerRect(this.props);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     this.updateTriggerRect(nextProps);
   }
 

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -108,6 +108,7 @@ export default class Controller extends React.Component<Props, State> {
     this.setState({ relativeOffset, triggerBoundingRect });
   };
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     this.updateTriggerRect(nextProps);
   }

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -108,7 +108,6 @@ export default class Controller extends React.Component<Props, State> {
     this.setState({ relativeOffset, triggerBoundingRect });
   };
 
-  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     this.updateTriggerRect(nextProps);
   }


### PR DESCRIPTION
In order to prepare for an upgrade to React 17, we need to rename `componentWillReceiveProps` to `UNSAFE_componentWillRecieveProps`.

https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path

## TODO

- [x] Documentation
- [ ] Tests
