### PR TITLE
Video: Fix for `n.video.load is not a function` in Safari

### DIFF
--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -294,7 +294,7 @@ export default class Video extends React.PureComponent<Props, State> {
 
   // Change the video source and re-load the video
   load = () => {
-    if (this.video) {
+    if (this.video && this.video.load) {
       this.video.load();
     }
   };


### PR DESCRIPTION
- Fix for n.video.load is not a function. (In 'n.video.load()', 'n.video.load' is undefined) in Safari

- This is an issue specific to Safari 11 or below, and comes from the `load` call on HTMLMediaElement in gestalt https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Video.js#L298

- According to MDN doc, it should be supported since Safari 6.
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/load

- It could be some kind of race condition where the ref (this.video) exists but doesn’t yet have the load function.

 ## TODO

~~- [ ] Accessibility checkup~~
~~- [ ] Update documentation~~
~~- [ ] Add/update Tests~~
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
