### PR TITLE
SearchField: RTL support

### DIFF
--- a/packages/gestalt/src/SearchField.css
+++ b/packages/gestalt/src/SearchField.css
@@ -38,8 +38,12 @@
   color: var(--colorGray200);
 }
 
-.inputActive {
-  padding: calc(2 * var(--bt)) calc(8 * var(--bt)) calc(2 * var(--bt)) calc(4 * var(--bt));
+html:not([dir="rtl"]) .inputActive {
+  padding: 8px 32px 8px 16px;
+}
+
+html[dir="rtl"] .inputActive {
+  padding: 8px 16px 8px 32px;
 }
 
 .inputHovered {
@@ -53,7 +57,6 @@
   composes: paddingX1 from "./boxWhitespace.css";
   composes: paddingY1 from "./boxWhitespace.css";
   composes: pointer from "./Cursor.css";
-  composes: right0 from "./Layout.css";
   composes: transparentBg from "./Colors.css";
   outline: none;
   position: absolute;
@@ -65,3 +68,12 @@
   background-color: var(--colorGray100);
   border-radius: 50%;
 }
+
+html:not([dir="rtl"]) .clear {
+  right: 0;
+}
+
+html[dir="rtl"] .clear {
+  left: 0;
+}
+

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -108,6 +108,7 @@ const SearchField = ({
             },
           }}
           left
+          right
           paddingX={4}
           position="absolute"
         >


### PR DESCRIPTION
Add RTL (Right to Left) support to `SearchField`.

## Before
![searchfield-rtl-before](https://user-images.githubusercontent.com/127199/86801969-680b8900-c029-11ea-893c-e92e2ab675a4.gif)

## After
![searchfield-rtl-after](https://user-images.githubusercontent.com/127199/86801975-69d54c80-c029-11ea-8c1b-dcd30658c009.gif)
