### PR TITLE
Version bump: 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ### Minor
 
-- Text/Heading: Update letter spacing to default (normal) (#764)
-
 ### Patch
 
 </details>
+
+## 1.24.0 (Mar 23, 2020)
+
+### Minor
+
+- Text/Heading: Update letter spacing to default (normal) (#764)
 
 ## 1.23.2 (Mar 20, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.23.2",
+  "version": "1.24.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.24.0 (Mar 23, 2020)

### Minor

- Text/Heading: Update letter spacing to default (normal) (#764)