### PR TITLE
Pog: add optional accessibilityLabel

### DIFF
--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -24,6 +24,12 @@ card(
   <PropTable
     props={[
       {
+        name: 'accessibilityLabel',
+        type: 'string',
+        defaultValue: '',
+        description: `Omit if and only if an ancestor element already has the aria-label set.`,
+      },
+      {
         name: 'active',
         type: 'boolean',
         defaultValue: false,

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -23,6 +23,10 @@ const SIZE_NAME_TO_ICON_SIZE_PIXEL = {
 };
 
 type Props = {|
+  // Omit accessibilityLabel if and only if an ancestor element already has the aria-label set.
+  // This is similar to having empty `alt` attributes:
+  // https://davidwalsh.name/accessibility-tip-empty-alt-attributes
+  accessibilityLabel?: string,
   active?: boolean,
   bgColor?:
     | 'transparent'
@@ -54,6 +58,7 @@ const defaultIconButtonIconColors = {
 
 export default function Pog(props: Props): React.Node {
   const {
+    accessibilityLabel = '',
     active = false,
     bgColor = 'transparent',
     dangerouslySetSvgPath,
@@ -89,14 +94,8 @@ export default function Pog(props: Props): React.Node {
 
   return (
     <div className={classes} style={inlineStyle}>
-      {/*
-        We're explicitly setting an empty string as a label on the Icon since we
-        already have an aria-label on the button container.
-        This is similar to having empty `alt` attributes:
-        https://davidwalsh.name/accessibility-tip-empty-alt-attributes
-      */}
       <Icon
-        accessibilityLabel=""
+        accessibilityLabel={accessibilityLabel || ''}
         color={color}
         dangerouslySetSvgPath={dangerouslySetSvgPath}
         icon={icon}
@@ -107,6 +106,7 @@ export default function Pog(props: Props): React.Node {
 }
 
 Pog.propTypes = {
+  accessibilityLabel: PropTypes.string,
   active: PropTypes.bool,
   bgColor: PropTypes.oneOf([
     'transparent',

--- a/packages/gestalt/src/Pog.test.js
+++ b/packages/gestalt/src/Pog.test.js
@@ -18,6 +18,13 @@ test('Pog renders with size and custom padding', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Pog renders with accessibilityLabel', () => {
+  const tree = create(
+    <Pog icon="people" accessibilityLabel="Following" />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Pog renders with svg', () => {
   const tree = create(
     <Pog dangerouslySetSvgPath={{ __path: 'M13.00,20.00' }} />

--- a/packages/gestalt/src/__snapshots__/Pog.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pog.test.js.snap
@@ -78,6 +78,32 @@ exports[`Pog hovered renders 1`] = `
 </div>
 `;
 
+exports[`Pog renders with accessibilityLabel 1`] = `
+<div
+  className="pog transparent"
+  style={
+    Object {
+      "height": 40,
+      "width": 40,
+    }
+  }
+>
+  <svg
+    aria-hidden={null}
+    aria-label="Following"
+    className="icon gray iconBlock"
+    height={18}
+    role="img"
+    viewBox="0 0 24 24"
+    width={18}
+  >
+    <path
+      d="test-file-stub"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Pog renders with icon 1`] = `
 <div
   className="pog transparent"


### PR DESCRIPTION
Add optional `accessibilityLabel` prop to `Pog` component for the following use case:

```jsx
<Link to="/following/">
  <Pog icon="people" accessibilityLabel="Following" />
</Link>
```

![Screenshot 2020-07-14 15 31 53](https://user-images.githubusercontent.com/5341184/87483314-4b062580-c5e8-11ea-9ec8-30f6f2a7f636.png)


## Test Plan

jest
