### PR TITLE
Adding blue background color to Icon Button and Pog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Minor
 
+- IconButton: Allow `blue` background color prop to be passed as a value
+- Pog: Add `blue` background color prop to be passed as a value
+
 ### Patch
 
 </details>

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -44,7 +44,7 @@ card(
       {
         name: 'bgColor',
         type:
-          '"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white"',
+          '"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue"',
         defaultValue: 'transparent',
         href: 'backgroundColorCombinations',
       },

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -31,7 +31,7 @@ card(
       },
       {
         name: 'bgColor',
-        type: `"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white"`,
+        type: `"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue"`,
         defaultValue: 'transparent',
         href: 'colorCombinations',
       },

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -15,7 +15,8 @@ type Props = {|
     | 'transparentDarkGray'
     | 'gray'
     | 'lightGray'
-    | 'white',
+    | 'white'
+    | 'blue',
   dangerouslySetSvgPath?: { __path: string },
   disabled?: boolean,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white',
@@ -41,6 +42,7 @@ export default class IconButton extends React.Component<Props, State> {
       'gray',
       'lightGray',
       'white',
+      'blue',
     ]),
     dangerouslySetSvgPath: PropTypes.shape({
       __path: PropTypes.string,

--- a/packages/gestalt/src/Pog.css
+++ b/packages/gestalt/src/Pog.css
@@ -82,3 +82,17 @@
 .gray.active {
   background-color: #828282;
 }
+
+.blue {
+  composes: blueBg from "./Colors.css";
+}
+
+.blue.hovered,
+.blue.focused {
+  background-color: #4a8ad4;
+}
+
+.blue.active {
+  background-color: #4a85c9;
+}
+

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -22,7 +22,8 @@ type Props = {|
     | 'transparentDarkGray'
     | 'gray'
     | 'lightGray'
-    | 'white',
+    | 'white'
+    | 'blue',
   dangerouslySetSvgPath?: { __path: string },
   focused?: boolean,
   hovered?: boolean,
@@ -37,6 +38,7 @@ const defaultIconButtonIconColors = {
   lightGray: 'gray',
   white: 'gray',
   transparentDarkGray: 'white',
+  blue: 'white',
 };
 
 export default function Pog(props: Props) {
@@ -93,6 +95,7 @@ Pog.propTypes = {
     'gray',
     'lightGray',
     'white',
+    'blue',
   ]),
   dangerouslySetSvgPath: PropTypes.shape({
     __path: PropTypes.string,


### PR DESCRIPTION
Adding blue as an allowable prop for IconButton and Pog bgColor (background color), and setting the default color combination for blue background color and white icon for Pog, and updating CHANGELOG

- [x] Documentation
- [x] Tests

<img width="473" alt="スクリーンショット 2019-10-08 午後1 19 10" src="https://user-images.githubusercontent.com/3475106/66608517-9841fc00-eb6b-11e9-8e8c-6f3f1a45614e.png">
<img width="780" alt="スクリーンショット 2019-10-08 午後1 19 40" src="https://user-images.githubusercontent.com/3475106/66608518-9841fc00-eb6b-11e9-942b-155fbd6c7297.png">
