### PR TITLE
Version bump: 1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 1.35.0 (Apr 2, 2020)
+
+### Minor
+
 - Text: Remove prop `leading` and related css properties (#784)
 
 Run codemods:
 cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.35.0-1.36.0/leading-text-remove.js ~/code/repo
-
-### Patch
-
-</details>
 
 ## 1.34.0 (Apr 1, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.35.0 (Apr 2, 2020)

### Minor

- Text: Remove prop `leading` and related css properties (#784)

Run codemods:
cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.35.0-1.36.0/leading-text-remove.js ~/code/repo