### PR TITLE
ZIndex: Add support for Fixed & Composite zIndexes

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -204,6 +204,11 @@ card(
         defaultValue: false,
         description: `By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.`,
       },
+      {
+        name: 'zIndex',
+        type: 'interface { index(): number; }',
+        description: `An object representing the zIndex value of the Box.`,
+      },
     ]}
   />
 );
@@ -603,6 +608,23 @@ card(
       {props => <Box color="darkGray" width={60} height={60} {...props} />}
     </Combination>
   </Card>
+);
+
+card(
+  <Example
+    description={`
+It's possible to use box with external elements using the css \`z-index\` property by capturing those values in controlled objects. The example below shows using a \`FixedZIndex\` for a value that comes from somewhere else, and a \`CompositeZIndex\` to layer the Box on top of it.
+  `}
+    id="zindex"
+    name="ZIndex"
+    defaultCode={`
+function Example() {
+  const HEADER_ZINDEX = new FixedZIndex(100);
+  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+  return <Box color="blue" width={60} height={60} zIndex={zIndex} />
+}
+`}
+  />
 );
 
 export default cards;

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -206,7 +206,7 @@ card(
       },
       {
         name: 'zIndex',
-        type: 'interface { index(): number; }',
+        type: 'interface Indexable { index(): number; }',
         description: `An object representing the zIndex value of the Box.`,
       },
     ]}

--- a/docs/src/Sticky.doc.js
+++ b/docs/src/Sticky.doc.js
@@ -42,9 +42,9 @@ card(
         description: `Use numbers for pixels: top={100} and strings for percentages: top="100%"`,
       },
       {
-        name: 'dangerouslySetZIndex',
-        type: '{ __zIndex: number }',
-        defaultValue: '{ __zIndex: 1 }',
+        name: 'zIndex',
+        type: 'interface { index(): number; }',
+        description: `An object representing the zIndex value of the Sticky.`,
       },
     ]}
   />

--- a/docs/src/Sticky.doc.js
+++ b/docs/src/Sticky.doc.js
@@ -43,7 +43,7 @@ card(
       },
       {
         name: 'zIndex',
-        type: 'interface { index(): number; }',
+        type: 'interface Indexable { index(): number; }',
         description: `An object representing the zIndex value of the Sticky.`,
       },
     ]}

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -40,6 +40,7 @@ import {
   rangeWithoutZero,
 } from './transforms.js';
 import { getRoundingStyle } from './getRoundingClassName.js';
+import { type Indexable } from './zIndex.js';
 
 /*
 
@@ -253,6 +254,8 @@ type PropType = {
   userSelect?: 'auto' | 'none',
 
   role: string,
+
+  zIndex: Indexable,
 };
 
 // --
@@ -635,9 +638,16 @@ const propToFn = {
   }),
   width: width => fromInlineStyle({ width }),
   wrap: toggle(layout.flexWrap),
-  dangerouslySetInlineStyle: value =>
-    /* eslint-disable-next-line no-underscore-dangle */
-    value && value.__style ? fromInlineStyle(value.__style) : identity(),
+  dangerouslySetInlineStyle: value => {
+    // eslint-disable-next-line no-underscore-dangle
+    return value && value.__style ? fromInlineStyle(value.__style) : identity();
+  },
+  zIndex: (value: ?Indexable) => {
+    if (!value) {
+      return identity();
+    }
+    return fromInlineStyle({ zIndex: value.index() });
+  },
 };
 
 /*
@@ -1009,4 +1019,7 @@ Box.propTypes = {
   userSelect: PropTypes.oneOf(['auto', 'none']),
 
   role: PropTypes.string,
+
+  // eslint-disable-next-line react/forbid-prop-types
+  zIndex: PropTypes.any,
 };

--- a/packages/gestalt/src/Box.test.js
+++ b/packages/gestalt/src/Box.test.js
@@ -97,3 +97,13 @@ test('Box has correct classes when borderSize is lg', () => {
   const tree = create(<Box borderSize="lg" />).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Box has correct zIndex', () => {
+  const zIndexStub = {
+    index() {
+      return 100;
+    },
+  };
+  const tree = create(<Box zIndex={zIndexStub} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import layout from './Layout.css';
+import { type Indexable, FixedZIndex } from './zIndex.js';
 
 type Threshold =
   | {| top: number | string |}
@@ -20,19 +21,28 @@ type Threshold =
 
 type Props = {|
   children: React.Node,
+  zIndex?: Indexable,
   dangerouslySetZIndex?: {| __zIndex: number |},
   ...Threshold,
 |};
 
+const DEFAULT_ZINDEX = new FixedZIndex(1);
+
 export default function Sticky(props: Props): React.Node {
-  const { dangerouslySetZIndex = { __zIndex: 1 }, children } = props;
+  const { dangerouslySetZIndex, children } = props;
+  const zIndex =
+    props.zIndex ||
+    (dangerouslySetZIndex &&
+    Object.prototype.hasOwnProperty.call(dangerouslySetZIndex, '__zIndex')
+      ? // eslint-disable-next-line no-underscore-dangle
+        new FixedZIndex(dangerouslySetZIndex.__zIndex)
+      : DEFAULT_ZINDEX);
   const style = {
     top: props.top != null ? props.top : undefined,
     left: props.left != null ? props.left : undefined,
     right: props.right != null ? props.right : undefined,
     bottom: props.bottom != null ? props.bottom : undefined,
-    // eslint-disable-next-line no-underscore-dangle
-    zIndex: dangerouslySetZIndex.__zIndex,
+    zIndex: zIndex.index(),
   };
   return (
     <div className={layout.sticky} style={style}>
@@ -50,4 +60,6 @@ Sticky.propTypes = {
   left: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   right: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  // eslint-disable-next-line react/forbid-prop-types
+  zIndex: PropTypes.any,
 };

--- a/packages/gestalt/src/Sticky.test.js
+++ b/packages/gestalt/src/Sticky.test.js
@@ -25,3 +25,17 @@ test('Sticky correctly sets thresholds for string values', () => {
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Sticky correctly sets zIndex', () => {
+  const zIndexStub = {
+    index() {
+      return 100;
+    },
+  };
+  const tree = create(
+    <Sticky top={1} zIndex={zIndexStub}>
+      Sticky
+    </Sticky>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/Box.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Box.test.js.snap
@@ -95,6 +95,17 @@ exports[`Box has correct marginStart and marginEnd when marginStart equals 1 and
 />
 `;
 
+exports[`Box has correct zIndex 1`] = `
+<div
+  className="box"
+  style={
+    Object {
+      "zIndex": 100,
+    }
+  }
+/>
+`;
+
 exports[`Box renders 1`] = `
 <div
   className="box"

--- a/packages/gestalt/src/__snapshots__/Sticky.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sticky.test.js.snap
@@ -34,6 +34,23 @@ exports[`Sticky correctly sets thresholds for string values 1`] = `
 </div>
 `;
 
+exports[`Sticky correctly sets zIndex 1`] = `
+<div
+  className="sticky"
+  style={
+    Object {
+      "bottom": undefined,
+      "left": undefined,
+      "right": undefined,
+      "top": 1,
+      "zIndex": 100,
+    }
+  }
+>
+  Sticky
+</div>
+`;
+
 exports[`Sticky renders 1`] = `
 <div
   className="sticky"

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -47,6 +47,7 @@ import TextField from './TextField.js';
 import Toast from './Toast.js';
 import Tooltip from './Tooltip.js';
 import Video from './Video.js';
+import { FixedZIndex, CompositeZIndex } from './zIndex.js';
 
 export {
   Avatar,
@@ -59,8 +60,10 @@ export {
   Collage,
   Collection,
   Column,
+  CompositeZIndex,
   Container,
   Divider,
+  FixedZIndex,
   Flyout,
   GroupAvatar,
   Heading,

--- a/packages/gestalt/src/zIndex.js
+++ b/packages/gestalt/src/zIndex.js
@@ -1,0 +1,30 @@
+// @flow strict
+
+// eslint-disable-next-line max-classes-per-file
+export interface Indexable {
+  index(): number;
+}
+
+export class FixedZIndex implements Indexable {
+  +z: number;
+
+  constructor(z: number) {
+    this.z = z;
+  }
+
+  index(): number {
+    return this.z;
+  }
+}
+
+export class CompositeZIndex implements Indexable {
+  +deps: Array<Indexable>;
+
+  constructor(deps: Array<Indexable>) {
+    this.deps = deps;
+  }
+
+  index(): number {
+    return Math.max(...this.deps.map(dep => dep.index())) + 1;
+  }
+}

--- a/packages/gestalt/src/zIndex.js
+++ b/packages/gestalt/src/zIndex.js
@@ -25,6 +25,6 @@ export class CompositeZIndex implements Indexable {
   }
 
   index(): number {
-    return Math.max(...this.deps.map(dep => dep.index())) + 1;
+    return Math.max(-1, ...this.deps.map(dep => dep.index())) + 1;
   }
 }

--- a/packages/gestalt/src/zIndex.test.js
+++ b/packages/gestalt/src/zIndex.test.js
@@ -1,0 +1,31 @@
+// @flow strict
+
+import { FixedZIndex, CompositeZIndex } from './zIndex.js';
+
+describe(FixedZIndex, () => {
+  test('index', () => {
+    const subject = new FixedZIndex(100);
+    expect(subject.index()).toEqual(100);
+  });
+});
+
+describe(CompositeZIndex, () => {
+  test('empty', () => {
+    const subject = new CompositeZIndex([]);
+    expect(subject.index()).toEqual(0);
+  });
+
+  test('fixed parent', () => {
+    const parent = new FixedZIndex(100);
+    const subject = new CompositeZIndex([parent]);
+    expect(subject.index()).toEqual(101);
+  });
+
+  test('complex tree', () => {
+    const grandparent = new FixedZIndex(100);
+    const parentA = new CompositeZIndex([grandparent]);
+    const parentB = new FixedZIndex(50);
+    const subject = new CompositeZIndex([parentA, parentB]);
+    expect(subject.index()).toEqual(102);
+  });
+});


### PR DESCRIPTION
The `z-index` CSS property is difficult to work with as:

1. It's global. There's one index for the entire page, which goes against the composability of React's component model.
2. It's implicit. There's usually a relationship between `100` & `101` but at best that's only captured in comments and can't be verified. If `100` changes, `101` will break.

Previously, Gestalt has taken the ["War Games" approach](https://www.youtube.com/watch?v=MpmGXeAtWUw) to `z-index` - the only winning move is to not play the game. This resulted in components like `<Layer>` which help developers change the render order while still respecting the React component order. However, over time, `z-index` usage hasn't decreased and it remains one of the most commonly usages of `dangerouslySetInlineStyles` on `<Box>`. We continue to get similar kinds of incidents relating to `z-index`. Clearly this wasn't the winning move.

This PR attempts to help fix the problem by having native support for `z-index` in Gestalt, however with some principled restrictions. It attempts to solve the two issues with `z-index` (global and implicit) while also providing an escape hatch for engineers to migrate existing "dangerous" code.

It does this by providing 2 classes that "generate" a `z-index` for `<Box>` (& `<Sticky>`) - `FixedZIndex` & `CompositeZIndex`.

FixedZIndex is intended to capture existing places where we may use `z-index` today. A good example is in our `MobileModal`:

```jsx
const MODAL_Z_INDEX = 9999;
<Box dangerouslySetInlineStyle={{ __style: { zIndex: MODAL_Z_INDEX }}} />
```

This could be rewritten as:

```jsx
const MODAL_Z_INDEX = new FixedZIndex(9999);
<Box zIndex={MODAL_Z_INDEX} />
```

The goal is to capture current "fixed" indexes in a way that that's easy to search for and analyze.

The next class, `CompositeZIndex` is meant to be used in situations like in `AttributionWindowFilter.js`:

```jsx
const HEADER_ZINDEX = 600;
<Box position="absolute" dangerouslySetInlineStyle={{ __style: { zIndex: HEADER_ZINDEX + 1 } }}>
```

This could be rewritten as:

```jsx
const HEADER_ZINDEX = new FixedZIndex(600);
<Box position="absolute" zIndex={new CompositeZIndex([HEADER_ZINDEX])} />
```

While the initial pulling out of the `HEADER_ZINDEX` value was good, we have no way of knowing how that value is being used and what needs to go above it. `CompositeZIndex` helps us form a tree of `z-index` dependencies that can be analyzed with Flow.

Another common case is where the relationship is expressed in the opposite way, i.e.

```jsx
 // needs to go below whatever is at z-index 100
<Box dangerouslySetInlineStyle={{ __style: { zIndex: 100 - 1 }}} />
```

I would re-write this to make the dependency more of a purely upwards counting graph so that the artimatic here isn't complicated:

```js
const a = new FixedZIndex(99);
<Box zIndex={new CompositeZIndex([a]) />
```

A good initial outcome of this diff would be if we started transitioning existing fixed `z-index`'s to use `FixedZIndex`. This should help us explicitly capture dependencies. The next step would be to convert these `FixedZIndex`s to `CompositeZIndex`s all with one root index (`0`). Once we've got there, it should be straight forward to look at the resulting structure and see where we can carve out `<Layer>` usage.

## TODO

- [x] ~Accessibility checkup~
- [x] Update documentation
- [x] Add/update Tests
- [x] ~Pinterest Designer (for design changes)~
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
