### PR TITLE
Pog: Add padding prop

### DIFF
--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -66,8 +66,8 @@ card(
       },
       {
         name: 'padding',
-        type: `"xs" | "sm" | "md" | "lg" | "xl" | 4 | 12 | 20`,
-        description: `Available padding are "xs" (6px), "sm" (8px), "md" (11px), "lg" (14px), "xl" (16px), 4 (px), 12 (px), and 20 (px). By default, this value is the same as the \`size\` prop.`,
+        type: `1 | 2 | 3 | 4 | 5`,
+        description: `Padding in boints. If omitted, padding is derived from the \`size\` prop.`,
         href: 'paddingCombinations',
       },
       {
@@ -79,7 +79,7 @@ card(
       {
         name: 'size',
         type: `"xs" | "sm" | "md" | "lg" | "xl"`,
-        description: `This controls the icon size and the default padding size. Available sizes are "xs" (12px), "sm" (16px), "md" (18px), "lg" (20px), and "xl" (24px). If the default padding is used, button sizes are "xs" (24px), "sm" (32px), "md" (40px), "lg" (48px), and "xl" (56px)`,
+        description: `This controls the icon size and the default padding size. Available sizes are "xs" (12px), "sm" (16px), "md" (18px), "lg" (20px), and "xl" (24px). If padding is omitted, button sizes are "xs" (24px), "sm" (32px), "md" (40px), "lg" (48px), and "xl" (56px)`,
         defaultValue: 'md',
         href: 'sizeCombinations',
       },
@@ -114,7 +114,7 @@ card(
 card(
   <Combination
     id="sizeCombinations"
-    name="Combinations: Size"
+    name="Combinations: Size with default padding"
     size={['xs', 'sm', 'md', 'lg', 'xl']}
   >
     {props => <Pog icon="heart" {...props} />}
@@ -124,9 +124,9 @@ card(
 card(
   <Combination
     id="paddingCombinations"
-    name="Combinations: Padding"
-    size={['xs', 'xl']}
-    padding={[4, 'xs', 'sm', 'md', 12, 'lg', 'xl', 20]}
+    name="Combinations: Size with custom padding"
+    size={['xs', 'sm', 'md', 'lg', 'xl']}
+    padding={[1, 2, 3, 4, 5]}
   >
     {props => <Pog icon="heart" {...props} />}
   </Combination>

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -36,6 +36,11 @@ card(
         href: 'colorCombinations',
       },
       {
+        name: 'dangerouslySetSvgPath',
+        type: `{ __path: string }`,
+        description: `When using this prop, make sure that the viewbox around the SVG path is 24x24`,
+      },
+      {
         name: 'focused',
         type: 'boolean',
         defaultValue: false,
@@ -60,9 +65,10 @@ card(
         Icon`,
       },
       {
-        name: 'dangerouslySetSvgPath',
-        type: `{ __path: string }`,
-        description: `When using this prop, make sure that the viewbox around the SVG path is 24x24`,
+        name: 'padding',
+        type: `"xs" | "sm" | "md" | "lg" | "xl" | 4 | 12 | 20`,
+        description: `Available padding are "xs" (6px), "sm" (8px), "md" (11px), "lg" (14px), "xl" (16px), 4 (px), 12 (px), and 20 (px). By default, this value is the same as the \`size\` prop.`,
+        href: 'paddingCombinations',
       },
       {
         name: 'selected',
@@ -73,7 +79,7 @@ card(
       {
         name: 'size',
         type: `"xs" | "sm" | "md" | "lg" | "xl"`,
-        description: `xs: 24px, sm: 32px, md: 40px, lg: 48px, xl: 56px`,
+        description: `This controls the icon size and the default padding size. Available sizes are "xs" (12px), "sm" (16px), "md" (18px), "lg" (20px), and "xl" (24px). If the default padding is used, button sizes are "xs" (24px), "sm" (32px), "md" (40px), "lg" (48px), and "xl" (56px)`,
         defaultValue: 'md',
         href: 'sizeCombinations',
       },
@@ -110,6 +116,17 @@ card(
     id="sizeCombinations"
     name="Combinations: Size"
     size={['xs', 'sm', 'md', 'lg', 'xl']}
+  >
+    {props => <Pog icon="heart" {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="paddingCombinations"
+    name="Combinations: Padding"
+    size={['xs', 'xl']}
+    padding={[4, 'xs', 'sm', 'md', 12, 'lg', 'xl', 20]}
   >
     {props => <Pog icon="heart" {...props} />}
   </Combination>

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -2,17 +2,16 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Box from './Box.js';
 import Icon from './Icon.js';
 import icons from './icons/index.js';
 import styles from './Pog.css';
 
-const SIZE_NAME_TO_PIXEL = {
-  xs: 24,
-  sm: 32,
-  md: 40,
-  lg: 48,
-  xl: 56,
+const PADDING_NAME_TO_PADDING_PIXEL = {
+  xs: 6,
+  sm: 8,
+  md: 11,
+  lg: 14,
+  xl: 16,
 };
 
 const SIZE_NAME_TO_ICON_SIZE_PIXEL = {
@@ -36,10 +35,11 @@ type Props = {|
   dangerouslySetSvgPath?: { __path: string },
   focused?: boolean,
   hovered?: boolean,
-  selected?: boolean,
   icon?: $Keys<typeof icons>,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
-  size?: $Keys<typeof SIZE_NAME_TO_PIXEL>,
+  padding?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 4 | 12 | 20,
+  selected?: boolean,
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
 const defaultIconButtonIconColors = {
@@ -61,18 +61,25 @@ export default function Pog(props: Props) {
     hovered = false,
     icon,
     iconColor,
+    padding,
     selected = false,
     size = 'md',
   } = props;
 
-  const iconSize = SIZE_NAME_TO_ICON_SIZE_PIXEL[size];
+  const iconSizeInPx = SIZE_NAME_TO_ICON_SIZE_PIXEL[size];
+  const paddingInPx =
+    typeof padding === 'number'
+      ? padding
+      : PADDING_NAME_TO_PADDING_PIXEL[padding || size];
 
   const color =
     (selected && 'white') || iconColor || defaultIconButtonIconColors[bgColor];
 
+  const sizeInPx = iconSizeInPx + paddingInPx * 2;
+
   const inlineStyle = {
-    height: SIZE_NAME_TO_PIXEL[size],
-    width: SIZE_NAME_TO_PIXEL[size],
+    height: sizeInPx,
+    width: sizeInPx,
   };
 
   const classes = classnames(styles.pog, {
@@ -85,24 +92,24 @@ export default function Pog(props: Props) {
 
   return (
     <div className={classes} style={inlineStyle}>
-      <Box rounding="circle">
-        {/*
-          We're explicitly setting an empty string as a label on the Icon since we
-          already have an aria-label on the button container.
-          This is similar to having empty `alt` attributes:
-          https://davidwalsh.name/accessibility-tip-empty-alt-attributes
-        */}
-        <Icon
-          accessibilityLabel=""
-          color={color}
-          dangerouslySetSvgPath={dangerouslySetSvgPath}
-          icon={icon}
-          size={iconSize}
-        />
-      </Box>
+      {/*
+        We're explicitly setting an empty string as a label on the Icon since we
+        already have an aria-label on the button container.
+        This is similar to having empty `alt` attributes:
+        https://davidwalsh.name/accessibility-tip-empty-alt-attributes
+      */}
+      <Icon
+        accessibilityLabel=""
+        color={color}
+        dangerouslySetSvgPath={dangerouslySetSvgPath}
+        icon={icon}
+        size={iconSizeInPx}
+      />
     </div>
   );
 }
+
+const SIZE_NAMES = ['xs', 'sm', 'md', 'lg', 'xl'];
 
 Pog.propTypes = {
   active: PropTypes.bool,
@@ -121,6 +128,7 @@ Pog.propTypes = {
   hovered: PropTypes.bool,
   icon: PropTypes.oneOf(Object.keys(icons)),
   iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'white']),
+  padding: PropTypes.oneOf(SIZE_NAMES.concat([4, 12, 20])),
   selected: PropTypes.bool,
-  size: PropTypes.oneOf(Object.keys(SIZE_NAME_TO_PIXEL)),
+  size: PropTypes.oneOf(SIZE_NAMES),
 };

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -6,7 +6,7 @@ import Icon from './Icon.js';
 import icons from './icons/index.js';
 import styles from './Pog.css';
 
-const PADDING_NAME_TO_PADDING_PIXEL = {
+const SIZE_NAME_TO_PADDING_PIXEL = {
   xs: 6,
   sm: 8,
   md: 11,
@@ -37,7 +37,7 @@ type Props = {|
   hovered?: boolean,
   icon?: $Keys<typeof icons>,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
-  padding?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 4 | 12 | 20,
+  padding?: 1 | 2 | 3 | 4 | 5,
   selected?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
@@ -67,10 +67,7 @@ export default function Pog(props: Props) {
   } = props;
 
   const iconSizeInPx = SIZE_NAME_TO_ICON_SIZE_PIXEL[size];
-  const paddingInPx =
-    typeof padding === 'number'
-      ? padding
-      : PADDING_NAME_TO_PADDING_PIXEL[padding || size];
+  const paddingInPx = padding || SIZE_NAME_TO_PADDING_PIXEL[size];
 
   const color =
     (selected && 'white') || iconColor || defaultIconButtonIconColors[bgColor];
@@ -109,8 +106,6 @@ export default function Pog(props: Props) {
   );
 }
 
-const SIZE_NAMES = ['xs', 'sm', 'md', 'lg', 'xl'];
-
 Pog.propTypes = {
   active: PropTypes.bool,
   bgColor: PropTypes.oneOf([
@@ -128,7 +123,7 @@ Pog.propTypes = {
   hovered: PropTypes.bool,
   icon: PropTypes.oneOf(Object.keys(icons)),
   iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'white']),
-  padding: PropTypes.oneOf(SIZE_NAMES.concat([4, 12, 20])),
+  padding: PropTypes.oneOf([1, 2, 3, 4, 5]),
   selected: PropTypes.bool,
-  size: PropTypes.oneOf(SIZE_NAMES),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 };

--- a/packages/gestalt/src/Pog.test.js
+++ b/packages/gestalt/src/Pog.test.js
@@ -8,8 +8,13 @@ test('Pog renders with icon', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Pog renders with size and padding', () => {
-  const tree = create(<Pog icon="heart" size="xl" padding="xs" />).toJSON();
+test('Pog renders with size and default padding', () => {
+  const tree = create(<Pog icon="heart" size="xl" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Pog renders with size and custom padding', () => {
+  const tree = create(<Pog icon="heart" size="xl" padding={1} />).toJSON();
   expect(tree).toMatchSnapshot();
 });
 

--- a/packages/gestalt/src/Pog.test.js
+++ b/packages/gestalt/src/Pog.test.js
@@ -8,6 +8,11 @@ test('Pog renders with icon', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Pog renders with size and padding', () => {
+  const tree = create(<Pog icon="heart" size="xl" padding="xs" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Pog renders with svg', () => {
   const tree = create(
     <Pog dangerouslySetSvgPath={{ __path: 'M13.00,20.00' }} />

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -23,23 +23,19 @@ exports[`IconButton renders with disabled state 1`] = `
       }
     }
   >
-    <div
-      className="box circle"
+    <svg
+      aria-hidden={true}
+      aria-label=""
+      className="icon gray iconBlock"
+      height={18}
+      role="img"
+      viewBox="0 0 24 24"
+      width={18}
     >
-      <svg
-        aria-hidden={true}
-        aria-label=""
-        className="icon gray iconBlock"
-        height={18}
-        role="img"
-        viewBox="0 0 24 24"
-        width={18}
-      >
-        <path
-          d="test-file-stub"
-        />
-      </svg>
-    </div>
+      <path
+        d="test-file-stub"
+      />
+    </svg>
   </div>
 </button>
 `;
@@ -66,23 +62,19 @@ exports[`IconButton renders with icon 1`] = `
       }
     }
   >
-    <div
-      className="box circle"
+    <svg
+      aria-hidden={true}
+      aria-label=""
+      className="icon gray iconBlock"
+      height={18}
+      role="img"
+      viewBox="0 0 24 24"
+      width={18}
     >
-      <svg
-        aria-hidden={true}
-        aria-label=""
-        className="icon gray iconBlock"
-        height={18}
-        role="img"
-        viewBox="0 0 24 24"
-        width={18}
-      >
-        <path
-          d="test-file-stub"
-        />
-      </svg>
-    </div>
+      <path
+        d="test-file-stub"
+      />
+    </svg>
   </div>
 </button>
 `;
@@ -109,23 +101,19 @@ exports[`IconButton renders with svg 1`] = `
       }
     }
   >
-    <div
-      className="box circle"
+    <svg
+      aria-hidden={true}
+      aria-label=""
+      className="icon gray iconBlock"
+      height={18}
+      role="img"
+      viewBox="0 0 24 24"
+      width={18}
     >
-      <svg
-        aria-hidden={true}
-        aria-label=""
-        className="icon gray iconBlock"
-        height={18}
-        role="img"
-        viewBox="0 0 24 24"
-        width={18}
-      >
-        <path
-          d="M13.00,20.00"
-        />
-      </svg>
-    </div>
+      <path
+        d="M13.00,20.00"
+      />
+    </svg>
   </div>
 </button>
 `;

--- a/packages/gestalt/src/__snapshots__/Pog.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pog.test.js.snap
@@ -104,6 +104,32 @@ exports[`Pog renders with icon 1`] = `
 </div>
 `;
 
+exports[`Pog renders with size and padding 1`] = `
+<div
+  className="pog transparent"
+  style={
+    Object {
+      "height": 36,
+      "width": 36,
+    }
+  }
+>
+  <svg
+    aria-hidden={true}
+    aria-label=""
+    className="icon gray iconBlock"
+    height={24}
+    role="img"
+    viewBox="0 0 24 24"
+    width={24}
+  >
+    <path
+      d="test-file-stub"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Pog renders with svg 1`] = `
 <div
   className="pog transparent"

--- a/packages/gestalt/src/__snapshots__/Pog.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pog.test.js.snap
@@ -10,23 +10,19 @@ exports[`Pog active renders 1`] = `
     }
   }
 >
-  <div
-    className="box circle"
+  <svg
+    aria-hidden={true}
+    aria-label=""
+    className="icon gray iconBlock"
+    height={18}
+    role="img"
+    viewBox="0 0 24 24"
+    width={18}
   >
-    <svg
-      aria-hidden={true}
-      aria-label=""
-      className="icon gray iconBlock"
-      height={18}
-      role="img"
-      viewBox="0 0 24 24"
-      width={18}
-    >
-      <path
-        d="test-file-stub"
-      />
-    </svg>
-  </div>
+    <path
+      d="test-file-stub"
+    />
+  </svg>
 </div>
 `;
 
@@ -40,23 +36,19 @@ exports[`Pog focused renders 1`] = `
     }
   }
 >
-  <div
-    className="box circle"
+  <svg
+    aria-hidden={true}
+    aria-label=""
+    className="icon gray iconBlock"
+    height={18}
+    role="img"
+    viewBox="0 0 24 24"
+    width={18}
   >
-    <svg
-      aria-hidden={true}
-      aria-label=""
-      className="icon gray iconBlock"
-      height={18}
-      role="img"
-      viewBox="0 0 24 24"
-      width={18}
-    >
-      <path
-        d="test-file-stub"
-      />
-    </svg>
-  </div>
+    <path
+      d="test-file-stub"
+    />
+  </svg>
 </div>
 `;
 
@@ -70,23 +62,19 @@ exports[`Pog hovered renders 1`] = `
     }
   }
 >
-  <div
-    className="box circle"
+  <svg
+    aria-hidden={true}
+    aria-label=""
+    className="icon gray iconBlock"
+    height={18}
+    role="img"
+    viewBox="0 0 24 24"
+    width={18}
   >
-    <svg
-      aria-hidden={true}
-      aria-label=""
-      className="icon gray iconBlock"
-      height={18}
-      role="img"
-      viewBox="0 0 24 24"
-      width={18}
-    >
-      <path
-        d="test-file-stub"
-      />
-    </svg>
-  </div>
+    <path
+      d="test-file-stub"
+    />
+  </svg>
 </div>
 `;
 
@@ -100,23 +88,19 @@ exports[`Pog renders with icon 1`] = `
     }
   }
 >
-  <div
-    className="box circle"
+  <svg
+    aria-hidden={true}
+    aria-label=""
+    className="icon gray iconBlock"
+    height={18}
+    role="img"
+    viewBox="0 0 24 24"
+    width={18}
   >
-    <svg
-      aria-hidden={true}
-      aria-label=""
-      className="icon gray iconBlock"
-      height={18}
-      role="img"
-      viewBox="0 0 24 24"
-      width={18}
-    >
-      <path
-        d="test-file-stub"
-      />
-    </svg>
-  </div>
+    <path
+      d="test-file-stub"
+    />
+  </svg>
 </div>
 `;
 
@@ -130,22 +114,18 @@ exports[`Pog renders with svg 1`] = `
     }
   }
 >
-  <div
-    className="box circle"
+  <svg
+    aria-hidden={true}
+    aria-label=""
+    className="icon gray iconBlock"
+    height={18}
+    role="img"
+    viewBox="0 0 24 24"
+    width={18}
   >
-    <svg
-      aria-hidden={true}
-      aria-label=""
-      className="icon gray iconBlock"
-      height={18}
-      role="img"
-      viewBox="0 0 24 24"
-      width={18}
-    >
-      <path
-        d="M13.00,20.00"
-      />
-    </svg>
-  </div>
+    <path
+      d="M13.00,20.00"
+    />
+  </svg>
 </div>
 `;

--- a/packages/gestalt/src/__snapshots__/Pog.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pog.test.js.snap
@@ -104,13 +104,39 @@ exports[`Pog renders with icon 1`] = `
 </div>
 `;
 
-exports[`Pog renders with size and padding 1`] = `
+exports[`Pog renders with size and custom padding 1`] = `
 <div
   className="pog transparent"
   style={
     Object {
-      "height": 36,
-      "width": 36,
+      "height": 26,
+      "width": 26,
+    }
+  }
+>
+  <svg
+    aria-hidden={true}
+    aria-label=""
+    className="icon gray iconBlock"
+    height={24}
+    role="img"
+    viewBox="0 0 24 24"
+    width={24}
+  >
+    <path
+      d="test-file-stub"
+    />
+  </svg>
+</div>
+`;
+
+exports[`Pog renders with size and default padding 1`] = `
+<div
+  className="pog transparent"
+  style={
+    Object {
+      "height": 56,
+      "width": 56,
     }
   }
 >


### PR DESCRIPTION
## Changes

### Minor changes:
- add `padding` prop where possible value are 1 ~ 5 boints. if omitted, default padding (which may or may not be an integer boint) would be used.

### Revisions:
- removed unnecessary use of `Box` in the component

## TODO
- [x] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.

## Screenshots

### docs

<img width="1021" alt="Screenshot 2020-06-11 19 23 18" src="https://user-images.githubusercontent.com/5341184/84458067-0833e500-ac19-11ea-9107-6f9f4d63a7e1.png">

<img width="1037" alt="Screenshot 2020-06-11 19 24 04" src="https://user-images.githubusercontent.com/5341184/84458121-226dc300-ac19-11ea-91da-6b42442188c7.png">
