### PR TITLE
Internal: Test builds on Node.js 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [12, 13]
+        node_version: [12, 14]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Patch
 
+- Internal: Test builds on Node.js 14 (#826)
+
 </details>
 
 ## 1.43.0 (Apr 21, 2020)


### PR DESCRIPTION
Test the Gestalt build on Node.js 14 - allows us to spot issues early.