### PR TITLE
[Merge] Fix merging with no label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
       - '-draft'
       - '#approved-reviews-by>=1'
       - 'approved-reviews-by=@gestalt-core'
-      - 'status-success~=^Tests'
+      - 'status-success~=^Test'
       - 'base=master'
     actions:
       merge:


### PR DESCRIPTION
The prior regex was slightly too specific and excluded "Blocking PRs with no label".

Triaged this by looking through [the build log](https://github.com/pinterest/gestalt/runs/879721281) on #1054 which saw Mergify pass but other checks fail.
