### PR TITLE
Masonry/defaultLayout: Add a layout `basicCentered` to center justify grid content

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -29,6 +29,7 @@ type Layout =
   | LegacyMasonryLayout
   | LegacyUniformRowLayout
   | 'basic'
+  | 'basicCentered'
   | 'flexible'
   | 'uniformRow';
 
@@ -490,7 +491,9 @@ export default class Masonry<T: {}> extends React.Component<
         cache: measurementStore,
         columnWidth,
         gutter,
+        justify: layout === 'basicCentered' ? 'center' : 'start',
         minCols,
+        rawItemCount: items.length,
         width,
       });
     }

--- a/packages/gestalt/src/defaultLayout.js
+++ b/packages/gestalt/src/defaultLayout.js
@@ -29,13 +29,17 @@ export default <T>({
   cache,
   columnWidth = 236,
   gutter = 14,
+  justify,
   minCols = 2,
+  rawItemCount,
   width,
 }: {|
   columnWidth?: number,
   gutter?: number,
+  justify: 'center' | 'start',
   cache: Cache<T, number>,
   minCols?: number,
+  rawItemCount: number,
   width?: ?number,
 |}) => (items: Array<*>): Array<Position> => {
   if (width == null) {
@@ -49,10 +53,19 @@ export default <T>({
   );
   // the total height of each column
   const heights = new Array(columnCount).fill(0);
-  const centerOffset = Math.max(
-    Math.floor((width - columnWidthAndGutter * columnCount + gutter) / 2),
-    0
-  );
+
+  let centerOffset;
+  if (justify === 'center') {
+    const contentWidth =
+      Math.min(rawItemCount, columnCount) * columnWidthAndGutter + gutter;
+
+    centerOffset = Math.max(Math.floor((width - contentWidth) / 2), 0);
+  } else {
+    centerOffset = Math.max(
+      Math.floor((width - columnWidthAndGutter * columnCount + gutter) / 2),
+      0
+    );
+  }
 
   return items.reduce((acc, item) => {
     const positions = acc;

--- a/packages/gestalt/src/defaultLayout.test.js
+++ b/packages/gestalt/src/defaultLayout.test.js
@@ -102,3 +102,35 @@ test('only centers when theres extra space', () => {
     { top: 134, height: 100, left: 250, width: 236 },
   ]);
 });
+
+test('justify', () => {
+  const measurements = { a: 100, b: 120, c: 80, d: 100 };
+  const items = ['a', 'b', 'c', 'd'];
+
+  const makeLayout = justify =>
+    defaultLayout({
+      cache: stubCache(measurements),
+      columnWidth: 100,
+      gutter: 0,
+      justify,
+      width: 1000,
+      rawItemCount: items.length,
+    })(items);
+
+  const justifyStart = makeLayout('start');
+  const justifyCenter = makeLayout('center');
+
+  expect(justifyStart).toEqual([
+    { top: 0, left: 0, width: 100, height: 100 },
+    { top: 0, left: 100, width: 100, height: 120 },
+    { top: 0, left: 200, width: 100, height: 80 },
+    { top: 0, left: 300, width: 100, height: 100 },
+  ]);
+
+  expect(justifyCenter).toEqual([
+    { top: 0, left: 300, width: 100, height: 100 },
+    { top: 0, left: 400, width: 100, height: 120 },
+    { top: 0, left: 500, width: 100, height: 80 },
+    { top: 0, left: 600, width: 100, height: 100 },
+  ]);
+});

--- a/packages/gestalt/src/defaultLayout.test.js
+++ b/packages/gestalt/src/defaultLayout.test.js
@@ -21,11 +21,14 @@ const stubCache = (measurements?: { [item: string]: number, ... } = {}) => {
 };
 
 test('empty', () => {
+  const items = [];
   const layout = defaultLayout({
     cache: stubCache(),
+    justify: 'start',
+    rawItemCount: items.length,
     width: 486,
   });
-  expect(layout([])).toEqual([]);
+  expect(layout(items)).toEqual([]);
 });
 
 test('one row', () => {
@@ -33,6 +36,8 @@ test('one row', () => {
   const items = ['a', 'b', 'c'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
+    justify: 'start',
+    rawItemCount: items.length,
     width: 736,
   });
   expect(layout(items)).toEqual([
@@ -47,6 +52,8 @@ test('wrapping items', () => {
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
+    justify: 'start',
+    rawItemCount: items.length,
     width: 486,
   });
   expect(layout(items)).toEqual([
@@ -62,8 +69,10 @@ test('centers grid within the viewport', () => {
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
-    width: 8000,
+    justify: 'start',
     minCols: 2,
+    rawItemCount: items.length,
+    width: 8000,
   });
   expect(layout(items)).toEqual([
     { top: 0, height: 100, left: 7, width: 236 },
@@ -78,6 +87,8 @@ test('floors values when centering', () => {
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
+    justify: 'start',
+    rawItemCount: items.length,
     width: 501,
   });
   expect(layout(items)).toEqual([
@@ -93,6 +104,8 @@ test('only centers when theres extra space', () => {
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
+    justify: 'start',
+    rawItemCount: items.length,
     width: 200,
   });
   expect(layout(items)).toEqual([


### PR DESCRIPTION
The Masonry grid renders items from left to right with the first item left justified.  This change adds an option to the Masonry `layout` prop called `basicCentered`.  When passed this value `defaultLayout` modifies its calculation of position to center justify the contents of the grid.

Example board: https://www.pinterest.com/pinterestcreators/story-pins/

Masonry.props.layout === 'basic'
<img width="1591" alt="Screen Shot 2020-06-17 at 3 10 50 PM" src="https://user-images.githubusercontent.com/10646092/84955886-f2a53c00-b0ac-11ea-96e9-a81a700ffed2.png">


Masonry.props.layout === 'basicCentered'
<img width="1591" alt="Screen Shot 2020-06-17 at 3 10 40 PM" src="https://user-images.githubusercontent.com/10646092/84955902-f6d15980-b0ac-11ea-92cb-e606d067be7f.png">

## TODO

- [ ] Accessibility checkup
- [ ] Update documentation
- [✓] Add/update Tests
- [✓] Pinterest Designer (for design changes) (@annieteng)
- [✓] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
