### PR TITLE
Text: Remove "leading" prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Minor
 
+- Text: Remove prop `leading` and related css properties (#784)
+
+Run codemods:
+cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.35.0-1.36.0/leading-text-remove.js ~/code/repo
+
 ### Patch
 
 </details>

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -40,11 +40,6 @@ card(
         href: 'inline',
       },
       {
-        name: 'leading',
-        type: `"short" | "tall"`,
-        description: `short: line-height 1.2, tall: line-height 1.5, default: browser determines line-height based on language`,
-      },
-      {
         name: 'italic',
         type: 'boolean',
         defaultValue: false,
@@ -155,14 +150,14 @@ card(
 <Box maxWidth={240}>
   <Box marginBottom={2}>
     <Text weight="bold">normal:</Text>
-    <Text overflow="normal" leading="tall">
+    <Text overflow="normal">
       This is a long and Supercalifragilisticexpialidocious sentence.
       次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉&#39;
     </Text>
   </Box>
   <Box marginBottom={2}>
     <Text weight="bold">breakWord:</Text>
-    <Text leading="tall">
+    <Text>
       This is a long and Supercalifragilisticexpialidocious sentence.
       次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
       ｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗ&#39;
@@ -170,7 +165,7 @@ card(
   </Box>
   <Box marginBottom={2}>
     <Text weight="bold">truncate:</Text>
-    <Text truncate leading="tall">
+    <Text truncate>
       This is a long and Supercalifragilisticexpialidocious sentence.
       次の単語グレートブリテンおよび北アイルランド連合王国で本当に大きな言葉
       ｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗｗ&#39;

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -184,7 +184,7 @@ const Example = ({
         </Box>
 
         <Box padding={2}>
-          <Text color="watermelon" leading="tall">
+          <Text color="watermelon">
             <LiveError />
           </Text>
         </Box>

--- a/docs/src/components/Markdown.js
+++ b/docs/src/components/Markdown.js
@@ -39,7 +39,7 @@ export default function Markdown({ text, size = 'lg' }: Props) {
   const html = marked(stripIndent(text), { renderer });
 
   return (
-    <Text leading="tall" size={size}>
+    <Text size={size}>
       {/* eslint-disable-next-line react/no-danger */}
       <div className="Markdown" dangerouslySetInnerHTML={{ __html: html }} />
     </Text>

--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -21,7 +21,7 @@ export default function ComponentHeader({ name, description = '' }: Props) {
     <Box marginBottom={6}>
       <Box marginBottom={4}>
         <Heading>{name}</Heading>
-        <Text leading="tall" color="gray">
+        <Text color="gray">
           <Link href={githubUrl(name)} inline>
             Source
           </Link>

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -48,7 +48,7 @@ const Td = ({
     colSpan={colspan}
   >
     <Box paddingX={2} marginTop={2} marginBottom={border ? 2 : 0}>
-      <Text overflow="normal" leading="tall" color={color}>
+      <Text overflow="normal" color={color}>
         {children}
       </Text>
     </Box>
@@ -134,7 +134,7 @@ export default function PropTable({ props: properties, Component }: Props) {
                     )}
                     <Td shrink border={!description}>
                       <Box>
-                        <Text overflow="normal" leading="tall" weight="bold">
+                        <Text overflow="normal" weight="bold">
                           {href ? (
                             <Link
                               href={`#${href}`}
@@ -157,7 +157,7 @@ export default function PropTable({ props: properties, Component }: Props) {
                       </Box>
                       {responsive && (
                         <Box>
-                          <Text leading="tall">
+                          <Text>
                             <code>
                               sm{upcase(name)}, md{upcase(name)}, lg
                               {upcase(name)}

--- a/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/.eslintrc.json
+++ b/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "prettier/prettier": "off",
+    "no-undef": "off"
+  }
+}

--- a/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/leading-text-remove.input.js
+++ b/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/leading-text-remove.input.js
@@ -1,0 +1,12 @@
+// @flow
+import React from 'react';
+import { Box, Text, Text as Renamed } from 'gestalt';
+
+export default function TestBox() {
+  return (
+    <Box>
+      <Renamed leading='short'>Hello</Renamed>
+      <Text leading='short' color='blue'>Hello</Text>
+    </Box>
+  );
+}

--- a/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/leading-text-remove.output.js
+++ b/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/leading-text-remove.output.js
@@ -1,0 +1,12 @@
+// @flow
+import React from 'react';
+import { Box, Text, Text as Renamed } from 'gestalt';
+
+export default function TestBox() {
+  return (
+    <Box>
+      <Renamed>Hello</Renamed>
+      <Text color='blue'>Hello</Text>
+    </Box>
+  );
+}

--- a/packages/gestalt-codemods/1.35.0-1.36.0/__tests__/leading-text-remove.test.js
+++ b/packages/gestalt-codemods/1.35.0-1.36.0/__tests__/leading-text-remove.test.js
@@ -1,0 +1,13 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../leading-text-remove', () => {
+  return Object.assign(require.requireActual('../leading-text-remove'), {
+    parser: 'flow',
+  });
+});
+
+describe('leading-text-remove', () => {
+  ['leading-text-remove'].forEach(test => {
+    defineTest(__dirname, 'leading-text-remove', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/1.35.0-1.36.0/leading-text-remove.js
+++ b/packages/gestalt-codemods/1.35.0-1.36.0/leading-text-remove.js
@@ -1,0 +1,62 @@
+/*
+ * Converts
+ *  <Text leading='short' /> to <Text/>
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter(node => node.imported.name === 'Text')
+      .map(node => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach(jsxElement => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some(attr => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove Dynamic Text properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`
+        );
+      }
+
+      const newAppendAttr = [];
+      const newAttrs = attrs
+        .map(attr => {
+          if (attr?.name?.name && attr.name.name === 'leading') {
+            return null;
+          }
+          return attr;
+        })
+        .filter(Boolean);
+
+      fileHasModifications = true;
+      node.openingElement.attributes = [...newAppendAttr, ...newAttrs];
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -38,7 +38,6 @@ type Props = {|
   italic?: boolean,
   overflow?: 'normal' | 'breakWord',
   size?: 'sm' | 'md' | 'lg',
-  leading?: 'tall' | 'short',
   truncate?: boolean,
   weight?: 'bold' | 'normal',
 |};
@@ -51,7 +50,6 @@ export default function Text({
   italic = false,
   overflow = 'breakWord',
   size = 'lg',
-  leading,
   truncate = false,
   weight = 'normal',
 }: Props) {
@@ -77,8 +75,6 @@ export default function Text({
     color === 'red' && colors.red,
     color === 'watermelon' && colors.watermelon,
     color === 'white' && colors.white,
-    leading === 'short' && typography.leadingShort,
-    leading === 'tall' && typography.leadingTall,
     align === 'center' && typography.alignCenter,
     align === 'justify' && typography.alignJustify,
     align === 'left' && typography.alignLeft,
@@ -127,7 +123,6 @@ Text.propTypes = {
   ]),
   inline: PropTypes.bool,
   italic: PropTypes.bool,
-  leading: PropTypes.oneOf(['tall', 'short']),
   overflow: PropTypes.oneOf(['normal', 'breakWord']),
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   truncate: PropTypes.bool,

--- a/packages/gestalt/src/Text.test.js
+++ b/packages/gestalt/src/Text.test.js
@@ -18,16 +18,6 @@ test('Text size sm adds the small size class', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Text leading short adds the leadingShort class', () => {
-  const tree = create(<Text leading="short" />).toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
-test('Text leading tall adds the leadingTall class', () => {
-  const tree = create(<Text leading="tall" />).toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
 test('Text truncate should add a title when the children are text only', () => {
   const tree = create(
     <Text truncate>

--- a/packages/gestalt/src/TextArea.css
+++ b/packages/gestalt/src/TextArea.css
@@ -1,8 +1,8 @@
 .textArea {
   composes: borderBox from "./Layout.css";
   composes: Text fontSize3 from "./Text.css";
-  composes: leadingTall from "./Typography.css";
   composes: xsCol12 from "./Column.css";
+  line-height: 1.5;
   padding: 8px 16px;
   resize: none;
 }

--- a/packages/gestalt/src/Typography.css
+++ b/packages/gestalt/src/Typography.css
@@ -24,16 +24,6 @@
   quotes: "「" "」";
 }
 
-/* leading */
-
-.leadingShort {
-  line-height: 1.2;
-}
-
-.leadingTall {
-  line-height: 1.5;
-}
-
 /* font weight */
 
 .fontWeightNormal {

--- a/packages/gestalt/src/Typography.css.flow
+++ b/packages/gestalt/src/Typography.css.flow
@@ -11,8 +11,6 @@ declare module.exports: {|
   +'fontStyleRegular': string,
   +'fontWeightBold': string,
   +'fontWeightNormal': string,
-  +'leadingShort': string,
-  +'leadingTall': string,
   +'noUnderline': string,
   +'sansSerif': string,
   +'truncate': string,

--- a/packages/gestalt/src/__snapshots__/Text.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Text.test.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Text leading short adds the leadingShort class 1`] = `
-<div
-  className="Text fontSize3 darkGray leadingShort alignLeft breakWord fontWeightNormal"
-/>
-`;
-
-exports[`Text leading tall adds the leadingTall class 1`] = `
-<div
-  className="Text fontSize3 darkGray leadingTall alignLeft breakWord fontWeightNormal"
-/>
-`;
-
 exports[`Text orange adds the orange color class 1`] = `
 <div
   className="Text fontSize3 orange alignLeft breakWord fontWeightNormal"


### PR DESCRIPTION
# PR Changes

- Removed `leading` props (`leading='tall'`  & `leading='short' `)  from `<Text>`. 

To support this change, run codemods
cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.35.0-1.36.0/leading-text-remove.js ~/code/repo

- `leading` modifies `line-height`,  property in CSS that controls the space between lines of text. 

- leading: short: line-height 1.2, tall: line-height 1.5, default: browser determines line-height based on language

![image](https://user-images.githubusercontent.com/10593890/77962784-1a94b880-7291-11ea-9cd5-eba3423aa95b.png)
![image](https://user-images.githubusercontent.com/10593890/77962809-25e7e400-7291-11ea-8d3e-2164ff4d901b.png)

- By removing `leading,` the browser determines line-height based on language. To make sure we support all of them, including Thai, making sure they fully render. `leading` prop forces the line-height in CSS, which in certain conditions might cut text on the top. 
![image](https://user-images.githubusercontent.com/10593890/77962854-3a2be100-7291-11ea-8163-46ad72f64951.png)

### Potential Issues

- Removing leading props might remove the override of the `line-height` property that sometimes is defined in custom css files. 

## TODO

- [X] Documentation
- [X] Tests
~~- [ ] Experimental evidence (required for Masonry changes)~~
~~- [ ] Accessibility checkup~~
