### PR TITLE
[Flyout] Fix lightgray border separating caret from contents on white…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Pog: Add `blue` background color prop to be passed as a value (#572)
 - Masonry: Fixed a bug where all grids shared the same default measurement store (#573)
 - Icon: Add new add-layout icon (#574)
+- Flyout: Remove the lightgray border between content and caret on white flyouts
 
 ### Patch
 

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -483,7 +483,6 @@ export default class Contents extends React.Component<Props, State> {
     const visibility = mainDir === null ? 'hidden' : 'visible';
     const background = `${bgColor}Bg`;
     const stroke = bgColor === 'white' ? '#efefef' : null;
-    const borderColor = bgColor === 'white' ? 'lightGray' : bgColor;
 
     return (
       <div
@@ -493,7 +492,7 @@ export default class Contents extends React.Component<Props, State> {
         <div
           className={classnames(
             colors[background],
-            colors[borderColor],
+            colors[bgColor],
             styles.contents,
             styles.maxDimensions,
             width !== null && styles.minDimensions

--- a/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
@@ -15,7 +15,7 @@ exports[`Flyout renders 1`] = `
   }
 >
   <div
-    className="whiteBg lightGray contents maxDimensions minDimensions"
+    className="whiteBg white contents maxDimensions minDimensions"
     tabIndex={-1}
   >
     <div


### PR DESCRIPTION
… flyout

Before:
<img width="405" alt="スクリーンショット 2019-10-17 午後5 29 24" src="https://user-images.githubusercontent.com/3475106/67113507-89240500-f18e-11e9-9c64-3b68ac9b2aa1.png">

After:
<img width="337" alt="スクリーンショット 2019-10-17 午後5 31 35" src="https://user-images.githubusercontent.com/3475106/67113523-9214d680-f18e-11e9-921f-4105eb6bac0e.png">

No other flyout separate its content from the caret with a white flyout border; so, this PR removes that separation to make the white flyout design behavior match those of all the other color flyouts.


- [x] Documentation
- [x] Tests
