### PR TITLE
Tooltip bugfix: add Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### Minor
 
-- Tooltip: Bugfix: add layer (#717)
-
 ### Patch
+
+- Tooltip: Bugfix: add layer (#717)
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Tooltip: Bugfix: add layer (#717)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import Controller from './Controller.js';
 import Text from './Text.js';
 import Box from './Box.js';
+import Layer from './Layer.js';
 
 const noop = () => {};
 const TIMEOUT = 100;
@@ -93,32 +94,34 @@ export default function Tooltip({
         {children}
       </Box>
       {isOpen && !!anchor && (
-        <Controller
-          anchor={anchor}
-          caret={false}
-          bgColor="darkGray"
-          idealDirection={idealDirection}
-          onDismiss={noop}
-          positionRelativeToAnchor
-          size={null}
-        >
-          <Box
-            maxWidth={180}
-            paddingY={1}
-            paddingX={2}
-            onBlur={link ? handleTextMouseLeave : undefined}
-            onFocus={link ? handleTextMouseEnter : undefined}
-            onMouseEnter={link ? handleTextMouseEnter : undefined}
-            onMouseLeave={link ? handleTextMouseLeave : undefined}
-            role="tooltip"
-            tabIndex={0}
+        <Layer>
+          <Controller
+            anchor={anchor}
+            caret={false}
+            bgColor="darkGray"
+            idealDirection={idealDirection}
+            onDismiss={noop}
+            positionRelativeToAnchor={false}
+            size={null}
           >
-            <Text color="white" size="sm">
-              {text}
-            </Text>
-            {link && <Box paddingY={1}>{link}</Box>}
-          </Box>
-        </Controller>
+            <Box
+              maxWidth={180}
+              paddingY={1}
+              paddingX={2}
+              onBlur={link ? handleTextMouseLeave : undefined}
+              onFocus={link ? handleTextMouseEnter : undefined}
+              onMouseEnter={link ? handleTextMouseEnter : undefined}
+              onMouseLeave={link ? handleTextMouseLeave : undefined}
+              role="tooltip"
+              tabIndex={0}
+            >
+              <Text color="white" size="sm">
+                {text}
+              </Text>
+              {link && <Box paddingY={1}>{link}</Box>}
+            </Box>
+          </Controller>
+        </Layer>
       )}
     </Box>
   );

--- a/packages/gestalt/src/Tooltip.jsdom.test.js
+++ b/packages/gestalt/src/Tooltip.jsdom.test.js
@@ -5,6 +5,7 @@ import { fireEvent, render } from '@testing-library/react';
 import Tooltip from './Tooltip.js';
 import Link from './Link.js';
 import Text from './Text.js';
+import Layer from './Layer.js';
 
 test('Tooltip renders', () => {
   const component = create(
@@ -33,10 +34,9 @@ test('Tooltip renders the link when hovered', () => {
   );
 
   fireEvent.mouseEnter(container.querySelector('[aria-label]'));
-  expect(getByText('Learn more about logout')).toBeVisible();
-  expect(
-    container.querySelector('[href="https://pinterest.com"]')
-  ).toBeVisible();
+  const { body } = document;
+  const element = getByText('Learn more about logout');
+  expect(body && body.contains(element)).toBeTruthy();
 });
 
 test('Tooltip should render as expected when hovered', () => {

--- a/packages/gestalt/src/Tooltip.jsdom.test.js
+++ b/packages/gestalt/src/Tooltip.jsdom.test.js
@@ -5,7 +5,6 @@ import { fireEvent, render } from '@testing-library/react';
 import Tooltip from './Tooltip.js';
 import Link from './Link.js';
 import Text from './Text.js';
-import Layer from './Layer.js';
 
 test('Tooltip renders', () => {
   const component = create(

--- a/packages/gestalt/src/__snapshots__/Tooltip.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tooltip.jsdom.test.js.snap
@@ -17,21 +17,6 @@ exports[`Tooltip renders 1`] = `
 </div>
 `;
 
-exports[`Tooltip renders the link when hovered 1`] = `
-<div
-  class="box xsDisplayBlock"
->
-  <div
-    aria-label="This is a tooltip"
-    class="box"
-  >
-    <div>
-      Hi
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Tooltip renders with idealDirection 1`] = `
 <div
   className="box xsDisplayBlock"

--- a/packages/gestalt/src/__snapshots__/Tooltip.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tooltip.jsdom.test.js.snap
@@ -17,6 +17,21 @@ exports[`Tooltip renders 1`] = `
 </div>
 `;
 
+exports[`Tooltip renders the link when hovered 1`] = `
+<div
+  class="box xsDisplayBlock"
+>
+  <div
+    aria-label="This is a tooltip"
+    class="box"
+  >
+    <div>
+      Hi
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Tooltip renders with idealDirection 1`] = `
 <div
   className="box xsDisplayBlock"


### PR DESCRIPTION
## TODO

- [ ] Documentation
- [ ] Tests
- [ ] Experimental evidence (required for Masonry changes)
- [ ] Accessibility checkup


Notice how the tooltip now sits above the editor:
<img width="580" alt="Screen Shot 2020-03-03 at 9 53 51 AM" src="https://user-images.githubusercontent.com/13890265/75805660-18454a00-5d37-11ea-9d27-7f72677e2b66.png">
