### PR TITLE
Version bump: 1.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Patch
 
-- Toast: add back the color `red` as a deprecated feature (#760)
-
 </details>
+
+## 1.23.1 (Mar 20, 2020)
+
+### Patch
+
+- Toast: add back the color `red` as a deprecated feature (#760)
 
 ## 1.23.0 (Mar 20, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.23.1 (Mar 20, 2020)

### Patch

- Toast: add back the color `red` as a deprecated feature (#760)