### PR TITLE
VideoControls: overwriting overflow default behavior on timestamp text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## [Unreleased]
 
-## 1.47.1
-
 ### Patch
 
 - VideoControls: overwriting overflow default behavior on timestamp text (#845)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## 1.47.1
+
+### Patch
+
+- VideoControls: overwriting overflow default behavior on timestamp text (#845)
+
 <details>
   <summary>
     Changes that have landed in master but are not yet released.
@@ -11,12 +17,6 @@
 ### Patch
 
 </details>
-
-## 1.47.1 (May 7, 2020)
-
-### Patch
-
-- VideoControls: overwriting overflow default behavior on timestamp text (#845)
 
 ## 1.47.0 (May 6, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## [Unreleased]
 
-### Patch
-
-- VideoControls: overwriting overflow default behavior on timestamp text (#845)
-
 <details>
   <summary>
     Changes that have landed in master but are not yet released.
@@ -13,6 +9,8 @@
 ### Minor
 
 ### Patch
+
+- VideoControls: overwriting overflow default behavior on timestamp text (#845)
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 </details>
 
+## 1.47.1 (May 7, 2020)
+
+### Patch
+
+- VideoControls: overwriting overflow default behavior on timestamp text (#845)
+
 ## 1.47.0 (May 6, 2020)
 
 ### Minor

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -143,7 +143,7 @@ class VideoControls extends React.Component<Props> {
           </Touchable>
         </Box>
         <Box width={50} padding={2}>
-          <Text color="white" align="right" size="sm">
+          <Text align="right" color="white" overflow="normal" size="sm">
             {timeToString(currentTime)}
           </Text>
         </Box>
@@ -157,7 +157,7 @@ class VideoControls extends React.Component<Props> {
           />
         </Box>
         <Box width={50} padding={2}>
-          <Text color="white" align="right" size="sm">
+          <Text align="right" color="white" overflow="normal" size="sm">
             {timeToString(duration)}
           </Text>
         </Box>

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -107,7 +107,7 @@ exports[`Video with children 1`] = `
       }
     >
       <div
-        className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+        className="Text fontSize1 white alignRight fontWeightNormal"
       >
         00:00
       </div>
@@ -187,7 +187,7 @@ exports[`Video with children 1`] = `
       }
     >
       <div
-        className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+        className="Text fontSize1 white alignRight fontWeightNormal"
       >
         00:00
       </div>

--- a/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
@@ -42,7 +42,7 @@ exports[`VideoControls for double digit minutes 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       15:05
     </div>
@@ -122,7 +122,7 @@ exports[`VideoControls for double digit minutes 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       15:05
     </div>
@@ -201,7 +201,7 @@ exports[`VideoControls for double digit seconds 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       00:15
     </div>
@@ -281,7 +281,7 @@ exports[`VideoControls for double digit seconds 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       00:15
     </div>
@@ -360,7 +360,7 @@ exports[`VideoControls for single digit minutes 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       01:05
     </div>
@@ -440,7 +440,7 @@ exports[`VideoControls for single digit minutes 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       01:05
     </div>
@@ -519,7 +519,7 @@ exports[`VideoControls for single digit seconds 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       00:05
     </div>
@@ -599,7 +599,7 @@ exports[`VideoControls for single digit seconds 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       00:05
     </div>
@@ -678,7 +678,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       01:07
     </div>
@@ -758,7 +758,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
     }
   >
     <div
-      className="Text fontSize1 white alignRight breakWord fontWeightNormal"
+      className="Text fontSize1 white alignRight fontWeightNormal"
     >
       01:07
     </div>


### PR DESCRIPTION
Video controls were wrapping when too long.

Broken:
<img width="1177" alt="Screen Shot 2020-05-07 at 2 35 19 PM" src="https://user-images.githubusercontent.com/40552331/81346936-10c05b00-9070-11ea-847f-08339ee7ca07.png">

Fixed:
<img width="1141" alt="Screen Shot 2020-05-07 at 2 35 48 PM" src="https://user-images.githubusercontent.com/40552331/81346939-11f18800-9070-11ea-837c-5dce943fa6ba.png">
