### PR TITLE
Box: don't add border properties for borderSize=none

### DIFF
--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -526,16 +526,23 @@ const propToFn = {
     // default: auto
   }),
   bottom: toggle(layout.bottom0),
-  borderSize: value =>
-    concat([
+  borderSize: value => {
+    const borderProps =
+      value !== 'none'
+        ? [
+            fromClassName(borders.solid),
+            fromClassName(borders.borderColorLightGray),
+          ]
+        : [];
+    return concat([
       mapping({
         sm: borders.sizeSm,
         lg: borders.sizeLg,
         // default: none
       })(value),
-      fromClassName(borders.solid),
-      fromClassName(borders.borderColorLightGray),
-    ]),
+      ...borderProps,
+    ]);
+  },
   color: mapping({
     blue: colors.blueBg,
     darkGray: colors.darkGrayBg,


### PR DESCRIPTION
Noticed a bug when I had borderSize={someProperty ? 'none' : 'sm'} - I believe since the Box had a rounding property, there was a border and it was still getting the color/solid css properties applied. This checks to make sure the property is not none before applying those styles.

- [ ] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [ ] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
