### PR TITLE
Touchable: displayName should still be Touchable

### DIFF
--- a/packages/gestalt/src/Touchable.js
+++ b/packages/gestalt/src/Touchable.js
@@ -239,7 +239,10 @@ Touchable.propTypes = {
   rounding: RoundingPropType,
 };
 
-const forwardRef = (props, ref) => <Touchable {...props} forwardedRef={ref} />;
-forwardRef.displayName = 'Touchable';
+const TouchableWithForwardRef = React.forwardRef<Props, HTMLDivElement>(
+  (props, ref) => <Touchable {...props} forwardedRef={ref} />
+);
 
-export default React.forwardRef<Props, HTMLDivElement>(forwardRef);
+TouchableWithForwardRef.displayName = 'Touchable';
+
+export default TouchableWithForwardRef;


### PR DESCRIPTION
This is so that Touchable component is still named Touchable in shallow snapshots. manually tested by running shallow snapshot tests in Pinboard.