### PR TITLE
Version bump: v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 1.16.0 (Mar 6, 2020)
+
+### Minor
+
 - Tabs: Add white background, backgrounds for active and hover/focus states, 60px min width (#731)
 
 ### Patch
 
 - Internal: Detect and remove unused eslint disables (#723)
-
-</details>
 
 ## 1.15.0 (Mar 5, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.16.0 (Mar 6, 2020)

### Minor

- Tabs: Add white background, backgrounds for active and hover/focus states, 60px min width (#731)

### Patch

- Internal: Detect and remove unused eslint disables (#723)