### PR TITLE
Internal: Add default release type label on PR creation

### DIFF
--- a/.github/workflows/addDefaultReleaseType.yml
+++ b/.github/workflows/addDefaultReleaseType.yml
@@ -1,0 +1,20 @@
+name: Add Default Release Type
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: christianvuerings/add-labels@v1
+        with:
+          labels: |
+            patch release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Release
 
 on:
   push:
@@ -10,8 +10,8 @@ on:
       - master
 
 jobs:
-  publish:
-    name: Publish gestalt
+  release:
+    name: Release gestalt
     runs-on: ubuntu-latest
     if: contains(github.event.head_commit.message, 'Version bump:') == false && github.repository == 'pinterest/gestalt'
     steps:


### PR DESCRIPTION
Developers have been reaching out to me to understand why their build fails when they create a new PR. The root cause is #853 which requires a release type label to be set. That label can only be set by a maintainer or GitHub bot, so this PR automatically adds the patch release label upon opening a new PR.