### PR TITLE
Version bump: 1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@
 
 ### Minor
 
-- IconButton: Add bgColor "red", add iconSize prop (#778)
-- Pog: Add bgColor "red" (#778)
-
 ### Patch
 
 </details>
+
+## 1.29.0 (Mar 27, 2020)
+
+### Minor
+
+- IconButton/Pog: Add "red" backgroundColor + update icon sizes (#778)
 
 ## 1.28.0 (Mar 27, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.29.0 (Mar 27, 2020)

### Minor

- IconButton/Pog: Add "red" backgroundColor + update icon sizes (#778)