### PR TITLE
SelectList: Update wrapper rounding

### DIFF
--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -142,12 +142,11 @@ export default class SelectList extends React.Component<Props, State> {
             ref={this.setSelectListRef}
             value={value}
           >
-            {placeholder &&
-              !value && (
-                <option selected disabled value hidden>
-                  {placeholder}
-                </option>
-              )}
+            {placeholder && !value && (
+              <option selected disabled value hidden>
+                {placeholder}
+              </option>
+            )}
             {options.map(option => (
               <option key={option.value} value={option.value}>
                 {option.label}

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -107,9 +107,9 @@ export default class SelectList extends React.Component<Props, State> {
         {label && <FormLabel id={id} label={label} />}
         <Box
           color={disabled ? 'lightGray' : 'white'}
-          dangerouslySetInlineStyle={{ __style: { borderRadius: 4 } }}
           display="flex"
           position="relative"
+          rounding={4}
           width="100%"
         >
           <Box
@@ -142,11 +142,12 @@ export default class SelectList extends React.Component<Props, State> {
             ref={this.setSelectListRef}
             value={value}
           >
-            {placeholder && !value && (
-              <option selected disabled value hidden>
-                {placeholder}
-              </option>
-            )}
+            {placeholder &&
+              !value && (
+                <option selected disabled value hidden>
+                  {placeholder}
+                </option>
+              )}
             {options.map(option => (
               <option key={option.value} value={option.value}>
                 {option.label}

--- a/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
@@ -5,10 +5,9 @@ exports[`SelectList SelectList normal 1`] = `
   className="box"
 >
   <div
-    className="box relative whiteBg xsDisplayFlex"
+    className="box relative rounding4 whiteBg xsDisplayFlex"
     style={
       Object {
-        "borderRadius": 4,
         "width": "100%",
       }
     }


### PR DESCRIPTION
Fixes SelectList wrapper Box rounding bug. 

Before:
<img width="576" alt="Screen Shot 2020-03-19 at 11 07 08 AM" src="https://user-images.githubusercontent.com/159645/77099868-e76d4200-69d1-11ea-809a-4ab52ae8a350.png">

After:
<img width="578" alt="Screen Shot 2020-03-19 at 11 06 38 AM" src="https://user-images.githubusercontent.com/159645/77099886-eb995f80-69d1-11ea-99fd-fcdf003585ee.png">

