### PR TITLE
[IconButton/Pog]: Removed unused iconColor options: blue, orange; added bgColor: darkGray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Minor
 
+- IconButton/Pog: Removed unused iconColor options: blue, orange; added darkGray; added bgColor: darkGray (#823)
+- Docs: Replaced combinations in Pog with Combinations: Icon Color & Background Color. Removed IconButton-bgColor-blue option from Docs. (#823)
+
 ### Patch
 
 - Internal: Enable React.Strict on documentation (#821)

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -44,7 +44,7 @@ card(
       {
         name: 'bgColor',
         type:
-          '"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue" | "red"',
+          '"transparent" | "transparentDarkGray" | "darkGray" | "gray" | "lightGray" | "white" | "red"',
         defaultValue: 'transparent',
         href: 'backgroundColorCombinations',
       },
@@ -56,7 +56,7 @@ card(
       },
       {
         name: 'iconColor',
-        type: `"blue" | "darkGray" | "gray" | "red" | "white" | "orange"`,
+        type: `"darkGray" | "gray" | "red" | "white"`,
         defaultValue: 'gray',
         href: 'iconColorCombinations',
       },
@@ -163,7 +163,7 @@ card(
   <Combination
     id="iconColorCombinations"
     name="Combinations: Icon Color"
-    iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
+    iconColor={['darkGray', 'gray', 'red', 'white']}
   >
     {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
   </Combination>
@@ -176,9 +176,10 @@ card(
     bgColor={[
       'transparent',
       'transparentDarkGray',
-      'white',
-      'lightGray',
+      'darkGray',
       'gray',
+      'lightGray',
+      'white',
     ]}
   >
     {props => <IconButton icon="heart" accessibilityLabel="" {...props} />}
@@ -201,7 +202,7 @@ card(
     id="disabledCombinations"
     name="Combinations: Disabled"
     description="Icon buttons can be disabled as well. Adding the disabled flag to any color combination will add a 50% opacity and remove interactivity"
-    iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
+    iconColor={['darkGray', 'gray', 'red', 'white']}
   >
     {props => (
       <IconButton icon="heart" accessibilityLabel="" disabled {...props} />

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -31,7 +31,7 @@ card(
       },
       {
         name: 'bgColor',
-        type: `"transparent" | "transparentDarkGray" | "gray" | "lightGray" | "white" | "blue" | "red"`,
+        type: `"transparent" | "transparentDarkGray" | "darkGray" | "gray" | "lightGray" | "white" | "blue" | "red"`,
         defaultValue: 'transparent',
         href: 'colorCombinations',
       },
@@ -49,7 +49,7 @@ card(
       },
       {
         name: 'iconColor',
-        type: `"blue" | "darkGray" | "gray" | "red" | "white" | "orange"`,
+        type: `"darkGray" | "gray" | "red" | "white"`,
         defaultValue: 'gray',
         href: 'colorCombinations',
       },
@@ -96,7 +96,7 @@ card(
 card(
   <Combination
     id="stateCombinations"
-    name="State Combinations"
+    name="Combinations: State"
     hovered={[false, true]}
     focused={[false, true]}
     active={[false, true]}
@@ -108,7 +108,7 @@ card(
 card(
   <Combination
     id="sizeCombinations"
-    name="Size Combinations"
+    name="Combinations: Size"
     size={['xs', 'sm', 'md', 'lg', 'xl']}
   >
     {props => <Pog icon="heart" {...props} />}
@@ -117,12 +117,22 @@ card(
 
 card(
   <Combination
-    id="colorCombinations"
-    name="Color Combinations"
-    iconColor={['blue', 'darkGray', 'gray', 'red', 'white']}
+    id="iconColorCombinations"
+    name="Combinations: Icon Color"
+    iconColor={['darkGray', 'gray', 'red', 'white']}
+  >
+    {props => <Pog icon="heart" {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="backgroundColorCombinations"
+    name="Combinations: Background Color"
     bgColor={[
       'transparent',
       'transparentDarkGray',
+      'darkGray',
       'white',
       'lightGray',
       'gray',

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -12,6 +12,7 @@ type Props = {|
   accessibilityLabel: string,
   bgColor?:
     | 'transparent'
+    | 'darkGray'
     | 'transparentDarkGray'
     | 'gray'
     | 'lightGray'
@@ -21,7 +22,7 @@ type Props = {|
   dangerouslySetSvgPath?: { __path: string },
   disabled?: boolean,
   icon?: $Keys<typeof icons>,
-  iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   onClick?: ({ event: SyntheticMouseEvent<> }) => void,
   selected?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
@@ -87,6 +88,7 @@ IconButton.propTypes = {
   accessibilityLabel: PropTypes.string.isRequired,
   bgColor: PropTypes.oneOf([
     'transparent',
+    'darkGray',
     'transparentDarkGray',
     'gray',
     'lightGray',
@@ -99,14 +101,7 @@ IconButton.propTypes = {
   }),
   disabled: PropTypes.bool,
   icon: PropTypes.oneOf(Object.keys(icons)),
-  iconColor: PropTypes.oneOf([
-    'gray',
-    'darkGray',
-    'red',
-    'blue',
-    'white',
-    'orange',
-  ]),
+  iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'white']),
   onClick: PropTypes.func,
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -27,6 +27,7 @@ type Props = {|
   active?: boolean,
   bgColor?:
     | 'transparent'
+    | 'darkGray'
     | 'transparentDarkGray'
     | 'gray'
     | 'lightGray'
@@ -38,7 +39,7 @@ type Props = {|
   hovered?: boolean,
   selected?: boolean,
   icon?: $Keys<typeof icons>,
-  iconColor?: 'gray' | 'darkGray' | 'red' | 'blue' | 'white' | 'orange',
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   size?: $Keys<typeof SIZE_NAME_TO_PIXEL>,
 |};
 
@@ -109,6 +110,7 @@ Pog.propTypes = {
   active: PropTypes.bool,
   bgColor: PropTypes.oneOf([
     'transparent',
+    'darkGray',
     'transparentDarkGray',
     'gray',
     'lightGray',
@@ -121,14 +123,7 @@ Pog.propTypes = {
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   icon: PropTypes.oneOf(Object.keys(icons)),
-  iconColor: PropTypes.oneOf([
-    'gray',
-    'darkGray',
-    'red',
-    'blue',
-    'white',
-    'orange',
-  ]),
+  iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'white']),
   selected: PropTypes.bool,
   size: PropTypes.oneOf(Object.keys(SIZE_NAME_TO_PIXEL)),
 };


### PR DESCRIPTION
- IconButton/Pog: Removed unused `iconColor` options: `blue`, `orange`; added `bgColor` option: `darkGray`
- Docs for Pog: Replaced `Combination: Color` for `Combinations: Icon Color` & `Combinations: Background Color` to match IconButton.
- Removed IconButton-bgColor-blue option from Docs.

## TODO

- [x] Documentation
~~- [ ] Tests~~
~~- [ ] Experimental evidence (required for Masonry changes)~~
~~- [ ] Accessibility checkup~~
