### PR TITLE
IconButton, Pog: fix padding prop

### DIFF
--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -67,7 +67,7 @@ export default function Pog(props: Props): React.Node {
   } = props;
 
   const iconSizeInPx = SIZE_NAME_TO_ICON_SIZE_PIXEL[size];
-  const paddingInPx = padding || SIZE_NAME_TO_PADDING_PIXEL[size];
+  const paddingInPx = padding ? padding * 4 : SIZE_NAME_TO_PADDING_PIXEL[size];
 
   const color =
     (selected && 'white') || iconColor || defaultIconButtonIconColors[bgColor];

--- a/packages/gestalt/src/__snapshots__/Pog.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pog.test.js.snap
@@ -109,8 +109,8 @@ exports[`Pog renders with size and custom padding 1`] = `
   className="pog transparent"
   style={
     Object {
-      "height": 26,
-      "width": 26,
+      "height": 32,
+      "width": 32,
     }
   }
 >


### PR DESCRIPTION
The `padding` prop for `Pog` and `IconButton`, added in #911 and #949 respectively, is expected to be in boints (1 means 4 px), but I incorrectly treated it as pixels (1 means 1px). This PR fixes it.

<img width="744" alt="Screenshot 2020-07-10 23 11 29" src="https://user-images.githubusercontent.com/5341184/87217869-d50d7000-c302-11ea-98d4-15377de7ab9e.png">

## Test Plan

Before
<img width="1290" alt="Screenshot 2020-07-10 23 23 27" src="https://user-images.githubusercontent.com/5341184/87218078-63362600-c304-11ea-9fce-27bc7fdf4b05.png">


After
<img width="1291" alt="Screenshot 2020-07-10 23 10 49" src="https://user-images.githubusercontent.com/5341184/87217887-fd956a00-c302-11ea-9720-147719018aa5.png">

