### PR TITLE
[Container] Allow user to set max width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Container: Allow user to set max width (#799)
+
 ### Patch
 
 </details>

--- a/docs/src/Container.doc.js
+++ b/docs/src/Container.doc.js
@@ -21,6 +21,11 @@ card(
         name: 'children',
         type: 'React.Node',
       },
+      {
+        name: 'maxWidth',
+        type: 'number',
+        defaultValue: 800,
+      },
     ]}
   />
 );
@@ -28,7 +33,7 @@ card(
 card(
   <Example
     description="
-    On small screens, the container is the width of the screen. On large screens, it centers the content with a max-width of 800px.
+    On small screens, the container is the width of the screen. On large screens, it centers the content with a default max-width of 800px.
   "
     name="Responsive content"
     defaultCode={`

--- a/packages/gestalt/src/Container.js
+++ b/packages/gestalt/src/Container.js
@@ -5,13 +5,13 @@ import Box from './Box.js';
 
 type Props = {|
   children?: React.Node,
+  maxWidth?: number,
 |};
 
-export default function Container(props: Props) {
-  const { children } = props;
+export default function Container({ children, maxWidth }: Props) {
   return (
     <Box justifyContent="center" display="flex">
-      <Box maxWidth={800} width="100%">
+      <Box maxWidth={maxWidth ?? 800} width="100%">
         {children}
       </Box>
     </Box>
@@ -20,4 +20,5 @@ export default function Container(props: Props) {
 
 Container.propTypes = {
   children: PropTypes.node,
+  maxWidth: PropTypes.number,
 };

--- a/packages/gestalt/src/Container.test.js
+++ b/packages/gestalt/src/Container.test.js
@@ -3,8 +3,30 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import Container from './Container.js';
 
-test('Container renders', () => {
-  const component = renderer.create(<Container />);
-  const tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+describe('Container', () => {
+  test('Renders with no props', () => {
+    const component = renderer.create(<Container />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('Renders with children', () => {
+    const component = renderer.create(
+      <Container>
+        <div />
+      </Container>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('Renders with maxWidth', () => {
+    const component = renderer.create(
+      <Container maxWidth={400}>
+        <div />
+      </Container>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/gestalt/src/__snapshots__/Container.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Container.test.js.snap
@@ -1,6 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Container renders 1`] = `
+exports[`Container Renders with children 1`] = `
+<div
+  className="box justifyCenter xsDisplayFlex"
+>
+  <div
+    className="box"
+    style={
+      Object {
+        "maxWidth": 800,
+        "width": "100%",
+      }
+    }
+  >
+    <div />
+  </div>
+</div>
+`;
+
+exports[`Container Renders with maxWidth 1`] = `
+<div
+  className="box justifyCenter xsDisplayFlex"
+>
+  <div
+    className="box"
+    style={
+      Object {
+        "maxWidth": 400,
+        "width": "100%",
+      }
+    }
+  >
+    <div />
+  </div>
+</div>
+`;
+
+exports[`Container Renders with no props 1`] = `
 <div
   className="box justifyCenter xsDisplayFlex"
 >


### PR DESCRIPTION
Centering content is essential in many designs, but not all use a max-width of 800px. This keeps the existing behavior as the default, but allows the user to override if needed.

- [x] Documentation
- [x] Tests
- [ ] Experimental evidence (required for Masonry changes)
- [ ] Accessibility checkup
