### PR TITLE
Form Elements: Remove horizontal spacing for label / helperText and errorMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Form Elements: Remove horizontal spacing for label / helperText and errorMessage (#727)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/FormErrorMessage.js
+++ b/packages/gestalt/src/FormErrorMessage.js
@@ -13,7 +13,7 @@ export default function FormErrorMessage({
   text?: string,
 |}) {
   return (
-    <Box marginTop={2} paddingX={2}>
+    <Box marginTop={2}>
       <Text color="red" size="sm">
         <span id={`${id}-error`}>{text}</span>
       </Text>

--- a/packages/gestalt/src/FormHelperText.js
+++ b/packages/gestalt/src/FormHelperText.js
@@ -7,7 +7,7 @@ import Text from './Text.js';
 
 export default function FormHelperText({ text }: {| text: string |}) {
   return (
-    <Box marginTop={2} paddingX={2}>
+    <Box marginTop={2}>
       <Text color="gray" size="sm">
         {text}
       </Text>

--- a/packages/gestalt/src/FormLabel.css
+++ b/packages/gestalt/src/FormLabel.css
@@ -1,4 +1,3 @@
 .formLabel {
-  composes: paddingX2 from "./boxWhitespace.css";
   padding-bottom: 8px;
 }

--- a/packages/gestalt/src/__snapshots__/FormErrorMessage.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/FormErrorMessage.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FormErrorMessage with errorMessage 1`] = `
 <div
-  className="box marginTop2 paddingX2"
+  className="box marginTop2"
 >
   <div
     className="Text fontSize1 red alignLeft breakWord fontWeightNormal"
@@ -18,7 +18,7 @@ exports[`FormErrorMessage with errorMessage 1`] = `
 
 exports[`FormErrorMessage with no errorMessage 1`] = `
 <div
-  className="box marginTop2 paddingX2"
+  className="box marginTop2"
 >
   <div
     className="Text fontSize1 red alignLeft breakWord fontWeightNormal"

--- a/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
@@ -32,7 +32,7 @@ exports[`TextArea TextArea with error 1`] = `
     rows={3}
   />
   <div
-    className="box marginTop2 paddingX2"
+    className="box marginTop2"
   >
     <div
       className="Text fontSize1 red alignLeft breakWord fontWeightNormal"

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -50,7 +50,7 @@ exports[`TextField TextField with error 1`] = `
     type="text"
   />
   <div
-    className="box marginTop2 paddingX2"
+    className="box marginTop2"
   >
     <div
       className="Text fontSize1 red alignLeft breakWord fontWeightNormal"


### PR DESCRIPTION
Remove horizontal spacing for label / helperText and errorMessage

![image](https://user-images.githubusercontent.com/127199/76016814-5dea4a00-5ed2-11ea-9d8e-b124eace3ba2.png)
