### PR TITLE
Version bump: v1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 1.23.0 (Mar 20, 2020)
+
+### Minor
+
 - Toast: Update design + remove icon/color + add thumbnailShape/button (#755)
 
 Run codemods:
 `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.22.0-1.23.0/toast-remove-color-icon.js ~/code/repo`
-
-### Patch
-
-</details>
 
 ## 1.22.1 (Mar 19, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.23.0 (Mar 20, 2020)

### Minor

- Toast: Update design + remove icon/color + add thumbnailShape/button (#755)

Run codemods:
`cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.22.0-1.23.0/toast-remove-color-icon.js ~/code/repo`