### PR TITLE
Version bump: v1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ### Minor
 
-- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#782)
-
 ### Patch
 
 </details>
+
+## 1.37.0 (Apr 3, 2020)
+
+### Minor
+
+- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#782)
 
 ## 1.36.0 (Apr 3, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.37.0 (Apr 3, 2020)

### Minor

- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#782)