### PR TITLE
Bump version to v0.123.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@
 
 ### Minor
 
-- Color: update dark gray color to #111 (#648)
-- Masonry: Shipped "fixFetchMoreBug" behavior and removed flag. This makes Masonry fetch less aggressively in some cases. (#651)
-
 ### Patch
 
 </details>
 
+## 0.123.0 (Feb 7, 2020)
+
+### Minor
+
+- Color: update dark gray color to #111 (#648)
+- Masonry: Shipped "fixFetchMoreBug" behavior and removed flag. This makes Masonry fetch less aggressively in some cases. (#651)
+
 ## 0.122.3 (Jan 30, 2020)
+
+### Patch
 
 - Bumping version with no other changes for the sake of fixing release to npm.
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "0.122.3",
+  "version": "0.123.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 0.123.0 (Feb 7, 2020)

### Minor

- Color: update dark gray color to #111 (#648)
- Masonry: Shipped "fixFetchMoreBug" behavior and removed flag. This makes Masonry fetch less aggressively in some cases. (#651)
