### PR TITLE
Video: Add captions + controls

### DIFF
--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -12,6 +12,8 @@ type Source =
   | Array<{| type: 'video/m3u8' | 'video/mp4' | 'video/ogg', src: string |}>;
 
 type Props = {|
+  accessibilityHideCaptionsLabel?: string,
+  accessibilityShowCaptionsLabel?: string,
   accessibilityMaximizeLabel: string,
   accessibilityMinimizeLabel: string,
   accessibilityMuteLabel: string,
@@ -159,6 +161,8 @@ export default class Video extends React.PureComponent<Props, State> {
   player: ?HTMLDivElement;
 
   static propTypes = {
+    accessibilityHideCaptionsLabel: PropTypes.string,
+    accessibilityShowCaptionsLabel: PropTypes.string,
     accessibilityMaximizeLabel: PropTypes.string,
     accessibilityMinimizeLabel: PropTypes.string,
     accessibilityMuteLabel: PropTypes.string,
@@ -550,6 +554,12 @@ export default class Video extends React.PureComponent<Props, State> {
           {/* Need to use full path for these props so Flow can infer correct subtype */}
           {this.props.controls && (
             <VideoControls
+              accessibilityHideCaptionsLabel={
+                this.props.accessibilityHideCaptionsLabel || ''
+              }
+              accessibilityShowCaptionsLabel={
+                this.props.accessibilityHideCaptionsLabel || ''
+              }
               accessibilityMaximizeLabel={this.props.accessibilityMaximizeLabel}
               accessibilityMinimizeLabel={this.props.accessibilityMinimizeLabel}
               accessibilityMuteLabel={this.props.accessibilityMuteLabel}

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -222,7 +222,7 @@ export default class Video extends React.PureComponent<Props, State> {
    */
 
   componentDidMount() {
-    const { playbackRate, playing, volume } = this.props;
+    const { captions, playbackRate, playing, volume } = this.props;
     // Set up event listeners to catch backdoors in fullscreen
     // changes such as using the ESC key to exit
     if (typeof document !== 'undefined') {
@@ -239,7 +239,12 @@ export default class Video extends React.PureComponent<Props, State> {
       this.play();
     }
 
-    if (this.video && this.video.textTracks && this.video.textTracks[0]) {
+    if (
+      captions &&
+      this.video &&
+      this.video.textTracks &&
+      this.video.textTracks[0]
+    ) {
       this.video.textTracks[0].mode = 'showing';
     }
   }
@@ -339,20 +344,11 @@ export default class Video extends React.PureComponent<Props, State> {
 
   // Toggle captions on/off
   toggleCaptions: () => void = () => {
-    if (this.video && this.video.textTracks && this.video.textTracks[0]) {
-      const isShowing = this.video.textTracks[0].mode === 'showing';
-      if (isShowing) {
-        this.video.textTracks[0].mode = 'disabled';
-        this.setState({
-          captionsButton: 'disabled',
-        });
-        return;
-      }
-
-      this.video.textTracks[0].mode = 'showing';
-      this.setState({
-        captionsButton: 'enabled',
-      });
+    const [videoTrack] = this.video?.textTracks || [];
+    if (videoTrack) {
+      const isShowing = videoTrack.mode === 'showing';
+      videoTrack.mode = isShowing ? 'disabled' : 'showing';
+      this.setState({ captionsButton: isShowing ? 'disabled' : 'enabled' });
     }
   };
 

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -20,6 +20,7 @@ type Props = {|
   accessibilityUnmuteLabel: string,
   aspectRatio: number,
   captions: string,
+  children?: React.Node,
   controls?: boolean,
   loop?: boolean,
   onDurationChange?: ({|

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -523,6 +523,7 @@ export default class Video extends React.PureComponent<Props, State> {
         <ColorSchemeProvider id="Video" colorScheme="light">
           <video
             autoPlay={playing}
+            crossOrigin="anonymous"
             loop={loop}
             muted={volume === 0}
             playsInline={playsInline}

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -558,7 +558,7 @@ export default class Video extends React.PureComponent<Props, State> {
                 this.props.accessibilityHideCaptionsLabel || ''
               }
               accessibilityShowCaptionsLabel={
-                this.props.accessibilityHideCaptionsLabel || ''
+                this.props.accessibilityShowCaptionsLabel || ''
               }
               accessibilityMaximizeLabel={this.props.accessibilityMaximizeLabel}
               accessibilityMinimizeLabel={this.props.accessibilityMinimizeLabel}

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -20,7 +20,6 @@ type Props = {|
   accessibilityUnmuteLabel: string,
   aspectRatio: number,
   captions: string,
-  children?: React.Node,
   controls?: boolean,
   loop?: boolean,
   onDurationChange?: ({|
@@ -60,6 +59,7 @@ type State = {|
   currentTime: number,
   duration: number,
   fullscreen: boolean,
+  captionsButton: 'enabled' | 'disabled' | null,
 |};
 
 // For more information on fullscreen and vendor prefixes see
@@ -213,6 +213,7 @@ export default class Video extends React.PureComponent<Props, State> {
     currentTime: 0,
     duration: 0,
     fullscreen: false,
+    captionsButton: this.props.captions ? 'enabled' : null,
   };
 
   /**
@@ -235,6 +236,10 @@ export default class Video extends React.PureComponent<Props, State> {
     // Simulate an autoplay effect if the component
     if (playing) {
       this.play();
+    }
+
+    if (this.video && this.video.textTracks && this.video.textTracks[0]) {
+      this.video.textTracks[0].mode = 'showing';
     }
   }
 
@@ -328,6 +333,25 @@ export default class Video extends React.PureComponent<Props, State> {
   seek: (time: number) => void = time => {
     if (this.video) {
       this.video.currentTime = time;
+    }
+  };
+
+  // Toggle captions on/off
+  toggleCaptions: () => void = () => {
+    if (this.video && this.video.textTracks && this.video.textTracks[0]) {
+      const isShowing = this.video.textTracks[0].mode === 'showing';
+      if (isShowing) {
+        this.video.textTracks[0].mode = 'disabled';
+        this.setState({
+          captionsButton: 'disabled',
+        });
+        return;
+      }
+
+      this.video.textTracks[0].mode = 'showing';
+      this.setState({
+        captionsButton: 'enabled',
+      });
     }
   };
 
@@ -486,7 +510,7 @@ export default class Video extends React.PureComponent<Props, State> {
       src,
       volume,
     } = this.props;
-    const { currentTime, duration, fullscreen } = this.state;
+    const { currentTime, duration, fullscreen, captionsButton } = this.state;
 
     const paddingBottom = (fullscreen && '0') || `${(1 / aspectRatio) * 100}%`;
 
@@ -534,9 +558,11 @@ export default class Video extends React.PureComponent<Props, State> {
               accessibilityPauseLabel={this.props.accessibilityPauseLabel}
               accessibilityPlayLabel={this.props.accessibilityPlayLabel}
               accessibilityUnmuteLabel={this.props.accessibilityUnmuteLabel}
+              captionsButton={captionsButton}
               currentTime={currentTime}
               duration={duration}
               fullscreen={fullscreen}
+              onCaptionsChange={this.toggleCaptions}
               onPlay={this.handlePlay}
               onPlayheadDown={this.handlePlayheadDown}
               onPlayheadUp={this.handlePlayheadUp}

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -10,6 +10,8 @@ import VideoPlayhead from './VideoPlayhead.js';
 import styles from './Video.css';
 
 type Props = {|
+  accessibilityHideCaptionsLabel: string,
+  accessibilityShowCaptionsLabel: string,
   accessibilityMaximizeLabel: string,
   accessibilityMinimizeLabel: string,
   accessibilityMuteLabel: string,
@@ -52,6 +54,8 @@ const timeToString = (time?: number) => {
 
 class VideoControls extends React.Component<Props> {
   static propTypes = {
+    accessibilityHideCaptionsLabel: PropTypes.string,
+    accessibilityShowCaptionsLabel: PropTypes.string,
     accessibilityMaximizeLabel: PropTypes.string.isRequired,
     accessibilityMinimizeLabel: PropTypes.string.isRequired,
     accessibilityMuteLabel: PropTypes.string.isRequired,
@@ -140,6 +144,8 @@ class VideoControls extends React.Component<Props> {
 
   render(): React.Node {
     const {
+      accessibilityHideCaptionsLabel,
+      accessibilityShowCaptionsLabel,
       accessibilityMaximizeLabel,
       accessibilityMinimizeLabel,
       accessibilityMuteLabel,
@@ -178,7 +184,11 @@ class VideoControls extends React.Component<Props> {
           <Box padding={2}>
             <TapArea onTap={this.handleCaptionsChange} fullWidth={false}>
               <Icon
-                accessibilityLabel="closed-captions"
+                accessibilityLabel={
+                  captionsButton === 'enabled'
+                    ? accessibilityHideCaptionsLabel
+                    : accessibilityShowCaptionsLabel
+                }
                 color="white"
                 icon={
                   captionsButton === 'enabled' ? 'speech-ellipsis' : 'speech'

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -16,9 +16,11 @@ type Props = {|
   accessibilityPauseLabel: string,
   accessibilityPlayLabel: string,
   accessibilityUnmuteLabel: string,
+  captionsButton: 'enabled' | 'disabled' | null,
   currentTime: number,
   duration: number,
   fullscreen: boolean,
+  onCaptionsChange: (event: SyntheticEvent<HTMLDivElement>) => void,
   onFullscreenChange: () => void,
   onPause: (event: SyntheticEvent<HTMLDivElement>) => void,
   onPlay: (event: SyntheticEvent<HTMLDivElement>) => void,
@@ -56,6 +58,7 @@ class VideoControls extends React.Component<Props> {
     accessibilityPauseLabel: PropTypes.string.isRequired,
     accessibilityPlayLabel: PropTypes.string.isRequired,
     accessibilityUnmuteLabel: PropTypes.string.isRequired,
+    captionsButton: PropTypes.string,
     currentTime: PropTypes.number.isRequired,
     duration: PropTypes.number.isRequired,
     fullscreen: PropTypes.bool.isRequired,
@@ -105,6 +108,21 @@ class VideoControls extends React.Component<Props> {
     }
   };
 
+  handleCaptionsChange: ({|
+    event:
+      | SyntheticMouseEvent<HTMLDivElement>
+      | SyntheticKeyboardEvent<HTMLDivElement>,
+  |}) => void = ({
+    event,
+  }: {|
+    event:
+      | SyntheticMouseEvent<HTMLDivElement>
+      | SyntheticKeyboardEvent<HTMLDivElement>,
+  |}) => {
+    event.stopPropagation();
+    this.props.onCaptionsChange(event);
+  };
+
   handleVolumeChange: ({|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
@@ -128,6 +146,7 @@ class VideoControls extends React.Component<Props> {
       accessibilityPauseLabel,
       accessibilityPlayLabel,
       accessibilityUnmuteLabel,
+      captionsButton,
       currentTime,
       duration,
       fullscreen,
@@ -140,6 +159,7 @@ class VideoControls extends React.Component<Props> {
     const muted = volume === 0;
     const showFullscreenButton =
       typeof document !== 'undefined' && !!fullscreenEnabled();
+
     return (
       <div className={styles.controls}>
         <Box padding={2}>
@@ -154,6 +174,20 @@ class VideoControls extends React.Component<Props> {
             />
           </TapArea>
         </Box>
+        {captionsButton && (
+          <Box padding={2}>
+            <TapArea onTap={this.handleCaptionsChange} fullWidth={false}>
+              <Icon
+                accessibilityLabel="closed-captions"
+                color="white"
+                icon={
+                  captionsButton === 'enabled' ? 'speech-ellipsis' : 'speech'
+                }
+                size={20}
+              />
+            </TapArea>
+          </Box>
+        )}
         <Box width={50} padding={2}>
           <Text align="right" color="white" overflow="normal" size="sm">
             {timeToString(currentTime)}

--- a/packages/gestalt/src/VideoControls.jsdom.test.js
+++ b/packages/gestalt/src/VideoControls.jsdom.test.js
@@ -13,9 +13,11 @@ test('VideoControls handles play events', () => {
       accessibilityPauseLabel="Pause"
       accessibilityPlayLabel="Play"
       accessibilityUnmuteLabel="Unmute"
+      captionsButton={null}
       currentTime={67.3}
       duration={67.3}
       fullscreen={false}
+      onCaptionsChange={() => {}}
       onFullscreenChange={() => {}}
       onPause={() => {}}
       onPlay={mockOnPlay}
@@ -41,9 +43,11 @@ test('VideoControls handles pause events', () => {
       accessibilityPauseLabel="Pause"
       accessibilityPlayLabel="Play"
       accessibilityUnmuteLabel="Unmute"
+      captionsButton={null}
       currentTime={67.3}
       duration={67.3}
       fullscreen={false}
+      onCaptionsChange={() => {}}
       onFullscreenChange={() => {}}
       onPause={mockOnPause}
       onPlay={() => {}}
@@ -69,9 +73,11 @@ test('VideoControls handles volume events', () => {
       accessibilityPauseLabel="Pause"
       accessibilityPlayLabel="Play"
       accessibilityUnmuteLabel="Unmute"
+      captionsButton={null}
       currentTime={67.3}
       duration={67.3}
       fullscreen={false}
+      onCaptionsChange={() => {}}
       onFullscreenChange={() => {}}
       onPause={() => {}}
       onPlay={() => {}}

--- a/packages/gestalt/src/VideoControls.jsdom.test.js
+++ b/packages/gestalt/src/VideoControls.jsdom.test.js
@@ -7,6 +7,8 @@ test('VideoControls handles play events', () => {
   const mockOnPlay = jest.fn();
   const { getByLabelText } = render(
     <VideoControls
+      accessibilityHideCaptionsLabel="Hide captions"
+      accessibilityShowCaptionsLabel="Show captions"
       accessibilityMaximizeLabel="Maximize"
       accessibilityMinimizeLabel="Minimize"
       accessibilityMuteLabel="Mute"
@@ -37,6 +39,8 @@ test('VideoControls handles pause events', () => {
   const mockOnPause = jest.fn();
   const { getByLabelText } = render(
     <VideoControls
+      accessibilityHideCaptionsLabel="Hide captions"
+      accessibilityShowCaptionsLabel="Show captions"
       accessibilityMaximizeLabel="Maximize"
       accessibilityMinimizeLabel="Minimize"
       accessibilityMuteLabel="Mute"
@@ -67,6 +71,8 @@ test('VideoControls handles volume events', () => {
   const mockOnVolumeChange = jest.fn();
   const { getByLabelText } = render(
     <VideoControls
+      accessibilityHideCaptionsLabel="Hide captions"
+      accessibilityShowCaptionsLabel="Show captions"
       accessibilityMaximizeLabel="Maximize"
       accessibilityMinimizeLabel="Minimize"
       accessibilityMuteLabel="Mute"

--- a/packages/gestalt/src/VideoControls.test.js
+++ b/packages/gestalt/src/VideoControls.test.js
@@ -6,6 +6,8 @@ import VideoControls from './VideoControls.js';
 test('VideoControls for single digit seconds', () => {
   const tree = create(
     <VideoControls
+      accessibilityHideCaptionsLabel="Hide captions"
+      accessibilityShowCaptionsLabel="Show captions"
       accessibilityMaximizeLabel="Maximize"
       accessibilityMinimizeLabel="Minimize"
       accessibilityMuteLabel="Mute"
@@ -34,6 +36,8 @@ test('VideoControls for single digit seconds', () => {
 test('VideoControls for double digit seconds', () => {
   const tree = create(
     <VideoControls
+      accessibilityHideCaptionsLabel="Hide captions"
+      accessibilityShowCaptionsLabel="Show captions"
       accessibilityMaximizeLabel="Maximize"
       accessibilityMinimizeLabel="Minimize"
       accessibilityMuteLabel="Mute"
@@ -62,6 +66,8 @@ test('VideoControls for double digit seconds', () => {
 test('VideoControls for single digit minutes', () => {
   const tree = create(
     <VideoControls
+      accessibilityHideCaptionsLabel="Hide captions"
+      accessibilityShowCaptionsLabel="Show captions"
       accessibilityMaximizeLabel="Maximize"
       accessibilityMinimizeLabel="Minimize"
       accessibilityMuteLabel="Mute"
@@ -90,6 +96,8 @@ test('VideoControls for single digit minutes', () => {
 test('VideoControls for double digit minutes', () => {
   const tree = create(
     <VideoControls
+      accessibilityHideCaptionsLabel="Hide captions"
+      accessibilityShowCaptionsLabel="Show captions"
       accessibilityMaximizeLabel="Maximize"
       accessibilityMinimizeLabel="Minimize"
       accessibilityMuteLabel="Mute"
@@ -118,6 +126,8 @@ test('VideoControls for double digit minutes', () => {
 test('VideoControls rounds for partial seconds', () => {
   const tree = create(
     <VideoControls
+      accessibilityHideCaptionsLabel="Hide captions"
+      accessibilityShowCaptionsLabel="Show captions"
       accessibilityMaximizeLabel="Maximize"
       accessibilityMinimizeLabel="Minimize"
       accessibilityMuteLabel="Mute"

--- a/packages/gestalt/src/VideoControls.test.js
+++ b/packages/gestalt/src/VideoControls.test.js
@@ -12,9 +12,11 @@ test('VideoControls for single digit seconds', () => {
       accessibilityPauseLabel="Pause"
       accessibilityPlayLabel="Play"
       accessibilityUnmuteLabel="Unmute"
+      captionsButton={null}
       currentTime={5}
       duration={5}
       fullscreen={false}
+      onCaptionsChange={() => {}}
       onFullscreenChange={() => {}}
       onPause={() => {}}
       onPlay={() => {}}
@@ -38,9 +40,11 @@ test('VideoControls for double digit seconds', () => {
       accessibilityPauseLabel="Pause"
       accessibilityPlayLabel="Play"
       accessibilityUnmuteLabel="Unmute"
+      captionsButton={null}
       currentTime={15}
       duration={15}
       fullscreen={false}
+      onCaptionsChange={() => {}}
       onFullscreenChange={() => {}}
       onPause={() => {}}
       onPlay={() => {}}
@@ -64,9 +68,11 @@ test('VideoControls for single digit minutes', () => {
       accessibilityPauseLabel="Pause"
       accessibilityPlayLabel="Play"
       accessibilityUnmuteLabel="Unmute"
+      captionsButton={null}
       currentTime={65}
       duration={65}
       fullscreen={false}
+      onCaptionsChange={() => {}}
       onFullscreenChange={() => {}}
       onPause={() => {}}
       onPlay={() => {}}
@@ -90,9 +96,11 @@ test('VideoControls for double digit minutes', () => {
       accessibilityPauseLabel="Pause"
       accessibilityPlayLabel="Play"
       accessibilityUnmuteLabel="Unmute"
+      captionsButton={null}
       currentTime={905}
       duration={905}
       fullscreen={false}
+      onCaptionsChange={() => {}}
       onFullscreenChange={() => {}}
       onPause={() => {}}
       onPlay={() => {}}
@@ -116,9 +124,11 @@ test('VideoControls rounds for partial seconds', () => {
       accessibilityPauseLabel="Pause"
       accessibilityPlayLabel="Play"
       accessibilityUnmuteLabel="Unmute"
+      captionsButton={null}
       currentTime={67.3}
       duration={67.3}
       fullscreen={false}
+      onCaptionsChange={() => {}}
       onFullscreenChange={() => {}}
       onPause={() => {}}
       onPlay={() => {}}

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -180,8 +180,8 @@ exports[`Video with children 1`] = `
           tabIndex="0"
         >
           <svg
-            aria-hidden={null}
-            aria-label="closed-captions"
+            aria-hidden={true}
+            aria-label=""
             className="rtlSupport icon white iconBlock"
             height={20}
             role="img"

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -37,6 +37,7 @@ exports[`Video with callbacks 1`] = `
     <video
       autoPlay={false}
       className="video"
+      crossOrigin="anonymous"
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}
@@ -93,6 +94,7 @@ exports[`Video with children 1`] = `
     <video
       autoPlay={false}
       className="video"
+      crossOrigin="anonymous"
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}
@@ -144,6 +146,43 @@ exports[`Video with children 1`] = `
             aria-hidden={null}
             aria-label="Play"
             className="icon white iconBlock"
+            height={20}
+            role="img"
+            viewBox="0 0 24 24"
+            width={20}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        className="box paddingX2 paddingY2"
+      >
+        <div
+          aria-disabled={false}
+          className="touchable rounding0 pointer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <svg
+            aria-hidden={null}
+            aria-label="closed-captions"
+            className="rtlSupport icon white iconBlock"
             height={20}
             role="img"
             viewBox="0 0 24 24"
@@ -328,6 +367,7 @@ exports[`Video with media attributes 1`] = `
     <video
       autoPlay={false}
       className="video"
+      crossOrigin="anonymous"
       loop={true}
       muted={true}
       onCanPlay={[Function]}
@@ -385,6 +425,7 @@ exports[`Video with multiple sources 1`] = `
     <video
       autoPlay={false}
       className="video"
+      crossOrigin="anonymous"
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}
@@ -448,6 +489,7 @@ exports[`Video with source 1`] = `
     <video
       autoPlay={false}
       className="video"
+      crossOrigin="anonymous"
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}


### PR DESCRIPTION
Currently, the `captions` attribute on videos doesn't actually show captions on a video, we need to update the video text track state to show the captions.

## Test Plan
  - [x] verify that captions auto-play when provided
  - [x] verify that captions stop when toggled off
  - [x] verify captions restart when toggled on

![captions](https://user-images.githubusercontent.com/4467473/87185201-38b18200-c29e-11ea-8535-faddd3e0fb24.gif)
