### PR TITLE
TapArea: fix codemod

### DIFF
--- a/packages/gestalt-codemods/4.0.0-5.0.0/__testfixtures__/.eslintrc.json
+++ b/packages/gestalt-codemods/4.0.0-5.0.0/__testfixtures__/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "rules": {
     "prettier/prettier": "off",
+    "react/jsx-fragments": "off",
     "no-undef": "off"
   }
 }

--- a/packages/gestalt-codemods/4.0.0-5.0.0/__testfixtures__/touchable-to-taparea-3.input.js
+++ b/packages/gestalt-codemods/4.0.0-5.0.0/__testfixtures__/touchable-to-taparea-3.input.js
@@ -1,0 +1,6 @@
+// @flow strict
+import React, { Fragment } from 'react';
+
+export default function TestTouchable() {
+  return <><Fragment><React.Fragment>test</React.Fragment></Fragment></>;
+}

--- a/packages/gestalt-codemods/4.0.0-5.0.0/__tests__/touchable-to-taparea.test.js
+++ b/packages/gestalt-codemods/4.0.0-5.0.0/__tests__/touchable-to-taparea.test.js
@@ -7,7 +7,11 @@ jest.mock('../touchable-to-taparea', () => {
 });
 
 describe('touchable-to-taparea', () => {
-  ['touchable-to-taparea-1', 'touchable-to-taparea-2'].forEach(test => {
+  [
+    'touchable-to-taparea-1',
+    'touchable-to-taparea-2',
+    'touchable-to-taparea-3',
+  ].forEach(test => {
     defineTest(__dirname, 'touchable-to-taparea', { quote: 'single' }, test);
   });
 });

--- a/packages/gestalt-codemods/4.0.0-5.0.0/touchable-to-taparea.js
+++ b/packages/gestalt-codemods/4.0.0-5.0.0/touchable-to-taparea.js
@@ -43,6 +43,11 @@ export default function transformer(file, api) {
     j(path).replaceWith(newNode);
   });
 
+  if (!touchableLocalIdentifierName) {
+    // not imported
+    return null;
+  }
+
   let hasModifications = false;
 
   const transform = src


### PR DESCRIPTION
## Changes

### Revision

This fixes the bug from https://github.com/pinterest/gestalt/pull/923 where the codemod `packages/gestalt-codemods/4.0.0-5.0.0/touchable-to-taparea.js` sometimes incorrectly treats `React.Fragment` as `Touchable` and transforms it to `TapArea`.

![Screenshot 2020-06-17 19 41 40](https://user-images.githubusercontent.com/5341184/84972730-5727c180-b0d4-11ea-92c8-ba6e5ac514dd.png)

It happens when the processed file does not import `Touchable` (so the local name is `undefined`) because the name of `React.Fragment` is also `undefined`. The fix is to skip a file when the local name of `Touchable` is undefined.

## TODO

- [ ] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [ ] Pinterest Designer (for design changes)
- [ ] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
