### PR TITLE
Version bump: v1.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Patch
 
-- Readme: Remove greenkeeper reference (#835)
-
 </details>
+
+## 1.46.1 (Apr 28, 2020)
+
+### Patch
+
+- Readme: Remove greenkeeper reference (#835)
 
 ## 1.46.0 (Apr 27, 2020)
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.46.1 (Apr 28, 2020)

### Patch

- Readme: Remove greenkeeper reference (#835)
