### PR TITLE
TableSortableHeaderCell: Change clickable area

### DIFF
--- a/packages/gestalt/src/Table.css
+++ b/packages/gestalt/src/Table.css
@@ -5,6 +5,7 @@
 }
 
 .th {
+  composes: alignLeft from "./Typography.css";
   composes: paddingY3 from "./boxWhitespace.css";
   composes: paddingX3 from "./boxWhitespace.css";
 }

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -38,33 +38,36 @@ export default function TableSortableHeaderCell(props: Props) {
 
   return (
     <TableHeaderCell colSpan={colSpan} rowSpan={rowSpan} scope={scope}>
-      <Touchable
-        onTouch={onSortChange}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
-      >
-        <Box display="flex">
-          {children}
-          <Box
-            marginLeft={2}
-            dangerouslySetInlineStyle={{
-              __style: { visibility },
-            }}
-          >
-            <Icon
-              accessibilityLabel=""
-              icon={
-                status === 'active' && sortOrder === 'asc'
-                  ? 'sort-ascending'
-                  : 'sort-descending'
-              }
-              color={status === 'active' ? 'darkGray' : 'gray'}
-            />
+      <Box width="fit-content">
+        <Touchable
+          fullWidth={false}
+          onTouch={onSortChange}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+        >
+          <Box display="flex">
+            {children}
+            <Box
+              marginLeft={2}
+              dangerouslySetInlineStyle={{
+                __style: { visibility },
+              }}
+            >
+              <Icon
+                accessibilityLabel=""
+                icon={
+                  status === 'active' && sortOrder === 'asc'
+                    ? 'sort-ascending'
+                    : 'sort-descending'
+                }
+                color={status === 'active' ? 'darkGray' : 'gray'}
+              />
+            </Box>
           </Box>
-        </Box>
-      </Touchable>
+        </Touchable>
+      </Box>
     </TableHeaderCell>
   );
 }

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -38,7 +38,7 @@ export default function TableSortableHeaderCell(props: Props) {
 
   return (
     <TableHeaderCell colSpan={colSpan} rowSpan={rowSpan} scope={scope}>
-      <Box width="fit-content">
+      <Box display="inlineBlock">
         <Touchable
           fullWidth={false}
           onTouch={onSortChange}
@@ -47,10 +47,10 @@ export default function TableSortableHeaderCell(props: Props) {
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
         >
-          <Box display="flex">
+          <Box display="flex" alignItems="center">
             {children}
             <Box
-              marginLeft={2}
+              marginStart={2}
               dangerouslySetInlineStyle={{
                 __style: { visibility },
               }}

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -6,12 +6,7 @@ exports[`renders correctly when active 1`] = `
   scope="col"
 >
   <div
-    className="box"
-    style={
-      Object {
-        "width": "fit-content",
-      }
-    }
+    className="box xsDisplayInlineBlock"
   >
     <div
       aria-disabled={false}
@@ -26,11 +21,11 @@ exports[`renders correctly when active 1`] = `
       tabIndex="0"
     >
       <div
-        className="box xsDisplayFlex"
+        className="box itemsCenter xsDisplayFlex"
       >
         column name
         <div
-          className="box marginLeft2"
+          className="box marginStart2"
           style={
             Object {
               "visibility": "visible",
@@ -63,12 +58,7 @@ exports[`renders correctly when inactive 1`] = `
   scope="col"
 >
   <div
-    className="box"
-    style={
-      Object {
-        "width": "fit-content",
-      }
-    }
+    className="box xsDisplayInlineBlock"
   >
     <div
       aria-disabled={false}
@@ -83,11 +73,11 @@ exports[`renders correctly when inactive 1`] = `
       tabIndex="0"
     >
       <div
-        className="box xsDisplayFlex"
+        className="box itemsCenter xsDisplayFlex"
       >
         column name
         <div
-          className="box marginLeft2"
+          className="box marginStart2"
           style={
             Object {
               "visibility": "hidden",

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -6,42 +6,51 @@ exports[`renders correctly when active 1`] = `
   scope="col"
 >
   <div
-    aria-disabled={false}
-    className="touchable rounding0 fullWidth pointer"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyPress={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    role="button"
-    tabIndex="0"
+    className="box"
+    style={
+      Object {
+        "width": "fit-content",
+      }
+    }
   >
     <div
-      className="box xsDisplayFlex"
+      aria-disabled={false}
+      className="touchable rounding0 pointer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyPress={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      role="button"
+      tabIndex="0"
     >
-      column name
       <div
-        className="box marginLeft2"
-        style={
-          Object {
-            "visibility": "visible",
-          }
-        }
+        className="box xsDisplayFlex"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon darkGray iconBlock"
-          height={16}
-          role="img"
-          viewBox="0 0 24 24"
-          width={16}
+        column name
+        <div
+          className="box marginLeft2"
+          style={
+            Object {
+              "visibility": "visible",
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon darkGray iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </div>
   </div>
@@ -54,42 +63,51 @@ exports[`renders correctly when inactive 1`] = `
   scope="col"
 >
   <div
-    aria-disabled={false}
-    className="touchable rounding0 fullWidth pointer"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyPress={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    role="button"
-    tabIndex="0"
+    className="box"
+    style={
+      Object {
+        "width": "fit-content",
+      }
+    }
   >
     <div
-      className="box xsDisplayFlex"
+      aria-disabled={false}
+      className="touchable rounding0 pointer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyPress={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      role="button"
+      tabIndex="0"
     >
-      column name
       <div
-        className="box marginLeft2"
-        style={
-          Object {
-            "visibility": "hidden",
-          }
-        }
+        className="box xsDisplayFlex"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon gray iconBlock"
-          height={16}
-          role="img"
-          viewBox="0 0 24 24"
-          width={16}
+        column name
+        <div
+          className="box marginLeft2"
+          style={
+            Object {
+              "visibility": "hidden",
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon gray iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Changed the clickable area on the sortable header cell to only be around the children and the sorting icon, so that the clickable area doesn't span the entire width of the header cell. I added a Box with width as fit-content around the Touchable, and added fullWidth={false} to Touchable.

Focus state:
<img width="887" alt="Screen Shot 2020-05-29 at 2 05 35 PM" src="https://user-images.githubusercontent.com/5513405/83305785-3eec1300-a1b6-11ea-9e1f-ae982a5f859b.png">

After clicking:
<img width="883" alt="Screen Shot 2020-05-29 at 2 06 06 PM" src="https://user-images.githubusercontent.com/5513405/83305808-490e1180-a1b6-11ea-807f-c75cf7568a2f.png">

- [x] Accessibility checkup - no change required
- [x] Update documentation - no change required
- [x] Add/update Tests
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
