### PR TITLE
Version bump 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 1.2.0 (Feb 20, 2020)
+
+### Minor
+
 - Internal: Update dependencies (#671)
 
 ### Patch
 
 - Heading: removed unused weight prop from docs (#653)
-
-</details>
 
 ## 1.1.0 (Feb 20, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.2.0 (Feb 20, 2020)

### Minor

- Internal: Update dependencies (#671)

### Patch

- Heading: removed unused weight prop from docs (#653)