### PR TITLE
Text/Heading: Use default (manual) hyphenation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
           node-version: ${{ matrix.node_version }}
       - name: yarn install, build, and test
         run: |
-          yarn install
+          yarn install --force
           yarn build
           yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor
 
+- Text/Heading: Use default (manual) hyphenation (#807)
+
 ### Patch
 
 </details>

--- a/packages/gestalt/src/Typography.css
+++ b/packages/gestalt/src/Typography.css
@@ -57,7 +57,6 @@
 /* overflow */
 
 .breakWord {
-  hyphens: auto;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
Internal mweb and desktop experiments were successful, so let's ship the default (manual) hyphenation

The default value of `hyphens` is `manual`, so there is no need to explicitly set it
![image](https://user-images.githubusercontent.com/127199/79261435-ac312800-7e44-11ea-91e4-a17c998a8c75.png)
https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens

![image](https://user-images.githubusercontent.com/127199/79261527-d84ca900-7e44-11ea-892d-96f4b92dc1c8.png)
