### PR TITLE
Ship "fixFetchMoreBug”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Minor
 
 - Color: update dark gray color to #111 (#648)
-- Masonry: Shipped "fixFetchMoreBug" behavior and removed flag. This makes Masonry fetch less aggressively in some cases. (#649)
+- Masonry: Shipped "fixFetchMoreBug" behavior and removed flag. This makes Masonry fetch less aggressively in some cases. (#651)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 - Color: update dark gray color to #111 (#648)
+- Masonry: Shipped "fixFetchMoreBug" behavior and removed flag. This makes Masonry fetch less aggressively in some cases. (#649)
 
 ### Patch
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -55,8 +55,6 @@ type Props<T> = {|
   virtualBoundsTop?: number,
   virtualBoundsBottom?: number,
   virtualize?: boolean,
-
-  fixFetchMoreBug?: boolean,
 |};
 
 type State<T> = {|
@@ -190,11 +188,6 @@ export default class Masonry<T: {}> extends React.Component<
      * Whether or not to use actual virtualization
      */
     virtualize: PropTypes.bool,
-
-    /**
-     * Flag to decide if we should fix fetch more bug (see commit notes)
-     */
-    fixFetchMoreBug: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -203,8 +196,6 @@ export default class Masonry<T: {}> extends React.Component<
     layout: DefaultLayoutSymbol,
     loadItems: () => {},
     virtualize: false,
-
-    fixFetchMoreBug: false,
   };
 
   constructor(props: Props<T>) {
@@ -462,7 +453,6 @@ export default class Masonry<T: {}> extends React.Component<
       gutterWidth: gutter,
       items,
       minCols,
-      fixFetchMoreBug,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
 
@@ -601,9 +591,7 @@ export default class Masonry<T: {}> extends React.Component<
               isFetching={
                 this.state.isFetching || this.state.hasPendingMeasurements
               }
-              scrollHeight={
-                height + (fixFetchMoreBug ? this.containerOffset : 0)
-              }
+              scrollHeight={height + this.containerOffset}
               scrollTop={this.state.scrollTop}
             />
           )}


### PR DESCRIPTION
Following the results of internal experimentation (see web_fix_masonry_fetchmore_bug), I decided it's fine to ship this fix. This will cause Masonry to fetch less aggressively on pages where there's lots of content inside the scroll container above Masonry. An example of this is the Pinterest Pin Closeup page.