### PR TITLE
Internal: Require release type on every PR

### DIFF
--- a/.github/workflows/requireReleaseType.yml
+++ b/.github/workflows/requireReleaseType.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - labeled
       - unlabeled
-      - edited
       - synchronize
 
 jobs:

--- a/.github/workflows/requireReleaseType.yml
+++ b/.github/workflows/requireReleaseType.yml
@@ -1,0 +1,20 @@
+name: Require Release Type
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  checkReleaseType:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zwaldowski/match-label-action@v2
+        with:
+          allowed: >
+            major release
+            minor release
+            patch release

--- a/.github/workflows/requireReleaseType.yml
+++ b/.github/workflows/requireReleaseType.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: zwaldowski/match-label-action@v2
         with:
           allowed: >
-            major release
-            minor release
-            patch release
+            "major release"
+            "minor release"
+            "patch release"

--- a/.github/workflows/requireReleaseType.yml
+++ b/.github/workflows/requireReleaseType.yml
@@ -16,7 +16,4 @@ jobs:
     steps:
       - uses: zwaldowski/match-label-action@v2
         with:
-          allowed: >
-            "major release"
-            "minor release"
-            "patch release"
+          allowed: major release, minor release, patch release

--- a/.github/workflows/requireReleaseType.yml
+++ b/.github/workflows/requireReleaseType.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - labeled
       - unlabeled
+      - edited
+      - synchronize
 
 jobs:
   checkReleaseType:

--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -45,14 +45,13 @@ async function getReleaseNotes({ lastCommitMessage, newVersion, releaseType }) {
 
 async function bumpPackageVersion() {
   // Define the version bump type depending on the attached label:
-  // - 'patch release' (default)
+  // - 'patch release'
   // - 'minor release'
   // - 'major release'
   const types = ['patch', 'minor', 'major'];
-  const releaseType =
-    types.find(type =>
-      (process.env.LABELS || '').toLowerCase().includes(`${type} release`)
-    ) || 'patch';
+  const releaseType = types.find(type =>
+    (process.env.LABELS || '').toLowerCase().includes(`${type} release`)
+  );
 
   // Previous version
   const { version: previousVersion } = packageJSONParsed;


### PR DESCRIPTION
Suggestion by @bishwei in #848 to make the release type required:

> thinking out loud - is defaulting to `patch` here the right behavior or should we throw if a release type label wasn't properly specified?

We also require for just one release type to be defined, if you define multiple, the build will fail. Uses [zwaldowski/match-label-action](https://github.com/zwaldowski/match-label-action) under the hood.

## Steps

### No release type label defined => Build fails
![image](https://user-images.githubusercontent.com/127199/81714549-087b6d80-942c-11ea-8756-20b5edd11893.png)

### Add release label
![image](https://user-images.githubusercontent.com/127199/81715793-7b391880-942d-11ea-8eb1-8c4c239fad0d.png)

### Release label defined => Build passes
![image](https://user-images.githubusercontent.com/127199/81716229-fef30500-942d-11ea-9e67-f90e20d9f01c.png)

