### PR TITLE
Internal: Use octokit/graphql-action@v2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Release
 
 on:
   push:
@@ -10,12 +10,12 @@ on:
       - master
 
 jobs:
-  publish:
-    name: Publish gestalt
+  release:
+    name: Release gestalt
     runs-on: ubuntu-latest
     if: contains(github.event.head_commit.message, 'Version bump:') == false && github.repository == 'pinterest/gestalt'
     steps:
-      - uses: octokit/graphql-action@v2.x
+      - uses: octokit/graphql-action@v2.0.0
         id: query_labels
         with:
           query: |


### PR DESCRIPTION
Tried it out at https://github.com/christianvuerings/gestalt-copy/runs/686104220

The issue seems to be https://github.com/octokit/graphql-action/commit/cb8e559edb9aa23c11b50e1e98f9223b8f1f1fbc where they changed how they parse the yaml
