### PR TITLE
Release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 1.15.0 (Mar 5, 2020)
+
+### Minor
+
 - Text [Breaking]: Removes deprecated size=xl (#729)
 
 Run codemod:
 
 `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.14.0-1.15.0/remove-text-size-xl.js ~/code/repo`
-
-### Patch
-
-</details>
 
 ## 1.14.0 (Mar 5, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.15.0 (Mar 5, 2020)

### Minor

- Text [Breaking]: Removes deprecated size=xl (#729)

Run codemod:

`cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.14.0-1.15.0/remove-text-size-xl.js ~/code/repo`