### PR TITLE
Internal: Catch CSS variable usage in legacy build

### DIFF
--- a/scripts/cssValidate.js
+++ b/scripts/cssValidate.js
@@ -44,10 +44,20 @@ const noVarInLegacyCSS = async () => {
 
   const astRoot = postcss.parse(combined);
 
+  // Define a CSS variable
   astRoot.walkDecls(/^--gestalt/, ({ prop, value }) => {
     throw new Error(
       `CSS Validate error: ${prop} CSS variable with value ${value} is defined in the legacy CSS - this will break IE and older browsers`
     );
+  });
+
+  // Use a CSS variable
+  astRoot.walkDecls(({ prop, value }) => {
+    if (value.startsWith('var(')) {
+      throw new Error(
+        `CSS Validate error: ${prop} property with CSS variable ${value} is used in the legacy CSS - this will break IE and older browsers`
+      );
+    }
   });
 };
 


### PR DESCRIPTION
Would have caught #1048

![image](https://user-images.githubusercontent.com/127199/87362995-0796b300-c525-11ea-86f9-73ff370dbeac.png)
