### PR TITLE
Tabs: Allow an id on tabs

### DIFF
--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -26,7 +26,7 @@ card(
       },
       {
         name: 'tabs',
-        type: `Array<{| text: React.Node, href: string |}>`,
+        type: `Array<{| text: React.Node, href: string, id?: string |}>`,
         required: true,
       },
       {

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -20,8 +20,9 @@ export default function Tabs({
   }) => void,
   size?: 'md' | 'lg',
   tabs: Array<{|
-    text: React.Node,
     href: string,
+    id?: string,
+    text: React.Node,
   |}>,
   wrap?: boolean,
 |}) {
@@ -37,7 +38,7 @@ export default function Tabs({
       )}
       role="tablist"
     >
-      {tabs.map(({ text, href }, i) => {
+      {tabs.map(({ href, id, text }, i) => {
         const isActive = i === activeTabIndex;
         const cs = classnames(styles.tab, {
           [styles.tabIsNotActive]: !isActive,
@@ -48,6 +49,7 @@ export default function Tabs({
             aria-selected={isActive}
             className={cs}
             href={href}
+            {...(id ? { id } : {})}
             key={`${i}${href}`}
             onClick={(e: SyntheticMouseEvent<>) => handleTabClick(i, e)}
             role="tab"
@@ -66,8 +68,9 @@ Tabs.propTypes = {
   activeTabIndex: PropTypes.number.isRequired,
   tabs: PropTypes.arrayOf(
     PropTypes.exact({
-      text: PropTypes.node,
       href: PropTypes.string,
+      id: PropTypes.string,
+      text: PropTypes.node,
     })
   ).isRequired,
   onChange: PropTypes.func.isRequired,

--- a/packages/gestalt/src/Tabs.test.js
+++ b/packages/gestalt/src/Tabs.test.js
@@ -22,4 +22,21 @@ describe('<Tabs />', () => {
     expect(children && children[1].props['aria-selected']).toEqual(false);
     expect(children && children[2].props['aria-selected']).toEqual(false);
   });
+
+  test('Adds id only if given', () => {
+    const tree = create(
+      <Tabs
+        tabs={[
+          { text: 'News', href: '#', id: 'news-tab' },
+          { text: 'You', href: '#' },
+        ]}
+        activeTabIndex={0}
+        onChange={() => {}}
+      />
+    ).toJSON();
+
+    const children = tree && tree.children;
+    expect(children && children[0].props.id).toEqual('news-tab');
+    expect(children && children[1].props.id).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Allow a developer to specify ids for tabs, for use in selecting elements for tests and other uses.

- [ ] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
