### PR TITLE
Link: add React.forwardRef

### DIFF
--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -64,6 +64,11 @@ card(
         type: '() => void',
       },
       {
+        name: 'ref',
+        type: "React.Ref<'a'>",
+        description: 'Forward the ref to the underlying anchor element',
+      },
+      {
         name: 'rel',
         type: `"none" | "nofollow"`,
         defaultValue: 'none',

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -17,6 +17,7 @@ type TapEvent =
 type Props = {|
   accessibilitySelected?: boolean,
   children?: React.Node,
+  forwardedRef?: React.Ref<'a'>,
   hoverStyle?: 'none' | 'underline',
   href: string,
   id?: string,
@@ -34,6 +35,7 @@ type Props = {|
 function Link({
   accessibilitySelected,
   children,
+  forwardedRef,
   href,
   id,
   inline = false,
@@ -105,6 +107,7 @@ function Link({
       onTouchMove={handleTouchMove}
       onTouchCancel={handleTouchCancel}
       onTouchEnd={handleTouchEnd}
+      ref={forwardedRef}
       rel={[
         ...(target === 'blank' ? ['noopener', 'noreferrer'] : []),
         ...(rel === 'nofollow' ? ['nofollow'] : []),
@@ -117,9 +120,15 @@ function Link({
   );
 }
 
-const LinkPropTypes = {
+Link.propTypes = {
   accessibilitySelected: PropTypes.bool,
   children: PropTypes.node,
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.any,
+    }),
+  ]),
   hoverStyle: (PropTypes.oneOf(['none', 'underline']): React$PropType$Primitive<
     'none' | 'underline'
   >),
@@ -142,6 +151,11 @@ const LinkPropTypes = {
   >),
 };
 
-Link.propTypes = LinkPropTypes;
+function LinkWithRef(props, ref) {
+  return <Link {...props} forwardedRef={ref} />;
+}
+LinkWithRef.displayName = 'Link';
 
-export default Link;
+export default (React.forwardRef<Props, HTMLAnchorElement>(
+  LinkWithRef
+): React$AbstractComponent<Props, HTMLAnchorElement>);

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -154,8 +154,12 @@ Link.propTypes = {
 function LinkWithRef(props, ref) {
   return <Link {...props} forwardedRef={ref} />;
 }
-LinkWithRef.displayName = 'Link';
 
-export default (React.forwardRef<Props, HTMLAnchorElement>(
-  LinkWithRef
-): React$AbstractComponent<Props, HTMLAnchorElement>);
+const LinkWithForwardRef: React.AbstractComponent<
+  Props,
+  HTMLAnchorElement
+> = React.forwardRef<Props, HTMLAnchorElement>(LinkWithRef);
+
+LinkWithForwardRef.displayName = 'Link';
+
+export default LinkWithForwardRef;


### PR DESCRIPTION
Follow up from #1044 with the following changes:

* Uses the same forwardRef approach as we do with other components
* Add docs
* Sets the `displayName` to `Link` (avoid having to update too many snapshots)
* Add the correct propType

From @chrislloyd 
> When trying to add Next.js in #1043, I've run into a few issues with the Next link and Gestalt's Link. Mostly, it expects access to the underlying ref. I think this is pretty straight-forward and a fairly safe change (seeing and not many places use Link). It also feels similar to other places where we use `forwardRef` (like `<Box/>`) in that Link is just a thin wrapper over `HTMLLinkElement`.

## Test Plan

CI