### PR TITLE
TextField: Add forward ref (BREAKING CHANGE)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,8 @@
 
 [options]
 include_warnings=true
+esproposal.optional_chaining=enable
+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -195,6 +195,47 @@ function Example(props) {
 );
 
 card(
+  <Example
+    id="ref example"
+    name="Example: ref"
+    description={`
+    A \`TextField\` with an anchor ref to a Flyout component
+  `}
+    defaultCode={`
+function TextFieldFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef();
+  return (
+    <Box marginBottom={12}>
+      <TextField
+        ref={anchorRef}
+        label="Focus the TextField to show the Flyout"
+        id="my-example"
+        onChange={() => {}}
+        onBlur={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+      />
+      {open && (
+        <Flyout
+          anchor={anchorRef.current}
+          idealDirection="down"
+          onDismiss={() => setOpen(false)}
+          shouldFocus={false}
+          size="md"
+        >
+          <Box padding={3}>
+            <Text weight="bold">Example with Flyout</Text>
+          </Box>
+        </Flyout>
+      )}
+    </Box>
+  );
+}
+`}
+  />
+);
+
+card(
   <Card
     description={`
     \`TextField\` intentionally lacks support for autofocus. Generally speaking,

--- a/flow-typed/npm/jest_v26.x.x.js
+++ b/flow-typed/npm/jest_v26.x.x.js
@@ -259,6 +259,7 @@ type DomTestingLibraryType = {
   // 5.x
   toHaveDisplayValue(value: string | string[]): void,
   toBeChecked(): void,
+  toHaveDescription(value: string | string[]): Result,
   ...
 };
 

--- a/packages/gestalt-codemods/1.61.0-2.0.0/textfield-find-deprecated-refs.js
+++ b/packages/gestalt-codemods/1.61.0-2.0.0/textfield-find-deprecated-refs.js
@@ -1,0 +1,51 @@
+/*
+ * Log an error when a `ref` is specified on `<TextField />`
+ * In 2.0.0 we added forwardRef functionality to TextField which will break places which already set `ref` on TextField
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter(node => node.imported.name === 'TextField')
+      .map(node => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  src
+    .find(j.JSXElement)
+    .forEach(jsxElement => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      attrs.forEach(attr => {
+        if (attr.name && attr.name.name === 'ref') {
+          // eslint-disable-next-line no-console
+          console.error(
+            `Update legacy ref on TextField: ${file.path}:${attr.loc.start.line}:${attr.loc.start.column}`
+          );
+        }
+      });
+      return null;
+    })
+    .toSource();
+
+  return null;
+}

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -142,6 +142,9 @@ TextField.propTypes = {
   ]),
   disabled: PropTypes.bool,
   errorMessage: PropTypes.string,
+  forwardedRef: PropTypes.shape({
+    current: PropTypes.any,
+  }),
   hasError: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -18,6 +18,7 @@ type Props = {|
     | 'username',
   disabled?: boolean,
   errorMessage?: string,
+  forwardedRef?: React.Ref<'input'>,
   hasError?: boolean,
   helperText?: string,
   id: string,
@@ -45,144 +46,120 @@ type Props = {|
   value?: string,
 |};
 
-type State = {|
-  focused: boolean,
-|};
+function TextField({
+  autoComplete,
+  disabled = false,
+  errorMessage,
+  forwardedRef,
+  hasError = false,
+  helperText,
+  id,
+  label,
+  name,
+  onBlur,
+  onChange,
+  onFocus,
+  onKeyDown,
+  placeholder,
+  size = 'md',
+  type = 'text',
+  value,
+}: Props) {
+  const [focused, setFocused] = React.useState(false);
 
-export default class TextField extends React.Component<Props, State> {
-  // NOTE: we cannot move to React createRef until we audit uses of callsites
-  // that reach into this component and use this instance variable
-  textfield: ?HTMLInputElement;
-
-  static propTypes = {
-    autoComplete: PropTypes.oneOf([
-      'current-password',
-      'new-password',
-      'on',
-      'off',
-      'username',
-    ]),
-    disabled: PropTypes.bool,
-    errorMessage: PropTypes.string,
-    hasError: PropTypes.bool,
-    helperText: PropTypes.string,
-    id: PropTypes.string.isRequired,
-    label: PropTypes.string,
-    name: PropTypes.string,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func.isRequired,
-    onFocus: PropTypes.func,
-    onKeyDown: PropTypes.func,
-    placeholder: PropTypes.string,
-    size: PropTypes.oneOf(['md', 'lg']),
-    type: PropTypes.oneOf([
-      'date',
-      'email',
-      'number',
-      'password',
-      'text',
-      'url',
-    ]),
-    value: PropTypes.string,
-  };
-
-  static defaultProps = {
-    disabled: false,
-    hasError: false,
-    size: 'md',
-    type: 'text',
-  };
-
-  state = {
-    focused: false,
-  };
-
-  setTextFieldRef = (ref: ?HTMLInputElement) => {
-    this.textfield = ref;
-  };
-
-  handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
-    const { onChange } = this.props;
+  const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
     onChange({ event, value: event.currentTarget.value });
   };
 
-  handleBlur = (event: SyntheticFocusEvent<HTMLInputElement>) => {
-    const { onBlur } = this.props;
+  const handleBlur = (event: SyntheticFocusEvent<HTMLInputElement>) => {
+    setFocused(false);
     if (onBlur) {
       onBlur({ event, value: event.currentTarget.value });
     }
   };
 
-  handleFocus = (event: SyntheticFocusEvent<HTMLInputElement>) => {
-    const { onFocus } = this.props;
+  const handleFocus = (event: SyntheticFocusEvent<HTMLInputElement>) => {
+    setFocused(true);
     if (onFocus) {
       onFocus({ event, value: event.currentTarget.value });
     }
   };
 
-  handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
-    const { onKeyDown } = this.props;
+  const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
     if (onKeyDown) {
       onKeyDown({ event, value: event.currentTarget.value });
     }
   };
 
-  render() {
-    const {
-      autoComplete,
-      disabled,
-      errorMessage,
-      hasError,
-      helperText,
-      id,
-      label,
-      name,
-      placeholder,
-      size,
-      type,
-      value,
-    } = this.props;
+  const classes = classnames(
+    styles.textField,
+    formElement.base,
+    disabled ? formElement.disabled : formElement.enabled,
+    hasError || errorMessage ? formElement.errored : formElement.normal,
+    size === 'md' ? layout.medium : layout.large
+  );
 
-    const { focused } = this.state;
+  // type='number' doesn't work on ios safari without a pattern
+  // https://stackoverflow.com/questions/14447668/input-type-number-is-not-showing-a-number-keypad-on-ios
+  const pattern = type === 'number' ? '\\d*' : undefined;
 
-    const classes = classnames(
-      styles.textField,
-      formElement.base,
-      disabled ? formElement.disabled : formElement.enabled,
-      hasError || errorMessage ? formElement.errored : formElement.normal,
-      size === 'md' ? layout.medium : layout.large
-    );
-
-    // type='number' doesn't work on ios safari without a pattern
-    // https://stackoverflow.com/questions/14447668/input-type-number-is-not-showing-a-number-keypad-on-ios
-    const pattern = type === 'number' ? '\\d*' : undefined;
-
-    return (
-      <span>
-        {label && <FormLabel id={id} label={label} />}
-        <input
-          aria-describedby={errorMessage && focused ? `${id}-error` : null}
-          aria-invalid={errorMessage || hasError ? 'true' : 'false'}
-          autoComplete={autoComplete}
-          className={classes}
-          disabled={disabled}
-          id={id}
-          name={name}
-          onBlur={this.handleBlur}
-          onChange={this.handleChange}
-          onFocus={this.handleFocus}
-          onKeyDown={this.handleKeyDown}
-          pattern={pattern}
-          placeholder={placeholder}
-          ref={this.setTextFieldRef}
-          type={type}
-          value={value}
-        />
-        {helperText && !errorMessage ? (
-          <FormHelperText text={helperText} />
-        ) : null}
-        {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
-      </span>
-    );
-  }
+  return (
+    <span>
+      {label && <FormLabel id={id} label={label} />}
+      <input
+        aria-describedby={errorMessage && focused ? `${id}-error` : null}
+        aria-invalid={errorMessage || hasError ? 'true' : 'false'}
+        autoComplete={autoComplete}
+        className={classes}
+        disabled={disabled}
+        id={id}
+        name={name}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
+        pattern={pattern}
+        placeholder={placeholder}
+        ref={forwardedRef}
+        type={type}
+        value={value}
+      />
+      {helperText && !errorMessage ? (
+        <FormHelperText text={helperText} />
+      ) : null}
+      {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
+    </span>
+  );
 }
+
+TextField.propTypes = {
+  autoComplete: PropTypes.oneOf([
+    'current-password',
+    'new-password',
+    'on',
+    'off',
+    'username',
+  ]),
+  disabled: PropTypes.bool,
+  errorMessage: PropTypes.string,
+  hasError: PropTypes.bool,
+  helperText: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  name: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  placeholder: PropTypes.string,
+  size: PropTypes.oneOf(['md', 'lg']),
+  type: PropTypes.oneOf(['date', 'email', 'number', 'password', 'text', 'url']),
+  value: PropTypes.string,
+};
+
+function forwardRef(props, ref) {
+  return <TextField {...props} forwardedRef={ref} />;
+}
+forwardRef.displayName = 'TextField';
+
+export default React.forwardRef<Props, HTMLInputElement>(forwardRef);

--- a/packages/gestalt/src/TextField.jsdom.test.js
+++ b/packages/gestalt/src/TextField.jsdom.test.js
@@ -4,7 +4,7 @@ import { fireEvent, render } from '@testing-library/react';
 import TextField from './TextField.js';
 
 describe('TextField', () => {
-  it('TextField with errorMessage prop change', () => {
+  it('renders error message on errorMessage prop change', () => {
     const { getByText, rerender } = render(
       <TextField
         id="test"
@@ -27,6 +27,38 @@ describe('TextField', () => {
       />
     );
     expect(getByText('Error message')).toBeVisible();
+  });
+
+  it('reads the error message on focus', () => {
+    const { getByDisplayValue } = render(
+      <TextField
+        errorMessage="Error message"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+        value="TextField Text"
+      />
+    );
+    const input = getByDisplayValue('TextField Text');
+    fireEvent.focus(input);
+    expect(input).toHaveDescription('Error message');
+  });
+
+  it('forwards a ref to <input />', () => {
+    const ref = React.createRef();
+    render(
+      <TextField
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+        value="TextField Text"
+        ref={ref}
+      />
+    );
+    expect(ref.current instanceof HTMLInputElement).toEqual(true);
+    expect(ref.current?.value).toEqual('TextField Text');
   });
 
   it('handles blur events', () => {


### PR DESCRIPTION
Adds ref forwarding to `TextField`

We have 13 places in the Pinterest codebase where we already set a `ref` on the current `<TextField />`. However, that ref is set on the component's instance, not the actual input. So in each of those cases, people drill down to get the `<input />`. That is pretty hacky, so let's add a way for them to get it in a cleaner way.

## Why is this a breaking change?

https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers
> When you start using forwardRef in a component library, you should treat it as a breaking change and release a new major version of your library. This is because your library likely has an observably different behavior (such as what refs get assigned to, and what types are exported), and this can break apps and other libraries that depend on the old behavior.

## Can I get more documentation around this feature?

https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components

## How can we find in which location we already have these legacy refs set?

Run the codemod:

```
cd ~/code/gestalt
yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.61.0-2.0.0/textfield-find-deprecated-refs.js ~/code/pinboard/webapp
```

Which will output the following:

```
Update legacy ref on TextField: /home/christian/code/pinterest/PasswordStep.js:125:12
```
We supply the line number and column name so you brings you to the right location in the editor.