### PR TITLE
Table: Add clickable row

### DIFF
--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -176,7 +176,12 @@ card(
   />
 );
 
-card(<Card name="Table.Row" />);
+card(
+  <Card
+    name="Table.Row"
+    description="If there is an onClick function passed in, the row will be clickable and have cursor and hover style changes. With the onClick function, the row can be selected by mouse click, enter or space."
+  />
+);
 
 card(
   <PropTable
@@ -185,6 +190,11 @@ card(
       {
         name: 'children',
         type: 'React.Node',
+      },
+      {
+        name: 'onClick',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> }) => void',
       },
     ]}
   />

--- a/packages/gestalt/src/Table.css
+++ b/packages/gestalt/src/Table.css
@@ -1,10 +1,12 @@
 .table {
-  border-collapse: collapse;
-  border-spacing: 0;
+  border-collapse: separate;
+  border-spacing: 0 4px;
+  cursor: default;
   width: 100%;
 }
 
 .th {
+  composes: borderBottom from "./Borders.css";
   composes: paddingY3 from "./boxWhitespace.css";
   composes: paddingX3 from "./boxWhitespace.css";
 }
@@ -14,6 +16,15 @@
   composes: paddingX3 from "./boxWhitespace.css";
 }
 
-.thead {
-  composes: borderBottom from "./Borders.css";
+.trClickable:hover {
+  background-color: #efefef;
+  cursor: pointer;
+}
+
+.trClickable:hover td:first-child {
+  border-radius: 8px 0 0 8px;
+}
+
+.trClickable:hover td:last-child {
+  border-radius: 0 8px 8px 0;
 }

--- a/packages/gestalt/src/Table.css.flow
+++ b/packages/gestalt/src/Table.css.flow
@@ -4,5 +4,5 @@ declare module.exports: {|
   +'table': string,
   +'td': string,
   +'th': string,
-  +'thead': string,
+  +'trClickable': string,
 |};

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -20,6 +20,7 @@ export default function Table(props: Props) {
   return (
     <Box
       overflow="scrollX"
+      paddingX={1}
       {...(borderSize === 'sm' ? { borderSize: 'sm', rounding: 1 } : {})}
     >
       <table className={styles.table}>{children}</table>

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -1,11 +1,10 @@
 // @flow strict
 import * as React from 'react';
-import styles from './Table.css';
 
 type Props = {|
   children: React.Node,
 |};
 
 export default function TableHeader(props: Props) {
-  return <thead className={styles.thead}>{props.children}</thead>;
+  return <thead>{props.children}</thead>;
 }

--- a/packages/gestalt/src/TableRow.js
+++ b/packages/gestalt/src/TableRow.js
@@ -1,10 +1,52 @@
 // @flow strict
 import * as React from 'react';
+import styles from './Table.css';
 
 type Props = {|
   children: React.Node,
+  onClick?: ({
+    event:
+      | SyntheticMouseEvent<HTMLDivElement>
+      | SyntheticKeyboardEvent<HTMLDivElement>,
+  }) => void,
 |};
 
+const SPACE_CHAR_CODE = 32;
+const ENTER_CHAR_CODE = 13;
+
 export default function TableRow(props: Props) {
-  return <tr>{props.children}</tr>;
+  const { children, onClick } = props;
+
+  const handleKeyPress = (event: SyntheticKeyboardEvent<HTMLDivElement>) => {
+    if (
+      onClick &&
+      (event.charCode === SPACE_CHAR_CODE || event.charCode === ENTER_CHAR_CODE)
+    ) {
+      // Prevent the default action to stop scrolling when space is pressed
+      event.preventDefault();
+      onClick({ event });
+    }
+  };
+
+  const handleOnClick = (event: SyntheticMouseEvent<HTMLDivElement>) => {
+    if (onClick) {
+      onClick({ event });
+    }
+  };
+
+  if (onClick) {
+    return (
+      <tr
+        className={styles.trClickable}
+        onClick={handleOnClick}
+        onKeyPress={handleKeyPress}
+        tabIndex="0"
+        role="button"
+      >
+        {children}
+      </tr>
+    );
+  }
+
+  return <tr>{children}</tr>;
 }

--- a/packages/gestalt/src/TableRow.test.js
+++ b/packages/gestalt/src/TableRow.test.js
@@ -7,7 +7,22 @@ test('renders correctly', () => {
   const tree = renderer
     .create(
       <TableRow>
-        <div>row cells</div>
+        <td>cell 1</td>
+        <td>cell 2</td>
+        <td>cell 3</td>
+      </TableRow>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('renders correctly when clickable', () => {
+  const tree = renderer
+    .create(
+      <TableRow onClick={() => {}}>
+        <td>cell 1</td>
+        <td>cell 2</td>
+        <td>cell 3</td>
       </TableRow>
     )
     .toJSON();

--- a/packages/gestalt/src/__snapshots__/Table.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Table.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <div
-  className="box overflowScrollX"
+  className="box overflowScrollX paddingX1"
 >
   <table
     className="table"
@@ -16,7 +16,7 @@ exports[`renders correctly 1`] = `
 
 exports[`renders correctly with border 1`] = `
 <div
-  className="borderColorLightGray box overflowScrollX rounding1 sizeSm solid"
+  className="borderColorLightGray box overflowScrollX paddingX1 rounding1 sizeSm solid"
 >
   <table
     className="table"

--- a/packages/gestalt/src/__snapshots__/TableHeader.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableHeader.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<thead
-  className="thead"
->
+<thead>
   <div>
     row with column names
   </div>

--- a/packages/gestalt/src/__snapshots__/TableRow.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableRow.test.js.snap
@@ -2,8 +2,34 @@
 
 exports[`renders correctly 1`] = `
 <tr>
-  <div>
-    row cells
-  </div>
+  <td>
+    cell 1
+  </td>
+  <td>
+    cell 2
+  </td>
+  <td>
+    cell 3
+  </td>
+</tr>
+`;
+
+exports[`renders correctly when clickable 1`] = `
+<tr
+  className="trClickable"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  role="button"
+  tabIndex="0"
+>
+  <td>
+    cell 1
+  </td>
+  <td>
+    cell 2
+  </td>
+  <td>
+    cell 3
+  </td>
 </tr>
 `;


### PR DESCRIPTION
Adds support for clickable rows in the Table by adding an optional prop onClick for Table.Row. If onClick is passed in, the row will be clickable. Similar to Touchable, the row can be clicked by mouse click, space key, or enter key and can be tabbed through.

This also includes the related CSS changes:
- adds padding within the border to match design
- adds spacing between rows
- adds default cursor style for table
- adds hover style changes for clickable rows (background color, rounded borders, pointer cursor)

- [x] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.

With table border:
<img width="887" alt="Screen Shot 2020-05-18 at 12 01 27 PM" src="https://user-images.githubusercontent.com/5513405/82265271-74be0b80-991b-11ea-8487-0fd90bfc4d1d.png">

Without table border:
<img width="872" alt="Screen Shot 2020-05-18 at 12 04 30 PM" src="https://user-images.githubusercontent.com/5513405/82265288-7f78a080-991b-11ea-98ca-1bf255f90cec.png">