### PR TITLE
Table: Only show scrollbar when necessary

### DIFF
--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -20,7 +20,7 @@ export default function Table(props: Props) {
 
   return (
     <Box
-      overflow="scrollX"
+      overflow="auto"
       {...(borderSize === 'sm' ? { borderSize: 'sm', rounding: 1 } : {})}
     >
       <table className={styles.table}>{children}</table>

--- a/packages/gestalt/src/__snapshots__/Table.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Table.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <div
-  className="box overflowScrollX"
+  className="box overflowAuto"
 >
   <table
     className="table"
@@ -16,7 +16,7 @@ exports[`renders correctly 1`] = `
 
 exports[`renders correctly with border 1`] = `
 <div
-  className="borderColorLightGray box overflowScrollX rounding1 sizeSm solid"
+  className="borderColorLightGray box overflowAuto rounding1 sizeSm solid"
 >
   <table
     className="table"


### PR DESCRIPTION
We always see a horizontal scrollbar on `Table` even when it's not necessary. I have the following OS X settings set:

![image](https://user-images.githubusercontent.com/127199/83149627-2b09b980-a0af-11ea-88a0-2d7d1836fcad.png)

# Before
![table-overflow-scroll-before](https://user-images.githubusercontent.com/127199/83149424-e54cf100-a0ae-11ea-9c72-d69e45be9ddc.gif)
# After
![table-overflow-auto-after](https://user-images.githubusercontent.com/127199/83149426-e67e1e00-a0ae-11ea-847e-04a5855edcd1.gif)


