### PR TITLE
Docs: support IE11

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -9,6 +9,13 @@
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/pinterest_favicon.png" />
+    <script type="text/javascript">
+      // Load polyfills for IE 11
+      if (/MSIE \d|Trident.*rv:/.test(navigator.userAgent))
+        document.write(
+          '<script src="https://polyfill.io/v3/polyfill.min.js?features=default"><\/script>'
+        );
+    </script>
     <script
       type="text/javascript"
       src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"


### PR DESCRIPTION
Conditionally load a script with polyfills in IE 11 so the docs render correctly.

## Before: 'Symbol' is undefined
![Screen Shot 2020-06-30 at 7 11 34 AM](https://user-images.githubusercontent.com/127199/86136844-64b05480-baa1-11ea-9853-625726d4f6d3.png)

## After: Documentation renders in IE11
![Screen Shot 2020-06-30 at 7 11 18 AM](https://user-images.githubusercontent.com/127199/86136853-667a1800-baa1-11ea-9f9f-6f64d33e4c6d.png)

