### PR TITLE
Internal: Support GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Gestalt: Node.js 12",
+  // https://github.com/microsoft/vscode-dev-containers/tree/master/containers/
+  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:12",
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
+    "flowtype.flow-for-vscode",
+    "orta.vscode-jest"
+  ],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [3000],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "yarn install"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ docs/build/
 *.log
 stats.html
 screenshots
-.vscode
 
 packages/gestalt/dist/*
 packages/gestalt-datepicker/dist/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "css.lint.validProperties": ["composes"],
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
+  "editor.formatOnSave": true,
+  "eslint.packageManager": "yarn",
+  "grunt.autoDetect": "off",
+  "javascript.validate.enable": false,
+  "npm.packageManager": "yarn",
+  "prettier.packageManager": "yarn",
+  "typescript.validate.enable": false
+}


### PR DESCRIPTION
Add support for [GitHub Codespaces](https://github.com/features/codespaces/) - a new beta feature from GitHub to allow
* Editing of files in VS Code in a browser window
* Run Gestalt docs on a remote browser

## Update docs remotely
![github-codespaces-gestalt](https://user-images.githubusercontent.com/127199/86022377-1fc3e980-b9df-11ea-906f-fffc9a8aed8b.gif)

## Flow support
![Screen Shot 2020-06-29 at 7 52 18 AM](https://user-images.githubusercontent.com/127199/86021645-2c940d80-b9de-11ea-901f-1f38949cfc19.png)

## Creation log
![Screen Shot 2020-06-29 at 7 46 10 AM](https://user-images.githubusercontent.com/127199/86021649-2dc53a80-b9de-11ea-9139-aa185091657c.png)
