### PR TITLE
Version bump: v1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 </details>
 
+## 1.31.0 (Mar 31, 2020)
+
+### Minor
+
+- [Revert] Modal: Update OutsideEventBehavior to work well with Portals (#778)
+
 ## 1.30.0 (Mar 30, 2020)
 
 ### Minor

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.31.0 (Mar 31, 2020)

### Minor

- [Revert] Modal: Update OutsideEventBehavior to work well with Portals (#778)