### PR TITLE
Button: Fix disabled state to prevent it to be interacted with and event bubbling

### DIFF
--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -42,6 +42,7 @@
 .disabled {
   composes: lightGrayBg from "./Colors.css";
   cursor: default;
+  pointer-events: none;
 }
 
 .selected {


### PR DESCRIPTION
A bug was reported were Tooltips wrapping disabled buttons were persisting.
`<Tooltip inline text='wow great tooltip'>
        <Button disabled text='Submit Application' size="lg" />
</Tooltip>`
 
Mouse events don't fire when the pointer is over disabled form elements but pointer-events do.  
For example, if console.logging inside `onMouseEnter` and `onMouseLeave` for Tooltip and Button:
**enabled**
![image](https://user-images.githubusercontent.com/10593890/85639030-6232a280-b63c-11ea-918e-478175a1ea1e.png)
**disabled** 
![image](https://user-images.githubusercontent.com/10593890/85639538-dcaff200-b63d-11ea-8f0d-0b981a015b4c.png)

Based on this [article](https://jakearchibald.com/2017/events-and-disabled-form-fields/), a workaround is to disable pointer events so disabled buttons cannot be interacted with at all. 

From this [article](https://css-tricks.com/almanac/properties/p/pointer-events/), 
- The pointer-events property allows for control over how HTML elements respond to mouse/touch events – including CSS hover/active states, click/tap events in Javascript, and whether or not the cursor is visible.
- value none prevents all click, state and cursor options on the specified HTML element

After applying the workaround, 
![image](https://user-images.githubusercontent.com/10593890/85639633-2993c880-b63e-11ea-9a47-f6f6126f290b.png)

## TODO

- [-] Accessibility checkup
- [-] Update documentation
- [-] Add/update Tests
- [-] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
