### PR TITLE
Docs: Remove code coverage status badge

### DIFF
--- a/.github/workflows/addDefaultReleaseType.yml
+++ b/.github/workflows/addDefaultReleaseType.yml
@@ -17,4 +17,4 @@ jobs:
           labels: |
             patch release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PERSONAL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Gestalt
 
 [![NPM Version](https://img.shields.io/npm/v/gestalt.svg)](https://www.npmjs.com/package/gestalt)
-[![Coverage status](https://codecov.io/gh/pinterest/gestalt/branch/master/graph/badge.svg)](https://codecov.io/github/pinterest/gestalt)
 
 Gestalt is a set of React UI components that enforces Pinterest’s design language. We use it to streamline communication between designers and developers by enforcing a bunch of fundamental UI components. This common set of components helps raise the bar for UX & accessibility across Pinterest.
 


### PR DESCRIPTION
We no longer upload our code coverage to codecov.io - so let's remove the badge for now.
