### PR TITLE
Docs: Fix layout for 1 line code example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Patch
 
+- Docs: Fix layout for 1 line code example (#779)
+
 </details>
 
 ## 1.27.0 (Mar 26, 2020)

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -159,16 +159,11 @@ const Example = ({
                   Editor
                 </Text>
               </Box>
-              <Box position="relative" display="flex">
+              <Box position="relative" display="flex" color="darkGray">
                 <Box flex="grow">
                   <LiveEditor padding={16} />
                 </Box>
-                <Box
-                  dangerouslySetInlineStyle={{
-                    __style: { backgroundColor: theme.plain.backgroundColor },
-                  }}
-                  padding={2}
-                >
+                <Box padding={2}>
                   <Tooltip inline text="Open in CodeSandbox">
                     <IconButton
                       dangerouslySetSvgPath={{


### PR DESCRIPTION
Before, it looked like we had a 1px white border below the code example. Instead, it should look like the heights are equal between the code & buttons

Before
![Screen Shot 2020-03-27 at 8 41 01 AM](https://user-images.githubusercontent.com/127199/77773545-fc1b8c80-7006-11ea-9a01-6745a03e93cb.png)

After
![Screen Shot 2020-03-27 at 8 41 10 AM](https://user-images.githubusercontent.com/127199/77773553-fde55000-7006-11ea-83ab-db65640ef00d.png)
