### PR TITLE
Version bump: 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 </details>
 
+## 1.30.0 (Mar 30, 2020)
+
+### Minor
+
+- Modal: Update OutsideEventBehavior to work well with Portals (#777)
+
 ## 1.29.0 (Mar 27, 2020)
 
 ### Minor

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.30.0 (Mar 30, 2020)

### Minor

- Modal: Update OutsideEventBehavior to work well with Portals (#777)