### PR TITLE
Badge: Add BackGround Colors

### DIFF
--- a/docs/src/Badge.doc.js
+++ b/docs/src/Badge.doc.js
@@ -1,8 +1,10 @@
 // @flow strict
 import * as React from 'react';
+import { Box } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
+import Combination from './components/Combination.js';
 
 const cards = [];
 const card = c => cards.push(c);
@@ -31,6 +33,12 @@ card(
         defaultValue: 'middle',
         description: 'Badge position relative to its parent element.',
       },
+      {
+        name: 'color',
+        type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
+        defaultValue: 'blue',
+        description: 'The background color of the Badge.',
+      },
     ]}
   />
 );
@@ -49,12 +57,55 @@ card(
 card(
   <Example
     description="
+    The `Badge` component is rendered with alternative background color."
+    name="Example: color"
+    defaultCode={`
+<Text size="lg" weight="bold">Inbox <Badge text="78" color="red"/></Text>
+`}
+  />
+);
+
+card(
+  <Example
+    description="
     Larger text example rendered with a top positioned `Badge`."
     name="Example: positioning"
     defaultCode={`
   <Heading>Heading <Badge text="Beta" position="top"/></Heading>
 `}
   />
+);
+
+card(
+  <Combination
+    id="color"
+    name="Colors"
+    color={[
+      'red',
+      'white',
+      'lightGray',
+      'gray',
+      'darkGray',
+      'green',
+      'pine',
+      'olive',
+      'blue',
+      'navy',
+      'midnight',
+      'purple',
+      'orchid',
+      'eggplant',
+      'maroon',
+      'watermelon',
+      'orange',
+      'transparent',
+      'transparentDarkGray',
+      'lightWash',
+      'darkWash',
+    ]}
+  >
+    {props => <Box width={60} height={60} rounding="circle" {...props} />}
+  </Combination>
 );
 
 export default cards;

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -33,9 +33,9 @@ type Props = {|
 |};
 
 export default function Badge(props: Props) {
-  const { position = 'middle', text, color = 'red' } = props;
+  const { position = 'middle', text, color = 'blue' } = props;
 
-  const cs = cx(styles.Badge, styles[position], colors[color]);
+  const cs = cx(styles.Badge, styles[position], colors[`${color}Bg`]);
 
   return <span className={cs}>{text}</span>;
 }

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -8,12 +8,34 @@ import colors from './Colors.css';
 type Props = {|
   position?: 'middle' | 'top',
   text: string,
+  color?:
+    | 'blue'
+    | 'darkGray'
+    | 'darkWash'
+    | 'eggplant'
+    | 'gray'
+    | 'green'
+    | 'lightGray'
+    | 'lightWash'
+    | 'maroon'
+    | 'midnight'
+    | 'navy'
+    | 'olive'
+    | 'orange'
+    | 'orchid'
+    | 'pine'
+    | 'purple'
+    | 'red'
+    | 'transparent'
+    | 'transparentDarkGray'
+    | 'watermelon'
+    | 'white',
 |};
 
 export default function Badge(props: Props) {
-  const { position = 'middle', text } = props;
+  const { position = 'middle', text, color = 'red' } = props;
 
-  const cs = cx(styles.Badge, styles[position], colors.blueBg);
+  const cs = cx(styles.Badge, styles[position], colors[color]);
 
   return <span className={cs}>{text}</span>;
 }
@@ -21,4 +43,27 @@ export default function Badge(props: Props) {
 Badge.propTypes = {
   position: PropTypes.oneOf(['middle', 'top']),
   text: PropTypes.string.isRequired,
+  color: PropTypes.oneOf([
+    'blue',
+    'darkGray',
+    'darkWash',
+    'eggplant',
+    'gray',
+    'green',
+    'lightGray',
+    'lightWash',
+    'maroon',
+    'midnight',
+    'navy',
+    'olive',
+    'orange',
+    'orchid',
+    'pine',
+    'purple',
+    'red',
+    'transparent',
+    'transparentDarkGray',
+    'watermelon',
+    'white',
+  ]),
 };

--- a/packages/gestalt/src/Badge.test.js
+++ b/packages/gestalt/src/Badge.test.js
@@ -15,3 +15,10 @@ it('should render with white text and blue background', () => {
 
   expect(className).toContain('blueBg');
 });
+
+it('should render with white text and red background', () => {
+  const instance = create(<Badge text="Badge" color="red" />).root;
+  const { className } = instance.find(element => element.type === 'span').props;
+
+  expect(className).toContain('redBg');
+});


### PR DESCRIPTION
Add more colors to the badge component but continue to default to blue. This only addresses the Background color and not the text color.

## TODO

- [x] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
