### PR TITLE
Internal: Enable React Strict Mode on documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Patch
 
+- Internal: Enable React.Strict on documentation (#821)
+
 </details>
 
 ## 1.42.0 (Apr 20, 2020)

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -12,19 +12,21 @@ const container = document.getElementById('root');
 
 if (container instanceof Element) {
   render(
-    <HashRouter>
-      <App>
-        <Switch>
-          {Object.keys(routes).map(pathname => (
-            <Route
-              path={`/${pathname}`}
-              key={pathname}
-              render={() => <CardPage cards={routes[pathname]} />}
-            />
-          ))}
-        </Switch>
-      </App>
-    </HashRouter>,
+    <React.StrictMode>
+      <HashRouter>
+        <App>
+          <Switch>
+            {Object.keys(routes).map(pathname => (
+              <Route
+                path={`/${pathname}`}
+                key={pathname}
+                render={() => <CardPage cards={routes[pathname]} />}
+              />
+            ))}
+          </Switch>
+        </App>
+      </HashRouter>
+    </React.StrictMode>,
     container
   );
 } else {


### PR DESCRIPTION
https://reactjs.org/docs/strict-mode.html

>StrictMode is a tool for highlighting potential problems in an application. Like Fragment, StrictMode does not render any visible UI. It activates additional checks and warnings for its descendants.

The only error/warning I found is caused by `react-live` which uses an unsafe lifecycle method: `UNSAFE_componentWillMount`: https://github.com/FormidableLabs/react-live/blob/05e0ad7ab8231a2c119a91240a2bcc67cf8c6d02/src/components/Live/LiveProvider.js#L27

![image](https://user-images.githubusercontent.com/127199/79780654-14728480-82f1-11ea-99ea-fd1e07377ff8.png)