### PR TITLE
Allow string enums for Masonry layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#782)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -27,7 +27,10 @@ type Layout =
   | typeof DefaultLayoutSymbol
   | typeof UniformRowLayoutSymbol
   | LegacyMasonryLayout
-  | LegacyUniformRowLayout;
+  | LegacyUniformRowLayout
+  | 'basic'
+  | 'flexible'
+  | 'uniformRow';
 
 type Props<T> = {|
   columnWidth?: number,
@@ -164,6 +167,7 @@ export default class Masonry<T: {}> extends React.Component<
       PropTypes.instanceOf(LegacyMasonryLayout),
       PropTypes.instanceOf(LegacyUniformRowLayout),
       PropTypes.symbol,
+      PropTypes.string,
     ]),
 
     /**
@@ -193,7 +197,7 @@ export default class Masonry<T: {}> extends React.Component<
   static defaultProps = {
     columnWidth: 236,
     minCols: 3,
-    layout: DefaultLayoutSymbol,
+    layout: 'basic',
     loadItems: () => {},
     virtualize: false,
   };
@@ -350,13 +354,13 @@ export default class Masonry<T: {}> extends React.Component<
   };
 
   fetchMore = () => {
-    const { loadItems } = this.props;
+    const { loadItems, items } = this.props;
     if (loadItems && typeof loadItems === 'function') {
       this.setState(
         {
           isFetching: true,
         },
-        () => loadItems({ from: this.props.items.length })
+        () => loadItems({ from: items.length })
       );
     }
   };
@@ -383,8 +387,10 @@ export default class Masonry<T: {}> extends React.Component<
    * number of columns we would display should change after a resize.
    */
   reflow() {
-    if (this.props.measurementStore) {
-      this.props.measurementStore.reset();
+    const { measurementStore } = this.props;
+
+    if (measurementStore) {
+      measurementStore.reset();
     }
     this.state.measurementStore.reset();
 
@@ -395,6 +401,7 @@ export default class Masonry<T: {}> extends React.Component<
   renderMasonryComponent = (itemData: T, idx: number, position: *) => {
     const {
       comp: Component,
+      scrollContainer,
       virtualize,
       virtualBoundsTop,
       virtualBoundsBottom,
@@ -402,7 +409,7 @@ export default class Masonry<T: {}> extends React.Component<
     const { top, left, width, height } = position;
 
     let isVisible;
-    if (this.props.scrollContainer) {
+    if (scrollContainer) {
       const virtualBuffer = this.containerHeight * VIRTUAL_BUFFER_FACTOR;
       const offsetScrollPos = this.state.scrollTop - this.containerOffset;
       const viewportTop = virtualBoundsTop
@@ -451,13 +458,15 @@ export default class Masonry<T: {}> extends React.Component<
       flexible,
       gutterWidth: gutter,
       items,
+      layout,
       minCols,
+      scrollContainer,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
 
-    let layout;
-    if (flexible && width !== null) {
-      layout = fullWidthLayout({
+    let getPositions;
+    if ((flexible || layout === 'flexible') && width !== null) {
+      getPositions = fullWidthLayout({
         gutter,
         cache: measurementStore,
         minCols,
@@ -465,10 +474,11 @@ export default class Masonry<T: {}> extends React.Component<
         width,
       });
     } else if (
-      this.props.layout === UniformRowLayoutSymbol ||
-      this.props.layout instanceof LegacyUniformRowLayout
+      layout === UniformRowLayoutSymbol ||
+      layout instanceof LegacyUniformRowLayout ||
+      layout === 'uniformRow'
     ) {
-      layout = uniformRowLayout({
+      getPositions = uniformRowLayout({
         cache: measurementStore,
         columnWidth,
         gutter,
@@ -476,7 +486,7 @@ export default class Masonry<T: {}> extends React.Component<
         width,
       });
     } else {
-      layout = defaultLayout({
+      getPositions = defaultLayout({
         cache: measurementStore,
         columnWidth,
         gutter,
@@ -507,12 +517,13 @@ export default class Masonry<T: {}> extends React.Component<
                   left: 0,
                   transform: 'translateX(0px) translateY(0px)',
                   WebkitTransform: 'translateX(0px) translateY(0px)',
-                  width: flexible
-                    ? undefined
-                    : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
+                  width:
+                    flexible || layout === 'flexible'
+                      ? undefined
+                      : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
                 }}
                 ref={el => {
-                  if (el && !flexible) {
+                  if (el && !(flexible || layout === 'flexible')) {
                     // only measure flexible items on client
                     measurementStore.set(item, el.clientHeight);
                   }
@@ -536,8 +547,8 @@ export default class Masonry<T: {}> extends React.Component<
         .filter(item => item && !measurementStore.has(item))
         .slice(0, minCols);
 
-      const positions = layout(itemsToRender);
-      const measuringPositions = layout(itemsToMeasure);
+      const positions = getPositions(itemsToRender);
+      const measuringPositions = getPositions(itemsToMeasure);
       // Math.max() === -Infinity when there are no positions
       const height = positions.length
         ? Math.max(...positions.map(pos => pos.top + pos.height))
@@ -598,11 +609,11 @@ export default class Masonry<T: {}> extends React.Component<
       );
     }
 
-    return this.props.scrollContainer ? (
+    return scrollContainer ? (
       <ScrollContainer
         ref={this.setScrollContainerRef}
         onScroll={this.updateScrollPosition}
-        scrollContainer={this.props.scrollContainer}
+        scrollContainer={scrollContainer}
       >
         {gridBody}
       </ScrollContainer>


### PR DESCRIPTION
This is my second attempt at landing this PR, after #667 needed to be reverted. I root-caused the previous issue to be one instance of the `flexible` variable that I had modified despite the fact that we still want to support `flexible` in its current form until we've modified Pinboard code.

### Notes copied from #667:

Masonry currently allows three ways to specify which layout you'd like to use:

1. Use a `Symbol` as part of `legacyLayoutSymbols.js`, although this is not exported so only relevant inside the package.
2. Use one of class-based layouts in the `/layouts` folder. These _are_ exported but are considered "legacy".
3. Specify nothing and get the default columnar layout.

Because extra exports are annoying and we're already split on what to use, I'd like to update to one true system: strings. I'd like layout to eventually be `type Layout = 'basic' | 'uniformRow' | 'flexible';`. This PR is the first step -- allow the string versions. I already have a pinboard diff that switches all uses over to it, and we can follow up by removing the `Symbol` and class versions once that PR lands.

One other future goal: I'd like to remove the `flexible` bool prop. When true, Masonry currently uses a completely different layout engine. For instance, if the user asks for uniform row layout and specifies `flexible={true}`, the uniform layout flag will be ignored. Once this lands, I intend to convert all instances of `flexible={true}` to `layout="flexible"`.

### Testing:

This time around, I tested all code paths more meticulously inside Pinboard. I've verified that all three supported layouts (basic, uniformRow, and flexible) work as expected:

<img width="985" alt="Screen Shot 2020-03-28 at 11 49 12 PM" src="https://user-images.githubusercontent.com/967591/77843285-7277d600-7150-11ea-8d06-1869ba6fce58.png">
<img width="910" alt="Screen Shot 2020-03-28 at 11 49 02 PM" src="https://user-images.githubusercontent.com/967591/77843286-760b5d00-7150-11ea-8a38-1779f51fc194.png">
<img width="387" alt="Screen Shot 2020-03-28 at 11 49 36 PM" src="https://user-images.githubusercontent.com/967591/77843287-77d52080-7150-11ea-9b10-ad2316b425e0.png">
