### PR TITLE
Version bump: v1.19.0 / Remove IconWithTooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ### Minor
 
-- IconWithTooltip: Remove deprecated component (#741)
-
 ### Patch
 
 </details>
+
+## 1.19.0 (Mar 11, 2020)
+
+### Minor
+
+- IconWithTooltip: Remove deprecated component (#741)
 
 ## 1.18.0 (Mar 10, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.19.0 (Mar 11, 2020)

### Minor

- IconWithTooltip: Remove deprecated component (#741)