### PR TITLE
WIP[Masonry]- Add option to center justify grid content

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -29,6 +29,7 @@ type Layout =
   | LegacyMasonryLayout
   | LegacyUniformRowLayout
   | 'basic'
+  | 'basicCentered'
   | 'flexible'
   | 'uniformRow';
 
@@ -490,6 +491,7 @@ export default class Masonry<T: {}> extends React.Component<
         cache: measurementStore,
         columnWidth,
         gutter,
+        justify: layout === 'basicCentered' ? 'center' : 'start',
         minCols,
         width,
       });

--- a/packages/gestalt/src/defaultLayout.js
+++ b/packages/gestalt/src/defaultLayout.js
@@ -29,11 +29,13 @@ export default <T>({
   cache,
   columnWidth = 236,
   gutter = 14,
+  justify = 'start',
   minCols = 2,
   width,
 }: {|
   columnWidth?: number,
   gutter?: number,
+  justify?: 'center' | 'start',
   cache: Cache<T, number>,
   minCols?: number,
   width?: ?number,
@@ -47,12 +49,22 @@ export default <T>({
     Math.floor((width + gutter) / columnWidthAndGutter),
     minCols
   );
+
+  let centerOffset;
+  if (justify === 'center') {
+    const contentWidth =
+      Math.min(items.length, columnCount) * columnWidthAndGutter + gutter;
+
+    centerOffset = Math.max(Math.floor((width - contentWidth) / 2), 0);
+  } else {
+    centerOffset = Math.max(
+      Math.floor((width - columnWidthAndGutter * columnCount + gutter) / 2),
+      0
+    );
+  }
+
   // the total height of each column
   const heights = new Array(columnCount).fill(0);
-  const centerOffset = Math.max(
-    Math.floor((width - columnWidthAndGutter * columnCount + gutter) / 2),
-    0
-  );
 
   return items.reduce((acc, item) => {
     const positions = acc;

--- a/packages/gestalt/src/defaultLayout.test.js
+++ b/packages/gestalt/src/defaultLayout.test.js
@@ -102,3 +102,34 @@ test('only centers when theres extra space', () => {
     { top: 134, height: 100, left: 250, width: 236 },
   ]);
 });
+
+test('justify', () => {
+  const measurements = { a: 100, b: 120, c: 80, d: 100 };
+  const items = ['a', 'b', 'c', 'd'];
+
+  const makeLayout = justify =>
+    defaultLayout({
+      cache: stubCache(measurements),
+      columnWidth: 100,
+      gutter: 0,
+      justify,
+      width: 1000,
+    })(items);
+
+  const justifyStart = makeLayout('start');
+  const justifyCenter = makeLayout('center');
+
+  expect(justifyStart).toEqual([
+    { top: 0, left: 0, width: 100, height: 100 },
+    { top: 0, left: 100, width: 100, height: 120 },
+    { top: 0, left: 200, width: 100, height: 80 },
+    { top: 0, left: 300, width: 100, height: 100 },
+  ]);
+
+  expect(justifyCenter).toEqual([
+    { top: 0, left: 300, width: 100, height: 100 },
+    { top: 0, left: 400, width: 100, height: 120 },
+    { top: 0, left: 500, width: 100, height: 80 },
+    { top: 0, left: 600, width: 100, height: 100 },
+  ]);
+});


### PR DESCRIPTION
Add a layout `basicCentered` that uses the basic layout but centers the contents of the grid.

ex) https://www.pinterest.com/pinterestcreators/story-pins/

Existing:
<img width="1643" alt="Screen Shot 2020-06-08 at 2 03 51 PM" src="https://user-images.githubusercontent.com/10646092/84080408-fdffb580-a990-11ea-9f2b-07309cb81738.png">


Proposed (in red):
<img width="1305" alt="Screen Shot 2020-06-05 at 2 53 58 PM" src="https://user-images.githubusercontent.com/10646092/84080431-0526c380-a991-11ea-81ea-e69987e207c6.png">


## TODO

- [ ] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [ ] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
