### PR TITLE
Revert bad Masonry and Flyout commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 Button: update horizontal padding to 12px (#688)
 [Revert] Flyout: Update spacing around items to 8px + remove caret code (#668)
+[Revert] Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#667)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 Button: update horizontal padding to 12px (#688)
+[Revert] Flyout: Update spacing around items to 8px + remove caret code (#668)
 
 ### Patch
 

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -191,7 +191,7 @@ card(
 
     If no \`idealDirection\` is provided, the flyout will open in the direction where there is the
     most space available within the viewport. If there is not enough space in any direction, the flyout
-    will no longer be context-specific (linked to the anchor) and will appear at the bottom of
+    will no longer be context-specific (with a caret to the anchor) and will appear at the bottom of
     the screen. This is to ensure that users are always able to view the contents of the flyout,
     regardless of their screen size.
   `}

--- a/packages/gestalt/src/Caret.js
+++ b/packages/gestalt/src/Caret.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+type Props = {
+  direction?: ?'up' | 'right' | 'down' | 'left',
+};
+
+export default function Caret(props: Props) {
+  const { direction } = props;
+  let path;
+  switch (direction) {
+    case 'up':
+      path = 'M0 0 L12 12 L24 0';
+      break;
+    case 'right':
+      path = 'M24 0 L12 12 L24 24';
+      break;
+    case 'down':
+      path = 'M0 24 L12 12 L24 24';
+      break;
+    case 'left':
+      path = 'M0 0 L12 12 L0 24';
+      break;
+    default:
+  }
+
+  return (
+    <svg width="24" height="24">
+      <path d={path} />
+    </svg>
+  );
+}
+
+Caret.propTypes = {
+  direction: PropTypes.oneOf(['up', 'right', 'down', 'left']),
+};

--- a/packages/gestalt/src/Caret.test.js
+++ b/packages/gestalt/src/Caret.test.js
@@ -1,0 +1,28 @@
+// @flow
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Caret from './Caret.js';
+
+test('Caret renders with direction up', () => {
+  const component = renderer.create(<Caret direction="up" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Caret renders with direction down', () => {
+  const component = renderer.create(<Caret direction="down" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Caret renders with direction left', () => {
+  const component = renderer.create(<Caret direction="left" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Caret renders with direction right', () => {
+  const component = renderer.create(<Caret direction="right" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/Contents.css
+++ b/packages/gestalt/src/Contents.css
@@ -25,3 +25,10 @@
   composes: overflowAuto from "./Layout.css";
   composes: rounding2 from "./Borders.css";
 }
+
+.caret {
+  composes: absolute from "./Layout.css";
+  fill: currentColor;
+  height: 24px;
+  pointer-events: none;
+}

--- a/packages/gestalt/src/Contents.test.js
+++ b/packages/gestalt/src/Contents.test.js
@@ -5,7 +5,7 @@ import {
   calcEdgeShifts,
   baseOffsets,
   adjustOffsets,
-  SPACING_OUTSIDE,
+  CARET_HEIGHT,
   BORDER_RADIUS,
 } from './Contents.js';
 
@@ -46,7 +46,7 @@ const upperMiddleTriggerRect = (props = {}) => ({
   ...props,
 });
 
-// between BORDER_RADIUS away from the edge of the scrren
+// between BORDER_RADIUS & CARET_HEIGHT away from the edge of the scrren
 const upperLeftTriggerRect = (props = {}) => ({
   bottom: 50,
   height: 40,
@@ -128,7 +128,7 @@ describe('Contents', () => {
         top: windowSize.scrollY + triggerRect.top,
         left:
           windowSize.scrollX +
-          (triggerRect.left - flyoutSize.width - SPACING_OUTSIDE),
+          (triggerRect.left - flyoutSize.width - CARET_HEIGHT / 2),
       };
       const base = baseOffsets(
         fixedOffset,
@@ -145,7 +145,7 @@ describe('Contents', () => {
       const mainDir = 'right';
       const expectedBase = {
         top: windowSize.scrollY + triggerRect.top,
-        left: windowSize.scrollX + (triggerRect.right + SPACING_OUTSIDE),
+        left: windowSize.scrollX + (triggerRect.right + CARET_HEIGHT / 2),
       };
       const base = baseOffsets(
         fixedOffset,
@@ -163,7 +163,7 @@ describe('Contents', () => {
       const expectedBase = {
         top:
           windowSize.scrollY +
-          (triggerRect.top - flyoutSize.height - SPACING_OUTSIDE),
+          (triggerRect.top - flyoutSize.height - CARET_HEIGHT / 2),
         left: windowSize.scrollX + triggerRect.left,
       };
       const base = baseOffsets(
@@ -180,7 +180,7 @@ describe('Contents', () => {
       const triggerRect = centerTriggerRect();
       const mainDir = 'down';
       const expectedBase = {
-        top: windowSize.scrollY + triggerRect.bottom + SPACING_OUTSIDE,
+        top: windowSize.scrollY + triggerRect.bottom + CARET_HEIGHT / 2,
         left: windowSize.scrollX + triggerRect.left,
       };
       const base = baseOffsets(
@@ -208,12 +208,22 @@ describe('Contents', () => {
           x: 24,
           y: 24,
         },
+        caret: {
+          x: 24,
+          y: 24,
+        },
       };
       const expectedFlyoutOffset = {
         top: base.top - edgeShift.flyout.y,
         left: base.left,
       };
-      const flyoutOffset = adjustOffsets(
+      const expectedCaretOffset = {
+        top: edgeShift.caret.y,
+        right: -edgeShift.caret.x,
+        bottom: null,
+        left: null,
+      };
+      const { flyoutOffset, caretOffset } = adjustOffsets(
         base,
         edgeShift,
         flyoutSize,
@@ -222,6 +232,7 @@ describe('Contents', () => {
         triggerRect
       );
       expect(flyoutOffset).toEqual(expectedFlyoutOffset);
+      expect(caretOffset).toEqual(expectedCaretOffset);
     });
   });
 
@@ -229,9 +240,11 @@ describe('Contents', () => {
     it('Keeps Container on screen when trigger is on the edge', () => {
       const triggerRect = upperLeftTriggerRect();
       const subDir = 'up';
-      const { flyout } = calcEdgeShifts(subDir, triggerRect, windowSize);
+      const { flyout, caret } = calcEdgeShifts(subDir, triggerRect, windowSize);
       expect(triggerRect.bottom - flyout.y).toBeGreaterThan(0);
       expect(flyout.x).toBeLessThan(BORDER_RADIUS);
+      expect(caret.x).toEqual(caret.y);
+      expect(caret.x).toEqual(BORDER_RADIUS);
     });
   });
 });

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -7,6 +7,7 @@ import OutsideEventBehavior from './behaviors/OutsideEventBehavior.js';
 type Props = {|
   anchor: HTMLElement,
   bgColor: 'blue' | 'darkGray' | 'orange' | 'red' | 'white',
+  caret?: boolean,
   children?: React.Node,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
@@ -141,6 +142,7 @@ export default class Controller extends React.Component<Props, State> {
   render() {
     const {
       bgColor,
+      caret,
       children,
       idealDirection,
       positionRelativeToAnchor,
@@ -155,6 +157,7 @@ export default class Controller extends React.Component<Props, State> {
       <OutsideEventBehavior onClick={this.handlePageClick}>
         <Contents
           bgColor={bgColor}
+          caret={caret}
           idealDirection={idealDirection}
           onKeyDown={this.handleKeyDown}
           onResize={this.handleResize}

--- a/packages/gestalt/src/Flyout.js
+++ b/packages/gestalt/src/Flyout.js
@@ -34,6 +34,7 @@ export default function Flyout(props: Props) {
     <Controller
       anchor={anchor}
       bgColor={color}
+      caret={false}
       idealDirection={idealDirection}
       onDismiss={onDismiss}
       positionRelativeToAnchor={positionRelativeToAnchor}

--- a/packages/gestalt/src/IconWithTooltip.js
+++ b/packages/gestalt/src/IconWithTooltip.js
@@ -107,6 +107,7 @@ export default function IconWithTooltip({
         <Controller
           anchor={anchor}
           bgColor="darkGray"
+          caret={false}
           idealDirection="down"
           onDismiss={noop}
           positionRelativeToAnchor

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -27,10 +27,7 @@ type Layout =
   | typeof DefaultLayoutSymbol
   | typeof UniformRowLayoutSymbol
   | LegacyMasonryLayout
-  | LegacyUniformRowLayout
-  | 'basic'
-  | 'flexible'
-  | 'uniformRow';
+  | LegacyUniformRowLayout;
 
 type Props<T> = {|
   columnWidth?: number,
@@ -167,7 +164,6 @@ export default class Masonry<T: {}> extends React.Component<
       PropTypes.instanceOf(LegacyMasonryLayout),
       PropTypes.instanceOf(LegacyUniformRowLayout),
       PropTypes.symbol,
-      PropTypes.string,
     ]),
 
     /**
@@ -197,7 +193,7 @@ export default class Masonry<T: {}> extends React.Component<
   static defaultProps = {
     columnWidth: 236,
     minCols: 3,
-    layout: 'basic',
+    layout: DefaultLayoutSymbol,
     loadItems: () => {},
     virtualize: false,
   };
@@ -355,13 +351,13 @@ export default class Masonry<T: {}> extends React.Component<
   };
 
   fetchMore = () => {
-    const { loadItems, items } = this.props;
+    const { loadItems } = this.props;
     if (loadItems && typeof loadItems === 'function') {
       this.setState(
         {
           isFetching: true,
         },
-        () => loadItems({ from: items.length })
+        () => loadItems({ from: this.props.items.length })
       );
     }
   };
@@ -388,10 +384,8 @@ export default class Masonry<T: {}> extends React.Component<
    * number of columns we would display should change after a resize.
    */
   reflow() {
-    const { measurementStore } = this.props;
-
-    if (measurementStore) {
-      measurementStore.reset();
+    if (this.props.measurementStore) {
+      this.props.measurementStore.reset();
     }
     this.state.measurementStore.reset();
 
@@ -402,7 +396,6 @@ export default class Masonry<T: {}> extends React.Component<
   renderMasonryComponent = (itemData: T, idx: number, position: *) => {
     const {
       comp: Component,
-      scrollContainer,
       virtualize,
       virtualBoundsTop,
       virtualBoundsBottom,
@@ -410,7 +403,7 @@ export default class Masonry<T: {}> extends React.Component<
     const { top, left, width, height } = position;
 
     let isVisible;
-    if (scrollContainer) {
+    if (this.props.scrollContainer) {
       const virtualBuffer = this.containerHeight * VIRTUAL_BUFFER_FACTOR;
       const offsetScrollPos = this.state.scrollTop - this.containerOffset;
       const viewportTop = virtualBoundsTop
@@ -459,15 +452,13 @@ export default class Masonry<T: {}> extends React.Component<
       flexible,
       gutterWidth: gutter,
       items,
-      layout,
       minCols,
-      scrollContainer,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
 
-    let getPositions;
-    if ((flexible || layout === 'flexible') && width !== null) {
-      getPositions = fullWidthLayout({
+    let layout;
+    if (flexible && width !== null) {
+      layout = fullWidthLayout({
         gutter,
         cache: measurementStore,
         minCols,
@@ -475,11 +466,10 @@ export default class Masonry<T: {}> extends React.Component<
         width,
       });
     } else if (
-      layout === UniformRowLayoutSymbol ||
-      layout instanceof LegacyUniformRowLayout ||
-      layout === 'uniformRow'
+      this.props.layout === UniformRowLayoutSymbol ||
+      this.props.layout instanceof LegacyUniformRowLayout
     ) {
-      getPositions = uniformRowLayout({
+      layout = uniformRowLayout({
         cache: measurementStore,
         columnWidth,
         gutter,
@@ -487,7 +477,7 @@ export default class Masonry<T: {}> extends React.Component<
         width,
       });
     } else {
-      getPositions = defaultLayout({
+      layout = defaultLayout({
         cache: measurementStore,
         columnWidth,
         gutter,
@@ -518,13 +508,12 @@ export default class Masonry<T: {}> extends React.Component<
                   left: 0,
                   transform: 'translateX(0px) translateY(0px)',
                   WebkitTransform: 'translateX(0px) translateY(0px)',
-                  width:
-                    flexible || layout === 'flexible'
-                      ? undefined
-                      : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
+                  width: flexible
+                    ? undefined
+                    : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
                 }}
                 ref={el => {
-                  if (el && layout !== 'flexible') {
+                  if (el && !flexible) {
                     // only measure flexible items on client
                     measurementStore.set(item, el.clientHeight);
                   }
@@ -548,8 +537,8 @@ export default class Masonry<T: {}> extends React.Component<
         .filter(item => item && !measurementStore.has(item))
         .slice(0, minCols);
 
-      const positions = getPositions(itemsToRender);
-      const measuringPositions = getPositions(itemsToMeasure);
+      const positions = layout(itemsToRender);
+      const measuringPositions = layout(itemsToMeasure);
       // Math.max() === -Infinity when there are no positions
       const height = positions.length
         ? Math.max(...positions.map(pos => pos.top + pos.height))
@@ -610,11 +599,11 @@ export default class Masonry<T: {}> extends React.Component<
       );
     }
 
-    return scrollContainer ? (
+    return this.props.scrollContainer ? (
       <ScrollContainer
         ref={this.setScrollContainerRef}
         onScroll={this.updateScrollPosition}
-        scrollContainer={scrollContainer}
+        scrollContainer={this.props.scrollContainer}
       >
         {gridBody}
       </ScrollContainer>

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -46,6 +46,7 @@ export default class Tooltip extends React.Component<Props, State> {
           <Controller
             anchor={anchor}
             bgColor="darkGray"
+            caret={false}
             idealDirection="down"
             onDismiss={noop}
             positionRelativeToAnchor

--- a/packages/gestalt/src/__snapshots__/Caret.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Caret.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Caret renders with direction down 1`] = `
+<svg
+  height="24"
+  width="24"
+>
+  <path
+    d="M0 24 L12 12 L24 24"
+  />
+</svg>
+`;
+
+exports[`Caret renders with direction left 1`] = `
+<svg
+  height="24"
+  width="24"
+>
+  <path
+    d="M0 0 L12 12 L0 24"
+  />
+</svg>
+`;
+
+exports[`Caret renders with direction right 1`] = `
+<svg
+  height="24"
+  width="24"
+>
+  <path
+    d="M24 0 L12 12 L24 24"
+  />
+</svg>
+`;
+
+exports[`Caret renders with direction up 1`] = `
+<svg
+  height="24"
+  width="24"
+>
+  <path
+    d="M0 0 L12 12 L24 0"
+  />
+</svg>
+`;

--- a/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
@@ -5,9 +5,9 @@ exports[`Controller renders 1`] = `
   className="container"
   style={
     Object {
-      "left": -28,
+      "left": -20,
       "stroke": null,
-      "top": -8,
+      "top": -12,
       "visibility": "visible",
     }
   }
@@ -24,6 +24,26 @@ exports[`Controller renders 1`] = `
         }
       }
     />
+    <div
+      className="darkGray caret"
+      style={
+        Object {
+          "bottom": null,
+          "left": 8,
+          "right": null,
+          "top": null,
+        }
+      }
+    >
+      <svg
+        height="24"
+        width="24"
+      >
+        <path
+          d="M0 0 L12 12 L24 0"
+        />
+      </svg>
+    </div>
   </div>
 </div>
 `;

--- a/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
@@ -7,7 +7,7 @@ exports[`Flyout renders 1`] = `
   className="container"
   style={
     Object {
-      "left": -28,
+      "left": -20,
       "stroke": "#efefef",
       "top": NaN,
       "visibility": "visible",
@@ -35,7 +35,7 @@ exports[`Flyout renders as blue 1`] = `
   className="container"
   style={
     Object {
-      "left": -28,
+      "left": -20,
       "stroke": null,
       "top": NaN,
       "visibility": "visible",
@@ -63,7 +63,7 @@ exports[`Flyout renders as error 1`] = `
   className="container"
   style={
     Object {
-      "left": -28,
+      "left": -20,
       "stroke": null,
       "top": NaN,
       "visibility": "visible",


### PR DESCRIPTION
[Revert] Masonry: Allowing string enums for Masonry layout
[Revert] Flyout: Update spacing around items to 8px + remove caret code