### PR TITLE
Merge: Remove status-check=0 check

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ pull_request_rules:
       - '#approved-reviews-by>=1'
       - 'approved-reviews-by=@gestalt-core'
       - 'status-success~=^Tests'
-      - '#status-failure=0'
       - 'base=master'
     actions:
       merge:


### PR DESCRIPTION
This isn't technically needed as Mergeify will rebase and it seems to be blocking other commits from being merged.
