### PR TITLE
Flyout: Responsive, updated sizes + minimum width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Flyout: Responsive, updated sizes + minimum width (#743)
+
 ### Patch
 
 </details>

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -75,7 +75,7 @@ card(
       {
         name: 'size',
         type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | number`,
-        description: `xs: 185px, sm: 230px, md: 284px, lg: 320px, xl:375px`,
+        description: `xs: 180px, sm: 230px, md: 284px, lg: 320px, xl: 360px`,
         defaultValue: 'sm',
         href: 'basicExample',
       },
@@ -110,7 +110,7 @@ function FlyoutExample() {
             positionRelativeToAnchor={false}
             size="md"
           >
-            <Box padding={3}>
+            <Box padding={3} display="flex" alignItems="center" direction="column" column={12}>
               <Text align="center" weight="bold">
                 Need help with something? Check out our Help Center.
               </Text>

--- a/packages/gestalt/src/Contents.css
+++ b/packages/gestalt/src/Contents.css
@@ -18,6 +18,7 @@
 
 .minDimensions {
   min-height: 40px;
+  min-width: 180px;
 }
 
 .innerContents {

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -430,7 +430,7 @@ export default class Contents extends React.Component<Props, State> {
 
     const flyoutSize = {
       height: flyoutRef ? flyoutRef.clientHeight : 0,
-      width: width || (flyoutRef ? flyoutRef.clientWidth : 0),
+      width: (flyoutRef ? flyoutRef.clientWidth : width) || 0,
     };
 
     // First choose one of 4 main direction
@@ -515,7 +515,7 @@ export default class Contents extends React.Component<Props, State> {
               styles.maxDimensions,
               width !== null && styles.minDimensions
             )}
-            style={{ width }}
+            style={{ maxWidth: width }}
           >
             {children}
           </div>

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -17,11 +17,11 @@ type Props = {|
 |};
 
 const SIZE_WIDTH_MAP = {
-  xs: 185,
+  xs: 180,
   sm: 230,
   md: 284,
   lg: 320,
-  xl: 375,
+  xl: 360,
 };
 
 const ESCAPE_KEY_CODE = 27;

--- a/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
@@ -20,7 +20,7 @@ exports[`Controller renders 1`] = `
       className="innerContents maxDimensions minDimensions"
       style={
         Object {
-          "width": 230,
+          "maxWidth": 230,
         }
       }
     />

--- a/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
@@ -22,7 +22,7 @@ exports[`Flyout renders 1`] = `
       className="innerContents maxDimensions minDimensions"
       style={
         Object {
-          "width": 230,
+          "maxWidth": 230,
         }
       }
     />
@@ -50,7 +50,7 @@ exports[`Flyout renders as blue 1`] = `
       className="innerContents maxDimensions minDimensions"
       style={
         Object {
-          "width": 230,
+          "maxWidth": 230,
         }
       }
     />
@@ -78,7 +78,7 @@ exports[`Flyout renders as error 1`] = `
       className="innerContents maxDimensions minDimensions"
       style={
         Object {
-          "width": 230,
+          "maxWidth": 230,
         }
       }
     />


### PR DESCRIPTION
Makes `Flyout` responsive between `180px` and the specified width. It's especially nice for for flyouts that don't have that much content.

![flyout-responsive-before-after](https://user-images.githubusercontent.com/127199/76466695-609ee080-63a5-11ea-95ec-a1827791e413.png)

## Notes

* Doesn't make changes to `Tooltip` - in that case `width` is set to `null` so we don't apply `minDimensions`