### PR TITLE
Dark Mode: update toggle in docs

### DIFF
--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -25,8 +25,8 @@ export default function App(props: Props) {
         <Box minHeight="100vh" color="white">
           <Header
             colorScheme={colorScheme}
-            onChangeColorScheme={newColorScheme =>
-              setColorScheme(newColorScheme)
+            onChangeColorScheme={() =>
+              setColorScheme(colorScheme === 'light' ? 'dark' : 'light')
             }
           />
           <Box mdDisplay="flex" direction="row">

--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -7,21 +7,17 @@ import {
   IconButton,
   Tooltip,
   Link as GestaltLink,
-  SelectList,
   Sticky,
 } from 'gestalt';
 import DocSearch from './DocSearch.js';
 import Link from './Link.js';
 import { useSidebarContext } from './sidebarContext.js';
 
-type ColorScheme = 'light' | 'dark' | 'userPreference';
-
 type Props = {|
-  colorScheme: ColorScheme,
-  onChangeColorScheme: ColorScheme => void,
+  onChangeColorScheme: () => void,
 |};
 
-export default function Header({ colorScheme, onChangeColorScheme }: Props) {
+export default function Header({ onChangeColorScheme }: Props) {
   const [isRTL, setIsRTL] = React.useState(false);
   const { isSidebarOpen, setIsSidebarOpen } = useSidebarContext();
 
@@ -36,20 +32,6 @@ export default function Header({ colorScheme, onChangeColorScheme }: Props) {
       ? 'M9 10v5h2V4h2v11h2V4h2V2H9C6.79 2 5 3.79 5 6s1.79 4 4 4zm12 8l-4-4v3H5v2h12v3l4-4z'
       : 'M10 10v5h2V4h2v11h2V4h2V2h-8C7.79 2 6 3.79 6 6s1.79 4 4 4zm-2 7v-3l-4 4 4 4v-3h12v-2H8z',
   };
-  const schemeOptions = [
-    {
-      value: 'light',
-      label: 'Light color scheme',
-    },
-    {
-      value: 'dark',
-      label: 'Dark color scheme',
-    },
-    {
-      value: 'userPreference',
-      label: 'User color scheme',
-    },
-  ];
 
   return (
     <Sticky top={0}>
@@ -101,14 +83,13 @@ export default function Header({ colorScheme, onChangeColorScheme }: Props) {
                 onClick={toggleRTL}
               />
             </Tooltip>
-            <Tooltip inline text="Changes the component color scheme">
-              <SelectList
-                id="scheme"
-                name="scheme"
-                onChange={({ value }) => onChangeColorScheme(value)}
-                options={schemeOptions}
-                placeholder="Select color scheme"
-                value={colorScheme}
+            <Tooltip inline text="Toggle color scheme">
+              <IconButton
+                size="md"
+                accessibilityLabel="Toggle color scheme"
+                iconColor="white"
+                icon="workflow-status-in-progress"
+                onClick={() => onChangeColorScheme()}
               />
             </Tooltip>
             <Tooltip


### PR DESCRIPTION
* Header in the docs becomes less crowded
* Easy one-click toggle (instead of having to use the dropdown)

Major downside is that we can no longer test with user selected option but since it's either light or dark, that should be ok.

## Before
![image](https://user-images.githubusercontent.com/127199/86846806-39f56b80-c060-11ea-96b5-b41ed14f21ed.png)
![image](https://user-images.githubusercontent.com/127199/86846831-41b51000-c060-11ea-82dc-2e6b9c64fb45.png)

## After
![image](https://user-images.githubusercontent.com/127199/86846712-1e8a6080-c060-11ea-9f70-9a2d4d883f12.png) 
![image](https://user-images.githubusercontent.com/127199/86846763-2ba74f80-c060-11ea-9f77-475ca130fe55.png)


