### PR TITLE
Add support for Badge with blue background and white text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   </summary>
 
 ### Minor
+- Badge: Update to solid background and white text (#839)
 
 ### Patch
 

--- a/docs/src/Badge.doc.js
+++ b/docs/src/Badge.doc.js
@@ -22,6 +22,8 @@ card(
         name: 'text',
         type: `string`,
         required: true,
+        description:
+          'Text displayed inside of the Badge. Sentence case is best.',
       },
       {
         name: 'position',
@@ -39,7 +41,7 @@ card(
     The `Badge` component is rendered inline within parent element."
     name="Example"
     defaultCode={`
-<Text>Some text that uses Badge component as its child <Badge text="new" /></Text>
+<Text>Some text that uses Badge component as its child <Badge text="New" /></Text>
 `}
   />
 );
@@ -47,10 +49,10 @@ card(
 card(
   <Example
     description="
-    Larger text looks better with a superscript `Badge`."
-    name="Example"
+    Larger text example rendered with a top positioned `Badge`."
+    name="Example: positioning"
     defaultCode={`
-  <Heading>Heading <Badge text="new" position="top" /></Heading>
+  <Heading>Heading <Badge text="Beta" position="top"/></Heading>
 `}
   />
 );

--- a/packages/gestalt/src/Badge.css
+++ b/packages/gestalt/src/Badge.css
@@ -1,16 +1,12 @@
 .Badge {
   composes: antialiased sansSerif from "./Typography.css";
-  composes: fontWeightBold from "./Typography.css";
-  composes: blue from "./Colors.css";
   composes: inlineBlock from "./Layout.css";
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
+  composes: rounding1 from "./Borders.css";
+  composes: white from "./Colors.css";
+  composes: fontWeightBold from './Typography.css';
   font-size: 10px;
-  line-height: 1;
   margin-top: -4px;
   padding: 2px;
-  text-transform: uppercase;
   white-space: nowrap;
 }
 

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import styles from './Badge.css';
+import colors from './Colors.css';
 
 type Props = {|
   position?: 'middle' | 'top',
@@ -11,7 +12,8 @@ type Props = {|
 
 export default function Badge(props: Props) {
   const { position = 'middle', text } = props;
-  const cs = cx(styles.Badge, styles[position]);
+
+  const cs = cx(styles.Badge, styles[position], colors.blueBg);
 
   return <span className={cs}>{text}</span>;
 }

--- a/packages/gestalt/src/Badge.test.js
+++ b/packages/gestalt/src/Badge.test.js
@@ -1,10 +1,17 @@
 // @flow strict
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import Badge from './Badge.js';
 
 it('Badge renders', () => {
-  const component = renderer.create(<Badge text="Badge" />);
+  const component = create(<Badge text="Badge" />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+it('should render with white text and blue background', () => {
+  const instance = create(<Badge text="Badge" />).root;
+  const { className } = instance.find(element => element.type === 'span').props;
+
+  expect(className).toContain('blueBg');
 });

--- a/packages/gestalt/src/__snapshots__/Badge.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Badge.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Badge renders 1`] = `
 <span
-  className="Badge middle"
+  className="Badge middle blueBg"
 >
   Badge
 </span>


### PR DESCRIPTION
This change updates the existing Badge component to match updated specs featuring:
- solid background (blue)
- white text
- remove enforcement of upper casing (consensus is sentence casing is better)
- update docs examples to include sentence casing, remove sentence suggesting we encourage use of top with headings.

I anticipate extending the implementation to include additional sizing and color props so i've tried to write this with that in mind while still being restrictive to match our current spec. For example, I allow for an optional color prop but I don't list this in the documentation and I restrict the Proptypes. Let me know if this is confusing in any way but I figured we'll likely be expanding this in the near future.

After
<img width="975" alt="Screen Shot 2020-05-05 at 5 38 07 PM" src="https://user-images.githubusercontent.com/16228317/81122821-602f4b80-8ef7-11ea-8738-a6e4be5559e4.png">

Before
<img width="1068" alt="Screen Shot 2020-05-05 at 5 37 59 PM" src="https://user-images.githubusercontent.com/16228317/81122824-60c7e200-8ef7-11ea-9af6-ee9c4d3ff185.png">



## TODO

- [x ] Documentation
- [x ] Tests
- [ ] Experimental evidence (required for Masonry changes)
- [ ] Accessibility checkup
