### PR TITLE
IconButton/Pog: Add "red" backgroundColor + update icon sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Minor
 
+- IconButton: Add bgColor "red", add iconSize prop (#778)
+- Pog: Add bgColor "red" (#778)
+
 ### Patch
 
 </details>

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -44,7 +44,7 @@ card(
       {
         name: 'bgColor',
         type:
-          '"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue"',
+          '"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue" | "red"',
         defaultValue: 'transparent',
         href: 'backgroundColorCombinations',
       },

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -31,7 +31,7 @@ card(
       },
       {
         name: 'bgColor',
-        type: `"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue"`,
+        type: `"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue" | "red"`,
         defaultValue: 'transparent',
         href: 'colorCombinations',
       },

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -16,11 +16,13 @@ type Props = {|
     | 'gray'
     | 'lightGray'
     | 'white'
-    | 'blue',
+    | 'blue'
+    | 'red',
   dangerouslySetSvgPath?: { __path: string },
   disabled?: boolean,
-  iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
   icon?: $Keys<typeof icons>,
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
+  iconSize?: 'default' | 'small',
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
   selected?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
@@ -33,8 +35,9 @@ export default function IconButton({
   bgColor,
   dangerouslySetSvgPath,
   disabled,
-  iconColor,
   icon,
+  iconColor,
+  iconSize,
   selected,
   size,
   onClick,
@@ -71,9 +74,10 @@ export default function IconButton({
         dangerouslySetSvgPath={dangerouslySetSvgPath}
         focused={!disabled && isFocused}
         hovered={!disabled && isHovered}
-        iconColor={iconColor}
-        selected={selected}
         icon={icon}
+        iconColor={iconColor}
+        iconSize={iconSize}
+        selected={selected}
         size={size}
       />
     </button>
@@ -91,6 +95,7 @@ IconButton.propTypes = {
     'lightGray',
     'white',
     'blue',
+    'red',
   ]),
   dangerouslySetSvgPath: PropTypes.shape({
     __path: PropTypes.string,
@@ -105,6 +110,7 @@ IconButton.propTypes = {
     'white',
     'orange',
   ]),
+  iconSize: PropTypes.oneOf(['default', 'small']),
   onClick: PropTypes.func,
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -22,7 +22,6 @@ type Props = {|
   disabled?: boolean,
   icon?: $Keys<typeof icons>,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
-  iconSize?: 'default' | 'small',
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
   selected?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
@@ -37,7 +36,6 @@ export default function IconButton({
   disabled,
   icon,
   iconColor,
-  iconSize,
   selected,
   size,
   onClick,
@@ -76,7 +74,6 @@ export default function IconButton({
         hovered={!disabled && isHovered}
         icon={icon}
         iconColor={iconColor}
-        iconSize={iconSize}
         selected={selected}
         size={size}
       />
@@ -110,7 +107,6 @@ IconButton.propTypes = {
     'white',
     'orange',
   ]),
-  iconSize: PropTypes.oneOf(['default', 'small']),
   onClick: PropTypes.func,
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),

--- a/packages/gestalt/src/Pog.css
+++ b/packages/gestalt/src/Pog.css
@@ -101,3 +101,16 @@
 .blue.active {
   background-color: #4a85c9;
 }
+
+.red {
+  composes: redBg from "./Colors.css";
+}
+
+.red.hovered,
+.red.focused {
+  background-color: #ad081b;
+}
+
+.red.active {
+  background-color: #a3081a;
+}

--- a/packages/gestalt/src/Pog.css.flow
+++ b/packages/gestalt/src/Pog.css.flow
@@ -9,6 +9,7 @@ declare module.exports: {|
   +'hovered': string,
   +'lightGray': string,
   +'pog': string,
+  +'red': string,
   +'selected': string,
   +'transparent': string,
   +'transparentDarkGray': string,

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -15,10 +15,10 @@ const SIZE_NAME_TO_PIXEL = {
   xl: 56,
 };
 
-const ICON_SIZES_SMALL = {
+const SIZE_NAME_TO_ICON_SIZE_PIXEL = {
   xs: 12,
-  sm: 12,
-  md: 16,
+  sm: 16,
+  md: 18,
   lg: 20,
   xl: 24,
 };
@@ -39,7 +39,6 @@ type Props = {|
   selected?: boolean,
   icon?: $Keys<typeof icons>,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
-  iconSize?: 'default' | 'small',
   size?: $Keys<typeof SIZE_NAME_TO_PIXEL>,
 |};
 
@@ -63,15 +62,12 @@ export default function Pog(props: Props) {
     hovered = false,
     icon,
     iconColor,
-    iconSize: iconSizeProp,
     selected = false,
     size = 'md',
   } = props;
 
-  const iconSize =
-    iconSizeProp === 'small'
-      ? ICON_SIZES_SMALL[size]
-      : SIZE_NAME_TO_PIXEL[size] / 2;
+  const iconSize = SIZE_NAME_TO_ICON_SIZE_PIXEL[size];
+
   const color =
     (selected && 'white') || iconColor || defaultIconButtonIconColors[bgColor];
 
@@ -133,7 +129,6 @@ Pog.propTypes = {
     'white',
     'orange',
   ]),
-  iconSize: PropTypes.oneOf(['default', 'small']),
   selected: PropTypes.bool,
   size: PropTypes.oneOf(Object.keys(SIZE_NAME_TO_PIXEL)),
 };

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -15,6 +15,14 @@ const SIZE_NAME_TO_PIXEL = {
   xl: 56,
 };
 
+const ICON_SIZES_SMALL = {
+  xs: 12,
+  sm: 12,
+  md: 16,
+  lg: 20,
+  xl: 24,
+};
+
 type Props = {|
   active?: boolean,
   bgColor?:
@@ -23,13 +31,15 @@ type Props = {|
     | 'gray'
     | 'lightGray'
     | 'white'
-    | 'blue',
+    | 'blue'
+    | 'red',
   dangerouslySetSvgPath?: { __path: string },
   focused?: boolean,
   hovered?: boolean,
   selected?: boolean,
-  iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
   icon?: $Keys<typeof icons>,
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
+  iconSize?: 'default' | 'small',
   size?: $Keys<typeof SIZE_NAME_TO_PIXEL>,
 |};
 
@@ -39,6 +49,7 @@ const defaultIconButtonIconColors = {
   gray: 'white',
   lightGray: 'gray',
   transparent: 'gray',
+  red: 'white',
   transparentDarkGray: 'white',
   white: 'gray',
 };
@@ -50,13 +61,17 @@ export default function Pog(props: Props) {
     dangerouslySetSvgPath,
     focused = false,
     hovered = false,
-    iconColor,
     icon,
+    iconColor,
+    iconSize: iconSizeProp,
     selected = false,
     size = 'md',
   } = props;
 
-  const iconSize = SIZE_NAME_TO_PIXEL[size] / 2;
+  const iconSize =
+    iconSizeProp === 'small'
+      ? ICON_SIZES_SMALL[size]
+      : SIZE_NAME_TO_PIXEL[size] / 2;
   const color =
     (selected && 'white') || iconColor || defaultIconButtonIconColors[bgColor];
 
@@ -109,6 +124,7 @@ Pog.propTypes = {
   }),
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
+  icon: PropTypes.oneOf(Object.keys(icons)),
   iconColor: PropTypes.oneOf([
     'gray',
     'darkGray',
@@ -117,7 +133,7 @@ Pog.propTypes = {
     'white',
     'orange',
   ]),
-  icon: PropTypes.oneOf(Object.keys(icons)),
+  iconSize: PropTypes.oneOf(['default', 'small']),
   selected: PropTypes.bool,
   size: PropTypes.oneOf(Object.keys(SIZE_NAME_TO_PIXEL)),
 };

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -30,10 +30,10 @@ exports[`IconButton renders with disabled state 1`] = `
         aria-hidden={true}
         aria-label=""
         className="icon gray iconBlock"
-        height={20}
+        height={18}
         role="img"
         viewBox="0 0 24 24"
-        width={20}
+        width={18}
       >
         <path
           d="test-file-stub"
@@ -73,10 +73,10 @@ exports[`IconButton renders with icon 1`] = `
         aria-hidden={true}
         aria-label=""
         className="icon gray iconBlock"
-        height={20}
+        height={18}
         role="img"
         viewBox="0 0 24 24"
-        width={20}
+        width={18}
       >
         <path
           d="test-file-stub"
@@ -116,10 +116,10 @@ exports[`IconButton renders with svg 1`] = `
         aria-hidden={true}
         aria-label=""
         className="icon gray iconBlock"
-        height={20}
+        height={18}
         role="img"
         viewBox="0 0 24 24"
-        width={20}
+        width={18}
       >
         <path
           d="M13.00,20.00"

--- a/packages/gestalt/src/__snapshots__/Pog.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pog.test.js.snap
@@ -17,10 +17,10 @@ exports[`Pog active renders 1`] = `
       aria-hidden={true}
       aria-label=""
       className="icon gray iconBlock"
-      height={20}
+      height={18}
       role="img"
       viewBox="0 0 24 24"
-      width={20}
+      width={18}
     >
       <path
         d="test-file-stub"
@@ -47,10 +47,10 @@ exports[`Pog focused renders 1`] = `
       aria-hidden={true}
       aria-label=""
       className="icon gray iconBlock"
-      height={20}
+      height={18}
       role="img"
       viewBox="0 0 24 24"
-      width={20}
+      width={18}
     >
       <path
         d="test-file-stub"
@@ -77,10 +77,10 @@ exports[`Pog hovered renders 1`] = `
       aria-hidden={true}
       aria-label=""
       className="icon gray iconBlock"
-      height={20}
+      height={18}
       role="img"
       viewBox="0 0 24 24"
-      width={20}
+      width={18}
     >
       <path
         d="test-file-stub"
@@ -107,10 +107,10 @@ exports[`Pog renders with icon 1`] = `
       aria-hidden={true}
       aria-label=""
       className="icon gray iconBlock"
-      height={20}
+      height={18}
       role="img"
       viewBox="0 0 24 24"
-      width={20}
+      width={18}
     >
       <path
         d="test-file-stub"
@@ -137,10 +137,10 @@ exports[`Pog renders with svg 1`] = `
       aria-hidden={true}
       aria-label=""
       className="icon gray iconBlock"
-      height={20}
+      height={18}
       role="img"
       viewBox="0 0 24 24"
-      width={20}
+      width={18}
     >
       <path
         d="M13.00,20.00"


### PR DESCRIPTION
About a year ago, I forked a handful of Gestalt components into Pinboard to make changes necessary for Lego PinRep and Closeup. This PR will allow the deletion of the last of those forks, by making two changes:
- Add the background color "red" to both IconButton and Pog, including active/focus/hover states
- Update icon sizes app-wide

- [x] Documentation
- [ ] Tests
- [ ] Experimental evidence (required for Masonry changes)
- [ ] Accessibility checkup

## Before
![image](https://user-images.githubusercontent.com/127199/77806942-75d16b80-7043-11ea-8942-269824f228e3.png)

## After
![image](https://user-images.githubusercontent.com/127199/77806955-7d911000-7043-11ea-8ba0-4f7e855c2fa5.png)
