### PR TITLE
Docs: Add missing parameter for Toast

### DIFF
--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -27,6 +27,11 @@ card(
         href: 'imageTextButtonExample',
       },
       {
+        name: 'color',
+        type: `'darkGray' | 'red'`,
+        href: 'redBackgroundColorExample',
+      },
+      {
         name: 'thumbnail',
         type: 'React.Node',
         href: 'imageTextExample',
@@ -77,6 +82,56 @@ function ToastExample() {
         >
           {showToast && (
             <Toast
+              text={
+                <>
+                  Saved to{' '}
+                  <Text inline color="white" weight="bold">
+                    <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+                      Home decor
+                    </Link>
+                  </Text>
+                </>
+              }
+            />
+          )}
+        </Box>
+      </Layer>
+    </Box>
+  );
+}`}
+  />
+);
+
+card(
+  <Example
+    id="redBackgroundColorExample"
+    name="Example: Red background color "
+    defaultCode={`
+function ToastExample() {
+  const [showToast, setShowToast] = React.useState(false);
+  return (
+    <Box>
+      <Button
+        inline
+        text={ showToast ? 'Close toast' : 'Show toast' }
+        onClick={() => setShowToast(!showToast)}
+      />
+      <Layer>
+        <Box
+          fit
+          dangerouslySetInlineStyle={{
+            __style: {
+              bottom: 50,
+              left: '50%',
+              transform: 'translateX(-50%)',
+            },
+          }}
+          paddingX={1}
+          position='fixed'
+        >
+          {showToast && (
+            <Toast
+              color="red"
               text={
                 <>
                   Saved to{' '}

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -29,7 +29,7 @@ card(
       {
         name: 'color',
         type: `'darkGray' | 'red'`,
-        href: 'redBackgroundColorExample',
+        href: 'redColorTextAlertExample',
       },
       {
         name: 'thumbnail',
@@ -104,8 +104,8 @@ function ToastExample() {
 
 card(
   <Example
-    id="redBackgroundColorExample"
-    name="Example: Red background color "
+    id="redColorTextAlertExample"
+    name="Example: Red background color"
     defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
@@ -134,12 +134,7 @@ function ToastExample() {
               color="red"
               text={
                 <>
-                  Saved to{' '}
-                  <Text inline color="white" weight="bold">
-                    <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
-                      Home decor
-                    </Link>
-                  </Text>
+                  Oops! Something went wrong. Please try again later.
                 </>
               }
             />


### PR DESCRIPTION
* Docs: The parameter `color` exists in the code but not in the docs. Add the parameter and a corresponding example for it in Toast.

![image](https://user-images.githubusercontent.com/23090573/83579780-11250800-a4ef-11ea-9c4b-d812146126f3.png)
![image](https://user-images.githubusercontent.com/23090573/83579807-239f4180-a4ef-11ea-99e3-c72236ab4e4d.png)
