### PR TITLE
Docs: Expand Navigation subsections

### DIFF
--- a/docs/src/components/CollapsibleSection.js
+++ b/docs/src/components/CollapsibleSection.js
@@ -1,22 +1,18 @@
 // @flow strict
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, Icon, Row, TapArea, Text } from 'gestalt';
-import { useLocation } from 'react-router-dom';
 import CollapsibleSubsection from './CollapsibleSubsection.js';
 import { type sidebarIndexType } from './sidebarIndex.js';
 import NavLink from './NavLink.js';
 
 export default function CollapsibleSection({ section }: sidebarIndexType) {
-  const { pathname } = useLocation();
-  const [isSectionCollapsed, setIsSectionCollapsed] = useState(
-    section.sectionPathname === pathname.split('/')[1]
-  );
+  const [isSectionOpen, setIsSectionOpen] = useState(true);
 
   // Check if section and pathname from react-router-dom equality same everytime URL changes.
   // If both match, keep section in sidebar open.
-  useEffect(() => {
-    setIsSectionCollapsed(section.sectionPathname === pathname.split('/')[1]);
-  }, [section, pathname]);
+  // useEffect(() => {
+  //   setIsSectionOpen(section.sectionPathname === pathname.split('/')[1]);
+  // }, [section, pathname]);
 
   const showSection = () =>
     section.pages
@@ -43,7 +39,7 @@ export default function CollapsibleSection({ section }: sidebarIndexType) {
     <>
       <TapArea
         onTap={() => {
-          setIsSectionCollapsed(!isSectionCollapsed);
+          setIsSectionOpen(!isSectionOpen);
         }}
       >
         <Box padding={2} role="list">
@@ -53,13 +49,13 @@ export default function CollapsibleSection({ section }: sidebarIndexType) {
             </Text>
             <Icon
               accessibilityLabel=""
-              icon={isSectionCollapsed ? 'arrow-down' : 'arrow-forward'}
+              icon={isSectionOpen ? 'arrow-down' : 'arrow-forward'}
               size={10}
             />
           </Row>
         </Box>
       </TapArea>
-      {isSectionCollapsed && showSection()}
+      {isSectionOpen && showSection()}
     </>
   );
 }

--- a/docs/src/components/CollapsibleSection.js
+++ b/docs/src/components/CollapsibleSection.js
@@ -8,12 +8,6 @@ import NavLink from './NavLink.js';
 export default function CollapsibleSection({ section }: sidebarIndexType) {
   const [isSectionOpen, setIsSectionOpen] = useState(true);
 
-  // Check if section and pathname from react-router-dom equality same everytime URL changes.
-  // If both match, keep section in sidebar open.
-  // useEffect(() => {
-  //   setIsSectionOpen(section.sectionPathname === pathname.split('/')[1]);
-  // }, [section, pathname]);
-
   const showSection = () =>
     section.pages
       ? section.pages.map((component, i) => (

--- a/docs/src/components/CollapsibleSubsection.js
+++ b/docs/src/components/CollapsibleSubsection.js
@@ -1,7 +1,6 @@
 // @flow strict
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, Icon, Row, Text, TapArea } from 'gestalt';
-import { useLocation } from 'react-router-dom';
 import NavLink from './NavLink.js';
 
 export default function CollapsibleSubsection({
@@ -11,22 +10,16 @@ export default function CollapsibleSubsection({
   subsection: any,
   sectionPathname: string,
 |}) {
-  const { pathname } = useLocation();
-  const [isSubsectionCollapsed, setIsSubsectionCollapsed] = useState(
-    subsection.pages?.includes(pathname.split('/')[2])
+  const [isSubsectionOpen, setIsSubsectionOpen] = useState(
+    subsection.subsectionName !== 'All'
   );
-  useEffect(() => {
-    setIsSubsectionCollapsed(
-      subsection.pages?.includes(pathname.split('/')[2])
-    );
-  }, [subsection, pathname]);
 
   return (
     <Box direction="column" display="flex">
       <Box marginStart={4}>
         <TapArea
           onTap={() => {
-            setIsSubsectionCollapsed(!isSubsectionCollapsed);
+            setIsSubsectionOpen(!isSubsectionOpen);
           }}
         >
           <Box padding={2} role="listitem">
@@ -36,14 +29,14 @@ export default function CollapsibleSubsection({
               </Text>
               <Icon
                 accessibilityLabel=""
-                icon={isSubsectionCollapsed ? 'arrow-down' : 'arrow-forward'}
+                icon={isSubsectionOpen ? 'arrow-down' : 'arrow-forward'}
                 size={10}
               />
             </Row>
           </Box>
         </TapArea>
       </Box>
-      {isSubsectionCollapsed && (
+      {isSubsectionOpen && (
         <Box role="list" marginStart={8}>
           {subsection.pages.map((component, i) => (
             <NavLink key={i} to={`/${sectionPathname}/${component}`}>

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -7,6 +7,44 @@ export type sidebarIndexType = Array<{|
   subsections?: Array<{| [string]: Array<string> |}>,
 |}>;
 
+const componentSubSectionPages = {
+  displayDate: ['Avatar', 'AvatarPair', 'Badge', 'GroupAvatar', 'Table'],
+  feedBack: ['Modal', 'Pulsar', 'Spinner', 'Toast'],
+  foundations: ['Heading', 'Icon', 'Text'],
+  forms: [
+    'Button',
+    'Checkbox',
+    'DatePicker',
+    'Flyout',
+    'IconButton',
+    'Label',
+    'Pog',
+    'RadioButton',
+    'SearchField',
+    'SelectList',
+    'Switch',
+    'TapArea',
+    'TextArea',
+    'TextField',
+    'Tooltip',
+  ],
+  layout: [
+    'Box',
+    'Card',
+    'Collage',
+    'Column',
+    'Container',
+    'Divider',
+    'Layer',
+    'Masonry',
+    'Row',
+    'Stack',
+    'Sticky',
+  ],
+  media: ['Image', 'Letterbox', 'Mask', 'Video'],
+  navigation: ['Link', 'SegmentedControl', 'Tabs'],
+};
+
 // sidebarIndex is the source of truth for the sidebar documentation menu.
 // sidebarIndex establishes the sidebar hierarchical menu order:
 // section 1
@@ -30,59 +68,37 @@ const sidebarIndex: sidebarIndexType = [
     subsections: [
       {
         subsectionName: 'Data Display',
-        pages: ['Avatar', 'AvatarPair', 'Badge', 'GroupAvatar', 'Table'],
+        pages: componentSubSectionPages.displayDate,
       },
       {
         subsectionName: 'Feedback',
-        pages: ['Modal', 'Pulsar', 'Spinner', 'Toast'],
+        pages: componentSubSectionPages.feedBack,
       },
       {
         subsectionName: 'Foundation',
-        pages: ['Heading', 'Icon', 'Text'],
+        pages: componentSubSectionPages.foundations,
       },
       {
         subsectionName: 'Forms',
-        pages: [
-          'Button',
-          'Checkbox',
-          'DatePicker',
-          'Flyout',
-          'IconButton',
-          'Label',
-          'Pog',
-          'RadioButton',
-          'SearchField',
-          'SelectList',
-          'Switch',
-          'TapArea',
-          'TextArea',
-          'TextField',
-          'Tooltip',
-        ],
+        pages: componentSubSectionPages.forms,
       },
       {
         subsectionName: 'Layout',
-        pages: [
-          'Box',
-          'Card',
-          'Collage',
-          'Column',
-          'Container',
-          'Divider',
-          'Layer',
-          'Masonry',
-          'Row',
-          'Stack',
-          'Sticky',
-        ],
+        pages: componentSubSectionPages.layout,
       },
       {
         subsectionName: 'Media',
-        pages: ['Image', 'Letterbox', 'Mask', 'Video'],
+        pages: componentSubSectionPages.media,
       },
       {
         subsectionName: 'Navigation',
-        pages: ['Link', 'SegmentedControl', 'Tabs'],
+        pages: componentSubSectionPages.navigation,
+      },
+      {
+        subsectionName: 'All',
+        pages: [
+          ...new Set(Object.values(componentSubSectionPages).flat()),
+        ].sort(),
       },
     ],
   },

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -94,12 +94,6 @@ const sidebarIndex: sidebarIndexType = [
         subsectionName: 'Navigation',
         pages: componentSubSectionPages.navigation,
       },
-      {
-        subsectionName: 'All',
-        pages: [
-          ...new Set(Object.values(componentSubSectionPages).flat()),
-        ].sort(),
-      },
     ],
   },
 ];


### PR DESCRIPTION
Update the docs navigation to expand the sections/subsections by default.

Potential improvements:
1. Collapse all for components
2. Make the navigation sticky so that it stays in view when scrolling through longer component docs

<img width="243" alt="Screen Shot 2020-07-01 at 12 44 24 PM" src="https://user-images.githubusercontent.com/10646092/86284947-a112ac00-bb98-11ea-873d-7ffff50bf865.png">


- [ ] Accessibility checkup
- [x] Update documentation
- [ ] Add/update Tests
- [ ] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
