### PR TITLE
Internal: Perform releases with GitHub CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    name: Publish gestalt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the version
+        id: version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+      - name: Checkout the repo
+        uses: actions/checkout@master
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Setup npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
+      - name: Publish to npm
+        run: |
+          yarn install
+          cd packages/gestalt
+          yarn publish --registry=https://registry.npmjs.org --no-git-tag-version --new-version ${{ steps.version.outputs.VERSION }}
+      - name: Setup github access tokens
+        env:
+          GITHUB_PERSONAL_TOKEN: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
+        run: |
+          echo "machine github.com" >> .netrc
+          echo "login christianvuerings" >> .netrc
+          echo "password $GITHUB_PERSONAL_TOKEN" >> .netrc
+      - name: Update github pages
+        run: |
+          git config user.name "Publish gestalt"
+          git config user.email "gestalt@users.noreply.github.com"
+          git checkout -b tmp-deploy
+          (cd docs && NODE_ENV=production yarn build --output-public-path '/gestalt')
+          git add -f docs/build
+          git commit -m "Deployed to Github Pages" --no-verify
+          git subtree split --prefix docs/build -b tmp-gh-pages
+          git push -f https://github.com/pinterest/gestalt.git tmp-gh-pages:gh-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - IconButton: Convert examples & component to use hooks (#612)
 - Internal: Convert from Travis.ci to GitHub workflows (#610)
 - Internal: include flow warnings in error output (#611)
+- Internal: Perform releases with GitHub CI (#615)
 - Link: Convert component to use hooks (#613)
 
 </details>


### PR DESCRIPTION
In the past we had to manually run `./scripts/publish.js` which was painful since you've had to set up your npm / yarn and GitHub permissions. 

With this PR, we will automatically publish to npm and update GitHub pages whenever we create a new version tag. Please check out the [successful build & npm release for the `gestalt-copy` package](https://github.com/christianvuerings/gestalt-copy/commit/4516c8a82d386033f2e354e2ed09c722f983ff51/checks?check_suite_id=365763646)

Follow up after we've tested publishing through CI:
- [ ] Remove the legacy scripts
- [ ] Update release / publishing docs