### PR TITLE
TextField / TextArea / SelectList: Fix error focus state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Patch
 
+- TextField / TextArea / SelectList: Fix error focus state (#744)
+
 </details>
 
 ## 1.19.0 (Mar 11, 2020)

--- a/packages/gestalt/src/FormElement.css
+++ b/packages/gestalt/src/FormElement.css
@@ -20,7 +20,7 @@
 }
 
 .errored:focus {
-  border-color: #111;
+  border-color: #efefef;
 }
 
 .errored:hover:not(:focus) {


### PR DESCRIPTION
The focus state when there is an `error` on the field is wrong. So updated it to be consistent with regular focus styles:

**Before**
![Screen Shot 2020-03-11 at 2 38 59 PM](https://user-images.githubusercontent.com/127199/76467322-9abcb200-63a6-11ea-95fe-3424db3f6d91.png)

**After**
![Screen Shot 2020-03-11 at 2 38 37 PM](https://user-images.githubusercontent.com/127199/76467327-9e503900-63a6-11ea-8338-4ae0f8b79341.png)
