### PR TITLE
Internal: Add CSS variables CI checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,15 +55,16 @@
   "scripts": {
     "build": "cd packages/gestalt && yarn build && cd ../gestalt-datepicker && yarn build",
     "codemod": "jscodeshift --ignore-pattern=**/node_modules/**",
-    "lint:js": "eslint .",
-    "lint:css": "stylelint \"packages/**/*.css\"",
+    "css:validate": "./scripts/cssValidate.js",
     "flow-generate:css": "(css-modules-flow-types packages/gestalt/src/ >/dev/null) && (css-modules-flow-types packages/gestalt-datepicker/src/ >/dev/null)",
+    "format": "prettier --write \"**/*.{css,html,js,md,yml}\"",
     "greenkeeper-lockfile-update": "greenkeeper-lockfile-update",
     "greenkeeper-lockfile-upload": "greenkeeper-lockfile-upload",
+    "lint:css": "stylelint \"packages/**/*.css\"",
+    "lint:js": "eslint .",
+    "precommit": "lint-staged",
     "start": "(cd docs && yarn start) & (cd packages/gestalt && yarn watch) & (cd packages/gestalt-datepicker && yarn watch)",
-    "test": "./scripts/test.sh",
-    "format": "prettier --write \"**/*.{css,html,js,md,yml}\"",
-    "precommit": "lint-staged"
+    "test": "./scripts/test.sh"
   },
   "jest": {
     "projects": [

--- a/scripts/cssValidate.js
+++ b/scripts/cssValidate.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const postcss = require('postcss');
+const globby = require('globby');
+
+const duplicateVariablesDifferentValues = async () => {
+  const files = await globby([
+    'packages/gestalt/src/**/*.css',
+    'packages/gestalt-datepicker/src/**/*.css',
+  ]);
+
+  const combined = (
+    await Promise.all(
+      files.map(async file => {
+        return await fs.promises.readFile(file, 'utf8');
+      })
+    )
+  ).join('');
+
+  const astRoot = postcss.parse(combined);
+
+  const lookup = {};
+  astRoot.walkDecls(/^--gestalt/, ({ prop, value }) => {
+    if (lookup[prop] && lookup[prop] !== value) {
+      throw new Error(
+        `CSS Validate error: ${prop} is defined multiple times with different values: ${lookup[prop]} & ${value}.\nPlease make these the same`
+      );
+    }
+    lookup[prop] = value;
+  });
+};
+
+const noVarInLegacyCSS = async () => {
+  const combined = (
+    await Promise.all(
+      [
+        'packages/gestalt/dist/gestalt.css',
+        'packages/gestalt-datepicker/dist/gestalt-datepicker.css',
+      ].map(async file => {
+        return await fs.promises.readFile(file, 'utf8');
+      })
+    )
+  ).join('');
+
+  const astRoot = postcss.parse(combined);
+
+  astRoot.walkDecls(/^--gestalt/, ({ prop, value }) => {
+    throw new Error(
+      `CSS Validate error: ${prop} CSS variable with value ${value} is defined in the legacy CSS - this will break IE and older browsers`
+    );
+  });
+};
+
+(async function cssValidate() {
+  try {
+    await duplicateVariablesDifferentValues();
+    await noVarInLegacyCSS();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    process.exit(1);
+  }
+
+  process.exit(0);
+})();

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,6 +20,9 @@ yarn flow check
 echo "CSS: flow types"
 yarn run flow-generate:css
 
+echo "CSS: variables"
+yarn run css:validate
+
 FILES=$(git diff --name-only -- '*.flow')
 if [[ "$FILES" ]]
 then


### PR DESCRIPTION
Improves safety of our CSS variables.

We introduced a split CSS bundle for legacy and future CSS in #963 but this resulted in potential breakages:

    await duplicateVariablesDifferentValues();
    await noVarInLegacyCSS();

### Duplicate Variables with Different Values

We already saw this issue in #971 where the font-size variables for `Text` and `Heading` got overridden resulting in heading sizes to be the same as text sizes

![image](https://user-images.githubusercontent.com/127199/87101340-b4aabc00-c203-11ea-8b2a-2723a0cba707.png)

*Test*: change a color that appears multiple times in 1 location: 
```
--gestalt-colorGray100: #efefef;
```
to
```
--gestalt-colorGray100: #efefed;
```

![Screen Shot 2020-07-09 at 4 19 04 PM](https://user-images.githubusercontent.com/127199/87101365-c5f3c880-c203-11ea-8668-d2cb3a91be03.png)

### CSS Variables in legacy CSS

This will break in IE11 since the compiled CSS will still contain the `var()`. We can only use `:root` for now so it does get replaced in the legacy build.

*Test*: Add this to any file CSS file
```css
.textFieldTemp {
  --gestalt-colorGrad: #111;

  color: var(--gestalt-colorGrad);
}
```

![Screen Shot 2020-07-09 at 4 31 43 PM](https://user-images.githubusercontent.com/127199/87101356-c2604180-c203-11ea-9101-973dbf16a239.png)
