### PR TITLE
Tabs: remove underline on hover/focus

### DIFF
--- a/packages/gestalt/src/Tabs.css
+++ b/packages/gestalt/src/Tabs.css
@@ -22,11 +22,6 @@
   composes: whiteBg from "./Colors.css";
 }
 
-.tab:focus,
-.tab:hover {
-  text-decoration: underline;
-}
-
 .tabIsNotActive:focus,
 .tabIsNotActive:hover {
   background-color: #f1f1f1;


### PR DESCRIPTION
## Before
![Screen Shot 2020-06-11 at 12 56 35 PM](https://user-images.githubusercontent.com/127199/84433449-267eee00-abe3-11ea-921f-e3a00d722d8c.png)

## After
![Screen Shot 2020-06-11 at 12 56 28 PM](https://user-images.githubusercontent.com/127199/84433457-28e14800-abe3-11ea-9a3d-34b4f36ff753.png)

