### PR TITLE
Modal: [Docs] Fix default value for closeOnOutsideClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Modal: [Docs] Fix default value for closeOnOutsideClick (#697)
+
 ### Patch
 
 </details>

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -34,7 +34,7 @@ card(
         name: 'closeOnOutsideClick',
         type: 'boolean',
         description: 'Close the modal when you click outside of it',
-        defaultValue: false,
+        defaultValue: true,
       },
       {
         name: 'footer',


### PR DESCRIPTION
I got the default value wrong in our docs in #680 