### PR TITLE
Add IconWithTooltip component and tests

### DIFF
--- a/docs/src/IconWithTooltip.doc.js
+++ b/docs/src/IconWithTooltip.doc.js
@@ -1,0 +1,97 @@
+// @flow
+import React from 'react';
+import Example from './components/Example.js';
+import PropTable from './components/PropTable.js';
+import PageHeader from './components/PageHeader.js';
+
+const cards = [];
+const card = c => cards.push(c);
+
+card(
+  <PageHeader
+    name="IconWithTooltip"
+    description="The Icon with Tooltip component allows you to add a help tooltip on hover.
+    Similar to regular Tooltips, these are about way finding but they also allow for education 
+    with the option to link to additional information with a learn more link. They should
+    only include short descriptive text and are co-located with the element they describe."
+  />
+);
+
+card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibility label',
+        type: 'string',
+        required: true,
+        description:
+          'String that clients such as VoiceOver will read to describe the element. Always localize the label.',
+      },
+      {
+        name: 'icon',
+        type: 'string',
+        required: true,
+        description: 'The name of the icon to wrap with a hover tooltip.',
+      },
+      {
+        name: 'href',
+        type: 'string',
+        description: 'Url used for the learn more link.',
+      },
+      {
+        name: 'inline',
+        type: 'boolean',
+        href: 'inline',
+        description:
+          'Flag used to help render the tooltip inline to the element',
+      },
+      {
+        name: 'hrefText',
+        type: 'string',
+        description:
+          'Text used for the Link itself e.g. "Learn More". This should be a very short call to action and should always be localized.',
+      },
+      {
+        name: 'tooltipText',
+        type: 'string',
+        required: true,
+        description:
+          'String that is shown as additional information in a tooltip bubble on icon hover. Always localize the text.',
+      },
+    ]}
+  />
+);
+
+card(
+  <Example
+    name="Icon with Tooltip on hover"
+    description="Basic usage with a tooltip showing when icon is hovered. Be sure to internationalize your `tooltipText`."
+    defaultCode={`
+<IconWithTooltip
+  accessibilityLabel="informational-tooltip"
+  icon="info-circle" 
+  inline 
+  tooltipText="Icon with Tooltip" 
+/>
+`}
+  />
+);
+
+card(
+  <Example
+    name="Icon with Tooltip including link"
+    description="Passing a href prop will render a Learn More link below the provided tooltip text. Be sure to internationalize both your `tooltipText` and `hrefText`."
+    defaultCode={`
+<IconWithTooltip
+  accessibilityLabel="informational-tooltip"
+  icon="info-circle" 
+  inline 
+  tooltipText="Icon with Tooltip and link"
+  href="https://www.pinterest.com" 
+  hrefText="Learn More" 
+/>
+`}
+  />
+);
+
+export default cards;

--- a/packages/gestalt/src/IconWithTooltip.js
+++ b/packages/gestalt/src/IconWithTooltip.js
@@ -1,0 +1,140 @@
+// @flow
+
+import * as React from 'react';
+import Controller from './Controller.js';
+import Text from './Text.js';
+import Box from './Box.js';
+import Link from './Link.js';
+import Icon from './Icon.js';
+import icons from './icons/index.js';
+import Touchable from './Touchable.js';
+
+const noop = () => {};
+
+type Props = {|
+  accessibilityLabel: string,
+  icon?: $Keys<typeof icons>,
+  inline?: boolean,
+  href?: string,
+  hrefText?: string,
+  tooltipText: string,
+|};
+
+type State = {|
+  hoveredIcon: boolean,
+  hoveredText: boolean,
+  open: boolean,
+|};
+
+export default class IconWithTooltip extends React.Component<Props, State> {
+  state = {
+    hoveredIcon: false,
+    hoveredText: false,
+    open: false,
+  };
+
+  childRef: {| current: null | React.ElementRef<'div'> |} = React.createRef();
+
+  handleIconMouseEnter = () => {
+    this.setState({
+      hoveredIcon: true,
+      open: true,
+    });
+  };
+
+  handleIconMouseLeave = () => {
+    setTimeout(() => {
+      this.setState(state => {
+        return {
+          ...(!state.hoveredText ? { open: false } : {}),
+          hoveredIcon: false,
+        };
+      });
+    }, 75);
+  };
+
+  handleTextMouseEnter = () => {
+    this.setState({
+      hoveredText: true,
+    });
+  };
+
+  handleTextMouseLeave = () => {
+    setTimeout(() => {
+      this.setState(state => {
+        return {
+          ...(!state.hoveredIcon ? { open: false } : {}),
+          hoveredText: false,
+        };
+      });
+    }, 75);
+  };
+
+  render() {
+    const {
+      accessibilityLabel,
+      icon,
+      inline,
+      tooltipText,
+      href,
+      hrefText,
+    } = this.props;
+    const { open } = this.state;
+    const { current: anchor } = this.childRef;
+
+    return (
+      <Box
+        display={inline ? 'inlineBlock' : 'block'}
+        ref={this.childRef}
+        onMouseEnter={this.handleIconMouseEnter}
+        onMouseLeave={this.handleIconMouseLeave}
+        onFocus={this.handleIconMouseEnter}
+        onBlur={this.handleIconMouseLeave}
+      >
+        <Touchable onTouch={this.handleIconMouseEnter} shape="rounded">
+          <Icon
+            color={open ? 'darkGray' : 'gray'}
+            icon={icon}
+            accessibilityLabel={accessibilityLabel}
+          />
+        </Touchable>
+
+        {open && !!anchor && (
+          <Controller
+            anchor={anchor}
+            bgColor="darkGray"
+            caret={false}
+            idealDirection="down"
+            onDismiss={noop}
+            positionRelativeToAnchor
+            size={null}
+          >
+            <Box
+              maxWidth={180}
+              paddingY={1}
+              paddingX={2}
+              role="tooltip"
+              onMouseEnter={this.handleTextMouseEnter}
+              onMouseLeave={this.handleTextMouseLeave}
+              onFocus={this.handleTextMouseEnter}
+              onBlur={this.handleTextMouseLeave}
+            >
+              <Text color="white" size="xs">
+                {tooltipText}
+              </Text>
+              {href && hrefText && (
+                <Box paddingY={1} role="link">
+                  <Link href={href}>
+                    <Text color="white" size="xs" weight="bold">
+                      {hrefText}
+                    </Text>
+                  </Link>
+                </Box>
+              )}
+            </Box>
+          </Controller>
+        )}
+      </Box>
+    );
+  }
+}

--- a/packages/gestalt/src/IconWithTooltip.jsdom.test.js
+++ b/packages/gestalt/src/IconWithTooltip.jsdom.test.js
@@ -1,0 +1,96 @@
+// @flow
+import React from 'react';
+import '@babel/polyfill';
+import {
+  render,
+  fireEvent,
+  wait,
+  waitForElement,
+} from '@testing-library/react';
+import IconWithTooltip from './IconWithTooltip.js';
+
+test('Icon with Tooltip and no href renders', () => {
+  const { getByRole, queryByRole } = render(
+    <IconWithTooltip
+      accessibilityLabel="informational-tooltip"
+      icon="circle-outline"
+      inline
+      tooltipText="Icon with Tooltip and Learn More link"
+    />
+  );
+
+  expect(getByRole('img')).toBeVisible();
+  fireEvent.mouseEnter(getByRole('img'));
+  expect(getByRole('tooltip')).toBeVisible();
+  expect(queryByRole('link')).toEqual(null);
+});
+
+test('Icon with Tooltip and href renders', () => {
+  const { getByRole, getAllByRole } = render(
+    <IconWithTooltip
+      accessibilityLabel="informational-tooltip"
+      icon="circle-outline"
+      inline
+      tooltipText="Icon with Tooltip and Learn More link"
+      href="https://www.pinterest.com"
+      hrefText="Learn More"
+    />
+  );
+
+  expect(getByRole('img')).toBeVisible();
+  fireEvent.mouseEnter(getByRole('img'));
+  expect(getByRole('tooltip')).toBeVisible();
+  expect(getAllByRole('link').length).toEqual(2);
+});
+
+test('Icon mouse enter and leave behavior works as expected', async () => {
+  const { getByRole, queryByRole } = render(
+    <IconWithTooltip
+      accessibilityLabel="informational-tooltip"
+      icon="circle-outline"
+      inline
+      tooltipText="Icon with Tooltip and Learn More link"
+      href="https://www.pinterest.com"
+      hrefText="Learn More"
+    />
+  );
+
+  // start with just the icon visible
+  expect(getByRole('img')).toBeVisible();
+  expect(queryByRole('tooltip')).toEqual(null);
+
+  // hover on icon - tooltip should appear
+  fireEvent.mouseEnter(getByRole('img'));
+  await waitForElement(() => getByRole('tooltip'));
+
+  // leave icon, hover on tooltip - tooltip should remain visible
+  fireEvent.mouseLeave(getByRole('img'));
+  fireEvent.mouseEnter(getByRole('tooltip'));
+  expect(getByRole('tooltip')).toBeVisible();
+
+  // leave tooltip, hover on icon - tooltip should remain visible
+  fireEvent.mouseLeave(getByRole('tooltip'));
+  fireEvent.mouseEnter(getByRole('img'));
+  expect(getByRole('tooltip')).toBeVisible();
+
+  // leave tooltip, leave icon - tooltip should no longer be visible
+  fireEvent.mouseLeave(getByRole('img'));
+  await wait(() => expect(queryByRole('tooltip')).toEqual(null));
+});
+
+test('Icon with Tooltip and href but missing href text renders', () => {
+  const { getByRole, queryByRole } = render(
+    <IconWithTooltip
+      accessibilityLabel="informational-tooltip"
+      icon="circle-outline"
+      inline
+      tooltipText="Icon with Tooltip and Learn More link"
+      href="https://www.pinterest.com"
+    />
+  );
+
+  expect(getByRole('img')).toBeVisible();
+  fireEvent.mouseEnter(getByRole('img'));
+  expect(getByRole('tooltip')).toBeVisible();
+  expect(queryByRole('link')).toEqual(null);
+});

--- a/packages/gestalt/src/IconWithTooltip.test.js
+++ b/packages/gestalt/src/IconWithTooltip.test.js
@@ -1,0 +1,46 @@
+// @flow
+import React from 'react';
+import renderer from 'react-test-renderer';
+import IconWithTooltip from './IconWithTooltip.js';
+
+test('IconWithTooltip renders', () => {
+  const component = renderer.create(
+    <IconWithTooltip
+      accessibilityLabel="informational-tooltip"
+      icon="circle-outline"
+      inline
+      tooltipText="Icon with Tooltip and Learn More link"
+    />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('IconWithTooltip renders with href', () => {
+  const component = renderer.create(
+    <IconWithTooltip
+      accessibilityLabel="informational-tooltip"
+      icon="circle-outline"
+      inline
+      tooltipText="Icon with Tooltip and Learn More link"
+      href="https://www.pinterest.com"
+      hrefText="Learn More"
+    />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('IconWithTooltip renders with missing hrefText', () => {
+  const component = renderer.create(
+    <IconWithTooltip
+      accessibilityLabel="informational-tooltip"
+      icon="circle-outline"
+      inline
+      tooltipText="Icon with Tooltip and Learn More link"
+      href="https://www.pinterest.com"
+    />
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/IconWithTooltip.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconWithTooltip.test.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IconWithTooltip renders 1`] = `
+<div
+  className="box xsDisplayInlineBlock"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="touchable pointer rounded fullWidth"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <svg
+      aria-hidden={null}
+      aria-label="informational-tooltip"
+      className="icon gray iconBlock"
+      height={16}
+      role="img"
+      viewBox="0 0 24 24"
+      width={16}
+    >
+      <path
+        d="test-file-stub"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`IconWithTooltip renders with href 1`] = `
+<div
+  className="box xsDisplayInlineBlock"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="touchable pointer rounded fullWidth"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <svg
+      aria-hidden={null}
+      aria-label="informational-tooltip"
+      className="icon gray iconBlock"
+      height={16}
+      role="img"
+      viewBox="0 0 24 24"
+      width={16}
+    >
+      <path
+        d="test-file-stub"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`IconWithTooltip renders with missing hrefText 1`] = `
+<div
+  className="box xsDisplayInlineBlock"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="touchable pointer rounded fullWidth"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    <svg
+      aria-hidden={null}
+      aria-label="informational-tooltip"
+      className="icon gray iconBlock"
+      height={16}
+      role="img"
+      viewBox="0 0 24 24"
+      width={16}
+    >
+      <path
+        d="test-file-stub"
+      />
+    </svg>
+  </div>
+</div>
+`;

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -15,6 +15,7 @@ import GroupAvatar from './GroupAvatar.js';
 import Heading from './Heading.js';
 import Icon from './Icon.js';
 import IconButton from './IconButton.js';
+import IconWithTooltip from './IconWithTooltip.js';
 import Image from './Image.js';
 import Label from './Label.js';
 import Layer from './Layer.js';
@@ -61,6 +62,7 @@ export {
   Heading,
   Icon,
   IconButton,
+  IconWithTooltip,
   Image,
   Label,
   Layer,


### PR DESCRIPTION
Background: We have an initiative to push for in product education within the sterling codebase in H1 that requires a tooltip on an info-icon hover with support for a "Learn More" link.

Proposed: We don't want to support this for all our Tooltips so this new IconWithTooltip component will allow us to be very specific in the implementation. PDS approved it for the info-icon specifically- i'm leaving the icon assignment flexible for others' use cases.

~Open question: accessibility standards. I had one suggestion to make the tooltip visible on focus in addition to on hover. Is this sufficient?~

*Updated behavior with focus and blur*

![iconwithtooltip3](https://user-images.githubusercontent.com/16228317/71031076-8cbd0500-20c7-11ea-9c18-3b7239c53fbb.gif)

## TODO

- [x] Documentation
- [x] Tests
- [ ] Experimental evidence (required for Masonry changes)
- [x] Accessibility checkup
