### PR TITLE
Modal: Fix shadows on scroll

### DIFF
--- a/packages/gestalt/src/Modal.css
+++ b/packages/gestalt/src/Modal.css
@@ -22,19 +22,11 @@
   outline: none;
 }
 
-.content {
-  composes: borderBox flexGrow overflowAuto relative from "./Layout.css";
+.shadowContainer {
+  composes: borderBox relative fit from "./Layout.css";
+  z-index: 1;
+}
 
-  /* Show top / bottom shadow when scrolling down */
-  background: linear-gradient(#fff 30%, rgba(255, 255, 255, 0)),
-    linear-gradient(rgba(255, 255, 255, 0), #fff 70%) 0 100%,
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 0%, #fff 50%),
-    linear-gradient(to top, rgba(0, 0, 0, 0.1) 0%, #fff 50%) 0 100%;
-  background-attachment: local, local, scroll, scroll;
-  background-color: #fff;
-  background-repeat: no-repeat;
-  background-size: 100% 20px, 100% 20px, 100% 8px, 100% 8px;
-
-  /* Hack to avoid the extra gray border between the content and footer */
-  transform: scaleX(1.0000001);
+.shadow {
+  box-shadow: rgba(0, 0, 0, 0.1) 0 0 8px 0;
 }

--- a/packages/gestalt/src/Modal.css.flow
+++ b/packages/gestalt/src/Modal.css.flow
@@ -3,6 +3,7 @@
 declare module.exports: {|
   +'backdrop': string,
   +'container': string,
-  +'content': string,
+  +'shadow': string,
+  +'shadowContainer': string,
   +'wrapper': string,
 |};


### PR DESCRIPTION
We have these bugs with shadows that should show when you scroll:
1. On Safari, the shadow is too thick and shows up a grey border
2. Components like `<TextField />` show on top of the shadow

This PR addresses both by moving away from the CSS only approach and add event listeners + use box shadow instead.

**Chrome before / after**
![chrome-modal-shadows](https://user-images.githubusercontent.com/127199/81877999-909c6880-953b-11ea-8914-5c230c4adea6.gif)

**Safari before / after**
![safari-modal-shadows](https://user-images.githubusercontent.com/127199/81878002-92fec280-953b-11ea-997f-83252d4ceb4e.gif)
