### PR TITLE
Toast: Update design + remove icon/color + add thumbnailShape/button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Minor
 
+- Toast: Update design + remove icon/color + add thumbnailShape/button (#755)
+
+Run codemods:
+`cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.22.0-1.23.0/toast-remove-color-icon.js ~/code/repo`
+
 ### Patch
 
 </details>

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -40,6 +40,7 @@ card(
       {
         name: 'rounding',
         type: `"circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
+        defaultValue: 0,
         href: 'roundingCombinations',
       },
       {

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -1,8 +1,10 @@
 // @flow
 import * as React from 'react';
-import PropTable from './components/PropTable.js';
-import PageHeader from './components/PageHeader.js';
+import { Button, Link, Image, Text, Toast } from 'gestalt';
+import Combination from './components/Combination.js';
 import Example from './components/Example.js';
+import PageHeader from './components/PageHeader.js';
+import PropTable from './components/PropTable.js';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -10,11 +12,9 @@ const card = c => cards.push(c);
 card(
   <PageHeader
     name="Toast"
-    description={`Toasts can educate people on the content of the screen, provide confirmation when people complete
-an action, or simply communicate a short message.
+    description={`Toasts can educate people on the content of the screen, provide confirmation when people complete an action, or simply communicate a short message.
 
-<b><i>The Toast component is purely visual. In order to properly
-handle the showing and dismissing of Toasts, as well as any animations, you will need to implement a Toast manager.<i><b>`}
+The Toast component is purely visual. In order to properly handle the showing and dismissing of Toasts, as well as any animations, you will need to implement a Toast manager.`}
   />
 );
 
@@ -22,30 +22,27 @@ card(
   <PropTable
     props={[
       {
-        name: 'color',
-        type: `'darkGray' | 'orange' | 'red'`,
-        defaultValue: 'darkGray',
-        href: 'errorExample',
-      },
-      {
-        name: 'icon',
-        type: 'arrow-circle-forward',
-        defaultValue: 'arrow-circle-forward',
-        description: 'More icons can be added in the future.',
-        href: 'guideExample',
+        name: 'button',
+        type: 'React.Node',
+        href: 'imageTextButtonExample',
       },
       {
         name: 'thumbnail',
         type: 'React.Node',
-        description: 'Image should fit nicely into a square',
-        href: 'confirmationExample',
+        href: 'imageTextExample',
+      },
+      {
+        name: 'thumbnailShape',
+        type: `'circle' | 'rectangle' | 'square'`,
+        defaultValue: 'square',
+        href: 'imageTextExample',
       },
       {
         name: 'text',
         type: 'string | Array<string>',
         description:
           'Use string for guide toasts (one line of text) and Array<string> for confirmation toasts (two lines of text).',
-        href: 'confirmationExample',
+        href: 'textOnlyExample',
       },
     ]}
   />
@@ -53,20 +50,17 @@ card(
 
 card(
   <Example
-    id="confirmationExample"
-    name="Confirmation Toasts"
-    description="You can use Toasts to confirm an action has occured. When you are using a Toast as a confirmation, you should
-        always include a thumbnail and two lines of text."
+    id="textOnlyExample"
+    name="Example: Text only"
     defaultCode={`
 function ToastExample() {
-  const [showConfirmationToast, setShowConfirmationToast] = React.useState(false);
+  const [showToast, setShowToast] = React.useState(false);
   return (
     <Box>
       <Button
         inline
-        text={ showConfirmationToast ? 'Close toast' : 'Show confirmation toast' }
-        onClick={() => setShowConfirmationToast(!showConfirmationToast)}
-        size='md'
+        text={ showToast ? 'Close toast' : 'Show toast' }
+        onClick={() => setShowToast(!showToast)}
       />
       <Layer>
         <Box
@@ -81,19 +75,20 @@ function ToastExample() {
           paddingX={1}
           position='fixed'
         >
-          {showConfirmationToast ? (
-              <Toast
-                text={['Saved to', 'Home decor']}
-                thumbnail={
-                  <Image
-                    alt='Saved to home decor board'
-                    naturalHeight={564}
-                    naturalWidth={564}
-                    src='https://i.ibb.co/Lx54BCT/stock1.jpg'
-                  />
-                }
-              />
-          ) : null}
+          {showToast && (
+            <Toast
+              text={
+                <>
+                  Saved to{' '}
+                  <Text inline color="white" weight="bold">
+                    <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+                      Home decor
+                    </Link>
+                  </Text>
+                </>
+              }
+            />
+          )}
         </Box>
       </Layer>
     </Box>
@@ -104,21 +99,17 @@ function ToastExample() {
 
 card(
   <Example
-    id="guideExample"
-    name="Guide Toasts"
-    description="You can also use Toasts to guide and educate your users. In this case, no thumbnail is needed. Simply provide
-      your instructional text to the Toast component. The arrow icon indicating the Toast is a link will be automatically
-      added. If you need a different Icon here, please contact the Gestalt team."
+    id="imageTextExample"
+    name="Example: Image + Text"
     defaultCode={`
 function ToastExample() {
-  const [showGuideToast, setShowGuideToast] = React.useState(false);
+  const [showToast, setShowToast] = React.useState(false);
   return (
     <Box>
       <Button
         inline
-        text={ showGuideToast ? 'Close toast' : 'Show guide toast' }
-        onClick={() => setShowGuideToast(!showGuideToast)}
-        size='md'
+        text={ showToast ? 'Close toast' : 'Show toast' }
+        onClick={() => setShowToast(!showToast)}
       />
       <Layer>
         <Box
@@ -133,12 +124,28 @@ function ToastExample() {
           paddingX={1}
           position='fixed'
         >
-          {showGuideToast ? (
+          {showToast && (
             <Toast
-              icon='arrow-circle-forward'
-              text='Same great profile, just a new look. Learn more?'
+              thumbnail={
+                <Image
+                  alt='Saved to home decor board'
+                  naturalHeight={564}
+                  naturalWidth={564}
+                  src='https://i.ibb.co/Lx54BCT/stock1.jpg'
+                />
+              }
+              text={
+                <>
+                  Saved to{' '}
+                  <Text inline color="white" weight="bold">
+                    <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+                      Home decor
+                    </Link>
+                  </Text>
+                </>
+              }
             />
-          ) : null}
+          )}
         </Box>
       </Layer>
     </Box>
@@ -149,21 +156,17 @@ function ToastExample() {
 
 card(
   <Example
-    id="errorExample"
-    description="
-      You can use Toasts to indicate that something wrong occurred by setting the color to red.
-    "
-    name="Error Toasts"
+    id="imageTextButtonExample"
+    name="Example: Image + Text + Button"
     defaultCode={`
 function ToastExample() {
-  const [showErrorToast, setShowErrorToast] = React.useState(false);
+  const [showToast, setShowToast] = React.useState(false);
   return (
     <Box>
       <Button
         inline
-        text={ showErrorToast ? 'Close toast' : 'Show error toast' }
-        onClick={() => setShowErrorToast(!showErrorToast)}
-        size='md'
+        text={ showToast ? 'Close toast' : 'Show toast' }
+        onClick={() => setShowToast(!showToast)}
       />
       <Layer>
         <Box
@@ -178,15 +181,112 @@ function ToastExample() {
           paddingX={1}
           position='fixed'
         >
-          {showErrorToast ? (
-            <Toast color='red' text="Oops, we couldn't find that!" />
-          ) : null}
+          {showToast && (
+            <Toast
+              thumbnail={
+                <Image
+                  alt='Saved to home decor board'
+                  naturalHeight={564}
+                  naturalWidth={564}
+                  src='https://i.ibb.co/Lx54BCT/stock1.jpg'
+                />
+              }
+              text={
+                <>
+                  Saved to{' '}
+                  <Text inline color="white" weight="bold">
+                    <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+                      Home decor
+                    </Link>
+                  </Text>
+                </>
+              }
+              button={<Button key="button-key" inline text="Undo" size="lg" />}
+            />
+          )}
         </Box>
       </Layer>
     </Box>
   );
 }`}
   />
+);
+
+card(
+  <Combination
+    id="combinations"
+    name="Combinations: Overview"
+    fullWidth
+    showValues={false}
+    text={[
+      'Section created!',
+      <>
+        Saved to{' '}
+        <Text inline color="white" weight="bold">
+          <Link
+            inline
+            target="blank"
+            href="https://www.pinterest.com/search/pins/?q=home%20decor"
+          >
+            Home decor
+          </Link>
+        </Text>
+      </>,
+    ]}
+    thumbnail={[
+      null,
+      <Image
+        key="image-key"
+        alt="Saved to home decor board"
+        naturalHeight={564}
+        naturalWidth={564}
+        src="https://i.ibb.co/Lx54BCT/stock1.jpg"
+      />,
+    ]}
+    button={[null, <Button key="button-key" inline text="Undo" size="lg" />]}
+  >
+    {props => <Toast {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="combinations"
+    name="Combinations: Thumbnail shapes"
+    fullWidth
+    showValues={false}
+    thumbnailShape={['circle', 'rectangle', 'square']}
+  >
+    {props => (
+      <Toast
+        {...props}
+        thumbnail={
+          <Image
+            key="image-key"
+            alt="Saved to home decor board"
+            naturalHeight={751}
+            naturalWidth={564}
+            src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+          />
+        }
+        text={
+          <>
+            Saved to{' '}
+            <Text inline color="white" weight="bold">
+              <Link
+                inline
+                target="blank"
+                href="https://www.pinterest.com/search/pins/?q=home%20decor"
+              >
+                Home decor
+              </Link>
+            </Text>
+          </>
+        }
+        button={<Button key="button-key" inline text="Undo" size="lg" />}
+      />
+    )}
+  </Combination>
 );
 
 export default cards;

--- a/docs/src/components/Combination.js
+++ b/docs/src/components/Combination.js
@@ -10,6 +10,8 @@ type Props = {
   heading?: boolean,
   id?: string,
   name?: string,
+  fullWidth?: boolean,
+  showValues?: boolean,
   stacked?: boolean,
 };
 
@@ -57,7 +59,9 @@ export default function Combination({
   name = '',
   description = '',
   id,
+  showValues = true,
   stacked = false,
+  fullWidth = false,
   heading = true,
   children,
   ...props
@@ -73,22 +77,24 @@ export default function Combination({
       <Box display="flex" wrap>
         {combinations(props).map((combination, i) => (
           <Box
-            column={4}
-            mdColumn={3}
-            lgColumn={2}
+            column={fullWidth ? 12 : 4}
+            mdColumn={fullWidth ? 12 : 3}
+            lgColumn={fullWidth ? 12 : 2}
             key={i}
             padding={4}
             display="flex"
             direction="column"
             alignItems="center"
           >
-            <Box marginBottom={2}>
-              {Object.keys(combination).map(key => (
-                <Text align="center" size="md" key={`${i}-${key}`}>
-                  {toReactAttribute(key, combination[key])}
-                </Text>
-              ))}
-            </Box>
+            {showValues && (
+              <Box marginBottom={2}>
+                {Object.keys(combination).map(key => (
+                  <Text align="center" size="md" key={`${i}-${key}`}>
+                    {toReactAttribute(key, combination[key])}
+                  </Text>
+                ))}
+              </Box>
+            )}
             <Box position="relative" padding={4}>
               <Box position="absolute" top left bottom right>
                 <Checkerboard />

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/.eslintrc.json
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "prettier/prettier": "off",
+    "no-undef": "off",
+    "no-unused-vars": "off",
+    "react/jsx-no-undef": "off"
+  }
+}

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-both.input.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-both.input.js
@@ -1,0 +1,9 @@
+// @flow
+import React from 'react';
+import { Toast } from 'gestalt';
+
+export default function ToastExample() {
+  return (
+    <Toast text="Help" color="orange" icon="arrow-circle-forward" />
+  );
+}

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-both.output.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-both.output.js
@@ -1,0 +1,7 @@
+// @flow
+import React from 'react';
+import { Toast } from 'gestalt';
+
+export default function ToastExample() {
+  return <Toast text="Help" />;
+}

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-single.input.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-single.input.js
@@ -1,0 +1,9 @@
+// @flow
+import React from 'react';
+import { Toast } from 'gestalt';
+
+export default function ToastExample() {
+  return (
+    <Toast text="Help" color="orange" />
+  );
+}

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-single.output.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-single.output.js
@@ -1,0 +1,7 @@
+// @flow
+import React from 'react';
+import { Toast } from 'gestalt';
+
+export default function ToastExample() {
+  return <Toast text="Help" />;
+}

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__tests__/toast-remove-color-icon.test.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__tests__/toast-remove-color-icon.test.js
@@ -1,0 +1,20 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../toast-remove-color-icon', () => {
+  return Object.assign(require.requireActual('../toast-remove-color-icon'), {
+    parser: 'flow',
+  });
+});
+
+describe('toast-remove-color-icon', () => {
+  ['toast-remove-color-icon-both', 'toast-remove-color-icon-single'].forEach(
+    test => {
+      defineTest(
+        __dirname,
+        'toast-remove-color-icon',
+        { quote: 'single' },
+        test
+      );
+    }
+  );
+});

--- a/packages/gestalt-codemods/1.22.0-1.23.0/toast-remove-color-icon.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/toast-remove-color-icon.js
@@ -1,0 +1,67 @@
+/**
+ * Converts
+ *  <Toast text="Help" color="orange" icon="arrow-circle-forward" />
+ * to
+ *  <Toast text="Help" />
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return;
+    }
+    const specifier = decl.specifiers.find(
+      node => node.imported.name === 'Toast'
+    );
+    if (!specifier) {
+      return;
+    }
+    localIdentifierName = specifier.local.name;
+  });
+
+  let hasModifications = false;
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach(path => {
+      const { node } = path;
+      if (node.openingElement.name.name !== localIdentifierName) {
+        return;
+      }
+
+      const hasColorAttribute = node.openingElement.attributes.find(
+        attr => attr.name && attr.name.name === 'color'
+      );
+
+      const hasIconAttribute = node.openingElement.attributes.find(
+        attr => attr.name && attr.name.name === 'icon'
+      );
+
+      if (!hasColorAttribute && !hasIconAttribute) {
+        return;
+      }
+
+      node.openingElement.attributes = node.openingElement.attributes
+        .map(attr => {
+          if (
+            attr.name &&
+            (attr.name.name === 'color' || attr.name.name === 'icon')
+          ) {
+            return null;
+          }
+          return attr;
+        })
+        .filter(Boolean);
+
+      j(path).replaceWith(node);
+
+      hasModifications = true;
+    })
+    .toSource();
+
+  return hasModifications ? transform : null;
+}

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -4,83 +4,73 @@ import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Mask from './Mask.js';
 import Text from './Text.js';
-import Icon from './Icon.js';
 
 type Props = {|
-  color?: 'darkGray' | 'orange' | 'red',
-  icon?: 'arrow-circle-forward', // leaving open to additional icons in the future
-  text: string | Array<string>,
+  button?: React.Node,
+  text: string | React.Element<*>,
   thumbnail?: React.Node,
+  thumbnailShape?: 'circle' | 'rectangle' | 'square',
 |};
 
-export default function Toast(props: Props) {
-  const { color = 'darkGray', icon, thumbnail, text } = props;
-
-  let contents;
-  // Confirmation Toasts
-  if (text instanceof Array && text.length > 1) {
-    contents = (
-      <Box xs={{ display: 'flex' }}>
-        <Box xs={{ display: 'flexColumn' }} flex="none" justifyContent="center">
-          {thumbnail ? (
-            <Mask rounding={2} height={48} width={48}>
-              {thumbnail}
-            </Mask>
-          ) : null}
-        </Box>
+export default function Toast({
+  button,
+  text,
+  thumbnail,
+  thumbnailShape = 'square',
+}: Props) {
+  return (
+    <Box marginBottom={3} paddingX={4} maxWidth={360} width="100vw">
+      <Box color="darkGray" fit padding={6} rounding="pill">
         <Box
-          xs={{ display: 'flexColumn' }}
-          justifyContent="center"
-          dangerouslySetInlineStyle={{ __style: { paddingLeft: 10 } }}
+          display="flex"
+          marginLeft={-2}
+          marginRight={-2}
+          alignItems="center"
         >
+          {thumbnail ? (
+            <Box
+              display="flex"
+              flex="none"
+              justifyContent="center"
+              paddingX={2}
+            >
+              <Mask
+                rounding={thumbnailShape === 'circle' ? 'circle' : 2}
+                height={thumbnailShape === 'rectangle' ? 64 : 48}
+                width={48}
+              >
+                {thumbnail}
+              </Mask>
+            </Box>
+          ) : null}
           <Box
-            dangerouslySetInlineStyle={{ __style: { fontWeight: 'normal' } }}
+            display="flex"
+            direction="column"
+            flex="grow"
+            justifyContent="center"
+            paddingX={2}
           >
-            <Text color="white" size="lg">
-              {text[0]}
+            <Text
+              color="white"
+              align={!thumbnail && !button ? 'center' : 'left'}
+            >
+              {text}
             </Text>
           </Box>
-          <Text color="white" size="lg" weight="bold">
-            {text[1]}
-          </Text>
+          {button ? (
+            <Box flex="none" paddingX={2}>
+              {button}
+            </Box>
+          ) : null}
         </Box>
-      </Box>
-    );
-  } else {
-    // Toasts as Guides
-    contents = (
-      <Box
-        xs={{ display: 'flex' }}
-        justifyContent="between"
-        alignItems="center"
-      >
-        <Text color="white" size="lg" weight="bold">
-          {text}
-        </Text>
-        {icon && (
-          <Box dangerouslySetInlineStyle={{ __style: { paddingLeft: 24 } }}>
-            <Icon accessibilityLabel="" color="white" icon={icon} size={36} />
-          </Box>
-        )}
-      </Box>
-    );
-  }
-
-  return (
-    <Box marginBottom={3} paddingX={4} maxWidth={376} width="100vw">
-      <Box color={color} fit paddingX={8} paddingY={5} rounding="pill">
-        {contents}
       </Box>
     </Box>
   );
 }
 
 Toast.propTypes = {
-  color: PropTypes.oneOf(['darkGray', 'orange', 'red']),
-  icon: PropTypes.oneOf(['arrow-circle-forward']), // leaving open to additional icons in the future
-  text: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
-  ]).isRequired,
+  button: PropTypes.node,
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   thumbnail: PropTypes.node,
+  thumbnailShape: PropTypes.oneOf(['circle', 'rectangle', 'square']),
 };

--- a/packages/gestalt/src/Toast.test.js
+++ b/packages/gestalt/src/Toast.test.js
@@ -1,33 +1,60 @@
 // @flow
 import React from 'react';
 import { create } from 'react-test-renderer';
+import Button from './Button.js';
+import Link from './Link.js';
 import Toast from './Toast.js';
 
-test('Confirmation Toast', () => {
-  const tree = create(
-    <Toast
-      text={['Saved to', 'Home decor']}
-      thumbnail={
-        <img
-          alt=""
-          src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
-        />
-      }
-    />
-  ).toJSON();
-  expect(tree).toMatchSnapshot();
-});
+describe('<Toast />', () => {
+  test('Text Only', () => {
+    const tree = create(
+      <Toast text="Same great profile, slightly new look. Learn more?" />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Guide Toast', () => {
-  const tree = create(
-    <Toast text="Same great profile, slightly new look. Learn more?" />
-  ).toJSON();
-  expect(tree).toMatchSnapshot();
-});
+  test('Text + Image', () => {
+    const tree = create(
+      <Toast
+        thumbnail={
+          <img
+            alt=""
+            src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+          />
+        }
+        text={
+          <>
+            Saved to{' '}
+            <Link href="https://www.pinterest.com/search/pins/?q=home%20decor">
+              Home decor
+            </Link>
+          </>
+        }
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-test('Error Toast', () => {
-  const tree = create(
-    <Toast color="red" text="Oops, we couldn't find that!" />
-  ).toJSON();
-  expect(tree).toMatchSnapshot();
+  test('Text + Image + Button', () => {
+    const tree = create(
+      <Toast
+        thumbnail={
+          <img
+            alt=""
+            src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+          />
+        }
+        text={
+          <>
+            Saved to{' '}
+            <Link href="https://www.pinterest.com/search/pins/?q=home%20decor">
+              Home decor
+            </Link>
+          </>
+        }
+        button={<Button size="lg" text="Undo" />}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Confirmation Toast 1`] = `
+exports[`<Toast /> Text + Image + Button 1`] = `
 <div
   className="box marginBottom3 paddingX4"
   style={
     Object {
-      "maxWidth": 376,
+      "maxWidth": 360,
       "width": "100vw",
     }
   }
 >
   <div
-    className="box darkGrayBg fit paddingX8 paddingY5 pill"
+    className="box darkGrayBg fit paddingX6 paddingY6 pill"
   >
     <div
-      className="box xsDirectionRow xsDisplayFlex"
+      className="box itemsCenter marginLeftN2 marginRightN2 xsDisplayFlex"
     >
       <div
-        className="box flexNone justifyCenter xsDirectionColumn xsDisplayFlex"
+        className="box flexNone justifyCenter paddingX2 xsDisplayFlex"
       >
         <div
           className="Mask rounding2 willChangeTransform"
@@ -35,31 +35,100 @@ exports[`Confirmation Toast 1`] = `
         </div>
       </div>
       <div
-        className="box justifyCenter xsDirectionColumn xsDisplayFlex"
-        style={
-          Object {
-            "paddingLeft": 10,
-          }
-        }
+        className="box flexGrow justifyCenter paddingX2 xsDirectionColumn xsDisplayFlex"
       >
         <div
-          className="box"
+          className="Text fontSize3 white alignLeft breakWord fontWeightNormal"
+        >
+          Saved to
+           
+          <a
+            className="link accessibleFocusStyle block"
+            href="https://www.pinterest.com/search/pins/?q=home%20decor"
+            onClick={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            rel={null}
+            target={null}
+          >
+            Home decor
+          </a>
+        </div>
+      </div>
+      <div
+        className="box flexNone paddingX2"
+      >
+        <button
+          className="button lg solid gray enabled block"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <div
+            className="Text fontSize3 darkGray alignCenter fontWeightBold"
+          >
+            Undo
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Toast /> Text + Image 1`] = `
+<div
+  className="box marginBottom3 paddingX4"
+  style={
+    Object {
+      "maxWidth": 360,
+      "width": "100vw",
+    }
+  }
+>
+  <div
+    className="box darkGrayBg fit paddingX6 paddingY6 pill"
+  >
+    <div
+      className="box itemsCenter marginLeftN2 marginRightN2 xsDisplayFlex"
+    >
+      <div
+        className="box flexNone justifyCenter paddingX2 xsDisplayFlex"
+      >
+        <div
+          className="Mask rounding2 willChangeTransform"
           style={
             Object {
-              "fontWeight": "normal",
+              "height": 48,
+              "width": 48,
             }
           }
         >
-          <div
-            className="Text fontSize3 white alignLeft breakWord fontWeightNormal"
-          >
-            Saved to
-          </div>
+          <img
+            alt=""
+            src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+          />
         </div>
+      </div>
+      <div
+        className="box flexGrow justifyCenter paddingX2 xsDirectionColumn xsDisplayFlex"
+      >
         <div
-          className="Text fontSize3 white alignLeft breakWord fontWeightBold"
+          className="Text fontSize3 white alignLeft breakWord fontWeightNormal"
         >
-          Home decor
+          Saved to
+           
+          <a
+            className="link accessibleFocusStyle block"
+            href="https://www.pinterest.com/search/pins/?q=home%20decor"
+            onClick={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            rel={null}
+            target={null}
+          >
+            Home decor
+          </a>
         </div>
       </div>
     </div>
@@ -67,52 +136,30 @@ exports[`Confirmation Toast 1`] = `
 </div>
 `;
 
-exports[`Error Toast 1`] = `
+exports[`<Toast /> Text Only 1`] = `
 <div
   className="box marginBottom3 paddingX4"
   style={
     Object {
-      "maxWidth": 376,
+      "maxWidth": 360,
       "width": "100vw",
     }
   }
 >
   <div
-    className="box fit paddingX8 paddingY5 pill redBg"
+    className="box darkGrayBg fit paddingX6 paddingY6 pill"
   >
     <div
-      className="box itemsCenter justifyBetween xsDirectionRow xsDisplayFlex"
+      className="box itemsCenter marginLeftN2 marginRightN2 xsDisplayFlex"
     >
       <div
-        className="Text fontSize3 white alignLeft breakWord fontWeightBold"
+        className="box flexGrow justifyCenter paddingX2 xsDirectionColumn xsDisplayFlex"
       >
-        Oops, we couldn't find that!
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Guide Toast 1`] = `
-<div
-  className="box marginBottom3 paddingX4"
-  style={
-    Object {
-      "maxWidth": 376,
-      "width": "100vw",
-    }
-  }
->
-  <div
-    className="box darkGrayBg fit paddingX8 paddingY5 pill"
-  >
-    <div
-      className="box itemsCenter justifyBetween xsDirectionRow xsDisplayFlex"
-    >
-      <div
-        className="Text fontSize3 white alignLeft breakWord fontWeightBold"
-      >
-        Same great profile, slightly new look. Learn more?
+        <div
+          className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
+        >
+          Same great profile, slightly new look. Learn more?
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Also changes:
* Codemod to remove `color` and `icon`
* Combinations cards: easily see the different variations for a `<Toast />` component.
* Add `fullWidth` and `showValues` option to `<Combination />`
* `xs={{ display: 'flex' }}` syntax on `<Box />` with `display="flex"`

## Before / After
  | Before | After
-- | -- | --
Button | (does not exist) | (added)
Color | ‘orange’ \| ‘blue’ \| ‘darkGray’ | ‘darkGray’
Icon | (exists) | (removed)
Padding (inside) | 20px / 32px | 24px
Thumbnail Shape | ‘square’ | ‘circle’ \| ‘rectangle’ \| ‘square’ (default)
Width | 376px | 360px

## Combinations
![Screen Shot 2020-03-18 at 9 20 42 AM](https://user-images.githubusercontent.com/127199/76986584-1666b380-68ff-11ea-981d-df7af837cc01.png)
