### PR TITLE
Version bump: 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@
 
 ### Minor
 
-- Flyout/Tooltip: Update spacing around to 8px when caret is hidden (#737)
-- Docs: Open in CodeSandbox & remove checkerbox from example (#735)
-- Internal: fail build when CSS flow changes are required (#738)
-
 ### Patch
 
 </details>
+
+## 1.18.0 (Mar 10, 2020)
+
+### Minor
+
+- Flyout/Tooltip: Update spacing around to 8px when caret is hidden (#737)
+- Docs: Open in CodeSandbox & remove checkerbox from example (#735)
+- Internal: fail build when CSS flow changes are required (#738)
 
 ## 1.17.0 (Mar 9, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.18.0 (Mar 10, 2020)

### Minor

- Flyout/Tooltip: Update spacing around to 8px when caret is hidden (#737)
- Docs: Open in CodeSandbox & remove checkerbox from example (#735)
- Internal: fail build when CSS flow changes are required (#738)