### PR TITLE
[Table] Fix sticky header in darkMode

### DIFF
--- a/packages/gestalt/src/Table.css
+++ b/packages/gestalt/src/Table.css
@@ -1,3 +1,8 @@
+:root {
+  /* primary colors */
+  --gestalt-colorGray0: #fff;
+}
+
 .table {
   border-collapse: separate;
   border-spacing: 0;
@@ -16,7 +21,7 @@
 }
 
 .sticky tr th {
-  background-color: #fff;
+  background-color: var(--gestalt-colorGray0);
   position: sticky;
   top: 0;
 }


### PR DESCRIPTION
Fixes: https://github.com/pinterest/gestalt/issues/980

![image](https://user-images.githubusercontent.com/10593890/86984336-2bcc4b80-c143-11ea-9e03-3d40fda5b392.png)

## TODO

- [x] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [x] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
