### PR TITLE
Internal: Fix automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.head_commit.message, 'Version bump:') == false && github.repository == 'pinterest/gestalt'
     steps:
-      - uses: octokit/graphql-action@v2.x
+      - uses: octokit/graphql-action@v2.1
         id: query_labels
         with:
           query: |


### PR DESCRIPTION
Most likely an update to "octokit/graphql-action" caused the release action to break.

```
2020-05-18T16:24:54.3601454Z Prepare workflow directory
2020-05-18T16:24:54.3800455Z Prepare all required actions
2020-05-18T16:24:54.3812673Z Download action repository 'octokit/graphql-action@v2.x'
2020-05-18T16:24:55.3819475Z Download action repository 'actions/checkout@v2'
2020-05-18T16:24:56.3636660Z Download action repository 'actions/setup-node@v1'
2020-05-18T16:24:56.5667147Z ##[warning]Unexpected input 'owner', valid inputs are ['query']
2020-05-18T16:24:56.5670079Z ##[warning]Unexpected input 'name', valid inputs are ['query']
2020-05-18T16:24:56.5670677Z ##[warning]Unexpected input 'oid', valid inputs are ['query']
2020-05-18T16:24:56.5705049Z ##[group]Run octokit/graphql-action@v2.x
2020-05-18T16:24:56.5705360Z with:
2020-05-18T16:24:56.5705619Z   query: query labels($owner:String!, $name:String!, $oid:GitObjectID!) {
  repository(owner: $owner, name: $name) {
    object(oid: $oid) {
      ... on Commit {
        message
        associatedPullRequests(first: 1) {
          edges {
            node {
              title
              labels(first: 5) {
                edges {
                  node {
                    name
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}

2020-05-18T16:24:56.5705873Z   owner: pinterest
2020-05-18T16:24:56.5706047Z   name: gestalt
2020-05-18T16:24:56.5706256Z   oid: 658528b8b11406da6fbbb569bf5b4512082cb71c
2020-05-18T16:24:56.5706593Z env:
2020-05-18T16:24:56.5707030Z   GITHUB_TOKEN: ***
2020-05-18T16:24:56.5707192Z ##[endgroup]
2020-05-18T16:24:56.9376058Z ##[error]end of the stream or a document separator is expected at line 2, column 19:
      repository(owner: $owner, name: $name) {
                      ^
2020-05-18T16:24:56.9489458Z Cleaning up orphan processes
```