### PR TITLE
Avatar: Update hardcoded svg fills to use theme colors

### DIFF
--- a/docs/src/components/Checkerboard.js
+++ b/docs/src/components/Checkerboard.js
@@ -1,11 +1,13 @@
 // @flow strict
 import React from 'react';
+import { useTheme } from 'gestalt';
 
 type Props = {|
   size?: number,
 |};
 
 export default function Checkerboard({ size = 8 }: Props) {
+  const { colorGray400 } = useTheme();
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -24,14 +26,16 @@ export default function Checkerboard({ size = 8 }: Props) {
         patternUnits="userSpaceOnUse"
       >
         <rect
-          fill="rgba(0, 0, 0, 0.06)"
+          fill={colorGray400}
+          fillOpacity="0.1"
           x={0}
           width={size}
           height={size}
           y={0}
         />
         <rect
-          fill="rgba(0, 0, 0, 0.06)"
+          fill={colorGray400}
+          fillOpacity="0.1"
           x={size}
           width={size}
           height={size}

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -7,6 +7,7 @@ import Image from './Image.js';
 import Mask from './Mask.js';
 import PersonSvg from './icons/person.svg';
 import typography from './Typography.css';
+import { useTheme } from './contexts/Theme.js';
 
 const Square = (props: *) => (
   <Box {...props} position="relative">
@@ -29,6 +30,7 @@ const DefaultAvatar = ({
   name: string,
   useDefaultIcon: boolean,
 |}) => {
+  const { colorGray300 } = useTheme();
   const firstInitial = name ? [...name][0].toUpperCase() : '';
   const title = accessibilityLabel ?? name;
 
@@ -43,7 +45,7 @@ const DefaultAvatar = ({
           xmlns="http://www.w3.org/2000/svg"
         >
           {title && <title>{title}</title>}
-          <path d={PersonSvg} fill="#111" />
+          <path d={PersonSvg} fill={colorGray300} />
         </svg>
       ) : (
         <svg
@@ -56,7 +58,7 @@ const DefaultAvatar = ({
           <title>{title}</title>
           <text
             fontSize="40px"
-            fill="#111"
+            fill={colorGray300}
             dy="0.35em"
             textAnchor="middle"
             className={[


### PR DESCRIPTION
Fixes #973

## Avatar in dark mode
### Before
<img width="450" alt="Screen Shot 2020-07-07 at 2 56 25 PM" src="https://user-images.githubusercontent.com/1767822/86848084-3ebb1f00-c062-11ea-9ce9-14c52956072e.png">

### After
<img width="517" alt="Screen Shot 2020-07-07 at 2 56 33 PM" src="https://user-images.githubusercontent.com/1767822/86848089-411d7900-c062-11ea-8900-69d49cdc7fbf.png">

## Docs checkerboard in dark mode
### Before
<img width="121" alt="Screen Shot 2020-07-07 at 2 55 17 PM" src="https://user-images.githubusercontent.com/1767822/86848056-31059980-c062-11ea-8f54-2b431c0c1c65.png">

### After
<img width="105" alt="Screen Shot 2020-07-07 at 2 55 43 PM" src="https://user-images.githubusercontent.com/1767822/86848077-3b279800-c062-11ea-8636-63fe0938ce98.png">


- [x] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [ ] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
