### PR TITLE
Internal: Fix automatic releases (second try)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.head_commit.message, 'Version bump:') == false && github.repository == 'pinterest/gestalt'
     steps:
-      - uses: octokit/graphql-action@v2.1
+      - uses: octokit/graphql-action@v2.1.0
         id: query_labels
         with:
           query: |


### PR DESCRIPTION
https://codeload.github.com/octokit/graphql-action/legacy.tar.gz/v2.1 does not exist
https://codeload.github.com/octokit/graphql-action/legacy.tar.gz/v2.1.0 does exist
