### PR TITLE
Version bump: v1.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@
   </summary>
 
 ### Minor
-- IconButton/Pog: Deprecated bgColor=blue in Pog and IconButton (#827)
 
 ### Patch
 
 </details>
+
+## 1.46.0 (Apr 27, 2020)
+
+### Minor
+
+- IconButton/Pog: Deprecated bgColor=blue in Pog and IconButton (#827)
+- Touchable: add optional onBlur / onFocus props (#832)
 
 ## 1.45.0 (Apr 23, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.46.0 (Apr 27, 2020)

### Minor

- IconButton/Pog: Deprecated bgColor=blue in Pog and IconButton (#827)
- Touchable: add optional onBlur / onFocus props (#832)