### PR TITLE
Release 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 </details>
 
+## 1.10.1 (Mar 2, 2020)
+
+### Patch
+
+- Text / Heading: Made typography changes more backwards-compatible by adding xl size back in as deprecated feature (#707)
+
 ## 1.10.0 (Feb 28, 2020)
 
 ### Minor

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.10.1 (Mar 2, 2020)

### Patch

- Text / Heading: Made typography changes more backwards-compatible by adding xl size back in as deprecated feature (#707)
