### PR TITLE
Internal: require exact flow types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
   ],
   "rules": {
     "eslint-comments/no-unused-disable": "error",
+    "flowtype/require-exact-type": ["error", "always"],
     "flowtype/require-valid-file-annotation": [
       "error",
       "always",
@@ -72,6 +73,7 @@
     {
       "files": ["packages/gestalt-codemods/**/*.js", "scripts/**/*.js"],
       "rules": {
+        "flowtype/require-exact-type": "off",
         "flowtype/require-valid-file-annotation": "off"
       }
     },

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -195,7 +195,7 @@ class ExampleMasonry extends React.Component<Props, State> {
     });
   }
 
-  updateWidth = ({ target }: { target: HTMLInputElement }) => {
+  updateWidth = ({ target }: {| target: HTMLInputElement |}) => {
     this.setState({ width: Number(target.value) }, () => {
       if (this.grid) {
         this.grid.handleResize();

--- a/docs/src/components/Combination.js
+++ b/docs/src/components/Combination.js
@@ -4,7 +4,7 @@ import { Box, Text } from 'gestalt';
 import Checkerboard from './Checkerboard.js';
 import Card from './Card.js';
 
-type Props = {
+type Props = {|
   children: (Object, number) => React.Node,
   description?: string,
   heading?: boolean,
@@ -13,7 +13,7 @@ type Props = {
   name?: string,
   showValues?: boolean,
   stacked?: boolean,
-};
+|};
 
 const flatMap = (arr, fn) => arr.map(fn).reduce((a, b) => a.concat(b));
 const combinations = variationsByField => {

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -31,13 +31,13 @@ const Td = ({
   colspan = 1,
   shrink = false,
   color = 'darkGray',
-}: {
+}: {|
   border?: boolean,
   children?: React.Node,
   colspan?: number,
   shrink?: boolean,
   color?: 'darkGray' | 'gray',
-}) => (
+|}) => (
   <td
     style={{
       verticalAlign: 'top',

--- a/packages/gestalt-datepicker/src/LocaleDataTypes.js
+++ b/packages/gestalt-datepicker/src/LocaleDataTypes.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 // flowlint unclear-type:off
 
 // LocaleData type from https://github.com/date-fns/date-fns/blob/81ab18785146405ca2ae28710cdfbb13a294ec50/src/locale/af/index.js.flow
+/* eslint-disable flowtype/require-exact-type */
 export type LocaleData = {
   code?: string,
   formatDistance?: (...args: Array<any>) => any,
@@ -35,6 +36,7 @@ export type LocaleData = {
     firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   },
 };
+/* eslint-enable flowtype/require-exact-type */
 
 // $FlowFixMe[signature-verification-failure]
 export const LocaleDataPropTypes = PropTypes.shape({

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -127,18 +127,19 @@ export type Overflow =
 
 export type Padding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-type ResponsiveProps = {
+type ResponsiveProps = {|
   column?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,
   display?: boolean | 'flex' | 'flexColumn' | 'inlineBlock',
-};
+|};
 
 type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill';
 
+// eslint-disable-next-line flowtype/require-exact-type
 type PropType = {
   children?: React.Node,
-  dangerouslySetInlineStyle?: {
+  dangerouslySetInlineStyle?: {|
     __style: { [key: string]: string | number | void },
-  },
+  |},
 
   xs?: ResponsiveProps,
   sm?: ResponsiveProps,

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -33,7 +33,7 @@ type Props = {|
   iconEnd?: $Keys<typeof icons>,
   inline?: boolean,
   name?: string,
-  onClick?: ({ event: SyntheticMouseEvent<> }) => void,
+  onClick?: ({| event: SyntheticMouseEvent<> |}) => void,
   selected?: boolean,
   size?: 'sm' | 'md' | 'lg',
   text: string,

--- a/packages/gestalt/src/Card.js
+++ b/packages/gestalt/src/Card.js
@@ -9,8 +9,8 @@ type Props = {|
   active?: ?boolean,
   children?: React.Node,
   image?: React.Node,
-  onMouseEnter?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
-  onMouseLeave?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
+  onMouseEnter?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
+  onMouseLeave?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
 |};
 
 export default function Card(props: Props): React.Node {

--- a/packages/gestalt/src/Caret.js
+++ b/packages/gestalt/src/Caret.js
@@ -2,9 +2,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-type Props = {
+type Props = {|
   direction?: ?'up' | 'right' | 'down' | 'left',
-};
+|};
 
 export default function Caret(props: Props): React.Node {
   const { direction } = props;

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -20,11 +20,11 @@ type Props = {|
   indeterminate?: boolean,
   label?: string,
   name?: string,
-  onChange: ({ event: SyntheticInputEvent<>, checked: boolean }) => void,
-  onClick?: ({
+  onChange: ({| event: SyntheticInputEvent<>, checked: boolean |}) => void,
+  onClick?: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
     checked: boolean,
-  }) => void,
+  |}) => void,
   size?: 'sm' | 'md',
 |};
 

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -72,14 +72,14 @@ function getCollageLayout({
   height: h,
   width: w,
   layoutKey,
-}: {
+}: {|
   gutter: number,
   cover: boolean,
   columns: Column,
   height: number,
   width: number,
   layoutKey: number,
-}) {
+|}) {
   let positions = [];
   const width = w + gutter;
   const height = h + gutter;

--- a/packages/gestalt/src/Collage.test.js
+++ b/packages/gestalt/src/Collage.test.js
@@ -3,11 +3,11 @@ import * as React from 'react';
 import { create } from 'react-test-renderer';
 import Collage from './Collage.js';
 
-type CollageImageProps = {
+type CollageImageProps = {|
   width: number,
   height: number,
   index: number,
-};
+|};
 
 describe('<Collage />', () => {
   function CollageImage({ width, height, index }: CollageImageProps) {

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -44,7 +44,7 @@ import PropTypes from 'prop-types';
 import layoutStyles from './Layout.css';
 
 type Props = {|
-  Item: ({ idx: number }) => React.Node,
+  Item: ({| idx: number |}) => React.Node,
   layout: Array<{|
     top: number,
     left: number,
@@ -75,7 +75,7 @@ export default class Collection extends React.PureComponent<Props, void> {
     viewportWidth: PropTypes.number,
   };
 
-  static defaultProps: {
+  static defaultProps: {|
     layout: Array<{|
       top: number,
       left: number,
@@ -84,7 +84,7 @@ export default class Collection extends React.PureComponent<Props, void> {
     |}>,
     viewportLeft: number,
     viewportTop: number,
-  } = {
+  |} = {
     layout: [],
     viewportLeft: 0,
     viewportTop: 0,

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -41,18 +41,18 @@ type ClientRect = {
   ...
 };
 
-type Window = {
+type Window = {|
   height: number,
   width: number,
   scrollY: number,
   scrollX: number,
-};
+|};
 
-type Flyout = { height: number, width: number };
+type Flyout = {| height: number, width: number |};
 
-type Shift = { x: number, y: number };
+type Shift = {| x: number, y: number |};
 
-type EdgeShift = { caret: Shift, flyout: Shift };
+type EdgeShift = {| caret: Shift, flyout: Shift |};
 
 type Props = {|
   bgColor: 'blue' | 'darkGray' | 'orange' | 'red' | 'white',
@@ -60,13 +60,13 @@ type Props = {|
   caret?: boolean,
   children?: React.Node,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
-  onKeyDown: (event: { keyCode: number }) => void,
+  onKeyDown: (event: {| keyCode: number |}) => void,
   onResize: () => void,
   positionRelativeToAnchor?: boolean,
-  relativeOffset: {
+  relativeOffset: {|
     x: number,
     y: number,
-  },
+  |},
   rounding?: 2 | 4,
   shouldFocus?: boolean,
   triggerRect: ClientRect,
@@ -78,12 +78,12 @@ type State = {|
     top: ?number,
     left: ?number,
   |},
-  caretOffset: {
+  caretOffset: {|
     top: ?number,
     right: ?number,
     bottom: ?number,
     left: ?number,
-  },
+  |},
   mainDir: ?MainDir,
   flyoutRef: ?HTMLElement,
 |};
@@ -190,7 +190,7 @@ export function calcEdgeShifts(
   subDir: SubDir,
   triggerRect: ClientRect,
   windowSize: Window
-): { caret: Shift, flyout: Shift } {
+): {| caret: Shift, flyout: Shift |} {
   // Target values for flyout and caret shifts
   let flyoutVerticalShift =
     CARET_OFFSET_FROM_SIDE - (triggerRect.height - CARET_HEIGHT) / 2;
@@ -234,21 +234,21 @@ export function calcEdgeShifts(
  * Calculates flyout and caret offsets for styling
  */
 export function adjustOffsets(
-  base: { top: number, left: number },
+  base: {| top: number, left: number |},
   edgeShift: EdgeShift,
   flyoutSize: Flyout,
   mainDir: MainDir,
   subDir: SubDir,
   triggerRect: ClientRect
-): {
-  caretOffset: {
+): {|
+  caretOffset: {|
     bottom: null | number,
     left: null | number,
     right: null | number,
     top: null | number,
-  },
-  flyoutOffset: { left: number, top: number },
-} {
+  |},
+  flyoutOffset: {| left: number, top: number |},
+|} {
   let flyoutLeft = base.left;
   let flyoutTop = base.top;
 
@@ -301,12 +301,12 @@ export function adjustOffsets(
 /* Calculates baseline top and left offset for flyout */
 export function baseOffsets(
   hasCaret: boolean,
-  relativeOffset: { x: number, y: number },
+  relativeOffset: {| x: number, y: number |},
   flyoutSize: Flyout,
   mainDir: MainDir,
   triggerRect: ClientRect,
   windowSize: Window
-): { left: number, top: number } {
+): {| left: number, top: number |} {
   const SPACING_OUTSIDE = hasCaret ? CARET_HEIGHT / 2 : 8;
   // TOP OFFSET
   let top;
@@ -367,7 +367,7 @@ export default class Contents extends React.Component<Props, State> {
     width: PropTypes.number,
   };
 
-  static defaultProps: { border: boolean, caret: boolean } = {
+  static defaultProps: {| border: boolean, caret: boolean |} = {
     border: true,
     caret: true,
   };
@@ -422,16 +422,16 @@ export default class Contents extends React.Component<Props, State> {
       width,
     }: Props,
     { flyoutRef }: State
-  ): {
-    caretOffset: {
+  ): {|
+    caretOffset: {|
       bottom: null | number,
       left: null | number,
       right: null | number,
       top: null | number,
-    },
-    flyoutOffset: { left: number, top: number },
+    |},
+    flyoutOffset: {| left: number, top: number |},
     mainDir: 'down' | 'left' | 'right' | 'up',
-  } {
+  |} {
     // Scroll not needed for relative elements
     // We can't use window.scrollX / window.scrollY since it's not supported by IE11
     const scrollX = positionRelativeToAnchor

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -39,10 +39,10 @@ type ClientRect = {
 };
 
 type State = {|
-  relativeOffset: {
+  relativeOffset: {|
     x: number,
     y: number,
-  },
+  |},
   triggerBoundingRect: ClientRect,
 |};
 
@@ -90,9 +90,9 @@ export default class Controller extends React.Component<Props, State> {
     ]),
   };
 
-  static defaultProps: {
+  static defaultProps: {|
     size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | null,
-  } = {
+  |} = {
     // Default size only applies when size is omitted,
     // if passed as null it will remain null
     size: 'sm',
@@ -101,10 +101,10 @@ export default class Controller extends React.Component<Props, State> {
   static getDerivedStateFromProps({
     anchor,
     positionRelativeToAnchor,
-  }: Props): {
-    relativeOffset: void | { x: number, y: number },
+  }: Props): {|
+    relativeOffset: void | {| x: number, y: number |},
     triggerBoundingRect: void | ClientRect,
-  } {
+  |} {
     return getTriggerRect(anchor, positionRelativeToAnchor);
   }
 
@@ -127,7 +127,7 @@ export default class Controller extends React.Component<Props, State> {
     this.updateTriggerRect(this.props);
   }
 
-  handleKeyDown: (event: { keyCode: number }) => void = event => {
+  handleKeyDown: (event: {| keyCode: number |}) => void = event => {
     const { onDismiss } = this.props;
     if (event.keyCode === ESCAPE_KEY_CODE) {
       onDismiss();

--- a/packages/gestalt/src/FetchItems.js
+++ b/packages/gestalt/src/FetchItems.js
@@ -14,14 +14,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-type Props = {
+type Props = {|
   containerHeight: number,
   isAtEnd?: boolean,
   isFetching: boolean,
   fetchMore?: () => void,
   scrollHeight: number,
   scrollTop: number,
-};
+|};
 
 export default class FetchItems extends React.PureComponent<Props> {
   static propTypes = {

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -27,7 +27,7 @@ type Props = {|
     | 'watermelon'
     | 'white',
   icon?: $Keys<typeof icons>,
-  dangerouslySetSvgPath?: { __path: string },
+  dangerouslySetSvgPath?: {| __path: string |},
   inline?: boolean,
   size?: number | string,
 |};

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -19,11 +19,11 @@ type Props = {|
     | 'lightGray'
     | 'white'
     | 'red',
-  dangerouslySetSvgPath?: { __path: string },
+  dangerouslySetSvgPath?: {| __path: string |},
   disabled?: boolean,
   icon?: $Keys<typeof icons>,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
-  onClick?: ({ event: SyntheticMouseEvent<> }) => void,
+  onClick?: ({| event: SyntheticMouseEvent<> |}) => void,
   selected?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -39,12 +39,12 @@ export default class Image extends React.PureComponent<Props> {
     srcSet: PropTypes.string,
   };
 
-  static defaultProps: {
+  static defaultProps: {|
     color: string,
     fit?: 'contain' | 'cover' | 'none',
     importance?: 'high' | 'low' | 'auto',
     loading?: 'eager' | 'lazy' | 'auto',
-  } = {
+  |} = {
     color: 'transparent',
     fit: 'none',
     importance: 'auto',

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -19,7 +19,7 @@ type Props = {|
   hoverStyle?: 'none' | 'underline',
   href: string,
   inline?: boolean,
-  onClick?: ({ event: TapEvent }) => void,
+  onClick?: ({| event: TapEvent |}) => void,
   rel?: 'none' | 'nofollow',
   rounding?: Rounding,
   tapStyle?: 'none' | 'compress',

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -35,6 +35,7 @@ type Layout =
 
 type Props<T> = {|
   columnWidth?: number,
+  // eslint-disable-next-line flowtype/require-exact-type
   comp: React.ComponentType<{
     data: T,
     itemIdx: number,
@@ -51,9 +52,11 @@ type Props<T> = {|
   loadItems?:
     | false
     | ((
+        // eslint-disable-next-line flowtype/require-exact-type
         ?{
           from: number,
         }
+        // eslint-disable-next-line flowtype/require-exact-type
       ) => void | boolean | {}),
   scrollContainer?: () => HTMLElement,
   virtualBoundsTop?: number,
@@ -77,10 +80,12 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 
 const layoutNumberToCssDimension = n => (n !== Infinity ? n : undefined);
 
+// eslint-disable-next-line flowtype/require-exact-type
 export default class Masonry<T: {}> extends React.Component<
   Props<T>,
   State<T>
 > {
+  // eslint-disable-next-line flowtype/require-exact-type
   static createMeasurementStore<T1: {}, T2>(): MeasurementStore<T1, T2> {
     return new MeasurementStore();
   }
@@ -198,13 +203,21 @@ export default class Masonry<T: {}> extends React.Component<
     virtualize: PropTypes.bool,
   };
 
-  static defaultProps: {
-    columnWidth: number,
-    layout: string,
-    loadItems: () => void,
+  static defaultProps: {|
+    columnWidth?: number,
+    layout?: Layout,
+    loadItems?:
+      | false
+      | ((
+          // eslint-disable-next-line flowtype/require-exact-type
+          ?{
+            from: number,
+          }
+          // eslint-disable-next-line flowtype/require-exact-type
+        ) => void | boolean | {}),
     minCols: number,
-    virtualize: boolean,
-  } = {
+    virtualize?: boolean,
+  |} = {
     columnWidth: 236,
     minCols: 3,
     layout: 'basic',
@@ -301,10 +314,11 @@ export default class Masonry<T: {}> extends React.Component<
   static getDerivedStateFromProps(
     props: Props<T>,
     state: State<T>
-  ):
-    | null
-    | { hasPendingMeasurements: boolean, isFetching: boolean, items: Array<T> }
-    | { hasPendingMeasurements: boolean, items: Array<T> } {
+  ): null | {|
+    hasPendingMeasurements: boolean,
+    isFetching?: boolean,
+    items: Array<T>,
+  |} {
     const { items } = props;
     const { measurementStore } = state;
 

--- a/packages/gestalt/src/MeasurementStore.js
+++ b/packages/gestalt/src/MeasurementStore.js
@@ -1,6 +1,7 @@
 // @flow strict
 import type { Cache } from './Cache.js';
 
+// eslint-disable-next-line flowtype/require-exact-type
 export default class MeasurementStore<T: {} | $ReadOnlyArray<mixed>, V>
   implements Cache<T, V> {
   map: WeakMap<T, V> = new WeakMap();

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -30,10 +30,10 @@ const ESCAPE_KEY_CODE = 27;
 function Backdrop({
   children,
   onClick,
-}: {
+}: {|
   children?: React.Node,
   onClick?: (event: MouseEvent) => void,
-}) {
+|}) {
   const handleClick = event => {
     if (event.target !== event.currentTarget) {
       return;
@@ -82,7 +82,7 @@ export default function Modal({
   const content = React.useRef<?HTMLDivElement>(null);
 
   React.useEffect(() => {
-    function handleKeyUp(event: { keyCode: number }) {
+    function handleKeyUp(event: {| keyCode: number |}) {
       if (event.keyCode === ESCAPE_KEY_CODE) {
         onDismiss();
       }

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -32,7 +32,7 @@ type Props = {|
     | 'lightGray'
     | 'white'
     | 'red',
-  dangerouslySetSvgPath?: { __path: string },
+  dangerouslySetSvgPath?: {| __path: string |},
   focused?: boolean,
   hovered?: boolean,
   icon?: $Keys<typeof icons>,

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -14,10 +14,10 @@ type Props = {|
   id: string,
   label?: string,
   name?: string,
-  onChange: ({
+  onChange: ({|
     event: SyntheticInputEvent<>,
     checked: boolean,
-  }) => void,
+  |}) => void,
   value: string,
   size?: 'sm' | 'md',
 |};
@@ -39,11 +39,11 @@ export default class RadioButton extends React.Component<Props, State> {
     size: PropTypes.oneOf(['sm', 'md']),
   };
 
-  static defaultProps: {
+  static defaultProps: {|
     checked: boolean,
     disabled: boolean,
     size?: 'sm' | 'md',
-  } = {
+  |} = {
     checked: false,
     disabled: false,
     size: 'md',

--- a/packages/gestalt/src/ScrollFetch.js
+++ b/packages/gestalt/src/ScrollFetch.js
@@ -10,19 +10,19 @@ import {
 } from './scrollUtils.js';
 import throttle from './throttle.js';
 
-type Props = {
+type Props = {|
   container?: HTMLElement,
   isAtEnd?: boolean,
   isFetching: boolean,
   fetchMore?: () => void,
   renderHeight?: () => number,
-};
+|};
 
-type State = {
+type State = {|
   containerHeight: number,
   scrollHeight: number,
   scrollTop: number,
-};
+|};
 
 export default class ScrollFetch extends React.PureComponent<Props, State> {
   /**
@@ -47,7 +47,7 @@ export default class ScrollFetch extends React.PureComponent<Props, State> {
     fetchMore: PropTypes.func,
   };
 
-  static defaultProps: { container?: HTMLElement } = {
+  static defaultProps: {| container?: HTMLElement |} = {
     container: typeof window !== 'undefined' ? window : undefined,
   };
 
@@ -92,7 +92,7 @@ export default class ScrollFetch extends React.PureComponent<Props, State> {
     return getScrollHeight(container);
   };
 
-  getScrollState(): null | { scrollHeight: number, scrollTop: number } {
+  getScrollState(): null | {| scrollHeight: number, scrollTop: number |} {
     const { container, renderHeight } = this.props;
     if (!container) {
       return null;

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -12,15 +12,15 @@ type Props = {|
   accessibilityLabel: string,
   autoComplete?: 'on' | 'off' | 'username' | 'name',
   id: string,
-  onBlur?: ({ event: SyntheticEvent<HTMLInputElement> }) => void,
-  onChange: ({
+  onBlur?: ({| event: SyntheticEvent<HTMLInputElement> |}) => void,
+  onChange: ({|
     value: string,
     syntheticEvent: SyntheticEvent<HTMLInputElement>,
-  }) => void,
-  onFocus?: ({
+  |}) => void,
+  onFocus?: ({|
     value: string,
     syntheticEvent: SyntheticEvent<HTMLInputElement>,
-  }) => void,
+  |}) => void,
   placeholder?: string,
   size?: 'md' | 'lg',
   value?: string,

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -9,7 +9,7 @@ import styles from './SegmentedControl.css';
 
 type Props = {|
   items: Array<React.Node>,
-  onChange: ({ event: SyntheticMouseEvent<>, activeIndex: number }) => void,
+  onChange: ({| event: SyntheticMouseEvent<>, activeIndex: number |}) => void,
   responsive?: boolean,
   selectedItemIndex: number,
   size?: 'md' | 'lg',

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -18,7 +18,8 @@ type Props = {|
   id: string,
   label?: string,
   name?: string,
-  onChange: ({ event: SyntheticInputEvent<>, value: string }) => void,
+  onChange: ({| event: SyntheticInputEvent<>, value: string |}) => void,
+  // eslint-disable-next-line flowtype/require-exact-type
   options: Array<{
     label: string,
     value: string,
@@ -54,14 +55,15 @@ export default class SelectList extends React.Component<Props, State> {
     value: PropTypes.string,
   };
 
-  static defaultProps: {
+  static defaultProps: {|
     disabled: boolean,
+    // eslint-disable-next-line flowtype/require-exact-type
     options: Array<{
       label: string,
       value: string,
     }>,
     size?: 'md' | 'lg',
-  } = {
+  |} = {
     disabled: false,
     size: 'md',
     options: [],

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -20,7 +20,7 @@ type Threshold =
 
 type Props = {|
   children: React.Node,
-  dangerouslySetZIndex?: { __zIndex: number },
+  dangerouslySetZIndex?: {| __zIndex: number |},
   ...Threshold,
 |};
 

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -8,7 +8,7 @@ type Props = {|
   disabled?: boolean,
   id: string,
   name?: string,
-  onChange: ({ event: SyntheticInputEvent<>, value: boolean }) => void,
+  onChange: ({| event: SyntheticInputEvent<>, value: boolean |}) => void,
   switched?: boolean,
 |};
 
@@ -25,7 +25,7 @@ export default class Switch extends React.Component<Props, State> {
     switched: PropTypes.bool,
   };
 
-  static defaultProps: { disabled: boolean, switched: boolean } = {
+  static defaultProps: {| disabled: boolean, switched: boolean |} = {
     disabled: false,
     switched: false,
   };

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -8,11 +8,11 @@ import TapArea from './TapArea.js';
 type Props = {|
   children: React.Node,
   colSpan?: number,
-  onSortChange: ({
+  onSortChange: ({|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
       | SyntheticKeyboardEvent<HTMLDivElement>,
-  }) => void,
+  |}) => void,
   rowSpan?: number,
   scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',
   sortOrder: 'asc' | 'desc',

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -14,10 +14,10 @@ export default function Tabs({
   wrap,
 }: {|
   activeTabIndex: number,
-  onChange: ({
+  onChange: ({|
     event: SyntheticMouseEvent<>,
     activeTabIndex: number,
-  }) => void,
+  |}) => void,
   size?: 'md' | 'lg',
   tabs: Array<{|
     href: string,

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -34,11 +34,11 @@ type Props = {|
     | 'pointer'
     | 'zoomIn'
     | 'zoomOut',
-  onBlur?: ({ event: SyntheticFocusEvent<HTMLDivElement> }) => void,
-  onFocus?: ({ event: SyntheticFocusEvent<HTMLDivElement> }) => void,
-  onMouseEnter?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
-  onMouseLeave?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
-  onTap?: ({ event: TapEvent }) => void,
+  onBlur?: ({| event: SyntheticFocusEvent<HTMLDivElement> |}) => void,
+  onFocus?: ({| event: SyntheticFocusEvent<HTMLDivElement> |}) => void,
+  onMouseEnter?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
+  onMouseLeave?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
+  onTap?: ({| event: TapEvent |}) => void,
   tapStyle?: TapStyle,
   rounding?: Rounding,
 |};

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -17,22 +17,22 @@ type Props = {|
   id: string,
   label?: string,
   name?: string,
-  onBlur?: ({
+  onBlur?: ({|
     event: SyntheticFocusEvent<HTMLTextAreaElement>,
     value: string,
-  }) => void,
-  onChange: ({
+  |}) => void,
+  onChange: ({|
     event: SyntheticInputEvent<HTMLTextAreaElement>,
     value: string,
-  }) => void,
-  onFocus?: ({
+  |}) => void,
+  onFocus?: ({|
     event: SyntheticFocusEvent<HTMLTextAreaElement>,
     value: string,
-  }) => void,
-  onKeyDown?: ({
+  |}) => void,
+  onKeyDown?: ({|
     event: SyntheticKeyboardEvent<HTMLTextAreaElement>,
     value: string,
-  }) => void,
+  |}) => void,
   placeholder?: string,
   rows?: number /* default: 3 */,
   value?: string,
@@ -64,11 +64,11 @@ export default class TextArea extends React.Component<Props, State> {
     value: PropTypes.string,
   };
 
-  static defaultProps: {
+  static defaultProps: {|
     disabled: boolean,
     hasError: boolean,
     rows: number,
-  } = {
+  |} = {
     disabled: false,
     hasError: false,
     rows: 3,

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -24,22 +24,22 @@ type Props = {|
   id: string,
   label?: string,
   name?: string,
-  onBlur?: ({
+  onBlur?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
     value: string,
-  }) => void,
-  onChange: ({
+  |}) => void,
+  onChange: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
     value: string,
-  }) => void,
-  onFocus?: ({
+  |}) => void,
+  onFocus?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
     value: string,
-  }) => void,
-  onKeyDown?: ({
+  |}) => void,
+  onKeyDown?: ({|
     event: SyntheticKeyboardEvent<HTMLInputElement>,
     value: string,
-  }) => void,
+  |}) => void,
   placeholder?: string,
   type?: 'date' | 'email' | 'number' | 'password' | 'text' | 'url',
   size?: 'md' | 'lg',

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -22,30 +22,30 @@ type Props = {|
   children?: React.Node,
   controls?: boolean,
   loop?: boolean,
-  onDurationChange?: ({
+  onDurationChange?: ({|
     event: SyntheticEvent<HTMLVideoElement>,
     duration: number,
-  }) => void,
-  onEnded?: ({ event: SyntheticEvent<HTMLVideoElement> }) => void,
-  onFullscreenChange?: ({ event: Event, fullscreen: boolean }) => void,
-  onLoadedChange?: ({
+  |}) => void,
+  onEnded?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
+  onFullscreenChange?: ({| event: Event, fullscreen: boolean |}) => void,
+  onLoadedChange?: ({|
     event: SyntheticEvent<HTMLVideoElement>,
     loaded: number,
-  }) => void,
-  onPlay?: ({ event: SyntheticEvent<HTMLDivElement> }) => void,
-  onPlayheadDown?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
-  onPlayheadUp?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
-  onPause?: ({ event: SyntheticEvent<HTMLDivElement> }) => void,
-  onReady?: ({ event: SyntheticEvent<HTMLVideoElement> }) => void,
-  onSeek?: ({ event: SyntheticEvent<HTMLVideoElement> }) => void,
-  onTimeChange?: ({
+  |}) => void,
+  onPlay?: ({| event: SyntheticEvent<HTMLDivElement> |}) => void,
+  onPlayheadDown?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
+  onPlayheadUp?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
+  onPause?: ({| event: SyntheticEvent<HTMLDivElement> |}) => void,
+  onReady?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
+  onSeek?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
+  onTimeChange?: ({|
     event: SyntheticEvent<HTMLVideoElement>,
     time: number,
-  }) => void,
-  onVolumeChange?: ({
+  |}) => void,
+  onVolumeChange?: ({|
     event: SyntheticEvent<HTMLDivElement>,
     volume: number,
-  }) => void,
+  |}) => void,
   playbackRate: number,
   playing: boolean,
   playsInline?: boolean,
@@ -196,12 +196,12 @@ export default class Video extends React.PureComponent<Props, State> {
     volume: PropTypes.number,
   };
 
-  static defaultProps: {
+  static defaultProps: {|
     playbackRate: number,
     playing: boolean,
     preload: 'auto' | 'metadata' | 'none',
     volume: number,
-  } = {
+  |} = {
     playbackRate: 1,
     playing: false,
     preload: 'auto',

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -70,33 +70,33 @@ class VideoControls extends React.Component<Props> {
     volume: PropTypes.number.isRequired,
   };
 
-  handleFullscreenChange: ({
+  handleFullscreenChange: ({|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
       | SyntheticKeyboardEvent<HTMLDivElement>,
-  }) => void = ({
+  |}) => void = ({
     event,
-  }: {
+  }: {|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
       | SyntheticKeyboardEvent<HTMLDivElement>,
-  }) => {
+  |}) => {
     const { onFullscreenChange } = this.props;
     event.stopPropagation();
     onFullscreenChange();
   };
 
-  handlePlayingChange: ({
+  handlePlayingChange: ({|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
       | SyntheticKeyboardEvent<HTMLDivElement>,
-  }) => void = ({
+  |}) => void = ({
     event,
-  }: {
+  }: {|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
       | SyntheticKeyboardEvent<HTMLDivElement>,
-  }) => {
+  |}) => {
     const { playing, onPause, onPlay } = this.props;
     if (playing) {
       onPause(event);
@@ -105,17 +105,17 @@ class VideoControls extends React.Component<Props> {
     }
   };
 
-  handleVolumeChange: ({
+  handleVolumeChange: ({|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
       | SyntheticKeyboardEvent<HTMLDivElement>,
-  }) => void = ({
+  |}) => void = ({
     event,
-  }: {
+  }: {|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
       | SyntheticKeyboardEvent<HTMLDivElement>,
-  }) => {
+  |}) => {
     const { onVolumeChange } = this.props;
     onVolumeChange(event);
   };

--- a/packages/gestalt/src/defaultLayout.js
+++ b/packages/gestalt/src/defaultLayout.js
@@ -1,12 +1,12 @@
 // @flow strict
 import type { Cache } from './Cache.js';
 
-export type Position = {
+export type Position = {|
   top: number,
   left: number,
   width: number,
   height: number,
-};
+|};
 
 const mindex = arr => {
   let idx = 0;

--- a/packages/gestalt/src/fullWidthLayout.js
+++ b/packages/gestalt/src/fullWidthLayout.js
@@ -1,7 +1,7 @@
 // @flow strict
 import type { Cache } from './Cache.js';
 
-type Position = { top: number, left: number, width: number, height: number };
+type Position = {| top: number, left: number, width: number, height: number |};
 
 const mindex = arr => {
   let idx = 0;
@@ -29,15 +29,12 @@ export default <T>({
   | ((items: Array<string>) => Array<Position>)
   | ((
       items: Array<T>
-    ) => Array<
-      | { height: number, left: number, top: number, width: number }
-      | {
-          height: number,
-          left: number,
-          top: number,
-          width: number,
-        }
-    >) => {
+    ) => Array<{|
+      height: number,
+      left: number,
+      top: number,
+      width: number,
+    |}>) => {
   if (width == null) {
     return (items: Array<string>): Array<Position> =>
       items.map(() => ({

--- a/packages/gestalt/src/uniformRowLayout.js
+++ b/packages/gestalt/src/uniformRowLayout.js
@@ -1,7 +1,7 @@
 // @flow strict
 import type { Cache } from './Cache.js';
 
-type Position = { top: number, left: number, width: number, height: number };
+type Position = {| top: number, left: number, width: number, height: number |};
 
 const offscreen = (width, height = Infinity) => ({
   top: -9999,

--- a/packages/gestalt/src/useTapFeedback.js
+++ b/packages/gestalt/src/useTapFeedback.js
@@ -16,7 +16,7 @@ export const keyPressShouldTriggerTap = (
   event: SyntheticKeyboardEvent<TapTargetHTMLElement>
 ): boolean => [SPACE_CHAR_CODE, ENTER_CHAR_CODE].includes(event.charCode);
 
-export default function useTapFeedback(): {
+export default function useTapFeedback(): {|
   handleBlur: () => void,
   handleMouseDown: () => void,
   handleMouseUp: () => void,
@@ -25,7 +25,7 @@ export default function useTapFeedback(): {
   handleTouchMove: (SyntheticTouchEvent<TapTargetHTMLElement>) => void,
   handleTouchStart: (SyntheticTouchEvent<TapTargetHTMLElement>) => void,
   isTapping: boolean,
-} {
+|} {
   const [isTapping, setTapping] = React.useState<boolean>(false);
   const [coordinate, setCoordinate] = React.useState<Coordinate>({
     x: 0,


### PR DESCRIPTION
Even though we added exact by default in #920, we still need to use the exact object syntax so places which import gestalt also know whether a type is exact.

Also added a linter to enforce it + avoid regressions moving forward.