### PR TITLE
Version bump 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@
 
 ### Minor
 
-Internal: Update Node.js version to 12.x (#686)
-Internal: update yarn.lock file (#687)
-
 ### Patch
 
 </details>
+
+## 1.6.0 (Feb 25, 2020)
+
+Internal: Update Node.js version to 12.x (#686)
+Internal: update yarn.lock file (#687)
 
 ## 1.5.0 (Feb 25, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.6.0 (Feb 25, 2020)

Internal: Update Node.js version to 12.x (#686)
Internal: update yarn.lock file (#687)
