### PR TITLE
DatePicker: Fix "locale object was not found for the provided string" warning

### DIFF
--- a/flow-typed/npm/react-datepicker_v2.x.x.js
+++ b/flow-typed/npm/react-datepicker_v2.x.x.js
@@ -74,7 +74,7 @@ declare module 'react-datepicker' {
     injectTimes?: Array<Date>,
     inline?: boolean,
     isClearable?: boolean,
-    locale?: string | { locale: any },
+    locale?: ?string,
     maxDate?: Date,
     minDate?: Date,
     monthsShown?: number,

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -61,6 +61,7 @@ function DatePicker(props: Props) {
   const [selected, setSelected] = React.useState<?Date>(dateValue);
   const [, setMonth] = React.useState<?number>();
   const [dateFormat, setDateFormat] = React.useState<?string>();
+  const [updatedLocale, setUpdatedLocale] = React.useState<?string>();
   const [initRangeHighlight, setInitRangeHighlight] = React.useState<?Date>();
 
   React.useEffect(() => {
@@ -72,6 +73,7 @@ function DatePicker(props: Props) {
   React.useEffect(() => {
     if (localeData && localeData.code) {
       registerLocale(localeData.code, localeData);
+      setUpdatedLocale(localeData.code);
       setDateFormat(
         localeData.formatLong && localeData.formatLong.date({ width: 'short' })
       );
@@ -116,7 +118,7 @@ function DatePicker(props: Props) {
         highlightDates={initRangeHighlight ? [initRangeHighlight] : []}
         id={id}
         includeDates={includeDates}
-        locale={localeData?.code}
+        locale={updatedLocale}
         maxDate={rangeSelector === 'end' ? maxDate : rangeEndDate || maxDate}
         minDate={
           rangeSelector === 'start' ? minDate : rangeStartDate || minDate


### PR DESCRIPTION
Fixed `locale object was not found for the provided string` warning due to locale not have been register yet.

## Before
![image](https://user-images.githubusercontent.com/10593890/85340593-39bf7280-b49b-11ea-8fac-33835aa563c1.png)

## After ![image](https://user-images.githubusercontent.com/10593890/85340408-e8af7e80-b49a-11ea-912a-0c9456a439c8.png)
## TODO

- [ ] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [ ] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.