### PR TITLE
Docs: Remove references to integrations tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 ### Patch
+- ReadMe/package.json: Removed references and script to run integrations tests. (#702)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ That syntax is Webpack specific (and will work with Create React App), but you c
 
 ## Development
 
-Gestalt is a [multi-project monorepo](https://yarnpkg.com/lang/en/docs/workspaces/). The docs, components and integration tests are all organized as separate packages that share similar tooling.
+Gestalt is a [multi-project monorepo](https://yarnpkg.com/lang/en/docs/workspaces/). The docs and components are all organized as separate packages that share similar tooling.
 
 Install project dependencies and run tests:
 
@@ -44,22 +44,9 @@ yarn start
 
 Visit [http://localhost:3000/](http://localhost:3000) and click on a component to view the docs.
 
-Using the Masonry playground:
-
-```bash
-cd test && yarn start
-open "http://localhost:3001/Masonry"
-```
-
-Running Masonry's integration tests. This will leave lots of Firefox processes hanging around, so please be warned.
-
-```bash
-./run_integration_tests
-```
-
 ## Codemods
 
-When a release will cause breaking changes — in usage or in typing — we provide a codemod to ease the upgrade process. Codemods are organized by release in `/packages/gestalt-codemods`. We recommend using [jscodeshift](https://github.com/facebook/jscodeshift) to upgrade.
+When a release will cause breaking changes — in usage or in typing — we provide a codemod to ease the upgrade process. Codemods are organized by release in `/packages/gestalt-codemods`.
 
 ### Usage:
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "greenkeeper-lockfile-upload": "greenkeeper-lockfile-upload",
     "start": "(cd docs && yarn start) & (cd packages/gestalt && yarn watch)",
     "test": "./scripts/test.sh",
-    "test:integration": "./run_integration_tests",
     "format": "prettier --write \"**/*.{css,html,js,md,yml}\"",
     "precommit": "lint-staged"
   },


### PR DESCRIPTION
Removed references and script to run already deprecated integrations tests.

## TODO

- [x ] Documentation
- ~~[ ] Tests~~
- ~~[ ] Experimental evidence (required for Masonry changes)~~
- ~~[ ] Accessibility checkup~~
