### PR TITLE
Flyout: Fix caret appearance in dark mode

### DIFF
--- a/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Flyout.jsdom.test.js.snap
@@ -20,7 +20,7 @@ exports[`Flyout renders 1`] = `
       tabIndex={-1}
     >
       <div
-        className="border whiteBgElevated white rounding4 innerContents maxDimensions minDimensions"
+        className="border whiteBgElevated whiteElevated rounding4 innerContents maxDimensions minDimensions"
         style={
           Object {
             "maxWidth": 230,


### PR DESCRIPTION
Closes #983 

Before
<img width="296" alt="Screen Shot 2020-07-08 at 4 59 53 PM" src="https://user-images.githubusercontent.com/1767822/86981894-b2c9f580-c13c-11ea-9518-55025efad308.png">

After
<img width="315" alt="Screen Shot 2020-07-08 at 4 59 27 PM" src="https://user-images.githubusercontent.com/1767822/86981900-b5c4e600-c13c-11ea-81a8-1ce44cab12f9.png">


- [ ] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [ ] Pinterest Designer (for design changes)
- [ ] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
