### PR TITLE
TextField: fix forwardedRef propType

### DIFF
--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -142,9 +142,12 @@ TextField.propTypes = {
   ]),
   disabled: PropTypes.bool,
   errorMessage: PropTypes.string,
-  forwardedRef: PropTypes.shape({
-    current: PropTypes.any,
-  }),
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.any,
+    }),
+  ]),
   hasError: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,


### PR DESCRIPTION
We added `forwardedRef` in #901 but the propType was incorrect. See https://stackoverflow.com/a/51127130/117193 for more info

Note that we still need to use `current: PropTypes.any,` since `current: PropTypes.instanceOf(Element)` breaks in jest - for testEnvironment set to `node`
https://github.com/facebook/jest/issues/7786