### PR TITLE
Remove Text size=xl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Minor
 
+- Text [Breaking]: Removes deprecated size=xl (#729)
+
+Run codemod:
+
+`cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.14.0-1.15.0/remove-text-size-xl.js ~/code/repo`
+
 ### Patch
 
 </details>

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/.eslintrc.json
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "prettier/prettier": "off",
+    "no-undef": "off",
+    "no-unused-vars": "off",
+    "react/jsx-no-undef": "off"
+  }
+}

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-sm.input.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-sm.input.js
@@ -1,0 +1,11 @@
+// @flow
+import React from 'react';
+import { Text } from 'gestalt';
+
+export default function SMText() {
+  return (
+    <Text size="sm">
+      sm
+    </Text>
+  );
+}

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-sm.output.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-sm.output.js
@@ -1,0 +1,11 @@
+// @flow
+import React from 'react';
+import { Text } from 'gestalt';
+
+export default function SMText() {
+  return (
+    <Text size="sm">
+      sm
+    </Text>
+  );
+}

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-xl.input.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-xl.input.js
@@ -1,0 +1,11 @@
+// @flow
+import React from 'react';
+import { Text } from 'gestalt';
+
+export default function XLText() {
+  return (
+    <Text size="xl" align="right">
+      xl
+    </Text>
+  );
+}

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-xl.output.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-xl.output.js
@@ -1,0 +1,16 @@
+// @flow
+import React from 'react';
+import { Text } from 'gestalt';
+
+export default function XLText() {
+  return (
+    <Text align="right">
+      <span
+        style={{
+          "fontSize": 21
+        }}>
+        xl
+      </span>
+    </Text>
+  );
+}

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__tests__/remove-text-size-xl.test.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__tests__/remove-text-size-xl.test.js
@@ -1,0 +1,13 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../remove-text-size-xl', () => {
+  return Object.assign(require.requireActual('../remove-text-size-xl'), {
+    parser: 'flow',
+  });
+});
+
+describe('remove-text-size-xl', () => {
+  ['remove-text-size-xl-sm', 'remove-text-size-xl-xl'].forEach(test => {
+    defineTest(__dirname, 'remove-text-size-xl', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/1.14.0-1.15.0/remove-text-size-xl.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/remove-text-size-xl.js
@@ -1,0 +1,87 @@
+/**
+ * Converts
+ *  <Text size="xl">content</Text>
+ * to
+ *  <Text><span style={{ fontSize: 21 }}>content</span></Text>
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return;
+    }
+    const specifier = decl.specifiers.find(
+      node => node.imported.name === 'Text'
+    );
+    if (!specifier) {
+      return;
+    }
+    localIdentifierName = specifier.local.name;
+  });
+
+  let hasModifications = false;
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach(path => {
+      const { node } = path;
+
+      if (node.openingElement.name.name !== localIdentifierName) {
+        return;
+      }
+
+      const hasSize = node.openingElement.attributes.find(
+        attr => attr.name && attr.name.name === 'size'
+      );
+
+      if (!hasSize) {
+        return;
+      }
+
+      node.openingElement.attributes = node.openingElement.attributes
+        .map(attr => {
+          if (attr.name && attr.name.name === 'size' && attr.value.value) {
+            if (attr.value.value === 'xl') {
+              const openingElement = j.jsxOpeningElement(
+                j.jsxIdentifier('span'),
+                [
+                  j.jsxAttribute(
+                    j.jsxIdentifier('style'),
+                    j.jsxExpressionContainer(
+                      j.objectExpression([
+                        j.property(
+                          'init',
+                          j.literal('fontSize'),
+                          j.literal(21)
+                        ),
+                      ])
+                    )
+                  ),
+                ]
+              );
+              const element = j.jsxElement(
+                openingElement,
+                j.jsxClosingElement(j.jsxIdentifier('span')),
+                [j.jsxText('\n'), ...node.children, j.jsxText('\n')]
+              );
+              node.children = [j.jsxText('\n'), element, j.jsxText('\n')];
+              return null;
+            }
+          }
+          return attr;
+        })
+        .filter(Boolean);
+
+      j(path).replaceWith(node);
+
+      hasModifications = true;
+    })
+    .toSource();
+
+  return hasModifications ? transform : null;
+}

--- a/packages/gestalt/src/Text.css
+++ b/packages/gestalt/src/Text.css
@@ -2,7 +2,6 @@
   --font-size-1: 12px;
   --font-size-2: 14px;
   --font-size-3: 16px;
-  --font-size-4: 21px;
 }
 
 .Text {
@@ -19,8 +18,4 @@
 
 .fontSize3 {
   font-size: var(--font-size-3);
-}
-
-.fontSize4 {
-  font-size: var(--font-size-4);
 }

--- a/packages/gestalt/src/Text.css.flow
+++ b/packages/gestalt/src/Text.css.flow
@@ -5,5 +5,4 @@ declare module.exports: {|
   +'fontSize1': string,
   +'fontSize2': string,
   +'fontSize3': string,
-  +'fontSize4': string,
 |};

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -11,7 +11,6 @@ const SIZE_SCALE: { [size: ?string]: number } = {
   sm: 1,
   md: 2,
   lg: 3,
-  xl: 4,
 };
 
 type Props = {|
@@ -38,7 +37,7 @@ type Props = {|
   inline?: boolean,
   italic?: boolean,
   overflow?: 'normal' | 'breakWord',
-  size?: 'sm' | 'md' | 'lg' | 'xl', // xl is intentionally undocumented because it is depreacted
+  size?: 'sm' | 'md' | 'lg',
   leading?: 'tall' | 'short',
   truncate?: boolean,
   weight?: 'bold' | 'normal',
@@ -134,7 +133,7 @@ Text.propTypes = {
   italic: PropTypes.bool,
   leading: PropTypes.oneOf(['tall', 'short']),
   overflow: PropTypes.oneOf(['normal', 'breakWord']),
-  size: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
   truncate: PropTypes.bool,
   weight: PropTypes.oneOf(['bold', 'normal']),
 };


### PR DESCRIPTION
Follow up to #707 this removes `Text size="xl"` completely plus adds a codemod to replace remaining uses with inline styling.

This is intended only to be inline styled to prevent breaking changes when the size is removed. Most cases can be fixed in one of these ways:

- If the `Text` element also has `weight="bold"` this is equivalent to `Heading size="sm"` (21px vs 20px). A previous codemod updated all instances that weren't using a prop not supported by `Heading` such as align or inline. Surface owners should aim to replace these with `Heading size="sm"` combined with another component to supply the differing behavior
- Non-bold `Text` should be checked to see if either 1) a smaller size would work to bring it into PDS-compliance or 2) making the text bold would be fine so it can be moved over to `Heading size="sm"`
- If none of the above work, leaving the inline styling is fine

- [x] Tests
