### PR TITLE
Modal: make focus state more specific

### DIFF
--- a/packages/gestalt/src/Modal.css
+++ b/packages/gestalt/src/Modal.css
@@ -19,6 +19,9 @@
   composes: rounding8 from "./Borders.css";
   composes: marginLeft4 marginRight4 from "./boxWhitespace.css";
   max-height: calc(100vh - 32px);
+}
+
+.wrapper:focus {
   outline: none;
 }
 


### PR DESCRIPTION
On pinterest.com, we have an issue where the default `:focus` style overrides the gestalt style. Since we make it more specific, the gestalt style will override the default Pinterest on.
![Screen Shot 2020-05-20 at 3 51 18 PM](https://user-images.githubusercontent.com/127199/82571760-46694780-9b38-11ea-9089-3359e0661d15.png)

Example of the issue:
![Screen Shot 2020-05-20 at 3 39 40 PM](https://user-images.githubusercontent.com/127199/82571956-934d1e00-9b38-11ea-9b9a-39242196815a.png)
