### PR TITLE
Version bump: v1.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@
 
 ### Minor
 
-- Color: update gray color to #767676 (#804)
-- Icon: update default #8e8e8e to #767676 (#811)
-
 ### Patch
 
 </details>
+
+## 1.41.0 (Apr 16, 2020)
+
+### Minor
+
+- Color: update gray color to #767676 (#804)
+- Icon: update default #8e8e8e to #767676 (#811)
 
 ## 1.40.0 (Apr 15, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.41.0 (Apr 16, 2020)

### Minor

- Color: update gray color to #767676 (#804)
- Icon: update default #8e8e8e to #767676 (#811)