### PR TITLE
[Checkbox/Radiobutton]: Updated checkbox and radiobutton borders for disabled state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### Patch
 
 - Internal: Enable React.Strict on documentation (#821)
-
+- Checkbox/Radiobutton: Updated checkbox and radiobutton borders for disabled state (disabled controls don't show outlines) (#795)
+ 
 </details>
 
 ## 1.42.0 (Apr 20, 2020)

--- a/packages/gestalt/src/Borders.css
+++ b/packages/gestalt/src/Borders.css
@@ -4,6 +4,7 @@
   --border-color-gray: #767676;
   --border-color-darkGray: #111;
   --border-color-lightGray: #ddd;
+  --border-color-lightGrayDisabled: #efefef;
   --border-color-red: #e60023;
   --border-color-lightGrayHovered: #d0d0d0;
   --bt: 4px;
@@ -33,6 +34,10 @@
 
 .borderColorLightGrayHovered {
   border-color: var(--border-color-lightGrayHovered);
+}
+
+.borderColorLightGrayDisabled {
+  border-color: var(--border-color-lightGrayDisabled);
 }
 
 .borderTop {

--- a/packages/gestalt/src/Borders.css.flow
+++ b/packages/gestalt/src/Borders.css.flow
@@ -6,6 +6,7 @@ declare module.exports: {|
   +'borderColorDarkGray': string,
   +'borderColorGray': string,
   +'borderColorLightGray': string,
+  +'borderColorLightGrayDisabled': string,
   +'borderColorLightGrayHovered': string,
   +'borderColorRed': string,
   +'borderLeft': string,

--- a/packages/gestalt/src/Checkbox.css
+++ b/packages/gestalt/src/Checkbox.css
@@ -6,6 +6,10 @@
   composes: borderColorDarkGray from "./Borders.css";
 }
 
+.borderDisabled {
+  composes: borderColorLightGrayDisabled from "./Borders.css";
+}
+
 .borderError {
   composes: borderColorRed from "./Borders.css";
 }

--- a/packages/gestalt/src/Checkbox.css.flow
+++ b/packages/gestalt/src/Checkbox.css.flow
@@ -3,6 +3,7 @@
 declare module.exports: {|
   +'border': string,
   +'borderDarkGray': string,
+  +'borderDisabled': string,
   +'borderError': string,
   +'borderHovered': string,
   +'borderRadiusMd': string,

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -75,7 +75,9 @@ export default function Checkbox({
   }
 
   let borderStyle = styles.border;
-  if (!disabled && (checked || indeterminate)) {
+  if (disabled) {
+    borderStyle = styles.borderDisabled;
+  } else if (!disabled && (checked || indeterminate)) {
     borderStyle = styles.borderDarkGray;
   } else if (hasError || errorMessage) {
     borderStyle = styles.borderError;

--- a/packages/gestalt/src/RadioButton.css
+++ b/packages/gestalt/src/RadioButton.css
@@ -36,6 +36,14 @@
   composes: borderColorDarkGray from "./Borders.css";
 }
 
+.BorderDisabled {
+  composes: noBorder from "./Borders.css";
+}
+
+.BorderDisabledChecked {
+  composes: borderColorLightGrayDisabled from "./Borders.css";
+}
+
 .BorderHovered {
   composes: borderColorLightGrayHovered from "./Borders.css";
 }

--- a/packages/gestalt/src/RadioButton.css.flow
+++ b/packages/gestalt/src/RadioButton.css.flow
@@ -7,6 +7,8 @@ declare module.exports: {|
   +'BorderCheckedMd': string,
   +'BorderCheckedSm': string,
   +'BorderDarkGray': string,
+  +'BorderDisabled': string,
+  +'BorderDisabledChecked': string,
   +'BorderHovered': string,
   +'BorderUnchecked': string,
   +'InputEnabled': string,

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -69,14 +69,18 @@ export default class RadioButton extends React.Component<Props, State> {
     const { focused, hovered } = this.state;
 
     let borderStyle = styles.Border;
-    if (!disabled && checked) {
+    if (disabled && checked) {
+      borderStyle = styles.BorderDisabledChecked;
+    } else if (!disabled && checked) {
       borderStyle = styles.BorderDarkGray;
     } else if (!disabled && hovered) {
       borderStyle = styles.BorderHovered;
     }
 
     let borderWidth = styles.BorderUnchecked;
-    if (checked && size === 'sm') {
+    if (disabled && !checked) {
+      borderWidth = styles.BorderDisabled;
+    } else if (checked && size === 'sm') {
       borderWidth = styles.BorderCheckedSm;
     } else if (checked && size === 'md') {
       borderWidth = styles.BorderCheckedMd;

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -142,7 +142,7 @@ exports[`Checkbox disabled & checked 1`] = `
           type="checkbox"
         />
         <div
-          className="lightGrayBg border borderRadiusSm sizeSm check"
+          className="lightGrayBg borderDisabled borderRadiusSm sizeSm check"
         >
           <svg
             aria-hidden={true}
@@ -206,7 +206,7 @@ exports[`Checkbox disabled 1`] = `
           type="checkbox"
         />
         <div
-          className="lightGrayBg border borderRadiusSm sizeSm check"
+          className="lightGrayBg borderDisabled borderRadiusSm sizeSm check"
         />
       </div>
     </label>

--- a/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
@@ -92,7 +92,7 @@ exports[`RadioButton disabled 1`] = `
       className="box paddingX1"
     >
       <div
-        className="BgDisabled Border BorderUnchecked sizeMd RadioButton"
+        className="BgDisabled Border BorderDisabled sizeMd RadioButton"
       >
         <input
           checked={false}
@@ -139,7 +139,7 @@ exports[`RadioButton disabled small 1`] = `
       className="box paddingX1"
     >
       <div
-        className="BgDisabled Border BorderUnchecked sizeSm RadioButton"
+        className="BgDisabled Border BorderDisabled sizeSm RadioButton"
       >
         <input
           checked={false}


### PR DESCRIPTION
- Updated Checkbox and Radiobutton borders for the disabled state to fix color mismatch introduced in 

1.28.0 (Mar 27, 2020) Minor: - Borders: Update lightgray border color to `#ddd` (#776)

### Before / After
![image](https://user-images.githubusercontent.com/10593890/79791764-b2227f80-8302-11ea-88ab-f1259a6c02da.png)

![image](https://user-images.githubusercontent.com/10593890/79791773-b64e9d00-8302-11ea-9e0f-6c79781cba2a.png)


## TODO
~~[ ] Documentation~~
~~[ ] Tests~~
~~[ ] Experimental evidence (required for Masonry changes)~~
~~[ ] Accessibility checkup~~
