### PR TITLE
Fix Masonry types

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -73,10 +73,12 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 
 const layoutNumberToCssDimension = n => (n !== Infinity ? n : undefined);
 
-export default class Masonry<T> extends React.Component<Props<T>, State<T>> {
-  static createMeasurementStore<M>() {
-    // $FlowFixMe: new errors found from flow 0.96 upgrade
-    return new MeasurementStore<M>();
+export default class Masonry<T: {}> extends React.Component<
+  Props<T>,
+  State<T>
+> {
+  static createMeasurementStore<T1: {}, T2>(): MeasurementStore<T1, T2> {
+    return new MeasurementStore();
   }
 
   /**


### PR DESCRIPTION
I accidentally broke the build with my latest push to fix Masonry. Flow didn't catch the issue, but it didn't build. This PR fixes the types and passes the build.

Why wasn't this caught when I originally pushed my Masonry PR? It… was. I just failed to understand that I was using admin privileges to override the error when I really thought I was doing the normal push.