### PR TITLE
Modal: lower bottom heading spacing for alert dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Modal: lower bottom heading spacing for alert dialogs (#736)
+
 ### Patch
 
 </details>

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -295,7 +295,7 @@ card(
     name="Alert Dialogs"
     description={`
       The \`alertdialog\` role is used to notify the user of urgent information that demands the user's immediate attention.
-      We need to specify this role separately from other dialogs for accessibility.
+      We need to specify this role separately from other dialogs for accessibility. The only visual difference is the spacing on the \`heading\`.
     `}
     defaultCode={`
 function Example(props) {

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -36,13 +36,25 @@ function Backdrop({ children }: { children?: React.Node }) {
   );
 }
 
-function Header({ heading }: {| heading: string | React.Node |}) {
+function Header({
+  heading,
+  role,
+}: {|
+  heading: string | React.Node,
+  role: 'alertdialog' | 'dialog',
+|}) {
   if (typeof heading !== 'string') {
     return heading;
   }
 
   return (
-    <Box display="flex" justifyContent="center" padding={8}>
+    <Box
+      display="flex"
+      justifyContent="center"
+      {...(role === 'dialog'
+        ? { padding: 8 }
+        : { paddingX: 8, marginTop: 8, marginBottom: 2 })}
+    >
       <Heading size="md" accessibilityLevel={1}>
         {heading}
       </Heading>
@@ -101,7 +113,7 @@ export default function Modal({
                 >
                   {heading && (
                     <Box fit>
-                      <Header heading={heading} />
+                      <Header heading={heading} role={role} />
                     </Box>
                   )}
                   <div className={styles.content}>{children}</div>


### PR DESCRIPTION
Design asked us to update the spacing on `heading` for alert dialogs.

## Before
![Screen Shot 2020-03-09 at 9 17 01 AM](https://user-images.githubusercontent.com/127199/76234658-40c1be00-61e7-11ea-86ea-b077ec545460.png)

## After
![Screen Shot 2020-03-09 at 9 16 46 AM](https://user-images.githubusercontent.com/127199/76234673-43bcae80-61e7-11ea-861e-20144fbf7b06.png)
