### PR TITLE
TapArea: Add PreventDefault to onMouseDown

### DIFF
--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -120,7 +120,10 @@ function TapArea({
           onMouseLeave({ event });
         }
       }}
-      onMouseDown={handleMouseDown}
+      onMouseDown={event => {
+        event.preventDefault();
+        handleMouseDown(event);
+      }}
       onMouseUp={handleMouseUp}
       onKeyPress={event => {
         // Check to see if space or enter were pressed

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -122,7 +122,7 @@ function TapArea({
       }}
       onMouseDown={event => {
         event.preventDefault();
-        handleMouseDown(event);
+        handleMouseDown();
       }}
       onMouseUp={handleMouseUp}
       onKeyPress={event => {


### PR DESCRIPTION
Was running into issues where onBlur event is being called before the onClick event is registered. The second answer from [this ](https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue)stackoverflow question explains that adding the `event.preventDefault()` to the onMouseDown event changes the order in which these events are being called in. 

## TODO

- [x] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [x] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
