### PR TITLE
Version bump: 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ### Minor
 
-- Flyout: Responsive, updated sizes + minimum width (#753)
-
 ### Patch
 
 </details>
+
+## 1.22.0 (Mar 16, 2020)
+
+### Minor
+
+- Docs: Use same React version as package (#753)
 
 ## 1.21.0 (Mar 16, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.20.0",
+  "version": "1.22.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.22.0 (Mar 16, 2020)

### Minor

- Docs: Use same React version as package (#753)