### PR TITLE
removing required heading in Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## 0.113.4 (Jan 16, 2020)
 
 <details>
   <summary>
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+- Modal: Removing required heading to support more design options
 
 ### Patch
 

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -46,7 +46,6 @@ card(
       {
         name: 'heading',
         type: `string | React.Node`,
-        required: true,
         href: 'heading',
       },
       {

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -143,21 +143,23 @@ export default class Modal extends React.Component<Props> {
                     direction="column"
                     width="100%"
                   >
-                    {heading && <Box fit>
-                      <Header heading={heading} role={role} />
-                      {role === 'dialog' && (
-                        <>
-                          <Box padding={2} position="absolute" top right>
-                            <IconButton
-                              accessibilityLabel={accessibilityCloseLabel}
-                              icon="cancel"
-                              onClick={this.handleCloseClick}
-                            />
-                          </Box>
-                          <Divider />
-                        </>
-                      )}
-                    </Box>)}
+                    {heading && (
+                      <Box fit>
+                        <Header heading={heading} role={role} />
+                        {role === 'dialog' && (
+                          <>
+                            <Box padding={2} position="absolute" top right>
+                              <IconButton
+                                accessibilityLabel={accessibilityCloseLabel}
+                                icon="cancel"
+                                onClick={this.handleCloseClick}
+                              />
+                            </Box>
+                            <Divider />
+                          </>
+                        )}
+                      </Box>
+                    )}
                     <Box flex="grow" overflow="auto" position="relative">
                       {children}
                     </Box>
@@ -168,7 +170,7 @@ export default class Modal extends React.Component<Props> {
                           <Box padding={4}>{footer}</Box>
                         </Box>
                       )}
-                    </Box>}
+                    </Box>
                   </Box>
                 </div>
               </OutsideEventBehavior>

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -15,7 +15,7 @@ type Props = {|
   accessibilityModalLabel: string,
   children?: React.Node,
   footer?: React.Node,
-  heading: string | React.Node,
+  heading?: string | React.Node,
   onDismiss: () => void,
   role?: 'alertdialog' | 'dialog',
   size?: 'sm' | 'md' | 'lg' | number,
@@ -81,7 +81,7 @@ export default class Modal extends React.Component<Props> {
     accessibilityModalLabel: PropTypes.string.isRequired,
     children: PropTypes.node,
     footer: PropTypes.node,
-    heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+    heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     onDismiss: PropTypes.func,
     role: PropTypes.oneOf(['alertdialog', 'dialog']),
     size: PropTypes.oneOfType([
@@ -143,7 +143,7 @@ export default class Modal extends React.Component<Props> {
                     direction="column"
                     width="100%"
                   >
-                    <Box fit>
+                    {heading && <Box fit>
                       <Header heading={heading} role={role} />
                       {role === 'dialog' && (
                         <>
@@ -157,7 +157,7 @@ export default class Modal extends React.Component<Props> {
                           <Divider />
                         </>
                       )}
-                    </Box>
+                    </Box>)}
                     <Box flex="grow" overflow="auto" position="relative">
                       {children}
                     </Box>
@@ -168,7 +168,7 @@ export default class Modal extends React.Component<Props> {
                           <Box padding={4}>{footer}</Box>
                         </Box>
                       )}
-                    </Box>
+                    </Box>}
                   </Box>
                 </div>
               </OutsideEventBehavior>


### PR DESCRIPTION
## TODO

- [x] Documentation: removed required flag for heading in the documentation
- [x] Tests: manually tested in devapp that current modal works as is with heading passed in, and also heading section is gone without being passed in
- [ ] Experimental evidence (required for Masonry changes)
- [ ] Accessibility checkup
