### PR TITLE
Version bump: 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 1.12.0 (Mar 4, 2020)
+
+### Minor
+
 - Tabs: update horizontal padding to 12px (#698)
 - SelectList/TextArea/TextField: Update focus states (#720)
 
 ### Patch
 
 - Docs: make checkerboard optional (#714)
-
-</details>
 
 ## 1.11.1 (Mar 3, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.12.0 (Mar 4, 2020)

### Minor

- Tabs: update horizontal padding to 12px (#698)
- SelectList/TextArea/TextField: Update focus states (#720)

### Patch

- Docs: make checkerboard optional (#714)