### PR TITLE
Internal: enable + enforce flow strict on every file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,14 +27,18 @@
   ],
   "rules": {
     "eslint-comments/no-unused-disable": "error",
+    "flowtype/require-valid-file-annotation": [
+      "error",
+      "always",
+      {
+        "annotationStyle": "line",
+        "strict": true
+      }
+    ],
     "import/extensions": ["error", "always", { "ignorePackages": true }],
     "import/no-extraneous-dependencies": "off",
     "import/no-relative-parent-imports": "error",
     "import/no-unresolved": "off",
-    "jsx-a11y/label-has-for": [
-      "error",
-      { "components": ["label"], "allowChildren": true }
-    ],
     "jsx-a11y/label-has-associated-control": [
       "error",
       {
@@ -43,6 +47,10 @@
         "controlComponents": ["CheckBox"],
         "depth": 3
       }
+    ],
+    "jsx-a11y/label-has-for": [
+      "error",
+      { "components": ["label"], "allowChildren": true }
     ],
     "no-await-in-loop": "off",
     "no-return-await": "off",
@@ -61,6 +69,12 @@
     "react/static-property-placement": ["error", "static public field"]
   },
   "overrides": [
+    {
+      "files": ["packages/gestalt-codemods/**/*.js", "scripts/**/*.js"],
+      "rules": {
+        "flowtype/require-valid-file-annotation": "off"
+      }
+    },
     {
       "files": ["**/*.test.js"],
       "env": {

--- a/.flowconfig
+++ b/.flowconfig
@@ -4,7 +4,6 @@
 [ignore]
 # Tracking https://github.com/facebook/flow/issues/4015
 <PROJECT_ROOT>/docs
-<PROJECT_ROOT>/test
 <PROJECT_ROOT>/packages/gestalt-codemods/.*/__testfixtures__
 
 [options]
@@ -16,9 +15,9 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 flow-typed
 
 [lints]
+nonstrict-import=error
 sketchy-number=error
-untyped-type-import=error
-untyped-import=error
 unclear-type=error
 unsafe-getters-setters=error
-nonstrict-import=error
+untyped-import=error
+untyped-type-import=error

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
+// @flow strict
 module.exports = {
   presets: ['@babel/preset-env', '@babel/react', '@babel/flow'],
   plugins: ['@babel/proposal-class-properties'],

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import changelog from './scripts/danger/changelog.js';
 import lockfile from './scripts/danger/lockfile.js';
 import experiments from './scripts/danger/experiments.js';

--- a/docs/src/Avatar.doc.js
+++ b/docs/src/Avatar.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Badge.doc.js
+++ b/docs/src/Badge.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Box, Button } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Button } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Card.doc.js
+++ b/docs/src/Card.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Checkbox } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Collage.doc.js
+++ b/docs/src/Collage.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Column.doc.js
+++ b/docs/src/Column.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Card from './components/Card.js';

--- a/docs/src/Container.doc.js
+++ b/docs/src/Container.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Divider.doc.js
+++ b/docs/src/Divider.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { GroupAvatar } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Icon } from 'gestalt';
 import Example from './components/Example.js';

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { IconButton } from 'gestalt';
 import Example from './components/Example.js';

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Label.doc.js
+++ b/docs/src/Label.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import Card from './components/Card.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Letterbox.doc.js
+++ b/docs/src/Letterbox.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Mask } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Box, Masonry, Image, Text, MasonryUniformRowLayout } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Pog } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Pulsar.doc.js
+++ b/docs/src/Pulsar.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { RadioButton } from 'gestalt';
 import Example from './components/Example.js';

--- a/docs/src/SearchField.doc.js
+++ b/docs/src/SearchField.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTable from './components/PropTable.js';

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/SelectList.doc.js
+++ b/docs/src/SelectList.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Spinner.doc.js
+++ b/docs/src/Spinner.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Sticky.doc.js
+++ b/docs/src/Sticky.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Switch } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Tabs } from 'gestalt';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Button, Link, Image, Text, Toast } from 'gestalt';
 import Combination from './components/Combination.js';

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Box, Column, Divider, Link, Text } from 'gestalt';
 import Header from './Header.js';

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Box, Heading } from 'gestalt';
 import Markdown from './Markdown.js';

--- a/docs/src/components/CardPage.js
+++ b/docs/src/components/CardPage.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Box } from 'gestalt';
 import SearchContent from './SearchContent.js';

--- a/docs/src/components/Checkerboard.js
+++ b/docs/src/components/Checkerboard.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 
 type Props = {|

--- a/docs/src/components/Combination.js
+++ b/docs/src/components/Combination.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Box, Text } from 'gestalt';
 import Checkerboard from './Checkerboard.js';

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import * as gestalt from 'gestalt';
 import LZString from 'lz-string';

--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Text, Icon, IconButton, Link as GestaltLink } from 'gestalt';
 import Link from './Link.js';

--- a/docs/src/components/Link.js
+++ b/docs/src/components/Link.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Link as GestaltLink } from 'gestalt';
 import { createLocation } from 'history';

--- a/docs/src/components/Markdown.js
+++ b/docs/src/components/Markdown.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 import marked, { Renderer } from 'marked';

--- a/docs/src/components/NavLink.js
+++ b/docs/src/components/NavLink.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Link, Text } from 'gestalt';
 import { withRouter, Route } from 'react-router-dom';

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 import NavLink from './NavLink.js';

--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Text, Heading, Link } from 'gestalt';
 import Markdown from './Markdown.js';

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { Box, Text, Icon, Link } from 'gestalt';
 

--- a/docs/src/components/SearchContent.js
+++ b/docs/src/components/SearchContent.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 
 type Props = {|

--- a/docs/src/components/atomDark.js
+++ b/docs/src/components/atomDark.js
@@ -1,3 +1,4 @@
+// @flow strict
 export default {
   plain: {
     color: '#c5c8c6',

--- a/docs/src/components/routes.js
+++ b/docs/src/components/routes.js
@@ -1,3 +1,4 @@
+// @flow strict
 const routes = {};
 
 const requireCard = require.context('..', true, /\.doc\.js$/);

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 import { render } from 'react-dom';

--- a/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-dynamic.input.js
+++ b/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-dynamic.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-dynamic.output.js
+++ b/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-dynamic.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-false.input.js
+++ b/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-false.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-false.output.js
+++ b/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-false.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-spread.input.js
+++ b/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-spread.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-spread.output.js
+++ b/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-spread.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-static.input.js
+++ b/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-static.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-static.output.js
+++ b/packages/gestalt-codemods/0.108.0-0.109.0/__testfixtures__/convert-font-weight-static.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/heading-remove-semibold-dynamic.input.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/heading-remove-semibold-dynamic.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/heading-remove-semibold-dynamic.output.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/heading-remove-semibold-dynamic.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/heading-remove-semibold-static.input.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/heading-remove-semibold-static.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/heading-remove-semibold-static.output.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/heading-remove-semibold-static.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-bold-first.input.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-bold-first.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-bold-first.output.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-bold-first.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-normal.input.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-normal.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-normal.output.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-normal.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-semibold-first.input.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-semibold-first.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-semibold-first.output.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-dynamic-semibold-first.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-static.input.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-static.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-static.output.js
+++ b/packages/gestalt-codemods/0.111.0-0.112.0/__testfixtures__/text-remove-semibold-static.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-bottom.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-bottom.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-bottom.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-bottom.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-circle.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-circle.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-circle.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-circle.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-left.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-left.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-left.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-left.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-right.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-right.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-right.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-right.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-top.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-top.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-top.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-roundedX-top.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-circle.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-circle.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-circle.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-circle.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-pill.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-pill.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-pill.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-pill.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-rounded.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-rounded.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-rounded.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-rounded.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-square.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-square.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-square.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-square.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-ternary.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-ternary.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-ternary.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-box-shape-to-rounding-ternary.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-circle.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-circle.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Mask } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-circle.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-circle.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Mask } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-rounded.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-rounded.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Mask } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-rounded.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-rounded.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Mask } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-square.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-square.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Mask } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-square.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-mask-shape-to-rounding-square.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Mask } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-bottom.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-bottom.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-bottom.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-bottom.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-circle.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-circle.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-circle.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-circle.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-left.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-left.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-left.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-left.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-right.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-right.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-right.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-right.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-top.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-top.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-top.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-roundedX-top.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-circle.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-circle.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-circle.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-circle.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-expression-circle.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-expression-circle.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-expression-circle.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-expression-circle.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-pill.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-pill.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-pill.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-pill.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-rounded.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-rounded.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-rounded.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-rounded.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-square.input.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-square.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-square.output.js
+++ b/packages/gestalt-codemods/0.125.0-1.0.0/__testfixtures__/convert-touchable-shape-to-rounding-square.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Touchable } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-sm.input.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-sm.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-sm.output.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-sm.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-xl.input.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-xl.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-xl.output.js
+++ b/packages/gestalt-codemods/1.14.0-1.15.0/__testfixtures__/remove-text-size-xl-xl.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.15.0-1.16.0/__testfixtures__/deprecatedMargin-box-replace.input.js
+++ b/packages/gestalt-codemods/1.15.0-1.16.0/__testfixtures__/deprecatedMargin-box-replace.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Box as Boxie } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.15.0-1.16.0/__testfixtures__/deprecatedMargin-box-replace.output.js
+++ b/packages/gestalt-codemods/1.15.0-1.16.0/__testfixtures__/deprecatedMargin-box-replace.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Box as Boxie } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.15.0-1.16.0/__testfixtures__/deprecatedPadding-box-replace.input.js
+++ b/packages/gestalt-codemods/1.15.0-1.16.0/__testfixtures__/deprecatedPadding-box-replace.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Box as Boxie } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.15.0-1.16.0/__testfixtures__/deprecatedPadding-box-replace.output.js
+++ b/packages/gestalt-codemods/1.15.0-1.16.0/__testfixtures__/deprecatedPadding-box-replace.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Box as Boxie } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-both.input.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-both.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Toast } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-both.output.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-both.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Toast } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-single.input.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-single.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Toast } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-single.output.js
+++ b/packages/gestalt-codemods/1.22.0-1.23.0/__testfixtures__/toast-remove-color-icon-single.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Toast } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.input.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Avatar } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.output.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Avatar } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.input.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { GroupAvatar } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.output.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { GroupAvatar } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-icon.input.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-icon.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Avatar } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-icon.output.js
+++ b/packages/gestalt-codemods/1.26.0-1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-icon.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Avatar } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.3.0-1.4.0/__testfixtures__/modal-remove-close-label.input.js
+++ b/packages/gestalt-codemods/1.3.0-1.4.0/__testfixtures__/modal-remove-close-label.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Modal } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.3.0-1.4.0/__testfixtures__/modal-remove-close-label.output.js
+++ b/packages/gestalt-codemods/1.3.0-1.4.0/__testfixtures__/modal-remove-close-label.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Modal } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/leading-text-remove.input.js
+++ b/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/leading-text-remove.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Text, Text as Renamed } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/leading-text-remove.output.js
+++ b/packages/gestalt-codemods/1.35.0-1.36.0/__testfixtures__/leading-text-remove.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Text, Text as Renamed } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-lg.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-lg.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-lg.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-lg.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-md.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-md.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-md.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-md.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-sm.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-sm.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-sm.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-sm.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-xl.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-xl.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-xl.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-xl.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-xs.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-xs.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-xs.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/heading-size-replace-xs.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Heading } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/remove-responsive-text-sizing-transform.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/remove-responsive-text-sizing-transform.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Heading as RenamedHeading, Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/remove-responsive-text-sizing-transform.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/remove-responsive-text-sizing-transform.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Box, Heading as RenamedHeading, Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-lg.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-lg.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-lg.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-lg.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-md.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-md.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-md.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-md.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-sm.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-sm.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-sm.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-sm.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-xl.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-xl.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-xl.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-xl.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-xs.input.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-xs.input.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-xs.output.js
+++ b/packages/gestalt-codemods/1.8.0-1.9.0/__testfixtures__/text-size-replace-xs.output.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { Text } from 'gestalt';
 

--- a/packages/gestalt/lib/classnameBuilder.js
+++ b/packages/gestalt/lib/classnameBuilder.js
@@ -8,6 +8,7 @@
 // classnames were added or removed. To solve this, we now hash based on the
 // class name and only add variation when hashes collide.
 
+// eslint-disable-next-line flowtype/require-valid-file-annotation
 import md5 from 'blueimp-md5';
 
 class ClassnameBuilder {

--- a/packages/gestalt/rollup.config.js
+++ b/packages/gestalt/rollup.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line flowtype/require-valid-file-annotation
 import babel from 'rollup-plugin-babel';
 import cssnano from 'cssnano';
 import filesize from 'rollup-plugin-filesize';

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';

--- a/packages/gestalt/src/Avatar.jsdom.test.js
+++ b/packages/gestalt/src/Avatar.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Avatar from './Avatar.js';

--- a/packages/gestalt/src/Avatar.test.js
+++ b/packages/gestalt/src/Avatar.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Avatar from './Avatar.js';

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';

--- a/packages/gestalt/src/Badge.test.js
+++ b/packages/gestalt/src/Badge.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Badge from './Badge.js';

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 /*
 

--- a/packages/gestalt/src/Box.test.js
+++ b/packages/gestalt/src/Box.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Box from './Box.js';

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/Button.jsdom.test.js
+++ b/packages/gestalt/src/Button.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
 import Button from './Button.js';

--- a/packages/gestalt/src/Button.test.js
+++ b/packages/gestalt/src/Button.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Button from './Button.js';

--- a/packages/gestalt/src/Cache.js
+++ b/packages/gestalt/src/Cache.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 export interface Cache<K, V> {
   get(key: K): ?V;
   has(key: K): boolean;

--- a/packages/gestalt/src/Card.js
+++ b/packages/gestalt/src/Card.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Card.test.js
+++ b/packages/gestalt/src/Card.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Card from './Card.js';

--- a/packages/gestalt/src/Caret.js
+++ b/packages/gestalt/src/Caret.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 

--- a/packages/gestalt/src/Caret.test.js
+++ b/packages/gestalt/src/Caret.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Caret from './Caret.js';

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Checkbox.jsdom.test.js
+++ b/packages/gestalt/src/Checkbox.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
 import Checkbox from './Checkbox.js';

--- a/packages/gestalt/src/Checkbox.test.js
+++ b/packages/gestalt/src/Checkbox.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Checkbox from './Checkbox.js';

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Collection from './Collection.js';

--- a/packages/gestalt/src/Collage.test.js
+++ b/packages/gestalt/src/Collage.test.js
@@ -1,4 +1,4 @@
-// // @flow
+// @flow strict
 import * as React from 'react';
 import { create } from 'react-test-renderer';
 import Collage from './Collage.js';

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 /*
   # Collection
 

--- a/packages/gestalt/src/Collection.test.js
+++ b/packages/gestalt/src/Collection.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Collection from './Collection.js';

--- a/packages/gestalt/src/Column.js
+++ b/packages/gestalt/src/Column.js
@@ -1,4 +1,4 @@
-/* @flow */
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Column.test.js
+++ b/packages/gestalt/src/Column.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Column from './Column.js';

--- a/packages/gestalt/src/Container.js
+++ b/packages/gestalt/src/Container.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';

--- a/packages/gestalt/src/Container.test.js
+++ b/packages/gestalt/src/Container.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Container from './Container.js';

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Contents.test.js
+++ b/packages/gestalt/src/Contents.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import {
   getMainDir,
   getSubDir,

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Contents from './Contents.js';

--- a/packages/gestalt/src/Controller.jsdom.test.js
+++ b/packages/gestalt/src/Controller.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Controller from './Controller.js';

--- a/packages/gestalt/src/Divider.js
+++ b/packages/gestalt/src/Divider.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import styles from './Divider.css';
 

--- a/packages/gestalt/src/Divider.test.js
+++ b/packages/gestalt/src/Divider.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Divider from './Divider.js';

--- a/packages/gestalt/src/FetchItems.js
+++ b/packages/gestalt/src/FetchItems.js
@@ -10,7 +10,7 @@
  * fetch calls.
  */
 
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 

--- a/packages/gestalt/src/Flyout.js
+++ b/packages/gestalt/src/Flyout.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Controller from './Controller.js';

--- a/packages/gestalt/src/Flyout.jsdom.test.js
+++ b/packages/gestalt/src/Flyout.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Flyout from './Flyout.js';

--- a/packages/gestalt/src/FormErrorMessage.js
+++ b/packages/gestalt/src/FormErrorMessage.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/FormErrorMessage.test.js
+++ b/packages/gestalt/src/FormErrorMessage.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import FormErrorMessage from './FormErrorMessage.js';

--- a/packages/gestalt/src/FormHelperText.js
+++ b/packages/gestalt/src/FormHelperText.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/FormLabel.js
+++ b/packages/gestalt/src/FormLabel.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/GroupAvatar.js
+++ b/packages/gestalt/src/GroupAvatar.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styles from './GroupAvatar.css';

--- a/packages/gestalt/src/GroupAvatar.test.js
+++ b/packages/gestalt/src/GroupAvatar.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import GroupAvatar from './GroupAvatar.js';

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';

--- a/packages/gestalt/src/Heading.test.js
+++ b/packages/gestalt/src/Heading.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Heading from './Heading.js';

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Icon.test.js
+++ b/packages/gestalt/src/Icon.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Icon from './Icon.js';

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/IconButton.test.js
+++ b/packages/gestalt/src/IconButton.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import IconButton from './IconButton.js';

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';

--- a/packages/gestalt/src/Image.test.js
+++ b/packages/gestalt/src/Image.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Image from './Image.js';

--- a/packages/gestalt/src/Label.js
+++ b/packages/gestalt/src/Label.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styles from './Label.css';

--- a/packages/gestalt/src/Label.test.js
+++ b/packages/gestalt/src/Label.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Label from './Label.js';

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 

--- a/packages/gestalt/src/Layer.jsdom.test.js
+++ b/packages/gestalt/src/Layer.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
 import Layer from './Layer.js';

--- a/packages/gestalt/src/Layer.test.js
+++ b/packages/gestalt/src/Layer.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Layer from './Layer.js';

--- a/packages/gestalt/src/Letterbox.js
+++ b/packages/gestalt/src/Letterbox.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Mask from './Mask.js';

--- a/packages/gestalt/src/Letterbox.test.js
+++ b/packages/gestalt/src/Letterbox.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Letterbox from './Letterbox.js';

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';

--- a/packages/gestalt/src/Link.test.js
+++ b/packages/gestalt/src/Link.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Link from './Link.js';

--- a/packages/gestalt/src/Mask.js
+++ b/packages/gestalt/src/Mask.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';

--- a/packages/gestalt/src/Mask.test.js
+++ b/packages/gestalt/src/Mask.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Mask from './Mask.js';

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import debounce from './debounce.js';

--- a/packages/gestalt/src/MeasurementStore.js
+++ b/packages/gestalt/src/MeasurementStore.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import type { Cache } from './Cache.js';
 
 export default class MeasurementStore<T: {} | $ReadOnlyArray<mixed>, V>

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Pog.test.js
+++ b/packages/gestalt/src/Pog.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Pog from './Pog.js';

--- a/packages/gestalt/src/Pulsar.js
+++ b/packages/gestalt/src/Pulsar.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';

--- a/packages/gestalt/src/Pulsar.test.js
+++ b/packages/gestalt/src/Pulsar.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Pulsar from './Pulsar.js';

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/RadioButton.test.js
+++ b/packages/gestalt/src/RadioButton.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import RadioButton from './RadioButton.js';

--- a/packages/gestalt/src/ScrollContainer.js
+++ b/packages/gestalt/src/ScrollContainer.js
@@ -12,7 +12,7 @@
  * or the API at all, so it could easily be adapted to other event types.
  */
 
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 

--- a/packages/gestalt/src/ScrollFetch.js
+++ b/packages/gestalt/src/ScrollFetch.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import FetchItems from './FetchItems.js';

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/SearchField.jsdom.test.js
+++ b/packages/gestalt/src/SearchField.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
 import SearchField from './SearchField.js';

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/SegmentedControl.jsdom.test.js
+++ b/packages/gestalt/src/SegmentedControl.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
 import SegmentedControl from './SegmentedControl.js';

--- a/packages/gestalt/src/SegmentedControl.test.js
+++ b/packages/gestalt/src/SegmentedControl.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import SegmentedControl from './SegmentedControl.js';

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/SelectList.jsdom.test.js
+++ b/packages/gestalt/src/SelectList.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
 import SelectList from './SelectList.js';

--- a/packages/gestalt/src/SelectList.test.js
+++ b/packages/gestalt/src/SelectList.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import SelectList from './SelectList.js';

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Spinner.test.js
+++ b/packages/gestalt/src/Spinner.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Spinner from './Spinner.js';

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/Sticky.test.js
+++ b/packages/gestalt/src/Sticky.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Sticky from './Sticky.js';

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Switch.test.js
+++ b/packages/gestalt/src/Switch.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Switch from './Switch.js';

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Tabs.jsdom.test.js
+++ b/packages/gestalt/src/Tabs.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
 import Tabs from './Tabs.js';

--- a/packages/gestalt/src/Tabs.test.js
+++ b/packages/gestalt/src/Tabs.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Tabs from './Tabs.js';

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/Text.test.js
+++ b/packages/gestalt/src/Text.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Text from './Text.js';

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/TextArea.jsdom.test.js
+++ b/packages/gestalt/src/TextArea.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import TextArea from './TextArea.js';

--- a/packages/gestalt/src/TextArea.test.js
+++ b/packages/gestalt/src/TextArea.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import TextArea from './TextArea.js';

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/TextField.jsdom.test.js
+++ b/packages/gestalt/src/TextField.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import TextField from './TextField.js';

--- a/packages/gestalt/src/TextField.test.js
+++ b/packages/gestalt/src/TextField.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import TextField from './TextField.js';

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';

--- a/packages/gestalt/src/Toast.test.js
+++ b/packages/gestalt/src/Toast.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Button from './Button.js';

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import Controller from './Controller.js';

--- a/packages/gestalt/src/Tooltip.jsdom.test.js
+++ b/packages/gestalt/src/Tooltip.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import { fireEvent, render } from '@testing-library/react';

--- a/packages/gestalt/src/Touchable.js
+++ b/packages/gestalt/src/Touchable.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/Video.jsdom.test.js
+++ b/packages/gestalt/src/Video.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
 import Video from './Video.js';

--- a/packages/gestalt/src/Video.test.js
+++ b/packages/gestalt/src/Video.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Video from './Video.js';

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/VideoControls.jsdom.test.js
+++ b/packages/gestalt/src/VideoControls.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import VideoControls from './VideoControls.js';

--- a/packages/gestalt/src/VideoControls.test.js
+++ b/packages/gestalt/src/VideoControls.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import VideoControls from './VideoControls.js';

--- a/packages/gestalt/src/VideoPlayhead.js
+++ b/packages/gestalt/src/VideoPlayhead.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import * as React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/gestalt/src/VideoPlayhead.jsdom.test.js
+++ b/packages/gestalt/src/VideoPlayhead.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import VideoPlayhead from './VideoPlayhead.js';

--- a/packages/gestalt/src/VideoPlayhead.test.js
+++ b/packages/gestalt/src/VideoPlayhead.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import VideoPlayhead from './VideoPlayhead.js';

--- a/packages/gestalt/src/__mocks__/fileMock.js
+++ b/packages/gestalt/src/__mocks__/fileMock.js
@@ -1,1 +1,2 @@
+// @flow strict
 module.exports = 'test-file-stub';

--- a/packages/gestalt/src/behaviors/OutsideEventBehavior.js
+++ b/packages/gestalt/src/behaviors/OutsideEventBehavior.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 
 type Props = {|

--- a/packages/gestalt/src/behaviors/StopScrollBehavior.js
+++ b/packages/gestalt/src/behaviors/StopScrollBehavior.js
@@ -1,4 +1,4 @@
-/* @flow */
+// @flow strict
 import * as React from 'react';
 
 type Props = {|

--- a/packages/gestalt/src/behaviors/StopScrollBehavior.test.js
+++ b/packages/gestalt/src/behaviors/StopScrollBehavior.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import StopScrollBehavior from './StopScrollBehavior.js';

--- a/packages/gestalt/src/behaviors/TrapFocusBehavior.js
+++ b/packages/gestalt/src/behaviors/TrapFocusBehavior.js
@@ -1,4 +1,4 @@
-/* @flow */
+// @flow strict
 import * as React from 'react';
 
 type Props = {|

--- a/packages/gestalt/src/debounce.js
+++ b/packages/gestalt/src/debounce.js
@@ -4,7 +4,7 @@
  * the cooldown.
  */
 
-// @flow
+// @flow strict
 export default function debounce(
   fn: (...args: *) => void,
   threshhold: number = 100

--- a/packages/gestalt/src/defaultLayout.js
+++ b/packages/gestalt/src/defaultLayout.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import type { Cache } from './Cache.js';
 
 export type Position = {

--- a/packages/gestalt/src/defaultLayout.test.js
+++ b/packages/gestalt/src/defaultLayout.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import defaultLayout from './defaultLayout.js';
 
 const stubCache = (measurements?: { [item: string]: number } = {}) => {

--- a/packages/gestalt/src/fullWidthLayout.js
+++ b/packages/gestalt/src/fullWidthLayout.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import type { Cache } from './Cache.js';
 
 type Position = { top: number, left: number, width: number, height: number };

--- a/packages/gestalt/src/fullWidthLayout.test.js
+++ b/packages/gestalt/src/fullWidthLayout.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import fullWidthLayout from './fullWidthLayout.js';
 
 const stubCache = (measurements?: { [item: string]: number } = {}) => {

--- a/packages/gestalt/src/icons/index.js
+++ b/packages/gestalt/src/icons/index.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import ad from './ad.svg';
 import add from './add.svg';
 import addCircle from './add-circle.svg';

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import Avatar from './Avatar.js';
 import Badge from './Badge.js';
 import Box from './Box.js';

--- a/packages/gestalt/src/layouts/MasonryLayout.js
+++ b/packages/gestalt/src/layouts/MasonryLayout.js
@@ -1,2 +1,2 @@
-// @flow
+// @flow strict
 export default class MasonryLayout {}

--- a/packages/gestalt/src/layouts/UniformRowLayout.js
+++ b/packages/gestalt/src/layouts/UniformRowLayout.js
@@ -1,2 +1,2 @@
-// @flow
+// @flow strict
 export default class UniformRowLayout {}

--- a/packages/gestalt/src/legacyLayoutSymbols.js
+++ b/packages/gestalt/src/legacyLayoutSymbols.js
@@ -1,3 +1,3 @@
-// @flow
+// @flow strict
 export const DefaultLayoutSymbol = Symbol('default');
 export const UniformRowLayoutSymbol = Symbol('uniformRow');

--- a/packages/gestalt/src/scrollUtils.js
+++ b/packages/gestalt/src/scrollUtils.js
@@ -4,7 +4,7 @@
  * utils abstract away these differences.
  */
 
-// @flow
+// @flow strict
 export function getElementHeight(element: HTMLElement): number {
   return element === window ? window.innerHeight : element.clientHeight;
 }

--- a/packages/gestalt/src/style.js
+++ b/packages/gestalt/src/style.js
@@ -1,4 +1,4 @@
-/* @flow */
+// @flow strict
 
 /*
 

--- a/packages/gestalt/src/style.test.js
+++ b/packages/gestalt/src/style.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import {
   concat,
   fromClassName,

--- a/packages/gestalt/src/throttle.js
+++ b/packages/gestalt/src/throttle.js
@@ -4,7 +4,7 @@
  * on the leading and trailing edge.
  */
 
-// @flow
+// @flow strict
 export default function throttle(
   fn: (...args: *) => void,
   threshhold: number = 100

--- a/packages/gestalt/src/touchable.jsdom.test.js
+++ b/packages/gestalt/src/touchable.jsdom.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import Touchable from './Touchable.js';

--- a/packages/gestalt/src/touchable.test.js
+++ b/packages/gestalt/src/touchable.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Touchable from './Touchable.js';

--- a/packages/gestalt/src/transforms.js
+++ b/packages/gestalt/src/transforms.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import {
   concat,

--- a/packages/gestalt/src/uniformRowLayout.js
+++ b/packages/gestalt/src/uniformRowLayout.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import type { Cache } from './Cache.js';
 
 type Position = { top: number, left: number, width: number, height: number };

--- a/packages/gestalt/src/uniformRowLayout.test.js
+++ b/packages/gestalt/src/uniformRowLayout.test.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import uniformRowLayout from './uniformRowLayout.js';
 
 const stubCache = (measurements?: { [item: string]: number } = {}) => {

--- a/scripts/danger/changelog.js
+++ b/scripts/danger/changelog.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 export default function changelog() {
   const changelogUpdated = danger.git.modified_files.includes('CHANGELOG.md');

--- a/scripts/danger/experiments.js
+++ b/scripts/danger/experiments.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 export default function experiments() {
   const changed = danger.git.modified_files.some(file =>

--- a/scripts/danger/lockfile.js
+++ b/scripts/danger/lockfile.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 export default function lockfile() {
   const packageChanged = danger.git.modified_files.includes('package.json');

--- a/scripts/fileMock.js
+++ b/scripts/fileMock.js
@@ -1,1 +1,2 @@
+// @flow strict
 module.exports = 'test-file-stub';


### PR DESCRIPTION
[Flow Strict](https://flow.org/en/docs/strict/)
> enable stronger safety guarantees in Flow (such as banning any/Object/Function types and requiring all dependencies to be typed)

Changes:
* Enabled flow strict for every file
* Add linter so we don't regress

Allows other repositories to use Gestalt in Flow strict mode.