### PR TITLE
Version bump: 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@
   </summary>
 
 ### Minor
-- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#667)
 
 ### Patch
 
 </details>
+
+## 1.1.0 (Feb 20, 2020)
+
+### Minor
+
+- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#667)
 
 ## 1.0.0 (Feb 20, 2020)
 
@@ -21,8 +26,9 @@
 - Box / Mask / Touchable [Breaking]: Replace `shape` prop with `rounding` (#666)
 
 Run codemods for breaking changes in order:
-1) `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/0.125.0-1.0.0/convert-roundedX.js ~/code/repo`
-2) `yarn run codemod --parser=flow -t=packages/gestalt-codemods/0.125.0-1.0.0/convert-shape-to-rounding.js ~/code/repo`
+
+1. `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/0.125.0-1.0.0/convert-roundedX.js ~/code/repo`
+2. `yarn run codemod --parser=flow -t=packages/gestalt-codemods/0.125.0-1.0.0/convert-shape-to-rounding.js ~/code/repo`
 
 ### Minor
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.1.0 (Feb 20, 2020)

### Minor

- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#667)