### PR TITLE
DatePicker/Tooltip: update idealDirection default value in docs

### DIFF
--- a/docs/src/DatePicker.doc.js
+++ b/docs/src/DatePicker.doc.js
@@ -115,6 +115,7 @@ card(
         type: `'up'|'right'|'down'|'left'`,
         description: 'Preferred direction for the calendar flyout to open.',
         href: 'idealDirection',
+        defaultValue: 'down',
       },
       {
         name: 'includeDates',

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -29,6 +29,7 @@ card(
         name: 'idealDirection',
         type: `'up' | 'right' | 'down' | 'left'`,
         description: 'Preferred direction for the Tooltip to open',
+        defaultValue: 'down',
       },
       {
         name: 'inline',


### PR DESCRIPTION
Both `DatePicker` and `Tooltip` had the wrong default value for `idealDirection` in the docs.