### PR TITLE
Version bump: 1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@
 
 ### Minor
 
-- Borders: Update lightgray border color to `#ddd`
+### Patch
+
+</details>
+
+## 1.28.0 (Mar 27, 2020)
+
+### Minor
+
+- Borders: Update lightgray border color to `#ddd` (#776)
 
 ### Patch
 
 - Docs: Fix layout for 1 line code example (#779)
-
-</details>
 
 ## 1.27.0 (Mar 26, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.28.0 (Mar 27, 2020)

### Minor

- Borders: Update lightgray border color to `#ddd` (#776)

### Patch

- Docs: Fix layout for 1 line code example (#779)