### PR TITLE
Styling: Prepare css for dark mode support

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -13,7 +13,8 @@
       // Load polyfills for IE 11
       if (/MSIE \d|Trident.*rv:/.test(navigator.userAgent))
         document.write(
-          '<script src="https://polyfill.io/v3/polyfill.min.js?features=default"><\/script>'
+          '<script src="https://polyfill.io/v3/polyfill.min.js?features=default"><\/script>' +
+          '<script src="https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js"><\/script>'
         );
     </script>
     <script

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { HashRouter, Route, Switch, Redirect } from 'react-router-dom';
 import { render } from 'react-dom';
-import 'gestalt/dist/gestalt.css';
+import 'gestalt/dist/gestalt-future.css';
 import 'gestalt-datepicker/dist/gestalt-datepicker.css';
 import App from './components/App.js';
 import CardPage from './components/CardPage.js';

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -1,10 +1,13 @@
 :root {
   /* primary colors */
-  --red: #e60023;
-  --white: #fff;
-  --lightGray: #efefef;
-  --gray: #767676;
-  --darkGray: #111;
+  --colorRed0: #ff5247;
+  --colorRed100: #e60023;
+  --colorGray0: #fff;
+  --colorGray50: #fff;
+  --colorGray100: #efefef;
+  --colorGray200: #767676;
+  --colorGray300: #111;
+  --colorGray400: #000;
 
   /* secondary colors */
   --green: #0fa573;
@@ -30,51 +33,59 @@
 /* red */
 
 .red {
-  color: var(--red);
+  color: var(--colorRed100);
 }
 
 .redBg {
-  background-color: var(--red);
+  background-color: var(--colorRed100);
 }
 
 /* white */
 
 .white {
-  color: var(--white);
+  color: var(--colorGray0);
 }
 
 .whiteBg {
-  background-color: var(--white);
+  background-color: var(--colorGray0);
+}
+
+.whiteElevated {
+  color: var(--colorGray50);
+}
+
+.whiteBgElevated {
+  background-color: var(--colorGray50);
 }
 
 /* lightGray */
 
 .lightGray {
-  color: var(--lightGray);
+  color: var(--colorGray100);
 }
 
 .lightGrayBg {
-  background-color: var(--lightGray);
+  background-color: var(--colorGray100);
 }
 
 /* gray */
 
 .gray {
-  color: var(--gray);
+  color: var(--colorGray200);
 }
 
 .grayBg {
-  background-color: var(--gray);
+  background-color: var(--colorGray200);
 }
 
 /* darkGray */
 
 .darkGray {
-  color: var(--darkGray);
+  color: var(--colorGray300);
 }
 
 .darkGrayBg {
-  background-color: var(--darkGray);
+  background-color: var(--colorGray300);
 }
 
 /** SECONDARY COLORS **/

--- a/packages/gestalt/src/Colors.css.flow
+++ b/packages/gestalt/src/Colors.css.flow
@@ -41,4 +41,6 @@ declare module.exports: {|
   +'watermelonBg': string,
   +'white': string,
   +'whiteBg': string,
+  +'whiteBgElevated': string,
+  +'whiteElevated': string,
 |};

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -516,7 +516,8 @@ export default class Contents extends React.Component<Props, State> {
 
     // Needed to prevent UI thrashing
     const visibility = mainDir === null ? 'hidden' : 'visible';
-    const background = `${bgColor}Bg`;
+    const background =
+      bgColor === 'white' ? `${bgColor}BgElevated` : `${bgColor}Bg`;
     const stroke = bgColor === 'white' ? '#efefef' : null;
 
     return (

--- a/packages/gestalt/src/Modal.css
+++ b/packages/gestalt/src/Modal.css
@@ -15,7 +15,7 @@
 
 .wrapper {
   composes: relative overflowAuto flex from "./Layout.css";
-  composes: whiteBg from "./Colors.css";
+  composes: whiteBgElevated from "./Colors.css";
   composes: rounding8 from "./Borders.css";
   composes: marginLeft4 marginRight4 from "./boxWhitespace.css";
   max-height: calc(100vh - 32px);

--- a/packages/gestalt/src/Pog.css
+++ b/packages/gestalt/src/Pog.css
@@ -1,5 +1,5 @@
 :root {
-  --darkGray: #111;
+  --colorGray300: #111;
 }
 
 .pog {
@@ -39,11 +39,11 @@
 
 .transparentDarkGray.hovered,
 .transparentDarkGray.focused {
-  background-color: var(--darkGray);
+  background-color: var(--colorGray300);
 }
 
 .transparentDarkGray.active {
-  background-color: var(--darkGray);
+  background-color: var(--colorGray300);
 }
 
 .white {

--- a/packages/gestalt/src/SearchField.css
+++ b/packages/gestalt/src/SearchField.css
@@ -1,8 +1,8 @@
 :root {
   --bt: 4px;
-  --gray: #767676;
-  --lightGray: #efefef;
-  --white: #fff;
+  --colorGray0: #fff;
+  --colorGray100: #efefef;
+  --colorGray200: #767676;
 }
 
 .input {
@@ -10,6 +10,7 @@
   composes: border pill sizeLg from "./Borders.css";
   composes: borderBox from "./Layout.css";
   composes: darkGray from "./Colors.css";
+  composes: whiteBg from "./Colors.css";
   composes: Text fontSize3 from "./Text.css";
   composes: xsCol12 from "./Column.css";
   appearance: none;
@@ -25,7 +26,7 @@
 }
 
 .input:focus {
-  background-color: var(--white);
+  background-color: var(--colorGray0);
   cursor: text;
 }
 
@@ -34,7 +35,7 @@
 }
 
 .input::placeholder {
-  color: var(--gray);
+  color: var(--colorGray200);
 }
 
 .inputActive {
@@ -61,6 +62,6 @@
 }
 
 .clear:hover {
-  background-color: var(--lightGray);
+  background-color: var(--colorGray100);
   border-radius: 50%;
 }

--- a/packages/gestalt/src/TextArea.css
+++ b/packages/gestalt/src/TextArea.css
@@ -1,5 +1,5 @@
 :root {
-  --gray: #767676;
+  --colorGray200: #767676;
 }
 
 .textArea {
@@ -12,5 +12,5 @@
 }
 
 .textArea::placeholder {
-  color: var(--gray);
+  color: var(--colorGray200);
 }

--- a/packages/gestalt/src/TextField.css
+++ b/packages/gestalt/src/TextField.css
@@ -1,5 +1,5 @@
 :root {
-  --gray: #767676;
+  --colorGray200: #767676;
 }
 
 .textField {
@@ -10,5 +10,5 @@
 }
 
 .textField::placeholder {
-  color: var(--gray);
+  color: var(--colorGray200);
 }

--- a/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
@@ -20,7 +20,7 @@ exports[`Flyout renders 1`] = `
       tabIndex={-1}
     >
       <div
-        className="border whiteBg white rounding4 innerContents maxDimensions minDimensions"
+        className="border whiteBgElevated white rounding4 innerContents maxDimensions minDimensions"
         style={
           Object {
             "maxWidth": 230,


### PR DESCRIPTION
This sets up our css generation so it's ready to support dark mode in follow up PRs
### Building two css files
Because css variables do not work on older browsers such as IE11, I'm generating a new css file with the css vars preserved and kept the old one with the existing behavior to substitute in the values during builds.
#### Why not just one file?
It's also possible to support both legacy and modern browsers in one css file by including a fallback value and the variable in each rule, but that ended up roughly doubling the css filesize.
#### Planned changes after shipping
Once this has had more testing and we consider dark mode stable, I'd like to make the "future" css the default one and rename the existing one "legacy". Anyone using gestalt who needs to support IE or doesn't need theme support can load that version of the css.
### Renamed css vars
The design team has already worked with the mobile clients to use a standard set of tokens for the colors. This updates our css variables to use the same names for consistency. We have more secondary colors on web than are currently specified, so I'll leave that update for a future PR.

Token name | Light mode value | Dark mode value
-- | -- | --
colorGray0 | #ffffff | #050505
colorGray50 | #ffffff | #272727
colorGray100 | #efefef | #494949
colorGray200 | #8e8e8e | #b8b8b8
colorGray300 | #111111 | #efefef
colorGray400 | #000000 | #ffffff
colorRed0 | #ff5247 | #e60023
colorRed100 | #e60023 | #ff5247
colorOrange0 | #ef955d | #cc4e00
colorOrange100 | #cc4e00 | #ef955d
colorGreen0 | #86da94 | #008a1c
colorGreen100 | #008a1c | #86da94
colorBlue0 | #66ccff | #0074e8
colorBlue100 | #0074e8 | #66ccff
colorPurple0 | #bf77e5 | #6c1ea6
colorPurple100 | #6c1ea6 | #bf77e5