### PR TITLE
Button: Use accessible colors for darkMode red button

### DIFF
--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -66,12 +66,19 @@
   composes: redBg from "./Colors.css";
 }
 
+.darkModeRed {
+  composes: red0Bg from "./Colors.css";
+}
+
 .red:hover,
-.red:focus {
+.red:focus,
+.darkModeRed:hover,
+.darkModeRed:focus {
   background-color: #ad081b;
 }
 
-.red:active {
+.red:active,
+.darkModeRed:active {
   background-color: #a3081a;
 }
 

--- a/packages/gestalt/src/Button.css.flow
+++ b/packages/gestalt/src/Button.css.flow
@@ -4,6 +4,7 @@ declare module.exports: {|
   +'block': string,
   +'blue': string,
   +'button': string,
+  +'darkModeRed': string,
   +'disabled': string,
   +'enabled': string,
   +'gray': string,

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -63,14 +63,14 @@ export default function Button(props: Props): Element<'button'> {
   const { name: colorSchemeName } = useColorScheme();
   // We need to make a few exceptions for accessibility reasons in darkMode for red buttons
   const isDarkModeRed = colorSchemeName === 'darkMode' && color === 'red';
+  const colorClass = isDarkModeRed ? 'darkModeRed' : color;
 
   const classes = classnames(styles.button, {
     [styles.sm]: size === 'sm',
     [styles.md]: size === 'md',
     [styles.lg]: size === 'lg',
     [styles.solid]: color !== 'transparent',
-    [styles[color]]: !disabled && !selected && !isDarkModeRed,
-    [styles.darkModeRed]: isDarkModeRed,
+    [styles[colorClass]]: !disabled && !selected,
     [styles.selected]: !disabled && selected,
     [styles.disabled]: disabled,
     [styles.enabled]: !disabled,

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -8,6 +8,7 @@ import Icon from './Icon.js';
 import icons from './icons/index.js';
 import styles from './Button.css';
 import Text from './Text.js';
+import { useColorScheme } from './contexts/ColorScheme.js';
 
 const DEFAULT_TEXT_COLORS = {
   blue: 'white',
@@ -59,13 +60,17 @@ export default function Button(props: Props): Element<'button'> {
     textColor: textColorProp,
     type = 'button',
   } = props;
+  const { name: colorSchemeName } = useColorScheme();
+  // We need to make a few exceptions for accessibility reasons in darkMode for red buttons
+  const isDarkModeRed = colorSchemeName === 'darkMode' && color === 'red';
 
   const classes = classnames(styles.button, {
     [styles.sm]: size === 'sm',
     [styles.md]: size === 'md',
     [styles.lg]: size === 'lg',
     [styles.solid]: color !== 'transparent',
-    [styles[color]]: !disabled && !selected,
+    [styles[color]]: !disabled && !selected && !isDarkModeRed,
+    [styles.darkModeRed]: isDarkModeRed,
     [styles.selected]: !disabled && selected,
     [styles.disabled]: disabled,
     [styles.enabled]: !disabled,
@@ -76,6 +81,7 @@ export default function Button(props: Props): Element<'button'> {
   const textColor =
     (disabled && 'gray') ||
     (selected && 'white') ||
+    (isDarkModeRed && 'darkGray') ||
     textColorProp ||
     DEFAULT_TEXT_COLORS[color];
 

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -40,6 +40,14 @@
   background-color: var(--gestalt-colorRed100);
 }
 
+.red0 {
+  color: var(--gestalt-colorRed0);
+}
+
+.red0Bg {
+  background-color: var(--gestalt-colorRed0);
+}
+
 /* white */
 
 .white {

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -40,10 +40,6 @@
   background-color: var(--gestalt-colorRed100);
 }
 
-.red0 {
-  color: var(--gestalt-colorRed0);
-}
-
 .red0Bg {
   background-color: var(--gestalt-colorRed0);
 }

--- a/packages/gestalt/src/Colors.css.flow
+++ b/packages/gestalt/src/Colors.css.flow
@@ -32,6 +32,8 @@ declare module.exports: {|
   +'purple': string,
   +'purpleBg': string,
   +'red': string,
+  +'red0': string,
+  +'red0Bg': string,
   +'redBg': string,
   +'transparentBg': string,
   +'transparentDarkGray': string,

--- a/packages/gestalt/src/Colors.css.flow
+++ b/packages/gestalt/src/Colors.css.flow
@@ -32,7 +32,6 @@ declare module.exports: {|
   +'purple': string,
   +'purpleBg': string,
   +'red': string,
-  +'red0': string,
   +'red0Bg': string,
   +'redBg': string,
   +'transparentBg': string,


### PR DESCRIPTION
Closes #992 

This checks if we're in dark mode and adjusts the colors slightly if so to keep an accessible contrast

## TODO

- [x] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [x] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
