### PR TITLE
Button/IconButton/Pog: Convert 'darkGray' color to selected state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - IconButton/Pog: Add darkGray background option (#659)
 - Tabs: update states + improve docs & test coverage (#658)
+- Button/IconButton/Pog: Convert 'darkGray' color to selected state (#661)
 
 ### Patch
 

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -42,12 +42,18 @@ card(
       },
       {
         name: 'color',
-        type: `"blue" | "darkGray" | "gray" | "red" | "transparent" | "white"`,
+        type: `"blue" | "gray" | "red" | "transparent" | "white"`,
         defaultValue: 'gray',
         href: 'color',
       },
       {
         name: 'disabled',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'combinations',
+      },
+      {
+        name: 'selected',
         type: 'boolean',
         defaultValue: false,
         href: 'combinations',
@@ -200,7 +206,7 @@ card(
 card(
   <Example
     description={`
-\`darkGray\` should only be used when the button is in a "selected" state.
+A "selected" state should be used as a toggle state to turn something on or off.
   `}
     id="selected"
     name="Selected state"
@@ -211,7 +217,8 @@ function Example() {
   return (
     <Button
       inline
-      color={selected ? 'darkGray' : 'red'}
+      color="red"
+      selected={selected}
       onClick={() => {setSelected(!selected)}}
       text={selected ? 'Selected' : 'Deselected'}
     />
@@ -269,8 +276,9 @@ card(
   <Combination
     id="combinations"
     name="Combinations"
-    color={['gray', 'red', 'darkGray']}
+    color={['gray', 'red']}
     disabled={[false, true]}
+    selected={[false, true]}
     size={['sm', 'md', 'lg']}
   >
     {(props, i) => (

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -44,13 +44,14 @@ card(
       {
         name: 'bgColor',
         type:
-          '"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "darkGray" | "white" | "blue"',
+          '"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue"',
         defaultValue: 'transparent',
         href: 'backgroundColorCombinations',
       },
       {
         name: 'disabled',
         type: 'boolean',
+        defaultValue: false,
         href: 'disabledCombinations',
       },
       {
@@ -69,6 +70,12 @@ card(
         name: 'dangerouslySetSvgPath',
         type: `{ __path: string }`,
         description: `When using this prop, make sure that the viewbox around the SVG path is 24x24`,
+      },
+      {
+        name: 'selected',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'selectedCombinations',
       },
       {
         name: 'size',
@@ -145,7 +152,7 @@ function A11yEx() {
 card(
   <Combination
     id="sizeCombinations"
-    name="Size Combinations"
+    name="Combinations: Size"
     size={['xs', 'sm', 'md', 'lg', 'xl']}
   >
     {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
@@ -155,7 +162,7 @@ card(
 card(
   <Combination
     id="iconColorCombinations"
-    name="Icon Color Combinations"
+    name="Combinations: Icon Color"
     iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
   >
     {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
@@ -165,14 +172,13 @@ card(
 card(
   <Combination
     id="backgroundColorCombinations"
-    name="Background Color Combinations"
+    name="Combinations: Background Color"
     bgColor={[
       'transparent',
       'transparentDarkGray',
       'white',
       'lightGray',
       'gray',
-      'darkGray',
     ]}
   >
     {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
@@ -181,8 +187,19 @@ card(
 
 card(
   <Combination
+    id="selectedCombinations"
+    name="Combinations: Selected"
+    color={['gray']}
+    selected={[false, true]}
+  >
+    {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
     id="disabledCombinations"
-    name="Disabled Combinations"
+    name="Combinations: Disabled"
     description="Icon buttons can be disabled as well. Adding the disabled flag to any color combination will add a 50% opacity and remove interactivity"
     iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
   >

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -65,6 +65,12 @@ card(
         description: `When using this prop, make sure that the viewbox around the SVG path is 24x24`,
       },
       {
+        name: 'selected',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'combinations',
+      },
+      {
         name: 'size',
         type: `"xs" | "sm" | "md" | "lg" | "xl"`,
         description: `xs: 24px, sm: 32px, md: 40px, lg: 48px, xl: 56px`,

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -143,7 +143,6 @@ export default function PropTable({ props: properties, Component }: Props) {
                                 const elem = document.getElementById(href);
                                 if (elem) {
                                   elem.scrollIntoView({
-                                    behavior: 'smooth',
                                     block: 'start',
                                   });
                                 }

--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -1,11 +1,3 @@
-:root {
-  --blue: #0074e8;
-  --darkGray: #111;
-  --red: #e60023;
-  --lightGray: #efefef;
-  --white: #fff;
-}
-
 .button {
   composes: borderBox from "./Layout.css";
   border-radius: 24px;
@@ -14,11 +6,6 @@
 
 .solid {
   composes: noBorder from "./Borders.css";
-}
-
-.enabled {
-  composes: accessibilityOutline from "./Focus.css";
-  composes: pointer from "./Cursor.css";
 }
 
 .sm {
@@ -45,9 +32,18 @@
   composes: inlineBlock from "./Layout.css";
 }
 
+.enabled {
+  composes: accessibilityOutline from "./Focus.css";
+  composes: pointer from "./Cursor.css";
+}
+
 .disabled {
   composes: lightGrayBg from "./Colors.css";
   cursor: default;
+}
+
+.selected {
+  composes: darkGrayBg from "./Colors.css";
 }
 
 .gray {
@@ -61,10 +57,6 @@
 
 .gray:active {
   background-color: #dadada;
-}
-
-.darkGray {
-  composes: darkGrayBg from "./Colors.css";
 }
 
 .red {

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -8,7 +8,6 @@ import Text from './Text.js';
 
 const DEFAULT_TEXT_COLORS = {
   blue: 'white',
-  darkGray: 'white',
   gray: 'darkGray',
   red: 'white',
   transparent: 'white',
@@ -19,11 +18,12 @@ type Props = {|
   accessibilityExpanded?: boolean,
   accessibilityHaspopup?: boolean,
   accessibilityLabel?: string,
-  color?: 'gray' | 'darkGray' | 'red' | 'blue' | 'transparent' | 'white',
+  color?: 'gray' | 'red' | 'blue' | 'transparent' | 'white',
   disabled?: boolean,
   inline?: boolean,
   name?: string,
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
+  selected?: boolean,
   size?: 'sm' | 'md' | 'lg',
   text: string,
   textColor?: 'white' | 'darkGray' | 'blue' | 'red',
@@ -40,6 +40,7 @@ export default function Button(props: Props) {
     inline = false,
     name,
     onClick,
+    selected = false,
     size = 'md',
     text,
     textColor,
@@ -51,7 +52,8 @@ export default function Button(props: Props) {
     [styles.md]: size === 'md',
     [styles.lg]: size === 'lg',
     [styles.solid]: color !== 'transparent',
-    [styles[color]]: !disabled,
+    [styles[color]]: !disabled && !selected,
+    [styles.selected]: !disabled && selected,
     [styles.disabled]: disabled,
     [styles.enabled]: !disabled,
     [styles.inline]: inline,
@@ -72,7 +74,12 @@ export default function Button(props: Props) {
     >
       <Text
         align="center"
-        color={(disabled && 'gray') || textColor || DEFAULT_TEXT_COLORS[color]}
+        color={
+          (disabled && 'gray') ||
+          (selected && 'white') ||
+          textColor ||
+          DEFAULT_TEXT_COLORS[color]
+        }
         overflow="normal"
         size="md"
         weight="bold"
@@ -88,18 +95,12 @@ Button.propTypes = {
   accessibilityExpanded: PropTypes.bool,
   accessibilityHaspopup: PropTypes.bool,
   accessibilityLabel: PropTypes.string,
-  color: PropTypes.oneOf([
-    'blue',
-    'darkGray',
-    'gray',
-    'red',
-    'transparent',
-    'white',
-  ]),
+  color: PropTypes.oneOf(['blue', 'gray', 'red', 'transparent', 'white']),
   disabled: PropTypes.bool,
   inline: PropTypes.bool,
   name: PropTypes.string,
   onClick: PropTypes.func,
+  selected: PropTypes.bool,
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   text: PropTypes.string.isRequired,
   textColor: PropTypes.oneOf(['white', 'darkGray', 'blue', 'red']),

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -15,7 +15,6 @@ type Props = {|
     | 'transparentDarkGray'
     | 'gray'
     | 'lightGray'
-    | 'darkGray'
     | 'white'
     | 'blue',
   dangerouslySetSvgPath?: { __path: string },
@@ -23,6 +22,7 @@ type Props = {|
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
   icon?: $Keys<typeof icons>,
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
+  selected?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
@@ -35,6 +35,7 @@ export default function IconButton({
   disabled,
   iconColor,
   icon,
+  selected,
   size,
   onClick,
 }: Props) {
@@ -71,6 +72,7 @@ export default function IconButton({
         focused={!disabled && isFocused}
         hovered={!disabled && isHovered}
         iconColor={iconColor}
+        selected={selected}
         icon={icon}
         size={size}
       />
@@ -104,5 +106,6 @@ IconButton.propTypes = {
     'orange',
   ]),
   onClick: PropTypes.func,
+  selected: PropTypes.bool,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 };

--- a/packages/gestalt/src/Pog.css
+++ b/packages/gestalt/src/Pog.css
@@ -15,6 +15,10 @@
   composes: accessibilityOutlineFocus from "./Focus.css";
 }
 
+.selected {
+  composes: darkGrayBg from "./Colors.css";
+}
+
 .transparent {
   composes: transparentBg from "./Colors.css";
 }

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -22,12 +22,12 @@ type Props = {|
     | 'transparentDarkGray'
     | 'gray'
     | 'lightGray'
-    | 'darkGray'
     | 'white'
     | 'blue',
   dangerouslySetSvgPath?: { __path: string },
   focused?: boolean,
   hovered?: boolean,
+  selected?: boolean,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
   icon?: $Keys<typeof icons>,
   size?: $Keys<typeof SIZE_NAME_TO_PIXEL>,
@@ -50,19 +50,24 @@ export default function Pog(props: Props) {
     dangerouslySetSvgPath,
     focused = false,
     hovered = false,
-    iconColor = defaultIconButtonIconColors[bgColor],
+    iconColor,
     icon,
+    selected = false,
     size = 'md',
   } = props;
 
   const iconSize = SIZE_NAME_TO_PIXEL[size] / 2;
+  const color =
+    (selected && 'white') || iconColor || defaultIconButtonIconColors[bgColor];
 
   const inlineStyle = {
     height: SIZE_NAME_TO_PIXEL[size],
     width: SIZE_NAME_TO_PIXEL[size],
   };
 
-  const classes = classnames(styles.pog, styles[bgColor], {
+  const classes = classnames(styles.pog, {
+    [styles[bgColor]]: !selected,
+    [styles.selected]: selected,
     [styles.active]: active,
     [styles.focused]: focused,
     [styles.hovered]: hovered && !focused && !active,
@@ -79,7 +84,7 @@ export default function Pog(props: Props) {
         */}
         <Icon
           accessibilityLabel=""
-          color={iconColor}
+          color={color}
           dangerouslySetSvgPath={dangerouslySetSvgPath}
           icon={icon}
           size={iconSize}
@@ -113,5 +118,6 @@ Pog.propTypes = {
     'orange',
   ]),
   icon: PropTypes.oneOf(Object.keys(icons)),
+  selected: PropTypes.bool,
   size: PropTypes.oneOf(Object.keys(SIZE_NAME_TO_PIXEL)),
 };


### PR DESCRIPTION
We decided to go for a selected state instead of a `darkGray` color option:
* It makes the intent of this new color more explicit
* Allows us to easily update the selected state moving forward

## Before
```js
<Button color={selected ? 'darkGray' : 'gray' } text="Show info" />
```
## After
```js
<Button selected={selected} text="Show info" />
```