### PR TITLE
Version bump: 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,19 @@
 
 ### Minor
 
-- Text: Remove deprecated prop __dangerouslyIncreaseLineHeight (#773)
-
 ### Patch
-- SelectList: Remove selected prop from the placeholder option tag for better React support (#759)
 
 </details>
+
+## 1.27.0 (Mar 26, 2020)
+
+### Minor
+
+- Text: Remove deprecated prop `__dangerouslyIncreaseLineHeight` (#773)
+
+### Patch
+
+- SelectList: Remove selected prop from the placeholder option tag for better React support (#759)
 
 ## 1.26.0 (Mar 25, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.27.0 (Mar 26, 2020)

### Minor

- Text: Remove deprecated prop `__dangerouslyIncreaseLineHeight` (#773)

### Patch

- SelectList: Remove selected prop from the placeholder option tag for better React support (#759)