### PR TITLE
[Color] Update gray color to #767676 for improved accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+- Color: update gray color to #767676 (#804)
 
 ### Patch
 

--- a/packages/gestalt/src/Borders.css
+++ b/packages/gestalt/src/Borders.css
@@ -1,6 +1,7 @@
 :root {
   --border-width: 1px;
   --border-width-lg: 2px;
+  --border-color-gray: #767676;
   --border-color-darkGray: #111;
   --border-color-lightGray: #ddd;
   --border-color-red: #e60023;
@@ -12,6 +13,10 @@
 
 .border {
   border: var(--border-width) solid var(--border-color-lightGray);
+}
+
+.borderColorGray {
+  border-color: var(--border-color-gray);
 }
 
 .borderColorDarkGray {

--- a/packages/gestalt/src/Borders.css.flow
+++ b/packages/gestalt/src/Borders.css.flow
@@ -4,6 +4,7 @@ declare module.exports: {|
   +'border': string,
   +'borderBottom': string,
   +'borderColorDarkGray': string,
+  +'borderColorGray': string,
   +'borderColorLightGray': string,
   +'borderColorLightGrayHovered': string,
   +'borderColorRed': string,

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -3,7 +3,7 @@
   --red: #e60023;
   --white: #fff;
   --lightGray: #efefef;
-  --gray: #8e8e8e;
+  --gray: #767676;
   --darkGray: #111;
 
   /* secondary colors */

--- a/packages/gestalt/src/SearchField.css
+++ b/packages/gestalt/src/SearchField.css
@@ -1,3 +1,7 @@
+:root {
+  --gray: #767676;
+}
+
 .input {
   composes: accessibilityOutline from "./Focus.css";
   composes: border from "./Borders.css";
@@ -17,7 +21,7 @@
 }
 
 .input::placeholder {
-  color: #8e8e8e;
+  color: var(--gray);
 }
 
 .input::-webkit-search-decoration,

--- a/packages/gestalt/src/Switch.css
+++ b/packages/gestalt/src/Switch.css
@@ -33,17 +33,17 @@ html[dir="rtl"] .switch {
 
 .switchGray {
   composes: grayBg from "./Colors.css";
-  border-color: #8e8e8e;
+  composes: borderColorGray from "./Borders.css";
 }
 
 .switchLightGray {
   composes: lightGrayBg from "./Colors.css";
-  border-color: #8e8e8e;
+  composes: borderColorGray from "./Borders.css";
 }
 
 .switchWhite {
   composes: whiteBg from "./Colors.css";
-  border-color: #8e8e8e;
+  composes: borderColorGray from "./Borders.css";
 }
 
 .slider {
@@ -71,7 +71,7 @@ html[dir="rtl"] .switch {
 }
 
 .sliderLight {
-  border-color: #8e8e8e;
+  composes: borderColorGray from "./Borders.css";
 }
 
 .checkbox {

--- a/packages/gestalt/src/TextArea.css
+++ b/packages/gestalt/src/TextArea.css
@@ -1,3 +1,7 @@
+:root {
+  --gray: #767676;
+}
+
 .textArea {
   composes: borderBox from "./Layout.css";
   composes: Text fontSize3 from "./Text.css";
@@ -8,5 +12,5 @@
 }
 
 .textArea::placeholder {
-  color: #8e8e8e;
+  color: var(--gray);
 }

--- a/packages/gestalt/src/TextField.css
+++ b/packages/gestalt/src/TextField.css
@@ -1,3 +1,7 @@
+:root {
+  --gray: #767676;
+}
+
 .textField {
   composes: borderBox from "./Layout.css";
   composes: Text fontSize3 from "./Text.css";
@@ -6,5 +10,5 @@
 }
 
 .textField::placeholder {
-  color: #8e8e8e;
+  color: var(--gray);
 }


### PR DESCRIPTION
- Previously Gray mapped to #8E8E8E which is a non-accessible color for small type sizes. 
- To improve accessibility and aligned with criteria for AA rating in WCAG for small text, all Gray color references change from  #8E8E8E  to #767676.

### Before and After
![image](https://user-images.githubusercontent.com/10593890/79163378-d080fc00-7d93-11ea-9777-fb25497f3a52.png)
![image](https://user-images.githubusercontent.com/10593890/79163328-b9420e80-7d93-11ea-83c1-a5740bc4e181.png)


## TODO

~~- [ ] Documentation~~
~~- [ ] Tests~~
~~- [ ] Experimental evidence (required for Masonry changes)~~
~~- [ ] Accessibility checkup~~
