### PR TITLE
Fix flow types on ScrollFetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- ScrollFetch: Fixed a tiny flow type bug on the default props (#587)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/ScrollFetch.js
+++ b/packages/gestalt/src/ScrollFetch.js
@@ -33,7 +33,7 @@ export default class ScrollFetch extends React.PureComponent<Props, State> {
   });
 
   static defaultProps = {
-    container: typeof window !== 'undefined' ? window : null,
+    container: typeof window !== 'undefined' ? window : undefined,
   };
 
   state = {


### PR DESCRIPTION
With #569, we updated the way ScrollFetch specifies default props to use `static` instead of setting an object after the class definition. This was functionally the same, but flow interpreted them differently. Specifically: flow is now covering these defaults whereas it wasn't before. Unfortunately, this didn't get exposed until we tried to import Gestalt v106 into pinboard.

This diff attempts to fix the default prop type. Unfortunately, I don't know how to test it other than to land it and pull it down from there.