### PR TITLE
Version bump: v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ### Minor
 
-- Avatar/GroupAvatar: update sizes / default avatar / remove verified outline
-
 ### Patch
 
 </details>
+
+## 1.32.0 (Mar 31, 2020)
+
+### Minor
+
+- Avatar/GroupAvatar: update sizes / default avatar / remove verified outline (#771)
 
 ## 1.31.0 (Mar 31, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.32.0 (Mar 31, 2020)

### Minor

- Avatar/GroupAvatar: update sizes / default avatar / remove verified outline (#771)