### PR TITLE
Flyout: Make caret optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Flyout: Make caret optional (#706)
+
 ### Patch
 
 </details>

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -66,6 +66,13 @@ card(
         href: 'errorFlyout',
       },
       {
+        name: 'showCaret',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Show the caret on the flyout',
+        href: 'showCaret',
+      },
+      {
         name: 'size',
         type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | number`,
         description: `xs: 185px, sm: 230px, md: 284px, lg: 320px, xl:375px`,
@@ -110,6 +117,48 @@ function FlyoutExample() {
               <Box paddingX={2} marginTop={3}>
                 <Button color="red" text="Visit the help center" />
               </Box>
+            </Box>
+          </Flyout>
+        </Layer>}
+    </Box>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    id="showCaret"
+    name="Example: Show Caret"
+    defaultCode={`
+function FlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef();
+  return (
+    <Box>
+      <Box display="inlineBlock" ref={anchorRef}>
+        <Button
+          accessibilityExpanded={!!open}
+          accessibilityHaspopup
+          onClick={() => setOpen(!open)}
+          text="Help"
+        />
+      </Box>
+      {open &&
+        <Layer>
+          <Flyout
+            anchor={anchorRef.current}
+            idealDirection="up"
+            showCaret
+            onDismiss={() => setOpen(false)}
+            positionRelativeToAnchor={false}
+            size="md"
+          >
+            <Box padding={3} column={12}>
+              <Text align="center" weight="bold">
+                Flyout with a caret, not a 🥕
+              </Text>
             </Box>
           </Flyout>
         </Layer>}

--- a/packages/gestalt/src/Flyout.js
+++ b/packages/gestalt/src/Flyout.js
@@ -6,11 +6,12 @@ import Controller from './Controller.js';
 type Props = {|
   anchor: ?HTMLElement,
   children?: React.Node,
+  color?: 'blue' | 'orange' | 'red' | 'white' | 'darkGray',
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
   positionRelativeToAnchor?: boolean,
-  color?: 'blue' | 'orange' | 'red' | 'white' | 'darkGray',
   shouldFocus?: boolean,
+  showCaret?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number,
 |};
 
@@ -23,6 +24,7 @@ export default function Flyout(props: Props) {
     positionRelativeToAnchor = true,
     color = 'white',
     shouldFocus = true,
+    showCaret = false,
     size,
   } = props;
 
@@ -34,7 +36,7 @@ export default function Flyout(props: Props) {
     <Controller
       anchor={anchor}
       bgColor={color}
-      caret={false}
+      caret={showCaret}
       idealDirection={idealDirection}
       onDismiss={onDismiss}
       positionRelativeToAnchor={positionRelativeToAnchor}
@@ -60,4 +62,5 @@ Flyout.propTypes = {
     PropTypes.number,
     PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']), // default: sm
   ]),
+  showCaret: PropTypes.bool,
 };


### PR DESCRIPTION
We have a request to make `caret` optional - we do leave the default `false`

![image](https://user-images.githubusercontent.com/127199/75572614-f9317a00-5a0f-11ea-9fef-24ca5e55f3c1.png)
