### PR TITLE
Version bump: 1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@
   </summary>
 
 ### Minor
-- RadioButton/Checkbox: Moved shared classes to RadioButtonCheckbox.css (#810)
 
+### Patch
+
+</details>
+
+## 1.42.0 (Apr 20, 2020)
+
+### Minor
+
+- RadioButton/Checkbox: Moved shared classes to RadioButtonCheckbox.css (#810)
 - Internal: update yarn.lock file (#814)
 - Internal: Minor version updates for several dependencies (#815)
 - Buttons/Tabs: Increase paddingX to 16px on lg Buttons and Tabs (#816)
@@ -16,8 +24,6 @@
 ### Patch
 
 - Docs: Add a note on the Tabs documentation about use with react-router (#813)
-
-</details>
 
 ## 1.41.0 (Apr 16, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.42.0 (Apr 20, 2020)

### Minor

- RadioButton/Checkbox: Moved shared classes to RadioButtonCheckbox.css (#810)
- Internal: update yarn.lock file (#814)
- Internal: Minor version updates for several dependencies (#815)
- Buttons/Tabs: Increase paddingX to 16px on lg Buttons and Tabs (#816)

### Patch

- Docs: Add a note on the Tabs documentation about use with react-router (#813)