### PR TITLE
Tabs: Add white background, background colors for active/focus/hover states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Tabs: Add white background, backgrounds for active and hover/focus states (#731)
+
 ### Patch
 
 </details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Minor
 
-- Tabs: Add white background, backgrounds for active and hover/focus states (#731)
+- Tabs: Add white background, backgrounds for active and hover/focus states, 60px min width (#731)
 
 ### Patch
 

--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -1,7 +1,6 @@
 .button {
-  composes: borderBox from "./Layout.css";
+  composes: borderBox minWidth60 from "./Layout.css";
   border-radius: 24px;
-  min-width: 60px;
 }
 
 .solid {

--- a/packages/gestalt/src/Layout.css
+++ b/packages/gestalt/src/Layout.css
@@ -250,3 +250,7 @@
 .orderLast {
   order: 99999;
 }
+
+.minWidth60 {
+  min-width: 60px;
+}

--- a/packages/gestalt/src/Tabs.css
+++ b/packages/gestalt/src/Tabs.css
@@ -19,7 +19,7 @@
 }
 
 .tabIsNotActive {
-  composes: transparentBg gray from "./Colors.css";
+  composes: whiteBg from "./Colors.css";
 }
 
 .tab:focus,
@@ -29,7 +29,12 @@
 
 .tabIsNotActive:focus,
 .tabIsNotActive:hover {
+  background-color: #f1f1f1;
   color: #111;
+}
+
+.tabIsNotActive:active {
+  background-color: #e8e8e8;
 }
 
 .tabIsActive {

--- a/packages/gestalt/src/Tabs.css
+++ b/packages/gestalt/src/Tabs.css
@@ -6,7 +6,7 @@
 .tab {
   composes: accessibilityOutline from "./Focus.css";
   composes: borderBox from "./Layout.css";
-  composes: flex flexColumn itemsCenter justifyCenter from "./Layout.css";
+  composes: flex flexColumn itemsCenter justifyCenter minWidth60 from "./Layout.css";
   composes: noBorder pill from "./Borders.css";
   composes: m0 from "./Whitespace.css";
   composes: pointer from "./Cursor.css";


### PR DESCRIPTION
This PR adds "overlays" (not actual overlays, represented as hex colors) for active and focus/hover states for tabs in the Tabs component.. Additionally, to ensure text is always readable regardless of what color background Tabs are used on, this adds a white background to each tab. Finally, this adds a tab min width of 60px — since this matches Button's min width, I moved things around a bit so both are composing from the same style.

## TODO

- [ ] Documentation
- [ ] Tests
- [ ] Experimental evidence (required for Masonry changes)
- [ ] Accessibility checkup
