### PR TITLE
Tabs: Add optional dot indicator

### DIFF
--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -37,9 +37,9 @@ card(
           'If your app uses a tool such as react-router to navigate between pages, be sure to use onChange to navigate instead of getting a full page refresh with href',
       },
       {
-        name: 'icon',
-        type: '"circle"',
-        description: `Icon to indicate a tab that needs attention.`,
+        name: 'indicator',
+        type: '"dot"',
+        description: `Indicate that a tab needs attention.`,
       },
       {
         name: 'size',
@@ -69,7 +69,7 @@ function TabExample() {
     setActiveIndex(activeTabIndex)
   };
   const TABS = [
-    { href: "https://pinterest.com", text: "Boards for You", icon: "circle" },
+    { href: "https://pinterest.com", text: "Boards for You", indicator: "dot" },
     { href: "https://pinterest.com", text: "Pins for You" },
     { href: "https://pinterest.com", text: "1" },
     { href: "https://pinterest.com", text: "❤" },

--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -39,7 +39,7 @@ card(
       {
         name: 'icon',
         type: '"circle"',
-        description: `Adds an icon to indicate a tab that needs attention.`,
+        description: `Icon to indicate a tab that needs attention.`,
       },
       {
         name: 'size',

--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -37,6 +37,11 @@ card(
           'If your app uses a tool such as react-router to navigate between pages, be sure to use onChange to navigate instead of getting a full page refresh with href',
       },
       {
+        name: 'icon',
+        type: '"circle"',
+        description: `Adds an icon to indicate a tab that needs attention.`,
+      },
+      {
         name: 'size',
         type: '"md" | "lg"',
         required: false,
@@ -64,7 +69,7 @@ function TabExample() {
     setActiveIndex(activeTabIndex)
   };
   const TABS = [
-    { href: "https://pinterest.com", text: "Boards for You" },
+    { href: "https://pinterest.com", text: "Boards for You", icon: "circle" },
     { href: "https://pinterest.com", text: "Pins for You" },
     { href: "https://pinterest.com", text: "1" },
     { href: "https://pinterest.com", text: "❤" },

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -28,7 +28,7 @@ function Tab({
   children,
   size,
   href,
-  icon,
+  indicator,
   id,
   index,
   isActive,
@@ -38,7 +38,7 @@ function Tab({
   size: 'md' | 'lg',
   isActive: boolean,
   href: string,
-  icon?: 'circle',
+  indicator?: 'dot',
   index: number,
   id?: string,
   onChange: OnChangeHandler,
@@ -83,7 +83,7 @@ function Tab({
           >
             {children}
           </Text>
-          {icon && icon === 'circle' && <Circle />}
+          {indicator === 'dot' && <Circle />}
         </Box>
       </Link>
     </Box>
@@ -97,8 +97,8 @@ type Props = {|
   tabs: Array<{|
     href: string,
     id?: string,
+    indicator?: 'dot',
     text: React.Node,
-    icon?: 'circle',
   |}>,
   wrap?: boolean,
 |};
@@ -112,7 +112,7 @@ export default function Tabs({
 }: Props): React.Node {
   return (
     <Row wrap={wrap}>
-      {tabs.map(({ id, href, text, icon }, index) => (
+      {tabs.map(({ id, href, text, indicator }, index) => (
         <Tab
           key={id || `${href}_${index}`}
           size={size}
@@ -121,7 +121,7 @@ export default function Tabs({
           id={id}
           index={index}
           isActive={activeTabIndex === index}
-          icon={icon}
+          indicator={indicator}
         >
           {text}
         </Tab>
@@ -138,6 +138,7 @@ Tabs.propTypes = {
     PropTypes.exact({
       href: PropTypes.string.isRequired,
       id: PropTypes.string,
+      indicator: PropTypes.string,
       text: PropTypes.node.isRequired,
     })
   ).isRequired,

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -11,10 +11,24 @@ type OnChangeHandler = ({|
   +activeTabIndex: number,
 |}) => void;
 
+function Circle() {
+  return (
+    <Box
+      color="red"
+      dangerouslySetInlineStyle={{ __style: { marginTop: '1px' } }}
+      height={6}
+      marginStart={2}
+      rounding="circle"
+      width={6}
+    />
+  );
+}
+
 function Tab({
   children,
   size,
   href,
+  icon,
   id,
   index,
   isActive,
@@ -24,6 +38,7 @@ function Tab({
   size: 'md' | 'lg',
   isActive: boolean,
   href: string,
+  icon?: 'circle',
   index: number,
   id?: string,
   onChange: OnChangeHandler,
@@ -68,6 +83,7 @@ function Tab({
           >
             {children}
           </Text>
+          {icon && icon === 'circle' && <Circle />}
         </Box>
       </Link>
     </Box>
@@ -82,6 +98,7 @@ type Props = {|
     href: string,
     id?: string,
     text: React.Node,
+    icon?: 'circle',
   |}>,
   wrap?: boolean,
 |};
@@ -95,7 +112,7 @@ export default function Tabs({
 }: Props): React.Node {
   return (
     <Row wrap={wrap}>
-      {tabs.map(({ id, href, text }, index) => (
+      {tabs.map(({ id, href, text, icon }, index) => (
         <Tab
           key={id || `${href}_${index}`}
           size={size}
@@ -104,6 +121,7 @@ export default function Tabs({
           id={id}
           index={index}
           isActive={activeTabIndex === index}
+          icon={icon}
         >
           {text}
         </Tab>

--- a/packages/gestalt/src/Tabs.test.js
+++ b/packages/gestalt/src/Tabs.test.js
@@ -68,4 +68,18 @@ describe('<Tabs />', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  test('matches snapshot with circle icons', () => {
+    const tree = create(
+      <Tabs
+        tabs={[
+          { text: 'News', href: '#', icon: 'circle' },
+          { text: 'You', href: '#', icon: 'circle' },
+        ]}
+        activeTabIndex={0}
+        onChange={() => {}}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/gestalt/src/Tabs.test.js
+++ b/packages/gestalt/src/Tabs.test.js
@@ -69,12 +69,12 @@ describe('<Tabs />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test('matches snapshot with circle icons', () => {
+  test('matches snapshot with dot indicators', () => {
     const tree = create(
       <Tabs
         tabs={[
-          { text: 'News', href: '#', icon: 'circle' },
-          { text: 'You', href: '#', icon: 'circle' },
+          { text: 'News', href: '#', indicator: 'dot' },
+          { text: 'You', href: '#', indicator: 'dot' },
         ]}
         activeTabIndex={0}
         onChange={() => {}}

--- a/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
@@ -1,5 +1,136 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Tabs /> matches snapshot with circle icons 1`] = `
+<div
+  className="box"
+  style={
+    Object {
+      "height": undefined,
+      "width": undefined,
+    }
+  }
+>
+  <div
+    className="box itemsCenter xsDirectionRow xsDisplayFlex"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="box"
+    >
+      <div
+        className="box"
+      >
+        <a
+          aria-selected={true}
+          className="link touchable block pill"
+          href="#"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          rel=""
+          role="tab"
+          target={null}
+        >
+          <div
+            className="box darkGrayBg itemsCenter justifyCenter paddingX4 paddingY2 pill userSelectNone xsDisplayFlex"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "height": 40,
+                "minWidth": 60,
+              }
+            }
+          >
+            <div
+              className="Text fontSize3 white alignLeft noWrap fontWeightBold"
+            >
+              News
+            </div>
+            <div
+              className="box circle marginStart2 redBg"
+              style={
+                Object {
+                  "height": 6,
+                  "marginTop": "1px",
+                  "width": 6,
+                }
+              }
+            />
+          </div>
+        </a>
+      </div>
+    </div>
+    <div
+      className="box"
+    >
+      <div
+        className="box"
+      >
+        <a
+          aria-selected={false}
+          className="link touchable block pill"
+          href="#"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          rel=""
+          role="tab"
+          target={null}
+        >
+          <div
+            className="box itemsCenter justifyCenter paddingX4 paddingY2 pill userSelectNone whiteBg xsDisplayFlex"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "height": 40,
+                "minWidth": 60,
+              }
+            }
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
+            >
+              You
+            </div>
+            <div
+              className="box circle marginStart2 redBg"
+              style={
+                Object {
+                  "height": 6,
+                  "marginTop": "1px",
+                  "width": 6,
+                }
+              }
+            />
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Tabs /> matches snapshot with default props 1`] = `
 <div
   className="box"

--- a/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
@@ -1,136 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tabs /> matches snapshot with circle icons 1`] = `
-<div
-  className="box"
-  style={
-    Object {
-      "height": undefined,
-      "width": undefined,
-    }
-  }
->
-  <div
-    className="box itemsCenter xsDirectionRow xsDisplayFlex"
-    style={
-      Object {
-        "height": undefined,
-        "width": undefined,
-      }
-    }
-  >
-    <div
-      className="box"
-    >
-      <div
-        className="box"
-      >
-        <a
-          aria-selected={true}
-          className="link touchable block pill"
-          href="#"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          onTouchCancel={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          rel=""
-          role="tab"
-          target={null}
-        >
-          <div
-            className="box darkGrayBg itemsCenter justifyCenter paddingX4 paddingY2 pill userSelectNone xsDisplayFlex"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            style={
-              Object {
-                "height": 40,
-                "minWidth": 60,
-              }
-            }
-          >
-            <div
-              className="Text fontSize3 white alignLeft noWrap fontWeightBold"
-            >
-              News
-            </div>
-            <div
-              className="box circle marginStart2 redBg"
-              style={
-                Object {
-                  "height": 6,
-                  "marginTop": "1px",
-                  "width": 6,
-                }
-              }
-            />
-          </div>
-        </a>
-      </div>
-    </div>
-    <div
-      className="box"
-    >
-      <div
-        className="box"
-      >
-        <a
-          aria-selected={false}
-          className="link touchable block pill"
-          href="#"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          onTouchCancel={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          rel=""
-          role="tab"
-          target={null}
-        >
-          <div
-            className="box itemsCenter justifyCenter paddingX4 paddingY2 pill userSelectNone whiteBg xsDisplayFlex"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            style={
-              Object {
-                "height": 40,
-                "minWidth": 60,
-              }
-            }
-          >
-            <div
-              className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
-            >
-              You
-            </div>
-            <div
-              className="box circle marginStart2 redBg"
-              style={
-                Object {
-                  "height": 6,
-                  "marginTop": "1px",
-                  "width": 6,
-                }
-              }
-            />
-          </div>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`<Tabs /> matches snapshot with default props 1`] = `
 <div
   className="box"
@@ -234,6 +103,137 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
             >
               You
             </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
+<div
+  className="box"
+  style={
+    Object {
+      "height": undefined,
+      "width": undefined,
+    }
+  }
+>
+  <div
+    className="box itemsCenter xsDirectionRow xsDisplayFlex"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="box"
+    >
+      <div
+        className="box"
+      >
+        <a
+          aria-selected={true}
+          className="link touchable block pill"
+          href="#"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          rel=""
+          role="tab"
+          target={null}
+        >
+          <div
+            className="box darkGrayBg itemsCenter justifyCenter paddingX4 paddingY2 pill userSelectNone xsDisplayFlex"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "height": 40,
+                "minWidth": 60,
+              }
+            }
+          >
+            <div
+              className="Text fontSize3 white alignLeft noWrap fontWeightBold"
+            >
+              News
+            </div>
+            <div
+              className="box circle marginStart2 redBg"
+              style={
+                Object {
+                  "height": 6,
+                  "marginTop": "1px",
+                  "width": 6,
+                }
+              }
+            />
+          </div>
+        </a>
+      </div>
+    </div>
+    <div
+      className="box"
+    >
+      <div
+        className="box"
+      >
+        <a
+          aria-selected={false}
+          className="link touchable block pill"
+          href="#"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          rel=""
+          role="tab"
+          target={null}
+        >
+          <div
+            className="box itemsCenter justifyCenter paddingX4 paddingY2 pill userSelectNone whiteBg xsDisplayFlex"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "height": 40,
+                "minWidth": 60,
+              }
+            }
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
+            >
+              You
+            </div>
+            <div
+              className="box circle marginStart2 redBg"
+              style={
+                Object {
+                  "height": 6,
+                  "marginTop": "1px",
+                  "width": 6,
+                }
+              }
+            />
           </div>
         </a>
       </div>


### PR DESCRIPTION
This PR adds the ability to render a small circular icon in a tab to indicate that the tab should be clicked per a new design we received in ads. 

<img width="576" alt="notifdot1" src="https://user-images.githubusercontent.com/6126839/86607870-a7b96e80-bf5e-11ea-8abe-70e686963641.png">
<img width="588" alt="notifdot2" src="https://user-images.githubusercontent.com/6126839/86607881-adaf4f80-bf5e-11ea-8776-449d4155475b.png">


## TODO

- [ ] Accessibility checkup
- [X] Update documentation
- [X] Add/update Tests
- [ ] Pinterest Designer (for design changes)
- [X] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
