### PR TITLE
[Buttons/Tabs]: Increase paddingX to 16px on lg Buttons and Tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Internal: update yarn.lock file (#814)
 - Internal: Minor version updates for several dependencies (#815)
+- Buttons/Tabs: Increase paddingX to 16px on lg Buttons and Tabs (#816)
 
 ### Patch
 

--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -21,7 +21,7 @@
 
 .lg {
   composes: large from "./Layout.css";
-  composes: paddingX3 from "./boxWhitespace.css";
+  composes: paddingX4 from "./boxWhitespace.css";
   composes: paddingY3 from "./boxWhitespace.css";
 }
 

--- a/packages/gestalt/src/Tabs.css
+++ b/packages/gestalt/src/Tabs.css
@@ -10,7 +10,7 @@
   composes: noBorder pill from "./Borders.css";
   composes: m0 from "./Whitespace.css";
   composes: pointer from "./Cursor.css";
-  composes: paddingX3 paddingY2 from "./boxWhitespace.css";
+  composes: paddingX4 paddingY2 from "./boxWhitespace.css";
   text-decoration: none;
 }
 


### PR DESCRIPTION
- Changes the horizontal padding from 12px to 16px for  48px Buttons (large) & Tabs components

![image](https://user-images.githubusercontent.com/10593890/79598678-3a9de780-8099-11ea-9d28-ff753091adbd.png)
![image](https://user-images.githubusercontent.com/10593890/79597159-a3379500-8096-11ea-9127-30eb0d56b1e1.png)
![image](https://user-images.githubusercontent.com/10593890/79597528-4688aa00-8097-11ea-8da4-5e322389216e.png)

## TODO

~~- [ ] Documentation~~
~~- [ ] Tests~~
~~- [ ] Experimental evidence (required for Masonry changes)~~
~~- [ ] Accessibility checkup~~