### PR TITLE
Version bump: v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ### Minor
 
-- Form fields: Add "lg" size option (#713)
-
 ### Patch
 
 </details>
+
+## 1.13.0 (Mar 5, 2020)
+
+### Minor
+
+- Form fields: Add "lg" size option (#713)
 
 ## 1.12.0 (Mar 4, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.13.0 (Mar 5, 2020)

### Minor

- Form fields: Add "lg" size option (#713)
