### PR TITLE
Version bump: v1.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,20 @@
 
 ### Patch
 
-- Flyout: fix stroke on caret (#837)
-
 </details>
 
+## 1.47.0 (May 6, 2020)
 
-### Minor 
-  - Icon: Add story pin icon (#842)
- 
+### Minor
+
+- Flyout: Add flexible size prop to flyout (#840)
+- Icon: Add story pin icon (#842)
+- Internal: Enable + enforce flow strict on every file (#841)
+
+### Patch
+
+- Flyout: Fix stroke on caret (#837)
+
 ## 1.46.1 (Apr 28, 2020)
 
 ### Patch

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestalt",
-  "version": "1.46.1",
+  "version": "1.47.0",
   "license": "Apache-2.0",
   "homepage": "https://pinterest.github.io/gestalt",
   "description": "A set of React UI components which enforce Pinterest’s design language",


### PR DESCRIPTION
## 1.47.0 (May 6, 2020)

### Minor

- Flyout: Add flexible size prop to flyout (#840)
- Icon: Add story pin icon (#842)
- Internal: Enable + enforce flow strict on every file (#841)

### Patch

- Flyout: Fix stroke on caret (#837)