### PR TITLE
SelectList: Refactor placeholder for better React support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor
 
 ### Patch
+- SelectList: Remove selected prop from the placeholder option tag for better React support (#759)
 
 </details>
 

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -102,6 +102,8 @@ export default class SelectList extends React.Component<Props, State> {
       size === 'md' ? layout.medium : layout.large
     );
 
+    const showPlaceholder = placeholder && !value;
+
     return (
       <Box>
         {label && <FormLabel id={id} label={label} />}
@@ -140,10 +142,10 @@ export default class SelectList extends React.Component<Props, State> {
             onBlur={this.handleOnChange}
             onChange={this.handleOnChange}
             ref={this.setSelectListRef}
-            value={value}
+            value={showPlaceholder ? placeholder : value}
           >
-            {placeholder && !value && (
-              <option selected disabled value hidden>
+            {showPlaceholder && (
+              <option disabled value={placeholder} hidden>
                 {placeholder}
               </option>
             )}

--- a/packages/gestalt/src/SelectList.test.js
+++ b/packages/gestalt/src/SelectList.test.js
@@ -30,6 +30,20 @@ describe('SelectList', () => {
     expect(JSON.stringify(component.toJSON())).not.toContain('Error message');
   });
 
+  it('Renders a hidden, disabled placeholder option if placeholder prop is passed', () => {
+    const component = create(
+      <SelectList
+        id="test"
+        onChange={jest.fn()}
+        options={options}
+        placeholder="Placeholder text"
+      />
+    );
+    expect(
+      component.root.findByProps({ hidden: true, disabled: true }).children
+    ).toEqual(['Placeholder text']);
+  });
+
   it('SelectList normal', () => {
     const tree = create(
       <SelectList id="test" onChange={jest.fn()} options={options} />


### PR DESCRIPTION
React warns against using "selected" prop directly on an "option". We currently only use "selected" for the placeholder feature.
This change removes "selected" and instead uses "value" prop when a placeholder is used.