### PR TITLE
Text/Heading: Update letter spacing to default (normal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Text/Heading: Update letter spacing to default (normal) (#764)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/Badge.css
+++ b/packages/gestalt/src/Badge.css
@@ -1,5 +1,5 @@
 .Badge {
-  composes: antialiased sansSerif letterSpacing from "./Typography.css";
+  composes: antialiased sansSerif from "./Typography.css";
   composes: fontWeightBold from "./Typography.css";
   composes: blue from "./Colors.css";
   composes: inlineBlock from "./Layout.css";

--- a/packages/gestalt/src/Heading.css
+++ b/packages/gestalt/src/Heading.css
@@ -5,7 +5,7 @@
 }
 
 .Heading {
-  composes: antialiased sansSerif letterSpacing from "./Typography.css";
+  composes: antialiased sansSerif from "./Typography.css";
   margin-bottom: 0;
   margin-top: 0;
 }

--- a/packages/gestalt/src/Text.css
+++ b/packages/gestalt/src/Text.css
@@ -5,7 +5,7 @@
 }
 
 .Text {
-  composes: antialiased sansSerif letterSpacing from "./Typography.css";
+  composes: antialiased sansSerif from "./Typography.css";
 }
 
 .fontSize1 {

--- a/packages/gestalt/src/Typography.css
+++ b/packages/gestalt/src/Typography.css
@@ -24,12 +24,6 @@
   quotes: "「" "」";
 }
 
-/* kerning */
-
-.letterSpacing {
-  letter-spacing: -0.4px;
-}
-
 /* leading */
 
 .leadingShort {

--- a/packages/gestalt/src/Typography.css.flow
+++ b/packages/gestalt/src/Typography.css.flow
@@ -13,7 +13,6 @@ declare module.exports: {|
   +'fontWeightNormal': string,
   +'leadingShort': string,
   +'leadingTall': string,
-  +'letterSpacing': string,
   +'noUnderline': string,
   +'sansSerif': string,
   +'truncate': string,


### PR DESCRIPTION
We ramped experiments on pinterest.com to 100% to set the letter spacing back to the default, which is `normal`. This improves readability and i18n support (no more overlapping)

![Screen Shot 2020-02-24 at 10 26 35 AM](https://user-images.githubusercontent.com/127199/75180095-57005200-56f0-11ea-92f3-6c8db573bc0d.png)
![Screen Shot 2020-02-24 at 10 26 52 AM](https://user-images.githubusercontent.com/127199/75180100-58ca1580-56f0-11ea-8be5-53bd056e9182.png)
