### PR TITLE
Toast: add back the color red as a deprecated feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Patch
 
+- Toast: add back the color `red` as a deprecated feature (#760)
+
 </details>
 
 ## 1.23.0 (Mar 20, 2020)

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -7,6 +7,7 @@ import Text from './Text.js';
 
 type Props = {|
   button?: React.Node,
+  color?: 'darkGray' | 'red',
   text: string | React.Element<*>,
   thumbnail?: React.Node,
   thumbnailShape?: 'circle' | 'rectangle' | 'square',
@@ -14,13 +15,14 @@ type Props = {|
 
 export default function Toast({
   button,
+  color = 'darkGray',
   text,
   thumbnail,
   thumbnailShape = 'square',
 }: Props) {
   return (
     <Box marginBottom={3} paddingX={4} maxWidth={360} width="100vw">
-      <Box color="darkGray" fit padding={6} rounding="pill">
+      <Box color={color} fit padding={6} rounding="pill">
         <Box
           display="flex"
           marginLeft={-2}

--- a/packages/gestalt/src/Toast.test.js
+++ b/packages/gestalt/src/Toast.test.js
@@ -13,6 +13,16 @@ describe('<Toast />', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('Red Toast', () => {
+    const tree = create(
+      <Toast
+        color="red"
+        text="Same great profile, slightly new look. Learn more?"
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('Text + Image', () => {
     const tree = create(
       <Toast

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Toast /> Red Toast 1`] = `
+<div
+  className="box marginBottom3 paddingX4"
+  style={
+    Object {
+      "maxWidth": 360,
+      "width": "100vw",
+    }
+  }
+>
+  <div
+    className="box fit paddingX6 paddingY6 pill redBg"
+  >
+    <div
+      className="box itemsCenter marginLeftN2 marginRightN2 xsDisplayFlex"
+    >
+      <div
+        className="box flexGrow justifyCenter paddingX2 xsDirectionColumn xsDisplayFlex"
+      >
+        <div
+          className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
+        >
+          Same great profile, slightly new look. Learn more?
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Toast /> Text + Image + Button 1`] = `
 <div
   className="box marginBottom3 paddingX4"


### PR DESCRIPTION
We removed the color option on `Toast` in #755. This was a breaking change and it is a bad user experience to suddenly see errors as success messages.

We are add just the color `red` back in and will leave it undocumented as a deprecated feature.