### PR TITLE
Support CloseupShop v2 Flyout UseCase

### DIFF
--- a/packages/gestalt/src/Contents.css
+++ b/packages/gestalt/src/Contents.css
@@ -24,7 +24,7 @@
 }
 
 .minDimensionsCustom {
-  padding: 3px
+  padding: 2px
 }
 
 .innerContents {

--- a/packages/gestalt/src/Contents.css
+++ b/packages/gestalt/src/Contents.css
@@ -23,6 +23,10 @@
   min-width: 180px;
 }
 
+.minDimensionsCustom {
+  padding: 3px
+}
+
 .innerContents {
   composes: flex from "./Layout.css";
   composes: overflowAuto from "./Layout.css";

--- a/packages/gestalt/src/Contents.css.flow
+++ b/packages/gestalt/src/Contents.css.flow
@@ -8,4 +8,5 @@ declare module.exports: {|
   +'innerContents': string,
   +'maxDimensions': string,
   +'minDimensions': string,
+  +'minDimensionsCustom': string,
 |};

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -498,6 +498,10 @@ export default class Contents extends React.Component<Props, State> {
     const visibility = mainDir === null ? 'hidden' : 'visible';
     const background = `${bgColor}Bg`;
     const stroke = bgColor === 'white' ? '#ddd' : null;
+    const minDims =
+      typeof width === 'number' && width < 180
+        ? styles.minDimensionsCustom
+        : styles.minDimensions;
 
     return (
       <div
@@ -513,7 +517,7 @@ export default class Contents extends React.Component<Props, State> {
             rounding === 4 && borders.rounding4,
             styles.contents,
             styles.maxDimensions,
-            width !== null && styles.minDimensions
+            width !== null && minDims
           )}
           ref={this.setFlyoutRef}
           tabIndex={-1}
@@ -522,7 +526,7 @@ export default class Contents extends React.Component<Props, State> {
             className={classnames(
               styles.innerContents,
               styles.maxDimensions,
-              width !== null && styles.minDimensions
+              width !== null && minDims
             )}
             style={{ maxWidth: width }}
           >


### PR DESCRIPTION
To support the sizing requirements of CloseupShop v2's useCase of a flyout-like component without having to reWrite flyout logic, I added custom logic for if the developer inputs a size below the "xs" size standard.

Examples within the context of the current docs: 
<img width="578" alt="Screen Shot 2020-04-27 at 2 35 06 PM" src="https://user-images.githubusercontent.com/7744422/80423227-810ef580-8894-11ea-841a-ecbdd4f0a19c.png">
<img width="113" alt="Screen Shot 2020-04-27 at 2 35 44 PM" src="https://user-images.githubusercontent.com/7744422/80423235-853b1300-8894-11ea-8b5e-1466606586cd.png">
