### PR TITLE
Fix Box types

### DIFF
--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -256,6 +256,7 @@ type PropType = {
   role?: string,
 
   zIndex?: Indexable,
+  ...
 };
 
 // --

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -253,9 +253,9 @@ type PropType = {
 
   userSelect?: 'auto' | 'none',
 
-  role: string,
+  role?: string,
 
-  zIndex: Indexable,
+  zIndex?: Indexable,
 };
 
 // --
@@ -675,54 +675,45 @@ const omit = (keys, obj) =>
 // (className, style) or accessibility (onClick).
 const blacklistProps = ['onClick', 'className', 'style'];
 
-// $FlowFixMe[missing-annot]
-// $FlowFixMe[signature-verification-failure]
-const Box = React.forwardRef(
-  ({ children, ...props }: PropType, ref: React.ElementRef<*>) => {
-    // Flow can't reason about the constant nature of Object.keys so we can't use
-    // a functional (reduce) style here.
+const BoxWithRef: React.AbstractComponent<
+  PropType,
+  HTMLDivElement
+> = React.forwardRef<PropType, HTMLDivElement>(function Box(props, ref) {
+  // Flow can't reason about the constant nature of Object.keys so we can't use
+  // a functional (reduce) style here.
 
-    // All Box's are box-sized by default, so we start off building up the styles
-    // to be applied with a Box base class.
-    let s = fromClassName(styles.box);
+  // All Box's are box-sized by default, so we start off building up the styles
+  // to be applied with a Box base class.
+  let s = fromClassName(styles.box);
 
-    // Init the list of props we'll omit from passthrough. We'll add to this
-    // list as we match props against the transforms list.
-    const omitProps = [...blacklistProps];
+  // Init the list of props we'll omit from passthrough. We'll add to this
+  // list as we match props against the transforms list.
+  const omitProps = [...blacklistProps];
 
-    // This loops through each property and if it exists in the previously
-    // defined transform map, concatentes the resulting styles to the base
-    // styles. If there's a match, we also don't pass through that property. This
-    // means Box's runtime is only dependent on the number of properties passed
-    // to it (which is typically small) instead of the total number of possible
-    // properties (~30 or so). While it may ~feel~ like Box is innefficient, its
-    // biggest performance impact is on startup time because there's so much code
-    // here.
+  // This loops through each property and if it exists in the previously
+  // defined transform map, concatentes the resulting styles to the base
+  // styles. If there's a match, we also don't pass through that property. This
+  // means Box's runtime is only dependent on the number of properties passed
+  // to it (which is typically small) instead of the total number of possible
+  // properties (~30 or so). While it may ~feel~ like Box is innefficient, its
+  // biggest performance impact is on startup time because there's so much code
+  // here.
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const prop in props) {
-      if (Object.prototype.hasOwnProperty.call(propToFn, prop)) {
-        const fn = propToFn[prop];
-        const value = props[prop];
-        omitProps.push(prop);
-        s = concat([s, fn(value)]);
-      }
+  // eslint-disable-next-line no-restricted-syntax
+  for (const prop in props) {
+    if (Object.prototype.hasOwnProperty.call(propToFn, prop)) {
+      const fn = propToFn[prop];
+      const value = props[prop];
+      omitProps.push(prop);
+      s = concat([s, fn(value)]);
     }
-
-    // And... magic!
-    return (
-      <div {...omit(omitProps, props)} {...toProps(s)} ref={ref}>
-        {children}
-      </div>
-    );
   }
-);
 
-//  NOTE: This is needed in order to override the ForwardRef display name that is
-//  used in dev tools and in snapshot testing.
-Box.displayName = 'Box';
+  // And... magic!
+  return <div {...omit(omitProps, props)} {...toProps(s)} ref={ref} />;
+});
 
-export default Box;
+export default BoxWithRef;
 
 /*
 
@@ -883,8 +874,8 @@ const SizeDisplayPropType = PropTypes.oneOf([
   'inlineBlock',
 ]);
 
-// $FlowFixMe[prop-missing]
-Box.propTypes = {
+// $FlowFixMe
+BoxWithRef.propTypes = {
   children: PropTypes.node,
   dangerouslySetInlineStyle: PropTypes.exact({
     __style: PropTypes.object,

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -135,7 +135,6 @@ type ResponsiveProps = {|
 
 type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill';
 
-// eslint-disable-next-line flowtype/require-exact-type
 type PropType = {
   children?: React.Node,
   dangerouslySetInlineStyle?: {|

--- a/packages/gestalt/src/Box.test.js
+++ b/packages/gestalt/src/Box.test.js
@@ -93,8 +93,8 @@ test('Box has correct class when rounding is circle', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Box has correct classes when borderSize is lg', () => {
-  const tree = create(<Box borderSize="lg" />).toJSON();
+test('Box has correct classes when borderSize is md', () => {
+  const tree = create(<Box borderSize="md" />).toJSON();
   expect(tree).toMatchSnapshot();
 });
 

--- a/packages/gestalt/src/__snapshots__/Box.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Box.test.js.snap
@@ -71,9 +71,9 @@ exports[`Box has correct class when rounding is circle 1`] = `
 />
 `;
 
-exports[`Box has correct classes when borderSize is lg 1`] = `
+exports[`Box has correct classes when borderSize is md 1`] = `
 <div
-  className="borderColorLightGray box sizeLg solid"
+  className="borderColorLightGray box solid"
 />
 `;
 


### PR DESCRIPTION
We found with #966 that Box's props are effectively untyped - `any`. This lead to an incident where somebody was incorrectly setting `zIndex` on Box, but Flow didn't catch it. This fixes the Flow suppressions on Box.

## Test Plan

I know this changed worked because Flow immediately found type errors in the DatePicker due to `role` and `zIndex` being (incorrectly) marked as required props. This diff also fixes those.