### PR TITLE
Button: update horizontal padding to 12px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+Button: update horizontal padding to 12px (#688)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -10,17 +10,20 @@
 
 .sm {
   composes: small from "./Layout.css";
-  padding: 6px 14px;
+  composes: paddingX3 from "./boxWhitespace.css";
+  composes: paddingY1 from "./boxWhitespace.css";
 }
 
 .md {
   composes: medium from "./Layout.css";
-  padding: 10px 14px;
+  composes: paddingX3 from "./boxWhitespace.css";
+  composes: paddingY2 from "./boxWhitespace.css";
 }
 
 .lg {
   composes: large from "./Layout.css";
-  padding: 12px 14px;
+  composes: paddingX3 from "./boxWhitespace.css";
+  composes: paddingY3 from "./boxWhitespace.css";
 }
 
 .block {


### PR DESCRIPTION
Before the spacing `left/right` was `14px`, now it's `12px` which is the same as our Figma files. Design signed off on these changes.

Before: https://deploy-preview-688--gestalt.netlify.com/#/Button
After: https://deploy-preview-689--gestalt.netlify.com/#/Button