### PR TITLE
Modal: fix scroll behavior in IE11

### DIFF
--- a/packages/gestalt/src/Modal.css
+++ b/packages/gestalt/src/Modal.css
@@ -14,7 +14,7 @@
 }
 
 .wrapper {
-  composes: relative overflowHidden flex from "./Layout.css";
+  composes: relative overflowAuto flex from "./Layout.css";
   composes: whiteBg from "./Colors.css";
   composes: rounding8 from "./Borders.css";
   composes: marginLeft4 marginRight4 from "./boxWhitespace.css";


### PR DESCRIPTION
## Before: Modal footer is not accessible in IE11 + Modal content does not scroll
![Screen Shot 2020-06-30 at 7 03 10 AM](https://user-images.githubusercontent.com/127199/86137859-9a097200-baa2-11ea-88a1-258c140ab20a.png)

## After: Modal footer is accessible in IE11 + Modal content scrolls
![Screen Shot 2020-06-30 at 7 01 43 AM](https://user-images.githubusercontent.com/127199/86137868-9b3a9f00-baa2-11ea-9342-3c73078ad1cd.png)
