### PR TITLE
Flyout: Remove caret, update shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ yarn run codemod --parser=flow -t=packages/gestalt-codemods/0.125.0-1.0.0/conver
 
 ### Minor
 
-- Flyout: Remove caret, update shadow
+- Flyout: Remove caret, update shadow (#663)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ yarn run codemod --parser=flow -t=packages/gestalt-codemods/0.125.0-1.0.0/conver
 
 ### Minor
 
+- Flyout: Remove caret, update shadow
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/Contents.css
+++ b/packages/gestalt/src/Contents.css
@@ -5,8 +5,10 @@
 .contents {
   composes: block from "./Layout.css";
   composes: borderBox from "./Layout.css";
-  composes: rounded from "./Borders.css";
+
+  /* composes: rounded from "./Borders.css"; TODO: switch back to "rounded" when that style is updated to 16px */
   border: 1px solid currentColor;
+  border-radius: 16px;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   outline: none;
 }

--- a/packages/gestalt/src/Contents.css
+++ b/packages/gestalt/src/Contents.css
@@ -7,7 +7,7 @@
   composes: borderBox from "./Layout.css";
   composes: rounded from "./Borders.css";
   border: 1px solid currentColor;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   outline: none;
 }
 

--- a/packages/gestalt/src/Contents.css
+++ b/packages/gestalt/src/Contents.css
@@ -5,8 +5,6 @@
 .contents {
   composes: block from "./Layout.css";
   composes: borderBox from "./Layout.css";
-
-  /* composes: rounded from "./Borders.css"; TODO: switch back to "rounded" when that style is updated to 16px */
   border: 1px solid currentColor;
   border-radius: 16px;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);

--- a/packages/gestalt/src/Flyout.js
+++ b/packages/gestalt/src/Flyout.js
@@ -34,6 +34,7 @@ export default function Flyout(props: Props) {
     <Controller
       anchor={anchor}
       bgColor={color}
+      caret={false}
       idealDirection={idealDirection}
       onDismiss={onDismiss}
       positionRelativeToAnchor={positionRelativeToAnchor}

--- a/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
@@ -26,26 +26,6 @@ exports[`Flyout renders 1`] = `
         }
       }
     />
-    <div
-      className="white caret"
-      style={
-        Object {
-          "bottom": null,
-          "left": 8,
-          "right": null,
-          "top": null,
-        }
-      }
-    >
-      <svg
-        height="24"
-        width="24"
-      >
-        <path
-          d="M0 0 L12 12 L24 0"
-        />
-      </svg>
-    </div>
   </div>
 </div>
 `;
@@ -74,26 +54,6 @@ exports[`Flyout renders as blue 1`] = `
         }
       }
     />
-    <div
-      className="blue caret"
-      style={
-        Object {
-          "bottom": null,
-          "left": 8,
-          "right": null,
-          "top": null,
-        }
-      }
-    >
-      <svg
-        height="24"
-        width="24"
-      >
-        <path
-          d="M0 0 L12 12 L24 0"
-        />
-      </svg>
-    </div>
   </div>
 </div>
 `;
@@ -122,26 +82,6 @@ exports[`Flyout renders as error 1`] = `
         }
       }
     />
-    <div
-      className="red caret"
-      style={
-        Object {
-          "bottom": null,
-          "left": 8,
-          "right": null,
-          "top": null,
-        }
-      }
-    >
-      <svg
-        height="24"
-        width="24"
-      >
-        <path
-          d="M0 0 L12 12 L24 0"
-        />
-      </svg>
-    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Flyout changes for Lego spec

This PR updates Flyout to the Lego spec:
- Remove caret
- Update shadow
- Update border radius

- [x] Documentation
- [x] Tests
- [ ] Experimental evidence (required for Masonry changes)
- [ ] Accessibility checkup
