### PR TITLE
Avatar/GroupAvatar: update sizes / default avatar / remove verified outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Avatar/GroupAvatar: update sizes / default avatar / remove verified outline
+
 ### Patch
 
 </details>

--- a/docs/src/Avatar.doc.js
+++ b/docs/src/Avatar.doc.js
@@ -30,9 +30,10 @@ card(
       },
       {
         name: 'size',
-        type: `"sm" | "md" | "lg"`,
+        type: `"xs" | "sm" | "md" | "lg" | "xl" | "fit"`,
+        defaultValue: 'fit',
         description:
-          'sm: 24px, md: 40px, lg: 72px. If size is undefined, Avatar will fill 100% of the parent container width',
+          'xs: 24px, sm: 32px, md: 48px, lg: 64px, xl: 120px. If size is `fit`, Avatar will fill 100% of the parent container width',
       },
       {
         name: 'src',
@@ -43,12 +44,6 @@ card(
         type: 'boolean',
         defaultValue: false,
       },
-      {
-        name: 'icon',
-        type: '"check-circle" | "pinterest"',
-        defaultValue: 'check-circle',
-        description: 'This is the icon shown only when "verified=true"',
-      },
     ]}
   />
 );
@@ -56,15 +51,47 @@ card(
 card(
   <Example
     description={`
-    There are 3 sizes you can choose for an \`Avatar\`. For certain designs you may need a container-based size. More information on that option is below.
+    There are 5 sizes you can choose for an \`Avatar\`. For certain designs you may need a container-based size. More information on that option is below.
   `}
     name="Fixed Sizes"
     defaultCode={`
-<Avatar
-  size="md"
-  src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
-  name="Keerthi"
-/>
+<Box display="flex" direction="row" marginLeft={-2} marginRight={-2} wrap>
+  <Box paddingX={2}>
+    <Avatar
+      size="xs"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+  </Box>
+  <Box paddingX={2}>
+    <Avatar
+      size="sm"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+  </Box>
+  <Box paddingX={2}>
+    <Avatar
+      size="md"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+  </Box>
+  <Box paddingX={2}>
+    <Avatar
+      size="lg"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+  </Box>
+  <Box paddingX={2}>
+    <Avatar
+      size="xl"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+  </Box>
+</Box>
 `}
   />
 );
@@ -128,22 +155,4 @@ card(
   />
 );
 
-card(
-  <Example
-    description={`
-    We can also changed the \`verified\` icon to the Pinterest logo by setting the
-    \`icon\` prop to \`pinterest\`.
-  `}
-    name="Verified"
-    defaultCode={`
-<Avatar
-  icon="pinterest"
-  name="Shanice"
-  size="lg"
-  src="https://i.ibb.co/7tGKGvb/shanice.jpg"
-  verified
-/>
-  `}
-  />
-);
 export default cards;

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -33,9 +33,10 @@ card(
       },
       {
         name: 'size',
-        type: `"sm" | "md" | "lg"`,
+        type: `"xs" | "sm" | "md" | "lg" | "xl" | "fit"`,
+        defaultValue: 'fit',
         description:
-          'sm: 24px, md: 40px, lg: 72px. If size is undefined, Avatar will fill 100% of the parent container width',
+          'xs: 24px, sm: 32px, md: 48px, lg: 64px, xl: 120px. If size is `fit`, GroupAvatar will fill 100% of the parent container width',
       },
     ]}
   />
@@ -78,19 +79,28 @@ card(
 );
 
 card(
-  <Combination name="Size Combinations: 1 Person" size={['sm', 'md', 'lg']}>
+  <Combination
+    name="Size Combinations: 1 Person"
+    size={['xs', 'sm', 'md', 'lg', 'xl']}
+  >
     {props => <GroupAvatar collaborators={[user1]} {...props} />}
   </Combination>
 );
 
 card(
-  <Combination name="Size Combinations: 2 People" size={['sm', 'md', 'lg']}>
+  <Combination
+    name="Size Combinations: 2 People"
+    size={['xs', 'sm', 'md', 'lg', 'xl']}
+  >
     {props => <GroupAvatar collaborators={[user1, user3]} {...props} />}
   </Combination>
 );
 
 card(
-  <Combination name="Size Combinations: 3 People" size={['sm', 'md', 'lg']}>
+  <Combination
+    name="Size Combinations: 3 People"
+    size={['xs', 'sm', 'md', 'lg', 'xl']}
+  >
     {props => <GroupAvatar collaborators={[user1, user3, user2]} {...props} />}
   </Combination>
 );

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/.eslintrc.json
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "prettier/prettier": "off",
+    "no-undef": "off",
+    "no-unused-vars": "off",
+    "react/jsx-no-undef": "off"
+  }
+}

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.input.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.input.js
@@ -1,0 +1,18 @@
+// @flow
+import React from 'react';
+import { Avatar } from 'gestalt';
+
+export default function Example() {
+  return <>
+    <Avatar
+      size="sm"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+    <Avatar
+      size="md"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+  </>;
+}

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.output.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.output.js
@@ -1,0 +1,18 @@
+// @flow
+import React from 'react';
+import { Avatar } from 'gestalt';
+
+export default function Example() {
+  return <>
+    <Avatar
+      size="xs"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+    <Avatar
+      size="sm"
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      name="Keerthi"
+    />
+  </>;
+}

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.input.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.input.js
@@ -1,0 +1,34 @@
+// @flow
+import React from 'react';
+import { GroupAvatar } from 'gestalt';
+
+export default function Example() {
+  return <>
+    <GroupAvatar
+      collaborators={[
+        {
+          name: 'Keerthi',
+          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+        },
+        {
+          name: 'Shanice',
+          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+        },
+      ]}
+      size="sm"
+    />
+    <GroupAvatar
+      collaborators={[
+        {
+          name: 'Keerthi',
+          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+        },
+        {
+          name: 'Shanice',
+          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+        },
+      ]}
+      size="md"
+    />
+  </>;
+}

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.output.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.output.js
@@ -1,0 +1,34 @@
+// @flow
+import React from 'react';
+import { GroupAvatar } from 'gestalt';
+
+export default function Example() {
+  return <>
+    <GroupAvatar
+      collaborators={[
+        {
+          name: 'Keerthi',
+          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+        },
+        {
+          name: 'Shanice',
+          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+        },
+      ]}
+      size="xs"
+    />
+    <GroupAvatar
+      collaborators={[
+        {
+          name: 'Keerthi',
+          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+        },
+        {
+          name: 'Shanice',
+          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+        },
+      ]}
+      size="sm"
+    />
+  </>;
+}

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-icon.input.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-icon.input.js
@@ -1,0 +1,14 @@
+// @flow
+import React from 'react';
+import { Avatar } from 'gestalt';
+
+export default function Example() {
+  return (
+    <Avatar
+      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+      verified
+      icon="pinterest"
+      name="Keerthi"
+    />
+  );
+}

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-icon.output.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-icon.output.js
@@ -1,0 +1,7 @@
+// @flow
+import React from 'react';
+import { Avatar } from 'gestalt';
+
+export default function Example() {
+  return <Avatar src="https://i.ibb.co/ZfCZrY8/keerthi.jpg" verified name="Keerthi" />;
+}

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__tests__/avatar-update-sizes-remove-icon.test.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__tests__/avatar-update-sizes-remove-icon.test.js
@@ -1,0 +1,25 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../avatar-update-sizes-remove-icon', () => {
+  return Object.assign(
+    require.requireActual('../avatar-update-sizes-remove-icon'),
+    {
+      parser: 'flow',
+    }
+  );
+});
+
+describe('avatar-update-sizes-remove-icon', () => {
+  [
+    'avatar-update-sizes-remove-icon-avatar',
+    'avatar-update-sizes-remove-icon-icon',
+    'avatar-update-sizes-remove-icon-groupavatar',
+  ].forEach(test => {
+    defineTest(
+      __dirname,
+      'avatar-update-sizes-remove-icon',
+      { quote: 'single' },
+      test
+    );
+  });
+});

--- a/packages/gestalt-codemods/1.26.0-1.27.0/avatar-update-sizes-remove-icon.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/avatar-update-sizes-remove-icon.js
@@ -1,0 +1,88 @@
+/**
+ * Converts
+ *  <Avatar size="sm" />
+ *  <Avatar size="md" />
+ *  <GroupAvatar size="sm" />
+ *  <GroupAvatar size="md" />
+ *  <Avatar icon="pinterest" />
+ * to
+ *  <Avatar size="xs" />
+ *  <Avatar size="sm" />
+ *  <GroupAvatar size="xs" />
+ *  <GroupAvatar size="sm" />
+ *  <Avatar />
+ */
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierAvatar;
+  let localIdentifierGroupAvatar;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return;
+    }
+    const avatarSpecifier = decl.specifiers.find(
+      node => node.imported.name === 'Avatar'
+    );
+    const groupAvatarSpecifier = decl.specifiers.find(
+      node => node.imported.name === 'GroupAvatar'
+    );
+    if (!avatarSpecifier && !groupAvatarSpecifier) {
+      return;
+    }
+    localIdentifierAvatar = avatarSpecifier?.local.name;
+    localIdentifierGroupAvatar = groupAvatarSpecifier?.local.name;
+  });
+
+  let hasModifications = false;
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach(path => {
+      const { node } = path;
+
+      if (
+        node.openingElement.name.name !== localIdentifierAvatar &&
+        node.openingElement.name.name !== localIdentifierGroupAvatar
+      ) {
+        return;
+      }
+
+      const hasSize = node.openingElement.attributes.find(
+        attr => attr.name && attr.name.name === 'size'
+      );
+      const hasIcon = node.openingElement.attributes.find(
+        attr => attr.name && attr.name.name === 'icon'
+      );
+
+      if (!hasSize && !hasIcon) {
+        return;
+      }
+
+      node.openingElement.attributes = node.openingElement.attributes
+        .map(attr => {
+          if (attr.name && attr.name.name === 'size' && attr.value.value) {
+            if (attr.value.value === 'sm') {
+              return j.jsxAttribute(j.jsxIdentifier('size'), j.literal('xs'));
+            }
+            if (attr.value.value === 'md') {
+              return j.jsxAttribute(j.jsxIdentifier('size'), j.literal('sm'));
+            }
+          }
+          if (attr.name && attr.name.name === 'icon') {
+            return null;
+          }
+          return attr;
+        })
+        .filter(Boolean);
+
+      j(path).replaceWith(node);
+
+      hasModifications = true;
+    })
+    .toSource();
+
+  return hasModifications ? transform : null;
+}

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -22,7 +22,7 @@ const Square = (props: *) => (
 const DefaultAvatar = ({ name }: { name: string }) => {
   const firstInitial = name ? [...name][0].toUpperCase() : '';
   return (
-    <Square color="gray" rounding="circle">
+    <Square color="lightGray" rounding="circle">
       {firstInitial && (
         <svg
           width="100%"
@@ -33,8 +33,8 @@ const DefaultAvatar = ({ name }: { name: string }) => {
         >
           <title>{name}</title>
           <text
-            fontSize="50px"
-            fill="#fff"
+            fontSize="40px"
+            fill="#111"
             dy="0.35em"
             textAnchor="middle"
             className={[
@@ -54,23 +54,24 @@ const DefaultAvatar = ({ name }: { name: string }) => {
 type Props = {|
   name: string,
   outline?: boolean,
-  size?: 'sm' | 'md' | 'lg',
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'fit',
   src?: string,
   verified?: boolean,
-  icon?: 'check-circle' | 'pinterest',
 |};
 
 const sizes = {
-  sm: 24,
-  md: 40,
-  lg: 72,
+  xs: 24,
+  sm: 32,
+  md: 48,
+  lg: 64,
+  xl: 120,
 };
 
 export default function Avatar(props: Props) {
   const [isImageLoaded, setIsImageLoaded] = React.useState(true);
-  const { name, outline, size, src, verified, icon = 'check-circle' } = props;
-  const width = size ? sizes[size] : '100%';
-  const height = size ? sizes[size] : '';
+  const { name, outline, size = 'fit', src, verified } = props;
+  const width = size === 'fit' ? '100%' : sizes[size];
+  const height = size === 'fit' ? '' : sizes[size];
 
   const handleImageError = () => setIsImageLoaded(false);
 
@@ -108,10 +109,10 @@ export default function Avatar(props: Props) {
       {verified && (
         <Box
           position="absolute"
-          width="20%"
-          height="20%"
-          minWidth={8}
-          minHeight={8}
+          width="25%"
+          height="25%"
+          minWidth={12}
+          minHeight={12}
           dangerouslySetInlineStyle={{
             __style: {
               bottom: '4%',
@@ -119,18 +120,13 @@ export default function Avatar(props: Props) {
             },
           }}
         >
-          <Box
-            color="white"
-            width="100%"
-            height="100%"
-            rounding="circle"
-            dangerouslySetInlineStyle={{
-              __style: {
-                boxShadow: '0 0 0 2px #fff',
-              },
-            }}
-          >
-            <Icon color="red" icon={icon} accessibilityLabel="" size="100%" />
+          <Box color="white" width="100%" height="100%" rounding="circle">
+            <Icon
+              color="red"
+              icon="check-circle"
+              accessibilityLabel=""
+              size="100%"
+            />
           </Box>
         </Box>
       )}
@@ -142,6 +138,6 @@ Avatar.propTypes = {
   name: PropTypes.string.isRequired,
   outline: PropTypes.bool,
   src: PropTypes.string,
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', 'fit']),
   verified: PropTypes.bool,
 };

--- a/packages/gestalt/src/Avatar.test.js
+++ b/packages/gestalt/src/Avatar.test.js
@@ -36,6 +36,17 @@ describe('Avatar', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders the correct size - xs', () => {
+    const tree = create(
+      <Avatar
+        name="Strava"
+        src="http://pinterest.com/img/strave.png"
+        size="xs"
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders the correct size - sm', () => {
     const tree = create(
       <Avatar
@@ -69,14 +80,12 @@ describe('Avatar', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders the Pinterest P on verified', () => {
+  it('renders the correct size - xl', () => {
     const tree = create(
       <Avatar
         name="Strava"
         src="http://pinterest.com/img/strave.png"
-        size="md"
-        verified
-        icon="pinterest"
+        size="xs"
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/GroupAvatar.js
+++ b/packages/gestalt/src/GroupAvatar.js
@@ -13,9 +13,11 @@ function zip(a, b) {
 const BORDER_WIDTH = 2;
 
 const AVATAR_SIZES = {
-  sm: 24,
-  md: 40,
-  lg: 72,
+  xs: 24,
+  sm: 32,
+  md: 48,
+  lg: 64,
+  xl: 120,
 };
 
 type Props = {|
@@ -24,7 +26,7 @@ type Props = {|
     src?: string,
   |}>,
   outline?: boolean,
-  size?: 'sm' | 'md' | 'lg',
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'fit',
 |};
 
 const avatarLayout = (n, size) => {
@@ -99,8 +101,8 @@ const DefaultAvatar = (props: {|
     >
       <title>{name}</title>
       <text
-        fontSize="50px"
-        fill="#fff"
+        fontSize="40px"
+        fill="#111"
         dominantBaseline="central"
         textAnchor="middle"
         className={[
@@ -118,7 +120,7 @@ const DefaultAvatar = (props: {|
       return (
         <Box
           aria-label={name}
-          color="gray"
+          color="lightGray"
           height="100%"
           display="flex"
           alignItems="end"
@@ -136,7 +138,7 @@ const DefaultAvatar = (props: {|
       return (
         <Box
           aria-label={name}
-          color="gray"
+          color="lightGray"
           height="100%"
           display="flex"
           alignItems="start"
@@ -154,7 +156,7 @@ const DefaultAvatar = (props: {|
       return (
         <Box
           aria-label={name}
-          color="gray"
+          color="lightGray"
           height="100%"
           display="flex"
           alignItems="center"
@@ -167,9 +169,9 @@ const DefaultAvatar = (props: {|
 };
 
 export default function GroupAvatar(props: Props) {
-  const { collaborators, outline, size } = props;
-  const avatarWidth = size ? AVATAR_SIZES[size] : '100%';
-  const avatarHeight = size ? AVATAR_SIZES[size] : '';
+  const { collaborators, outline, size = 'fit' } = props;
+  const avatarWidth = size === 'fit' ? '100%' : AVATAR_SIZES[size];
+  const avatarHeight = size === 'fit' ? '' : AVATAR_SIZES[size];
   const positions = avatarLayout(collaborators.length, avatarWidth);
   return (
     <Box
@@ -234,5 +236,5 @@ GroupAvatar.propTypes = {
     })
   ).isRequired,
   outline: PropTypes.bool,
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', 'fit']),
 };

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -12,7 +12,7 @@ exports[`Avatar renders an outline 1`] = `
   }
 >
   <div
-    className="box circle grayBg relative"
+    className="box circle lightGrayBg relative"
   >
     <div
       className="box relative"
@@ -38,8 +38,8 @@ exports[`Avatar renders an outline 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dy="0.35em"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           J
@@ -61,7 +61,7 @@ exports[`Avatar renders multi-byte character initials 1`] = `
   }
 >
   <div
-    className="box circle grayBg relative"
+    className="box circle lightGrayBg relative"
   >
     <div
       className="box relative"
@@ -87,95 +87,12 @@ exports[`Avatar renders multi-byte character initials 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dy="0.35em"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           💩
         </text>
-      </svg>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Avatar renders the Pinterest P on verified 1`] = `
-<div
-  className="box circle relative whiteBg"
-  style={
-    Object {
-      "height": 40,
-      "width": 40,
-    }
-  }
->
-  <div
-    className="Mask circle willChangeTransform"
-    style={
-      Object {
-        "height": undefined,
-        "width": undefined,
-      }
-    }
-  >
-    <div
-      className="box relative"
-      style={
-        Object {
-          "backgroundColor": "#EFEFEF",
-          "paddingBottom": "100%",
-        }
-      }
-    >
-      <img
-        alt="Strava"
-        className="img"
-        importance="auto"
-        loading="auto"
-        onError={[Function]}
-        onLoad={[Function]}
-        src="http://pinterest.com/img/strave.png"
-      />
-    </div>
-    <div
-      className="wash"
-    />
-  </div>
-  <div
-    className="absolute box"
-    style={
-      Object {
-        "bottom": "4%",
-        "height": "20%",
-        "minHeight": 8,
-        "minWidth": 8,
-        "right": "4%",
-        "width": "20%",
-      }
-    }
-  >
-    <div
-      className="box circle whiteBg"
-      style={
-        Object {
-          "boxShadow": "0 0 0 2px #fff",
-          "height": "100%",
-          "width": "100%",
-        }
-      }
-    >
-      <svg
-        aria-hidden={true}
-        aria-label=""
-        className="icon red iconBlock"
-        height="100%"
-        role="img"
-        viewBox="0 0 24 24"
-        width="100%"
-      >
-        <path
-          d="test-file-stub"
-        />
       </svg>
     </div>
   </div>
@@ -187,8 +104,8 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
   className="box circle relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
     }
   }
 >
@@ -229,11 +146,11 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
     style={
       Object {
         "bottom": "4%",
-        "height": "20%",
-        "minHeight": 8,
-        "minWidth": 8,
+        "height": "25%",
+        "minHeight": 12,
+        "minWidth": 12,
         "right": "4%",
-        "width": "20%",
+        "width": "25%",
       }
     }
   >
@@ -241,7 +158,6 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
       className="box circle whiteBg"
       style={
         Object {
-          "boxShadow": "0 0 0 2px #fff",
           "height": "100%",
           "width": "100%",
         }
@@ -270,8 +186,8 @@ exports[`Avatar renders the correct size - lg 1`] = `
   className="box circle relative whiteBg"
   style={
     Object {
-      "height": 72,
-      "width": 72,
+      "height": 64,
+      "width": 64,
     }
   }
 >
@@ -315,8 +231,8 @@ exports[`Avatar renders the correct size - md 1`] = `
   className="box circle relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
     }
   }
 >
@@ -356,6 +272,96 @@ exports[`Avatar renders the correct size - md 1`] = `
 `;
 
 exports[`Avatar renders the correct size - sm 1`] = `
+<div
+  className="box circle relative whiteBg"
+  style={
+    Object {
+      "height": 32,
+      "width": 32,
+    }
+  }
+>
+  <div
+    className="Mask circle willChangeTransform"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="box relative"
+      style={
+        Object {
+          "backgroundColor": "#EFEFEF",
+          "paddingBottom": "100%",
+        }
+      }
+    >
+      <img
+        alt="Strava"
+        className="img"
+        importance="auto"
+        loading="auto"
+        onError={[Function]}
+        onLoad={[Function]}
+        src="http://pinterest.com/img/strave.png"
+      />
+    </div>
+    <div
+      className="wash"
+    />
+  </div>
+</div>
+`;
+
+exports[`Avatar renders the correct size - xl 1`] = `
+<div
+  className="box circle relative whiteBg"
+  style={
+    Object {
+      "height": 24,
+      "width": 24,
+    }
+  }
+>
+  <div
+    className="Mask circle willChangeTransform"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="box relative"
+      style={
+        Object {
+          "backgroundColor": "#EFEFEF",
+          "paddingBottom": "100%",
+        }
+      }
+    >
+      <img
+        alt="Strava"
+        className="img"
+        importance="auto"
+        loading="auto"
+        onError={[Function]}
+        onLoad={[Function]}
+        src="http://pinterest.com/img/strave.png"
+      />
+    </div>
+    <div
+      className="wash"
+    />
+  </div>
+</div>
+`;
+
+exports[`Avatar renders the correct size - xs 1`] = `
 <div
   className="box circle relative whiteBg"
   style={
@@ -456,7 +462,7 @@ exports[`Avatar renders the verified icon 1`] = `
   }
 >
   <div
-    className="box circle grayBg relative"
+    className="box circle lightGrayBg relative"
   >
     <div
       className="box relative"
@@ -482,8 +488,8 @@ exports[`Avatar renders the verified icon 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dy="0.35em"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           J
@@ -496,11 +502,11 @@ exports[`Avatar renders the verified icon 1`] = `
     style={
       Object {
         "bottom": "4%",
-        "height": "20%",
-        "minHeight": 8,
-        "minWidth": 8,
+        "height": "25%",
+        "minHeight": 12,
+        "minWidth": 12,
         "right": "4%",
-        "width": "20%",
+        "width": "25%",
       }
     }
   >
@@ -508,7 +514,6 @@ exports[`Avatar renders the verified icon 1`] = `
       className="box circle whiteBg"
       style={
         Object {
-          "boxShadow": "0 0 0 2px #fff",
           "height": "100%",
           "width": "100%",
         }
@@ -543,7 +548,7 @@ exports[`Avatar renders with an empty name 1`] = `
   }
 >
   <div
-    className="box circle grayBg relative"
+    className="box circle lightGrayBg relative"
   >
     <div
       className="box relative"

--- a/packages/gestalt/src/__snapshots__/GroupAvatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/GroupAvatar.test.js.snap
@@ -6,8 +6,8 @@ exports[`GroupAvatar renders an outline 1`] = `
   style={
     Object {
       "boxShadow": "0 0 0 2px #fff",
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -24,7 +24,7 @@ exports[`GroupAvatar renders an outline 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
         "width": "calc(50% - 1px)",
@@ -50,7 +50,7 @@ exports[`GroupAvatar renders an outline 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": "calc(50% + 1px)",
         "top": 0,
         "width": "calc(50% - 1px)",
@@ -80,8 +80,8 @@ exports[`GroupAvatar renders avatars for 0 people 1`] = `
   className="box circle overflowHidden relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -98,16 +98,16 @@ exports[`GroupAvatar renders avatars for 0 people 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
-        "width": 40,
+        "width": 48,
       }
     }
   >
     <div
       aria-label=""
-      className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
+      className="box itemsCenter justifyCenter lightGrayBg xsDisplayFlex"
       style={
         Object {
           "height": "100%",
@@ -127,8 +127,8 @@ exports[`GroupAvatar renders avatars for 0 people 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dominantBaseline="central"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           
@@ -147,8 +147,8 @@ exports[`GroupAvatar renders avatars for 1 person 1`] = `
   className="box circle overflowHidden relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -165,10 +165,10 @@ exports[`GroupAvatar renders avatars for 1 person 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
-        "width": 40,
+        "width": 48,
       }
     }
   >
@@ -195,8 +195,8 @@ exports[`GroupAvatar renders avatars for 2 people 1`] = `
   className="box circle overflowHidden relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -213,7 +213,7 @@ exports[`GroupAvatar renders avatars for 2 people 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
         "width": "calc(50% - 1px)",
@@ -239,7 +239,7 @@ exports[`GroupAvatar renders avatars for 2 people 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": "calc(50% + 1px)",
         "top": 0,
         "width": "calc(50% - 1px)",
@@ -269,8 +269,8 @@ exports[`GroupAvatar renders avatars for 3 people 1`] = `
   className="box circle overflowHidden relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -287,7 +287,7 @@ exports[`GroupAvatar renders avatars for 3 people 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
         "width": "calc(50% - 1px)",
@@ -369,8 +369,8 @@ exports[`GroupAvatar renders avatars for more than 3 AVATAR_SIZES 1`] = `
   className="box circle overflowHidden relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -387,7 +387,7 @@ exports[`GroupAvatar renders avatars for more than 3 AVATAR_SIZES 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
         "width": "calc(50% - 1px)",
@@ -469,8 +469,8 @@ exports[`GroupAvatar renders multi-byte character initials 1`] = `
   className="box circle overflowHidden relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -487,16 +487,16 @@ exports[`GroupAvatar renders multi-byte character initials 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
-        "width": 40,
+        "width": 48,
       }
     }
   >
     <div
       aria-label="💩 astral"
-      className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
+      className="box itemsCenter justifyCenter lightGrayBg xsDisplayFlex"
       style={
         Object {
           "height": "100%",
@@ -516,8 +516,8 @@ exports[`GroupAvatar renders multi-byte character initials 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dominantBaseline="central"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           💩
@@ -536,8 +536,8 @@ exports[`GroupAvatar renders single-byte character initials for 1 person 1`] = `
   className="box circle overflowHidden relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -554,16 +554,16 @@ exports[`GroupAvatar renders single-byte character initials for 1 person 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
-        "width": 40,
+        "width": 48,
       }
     }
   >
     <div
       aria-label="Jane Smith"
-      className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
+      className="box itemsCenter justifyCenter lightGrayBg xsDisplayFlex"
       style={
         Object {
           "height": "100%",
@@ -583,8 +583,8 @@ exports[`GroupAvatar renders single-byte character initials for 1 person 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dominantBaseline="central"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           J
@@ -603,8 +603,8 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
   className="box circle overflowHidden relative whiteBg"
   style={
     Object {
-      "height": 40,
-      "width": 40,
+      "height": 48,
+      "width": 48,
       "willChange": "transform",
     }
   }
@@ -621,7 +621,7 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
     className="absolute box"
     style={
       Object {
-        "height": 40,
+        "height": 48,
         "left": 0,
         "top": 0,
         "width": "calc(50% - 1px)",
@@ -630,7 +630,7 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
   >
     <div
       aria-label="Jane Smith"
-      className="box grayBg itemsCenter justifyCenter xsDisplayFlex"
+      className="box itemsCenter justifyCenter lightGrayBg xsDisplayFlex"
       style={
         Object {
           "height": "100%",
@@ -650,8 +650,8 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dominantBaseline="central"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           J
@@ -675,7 +675,7 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
   >
     <div
       aria-label="Jane Smith"
-      className="box grayBg itemsStart xsDisplayFlex"
+      className="box itemsStart lightGrayBg xsDisplayFlex"
       style={
         Object {
           "height": "100%",
@@ -697,8 +697,8 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dominantBaseline="central"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           J
@@ -722,7 +722,7 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
   >
     <div
       aria-label="Jane Smith"
-      className="box grayBg itemsEnd xsDisplayFlex"
+      className="box itemsEnd lightGrayBg xsDisplayFlex"
       style={
         Object {
           "height": "100%",
@@ -744,8 +744,8 @@ exports[`GroupAvatar renders single-byte character initials for 3 people 1`] = `
         <text
           className="antialiased sansSerif fontWeightBold"
           dominantBaseline="central"
-          fill="#fff"
-          fontSize="50px"
+          fill="#111"
+          fontSize="40px"
           textAnchor="middle"
         >
           J


### PR DESCRIPTION
![avatar-before-after](https://user-images.githubusercontent.com/127199/77564931-b5038f00-6e80-11ea-9d17-e73c2e3b0abe.png)

## Changes

  | Before | After
-- | -- | --
Sizes | sm: 24px, md: 40px, lg: 72px | xs: 24px, sm: 32px, md: 48px, lg: 64px, xl: 120px
Verified outline | 2px white | (removed)
Text color (default) | #fff (White) | #111 (darkGray)
Background color (default) | #8e8e8e (Gray) | #efefef (lightGray)
Icon | "check-circle" \| "pinterest" | (removed - always “check-circle”)



## Size Mapping

Before | After
-- | --
sm: 24px | xs: 24px
md: 40px | sm: 32px
-- | md: 48px
lg: 72px | lg: 64px
-- | xl: 120px

