### PR TITLE
Add flexible size prop to Flyout

### DIFF
--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -74,8 +74,8 @@ card(
       },
       {
         name: 'size',
-        type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | number`,
-        description: `xs: 180px, sm: 230px, md: 284px, lg: 320px, xl: 360px`,
+        type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number`,
+        description: `xs: 180px, sm: 230px, md: 284px, lg: 320px, xl: 360px, flexible: no inherent sizing from flyout`,
         defaultValue: 'sm',
         href: 'basicExample',
       },

--- a/packages/gestalt/src/Flyout.js
+++ b/packages/gestalt/src/Flyout.js
@@ -12,7 +12,7 @@ type Props = {|
   positionRelativeToAnchor?: boolean,
   shouldFocus?: boolean,
   showCaret?: boolean,
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number,
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number,
 |};
 
 export default function Flyout(props: Props) {
@@ -43,7 +43,7 @@ export default function Flyout(props: Props) {
       positionRelativeToAnchor={positionRelativeToAnchor}
       rounding={4}
       shouldFocus={shouldFocus}
-      size={size}
+      size={size === 'flexible' ? null : size}
     >
       {children}
     </Controller>


### PR DESCRIPTION
Adding "flexible" as an acceptable prop string to Flyout's size prop that will allow custom sizing on a flyout's contents.

Screenshot of custom sizing in acton:
<img width="499" alt="Screen Shot 2020-05-04 at 10 18 42 AM" src="https://user-images.githubusercontent.com/7744422/81015170-10775400-8e13-11ea-832a-3ca487d95694.png">

