### PR TITLE
Removed unsafe lifecycle methods from Controller/Contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Masonry: Fixed a bug where all grids shared the same default measurement store (#573)
 - Icon: Add new add-layout icon (#574)
 - Flyout: Remove the lightgray border between content and caret on white flyouts
+- Contents/Controller: Remove UNSAFE\_ methods in favor of supported ones (#570)
 
 ### Patch
 

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -83,6 +83,7 @@ type State = {|
     left: ?number,
   },
   mainDir: ?MainDir,
+  flyoutRef: ?HTMLElement,
 |};
 
 /**
@@ -371,39 +372,44 @@ export default class Contents extends React.Component<Props, State> {
       left: undefined,
     },
     mainDir: null,
+    flyoutRef: null,
   };
 
-  flyout: {| current: null | React.ElementRef<'div'> |} = React.createRef();
-
   componentDidMount() {
-    this.setFlyoutPosition(this.props);
+    const { onResize, onKeyDown } = this.props;
+    const { flyoutRef } = this.state;
+
     setTimeout(() => {
-      if (this.props.shouldFocus && this.flyout.current) {
-        this.flyout.current.focus();
+      if (this.props.shouldFocus && flyoutRef) {
+        flyoutRef.focus();
       }
     });
-    window.addEventListener('resize', this.props.onResize);
-    window.addEventListener('keydown', this.props.onKeyDown);
+
+    window.addEventListener('resize', onResize);
+    window.addEventListener('keydown', onKeyDown);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.props.onResize);
-    window.removeEventListener('keydown', this.props.onKeyDown);
+    const { onResize, onKeyDown } = this.props;
+
+    window.removeEventListener('resize', onResize);
+    window.removeEventListener('keydown', onKeyDown);
   }
 
   /**
    * Determines the main direciton, sub direction, and corresponding offsets needed
    * to correctly position the offset
    */
-  setFlyoutPosition = (props: Props) => {
-    const {
+  static getDerivedStateFromProps(
+    {
       idealDirection,
       positionRelativeToAnchor,
       relativeOffset,
       triggerRect,
       width,
-    } = props;
-
+    }: Props,
+    { flyoutRef }: State
+  ) {
     // Scroll not needed for relative elements
     // We can't use window.scrollX / window.scrollY since it's not supported by IE11
     const scrollX = positionRelativeToAnchor
@@ -425,9 +431,8 @@ export default class Contents extends React.Component<Props, State> {
     };
 
     const flyoutSize = {
-      height: this.flyout.current ? this.flyout.current.clientHeight : 0,
-      width:
-        width || (this.flyout.current ? this.flyout.current.clientWidth : 0),
+      height: flyoutRef ? flyoutRef.clientHeight : 0,
+      width: width || (flyoutRef ? flyoutRef.clientWidth : 0),
     };
 
     // First choose one of 4 main direction
@@ -463,17 +468,22 @@ export default class Contents extends React.Component<Props, State> {
       triggerRect
     );
 
-    this.setState({
+    return {
       caretOffset,
       flyoutOffset,
       mainDir,
-    });
-  };
-
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    this.setFlyoutPosition(nextProps);
+    };
   }
+
+  // Copy the flyout DOM node to state. This is required because we need to
+  // derive the flyout location from it in getDerivedStateFromProps, and because
+  // this method is static, it doesn't have access to the component instance.
+  // Instead, we rely on React passing the state values into that method.
+  setFlyoutRef = (flyoutRef: ?HTMLElement) => {
+    if (!this.state.flyoutRef) {
+      this.setState({ flyoutRef });
+    }
+  };
 
   render() {
     const { bgColor, caret, children, width } = this.props;
@@ -497,7 +507,7 @@ export default class Contents extends React.Component<Props, State> {
             styles.maxDimensions,
             width !== null && styles.minDimensions
           )}
-          ref={this.flyout}
+          ref={this.setFlyoutRef}
           tabIndex={-1}
         >
           <div

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -43,12 +43,39 @@ type State = {|
   triggerBoundingRect: ClientRect,
 |};
 
+function getTriggerRect(
+  anchor: HTMLElement,
+  positionRelativeToAnchor: boolean
+) {
+  let triggerBoundingRect;
+  let relativeOffset;
+  if (anchor) {
+    triggerBoundingRect = anchor.getBoundingClientRect();
+
+    // Needed for correct positioning within Contents.js
+    relativeOffset = {
+      x: positionRelativeToAnchor
+        ? triggerBoundingRect.left - anchor.offsetLeft
+        : 0,
+      y: positionRelativeToAnchor
+        ? triggerBoundingRect.top - anchor.offsetTop
+        : 0,
+    };
+  }
+
+  return { relativeOffset, triggerBoundingRect };
+}
+
 export default class Controller extends React.Component<Props, State> {
   static defaultProps = {
     // Default size only applies when size is omitted,
     // if passed as null it will remain null
     size: 'sm',
   };
+
+  static getDerivedStateFromProps({ anchor, positionRelativeToAnchor }: Props) {
+    return getTriggerRect(anchor, positionRelativeToAnchor);
+  }
 
   state = {
     relativeOffset: {
@@ -87,31 +114,13 @@ export default class Controller extends React.Component<Props, State> {
     this.updateTriggerRect(this.props);
   };
 
-  updateTriggerRect = (props: Props) => {
-    const { anchor, positionRelativeToAnchor } = props;
-    let triggerBoundingRect;
-    let relativeOffset;
-    if (anchor) {
-      triggerBoundingRect = anchor.getBoundingClientRect();
-
-      // Needed for correct positioning within Contents.js
-      relativeOffset = {
-        x: positionRelativeToAnchor
-          ? triggerBoundingRect.left - anchor.offsetLeft
-          : 0,
-        y: positionRelativeToAnchor
-          ? triggerBoundingRect.top - anchor.offsetTop
-          : 0,
-      };
-    }
-
+  updateTriggerRect = ({ anchor, positionRelativeToAnchor }: Props) => {
+    const { relativeOffset, triggerBoundingRect } = getTriggerRect(
+      anchor,
+      positionRelativeToAnchor
+    );
     this.setState({ relativeOffset, triggerBoundingRect });
   };
-
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    this.updateTriggerRect(nextProps);
-  }
 
   render() {
     const {


### PR DESCRIPTION
As part of the React 17 readiness effort, we're doing our best to remove/refactor the deprecated lifecycle methods. In PR #566, we renamed the only remaining occurrences of these methods to use the `UNSAFE_` prefix. This diff follows this up by killing those methods outright, and instead migrating to `getDerivedStateFromProps`.

To test, I used the docs page to verify the Flyouts and Tooltips (both of these use Controller/Contents) still worked as intended. I also triggered props changes and validated that things work. Lastly, I validated that the snapshot test did not change.