### PR TITLE
Version bump: 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@
 
 ### Minor
 
-- SelectList / TextField / TextArea: Add `label` and `helperText` props (#705)
-- Flyout: Make caret optional (#706)
-
 ### Patch
 
 </details>
+
+## 1.11.0 (Mar 3, 2020)
+
+### Minor
+
+- SelectList / TextField / TextArea: Add `label` and `helperText` props (#705)
+- Flyout: Make caret optional (#706)
 
 ## 1.10.1 (Mar 2, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.11.0 (Mar 3, 2020)

### Minor

- SelectList / TextField / TextArea: Add `label` and `helperText` props (#705)
- Flyout: Make caret optional (#706)