### PR TITLE
TextArea: Add forward ref (BREAKING CHANGE)

### DIFF
--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -30,6 +30,12 @@ card(
         href: 'errorMessageExample',
       },
       {
+        name: 'ref',
+        type: "React.Ref<'textarea'>",
+        description: 'Forward the ref to the underlying textarea element',
+        href: 'refExample',
+      },
+      {
         name: 'helperText',
         type: 'string',
         description: 'More information about how to complete the form field',
@@ -155,6 +161,47 @@ function Example(props) {
         label="With a placeholder"
         value={value}
       />
+    </Box>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    id="refExample"
+    name="Example: ref"
+    description={`
+    A \`TextArea\` with an anchor ref to a Flyout component
+  `}
+    defaultCode={`
+function TextAreaFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef();
+  return (
+    <Box marginBottom={12}>
+      <TextArea
+        ref={anchorRef}
+        label="Focus the TextArea to show the Flyout"
+        id="my-example"
+        onChange={() => {}}
+        onBlur={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+      />
+      {open && (
+        <Flyout
+          anchor={anchorRef.current}
+          idealDirection="down"
+          onDismiss={() => setOpen(false)}
+          shouldFocus={false}
+          size="md"
+        >
+          <Box padding={3}>
+            <Text weight="bold">Example with Flyout</Text>
+          </Box>
+        </Flyout>
+      )}
     </Box>
   );
 }

--- a/packages/gestalt-codemods/6.2.0-7.0.0/textarea-find-deprecated-refs.js
+++ b/packages/gestalt-codemods/6.2.0-7.0.0/textarea-find-deprecated-refs.js
@@ -1,0 +1,51 @@
+/*
+ * Log an error when a `ref` is specified on `<TextArea />`
+ * In 7.0.0 we added forwardRef functionality to TextArea which will break places which already set `ref` on TextArea
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter(node => node.imported.name === 'TextArea')
+      .map(node => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  src
+    .find(j.JSXElement)
+    .forEach(jsxElement => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      attrs.forEach(attr => {
+        if (attr.name && attr.name.name === 'ref') {
+          // eslint-disable-next-line no-console
+          console.error(
+            `Update legacy ref on TextArea: ${file.path}:${attr.loc.start.line}:${attr.loc.start.column}`
+          );
+        }
+      });
+      return null;
+    })
+    .toSource();
+
+  return null;
+}

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -12,6 +12,7 @@ import styles from './TextArea.css';
 type Props = {|
   errorMessage?: string,
   disabled?: boolean,
+  forwardedRef?: React.Ref<'textarea'>,
   hasError?: boolean,
   helperText?: string,
   id: string,
@@ -34,137 +35,118 @@ type Props = {|
     value: string,
   |}) => void,
   placeholder?: string,
-  rows?: number /* default: 3 */,
+  rows?: number,
   value?: string,
 |};
 
-type State = {|
-  focused: boolean,
-|};
+function TextArea({
+  errorMessage,
+  disabled = false,
+  forwardedRef,
+  hasError = false,
+  helperText,
+  id,
+  label,
+  name,
+  onBlur,
+  onChange,
+  onFocus,
+  onKeyDown,
+  placeholder,
+  rows = 3,
+  value,
+}: Props) {
+  const [focused, setFocused] = React.useState(false);
 
-export default class TextArea extends React.Component<Props, State> {
-  // NOTE: we cannot move to React createRef until we audit uses of callsites
-  // that reach into this component and use this instance variable
-  textarea: ?HTMLElement;
-
-  static propTypes = {
-    disabled: PropTypes.bool,
-    errorMessage: PropTypes.string,
-    hasError: PropTypes.bool,
-    helperText: PropTypes.string,
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string,
-    label: PropTypes.string,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func.isRequired,
-    onFocus: PropTypes.func,
-    onKeyDown: PropTypes.func,
-    placeholder: PropTypes.string,
-    rows: PropTypes.number,
-    value: PropTypes.string,
-  };
-
-  static defaultProps: {|
-    disabled: boolean,
-    hasError: boolean,
-    rows: number,
-  |} = {
-    disabled: false,
-    hasError: false,
-    rows: 3,
-  };
-
-  state: State = {
-    focused: false,
-  };
-
-  setTextAreaRef: (ref: ?HTMLTextAreaElement) => void = (
-    ref: ?HTMLTextAreaElement
-  ) => {
-    this.textarea = ref;
-  };
-
-  handleChange: (
-    event: SyntheticInputEvent<HTMLTextAreaElement>
-  ) => void = event => {
-    const { onChange } = this.props;
+  const handleChange = (event: SyntheticInputEvent<HTMLTextAreaElement>) => {
     onChange({ event, value: event.currentTarget.value });
   };
 
-  handleBlur: (
-    event: SyntheticFocusEvent<HTMLTextAreaElement>
-  ) => void = event => {
-    const { onBlur } = this.props;
+  const handleBlur = (event: SyntheticFocusEvent<HTMLTextAreaElement>) => {
+    setFocused(false);
     if (onBlur) {
       onBlur({ event, value: event.currentTarget.value });
     }
   };
 
-  handleFocus: (
-    event: SyntheticFocusEvent<HTMLTextAreaElement>
-  ) => void = event => {
-    const { onFocus } = this.props;
+  const handleFocus = (event: SyntheticFocusEvent<HTMLTextAreaElement>) => {
+    setFocused(false);
     if (onFocus) {
       onFocus({ event, value: event.currentTarget.value });
     }
   };
 
-  handleKeyDown: (
+  const handleKeyDown = (
     event: SyntheticKeyboardEvent<HTMLTextAreaElement>
-  ) => void = event => {
-    const { onKeyDown } = this.props;
+  ) => {
     if (onKeyDown) {
       onKeyDown({ event, value: event.currentTarget.value });
     }
   };
 
-  render(): React.Node {
-    const {
-      disabled,
-      errorMessage,
-      hasError,
-      helperText,
-      id,
-      label,
-      name,
-      placeholder,
-      rows,
-      value,
-    } = this.props;
+  const classes = classnames(
+    styles.textArea,
+    formElement.base,
+    disabled ? formElement.disabled : formElement.enabled,
+    hasError || errorMessage ? formElement.errored : formElement.normal
+  );
 
-    const { focused } = this.state;
-
-    const classes = classnames(
-      styles.textArea,
-      formElement.base,
-      disabled ? formElement.disabled : formElement.enabled,
-      hasError || errorMessage ? formElement.errored : formElement.normal
-    );
-
-    return (
-      <span>
-        {label && <FormLabel id={id} label={label} />}
-        <textarea
-          aria-describedby={errorMessage && focused ? `${id}-error` : null}
-          aria-invalid={errorMessage || hasError ? 'true' : 'false'}
-          className={classes}
-          disabled={disabled}
-          id={id}
-          name={name}
-          onBlur={this.handleBlur}
-          onChange={this.handleChange}
-          onFocus={this.handleFocus}
-          onKeyDown={this.handleKeyDown}
-          placeholder={placeholder}
-          ref={this.setTextAreaRef}
-          rows={rows}
-          value={value}
-        />
-        {helperText && !errorMessage ? (
-          <FormHelperText text={helperText} />
-        ) : null}
-        {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
-      </span>
-    );
-  }
+  return (
+    <span>
+      {label && <FormLabel id={id} label={label} />}
+      <textarea
+        aria-describedby={errorMessage && focused ? `${id}-error` : null}
+        aria-invalid={errorMessage || hasError ? 'true' : 'false'}
+        className={classes}
+        disabled={disabled}
+        id={id}
+        name={name}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        ref={forwardedRef}
+        rows={rows}
+        value={value}
+      />
+      {helperText && !errorMessage ? (
+        <FormHelperText text={helperText} />
+      ) : null}
+      {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
+    </span>
+  );
 }
+
+TextArea.propTypes = {
+  disabled: PropTypes.bool,
+  errorMessage: PropTypes.string,
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.any,
+    }),
+  ]),
+  hasError: PropTypes.bool,
+  helperText: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  label: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  placeholder: PropTypes.string,
+  rows: PropTypes.number,
+  value: PropTypes.string,
+};
+
+function forwardRef(props, ref) {
+  return <TextArea {...props} forwardedRef={ref} />;
+}
+
+forwardRef.displayName = 'TextArea';
+
+export default (React.forwardRef<Props, HTMLTextAreaElement>(
+  forwardRef
+): React$AbstractComponent<Props, HTMLTextAreaElement>);

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -141,12 +141,17 @@ TextArea.propTypes = {
   value: PropTypes.string,
 };
 
-function forwardRef(props, ref) {
+function TextAreaWithRef(props, ref) {
   return <TextArea {...props} forwardedRef={ref} />;
 }
 
-forwardRef.displayName = 'TextArea';
+TextAreaWithRef.displayName = 'ForwardRef(TextArea)';
 
-export default (React.forwardRef<Props, HTMLTextAreaElement>(
-  forwardRef
-): React$AbstractComponent<Props, HTMLTextAreaElement>);
+const TextAreaWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLTextAreaElement
+> = React.forwardRef<Props, HTMLTextAreaElement>(TextAreaWithRef);
+
+TextAreaWithForwardRef.displayName = 'TextArea';
+
+export default TextAreaWithForwardRef;

--- a/packages/gestalt/src/TextArea.jsdom.test.js
+++ b/packages/gestalt/src/TextArea.jsdom.test.js
@@ -43,6 +43,7 @@ describe('TextArea', () => {
     fireEvent.blur(getByDisplayValue('TextArea Text'));
     expect(mockBlur).toHaveBeenCalled();
   });
+
   it('handles change events', () => {
     const mockChange = jest.fn();
     const { container } = render(
@@ -59,6 +60,7 @@ describe('TextArea', () => {
       expect(mockChange).toHaveBeenCalled();
     }
   });
+
   it('handles focus events', () => {
     const mockFocus = jest.fn();
     const { getByDisplayValue } = render(
@@ -73,6 +75,7 @@ describe('TextArea', () => {
     fireEvent.focus(getByDisplayValue('TextArea Text'));
     expect(mockFocus).toHaveBeenCalled();
   });
+
   it('handles key down events', () => {
     const mockKeyDown = jest.fn();
     const { container } = render(
@@ -93,6 +96,22 @@ describe('TextArea', () => {
       });
       expect(mockKeyDown).toHaveBeenCalled();
     }
+  });
+
+  it('forwards a ref to <input />', () => {
+    const ref = React.createRef();
+    render(
+      <TextArea
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+        value="TextArea Text"
+        ref={ref}
+      />
+    );
+    expect(ref.current instanceof HTMLTextAreaElement).toEqual(true);
+    expect(ref.current?.value).toEqual('TextArea Text');
   });
 
   it('shows a label for the text area', () => {

--- a/packages/gestalt/src/TextField.jsdom.test.js
+++ b/packages/gestalt/src/TextField.jsdom.test.js
@@ -75,6 +75,7 @@ describe('TextField', () => {
     fireEvent.blur(getByDisplayValue('TextField Text'));
     expect(mockBlur).toHaveBeenCalled();
   });
+
   it('handles change events', () => {
     const mockChange = jest.fn();
     const { container } = render(
@@ -91,6 +92,7 @@ describe('TextField', () => {
       expect(mockChange).toHaveBeenCalled();
     }
   });
+
   it('handles focus events', () => {
     const mockFocus = jest.fn();
     const { getByDisplayValue } = render(
@@ -105,6 +107,7 @@ describe('TextField', () => {
     fireEvent.focus(getByDisplayValue('TextField Text'));
     expect(mockFocus).toHaveBeenCalled();
   });
+
   it('handles key down events', () => {
     const mockKeyDown = jest.fn();
     const { container } = render(


### PR DESCRIPTION
- Adds ref forwarding to TextArea
- Added ref example to Docs
- Added codemod helper
- Added test for ref 

[ Follows the implementation in TextField ]

### Why?
We have _0_ places in the Pinterest codebase where we set a ref on the current <TextArea />.  

However, without forwardedRefs, refs are set on the component's instance, not the actual input. So in each of those cases, people drill down to get the <textarea />.

That is pretty hacky, so let's add a way for them to get it in a cleaner way.

### Why is this a breaking change?
[https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers
)
> When you start using forwardRef in a component library, you should treat it as a breaking change and release a new major version of your library. This is because your library likely has an observably different behavior (such as what refs get assigned to, and what types are exported), and this can break apps and other libraries that depend on the old behavior.

### Can I get more documentation around this feature?
https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components

### How can we find in which location we already have these legacy refs set?
Run the codemod:

```
cd ~/code/gestalt
yarn run codemod --parser=flow -t=packages/gestalt-codemods/6.2.0-7.0.0/textarea-find-deprecated-refs.js ~/code/pinboard/webapp
```

Which will output the following:

`Update legacy ref on TextArea: /home/<user>/code/pinterest/PasswordStep.js:125:12`

We supply the line number and column name so it brings you to the right location in the editor (`ctrl + P` file seach).

## Test Plan

* Is it tested? YES
~~* Is it accessible?~~
* Is it documented? YES
~~* Have you involved other stakeholders (such as a Pinterest Designer)?~~
