### PR TITLE
ColorScheme: Set transparent colors in dark mode

### DIFF
--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -230,15 +230,15 @@
 }
 
 .transparentDarkGray {
-  color: var(--gestalt-transparentDarkGray);
+  color: var(--gestalt-colorTransparentDarkGray);
 }
 
 .transparentDarkGrayBg {
-  background-color: var(--gestalt-transparentDarkGray);
+  background-color: var(--gestalt-colorTransparentDarkGray);
 }
 
 .transparentWhiteBg {
-  background-color: var(--gestalt-transparentWhite);
+  background-color: var(--gestalt-colorTransparentWhite);
 }
 
 /* light wash */

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -29,8 +29,8 @@
   --gestalt-colorRed100Hovered: #d80021;
 
   /* transparent colors */
-  --gestalt-transparentDarkGray: rgba(51, 51, 51, 0.8);
-  --gestalt-transparentWhite: rgba(255, 255, 255, 0.8);
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+  --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
 }
 
 /** PRIMARY COLORS **/
@@ -234,7 +234,7 @@
 }
 
 .transparentDarkGrayBg {
-  background-color: var(--gestalt-colorTransparentDarkGray);
+  background-color: var(--gestalt-f);
 }
 
 .transparentWhiteBg {

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -25,6 +25,8 @@ exports[`Video with callbacks 1`] = `
   --gestalt-colorGray400: #000;
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+  --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
     }
@@ -79,6 +81,8 @@ exports[`Video with children 1`] = `
   --gestalt-colorGray400: #000;
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+  --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
     }
@@ -312,6 +316,8 @@ exports[`Video with media attributes 1`] = `
   --gestalt-colorGray400: #000;
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+  --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
     }
@@ -367,6 +373,8 @@ exports[`Video with multiple sources 1`] = `
   --gestalt-colorGray400: #000;
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+  --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
     }
@@ -428,6 +436,8 @@ exports[`Video with source 1`] = `
   --gestalt-colorGray400: #000;
   --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+  --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+  --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
  }",
       }
     }

--- a/packages/gestalt/src/contexts/ColorScheme.js
+++ b/packages/gestalt/src/contexts/ColorScheme.js
@@ -21,6 +21,8 @@ type Theme = {|
   colorGray400: string,
   colorTransparentGray60: string,
   colorTransparentGray100: string,
+  colorTransparentDarkGray: string,
+  colorTransparentWhite: string,
 |};
 
 type Props = {|
@@ -42,6 +44,8 @@ const lightModeTheme = {
   colorGray400: '#000',
   colorTransparentGray60: 'rgba(0, 0, 0, 0.06)',
   colorTransparentGray100: 'rgba(0, 0, 0, 0.1)',
+  colorTransparentDarkGray: 'rgba(51, 51, 51, 0.8)',
+  colorTransparentWhite: 'rgba(255, 255, 255, 0.8)',
 };
 
 const darkModeTheme = {
@@ -57,6 +61,8 @@ const darkModeTheme = {
   colorGray400: '#fff',
   colorTransparentGray60: 'rgba(255, 255, 255, 0.5)',
   colorTransparentGray100: 'rgba(255, 255, 255, 0.5)',
+  colorTransparentDarkGray: 'rgba(255, 255, 255, 0.8)',
+  colorTransparentWhite: 'rgba(51, 51, 51, 0.8)',
 };
 
 const ThemeContext: React.Context<Theme> = React.createContext<Theme>(

--- a/packages/gestalt/src/contexts/ColorScheme.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorScheme.jsdom.test.js
@@ -37,6 +37,8 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray400: #000;
         --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
         --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+        --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
        }
       </style>
     `);
@@ -59,6 +61,8 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray400: #000;
         --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
         --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+        --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
        }
       </style>
     `);
@@ -81,6 +85,8 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray400: #fff;
         --gestalt-colorTransparentGray60: rgba(255, 255, 255, 0.5);
         --gestalt-colorTransparentGray100: rgba(255, 255, 255, 0.5);
+        --gestalt-colorTransparentDarkGray: rgba(255, 255, 255, 0.8);
+        --gestalt-colorTransparentWhite: rgba(51, 51, 51, 0.8);
        }
       </style>
     `);
@@ -106,6 +112,8 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray400: #fff;
         --gestalt-colorTransparentGray60: rgba(255, 255, 255, 0.5);
         --gestalt-colorTransparentGray100: rgba(255, 255, 255, 0.5);
+        --gestalt-colorTransparentDarkGray: rgba(255, 255, 255, 0.8);
+        --gestalt-colorTransparentWhite: rgba(51, 51, 51, 0.8);
        }
       }
       </style>
@@ -130,6 +138,8 @@ describe('ColorSchemeProvider', () => {
         --gestalt-colorGray400: #000;
         --gestalt-colorTransparentGray60: rgba(0, 0, 0, 0.06);
         --gestalt-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+        --gestalt-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+        --gestalt-colorTransparentWhite: rgba(255, 255, 255, 0.8);
        }
       </style>
     `);


### PR DESCRIPTION
Pogs using these background colors now properly inverse in dark mode. The hover colors are still not quite right in dark mode but this is an improvement

## Test Plan

Check Pogs in docs in light mode and dark mode. Make sure the "transparentDarkGray" and "white" colors reverse in dark mode

<img width="1272" alt="Screen Shot 2020-07-09 at 6 23 20 PM" src="https://user-images.githubusercontent.com/1767822/87106035-5389e500-c211-11ea-9bdb-3426aea502ad.png">

<img width="1265" alt="Screen Shot 2020-07-09 at 6 23 11 PM" src="https://user-images.githubusercontent.com/1767822/87106041-5684d580-c211-11ea-9095-2d2158b479e3.png">
