### PR TITLE
Add flag for fixing “fetch more” bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Patch
 
 - Stats: Calculate raw and percentage number of gestalt components vs native components
+- Masonry: Add a flag to optionally fix a bug (see PR notes) (#632)
 
 </details>
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -55,6 +55,8 @@ type Props<T> = {|
   virtualBoundsTop?: number,
   virtualBoundsBottom?: number,
   virtualize?: boolean,
+
+  fixFetchMoreBug?: boolean,
 |};
 
 type State<T> = {|
@@ -186,6 +188,11 @@ export default class Masonry<T: {}> extends React.Component<
      * Whether or not to use actual virtualization
      */
     virtualize: PropTypes.bool,
+
+    /**
+     * Flag to decide if we should fix fetch more bug (see commit notes)
+     */
+    fixFetchMoreBug: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -194,6 +201,8 @@ export default class Masonry<T: {}> extends React.Component<
     layout: DefaultLayoutSymbol,
     loadItems: () => {},
     virtualize: false,
+
+    fixFetchMoreBug: false,
   };
 
   constructor(props: Props<T>) {
@@ -451,6 +460,7 @@ export default class Masonry<T: {}> extends React.Component<
       gutterWidth: gutter,
       items,
       minCols,
+      fixFetchMoreBug,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
 
@@ -589,7 +599,9 @@ export default class Masonry<T: {}> extends React.Component<
               isFetching={
                 this.state.isFetching || this.state.hasPendingMeasurements
               }
-              scrollHeight={height}
+              scrollHeight={
+                height + (fixFetchMoreBug ? this.containerOffset : 0)
+              }
               scrollTop={this.state.scrollTop}
             />
           )}


### PR DESCRIPTION
This PR sets up an experimental flag `fixFetchMoreBug` that fixes a bug in Masonry. Because Masonry is the bread and butter of Pinterest, we can't simply fix the bug -- we need to measure the effects of the fix and decide if we should investigate a further change.

Here's the issue:

Let's say we have 1000px of content and Masonry is configured to fetch more content when the user scrolls within 200px of the bottom. The user will start scrolling, and as soon as the user gets 800px down the screen, it will fetch more. Masonry will do this perfectly by measuring the scroll position and the content height (along with the height of the user's viewport).

Now, let's say we have a header above Masonry that's 15000px tall. This means the user would have to scroll 14800px before we need to fetch more content. BUT -- our code currently doesn't consider this header at all. Instead, it will trigger to fetch more when the user has scrolled 800px down the page even though the user is still looking at the header and hasn't even made it down to Masonry content yet.

The result of this bug is that Masonry will fetch more aggressively on all pages that have content above Masonry. Because we use headers or controls on many of our pages, this affects the majority of our site.

The fix: Make Masonry aware of the header and don't fetch until the user is beyond it. In the example above, we don't want to fetch until the user has scrolled 14800px down. Turns out, this was a 1-line fix.

Once this flag lands in our code, I'll run an experiment to see how the will affect users. If we drop impressions or engagement, we can still apply the fix, but also expand the threshold we use to trigger fetching (200px in the example above).