### PR TITLE
Fixed memory leak in Masonry’s measurementStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ### Minor
 
-- IconButton: Allow `blue` background color prop to be passed as a value
-- Pog: Add `blue` background color prop to be passed as a value
+- IconButton: Allow `blue` background color prop to be passed as a value (#572)
+- Pog: Add `blue` background color prop to be passed as a value (#572)
+- Masonry: Fixed a bug where all grids shared the same default measurement store (#573)
 
 ### Patch
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -58,6 +58,7 @@ type Props<T> = {|
 |};
 
 type State<T> = {|
+  measurementStore: Cache<T, *>,
   hasPendingMeasurements: boolean,
   isFetching: boolean,
   items: Array<T>,
@@ -176,7 +177,6 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
   static defaultProps = {
     columnWidth: 236,
     // $FlowFixMe: new errors found from flow 0.96 upgrade
-    measurementStore: new MeasurementStore(),
     minCols: 3,
     layout: DefaultLayoutSymbol,
     loadItems: () => {},
@@ -201,13 +201,17 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     this.containerHeight = 0;
     this.containerOffset = 0;
 
+    const measurementStore =
+      props.measurementStore || Masonry.createMeasurementStore();
+
     this.state = {
       hasPendingMeasurements: props.items.some(
-        item => !!item && !props.measurementStore.has(item)
+        item => !!item && !measurementStore.has(item)
       ),
       isFetching: false,
       // eslint-disable-next-line react/no-unused-state
       items: props.items,
+      measurementStore,
       scrollTop: 0,
       width: undefined,
     };
@@ -236,7 +240,8 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
   }
 
   componentDidUpdate(prevProps: Props<T>, prevState: State<T>) {
-    const { items, measurementStore } = this.props;
+    const { items } = this.props;
+    const { measurementStore } = this.state;
 
     this.measureContainerAsync();
 
@@ -277,7 +282,9 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
   }
 
   static getDerivedStateFromProps(props: Props<T>, state: State<T>) {
-    const { items, measurementStore } = props;
+    const { items } = props;
+    const { measurementStore } = state;
+
     // whenever we're receiving new props, determine whether any items need to be measured
     // TODO - we should treat items as immutable
     const hasPendingMeasurements = items.some(
@@ -374,6 +381,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
    */
   reflow() {
     this.props.measurementStore.reset();
+    this.state.measurementStore.reset();
     this.measureContainer();
     this.forceUpdate();
   }
@@ -436,11 +444,10 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
       comp: Component,
       flexible,
       gutterWidth: gutter,
-      measurementStore,
       items,
       minCols,
     } = this.props;
-    const { hasPendingMeasurements, width } = this.state;
+    const { hasPendingMeasurements, measurementStore, width } = this.state;
 
     let layout;
     if (flexible && width !== null) {

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -74,9 +74,9 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 const layoutNumberToCssDimension = n => (n !== Infinity ? n : undefined);
 
 export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
-  static createMeasurementStore() {
+  static createMeasurementStore<M>() {
     // $FlowFixMe: new errors found from flow 0.96 upgrade
-    return new MeasurementStore();
+    return new MeasurementStore<M>();
   }
 
   /**
@@ -176,7 +176,6 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
 
   static defaultProps = {
     columnWidth: 236,
-    // $FlowFixMe: new errors found from flow 0.96 upgrade
     minCols: 3,
     layout: DefaultLayoutSymbol,
     loadItems: () => {},
@@ -201,7 +200,7 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
     this.containerHeight = 0;
     this.containerOffset = 0;
 
-    const measurementStore =
+    const measurementStore: Cache<T, *> =
       props.measurementStore || Masonry.createMeasurementStore();
 
     this.state = {

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -39,7 +39,7 @@ type Props<T> = {|
   flexible?: boolean,
   gutterWidth?: number,
   items: Array<T>,
-  measurementStore: Cache<T, *>,
+  measurementStore?: Cache<T, *>,
   minCols: number,
   layout?: Layout,
   // Support legacy loadItems usage.

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -380,8 +380,11 @@ export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
    * number of columns we would display should change after a resize.
    */
   reflow() {
-    this.props.measurementStore.reset();
+    if (this.props.measurementStore) {
+      this.props.measurementStore.reset();
+    }
     this.state.measurementStore.reset();
+
     this.measureContainer();
     this.forceUpdate();
   }


### PR DESCRIPTION
When comparing Gestalt's Masonry (Masonry8) with Masonry9, I stumbled on a bug in Masonry8. The bug is that a single `MeasurementCache` gets created when `defaultProps` are defined, and then this same `MeasurementCache` is used for _all_ grids that don't specify their own `measurementCache` via props. This means, since the `defaultProps` are static and live outside any instance of a component, the cache is shared across grids and it's never cleared, even when grids are unmounted.

This PR fixes the issue by turning `measurementCache` into an unmanaged prop and pulling it into `state` on component construction. While I tend not to like unmanaged props (especially when they're not named something like `initialMeasurementCache` or `defaultMeasurementCache`), I think this is the simplest solution to fix the bug. AFAIK, we never change up the `measurementCache` values within a component in Pinterest anyway.

Note: Masonry9 has the exact same bug and it'll need to fixed separately.