### PR TITLE
Touchable: Add inline prop

### DIFF
--- a/docs/src/Touchable.doc.js
+++ b/docs/src/Touchable.doc.js
@@ -69,6 +69,10 @@ card(
         href: 'fullHeightWidthExample',
       },
       {
+        name: 'inline',
+        type: 'boolean',
+      },
+      {
         name: 'mouseCursor',
         type: `"copy" | "grab" | "grabbing" | "move" | "noDrop" | "pointer" | "zoomIn" | "zoomOut"`,
         defaultValue: 'pointer',
@@ -212,12 +216,12 @@ function A11yExPopup() {
           accessibilityLabel="see more"
           onTouch={() => setOpen(!isOpen)}
         >
-        <Box 
-          alignItems="center" 
+        <Box
+          alignItems="center"
           borderSize="sm"
-          display="flex" 
-          padding={2} 
-          rounding="pill" 
+          display="flex"
+          padding={2}
+          rounding="pill"
         >
             <Box paddingX={1}>
               <Text weight="bold">See more</Text>
@@ -229,10 +233,10 @@ function A11yExPopup() {
         </Touchable>
       </Box>
       {isOpen && (
-        <Flyout 
-          anchor={anchorRef && anchorRef.current} 
+        <Flyout
+          anchor={anchorRef && anchorRef.current}
           idealDirection="right"
-          onDismiss={() => undefined} 
+          onDismiss={() => undefined}
         >
           <Box padding={2}>
             <Text>I am a popup.</Text>
@@ -270,13 +274,13 @@ function A11yExDisclosure() {
           accessibilityExpanded={isOpen}
           onTouch={() => setOpen(!isOpen)}
         >
-          <Box 
-            alignItems="center" 
+          <Box
+            alignItems="center"
             borderSize="sm"
-            display="flex" 
-            justifyContent="between" 
-            padding={2} 
-            rounding="pill" 
+            display="flex"
+            justifyContent="between"
+            padding={2}
+            rounding="pill"
           >
             <Box paddingX={1}>
               <Text weight="bold">{isOpen ? 'Collapse' : 'Expand'}</Text>

--- a/packages/gestalt/src/Touchable.css
+++ b/packages/gestalt/src/Touchable.css
@@ -41,3 +41,7 @@
 .grabbing {
   composes: grabbing from "./Cursor.css";
 }
+
+.inline {
+  composes: inline from "./Layout.css";
+}

--- a/packages/gestalt/src/Touchable.js
+++ b/packages/gestalt/src/Touchable.js
@@ -27,6 +27,7 @@ type Props = {|
   disabled?: boolean,
   fullHeight?: boolean,
   fullWidth?: boolean,
+  inline?: boolean,
   mouseCursor?: MouseCursor,
   onBlur?: ({ event: SyntheticFocusEvent<HTMLDivElement> }) => void,
   onFocus?: ({ event: SyntheticFocusEvent<HTMLDivElement> }) => void,
@@ -83,6 +84,7 @@ export default class Touchable extends React.Component<Props> {
     disabled: PropTypes.bool,
     fullHeight: PropTypes.bool,
     fullWidth: PropTypes.bool,
+    inline: PropTypes.bool,
     mouseCursor: PropTypes.oneOf([
       'copy',
       'grab',
@@ -160,6 +162,7 @@ export default class Touchable extends React.Component<Props> {
       disabled = false,
       fullWidth = true,
       fullHeight,
+      inline = false,
       mouseCursor = 'pointer',
       rounding = 0,
     } = this.props;
@@ -170,6 +173,7 @@ export default class Touchable extends React.Component<Props> {
       {
         [styles.fullHeight]: fullHeight,
         [styles.fullWidth]: fullWidth,
+        [styles.inline]: inline,
         [styles[mouseCursor]]: !disabled,
       }
     );


### PR DESCRIPTION
This is needed for clickable elements that are part of a `inline` layout. The specific use case I'm trying to solve right now is clickable text as part of an inline layout, which currently isn't possible. A flex layout allows for inline behavior if all the elements fit on one line, but that breaks if that wraps to the next line.

Consider this:
<img width="374" alt="Screen Shot 2020-06-11 at 6 06 51 PM" src="https://user-images.githubusercontent.com/12059539/84454062-69a28680-ac0e-11ea-875f-35f57bc1a29f.png">

Vs this:
<img width="650" alt="Screen Shot 2020-06-11 at 6 08 04 PM" src="https://user-images.githubusercontent.com/12059539/84454110-8474fb00-ac0e-11ea-86fd-6fe4c8b6625c.png">



- [ ] Accessibility checkup
- [x] Update documentation
- [ ] Add/update Tests
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
