### PR TITLE
Avatar and GroupAvatar: Use correct outline for dark mode

### DIFF
--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -95,6 +95,7 @@ const sizes = {
 
 export default function Avatar(props: Props): React.Node {
   const [isImageLoaded, setIsImageLoaded] = React.useState(true);
+  const { colorGray0, colorGray100 } = useColorScheme();
   const {
     accessibilityLabel,
     name,
@@ -116,7 +117,7 @@ export default function Avatar(props: Props): React.Node {
         ? {
             dangerouslySetInlineStyle: {
               __style: {
-                boxShadow: '0 0 0 1px #fff',
+                boxShadow: `0 0 0 1px ${colorGray0}`,
               },
             },
           }
@@ -130,7 +131,7 @@ export default function Avatar(props: Props): React.Node {
         <Mask rounding="circle" wash>
           <Image
             alt={accessibilityLabel ?? name}
-            color="#EFEFEF"
+            color={colorGray100}
             naturalHeight={1}
             naturalWidth={1}
             src={src}

--- a/packages/gestalt/src/GroupAvatar.js
+++ b/packages/gestalt/src/GroupAvatar.js
@@ -172,7 +172,7 @@ const DefaultAvatar = (props: {|
 
 export default function GroupAvatar(props: Props): React.Node {
   const { collaborators, outline, size = 'fit' } = props;
-  const { colorGray100 } = useColorScheme();
+  const { colorGray0, colorGray100 } = useColorScheme();
   const avatarWidth = size === 'fit' ? '100%' : AVATAR_SIZES[size];
   const avatarHeight = size === 'fit' ? '' : AVATAR_SIZES[size];
   const positions = avatarLayout(collaborators.length, avatarWidth);
@@ -186,7 +186,7 @@ export default function GroupAvatar(props: Props): React.Node {
       position="relative"
       dangerouslySetInlineStyle={{
         __style: {
-          ...(outline ? { boxShadow: '0 0 0 2px #fff' } : {}),
+          ...(outline ? { boxShadow: `0 0 0 2px ${colorGray0}` } : {}),
           // willChange: transform fixes a strange behavior where the border of the children
           // are not properly trimmed even though overflow: hidden is set
           willChange: 'transform',

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -122,7 +122,7 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "paddingBottom": "100%",
         }
       }
@@ -204,7 +204,7 @@ exports[`Avatar renders the correct size - lg 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "paddingBottom": "100%",
         }
       }
@@ -249,7 +249,7 @@ exports[`Avatar renders the correct size - md 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "paddingBottom": "100%",
         }
       }
@@ -294,7 +294,7 @@ exports[`Avatar renders the correct size - sm 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "paddingBottom": "100%",
         }
       }
@@ -339,7 +339,7 @@ exports[`Avatar renders the correct size - xl 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "paddingBottom": "100%",
         }
       }
@@ -384,7 +384,7 @@ exports[`Avatar renders the correct size - xs 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "paddingBottom": "100%",
         }
       }
@@ -429,7 +429,7 @@ exports[`Avatar renders the correct src 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#EFEFEF",
+          "backgroundColor": "#efefef",
           "paddingBottom": "100%",
         }
       }

--- a/packages/gestalt/src/__snapshots__/AvatarPair.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarPair.test.js.snap
@@ -51,7 +51,7 @@ exports[`AvatarPair Renders only the first 2 collobarators when multiple are pas
           className="box relative"
           style={
             Object {
-              "backgroundColor": "#EFEFEF",
+              "backgroundColor": "#efefef",
               "paddingBottom": "100%",
             }
           }
@@ -106,7 +106,7 @@ exports[`AvatarPair Renders only the first 2 collobarators when multiple are pas
           className="box relative"
           style={
             Object {
-              "backgroundColor": "#EFEFEF",
+              "backgroundColor": "#efefef",
               "paddingBottom": "100%",
             }
           }
@@ -181,7 +181,7 @@ exports[`AvatarPair Renders renders 2 collaborators 1`] = `
           className="box relative"
           style={
             Object {
-              "backgroundColor": "#EFEFEF",
+              "backgroundColor": "#efefef",
               "paddingBottom": "100%",
             }
           }
@@ -236,7 +236,7 @@ exports[`AvatarPair Renders renders 2 collaborators 1`] = `
           className="box relative"
           style={
             Object {
-              "backgroundColor": "#EFEFEF",
+              "backgroundColor": "#efefef",
               "paddingBottom": "100%",
             }
           }
@@ -311,7 +311,7 @@ exports[`AvatarPair Renders renders the avatar with text when no image is provid
           className="box relative"
           style={
             Object {
-              "backgroundColor": "#EFEFEF",
+              "backgroundColor": "#efefef",
               "paddingBottom": "100%",
             }
           }


### PR DESCRIPTION
Closes #990 

Also noticed the same issue on `GroupAvatar` as in the ticket so fixed that too.

## TODO

- [x] Accessibility checkup
- [x] Update documentation
- [x] Add/update Tests
- [x] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
