### PR TITLE
GestaltProvider: Adding a provider for color scheme and other future context used by Gestalt

### DIFF
--- a/docs/src/GestaltProvider.doc.js
+++ b/docs/src/GestaltProvider.doc.js
@@ -1,0 +1,77 @@
+// @flow strict
+import * as React from 'react';
+import Example from './components/Example.js';
+import PropTable from './components/PropTable.js';
+import PageHeader from './components/PageHeader.js';
+
+const cards = [];
+const card = c => cards.push(c);
+
+card(
+  <PageHeader
+    name="GestaltProvider"
+    description="An app may optionally have a `GestaltProvider` to set up context for components further down the tree. The first usecase is setting the color scheme, but other uses such as right to left support will be added in the future."
+  />
+);
+
+card(
+  <PropTable
+    props={[
+      {
+        name: 'colorScheme',
+        type: `"light" | "dark" | "userPref"`,
+        defaultValue: 'light',
+        description:
+          'The color scheme for components inside the provider. Specify "userPref" to use "prefers-color-scheme" media query.',
+        href: 'colorScheme',
+      },
+    ]}
+  />
+);
+
+card(
+  <Example
+    description="Specify a light or dark color scheme for components"
+    name="Color scheme"
+    id="colorScheme"
+    defaultCode={`
+function Example(props) {
+  const [scheme, setScheme] = React.useState('light')
+  const schemeOptions = [
+    {
+      value: "light",
+      label: "Light"
+    },
+    {
+      value: "dark",
+      label: "Dark"
+    },
+    {
+      value: "userPref",
+      label: "User Preference"
+    }
+  ];
+  return (
+    <GestaltProvider colorScheme={scheme}>
+      <Box color="white" padding={2}>
+        <SelectList
+          id="scheme"
+          name="scheme"
+          onChange={({ value }) => setScheme(value)}
+          options={schemeOptions}
+          placeholder="Select color scheme"
+          label="Color scheme"
+          value={scheme}
+        />
+        <Box padding={2}>
+          <Text>Some content</Text>
+        </Box>
+        <Button text="Example button" inline /> <Button color="red" text="Red Button" inline />
+      </Box>
+    </GestaltProvider>
+  );
+}`}
+  />
+);
+
+export default cards;

--- a/docs/src/GestaltProvider.doc.js
+++ b/docs/src/GestaltProvider.doc.js
@@ -19,10 +19,10 @@ card(
     props={[
       {
         name: 'colorScheme',
-        type: `"light" | "dark" | "userPreferance"`,
+        type: `"light" | "dark" | "userPreference"`,
         defaultValue: 'light',
         description:
-          'The color scheme for components inside the provider. Specify "userPreferance" to use "prefers-color-scheme" media query.',
+          'The color scheme for components inside the provider. Specify "userPreference" to use "prefers-color-scheme" media query.',
         href: 'colorScheme',
       },
     ]}
@@ -47,7 +47,7 @@ function Example(props) {
       label: "Dark"
     },
     {
-      value: "userPreferance",
+      value: "userPreference",
       label: "User Preference"
     }
   ];

--- a/docs/src/GestaltProvider.doc.js
+++ b/docs/src/GestaltProvider.doc.js
@@ -25,6 +25,12 @@ card(
           'The color scheme for components inside the provider. Specify "userPreference" to use "prefers-color-scheme" media query.',
         href: 'colorScheme',
       },
+      {
+        name: 'id',
+        type: 'string',
+        description:
+          'An optional id for your provider. If not passed in, settings will be applied as globally as possible (example: it sets color scheme variables at :root).',
+      },
     ]}
   />
 );
@@ -52,7 +58,7 @@ function Example(props) {
     }
   ];
   return (
-    <GestaltProvider colorScheme={scheme}>
+    <GestaltProvider colorScheme={scheme} id="docsExample">
       <Box color="white" padding={2}>
         <SelectList
           id="scheme"

--- a/docs/src/GestaltProvider.doc.js
+++ b/docs/src/GestaltProvider.doc.js
@@ -19,10 +19,10 @@ card(
     props={[
       {
         name: 'colorScheme',
-        type: `"light" | "dark" | "userPref"`,
+        type: `"light" | "dark" | "userPreferance"`,
         defaultValue: 'light',
         description:
-          'The color scheme for components inside the provider. Specify "userPref" to use "prefers-color-scheme" media query.',
+          'The color scheme for components inside the provider. Specify "userPreferance" to use "prefers-color-scheme" media query.',
         href: 'colorScheme',
       },
     ]}
@@ -47,7 +47,7 @@ function Example(props) {
       label: "Dark"
     },
     {
-      value: "userPref",
+      value: "userPreferance",
       label: "User Preference"
     }
   ];

--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React, { useState } from 'react';
-import { Box, Divider, Link, Text } from 'gestalt';
+import { Box, Divider, GestaltProvider, Link, Text } from 'gestalt';
 import Header from './Header.js';
 import Navigation from './Navigation.js';
 import { SidebarContextProvider } from './sidebarContext.js';
@@ -12,6 +12,7 @@ type Props = {|
 export default function App(props: Props) {
   const { children } = props;
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [colorScheme, setColorScheme] = useState('light');
 
   return (
     <SidebarContextProvider
@@ -20,33 +21,40 @@ export default function App(props: Props) {
         setIsSidebarOpen,
       }}
     >
-      <Box minHeight="100vh">
-        <Header />
-        <Box mdDisplay="flex" direction="row">
-          <Box minWidth={240}>
-            <Navigation />
-          </Box>
-          <Divider />
-          <Box width="auto">
-            <Box padding={4} mdPadding={6} lgPadding={8}>
-              {children}
+      <GestaltProvider colorScheme={colorScheme}>
+        <Box minHeight="100vh" color="white">
+          <Header
+            colorScheme={colorScheme}
+            onChangeColorScheme={newColorScheme =>
+              setColorScheme(newColorScheme)
+            }
+          />
+          <Box mdDisplay="flex" direction="row">
+            <Box minWidth={240}>
+              <Navigation />
             </Box>
-          </Box>
-        </Box>
-        {document.location.href.includes('netlify') ? (
-          <Box>
             <Divider />
-
-            <Box padding={4} mdPadding={6} lgPadding={8}>
-              <Link href="https://www.netlify.com/">
-                <Box paddingX={2} paddingY={1}>
-                  <Text align="right">This site is powered by Netlify</Text>
-                </Box>
-              </Link>
+            <Box width="auto">
+              <Box padding={4} mdPadding={6} lgPadding={8}>
+                {children}
+              </Box>
             </Box>
           </Box>
-        ) : null}
-      </Box>
+          {document.location.href.includes('netlify') ? (
+            <Box>
+              <Divider />
+
+              <Box padding={4} mdPadding={6} lgPadding={8}>
+                <Link href="https://www.netlify.com/">
+                  <Box paddingX={2} paddingY={1}>
+                    <Text align="right">This site is powered by Netlify</Text>
+                  </Box>
+                </Link>
+              </Box>
+            </Box>
+          ) : null}
+        </Box>
+      </GestaltProvider>
     </SidebarContextProvider>
   );
 }

--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -7,13 +7,21 @@ import {
   IconButton,
   Tooltip,
   Link as GestaltLink,
+  SelectList,
   Sticky,
 } from 'gestalt';
 import DocSearch from './DocSearch.js';
 import Link from './Link.js';
 import { useSidebarContext } from './sidebarContext.js';
 
-export default function Header() {
+type ColorScheme = 'light' | 'dark' | 'userPreference';
+
+type Props = {|
+  colorScheme: ColorScheme,
+  onChangeColorScheme: ColorScheme => void,
+|};
+
+export default function Header({ colorScheme, onChangeColorScheme }: Props) {
   const [isRTL, setIsRTL] = React.useState(false);
   const { isSidebarOpen, setIsSidebarOpen } = useSidebarContext();
 
@@ -28,6 +36,20 @@ export default function Header() {
       ? 'M9 10v5h2V4h2v11h2V4h2V2H9C6.79 2 5 3.79 5 6s1.79 4 4 4zm12 8l-4-4v3H5v2h12v3l4-4z'
       : 'M10 10v5h2V4h2v11h2V4h2V2h-8C7.79 2 6 3.79 6 6s1.79 4 4 4zm-2 7v-3l-4 4 4 4v-3h12v-2H8z',
   };
+  const schemeOptions = [
+    {
+      value: 'light',
+      label: 'Light color scheme',
+    },
+    {
+      value: 'dark',
+      label: 'Dark color scheme',
+    },
+    {
+      value: 'userPreference',
+      label: 'User color scheme',
+    },
+  ];
 
   return (
     <Sticky top={0}>
@@ -77,6 +99,16 @@ export default function Header() {
                 iconColor="white"
                 dangerouslySetSvgPath={togglePageDirSvgPath}
                 onClick={toggleRTL}
+              />
+            </Tooltip>
+            <Tooltip inline text="Changes the component color scheme">
+              <SelectList
+                id="scheme"
+                name="scheme"
+                onChange={({ value }) => onChangeColorScheme(value)}
+                options={schemeOptions}
+                placeholder="Select color scheme"
+                value={colorScheme}
               />
             </Tooltip>
             <Tooltip

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -10,7 +10,7 @@ export type sidebarIndexType = Array<{|
 const componentSubSectionPages = {
   displayDate: ['Avatar', 'AvatarPair', 'Badge', 'GroupAvatar', 'Table'],
   feedBack: ['Modal', 'Pulsar', 'Spinner', 'Toast'],
-  foundations: ['Heading', 'Icon', 'Text'],
+  foundations: ['GestaltProvider', 'Heading', 'Icon', 'Text'],
   forms: [
     'Button',
     'Checkbox',

--- a/packages/gestalt/src/GestaltProvider.js
+++ b/packages/gestalt/src/GestaltProvider.js
@@ -10,13 +10,19 @@ import {
 type Props = {|
   children: React.Node,
   colorScheme?: ColorScheme,
+  id: ?string,
 |};
 
 export default function GestaltProvider({
   children,
   colorScheme,
+  id,
 }: Props): React.Node {
-  return <ThemeProvider colorScheme={colorScheme}>{children}</ThemeProvider>;
+  return (
+    <ThemeProvider colorScheme={colorScheme} id={id}>
+      {children}
+    </ThemeProvider>
+  );
 }
 
 GestaltProvider.propTypes = {

--- a/packages/gestalt/src/GestaltProvider.js
+++ b/packages/gestalt/src/GestaltProvider.js
@@ -1,0 +1,25 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import {
+  ThemeProvider,
+  type ColorScheme,
+  ColorSchemePropType,
+} from './contexts/Theme.js';
+
+type Props = {|
+  children: React.Node,
+  colorScheme?: ColorScheme,
+|};
+
+export default function GestaltProvider({
+  children,
+  colorScheme,
+}: Props): React.Node {
+  return <ThemeProvider colorScheme={colorScheme}>{children}</ThemeProvider>;
+}
+
+GestaltProvider.propTypes = {
+  children: PropTypes.node,
+  colorScheme: ColorSchemePropType,
+};

--- a/packages/gestalt/src/GroupAvatar.js
+++ b/packages/gestalt/src/GroupAvatar.js
@@ -5,6 +5,7 @@ import styles from './GroupAvatar.css';
 import Box from './Box.js';
 import Image from './Image.js';
 import typography from './Typography.css';
+import { useTheme } from './contexts/Theme.js';
 
 function zip(a, b) {
   return a.map((item, idx) => [item, b[idx]]);
@@ -88,6 +89,7 @@ const DefaultAvatar = (props: {|
   textLayout: 'center' | 'topLeft' | 'bottomLeft',
 |}) => {
   const { size, name, textLayout } = props;
+  const { colorGray300 } = useTheme();
 
   const quarterPadding = `calc(${Math.sin(degToRad(45))} * (${size}) / 2)`;
 
@@ -102,7 +104,7 @@ const DefaultAvatar = (props: {|
       <title>{name}</title>
       <text
         fontSize="40px"
-        fill="#111"
+        fill={colorGray300}
         dominantBaseline="central"
         textAnchor="middle"
         className={[
@@ -170,6 +172,7 @@ const DefaultAvatar = (props: {|
 
 export default function GroupAvatar(props: Props): React.Node {
   const { collaborators, outline, size = 'fit' } = props;
+  const { colorGray100 } = useTheme();
   const avatarWidth = size === 'fit' ? '100%' : AVATAR_SIZES[size];
   const avatarHeight = size === 'fit' ? '' : AVATAR_SIZES[size];
   const positions = avatarLayout(collaborators.length, avatarWidth);
@@ -206,7 +209,7 @@ export default function GroupAvatar(props: Props): React.Node {
               {src ? (
                 <Image
                   alt={name}
-                  color="#EFEFEF"
+                  color={colorGray100}
                   src={src}
                   naturalWidth={1}
                   naturalHeight={1}

--- a/packages/gestalt/src/__snapshots__/GroupAvatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/GroupAvatar.test.js.snap
@@ -37,7 +37,7 @@ exports[`GroupAvatar renders an outline 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -63,7 +63,7 @@ exports[`GroupAvatar renders an outline 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -178,7 +178,7 @@ exports[`GroupAvatar renders avatars for 1 person 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -226,7 +226,7 @@ exports[`GroupAvatar renders avatars for 2 people 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -252,7 +252,7 @@ exports[`GroupAvatar renders avatars for 2 people 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -300,7 +300,7 @@ exports[`GroupAvatar renders avatars for 3 people 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -326,7 +326,7 @@ exports[`GroupAvatar renders avatars for 3 people 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -352,7 +352,7 @@ exports[`GroupAvatar renders avatars for 3 people 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -400,7 +400,7 @@ exports[`GroupAvatar renders avatars for more than 3 AVATAR_SIZES 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -426,7 +426,7 @@ exports[`GroupAvatar renders avatars for more than 3 AVATAR_SIZES 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -452,7 +452,7 @@ exports[`GroupAvatar renders avatars for more than 3 AVATAR_SIZES 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -795,7 +795,7 @@ exports[`GroupAvatar renders with container-based sizing 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }
@@ -821,7 +821,7 @@ exports[`GroupAvatar renders with container-based sizing 1`] = `
       role="img"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "backgroundImage": "url('foo.png')",
         }
       }

--- a/packages/gestalt/src/contexts/Theme.js
+++ b/packages/gestalt/src/contexts/Theme.js
@@ -23,6 +23,7 @@ type Theme = {|
 type Props = {|
   children: React.Node,
   colorScheme?: ColorScheme,
+  id?: ?string,
 |};
 
 const lightModeTheme = {
@@ -63,12 +64,6 @@ const themeToStyles = theme => {
   return styles;
 };
 
-let themeId = 0;
-const getThemeId = () => {
-  themeId += 1;
-  return themeId;
-};
-
 const getTheme = (colorScheme: ?ColorScheme) =>
   colorScheme === 'dark' ||
   (colorScheme === 'userPreference' &&
@@ -81,10 +76,11 @@ const getTheme = (colorScheme: ?ColorScheme) =>
 export function ThemeProvider({
   children,
   colorScheme,
+  id,
 }: Props): React.Element<typeof ThemeContext.Provider> {
   const [theme, setTheme] = React.useState(getTheme(colorScheme));
-  const themeIdRef = React.useRef(getThemeId());
-  const className = `__gestaltTheme${themeIdRef.current}`;
+  const className = id ? `__gestaltTheme${id}` : undefined;
+  const selector = className ? `.${className}` : ':root';
   const handlePrefChange = e => {
     setTheme(getTheme(e.matches ? 'dark' : 'light'));
   };
@@ -109,10 +105,10 @@ export function ThemeProvider({
           __html:
             colorScheme === 'userPreference'
               ? `@media(prefers-color-scheme: dark) {
-  .${className} {
+  ${selector} {
 ${themeToStyles(darkModeTheme)} }
 }`
-              : `.${className} {
+              : `${selector} {
 ${themeToStyles(theme)} }`,
         }}
       />

--- a/packages/gestalt/src/contexts/Theme.js
+++ b/packages/gestalt/src/contexts/Theme.js
@@ -2,10 +2,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-export type ColorScheme = 'light' | 'dark' | 'userPref';
+export type ColorScheme = 'light' | 'dark' | 'userPreferance';
 
 export const ColorSchemePropType: React$PropType$Primitive<ColorScheme> = PropTypes.oneOf(
-  ['light', 'dark', 'userPref']
+  ['light', 'dark', 'userPreferance']
 );
 
 type Theme = {|
@@ -71,8 +71,8 @@ const getThemeId = () => {
 
 const getTheme = (colorScheme: ?ColorScheme) =>
   colorScheme === 'dark' ||
-  (colorScheme === 'userPref' &&
-    window &&
+  (colorScheme === 'userPreferance' &&
+    typeof window !== 'undefined' &&
     window.matchMedia &&
     window.matchMedia('(prefers-color-scheme: dark)').matches)
     ? darkModeTheme
@@ -84,13 +84,13 @@ export function ThemeProvider({
 }: Props): React.Element<typeof ThemeContext.Provider> {
   const [theme, setTheme] = React.useState(getTheme(colorScheme));
   const themeIdRef = React.useRef(getThemeId());
-  const className = `gestaltTheme${themeIdRef.current}`;
+  const className = `__gestaltTheme${themeIdRef.current}`;
   const handlePrefChange = e => {
     setTheme(getTheme(e.matches ? 'dark' : 'light'));
   };
   React.useEffect(() => {
     setTheme(getTheme(colorScheme));
-    if (colorScheme === 'userPref' && window.matchMedia) {
+    if (colorScheme === 'userPreferance' && window.matchMedia) {
       window
         .matchMedia('(prefers-color-scheme: dark)')
         .addListener(handlePrefChange);
@@ -99,7 +99,7 @@ export function ThemeProvider({
           .matchMedia('(prefers-color-scheme: dark)')
           .removeListener(handlePrefChange);
     }
-    return undefined; // Flow doesn't like that only userPref returns a clean up func
+    return undefined; // Flow doesn't like that only userPreferance returns a clean up func
   }, [colorScheme]);
   return (
     <ThemeContext.Provider value={theme}>
@@ -107,7 +107,7 @@ export function ThemeProvider({
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{
           __html:
-            colorScheme === 'userPref'
+            colorScheme === 'userPreferance'
               ? `@media(prefers-color-scheme: dark) {
   .${className} {
 ${themeToStyles(darkModeTheme)} }

--- a/packages/gestalt/src/contexts/Theme.js
+++ b/packages/gestalt/src/contexts/Theme.js
@@ -58,7 +58,7 @@ const themeToStyles = theme => {
   let styles = '';
   Object.keys(theme).forEach(key => {
     if (key.startsWith('color')) {
-      styles += `  --${key}: ${theme[key]};\n`;
+      styles += `  --gestalt-${key}: ${theme[key]};\n`;
     }
   });
   return styles;

--- a/packages/gestalt/src/contexts/Theme.js
+++ b/packages/gestalt/src/contexts/Theme.js
@@ -1,0 +1,132 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+export type ColorScheme = 'light' | 'dark' | 'userPref';
+
+export const ColorSchemePropType: React$PropType$Primitive<ColorScheme> = PropTypes.oneOf(
+  ['light', 'dark', 'userPref']
+);
+
+type Theme = {|
+  name: string,
+  colorRed0: string,
+  colorRed100: string,
+  colorGray0: string,
+  colorGray50: string,
+  colorGray100: string,
+  colorGray200: string,
+  colorGray300: string,
+  colorGray400: string,
+|};
+
+type Props = {|
+  children: React.Node,
+  colorScheme?: ColorScheme,
+|};
+
+const lightModeTheme = {
+  name: 'lightMode',
+  colorRed0: '#ff5247',
+  colorRed100: '#e60023',
+  colorGray0: '#fff',
+  colorGray50: '#fff',
+  colorGray100: '#efefef',
+  colorGray200: '#767676',
+  colorGray300: '#111',
+  colorGray400: '#000',
+};
+
+const darkModeTheme = {
+  name: 'darkMode',
+  colorRed0: '#e60023',
+  colorRed100: '#ff5247',
+  colorGray0: '#050505',
+  colorGray50: '#272727',
+  colorGray100: '#494949',
+  colorGray200: '#b8b8b8',
+  colorGray300: '#efefef',
+  colorGray400: '#fff',
+};
+
+const ThemeContext: React.Context<Theme> = React.createContext<Theme>(
+  lightModeTheme
+);
+
+const themeToStyles = theme => {
+  let styles = '';
+  Object.keys(theme).forEach(key => {
+    if (key.startsWith('color')) {
+      styles += `  --${key}: ${theme[key]};\n`;
+    }
+  });
+  return styles;
+};
+
+let themeId = 0;
+const getThemeId = () => {
+  themeId += 1;
+  return themeId;
+};
+
+const getTheme = (colorScheme: ?ColorScheme) =>
+  colorScheme === 'dark' ||
+  (colorScheme === 'userPref' &&
+    window &&
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches)
+    ? darkModeTheme
+    : lightModeTheme;
+
+export function ThemeProvider({
+  children,
+  colorScheme,
+}: Props): React.Element<typeof ThemeContext.Provider> {
+  const [theme, setTheme] = React.useState(getTheme(colorScheme));
+  const themeIdRef = React.useRef(getThemeId());
+  const className = `gestaltTheme${themeIdRef.current}`;
+  const handlePrefChange = e => {
+    setTheme(getTheme(e.matches ? 'dark' : 'light'));
+  };
+  React.useEffect(() => {
+    setTheme(getTheme(colorScheme));
+    if (colorScheme === 'userPref' && window.matchMedia) {
+      window
+        .matchMedia('(prefers-color-scheme: dark)')
+        .addListener(handlePrefChange);
+      return () =>
+        window
+          .matchMedia('(prefers-color-scheme: dark)')
+          .removeListener(handlePrefChange);
+    }
+    return undefined; // Flow doesn't like that only userPref returns a clean up func
+  }, [colorScheme]);
+  return (
+    <ThemeContext.Provider value={theme}>
+      <style
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html:
+            colorScheme === 'userPref'
+              ? `@media(prefers-color-scheme: dark) {
+  .${className} {
+${themeToStyles(darkModeTheme)} }
+}`
+              : `.${className} {
+${themeToStyles(theme)} }`,
+        }}
+      />
+      <div className={className}>{children}</div>
+    </ThemeContext.Provider>
+  );
+}
+
+ThemeProvider.propTypes = {
+  children: PropTypes.node,
+  colorScheme: ColorSchemePropType,
+};
+
+export function useTheme(): Theme {
+  const theme = React.useContext(ThemeContext);
+  return theme || lightModeTheme;
+}

--- a/packages/gestalt/src/contexts/Theme.js
+++ b/packages/gestalt/src/contexts/Theme.js
@@ -2,10 +2,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-export type ColorScheme = 'light' | 'dark' | 'userPreferance';
+export type ColorScheme = 'light' | 'dark' | 'userPreference';
 
 export const ColorSchemePropType: React$PropType$Primitive<ColorScheme> = PropTypes.oneOf(
-  ['light', 'dark', 'userPreferance']
+  ['light', 'dark', 'userPreference']
 );
 
 type Theme = {|
@@ -71,7 +71,7 @@ const getThemeId = () => {
 
 const getTheme = (colorScheme: ?ColorScheme) =>
   colorScheme === 'dark' ||
-  (colorScheme === 'userPreferance' &&
+  (colorScheme === 'userPreference' &&
     typeof window !== 'undefined' &&
     window.matchMedia &&
     window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -90,7 +90,7 @@ export function ThemeProvider({
   };
   React.useEffect(() => {
     setTheme(getTheme(colorScheme));
-    if (colorScheme === 'userPreferance' && window.matchMedia) {
+    if (colorScheme === 'userPreference' && window.matchMedia) {
       window
         .matchMedia('(prefers-color-scheme: dark)')
         .addListener(handlePrefChange);
@@ -99,7 +99,7 @@ export function ThemeProvider({
           .matchMedia('(prefers-color-scheme: dark)')
           .removeListener(handlePrefChange);
     }
-    return undefined; // Flow doesn't like that only userPreferance returns a clean up func
+    return undefined; // Flow doesn't like that only userPreference returns a clean up func
   }, [colorScheme]);
   return (
     <ThemeContext.Provider value={theme}>
@@ -107,7 +107,7 @@ export function ThemeProvider({
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{
           __html:
-            colorScheme === 'userPreferance'
+            colorScheme === 'userPreference'
               ? `@media(prefers-color-scheme: dark) {
   .${className} {
 ${themeToStyles(darkModeTheme)} }

--- a/packages/gestalt/src/contexts/Theme.jsdom.test.js
+++ b/packages/gestalt/src/contexts/Theme.jsdom.test.js
@@ -10,34 +10,19 @@ function ThemeAwareComponent() {
 
 describe('Themeing', () => {
   describe('ThemeProvider', () => {
-    it('renders child content in a div with a unique className', () => {
-      const { container } = render(
-        <>
-          <ThemeProvider>Child 1</ThemeProvider>
-          <ThemeProvider>Child 2</ThemeProvider>
-        </>
-      );
-      expect(container.querySelectorAll('div')).toMatchInlineSnapshot(`
-        NodeList [
-          <div
-            class="__gestaltTheme1"
-          >
-            Child 1
-          </div>,
-          <div
-            class="__gestaltTheme2"
-          >
-            Child 2
-          </div>,
-        ]
+    it('renders child content in a div', () => {
+      const { container } = render(<ThemeProvider>Child 1</ThemeProvider>);
+      expect(container.querySelector('div')).toMatchInlineSnapshot(`
+        <div>
+          Child 1
+        </div>
       `);
     });
     it('renders styling for light mode when no color scheme specified', () => {
       const { container } = render(<ThemeProvider>Content</ThemeProvider>);
-      expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
-        NodeList [
-          <style>
-            .__gestaltTheme3 {
+      expect(container.querySelector('style')).toMatchInlineSnapshot(`
+        <style>
+          :root {
           --colorRed0: #ff5247;
           --colorRed100: #e60023;
           --colorGray0: #fff;
@@ -47,18 +32,16 @@ describe('Themeing', () => {
           --colorGray300: #111;
           --colorGray400: #000;
          }
-          </style>,
-        ]
+        </style>
       `);
     });
     it('renders styling for light mode when specified', () => {
       const { container } = render(
         <ThemeProvider colorScheme="light">Content</ThemeProvider>
       );
-      expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
-        NodeList [
-          <style>
-            .__gestaltTheme4 {
+      expect(container.querySelector('style')).toMatchInlineSnapshot(`
+        <style>
+          :root {
           --colorRed0: #ff5247;
           --colorRed100: #e60023;
           --colorGray0: #fff;
@@ -68,18 +51,16 @@ describe('Themeing', () => {
           --colorGray300: #111;
           --colorGray400: #000;
          }
-          </style>,
-        ]
+        </style>
       `);
     });
     it('renders styling for dark mode when specified', () => {
       const { container } = render(
         <ThemeProvider colorScheme="dark">Content</ThemeProvider>
       );
-      expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
-        NodeList [
-          <style>
-            .__gestaltTheme5 {
+      expect(container.querySelector('style')).toMatchInlineSnapshot(`
+        <style>
+          :root {
           --colorRed0: #e60023;
           --colorRed100: #ff5247;
           --colorGray0: #050505;
@@ -89,19 +70,17 @@ describe('Themeing', () => {
           --colorGray300: #efefef;
           --colorGray400: #fff;
          }
-          </style>,
-        ]
+        </style>
       `);
     });
     it('renders styling with media query when userPreference', () => {
       const { container } = render(
         <ThemeProvider colorScheme="userPreference">Content</ThemeProvider>
       );
-      expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
-        NodeList [
-          <style>
-            @media(prefers-color-scheme: dark) {
-          .__gestaltTheme6 {
+      expect(container.querySelector('style')).toMatchInlineSnapshot(`
+        <style>
+          @media(prefers-color-scheme: dark) {
+          :root {
           --colorRed0: #e60023;
           --colorRed100: #ff5247;
           --colorGray0: #050505;
@@ -112,8 +91,27 @@ describe('Themeing', () => {
           --colorGray400: #fff;
          }
         }
-          </style>,
-        ]
+        </style>
+      `);
+    });
+    it('renders styling with a custom class if has an id', () => {
+      const { container } = render(
+        <ThemeProvider id="testId">Content</ThemeProvider>
+      );
+      expect(container.querySelector('.__gestaltThemetestId')).toBeTruthy();
+      expect(container.querySelector('style')).toMatchInlineSnapshot(`
+        <style>
+          .__gestaltThemetestId {
+          --colorRed0: #ff5247;
+          --colorRed100: #e60023;
+          --colorGray0: #fff;
+          --colorGray50: #fff;
+          --colorGray100: #efefef;
+          --colorGray200: #767676;
+          --colorGray300: #111;
+          --colorGray400: #000;
+         }
+        </style>
       `);
     });
   });

--- a/packages/gestalt/src/contexts/Theme.jsdom.test.js
+++ b/packages/gestalt/src/contexts/Theme.jsdom.test.js
@@ -93,9 +93,9 @@ describe('Themeing', () => {
         ]
       `);
     });
-    it('renders styling with media query when userPreferance', () => {
+    it('renders styling with media query when userPreference', () => {
       const { container } = render(
-        <ThemeProvider colorScheme="userPreferance">Content</ThemeProvider>
+        <ThemeProvider colorScheme="userPreference">Content</ThemeProvider>
       );
       expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
         NodeList [
@@ -138,7 +138,7 @@ describe('Themeing', () => {
       );
       expect(getByText('darkMode')).toBeTruthy();
     });
-    it('uses theme based on matchMedia when userPreferance', () => {
+    it('uses theme based on matchMedia when userPreference', () => {
       let listener = jest.fn();
       window.matchMedia = () => ({
         addListener: cb => {
@@ -147,7 +147,7 @@ describe('Themeing', () => {
         removeListener: jest.fn(),
       });
       const { getByText } = render(
-        <ThemeProvider colorScheme="userPreferance">
+        <ThemeProvider colorScheme="userPreference">
           <ThemeAwareComponent />
         </ThemeProvider>
       );

--- a/packages/gestalt/src/contexts/Theme.jsdom.test.js
+++ b/packages/gestalt/src/contexts/Theme.jsdom.test.js
@@ -20,12 +20,12 @@ describe('Themeing', () => {
       expect(container.querySelectorAll('div')).toMatchInlineSnapshot(`
         NodeList [
           <div
-            class="gestaltTheme1"
+            class="__gestaltTheme1"
           >
             Child 1
           </div>,
           <div
-            class="gestaltTheme2"
+            class="__gestaltTheme2"
           >
             Child 2
           </div>,
@@ -37,7 +37,7 @@ describe('Themeing', () => {
       expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
         NodeList [
           <style>
-            .gestaltTheme3 {
+            .__gestaltTheme3 {
           --colorRed0: #ff5247;
           --colorRed100: #e60023;
           --colorGray0: #fff;
@@ -58,7 +58,7 @@ describe('Themeing', () => {
       expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
         NodeList [
           <style>
-            .gestaltTheme4 {
+            .__gestaltTheme4 {
           --colorRed0: #ff5247;
           --colorRed100: #e60023;
           --colorGray0: #fff;
@@ -79,7 +79,7 @@ describe('Themeing', () => {
       expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
         NodeList [
           <style>
-            .gestaltTheme5 {
+            .__gestaltTheme5 {
           --colorRed0: #e60023;
           --colorRed100: #ff5247;
           --colorGray0: #050505;
@@ -93,15 +93,15 @@ describe('Themeing', () => {
         ]
       `);
     });
-    it('renders styling with media query when userPref', () => {
+    it('renders styling with media query when userPreferance', () => {
       const { container } = render(
-        <ThemeProvider colorScheme="userPref">Content</ThemeProvider>
+        <ThemeProvider colorScheme="userPreferance">Content</ThemeProvider>
       );
       expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
         NodeList [
           <style>
             @media(prefers-color-scheme: dark) {
-          .gestaltTheme6 {
+          .__gestaltTheme6 {
           --colorRed0: #e60023;
           --colorRed100: #ff5247;
           --colorGray0: #050505;
@@ -138,7 +138,7 @@ describe('Themeing', () => {
       );
       expect(getByText('darkMode')).toBeTruthy();
     });
-    it('uses theme based on matchMedia when userPref', () => {
+    it('uses theme based on matchMedia when userPreferance', () => {
       let listener = jest.fn();
       window.matchMedia = () => ({
         addListener: cb => {
@@ -147,7 +147,7 @@ describe('Themeing', () => {
         removeListener: jest.fn(),
       });
       const { getByText } = render(
-        <ThemeProvider colorScheme="userPref">
+        <ThemeProvider colorScheme="userPreferance">
           <ThemeAwareComponent />
         </ThemeProvider>
       );

--- a/packages/gestalt/src/contexts/Theme.jsdom.test.js
+++ b/packages/gestalt/src/contexts/Theme.jsdom.test.js
@@ -23,14 +23,14 @@ describe('Themeing', () => {
       expect(container.querySelector('style')).toMatchInlineSnapshot(`
         <style>
           :root {
-          --colorRed0: #ff5247;
-          --colorRed100: #e60023;
-          --colorGray0: #fff;
-          --colorGray50: #fff;
-          --colorGray100: #efefef;
-          --colorGray200: #767676;
-          --colorGray300: #111;
-          --colorGray400: #000;
+          --gestalt-colorRed0: #ff5247;
+          --gestalt-colorRed100: #e60023;
+          --gestalt-colorGray0: #fff;
+          --gestalt-colorGray50: #fff;
+          --gestalt-colorGray100: #efefef;
+          --gestalt-colorGray200: #767676;
+          --gestalt-colorGray300: #111;
+          --gestalt-colorGray400: #000;
          }
         </style>
       `);
@@ -42,14 +42,14 @@ describe('Themeing', () => {
       expect(container.querySelector('style')).toMatchInlineSnapshot(`
         <style>
           :root {
-          --colorRed0: #ff5247;
-          --colorRed100: #e60023;
-          --colorGray0: #fff;
-          --colorGray50: #fff;
-          --colorGray100: #efefef;
-          --colorGray200: #767676;
-          --colorGray300: #111;
-          --colorGray400: #000;
+          --gestalt-colorRed0: #ff5247;
+          --gestalt-colorRed100: #e60023;
+          --gestalt-colorGray0: #fff;
+          --gestalt-colorGray50: #fff;
+          --gestalt-colorGray100: #efefef;
+          --gestalt-colorGray200: #767676;
+          --gestalt-colorGray300: #111;
+          --gestalt-colorGray400: #000;
          }
         </style>
       `);
@@ -61,14 +61,14 @@ describe('Themeing', () => {
       expect(container.querySelector('style')).toMatchInlineSnapshot(`
         <style>
           :root {
-          --colorRed0: #e60023;
-          --colorRed100: #ff5247;
-          --colorGray0: #050505;
-          --colorGray50: #272727;
-          --colorGray100: #494949;
-          --colorGray200: #b8b8b8;
-          --colorGray300: #efefef;
-          --colorGray400: #fff;
+          --gestalt-colorRed0: #e60023;
+          --gestalt-colorRed100: #ff5247;
+          --gestalt-colorGray0: #050505;
+          --gestalt-colorGray50: #272727;
+          --gestalt-colorGray100: #494949;
+          --gestalt-colorGray200: #b8b8b8;
+          --gestalt-colorGray300: #efefef;
+          --gestalt-colorGray400: #fff;
          }
         </style>
       `);
@@ -81,14 +81,14 @@ describe('Themeing', () => {
         <style>
           @media(prefers-color-scheme: dark) {
           :root {
-          --colorRed0: #e60023;
-          --colorRed100: #ff5247;
-          --colorGray0: #050505;
-          --colorGray50: #272727;
-          --colorGray100: #494949;
-          --colorGray200: #b8b8b8;
-          --colorGray300: #efefef;
-          --colorGray400: #fff;
+          --gestalt-colorRed0: #e60023;
+          --gestalt-colorRed100: #ff5247;
+          --gestalt-colorGray0: #050505;
+          --gestalt-colorGray50: #272727;
+          --gestalt-colorGray100: #494949;
+          --gestalt-colorGray200: #b8b8b8;
+          --gestalt-colorGray300: #efefef;
+          --gestalt-colorGray400: #fff;
          }
         }
         </style>
@@ -102,14 +102,14 @@ describe('Themeing', () => {
       expect(container.querySelector('style')).toMatchInlineSnapshot(`
         <style>
           .__gestaltThemetestId {
-          --colorRed0: #ff5247;
-          --colorRed100: #e60023;
-          --colorGray0: #fff;
-          --colorGray50: #fff;
-          --colorGray100: #efefef;
-          --colorGray200: #767676;
-          --colorGray300: #111;
-          --colorGray400: #000;
+          --gestalt-colorRed0: #ff5247;
+          --gestalt-colorRed100: #e60023;
+          --gestalt-colorGray0: #fff;
+          --gestalt-colorGray50: #fff;
+          --gestalt-colorGray100: #efefef;
+          --gestalt-colorGray200: #767676;
+          --gestalt-colorGray300: #111;
+          --gestalt-colorGray400: #000;
          }
         </style>
       `);

--- a/packages/gestalt/src/contexts/Theme.jsdom.test.js
+++ b/packages/gestalt/src/contexts/Theme.jsdom.test.js
@@ -1,0 +1,159 @@
+// @flow strict
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { ThemeProvider, useTheme } from './Theme.js';
+
+function ThemeAwareComponent() {
+  const theme = useTheme();
+  return <div>{theme.name}</div>;
+}
+
+describe('Themeing', () => {
+  describe('ThemeProvider', () => {
+    it('renders child content in a div with a unique className', () => {
+      const { container } = render(
+        <>
+          <ThemeProvider>Child 1</ThemeProvider>
+          <ThemeProvider>Child 2</ThemeProvider>
+        </>
+      );
+      expect(container.querySelectorAll('div')).toMatchInlineSnapshot(`
+        NodeList [
+          <div
+            class="gestaltTheme1"
+          >
+            Child 1
+          </div>,
+          <div
+            class="gestaltTheme2"
+          >
+            Child 2
+          </div>,
+        ]
+      `);
+    });
+    it('renders styling for light mode when no color scheme specified', () => {
+      const { container } = render(<ThemeProvider>Content</ThemeProvider>);
+      expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
+        NodeList [
+          <style>
+            .gestaltTheme3 {
+          --colorRed0: #ff5247;
+          --colorRed100: #e60023;
+          --colorGray0: #fff;
+          --colorGray50: #fff;
+          --colorGray100: #efefef;
+          --colorGray200: #767676;
+          --colorGray300: #111;
+          --colorGray400: #000;
+         }
+          </style>,
+        ]
+      `);
+    });
+    it('renders styling for light mode when specified', () => {
+      const { container } = render(
+        <ThemeProvider colorScheme="light">Content</ThemeProvider>
+      );
+      expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
+        NodeList [
+          <style>
+            .gestaltTheme4 {
+          --colorRed0: #ff5247;
+          --colorRed100: #e60023;
+          --colorGray0: #fff;
+          --colorGray50: #fff;
+          --colorGray100: #efefef;
+          --colorGray200: #767676;
+          --colorGray300: #111;
+          --colorGray400: #000;
+         }
+          </style>,
+        ]
+      `);
+    });
+    it('renders styling for dark mode when specified', () => {
+      const { container } = render(
+        <ThemeProvider colorScheme="dark">Content</ThemeProvider>
+      );
+      expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
+        NodeList [
+          <style>
+            .gestaltTheme5 {
+          --colorRed0: #e60023;
+          --colorRed100: #ff5247;
+          --colorGray0: #050505;
+          --colorGray50: #272727;
+          --colorGray100: #494949;
+          --colorGray200: #b8b8b8;
+          --colorGray300: #efefef;
+          --colorGray400: #fff;
+         }
+          </style>,
+        ]
+      `);
+    });
+    it('renders styling with media query when userPref', () => {
+      const { container } = render(
+        <ThemeProvider colorScheme="userPref">Content</ThemeProvider>
+      );
+      expect(container.querySelectorAll('style')).toMatchInlineSnapshot(`
+        NodeList [
+          <style>
+            @media(prefers-color-scheme: dark) {
+          .gestaltTheme6 {
+          --colorRed0: #e60023;
+          --colorRed100: #ff5247;
+          --colorGray0: #050505;
+          --colorGray50: #272727;
+          --colorGray100: #494949;
+          --colorGray200: #b8b8b8;
+          --colorGray300: #efefef;
+          --colorGray400: #fff;
+         }
+        }
+          </style>,
+        ]
+      `);
+    });
+  });
+  describe('useTheme', () => {
+    it('uses light mode theme when not in theme provider', () => {
+      const { getByText } = render(<ThemeAwareComponent />);
+      expect(getByText('lightMode')).toBeTruthy();
+    });
+    it('uses light mode theme when specified', () => {
+      const { getByText } = render(
+        <ThemeProvider colorScheme="light">
+          <ThemeAwareComponent />
+        </ThemeProvider>
+      );
+      expect(getByText('lightMode')).toBeTruthy();
+    });
+    it('uses dark mode theme when specified', () => {
+      const { getByText } = render(
+        <ThemeProvider colorScheme="dark">
+          <ThemeAwareComponent />
+        </ThemeProvider>
+      );
+      expect(getByText('darkMode')).toBeTruthy();
+    });
+    it('uses theme based on matchMedia when userPref', () => {
+      let listener = jest.fn();
+      window.matchMedia = () => ({
+        addListener: cb => {
+          listener = cb;
+        },
+        removeListener: jest.fn(),
+      });
+      const { getByText } = render(
+        <ThemeProvider colorScheme="userPref">
+          <ThemeAwareComponent />
+        </ThemeProvider>
+      );
+      expect(getByText('lightMode')).toBeTruthy();
+      act(() => listener({ matches: true }));
+      expect(getByText('darkMode')).toBeTruthy();
+    });
+  });
+});

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -12,6 +12,7 @@ import Column from './Column.js';
 import Container from './Container.js';
 import Divider from './Divider.js';
 import Flyout from './Flyout.js';
+import GestaltProvider from './GestaltProvider.js';
 import GroupAvatar from './GroupAvatar.js';
 import Heading from './Heading.js';
 import Icon from './Icon.js';
@@ -48,6 +49,7 @@ import Toast from './Toast.js';
 import Tooltip from './Tooltip.js';
 import Video from './Video.js';
 import { FixedZIndex, CompositeZIndex } from './zIndex.js';
+import { useTheme } from './contexts/Theme.js';
 
 export {
   Avatar,
@@ -65,6 +67,7 @@ export {
   Divider,
   FixedZIndex,
   Flyout,
+  GestaltProvider,
   GroupAvatar,
   Heading,
   Icon,
@@ -99,5 +102,6 @@ export {
   TextField,
   Toast,
   Tooltip,
+  useTheme,
   Video,
 };


### PR DESCRIPTION
This creates two new components `GestaltProvider` and `ThemeProvider` and a hook `useTheme`.

## `GestaltProvider`

This is a component that may **optionally** be set up to wrap gestalt components and provide context to them. In this PR I am just setting up support for color schemes, but we've also discussed using this provider for RTL support and to make `Link` work properly with react-router. Providers can be nested to override context set above. For now it's just a thin wrapper around `ThemeProvider`.

Open to better naming suggestions 😄 

## `ThemeProvider`

This is used internally by `GestaltProvider` to set up the theme context and generate a style tag for a custom class name. The style tag overrides the css variables we use to a new value. Options for `colorScheme` are:

- light: The standard gestalt theme
- dark: A new theme for users preferring dark mode
- userPref: Check the `prefers-color-scheme` media query to decide to use light/dark theme

Initially the color scheme will default to `light`, but once dark mode is more mature we may want to change the default to `userPref`.

## `useTheme`

This hook can be used internally to do things like change svg fills. I exported it so custom components that need to match gestalt can also use the theme.


Changing color schemes in the docs:

![color-scheme](https://user-images.githubusercontent.com/1767822/86648874-1960df00-bf96-11ea-8a12-c42972504a82.gif)

I confirmed locally that nesting `GestaltProviders` with different color schemes works correctly.

<img width="632" alt="Screen Shot 2020-07-06 at 12 52 38 PM" src="https://user-images.githubusercontent.com/1767822/86645298-20d2b900-bf93-11ea-9a7c-ac572d4d80c6.png">

- [x] Update documentation
- [x] Add/update Tests
- [x] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
