### PR TITLE
Fix documentation overlap issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Patch
 
-- Modal: Update docs to wrap Modals in Layers so they don't get overlapped by example code (#639)
+- Docs: Update docs to wrap Flyouts, Modals, and Tooltips in Layers so they don't get overlapped by example code (#639)
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Patch
 
+- Modal: Update docs to wrap Modals in Layers so they don't get overlapped by example code (#639)
+
 </details>
 
 ## 0.121.0 (Jan 21, 2020)

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -81,36 +81,26 @@ card(
     id="basicExample"
     name="Example"
     defaultCode={`
-class FlyoutExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false };
-    this.handleClick = this._handleClick.bind(this);
-    this.handleDismiss = this._handleDismiss.bind(this);
-    this.anchorRef = React.createRef();
-  }
-  _handleClick() {
-    this.setState(() => ({ open: !this.state.open }));
-  }
-  _handleDismiss() {
-    this.setState(() => ({ open: false }));
-  }
-  render() {
-    return (
-      <Box>
-        <Box display="inlineBlock" ref={this.anchorRef}>
-          <Button
-            accessibilityExpanded={!!this.state.open}
-            accessibilityHaspopup
-            onClick={this.handleClick}
-            text="Help"
-          />
-        </Box>
-        {this.state.open &&
+function FlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef();
+  return (
+    <Box>
+      <Box display="inlineBlock" ref={anchorRef}>
+        <Button
+          accessibilityExpanded={!!open}
+          accessibilityHaspopup
+          onClick={() => setOpen(!open)}
+          text="Help"
+        />
+      </Box>
+      {open &&
+        <Layer>
           <Flyout
-            anchor={this.anchorRef.current}
+            anchor={anchorRef.current}
             idealDirection="up"
-            onDismiss={this.handleDismiss}
+            onDismiss={() => setOpen(false)}
+            positionRelativeToAnchor={false}
             size="md"
           >
             <Box padding={3}>
@@ -121,10 +111,10 @@ class FlyoutExample extends React.Component {
                 <Button color="red" text="Visit the help center" />
               </Box>
             </Box>
-          </Flyout>}
-      </Box>
-    );
-  }
+          </Flyout>
+        </Layer>}
+    </Box>
+  );
 }
 `}
   />
@@ -137,32 +127,22 @@ card(
     description={`Flyout can also take on additional roles. Like [TextField](#TextField) and [TextArea](#TextArea), this component
 can be used to highlight errors on other types of form fields by setting the \`color\` to \`red.\``}
     defaultCode={`
-class ErrorFlyoutExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false };
-    this.handleClick = this._handleClick.bind(this);
-    this.handleDismiss = this._handleDismiss.bind(this);
-    this.anchorRef = React.createRef();
-  }
-  _handleClick() {
-    this.setState(() => ({ open: !this.state.open }));
-  }
-  _handleDismiss() {
-    this.setState(() => ({ open: false }));
-  }
-  render() {
-    return (
-      <Box>
-        <Box display="inlineBlock" ref={this.anchorRef}>
-          <Button onClick={this.handleClick} text="Remove" />
-        </Box>
-        {this.state.open &&
+function ErrorFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef();
+  return (
+    <Box>
+      <Box display="inlineBlock" ref={anchorRef}>
+        <Button onClick={() => setOpen(!open)} text="Remove" />
+      </Box>
+      {open &&
+        <Layer>
           <Flyout
-            anchor={this.anchorRef.current}
-            idealDirection="up"
-            onDismiss={this.handleDismiss}
+            anchor={anchorRef.current}
             color="red"
+            idealDirection="up"
+            onDismiss={() => setOpen(false)}
+            positionRelativeToAnchor={false}
             shouldFocus={false}
             size="md"
           >
@@ -172,10 +152,10 @@ class ErrorFlyoutExample extends React.Component {
               </Text>
             </Box>
           </Flyout>
-        }
-      </Box>
-    );
-  }
+        </Layer>
+      }
+    </Box>
+  );
 }
 `}
   />

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -117,18 +117,20 @@ class Example extends React.Component {
             onClick={this.handleToggleSmall}
           />
           {sm && (
-            <Modal
-              accessibilityCloseLabel="close"
-              accessibilityModalLabel="View default padding and styling"
-              heading="Small modal"
-              onDismiss={this.handleToggleSmall}
-              footer={<Heading size="sm">Footer</Heading>}
-              size="sm"
-            >
-              <Box padding={2}>
-                <Heading size="sm">Children</Heading>
-              </Box>
-            </Modal>
+            <Layer>
+              <Modal
+                accessibilityCloseLabel="close"
+                accessibilityModalLabel="View default padding and styling"
+                heading="Small modal"
+                onDismiss={this.handleToggleSmall}
+                footer={<Heading size="sm">Footer</Heading>}
+                size="sm"
+              >
+                <Box padding={2}>
+                  <Heading size="sm">Children</Heading>
+                </Box>
+              </Modal>
+            </Layer>
           )}
         </Box>
         <Box padding={1}>
@@ -137,18 +139,20 @@ class Example extends React.Component {
             onClick={this.handleToggleMedium}
           />
           {md && (
-            <Modal
-              accessibilityCloseLabel="close"
-              accessibilityModalLabel="View default padding and styling"
-              heading="Medium modal"
-              onDismiss={this.handleToggleMedium}
-              footer={<Heading size="sm">Footer</Heading>}
-              size="md"
-            >
-              <Box padding={2}>
-                <Heading size="sm">Children</Heading>
-              </Box>
-            </Modal>
+            <Layer>
+              <Modal
+                accessibilityCloseLabel="close"
+                accessibilityModalLabel="View default padding and styling"
+                heading="Medium modal"
+                onDismiss={this.handleToggleMedium}
+                footer={<Heading size="sm">Footer</Heading>}
+                size="md"
+              >
+                <Box padding={2}>
+                  <Heading size="sm">Children</Heading>
+                </Box>
+              </Modal>
+            </Layer>
           )}
         </Box>
         <Box padding={1}>
@@ -157,18 +161,20 @@ class Example extends React.Component {
             onClick={this.handleToggleLarge}
           />
           {lg && (
-            <Modal
-              accessibilityCloseLabel="close"
-              accessibilityModalLabel="View default padding and styling"
-              heading="Large modal"
-              onDismiss={this.handleToggleLarge}
-              footer={<Heading size="sm">Footer</Heading>}
-              size="lg"
-            >
-              <Box padding={2}>
-                <Heading size="sm">Children</Heading>
-              </Box>
-            </Modal>
+            <Layer>
+              <Modal
+                accessibilityCloseLabel="close"
+                accessibilityModalLabel="View default padding and styling"
+                heading="Large modal"
+                onDismiss={this.handleToggleLarge}
+                footer={<Heading size="sm">Footer</Heading>}
+                size="lg"
+              >
+                <Box padding={2}>
+                  <Heading size="sm">Children</Heading>
+                </Box>
+              </Modal>
+            </Layer>
           )}
         </Box>
       </Box>
@@ -211,22 +217,24 @@ class Example extends React.Component {
             onClick={this.handleToggleModal}
           />
           {showModal && (
-            <Modal
-              accessibilityCloseLabel="close"
-              accessibilityModalLabel="View default padding and styling"
-              heading="Heading"
-              onDismiss={this.handleToggleModal}
-              footer={
-                <Box color="gray">
-                  <Heading size="sm">Footer</Heading>
+            <Layer>
+              <Modal
+                accessibilityCloseLabel="close"
+                accessibilityModalLabel="View default padding and styling"
+                heading="Heading"
+                onDismiss={this.handleToggleModal}
+                footer={
+                  <Box color="gray">
+                    <Heading size="sm">Footer</Heading>
+                  </Box>
+                }
+                size="md"
+              >
+                <Box color="gray" height={400}>
+                  <Heading size="sm">Children</Heading>
                 </Box>
-              }
-              size="md"
-            >
-              <Box color="gray" height={400}>
-                <Heading size="sm">Children</Heading>
-              </Box>
-            </Modal>
+              </Modal>
+            </Layer>
           )}
         </Box>
       </Box>
@@ -276,43 +284,45 @@ class HeadingExample extends React.Component {
             onClick={this.handleToggleModal}
           />
           {showModal && (
-            <Modal
-              accessibilityCloseLabel="close"
-              accessibilityModalLabel="View custom modal heading"
-              heading={
-                <Box padding={2}>
-                  <Tabs
-                    tabs={[
-                      {
-                        text: "Boards",
-                        href: "#"
-                      },
-                      {
-                        text: "Pins",
-                        href: "#"
-                      },
-                      {
-                        text: "Topics",
-                        href: "#"
-                      }
-                    ]}
-                    activeTabIndex={this.state.activeTabIndex}
-                    onChange={this.handleChangeTab}
-                  />
+            <Layer>
+              <Modal
+                accessibilityCloseLabel="close"
+                accessibilityModalLabel="View custom modal heading"
+                heading={
+                  <Box padding={2}>
+                    <Tabs
+                      tabs={[
+                        {
+                          text: "Boards",
+                          href: "#"
+                        },
+                        {
+                          text: "Pins",
+                          href: "#"
+                        },
+                        {
+                          text: "Topics",
+                          href: "#"
+                        }
+                      ]}
+                      activeTabIndex={this.state.activeTabIndex}
+                      onChange={this.handleChangeTab}
+                    />
+                  </Box>
+                }
+                onDismiss={this.handleToggleModal}
+                footer={
+                  <Box color="gray">
+                    <Heading size="sm">Footer</Heading>
+                  </Box>
+                }
+                size="md"
+              >
+                <Box color="gray" height={400}>
+                  <Heading size="sm">Children</Heading>
                 </Box>
-              }
-              onDismiss={this.handleToggleModal}
-              footer={
-                <Box color="gray">
-                  <Heading size="sm">Footer</Heading>
-                </Box>
-              }
-              size="md"
-            >
-              <Box color="gray" height={400}>
-                <Heading size="sm">Children</Heading>
-              </Box>
-            </Modal>
+              </Modal>
+            </Layer>
           )}
         </Box>
       </Box>
@@ -359,45 +369,47 @@ class Example extends React.Component {
             onClick={this.handleToggleModal}
           />
           {showModal && (
-            <Modal
-              accessibilityCloseLabel="close"
-              accessibilityModalLabel="Would you like to block Chris?"
-              heading="Block Chris?"
-              onDismiss={this.handleToggleModal}
-              footer={
-                <Box
-                  display="flex"
-                  marginLeft={-1}
-                  marginRight={-1}
-                  justifyContent="end"
-                >
-                  <Box padding={1}>
-                    <Button
-                      size="lg"
-                      text="Cancel"
-                      onClick={this.handleToggleModal}
-                    />
+            <Layer>
+              <Modal
+                accessibilityCloseLabel="close"
+                accessibilityModalLabel="Would you like to block Chris?"
+                heading="Block Chris?"
+                onDismiss={this.handleToggleModal}
+                footer={
+                  <Box
+                    display="flex"
+                    marginLeft={-1}
+                    marginRight={-1}
+                    justifyContent="end"
+                  >
+                    <Box padding={1}>
+                      <Button
+                        size="lg"
+                        text="Cancel"
+                        onClick={this.handleToggleModal}
+                      />
+                    </Box>
+                    <Box padding={1}>
+                      <Button
+                        size="lg"
+                        color="red"
+                        text="Block"
+                        onClick={this.handleToggleModal}
+                      />
+                    </Box>
                   </Box>
-                  <Box padding={1}>
-                    <Button
-                      size="lg"
-                      color="red"
-                      text="Block"
-                      onClick={this.handleToggleModal}
-                    />
-                  </Box>
+                }
+                role="alertdialog"
+                size="sm"
+              >
+                <Box paddingX={4} paddingY={2}>
+                  <Text>
+                    You will not be able to follow each other or interact with each
+                    others Pins.
+                  </Text>
                 </Box>
-              }
-              role="alertdialog"
-              size="sm"
-            >
-              <Box paddingX={4} paddingY={2}>
-                <Text>
-                  You will not be able to follow each other or interact with each
-                  others Pins.
-                </Text>
-              </Box>
-            </Modal>
+              </Modal>
+            </Layer>
           )}
         </Box>
       </Box>
@@ -438,85 +450,87 @@ class Example extends React.Component {
             onClick={this.handleToggleModal}
           />
           {showModal && (
-            <Modal
-              accessibilityCloseLabel="close"
-              accessibilityModalLabel="Edit Julia's board"
-              heading="Edit your board"
-              onDismiss={this.handleToggleModal}
-              footer={
-                <Box
-                  justifyContent="between"
-                  display="flex"
-                  direction="row"
-                  marginLeft={-1}
-                  marginRight={-1}
-                >
-                  <Box column={6} paddingX={1}>
-                    <Button text="Delete Board" inline />
-                  </Box>
-                  <Box column={6} paddingX={1}>
-                    <Box
-                      display="flex"
-                      direction="row"
-                      justifyContent="end"
-                      marginLeft={-1}
-                      marginRight={-1}
-                    >
-                      <Box paddingX={1}>
-                        <Button text="Cancel" inline onClick={this.handleToggleModal} />
-                      </Box>
-                      <Box paddingX={1}>
-                        <Button color="red" inline text="Save" />
+            <Layer>
+              <Modal
+                accessibilityCloseLabel="close"
+                accessibilityModalLabel="Edit Julia's board"
+                heading="Edit your board"
+                onDismiss={this.handleToggleModal}
+                footer={
+                  <Box
+                    justifyContent="between"
+                    display="flex"
+                    direction="row"
+                    marginLeft={-1}
+                    marginRight={-1}
+                  >
+                    <Box column={6} paddingX={1}>
+                      <Button text="Delete Board" inline />
+                    </Box>
+                    <Box column={6} paddingX={1}>
+                      <Box
+                        display="flex"
+                        direction="row"
+                        justifyContent="end"
+                        marginLeft={-1}
+                        marginRight={-1}
+                      >
+                        <Box paddingX={1}>
+                          <Button text="Cancel" inline onClick={this.handleToggleModal} />
+                        </Box>
+                        <Box paddingX={1}>
+                          <Button color="red" inline text="Save" />
+                        </Box>
                       </Box>
                     </Box>
                   </Box>
+                }
+                size="md"
+              >
+                <Box display="flex" direction="row" position="relative">
+                  <Column span={12}>
+                    <Box paddingY={2} paddingX={4} display="flex">
+                      <Column span={4}>
+                        <Label htmlFor="name">
+                          <Text align="left" weight="bold">
+                            Name
+                          </Text>
+                        </Label>
+                      </Column>
+                      <Column span={8}>
+                        <TextField id="name" onChange={() => undefined} />
+                      </Column>
+                    </Box>
+                    <Divider />
+                    <Box paddingY={2} paddingX={4} display="flex">
+                      <Column span={4}>
+                        <Label htmlFor="desc">
+                          <Text align="left" weight="bold">
+                            Description
+                          </Text>
+                        </Label>
+                      </Column>
+                      <Column span={8}>
+                        <TextArea id="desc" onChange={() => undefined} />
+                      </Column>
+                    </Box>
+                    <Divider />
+                    <Box paddingY={2} paddingX={4} display="flex">
+                      <Column span={4}>
+                        <Label htmlFor="notifications">
+                          <Text align="left" weight="bold">
+                            Email Notifications
+                          </Text>
+                        </Label>
+                      </Column>
+                      <Column span={8}>
+                        <Switch id="notifications" onChange={() => undefined} switched />
+                      </Column>
+                    </Box>
+                  </Column>
                 </Box>
-              }
-              size="md"
-            >
-              <Box display="flex" direction="row" position="relative">
-                <Column span={12}>
-                  <Box paddingY={2} paddingX={4} display="flex">
-                    <Column span={4}>
-                      <Label htmlFor="name">
-                        <Text align="left" weight="bold">
-                          Name
-                        </Text>
-                      </Label>
-                    </Column>
-                    <Column span={8}>
-                      <TextField id="name" onChange={() => undefined} />
-                    </Column>
-                  </Box>
-                  <Divider />
-                  <Box paddingY={2} paddingX={4} display="flex">
-                    <Column span={4}>
-                      <Label htmlFor="desc">
-                        <Text align="left" weight="bold">
-                          Description
-                        </Text>
-                      </Label>
-                    </Column>
-                    <Column span={8}>
-                      <TextArea id="desc" onChange={() => undefined} />
-                    </Column>
-                  </Box>
-                  <Divider />
-                  <Box paddingY={2} paddingX={4} display="flex">
-                    <Column span={4}>
-                      <Label htmlFor="notifications">
-                        <Text align="left" weight="bold">
-                          Email Notifications
-                        </Text>
-                      </Label>
-                    </Column>
-                    <Column span={8}>
-                      <Switch id="notifications" onChange={() => undefined} switched />
-                    </Column>
-                  </Box>
-                </Column>
-              </Box>
-            </Modal>
+              </Modal>
+            </Layer>
           )}
         </Box>
       </Box>
@@ -567,30 +581,32 @@ class Example extends React.Component {
             onClick={this.handleToggleModal}
           />
           {showModal && (
-            <Modal
-              accessibilityCloseLabel="close"
-              accessibilityModalLabel="View random images"
-              heading="Images"
-              onDismiss={this.handleToggleModal}
-              footer={
-                <Box display="flex" direction="row" justifyContent="end">
-                  <Button size="lg" text="Cancel" onClick={this.handleToggleModal} />
+            <Layer>
+              <Modal
+                accessibilityCloseLabel="close"
+                accessibilityModalLabel="View random images"
+                heading="Images"
+                onDismiss={this.handleToggleModal}
+                footer={
+                  <Box display="flex" direction="row" justifyContent="end">
+                    <Button size="lg" text="Cancel" onClick={this.handleToggleModal} />
+                  </Box>
+                }
+                size="lg"
+              >
+                <Box display="flex" direction="row" justifyContent="center" alignItems="center">
+                  <Spinner
+                    accessibilityLabel="random image"
+                    show={!hasLoaded}
+                  />
+                  <img
+                    alt=""
+                    onLoad={this.handleLoad}
+                    src="http://lorempixel.com/400/400"
+                  />
                 </Box>
-              }
-              size="lg"
-            >
-              <Box display="flex" direction="row" justifyContent="center" alignItems="center">
-                <Spinner
-                  accessibilityLabel="random image"
-                  show={!hasLoaded}
-                />
-                <img
-                  alt=""
-                  onLoad={this.handleLoad}
-                  src="http://lorempixel.com/400/400"
-                />
-              </Box>
-            </Modal>
+              </Modal>
+            </Layer>
           )}
         </Box>
       </Box>

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -59,26 +59,17 @@ card(
     description="You can use Toasts to confirm an action has occured. When you are using a Toast as a confirmation, you should
         always include a thumbnail and two lines of text."
     defaultCode={`
-class ToastExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showConfirmationToast: false,
-    };
-    this.handleConfirmationClick = this.handleConfirmationClick.bind(this);
-  }
-  handleConfirmationClick({ event }) {
-    this.setState(prevState => ({ showConfirmationToast: !prevState.showConfirmationToast }));
-  };
-  render() {
-    return (
-      <Box>
-        <Button
-          inline
-          text={ this.state.showConfirmationToast ? 'Close toast' : 'Show confirmation toast' }
-          onClick={this.handleConfirmationClick}
-          size='md'
-        />
+function ToastExample() {
+  const [showConfirmationToast, setShowConfirmationToast] = React.useState(false);
+  return (
+    <Box>
+      <Button
+        inline
+        text={ showConfirmationToast ? 'Close toast' : 'Show confirmation toast' }
+        onClick={() => setShowConfirmationToast(!showConfirmationToast)}
+        size='md'
+      />
+      <Layer>
         <Box
           fit
           dangerouslySetInlineStyle={{
@@ -91,7 +82,7 @@ class ToastExample extends React.Component {
           paddingX={1}
           position='fixed'
         >
-          {this.state.showConfirmationToast ? (
+          {showConfirmationToast ? (
               <Toast
                 text={['Saved to', 'Home decor']}
                 thumbnail={
@@ -105,9 +96,9 @@ class ToastExample extends React.Component {
               />
           ) : null}
         </Box>
-      </Box>
-    );
-  }
+      </Layer>
+    </Box>
+  );
 }`}
   />
 );
@@ -120,26 +111,17 @@ card(
       your instructional text to the Toast component. The arrow icon indicating the Toast is a link will be automatically
       added. If you need a different Icon here, please contact the Gestalt team."
     defaultCode={`
-class ToastExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showGuideToast: false
-    };
-    this.handleGuideClick = this.handleGuideClick.bind(this);
-  }
-  handleGuideClick({ event }) {
-    this.setState(prevState => ({ showGuideToast: !prevState.showGuideToast }));
-  };
-  render() {
-    return (
-      <Box>
-        <Button
-          inline
-          text={ this.state.showGuideToast ? 'Close toast' : 'Show guide toast' }
-          onClick={this.handleGuideClick}
-          size='md'
-        />
+function ToastExample() {
+  const [showGuideToast, setShowGuideToast] = React.useState(false);
+  return (
+    <Box>
+      <Button
+        inline
+        text={ showGuideToast ? 'Close toast' : 'Show guide toast' }
+        onClick={() => setShowGuideToast(!showGuideToast)}
+        size='md'
+      />
+      <Layer>
         <Box
           fit
           dangerouslySetInlineStyle={{
@@ -152,16 +134,16 @@ class ToastExample extends React.Component {
           paddingX={1}
           position='fixed'
         >
-          {this.state.showGuideToast ? (
+          {showGuideToast ? (
             <Toast
               icon='arrow-circle-forward'
               text='Same great profile, just a new look. Learn more?'
             />
           ) : null}
         </Box>
-      </Box>
-    );
-  }
+      </Layer>
+    </Box>
+  );
 }`}
   />
 );
@@ -174,26 +156,17 @@ card(
     "
     name="Error Toasts"
     defaultCode={`
-class ToastExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showErrorToast: false
-    };
-    this.handleErrorClick = this.handleErrorClick.bind(this);
-  }
-  handleErrorClick({ event }) {
-    this.setState(prevState => ({ showErrorToast: !prevState.showErrorToast }));
-  };
-  render() {
-    return (
-      <Box>
-        <Button
-          inline
-          text={ this.state.showErrorToast ? 'Close toast' : 'Show error toast' }
-          onClick={this.handleErrorClick}
-          size='md'
-        />
+function ToastExample() {
+  const [showErrorToast, setShowErrorToast] = React.useState(false);
+  return (
+    <Box>
+      <Button
+        inline
+        text={ showErrorToast ? 'Close toast' : 'Show error toast' }
+        onClick={() => setShowErrorToast(!showErrorToast)}
+        size='md'
+      />
+      <Layer>
         <Box
           fit
           dangerouslySetInlineStyle={{
@@ -206,13 +179,13 @@ class ToastExample extends React.Component {
           paddingX={1}
           position='fixed'
         >
-          {this.state.showErrorToast ? (
+          {showErrorToast ? (
             <Toast color='red' text="Oops, we couldn't find that!" />
           ) : null}
         </Box>
-      </Box>
-    );
-  }
+      </Layer>
+    </Box>
+  );
 }`}
   />
 );


### PR DESCRIPTION
Fixes ticket #630 by adding `Layer` tags around `Modal`, `Toast`, and `Flyout` in the examples. I also refactored some of the docs to hooks while I was in there

- [x] Documentation
- [x] Tests
- [x] Accessibility checkup
