### PR TITLE
Text: removed __dangerouslyIncreaseLineHeight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+Box [Breaking]: Removes support to deprecated props __dangerouslyIncreaseLineHeight (#773)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   </summary>
 
 ### Minor
-Box: Removes support to deprecated props __dangerouslyIncreaseLineHeight (#773)
+
+- Text: Remove deprecated prop __dangerouslyIncreaseLineHeight (#773)
 
 ### Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   </summary>
 
 ### Minor
-Box [Breaking]: Removes support to deprecated props __dangerouslyIncreaseLineHeight (#773)
+Box: Removes support to deprecated props __dangerouslyIncreaseLineHeight (#773)
 
 ### Patch
 

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -41,7 +41,6 @@ type Props = {|
   leading?: 'tall' | 'short',
   truncate?: boolean,
   weight?: 'bold' | 'normal',
-  __dangerouslyIncreaseLineHeight?: boolean,
 |};
 
 export default function Text({
@@ -55,7 +54,6 @@ export default function Text({
   leading,
   truncate = false,
   weight = 'normal',
-  __dangerouslyIncreaseLineHeight = false,
 }: Props) {
   const scale = SIZE_SCALE[size];
 
@@ -80,8 +78,7 @@ export default function Text({
     color === 'watermelon' && colors.watermelon,
     color === 'white' && colors.white,
     leading === 'short' && typography.leadingShort,
-    (leading === 'tall' || __dangerouslyIncreaseLineHeight) &&
-      typography.leadingTall,
+    leading === 'tall' && typography.leadingTall,
     align === 'center' && typography.alignCenter,
     align === 'justify' && typography.alignJustify,
     align === 'left' && typography.alignLeft,
@@ -107,7 +104,6 @@ export default function Text({
 }
 
 Text.propTypes = {
-  __dangerouslyIncreaseLineHeight: PropTypes.bool,
   align: PropTypes.oneOf(['left', 'right', 'center', 'justify']),
   children: PropTypes.node,
   color: PropTypes.oneOf([


### PR DESCRIPTION
- Removing `__dangerouslyIncreaseLineHeight` on `Text` components OR
- `__dangerouslyIncreaseLineHeight` is an equivalent of `leading='tall'` on `Text` components

- They both modify `line-height`,  property in CSS controls the space between lines of text. 
From Gestalt. leading: short: line-height 1.2, tall: line-height 1.5, default: browser determines line-height based on language

## TODO

~~- [ ] Documentation~~
~~- [ ] Tests~~
~~- [ ] Experimental evidence (required for Masonry changes)~~
~~- [ ] Accessibility checkup~~
