### PR TITLE
RadioButton/Checkbox: Moved shared classes from RadioButton.css to FormElement.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+- RadioButton/Checkbox: Moved shared classes from RadioButton.css to FormElement.css (#772)
 
 ### Patch
 

--- a/packages/gestalt/src/Checkbox.css
+++ b/packages/gestalt/src/Checkbox.css
@@ -37,7 +37,7 @@
 }
 
 .input {
-  composes: Input from "./RadioButton.css";
+  composes: input from "./FormElement.css";
 }
 
 .inputEnabled {
@@ -45,9 +45,9 @@
 }
 
 .sizeSm {
-  composes: SizeSm from "./RadioButton.css";
+  composes: sizeSm from "./FormElement.css";
 }
 
 .sizeMd {
-  composes: SizeMd from "./RadioButton.css";
+  composes: sizeMd from "./FormElement.css";
 }

--- a/packages/gestalt/src/FormElement.css
+++ b/packages/gestalt/src/FormElement.css
@@ -1,9 +1,22 @@
+:root {
+  --size-sm: 16px;
+  --size-md: 24px;
+}
+
 .base {
   composes: accessibilityOutline from "./Focus.css";
   appearance: none;
   border-radius: 16px;
   border-style: solid;
   border-width: 2px;
+}
+
+.input {
+  composes: absolute from "./Layout.css";
+  composes: m0 from "./Whitespace.css";
+  appearance: none;
+  opacity: 0;
+  outline: 0;
 }
 
 .normal {
@@ -35,4 +48,15 @@
 .disabled {
   composes: gray from "./Colors.css";
   composes: lightGrayBg from "./Colors.css";
+}
+
+
+.sizeSm {
+  height: var(--size-sm);
+  width: var(--size-sm);
+}
+
+.sizeMd {
+  height: var(--size-md);
+  width: var(--size-md);
 }

--- a/packages/gestalt/src/FormElement.css.flow
+++ b/packages/gestalt/src/FormElement.css.flow
@@ -5,5 +5,8 @@ declare module.exports: {|
   +'disabled': string,
   +'enabled': string,
   +'errored': string,
+  +'input': string,
   +'normal': string,
+  +'sizeMd': string,
+  +'sizeSm': string,
 |};

--- a/packages/gestalt/src/RadioButton.css
+++ b/packages/gestalt/src/RadioButton.css
@@ -53,11 +53,7 @@
 }
 
 .Input {
-  composes: absolute from "./Layout.css";
-  composes: m0 from "./Whitespace.css";
-  appearance: none;
-  opacity: 0;
-  outline: 0;
+  composes: input from "./FormElement.css";
 }
 
 .InputEnabled {
@@ -65,11 +61,9 @@
 }
 
 .SizeSm {
-  height: var(--size-sm);
-  width: var(--size-sm);
+  composes: sizeSm from "./FormElement.css";
 }
 
 .SizeMd {
-  height: var(--size-md);
-  width: var(--size-md);
+  composes: sizeMd from "./FormElement.css";
 }


### PR DESCRIPTION
- RadioButton/Checkbox: Moved shared classes from RadioButton.css to FormElement.css

## TODO

- [x] Documentation
~~- [ ] Tests~~
~~- [ ] Experimental evidence (required for Masonry changes)~~
~~- [ ] Accessibility checkup~~
