### PR TITLE
Version bump: 1.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,19 @@
 
 ### Minor
 
+### Patch
+
+</details>
+
+## 1.40.0 (Apr 15, 2020)
+
+### Minor
+
 - Text/Heading: Use default (manual) hyphenation (#807)
 
 ### Patch
 
-</details>
+- Internal: remove reference to unused .integration.js (#808)
 
 ## 1.39.0 (Apr 14, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.40.0 (Apr 15, 2020)

### Minor

- Text/Heading: Use default (manual) hyphenation (#807)

### Patch

- Internal: remove reference to unused .integration.js (#808)