### PR TITLE
DatePicker: Implementing DarkMode color scheme

### DIFF
--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { HashRouter, Route, Switch, Redirect } from 'react-router-dom';
 import { render } from 'react-dom';
 import 'gestalt/dist/gestalt-future.css';
-import 'gestalt-datepicker/dist/gestalt-datepicker.css';
+import 'gestalt-datepicker/dist/gestalt-datepicker-future.css';
 import App from './components/App.js';
 import CardPage from './components/CardPage.js';
 import routes from './components/routes.js';

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -1,20 +1,31 @@
 :root {
-  --gestalt-color-darkGray: #111;
-  --gestalt-color-gray: #767676;
-  --gestalt-color-hover-lightGray: rgba(0, 0, 0, 0.06);
-  --gestalt-color-white: #fff;
+  /* fix colors for higher contrast in middle grays */
+  --gestalt-gray300: #111;
+
+  /* primary colors */
+  --gestalt-colorGray50: #fff;
+  --gestalt-colorGray200: #767676;
+  --gestalt-colorGray300: #111;
+  --gestalt-colorGray400: #000;
+
+  /* transparent colors */
+  --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
+  --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+  --gestalt-color-focus: rgba(0, 132, 255, 0.5);
+
+  /* border & dimensions */
   --gestalt-borderRadius-circle: 50%;
   --gestalt-borderRadius-halfCircle-End: 0 50% 50% 0;
   --gestalt-borderRadius-halfCircle-Start: 50% 0 0 50%;
   --gestalt-day-dimensions: 40px;
-  --gestalt-focus: 0 0 0 4px rgba(0, 132, 255, 0.5);
+  --gestalt-focus: 0 0 0 4px var(--gestalt-color-focus);
 }
 
 .react-datepicker {
-  background-color: var(--gestalt-color-white);
+  background-color: var(--gestalt-colorGray50);
   border-radius: 16px;
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-  color: var(--gestalt-color-darkGray);
+  box-shadow: 0 0 8px var(--gestalt-colorTransparentGray100);
+  color: var(--gestalt-colorGray300);
   display: inline-block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue",
@@ -26,7 +37,7 @@
 }
 
 :global ._gestalt .react-datepicker__current-month {
-  color: var(--gestalt-color-darkGray);
+  color: var(--gestalt-colorGray300);
   font-size: 20px;
   font-weight: bold;
   margin-bottom: 16px;
@@ -37,7 +48,7 @@ to prevent conflict with another CSS module */
 
 .react-datepicker__days {
   border-radius: var(--gestalt-borderRadius-circle);
-  color: var(--gestalt-color-darkGray);
+  color: var(--gestalt-colorGray300);
   cursor: pointer;
   display: inline-block;
   line-height: var(--gestalt-day-dimensions);
@@ -51,23 +62,23 @@ to prevent conflict with another CSS module */
 }
 
 .react-datepicker__days:hover {
-  background-color: var(--gestalt-color-hover-lightGray);
-  color: var(--gestalt-color-darkGray);
+  background-color: var(--gestalt-colorTransparentGray60);
+  color: var(--gestalt-gray300);
 }
 
 :global ._gestalt .react-datepicker__day--highlighted {
-  background-color: var(--gestalt-color-darkGray);
-  color: var(--gestalt-color-white);
+  background-color: var(--gestalt-colorGray300);
+  color: var(--gestalt-colorGray50);
 }
 
 :global ._gestalt .react-datepicker__day--disabled {
-  color: var(--gestalt-color-gray);
+  color: var(--gestalt-colorGray200);
   cursor: default;
 }
 
 :global ._gestalt .react-datepicker__day--disabled:hover {
-  background-color: var(--gestalt-color-white);
-  color: var(--gestalt-color-gray);
+  background-color: var(--gestalt-colorGray50);
+  color: var(--gestalt-colorGray200);
 }
 
 :global ._gestalt .react-datepicker__day--disabled:focus {
@@ -75,22 +86,23 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__day--selected {
-  background-color: var(--gestalt-color-darkGray);
-  color: var(--gestalt-color-white);
+  background-color: var(--gestalt-colorGray300);
+  color: var(--gestalt-colorGray50);
 }
 
 :global ._gestalt .react-datepicker__day--selected:hover {
-  background-color: var(--gestalt-color-hover-lightGray);
-  color: var(--gestalt-color-darkGray);
+  background-color: var(--gestalt-colorTransparentGray60);
+  color: var(--gestalt-gray300);
 }
 
 :global ._gestalt .react-datepicker__day--in-range {
-  background-color: var(--gestalt-color-hover-lightGray);
+  background-color: var(--gestalt-colorTransparentGray60);
   border-radius: 0;
+  color: var(--gestalt-gray300);
 }
 
 :global ._gestalt .react-datepicker__day--in-range:hover {
-  background: var(--gestalt-color-hover-lightGray);
+  background: var(--gestalt-colorTransparentGray60);
   border-radius: var(--gestalt-borderRadius-circle);
   position: relative;
 }
@@ -106,7 +118,7 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__day--in-range:not(.react-datepicker__day--selected):hover::before {
-  background: var(--gestalt-color-hover-lightGray);
+  background: var(--gestalt-colorTransparentGray60);
   border-radius: 0;
   content: "";
   display: block;
@@ -114,6 +126,9 @@ to prevent conflict with another CSS module */
   position: absolute;
   top: 0;
   width: 100%;
+
+  /* z-index required to position pseudo-elements behind parent */
+  z-index: -1;
 }
 
 :global ._gestalt .react-datepicker__day--in-range:first-child:hover::before {
@@ -127,14 +142,14 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__day--range-start {
-  background-color: var(--gestalt-color-darkGray);
+  background-color: var(--gestalt-colorGray400);
   border-radius: var(--gestalt-borderRadius-circle);
-  color: var(--gestalt-color-white);
+  color: var(--gestalt-colorGray50);
   position: relative;
 }
 
 :global ._gestalt .react-datepicker__day--range-start:not(:last-child):not(.react-datepicker__day--range-end)::before {
-  background: var(--gestalt-color-hover-lightGray);
+  background: var(--gestalt-colorTransparentGray60);
   border-radius: var(--gestalt-borderRadius-halfCircle-Start);
   content: "";
   display: block;
@@ -142,17 +157,20 @@ to prevent conflict with another CSS module */
   position: absolute;
   top: 0;
   width: 100%;
+
+  /* z-index required to position pseudo-elements behind parent */
+  z-index: -1;
 }
 
 :global ._gestalt .react-datepicker__day--range-start:hover {
   background-color: inherit;
   border-radius: var(--gestalt-borderRadius-circle);
-  color: var(--gestalt-color-darkGray);
+  color: var(--gestalt-gray300);
   position: relative;
 }
 
 :global ._gestalt .react-datepicker__day--range-start:hover::after {
-  background: var(--gestalt-color-hover-lightGray);
+  background: var(--gestalt-colorTransparentGray60);
   border-radius: var(--gestalt-borderRadius-circle);
   content: "";
   display: block;
@@ -160,17 +178,20 @@ to prevent conflict with another CSS module */
   position: absolute;
   top: 0;
   width: 100%;
+
+  /* z-index required to position pseudo-elements behind parent */
+  z-index: -1;
 }
 
 :global ._gestalt .react-datepicker__day--range-end {
-  background-color: var(--gestalt-color-darkGray);
+  background-color: var(--gestalt-colorGray400);
   border-radius: var(--gestalt-borderRadius-circle);
-  color: var(--gestalt-color-white);
+  color: var(--gestalt-colorGray50);
   position: relative;
 }
 
 :global ._gestalt .react-datepicker__day--range-end:not(:first-child):not(.react-datepicker__day--range-start)::before {
-  background: var(--gestalt-color-hover-lightGray);
+  background: var(--gestalt-colorTransparentGray60);
   border-radius: var(--gestalt-borderRadius-halfCircle-End);
   content: "";
   display: block;
@@ -178,29 +199,36 @@ to prevent conflict with another CSS module */
   position: absolute;
   top: 0;
   width: 100%;
+
+  /* z-index required to position pseudo-elements behind parent */
+  z-index: -1;
 }
 
 :global ._gestalt .react-datepicker__day--range-end:hover {
   background-color: inherit;
   border-radius: var(--gestalt-borderRadius-circle);
-  color: var(--gestalt-color-darkGray);
+  color: var(--gestalt-gray300);
   position: relative;
 }
 
 :global ._gestalt .react-datepicker__day--range-end:hover::after {
-  background: var(--gestalt-color-hover-lightGray);
+  background: var(--gestalt-colorTransparentGray60);
   border-radius: var(--gestalt-borderRadius-circle);
+  color: var(--gestalt-gray300);
   content: "";
   display: block;
   height: 100%;
   position: absolute;
   top: 0;
   width: 100%;
+
+  /* z-index required to position pseudo-elements behind parent */
+  z-index: -1;
 }
 
 :global ._gestalt .react-datepicker__day--selecting-range-start:not(.react-datepicker__day--in-range):not(.react-datepicker__day--highlighted),
 :global ._gestalt .react-datepicker__day--selecting-range-end:not(.react-datepicker__day--in-range):not(.react-datepicker__day--highlighted) {
-  background-color: var(--gestalt-color-hover-lightGray);
+  background-color: var(--gestalt-colorTransparentGray60);
 }
 
 :global ._gestalt .react-datepicker__day--outside-month {
@@ -208,7 +236,7 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__day-name {
-  color: var(--gestalt-color-gray);
+  color: var(--gestalt-colorGray200);
   display: inline-block;
   font-size: 16px;
   line-height: var(--gestalt-day-dimensions);
@@ -238,13 +266,17 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__month {
-  color: var(--gestalt-color-white);
+  color: var(--gestalt-colorGray50);
   text-align: center;
 }
 
 :global ._gestalt .react-datepicker__week {
   display: flex;
+  position: relative;
   white-space: nowrap;
+
+  /* z-index required to position pseudo-elements behind parent */
+  z-index: 1;
 }
 
 :global ._gestalt .react-datepicker__month-container {
@@ -270,11 +302,11 @@ to prevent conflict with another CSS module */
 
 :global ._gestalt .react-datepicker__navigation:hover,
 :global ._gestalt .react-datepicker__navigation:focus {
-  background: var(--gestalt-color-hover-lightGray);
+  background: var(--gestalt-colorTransparentGray60);
 }
 
 :global ._gestalt .react-datepicker__navigation:active::before {
-  background: var(--gestalt-color-hover-lightGray);
+  background: var(--gestalt-colorTransparentGray60);
   border-radius: var(--gestalt-borderRadius-circle);
   content: "";
   display: block;

--- a/packages/gestalt/src/Pog.css
+++ b/packages/gestalt/src/Pog.css
@@ -1,7 +1,7 @@
 :root {
   --gestalt-colorGray300: #111;
-  --gestalt-colorTransparentGray60: 'rgba(0, 0, 0, 0.06)';
-  --gestalt-colorTransparentGray100: 'rgba(0, 0, 0, 0.1)';
+  --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
+  --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
 }
 
 .pog {

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -23,9 +23,9 @@ exports[`Video with callbacks 1`] = `
   --gestalt-colorGray200: #767676;
   --gestalt-colorGray300: #111;
   --gestalt-colorGray400: #000;
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
@@ -79,9 +79,9 @@ exports[`Video with children 1`] = `
   --gestalt-colorGray200: #767676;
   --gestalt-colorGray300: #111;
   --gestalt-colorGray400: #000;
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
@@ -314,9 +314,9 @@ exports[`Video with media attributes 1`] = `
   --gestalt-colorGray200: #767676;
   --gestalt-colorGray300: #111;
   --gestalt-colorGray400: #000;
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
@@ -371,9 +371,9 @@ exports[`Video with multiple sources 1`] = `
   --gestalt-colorGray200: #767676;
   --gestalt-colorGray300: #111;
   --gestalt-colorGray400: #000;
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
@@ -434,9 +434,9 @@ exports[`Video with source 1`] = `
   --gestalt-colorGray200: #767676;
   --gestalt-colorGray300: #111;
   --gestalt-colorGray400: #000;
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }

--- a/packages/gestalt/src/contexts/ColorScheme.js
+++ b/packages/gestalt/src/contexts/ColorScheme.js
@@ -19,9 +19,9 @@ type Theme = {|
   colorGray200: string,
   colorGray300: string,
   colorGray400: string,
+  colorTransparentDarkGray: string,
   colorTransparentGray60: string,
   colorTransparentGray100: string,
-  colorTransparentDarkGray: string,
   colorTransparentWhite: string,
 |};
 
@@ -42,9 +42,9 @@ const lightModeTheme = {
   colorGray200: '#767676',
   colorGray300: '#111',
   colorGray400: '#000',
+  colorTransparentDarkGray: 'rgba(51, 51, 51, 0.8)',
   colorTransparentGray60: 'rgba(0, 0, 0, 0.06)',
   colorTransparentGray100: 'rgba(0, 0, 0, 0.1)',
-  colorTransparentDarkGray: 'rgba(51, 51, 51, 0.8)',
   colorTransparentWhite: 'rgba(255, 255, 255, 0.8)',
 };
 
@@ -59,9 +59,9 @@ const darkModeTheme = {
   colorGray200: '#ababab',
   colorGray300: '#efefef',
   colorGray400: '#fff',
-  colorTransparentGray60: 'rgba(255, 255, 255, 0.5)',
-  colorTransparentGray100: 'rgba(255, 255, 255, 0.5)',
   colorTransparentDarkGray: 'rgba(255, 255, 255, 0.8)',
+  colorTransparentGray60: 'rgba(250, 250, 250, 0.5)',
+  colorTransparentGray100: 'rgba(0, 0, 0, 0.5)',
   colorTransparentWhite: 'rgba(51, 51, 51, 0.8)',
 };
 

--- a/packages/gestalt/src/contexts/ColorScheme.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorScheme.jsdom.test.js
@@ -35,9 +35,9 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray200: #767676;
         --gestalt-colorGray300: #111;
         --gestalt-colorGray400: #000;
+        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
         --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
         --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
         --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
        }
       </style>
@@ -59,9 +59,9 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray200: #767676;
         --gestalt-colorGray300: #111;
         --gestalt-colorGray400: #000;
+        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
         --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
         --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
         --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
        }
       </style>
@@ -83,9 +83,9 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray200: #ababab;
         --gestalt-colorGray300: #efefef;
         --gestalt-colorGray400: #fff;
-        --gestalt-colorTransparentGray60: rgba(255, 255, 255, 0.5);
-        --gestalt-colorTransparentGray100: rgba(255, 255, 255, 0.5);
         --gestalt-colorTransparentDarkGray: rgba(255, 255, 255, 0.8);
+        --gestalt-colorTransparentGray60: rgba(250, 250, 250, 0.5);
+        --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.5);
         --gestalt-colorTransparentWhite: rgba(51, 51, 51, 0.8);
        }
       </style>
@@ -110,9 +110,9 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray200: #ababab;
         --gestalt-colorGray300: #efefef;
         --gestalt-colorGray400: #fff;
-        --gestalt-colorTransparentGray60: rgba(255, 255, 255, 0.5);
-        --gestalt-colorTransparentGray100: rgba(255, 255, 255, 0.5);
         --gestalt-colorTransparentDarkGray: rgba(255, 255, 255, 0.8);
+        --gestalt-colorTransparentGray60: rgba(250, 250, 250, 0.5);
+        --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.5);
         --gestalt-colorTransparentWhite: rgba(51, 51, 51, 0.8);
        }
       }
@@ -136,9 +136,9 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray200: #767676;
         --gestalt-colorGray300: #111;
         --gestalt-colorGray400: #000;
+        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
         --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
         --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
         --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
        }
       </style>


### PR DESCRIPTION
Fixes:
https://github.com/pinterest/gestalt/issues/995
https://github.com/pinterest/gestalt/issues/976


PENDING: Navigation Icon on Hover/Click should go DarkGray
PENDING: Day color upon hovering in days.

![Kapture 2020-07-09 at 18 38 28](https://user-images.githubusercontent.com/10593890/87107035-96e55300-c213-11ea-86c0-2a135ed9168a.gif)

## TODO

- [x] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [x] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
