### PR TITLE
Touchable: add optional onBlur / onFocus props

### DIFF
--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -39,6 +39,14 @@ card(
         href: 'basicExample',
       },
       {
+        name: 'onBlur',
+        type: '({ event: SyntheticFocusEvent<HTMLDivElement> }) => void',
+      },
+      {
+        name: 'onFocus',
+        type: '({ event: SyntheticFocusEvent<HTMLDivElement> }) => void',
+      },
+      {
         name: 'onMouseEnter',
         type: '({ event: SyntheticMouseEvent<HTMLDivElement> }) => void',
       },

--- a/packages/gestalt/src/Touchable.js
+++ b/packages/gestalt/src/Touchable.js
@@ -23,6 +23,8 @@ type Props = {|
   fullHeight?: boolean,
   fullWidth?: boolean,
   mouseCursor?: MouseCursor,
+  onBlur?: ({ event: SyntheticFocusEvent<HTMLDivElement> }) => void,
+  onFocus?: ({ event: SyntheticFocusEvent<HTMLDivElement> }) => void,
   onMouseEnter?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
   onMouseLeave?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
   onTouch?: ({
@@ -81,6 +83,8 @@ export default class Touchable extends React.Component<Props> {
       'zoomIn',
       'zoomOut',
     ]),
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
     onTouch: PropTypes.func,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
@@ -97,6 +101,20 @@ export default class Touchable extends React.Component<Props> {
       // Prevent the default action to stop scrolling when space is pressed
       event.preventDefault();
       onTouch({ event });
+    }
+  };
+
+  handleBlur = (event: SyntheticFocusEvent<HTMLDivElement>) => {
+    const { onBlur } = this.props;
+    if (onBlur) {
+      onBlur({ event });
+    }
+  };
+
+  handleFocus = (event: SyntheticFocusEvent<HTMLDivElement>) => {
+    const { onFocus } = this.props;
+    if (onFocus) {
+      onFocus({ event });
     }
   };
 
@@ -144,6 +162,8 @@ export default class Touchable extends React.Component<Props> {
       <div
         className={classes}
         onClick={this.handleClick}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
         onKeyPress={this.handleKeyPress}

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -74,7 +74,9 @@ exports[`Video with children 1`] = `
     >
       <div
         className="touchable pointer rounding0"
+        onBlur={[Function]}
         onClick={[Function]}
+        onFocus={[Function]}
         onKeyPress={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
@@ -195,7 +197,9 @@ exports[`Video with children 1`] = `
     >
       <div
         className="touchable pointer rounding0"
+        onBlur={[Function]}
         onClick={[Function]}
+        onFocus={[Function]}
         onKeyPress={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}

--- a/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
@@ -9,7 +9,9 @@ exports[`VideoControls for double digit minutes 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -130,7 +132,9 @@ exports[`VideoControls for double digit minutes 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -164,7 +168,9 @@ exports[`VideoControls for double digit seconds 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -285,7 +291,9 @@ exports[`VideoControls for double digit seconds 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -319,7 +327,9 @@ exports[`VideoControls for single digit minutes 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -440,7 +450,9 @@ exports[`VideoControls for single digit minutes 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -474,7 +486,9 @@ exports[`VideoControls for single digit seconds 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -595,7 +609,9 @@ exports[`VideoControls for single digit seconds 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -629,7 +645,9 @@ exports[`VideoControls rounds for partial seconds 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
@@ -750,7 +768,9 @@ exports[`VideoControls rounds for partial seconds 1`] = `
   >
     <div
       className="touchable pointer rounding0"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onKeyPress={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}

--- a/packages/gestalt/src/__snapshots__/touchable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/touchable.test.js.snap
@@ -3,7 +3,9 @@
 exports[`Touchable renders 1`] = `
 <div
   className="touchable pointer rounding0 fullWidth"
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -17,7 +19,9 @@ exports[`Touchable renders 1`] = `
 exports[`Touchable sets correct mouse cursor 1`] = `
 <div
   className="touchable zoomIn rounding0 fullWidth"
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -31,7 +35,9 @@ exports[`Touchable sets correct mouse cursor 1`] = `
 exports[`Touchable sets correct rounding 1`] = `
 <div
   className="touchable pointer circle fullWidth"
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -45,7 +51,9 @@ exports[`Touchable sets correct rounding 1`] = `
 exports[`Touchable sets fullHeight correctly 1`] = `
 <div
   className="touchable pointer rounding0 fullHeight fullWidth"
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -59,7 +67,9 @@ exports[`Touchable sets fullHeight correctly 1`] = `
 exports[`Touchable sets fullWidth correctly 1`] = `
 <div
   className="touchable pointer rounding0"
+  onBlur={[Function]}
   onClick={[Function]}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}

--- a/packages/gestalt/src/touchable.jsdom.test.js
+++ b/packages/gestalt/src/touchable.jsdom.test.js
@@ -12,6 +12,25 @@ test('Touchable handles onTouch callback', () => {
   expect(mockOnTouch).toHaveBeenCalled();
 });
 
+test('Touchable handles onBlur callback', () => {
+  const mockOnBlur = jest.fn();
+  const { getByText } = render(
+    <Touchable onBlur={mockOnBlur}>Touchable</Touchable>
+  );
+  fireEvent.focus(getByText('Touchable'));
+  fireEvent.blur(getByText('Touchable'));
+  expect(mockOnBlur).toHaveBeenCalled();
+});
+
+test('Touchable handles onFocus callback', () => {
+  const mockOnFocus = jest.fn();
+  const { getByText } = render(
+    <Touchable onFocus={mockOnFocus}>Touchable</Touchable>
+  );
+  fireEvent.focus(getByText('Touchable'));
+  expect(mockOnFocus).toHaveBeenCalled();
+});
+
 test('Touchable handles onMouseEnter callback', () => {
   const mockOnMouseEnter = jest.fn();
   const { getByText } = render(


### PR DESCRIPTION
Use case: in order to make a more accessible `Tooltip`, we need to fire onBlur / onFocus events from `Touchable` so the design syncs up.

In this example you can see the issue, hovering the Icon changes the color but focussing it does not.

![touchable-focus-blur](https://user-images.githubusercontent.com/127199/80160943-c5904d80-8583-11ea-8635-2a4abd11093a.gif)
