### PR TITLE
Version bump: 1.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 </details>
 
+## 1.38.0 (Apr 13, 2020)
+
+### Minor
+
+- Modal: support Flyout inside of a Modal (#793)
+
 ## 1.37.0 (Apr 3, 2020)
 
 ### Minor

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.38.0 (Apr 13, 2020)

### Minor

- Modal: support Flyout inside of a Modal (#793)
