### PR TITLE
Version bump 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 1.5.0 (Feb 25, 2020)
+
+### Minor
+
 - Box: Add `borderSize` prop for styling borders (#678)
 - Modal: visual refresh + heading optional + add closeOnOutsideClick (#680)
 
 Codemods:
 `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.3.0-1.4.0/modal-remove-close-label.js ~/code/repo`
-
-### Patch
-
-</details>
 
 ## 1.4.0 (Feb 24, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.5.0 (Feb 25, 2020)

### Minor

- Box: Add `borderSize` prop for styling borders (#678)
- Modal: visual refresh + heading optional + add closeOnOutsideClick (#680)

Codemods:
`cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.3.0-1.4.0/modal-remove-close-label.js ~/code/repo`