### PR TITLE
[Row, Stack] Add missing props to docs

### DIFF
--- a/docs/src/Row.doc.js
+++ b/docs/src/Row.doc.js
@@ -65,12 +65,41 @@ card(
           'Defines symmetrical horizontal padding to be applied to each child.',
       },
       {
+        name: 'height',
+        type: `number | string`,
+        description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
+      },
+      {
         name: 'justifyContent',
         type: `"start" | "end" | "center" | "between" | "around" | "evenly"`,
         defaultValue: 'start',
         description:
           'Defines the alignment along the horizontal axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.',
         href: 'layout',
+      },
+      {
+        name: 'maxHeight',
+        type: `number | string`,
+      },
+      {
+        name: 'maxWidth',
+        type: `number | string`,
+        description: `Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%"`,
+      },
+      {
+        name: 'minHeight',
+        type: `number | string`,
+        description: `Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%"`,
+      },
+      {
+        name: 'minWidth',
+        type: `number | string`,
+        description: `Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%"`,
+      },
+      {
+        name: 'width',
+        type: `number | string`,
+        description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
       },
       {
         name: 'wrap',

--- a/docs/src/Stack.doc.js
+++ b/docs/src/Stack.doc.js
@@ -65,12 +65,41 @@ card(
           'Defines symmetrical vertical padding to be applied to each child.',
       },
       {
+        name: 'height',
+        type: `number | string`,
+        description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
+      },
+      {
         name: 'justifyContent',
         type: `"start" | "end" | "center" | "between" | "around" | "evenly"`,
         defaultValue: 'center',
         description:
           'Defines the alignment along the vertical axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.',
         href: 'layout',
+      },
+      {
+        name: 'maxHeight',
+        type: `number | string`,
+      },
+      {
+        name: 'maxWidth',
+        type: `number | string`,
+        description: `Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%"`,
+      },
+      {
+        name: 'minHeight',
+        type: `number | string`,
+        description: `Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%"`,
+      },
+      {
+        name: 'minWidth',
+        type: `number | string`,
+        description: `Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%"`,
+      },
+      {
+        name: 'width',
+        type: `number | string`,
+        description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
       },
       {
         name: 'wrap',


### PR DESCRIPTION
This adds missing available props to the docs for Row and Stack: height, width, min/max for both

- [ ] Accessibility checkup
- [x] Update documentation
- [ ] Add/update Tests
- [ ] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
