### PR TITLE
Toast: Fix color proptypes

### DIFF
--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -72,6 +72,7 @@ export default function Toast({
 
 Toast.propTypes = {
   button: PropTypes.node,
+  color: PropTypes.oneOf(['darkGray', 'red']),
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   thumbnail: PropTypes.node,
   thumbnailShape: PropTypes.oneOf(['circle', 'rectangle', 'square']),


### PR DESCRIPTION
Added the `color` option back to `Toast` in #760 but forgot to update the propTypes.