### PR TITLE
Row, Stack: Fix nullish child gap bug

### DIFF
--- a/packages/gestalt/src/Row.js
+++ b/packages/gestalt/src/Row.js
@@ -63,9 +63,11 @@ export default function Row({
         width={width}
         {...rest}
       >
-        {React.Children.map(children, child => (
-          <Box paddingX={gap}>{child}</Box>
-        ))}
+        {React.Children.map(children, child =>
+          child !== null && child !== undefined ? (
+            <Box paddingX={gap}>{child}</Box>
+          ) : null
+        )}
       </FlexBox>
     </Box>
   );

--- a/packages/gestalt/src/Stack.js
+++ b/packages/gestalt/src/Stack.js
@@ -63,9 +63,11 @@ export default function Stack({
         width={width}
         {...rest}
       >
-        {React.Children.map(children, child => (
-          <Box paddingY={gap}>{child}</Box>
-        ))}
+        {React.Children.map(children, child =>
+          child !== null && child !== undefined ? (
+            <Box paddingY={gap}>{child}</Box>
+          ) : null
+        )}
       </FlexBox>
     </Box>
   );


### PR DESCRIPTION
`React.Children` doesn't filter out nullish children before mapping, so we were padding empty Boxes and throwing off layouts. This PR adds a nullish check and only wraps the child in a Box if it's defined, otherwise passing through null.

Before:
<img width="618" alt="Screen Shot 2020-06-15 at 6 41 43 PM" src="https://user-images.githubusercontent.com/12059539/84722533-5bb77300-af38-11ea-9586-5c19dd8db2d5.png">

After:
<img width="602" alt="Screen Shot 2020-06-15 at 6 42 11 PM" src="https://user-images.githubusercontent.com/12059539/84722544-62de8100-af38-11ea-8e1a-11fe03b5b09b.png">

- [ ] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [ ] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
