### PR TITLE
Version bump: 1.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 </details>
 
+## 1.23.2 (Mar 20, 2020)
+
+### Patch
+
+- Toast: Fix color proptypes (#762)
+
 ## 1.23.1 (Mar 20, 2020)
 
 ### Patch

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.23.2 (Mar 20, 2020)

### Patch

- Toast: Fix color proptypes (#762)