### PR TITLE
Internal: Request a Pinterest designer for design changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,5 @@
 - [ ] Accessibility checkup
 - [ ] Update documentation
 - [ ] Add/update Tests
+- [ ] Pinterest Designer (for design changes)
 - [ ] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.


### PR DESCRIPTION
Require a Pinterest designer for design changes in Gestalt. Makes it easier to get context around a change.