### PR TITLE
Internal: upgrade to flow 0.127.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.116.1
+0.127.0
 
 [ignore]
 # Tracking https://github.com/facebook/flow/issues/4015
@@ -10,9 +10,6 @@
 esproposal.optional_chaining=enable
 exact_by_default=true
 include_warnings=true
-
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 
 [libs]
 flow-typed

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^2.5.0",
-    "flow-bin": "^0.116.1",
+    "flow-bin": "^0.127.0",
     "husky": "^4.2.5",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.0.1",

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -670,7 +670,7 @@ const omit = (keys, obj) =>
 // (className, style) or accessibility (onClick).
 const blacklistProps = ['onClick', 'className', 'style'];
 
-// $FlowIssue https://github.com/facebook/flow/issues/6103
+// $FlowFixMe[missing-annot]
 const Box = React.forwardRef(
   ({ children, ...props }: PropType, ref: React.ElementRef<*>) => {
     // Flow can't reason about the constant nature of Object.keys so we can't use
@@ -869,7 +869,7 @@ const SizeDisplayPropType = PropTypes.oneOf([
   'inlineBlock',
 ]);
 
-// $FlowIssue https://github.com/facebook/flow/issues/7484
+// $FlowFixMe[prop-missing]
 Box.propTypes = {
   children: PropTypes.node,
   dangerouslySetInlineStyle: PropTypes.exact({

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+// flowlint-next-line untyped-import:off
 import { createPortal } from 'react-dom';
 
 type Props = {|

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -67,17 +67,17 @@ type State = {|
 const requestFullscreen = (element: HTMLElement) => {
   if (element.requestFullscreen) {
     element.requestFullscreen();
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[prop-missing]
   } else if (element.webkitRequestFullscreen) {
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[not-a-function]
     element.webkitRequestFullscreen();
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[prop-missing]
   } else if (element.mozRequestFullScreen) {
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[not-a-function]
     element.mozRequestFullScreen();
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[prop-missing]
   } else if (element.msRequestFullscreen) {
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[not-a-function]
     element.msRequestFullscreen();
   }
 };
@@ -85,17 +85,17 @@ const requestFullscreen = (element: HTMLElement) => {
 const exitFullscreen = () => {
   if (document.exitFullscreen) {
     document.exitFullscreen();
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[prop-missing]
   } else if (document.webkitExitFullscreen) {
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[not-a-function]
     document.webkitExitFullscreen();
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[prop-missing]
   } else if (document.mozCancelFullScreen) {
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[not-a-function]
     document.mozCancelFullScreen();
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[prop-missing]
   } else if (document.msExitFullscreen) {
-    // $FlowIssue - vendor prefix missing from Flow
+    // $FlowFixMe[not-a-function]
     document.msExitFullscreen();
   }
 };
@@ -103,12 +103,13 @@ const exitFullscreen = () => {
 // Normally document.fullscreen suffices here as a flag, but IE11 does not
 // have a vendor specific version so we must instead use the actual element
 const isFullscreen = () =>
+  // $FlowFixMe[unsafe-addition]
   document.fullscreenElement ||
-  // $FlowIssue - vendor prefix missing from Flow
+  // $FlowFixMe[prop-missing]
   document.webkitFullscreenElement ||
-  // $FlowIssue - vendor prefix missing from Flow
+  // $FlowFixMe[prop-missing]
   document.mozFullScreenElement ||
-  // $FlowIssue - vendor prefix missing from Flow
+  // $FlowFixMe[prop-missing]
   document.msFullscreenElement;
 
 const addFullscreenEventListener = (listener: EventListener) => {

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -32,11 +32,11 @@ type Props = {|
 
 const fullscreenEnabled = () =>
   document.fullscreenEnabled ||
-  // $FlowIssue - vendor prefix missing from Flow
+  // $FlowFixMe[prop-missing]
   document.webkitFullscreenEnabled ||
-  // $FlowIssue - vendor prefix missing from Flow
+  // $FlowFixMe[prop-missing]
   document.mozFullScreenEnabled ||
-  // $FlowIssue - vendor prefix missing from Flow
+  // $FlowFixMe[prop-missing]
   document.msFullscreenEnabled;
 
 const timeToString = (time?: number) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6164,10 +6164,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@^0.116.1:
-  version "0.116.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.116.1.tgz#797964df40f2e32cad7e334583535105161434f4"
-  integrity sha512-ZSvjx+S4PtDNKcA4U0Afm8sHzzSlTdBBT//N2AltcaN6M/gyxAOGXjC6VkMMGqKWttw+5Psq6fU+RIvD1q/ocA==
+flow-bin@^0.127.0:
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.127.0.tgz#0614cff4c1b783beef1feeb7108d536e09d77632"
+  integrity sha512-ywvCCdV4NJWzrqjFrMU5tAiVGyBiXjsJQ1+/kj8thXyX15V17x8BFvNwoAH97NrUU8T1HzmFBjLzWc0l2319qg==
 
 flow-parser@0.*:
   version "0.122.0"


### PR DESCRIPTION
Upgrade to 0.127.0 with more exact error suppressions + it unlocks types first: https://medium.com/flow-type/types-first-a-scalable-new-architecture-for-flow-3d8c7ba1d4eb

Release notes: https://github.com/facebook/flow/releases