### PR TITLE
Docs: Reorganize sidebar

### DIFF
--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -8,9 +8,9 @@ export type sidebarIndexType = Array<{|
 |}>;
 
 const componentSubSectionPages = {
-  displayDate: ['Avatar', 'AvatarPair', 'Badge', 'GroupAvatar', 'Table'],
+  displayDate: ['Badge', 'GroupAvatar', 'Table'],
   feedBack: ['Modal', 'Pulsar', 'Spinner', 'Toast'],
-  foundations: ['GestaltProvider', 'Heading', 'Icon', 'Text'],
+  foundations: ['GestaltProvider', 'Text', 'Heading', 'Icon'],
   forms: [
     'Button',
     'Checkbox',
@@ -41,7 +41,7 @@ const componentSubSectionPages = {
     'Stack',
     'Sticky',
   ],
-  media: ['Image', 'Letterbox', 'Mask', 'Video'],
+  media: ['Avatar', 'AvatarPair', 'Image', 'Letterbox', 'Mask', 'Video'],
   navigation: ['Link', 'SegmentedControl', 'Tabs'],
 };
 
@@ -67,32 +67,32 @@ const sidebarIndex: sidebarIndexType = [
     sectionName: 'Components',
     subsections: [
       {
-        subsectionName: 'Data Display',
-        pages: componentSubSectionPages.displayDate,
-      },
-      {
-        subsectionName: 'Feedback',
-        pages: componentSubSectionPages.feedBack,
-      },
-      {
-        subsectionName: 'Foundation',
+        subsectionName: 'Basics',
         pages: componentSubSectionPages.foundations,
-      },
-      {
-        subsectionName: 'Forms',
-        pages: componentSubSectionPages.forms,
       },
       {
         subsectionName: 'Layout',
         pages: componentSubSectionPages.layout,
       },
       {
+        subsectionName: 'Navigation',
+        pages: componentSubSectionPages.navigation,
+      },
+      {
         subsectionName: 'Media',
         pages: componentSubSectionPages.media,
       },
       {
-        subsectionName: 'Navigation',
-        pages: componentSubSectionPages.navigation,
+        subsectionName: 'Forms',
+        pages: componentSubSectionPages.forms,
+      },
+      {
+        subsectionName: 'Data',
+        pages: componentSubSectionPages.displayDate,
+      },
+      {
+        subsectionName: 'Feedback',
+        pages: componentSubSectionPages.feedBack,
       },
     ],
   },

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -8,7 +8,7 @@ export type sidebarIndexType = Array<{|
 |}>;
 
 const componentSubSectionPages = {
-  displayDate: ['Badge', 'GroupAvatar', 'Table'],
+  displayDate: ['Badge', 'Table'],
   feedBack: ['Modal', 'Pulsar', 'Spinner', 'Toast'],
   foundations: ['GestaltProvider', 'Text', 'Heading', 'Icon'],
   forms: [
@@ -41,7 +41,15 @@ const componentSubSectionPages = {
     'Stack',
     'Sticky',
   ],
-  media: ['Avatar', 'AvatarPair', 'Image', 'Letterbox', 'Mask', 'Video'],
+  media: [
+    'Avatar',
+    'AvatarPair',
+    'GroupAvatar',
+    'Image',
+    'Letterbox',
+    'Mask',
+    'Video',
+  ],
   navigation: ['Link', 'SegmentedControl', 'Tabs'],
 };
 


### PR DESCRIPTION
I really love the new sidebar! However, it's a bit confusing because the first thing that's presented is "Data Display" and "Avatar" which... seems like not the most important thing to introduce people to Gestalt with. This PR reorganizes the sidebar to roughly order things in the order of "frequently used".
