### PR TITLE
Version bump: 1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 <details>
   <summary>
-    Changes that have landed in master but are not yet released. (#774)
+    Changes that have landed in master but are not yet released.
     Click to see more.
   </summary>
 
 ### Minor
 
-- Avatar: Add `__dangerouslyUseDefaultIcon` prop
-
 ### Patch
 
 </details>
+
+## 1.33.0 (Mar 31, 2020)
+
+### Minor
+
+- Avatar: Add `__dangerouslyUseDefaultIcon` prop (#774)
 
 ## 1.32.0 (Mar 31, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.33.0 (Mar 31, 2020)

### Minor

- Avatar: Add `__dangerouslyUseDefaultIcon` prop (#774)