### PR TITLE
Version bump: 1.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@
   </summary>
 
 ### Minor
-- SegmentedControl: Update the border radius from 8px outer / 6px inner to 16px outer / 14px inner (#798)
 
 ### Patch
 
 </details>
+
+## 1.39.0 (Apr 14, 2020)
+
+### Minor
+
+- SegmentedControl: Update the border radius from 8px outer / 6px inner to 16px outer / 14px inner (#798)
 
 ## 1.38.0 (Apr 13, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.39.0 (Apr 14, 2020)

### Minor

- SegmentedControl: Update the border radius from 8px outer / 6px inner to 16px outer / 14px inner (#798)