### PR TITLE
Internal: include flow warnings in error output

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,8 +8,9 @@
 <PROJECT_ROOT>/packages/gestalt-codemods/.*/__testfixtures__
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
-suppress_comment= \\(.\\|\n\\)*\\$FlowIssue
+include_warnings=true
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 # necessary for webpack loader syntax.
 module.name_mapper='^.*\.css$' -> '<PROJECT_ROOT>/flow/stubs/CSSModuleStub.js'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Patch
 
 - Internal: Convert from Travis.ci to GitHub workflows (#610)
+- Internal: include flow warnings in error output (#611)
 
 </details>
 

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -31,7 +31,6 @@ type Props = {|
 |};
 
 const fullscreenEnabled = () =>
-  // $FlowIssue - vendor prefix missing from Flow
   document.fullscreenEnabled ||
   // $FlowIssue - vendor prefix missing from Flow
   document.webkitFullscreenEnabled ||


### PR DESCRIPTION
https://flow.org/en/docs/config/options/#toc-include-warnings-boolean

Makes sure that we're not accidentally adding new flow warnings to gestalt.