### PR TITLE
Version bump: 0.124.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@
 
 ### Minor
 
-- Box: Add new prop `opacity` to set css opacity with values 0 to 1 in tenth increments. (#654)
-- Button: Update border radius / small size + add dark gray option (#655)
-
 ### Patch
 
 </details>
+
+## 0.124.0 (Feb 12, 2020)
+
+### Minor
+
+- Box: Add new prop `opacity` to set css opacity with values 0 to 1 in tenth increments. (#654)
+- Button: Update border radius / small size + add dark gray option (#655)
 
 ## 0.123.0 (Feb 7, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "0.123.0",
+  "version": "0.124.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 0.124.0 (Feb 12, 2020)

### Minor

- Box: Add new prop `opacity` to set css opacity with values 0 to 1 in tenth increments. (#654)
- Button: Update border radius / small size + add dark gray option (#655)