### PR TITLE
Update version to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
   </summary>
 
 ### Minor
+
+### Patch
+
+</details>
+
+## 1.9.0 (Feb 27, 2020)
+
+### Minor
 - Text / Heading [Breaking]: Added codemod to support breaking changes from #693 (removed support for responsive size prop values smSize, mdSize, and lgSize in Text and Heading component) (#696)
 - Heading / Text [Breaking]: Reduce size options from xs-xl to sm-lg (#693)
 
@@ -14,10 +22,6 @@ Run codemods for breaking changes in order:
 1. `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.8.0-1.9.0/remove-responsive-text-sizing.js ~/code/repo`
 2. `yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.8.0-1.9.0/heading-size-replace.js ~/code/repo`
 3. `yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.8.0-1.9.0/text-size-replace.js ~/code/repo`
-
-### Patch
-
-</details>
 
 ## 1.8.0 (Feb 27, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.9.0 (Feb 27, 2020)

### Minor
- Text / Heading [Breaking]: Added codemod to support breaking changes from #693 (removed support for responsive size prop values smSize, mdSize, and lgSize in Text and Heading component) (#696)
- Heading / Text [Breaking]: Reduce size options from xs-xl to sm-lg (#693)

Run codemods for breaking changes in order:
1. `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.8.0-1.9.0/remove-responsive-text-sizing.js ~/code/repo`
2. `yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.8.0-1.9.0/heading-size-replace.js ~/code/repo`
3. `yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.8.0-1.9.0/text-size-replace.js ~/code/repo`