### PR TITLE
Version bump 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,22 @@
   </summary>
 
 ### Minor
+
+### Patch
+
+</details>
+
+## 1.17.0 (Mar 9, 2020)
+
+### Minor
+
+- Icon: Add credit-card and conversion-tag icons (#716)
 - Box [Breaking]: Removes support to deprecated props deprecatedMargin & deprecatedPadding (#711)
 
 Run codemods:
 
 `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.15.0-1.16.0/deprecatedMargin-box-replace.js ~/code/repo`
 `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.15.0-1.16.0/deprecatedPadding-box-replace.js ~/code/repo`
-
-- Icon: Add credit-card and conversion-tag icons (#716)
-
-### Patch
-
-</details>
 
 ## 1.16.0 (Mar 6, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.17.0 (Mar 9, 2020)

### Minor

- Icon: Add credit-card and conversion-tag icons (#716)
- Box [Breaking]: Removes support to deprecated props deprecatedMargin & deprecatedPadding (#711)

Run codemods:

`cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.15.0-1.16.0/deprecatedMargin-box-replace.js ~/code/repo`
`cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.15.0-1.16.0/deprecatedPadding-box-replace.js ~/code/repo`