### PR TITLE
[TextArea] Added border color to follow color schema

### DIFF
--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -146,7 +146,7 @@ card(
 function Example(props) {
   const [value, setValue] = React.useState('')
   return (
-    <Box padding={2} color="white">
+    <Box padding={2}>
       <TextArea
         id="aboutmemore"
         onChange={({value}) => setValue(value)}

--- a/packages/gestalt/src/Borders.css
+++ b/packages/gestalt/src/Borders.css
@@ -12,6 +12,7 @@
   /* remanent lightGray colors */
   --gestalt-border-color-lightGray: #ddd;
   --gestalt-border-color-lightGrayHovered: #d0d0d0;
+  --gestalt-border-color-redHovered: #d80021;
 }
 
 
@@ -36,6 +37,11 @@
 .borderColorRed {
   border-color: var(--gestalt-colorRed100);
 }
+
+.borderColorRedHovered {
+  border-color: var(--gestalt-border-color-redHovered);
+}
+
 
 .borderColorLightGrayHovered {
   border-color: var(--gestalt-border-color-lightGrayHovered);

--- a/packages/gestalt/src/FormElement.css
+++ b/packages/gestalt/src/FormElement.css
@@ -1,3 +1,10 @@
+:root {
+  /* remanent lightGray colors */
+  --gestalt-border-color-lightGray: #ddd;
+  --gestalt-border-color-lightGrayHovered: #d0d0d0;
+  --gestalt-border-color-redHovered: #d80021;
+}
+
 .base {
   composes: accessibilityOutline from "./Focus.css";
   appearance: none;
@@ -7,24 +14,24 @@
 }
 
 .normal {
-  border-color: #ddd;
+  composes: borderColorLightGray from "./Borders.css";
 }
 
 .normal:hover:not(:focus):not(.disabled) {
-  border-color: #d0d0d0;
+  border-color: var(--gestalt-border-color-lightGrayHovered);
 }
 
 .errored {
-  border-color: #e60023;
+  composes: borderColorRed from "./Borders.css";
   outline: none;
 }
 
 .errored:focus {
-  border-color: #ddd;
+  border-color: var(--gestalt-border-color-lightGray);
 }
 
 .errored:hover:not(:focus) {
-  border-color: #d80021;
+  border-color: var(--gestalt-border-color-redHovered);
 }
 
 .enabled {
@@ -35,5 +42,5 @@
 .disabled {
   composes: gray from "./Colors.css";
   composes: lightGrayBg from "./Colors.css";
-  border-color: #efefef;
+  composes: borderColorLightGrayDisabled from "./Borders.css";
 }

--- a/packages/gestalt/src/TextArea.css
+++ b/packages/gestalt/src/TextArea.css
@@ -6,6 +6,8 @@
   composes: borderBox from "./Layout.css";
   composes: Text fontSize3 from "./Text.css";
   composes: xsCol12 from "./Column.css";
+  /* composes: lightGray from "./Colors.css"; */
+  color: red;
   line-height: 1.5;
   padding: 8px 16px;
   resize: none;


### PR DESCRIPTION
Fixes: https://github.com/pinterest/gestalt/issues/1003

![image](https://user-images.githubusercontent.com/10593890/86986181-e65e4d00-c147-11ea-9fd2-76100ec15424.png)


## TODO

- [x] Accessibility checkup
- [ ] Update documentation
- [ ] Add/update Tests
- [x] Pinterest Designer (for design changes)
- [x] [Format PR title](https://github.com/pinterest/gestalt/#releasing): `ComponentName: Description`.
