### PR TITLE
Box/Link: add role prop to both and accessibilitySelected prop to Link

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -184,6 +184,10 @@ card(
         href: 'absolutePositioning',
       },
       {
+        name: 'role',
+        type: 'string',
+      },
+      {
         name: 'rounding',
         type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
         href: 'rounding',

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -159,7 +159,7 @@ card(
 function TabExample() {
   const [activeIndex, setActiveIndex] = React.useState(0);
   return (
-    <Box display="flex" alignItems="center">
+    <Box display="flex" alignItems="center" role="tablist">
       {['Boards', 'Pins'].map((text, index) => (
         <Box
           color={index === activeIndex ? "darkGray" : undefined}

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -20,6 +20,7 @@ card(
       {
         name: 'accessibilitySelected',
         type: 'boolean',
+        href: 'tab',
       },
       {
         name: 'children',
@@ -57,6 +58,7 @@ card(
       {
         name: 'role',
         type: `"tab"`,
+        href: 'tab',
       },
       {
         name: 'rounding',
@@ -148,6 +150,7 @@ card(
 
 card(
   <Example
+    id="tab"
     description={`
     Use accessibilitySelected and role when using it as a Tab.
   `}
@@ -165,6 +168,7 @@ function TabExample() {
           rounding="pill"
         >
           <Link
+            accessibilitySelected={index === activeIndex}
             hoverStyle="none"
             href="#"
             onClick={({ event }) => {
@@ -172,6 +176,7 @@ function TabExample() {
               setActiveIndex(index);
             }}
             rounding="pill"
+            role="tab"
           >
             <Box padding={3} rounding="pill">
               <Text color={index === activeIndex ? "white" : "darkGray"}>

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -18,6 +18,10 @@ card(
   <PropTable
     props={[
       {
+        name: 'accessibilitySelected',
+        type: 'boolean',
+      },
+      {
         name: 'children',
         type: 'React.Node',
       },
@@ -49,6 +53,10 @@ card(
         name: 'rel',
         type: `"none" | "nofollow"`,
         defaultValue: 'none',
+      },
+      {
+        name: 'role',
+        type: `"tab"`,
       },
       {
         name: 'rounding',
@@ -103,7 +111,7 @@ card(
     description={`
     When providing the content for the link, avoid phrases like "click here" or "go to".
   `}
-    name="Accessibility"
+    name="Accessible Content"
     defaultCode={`
 <Box>
   <Heading>
@@ -134,6 +142,48 @@ card(
     </Text>
   </Box>
 </Box>
+`}
+  />
+);
+
+card(
+  <Example
+    description={`
+    Use accessibilitySelected and role when using it as a Tab.
+  `}
+    name="Accessible Tab Link"
+    defaultCode={`
+function TabExample() {
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  return (
+    <Box display="flex" alignItems="center">
+      {['Boards', 'Pins'].map((text, index) => (
+        <Box
+          color={index === activeIndex ? "darkGray" : undefined}
+          display="inlineBlock"
+          key={text}
+          rounding="pill"
+        >
+          <Link
+            hoverStyle="none"
+            href="#"
+            onClick={({ event }) => {
+              event.preventDefault();
+              setActiveIndex(index);
+            }}
+            rounding="pill"
+          >
+            <Box padding={3} rounding="pill">
+              <Text color={index === activeIndex ? "white" : "darkGray"}>
+                {text}
+              </Text>
+            </Box>
+          </Link>
+        </Box>
+      ))}
+    </Box>
+  );
+}
 `}
   />
 );

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -249,6 +249,8 @@ type PropType = {
   top?: boolean,
   width?: Dimension,
   wrap?: boolean,
+
+  role: string,
 };
 
 // --
@@ -997,4 +999,6 @@ Box.propTypes = {
   top: PropTypes.bool,
   width: DimensionPropType,
   wrap: PropTypes.bool,
+
+  role: PropTypes.string,
 };

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -15,23 +15,27 @@ type TapEvent =
   | SyntheticKeyboardEvent<HTMLAnchorElement>;
 
 type Props = {|
+  accessibilitySelected?: boolean,
   children?: React.Node,
   hoverStyle?: 'none' | 'underline',
   href: string,
   inline?: boolean,
   onClick?: ({| event: TapEvent |}) => void,
   rel?: 'none' | 'nofollow',
+  role?: 'tab',
   rounding?: Rounding,
   tapStyle?: 'none' | 'compress',
   target?: null | 'self' | 'blank',
 |};
 
 function Link({
+  accessibilitySelected,
   children,
   href,
   inline = false,
   onClick,
   rel = 'none',
+  role,
   rounding = 0,
   hoverStyle = 'underline',
   tapStyle = 'none',
@@ -61,6 +65,7 @@ function Link({
 
   return (
     <a
+      aria-selected={accessibilitySelected}
       className={className}
       href={href}
       onClick={event => {
@@ -87,6 +92,7 @@ function Link({
         ...(target === 'blank' ? ['noopener', 'noreferrer'] : []),
         ...(rel === 'nofollow' ? ['nofollow'] : []),
       ].join(' ')}
+      role={role}
       target={target ? `_${target}` : null}
     >
       {children}
@@ -95,6 +101,7 @@ function Link({
 }
 
 const LinkPropTypes = {
+  accessibilitySelected: PropTypes.bool,
   children: PropTypes.node,
   hoverStyle: (PropTypes.oneOf(['none', 'underline']): React$PropType$Primitive<
     'none' | 'underline'
@@ -105,6 +112,7 @@ const LinkPropTypes = {
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<
     'none' | 'nofollow'
   >),
+  role: (PropTypes.oneOf(['tab']): React$PropType$Primitive<'tab'>),
   rounding: RoundingPropType,
   tapStyle: (PropTypes.oneOf(['none', 'compress']): React$PropType$Primitive<
     'none' | 'compress'

--- a/packages/gestalt/src/Link.test.js
+++ b/packages/gestalt/src/Link.test.js
@@ -94,3 +94,14 @@ it('with custom rounding, hoverStyle, and tapStyle', () =>
       )
       .toJSON()
   ).toMatchSnapshot());
+
+it('with accessibilitySelected and role', () =>
+  expect(
+    renderer
+      .create(
+        <Link href="https://example.com" accessibilitySelected role="tab">
+          Link
+        </Link>
+      )
+      .toJSON()
+  ).toMatchSnapshot());

--- a/packages/gestalt/src/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.js.snap
@@ -120,6 +120,28 @@ exports[`target self 1`] = `
 </a>
 `;
 
+exports[`with accessibilitySelected and role 1`] = `
+<a
+  aria-selected={true}
+  className="link touchable block rounding0 hoverUnderline"
+  href="https://example.com"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  rel=""
+  role="tab"
+  target={null}
+>
+  Link
+</a>
+`;
+
 exports[`with custom rounding, hoverStyle, and tapStyle 1`] = `
 <a
   className="link touchable block pill"


### PR DESCRIPTION
## Changes

### Minor

- Add `role` prop to `<Box>`
- Add `role` prop to `<Link>`
- Add `accessibilitySelected` prop to `<Link>`

This will allow us to implement the `<Tabs>` component with just `<Box>`, `<Text>`, and `<Link>`.

Docs Screenshots
<img width="1033" alt="Screenshot 2020-06-26 14 07 04" src="https://user-images.githubusercontent.com/5341184/85901321-73072380-b7b6-11ea-9ef6-849b50bb2025.png">
<img width="1046" alt="Screenshot 2020-06-26 14 17 51" src="https://user-images.githubusercontent.com/5341184/85902009-d47bc200-b7b7-11ea-8084-32e6a5c2d86c.png">


## TODO

- [x] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [x] ~Pinterest Designer (for design changes)~
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
