### PR TITLE
Reverted Masonry throttle change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 </details>
 
+## 0.122.2 (Jan 30, 2020)
+
+### Patch
+
+- Masonry: Reverts the past update to `wait`. Turns out this was more dangerous than expected, and we should experiment on it later. (#645)
+
 ## 0.122.1 (Jan 29, 2020)
 
 ### Patch

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -69,7 +69,6 @@ type State<T> = {|
 |};
 
 const RESIZE_DEBOUNCE = 300;
-const SCROLL_THROTTLE = 16;
 // Multiplied against container height.
 // The amount of extra buffer space for populating visible items.
 const VIRTUAL_BUFFER_FACTOR = 0.7;
@@ -93,6 +92,8 @@ export default class Masonry<T: {}> extends React.Component<
     }
   }, RESIZE_DEBOUNCE);
 
+  // Using throttle here to schedule the handler async, outside of the event
+  // loop that produced the event.
   updateScrollPosition = throttle(() => {
     if (!this.scrollContainer) {
       return;
@@ -106,7 +107,7 @@ export default class Masonry<T: {}> extends React.Component<
     this.setState({
       scrollTop: getScrollPos(scrollContainer),
     });
-  }, SCROLL_THROTTLE);
+  });
 
   measureContainerAsync = debounce(() => {
     this.measureContainer();


### PR DESCRIPTION
Reverting the last change to add longer throttling to Masonry scrolling (#641) based on the advice of @bishwei and @chrislloyd. We can revisit this with an experiment or punt until the rewrite of Masonry lands.