### PR TITLE
Box: Set display name

### DIFF
--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -713,6 +713,10 @@ const BoxWithRef: React.AbstractComponent<
   return <div {...omit(omitProps, props)} {...toProps(s)} ref={ref} />;
 });
 
+// This is a legacy backport around tools external to Gestalt (*waves hands*)
+// expecting Boxes' displayName to be just "Box" and not "ForwardRef(Box)".
+BoxWithRef.displayName = 'Box';
+
 export default BoxWithRef;
 
 /*


### PR DESCRIPTION
In #986 I removed the explicit setting of Box's displayName because I named the function that's passed to `forwardRef`. This resulted in React (correctly) setting the displayName of the resulting component to "ForwardRef(Box)". However, that breaks basically every snapshot test we have that expects the `displayName` to be Box. Considering upgrading is already delayed due to type errors, I want to minimize the number of changes we introduce.

This is worth coming back and refactoring later.