### PR TITLE
Button/IconButton: compress onClick or onTouch

### DIFF
--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -129,7 +129,7 @@ card(
 card(
   <Example
     description={`
-    There are two different width options for buttons. The inline buttons are
+    There are two different width options for buttons. The inline buttons
     are sized by the text within the button, whereas the default block buttons
     expand to the full width of their container. The default \`inline\` is false.
   `}

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import React, { type Element } from 'react';
+import React, { useRef, type Element } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
@@ -62,7 +62,10 @@ export default function Button(props: Props): Element<'button'> {
     textColor: textColorProp,
     type = 'button',
   } = props;
+  const buttonElement = useRef(null);
+
   const {
+    compressStyle,
     isTapping,
     handleBlur,
     handleMouseDown,
@@ -71,7 +74,10 @@ export default function Button(props: Props): Element<'button'> {
     handleTouchMove,
     handleTouchCancel,
     handleTouchEnd,
-  } = useTapFeedback();
+  } = useTapFeedback({
+    height: buttonElement?.current?.clientHeight,
+    width: buttonElement?.current?.clientWidth,
+  });
 
   const { name: colorSchemeName } = useColorScheme();
   // We need to make a few exceptions for accessibility reasons in darkMode for red buttons
@@ -97,7 +103,7 @@ export default function Button(props: Props): Element<'button'> {
     [styles.enabled]: !disabled,
     [styles.inline]: inline,
     [styles.block]: !inline,
-    [touchableStyles.tapCompress]: isTapping,
+    [touchableStyles.tapCompress]: !disabled && isTapping,
   });
 
   const textColor =
@@ -132,6 +138,8 @@ export default function Button(props: Props): Element<'button'> {
       onTouchMove={handleTouchMove}
       onTouchStart={handleTouchStart}
       type={type}
+      ref={buttonElement}
+      {...(compressStyle ? { style: compressStyle } : {})}
     >
       {iconEnd ? (
         <Box alignItems="center" display="flex">

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -9,6 +9,8 @@ import icons from './icons/index.js';
 import styles from './Button.css';
 import Text from './Text.js';
 import { useColorScheme } from './contexts/ColorScheme.js';
+import useTapFeedback from './useTapFeedback.js';
+import touchableStyles from './Touchable.css';
 
 const DEFAULT_TEXT_COLORS = {
   blue: 'white',
@@ -60,6 +62,17 @@ export default function Button(props: Props): Element<'button'> {
     textColor: textColorProp,
     type = 'button',
   } = props;
+  const {
+    isTapping,
+    handleBlur,
+    handleMouseDown,
+    handleMouseUp,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchCancel,
+    handleTouchEnd,
+  } = useTapFeedback();
+
   const { name: colorSchemeName } = useColorScheme();
   // We need to make a few exceptions for accessibility reasons in darkMode for red buttons
   const isDarkMode = colorSchemeName === 'darkMode';
@@ -73,7 +86,7 @@ export default function Button(props: Props): Element<'button'> {
     colorClass = 'darkModeGray';
   }
 
-  const classes = classnames(styles.button, {
+  const classes = classnames(styles.button, touchableStyles.tapTransition, {
     [styles.sm]: size === 'sm',
     [styles.md]: size === 'md',
     [styles.lg]: size === 'lg',
@@ -84,6 +97,7 @@ export default function Button(props: Props): Element<'button'> {
     [styles.enabled]: !disabled,
     [styles.inline]: inline,
     [styles.block]: !inline,
+    [touchableStyles.tapCompress]: isTapping,
   });
 
   const textColor =
@@ -109,7 +123,14 @@ export default function Button(props: Props): Element<'button'> {
       className={classes}
       disabled={disabled}
       name={name}
+      onBlur={handleBlur}
       onClick={event => onClick && onClick({ event })}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+      onTouchCancel={handleTouchCancel}
+      onTouchEnd={handleTouchEnd}
+      onTouchMove={handleTouchMove}
+      onTouchStart={handleTouchStart}
       type={type}
     >
       {iconEnd ? (

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import icons from './icons/index.js';
@@ -45,8 +45,11 @@ export default function IconButton({
   padding,
   selected,
   size,
-}: Props): React.Node {
+}: Props): Node {
+  const buttonElement = useRef(null);
+
   const {
+    compressStyle,
     isTapping,
     handleBlur,
     handleMouseDown,
@@ -55,7 +58,10 @@ export default function IconButton({
     handleTouchMove,
     handleTouchCancel,
     handleTouchEnd,
-  } = useTapFeedback();
+  } = useTapFeedback({
+    height: buttonElement?.current?.clientHeight,
+    width: buttonElement?.current?.clientWidth,
+  });
 
   const [isActive, setActive] = React.useState(false);
   const [isFocused, setFocused] = React.useState(false);
@@ -64,7 +70,7 @@ export default function IconButton({
   const classes = classnames(styles.button, touchableStyles.tapTransition, {
     [styles.disabled]: disabled,
     [styles.enabled]: !disabled,
-    [touchableStyles.tapCompress]: isTapping,
+    [touchableStyles.tapCompress]: !disabled && isTapping,
   });
 
   return (
@@ -98,6 +104,8 @@ export default function IconButton({
       onTouchEnd={handleTouchEnd}
       onTouchMove={handleTouchMove}
       onTouchStart={handleTouchStart}
+      ref={buttonElement}
+      {...(compressStyle ? { style: compressStyle } : {})}
       type="button"
     >
       <Pog

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -2,9 +2,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import styles from './IconButton.css';
 import icons from './icons/index.js';
 import Pog from './Pog.js';
+import styles from './IconButton.css';
+import touchableStyles from './Touchable.css';
+import useTapFeedback from './useTapFeedback.js';
 
 type Props = {|
   accessibilityControls?: string,
@@ -44,9 +46,26 @@ export default function IconButton({
   selected,
   size,
 }: Props): React.Node {
+  const {
+    isTapping,
+    handleBlur,
+    handleMouseDown,
+    handleMouseUp,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchCancel,
+    handleTouchEnd,
+  } = useTapFeedback();
+
   const [isActive, setActive] = React.useState(false);
   const [isFocused, setFocused] = React.useState(false);
   const [isHovered, setHovered] = React.useState(false);
+
+  const classes = classnames(styles.button, touchableStyles.tapTransition, {
+    [styles.disabled]: disabled,
+    [styles.enabled]: !disabled,
+    [touchableStyles.tapCompress]: isTapping,
+  });
 
   return (
     <button
@@ -54,21 +73,31 @@ export default function IconButton({
       aria-expanded={accessibilityExpanded}
       aria-haspopup={accessibilityHaspopup}
       aria-label={accessibilityLabel}
-      className={classnames(
-        styles.button,
-        disabled ? styles.disabled : styles.enabled
-      )}
+      className={classes}
       disabled={disabled}
-      onBlur={() => setFocused(false)}
+      onBlur={() => {
+        handleBlur();
+        setFocused(false);
+      }}
       onClick={event => onClick && onClick({ event })}
       onFocus={() => setFocused(true)}
-      onMouseDown={() => setActive(true)}
+      onMouseDown={() => {
+        handleMouseDown();
+        setActive(true);
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => {
         setActive(false);
         setHovered(false);
       }}
-      onMouseUp={() => setActive(false)}
+      onMouseUp={() => {
+        handleMouseUp();
+        setActive(false);
+      }}
+      onTouchCancel={handleTouchCancel}
+      onTouchEnd={handleTouchEnd}
+      onTouchMove={handleTouchMove}
+      onTouchStart={handleTouchStart}
       type="button"
     >
       <Pog

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -62,6 +62,7 @@ function Link({
 
   const className = classnames(
     styles.link,
+    touchableStyles.tapTransition,
     touchableStyles.touchable,
     inline ? styles.inlineBlock : styles.block,
     getRoundingClassName(rounding),

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -49,7 +49,12 @@ function Link({
   tapStyle = 'none',
   target = null,
 }: Props): React.Node {
+  const innerRef = React.useRef(null);
+  // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
+  React.useImperativeHandle(forwardedRef, () => innerRef.current);
+
   const {
+    compressStyle,
     isTapping,
     handleBlur,
     handleMouseDown,
@@ -58,7 +63,10 @@ function Link({
     handleTouchMove,
     handleTouchCancel,
     handleTouchEnd,
-  } = useTapFeedback();
+  } = useTapFeedback({
+    height: innerRef?.current?.clientHeight,
+    width: innerRef?.current?.clientWidth,
+  });
 
   const className = classnames(
     styles.link,
@@ -108,11 +116,14 @@ function Link({
       onTouchMove={handleTouchMove}
       onTouchCancel={handleTouchCancel}
       onTouchEnd={handleTouchEnd}
-      ref={forwardedRef}
+      ref={innerRef}
       rel={[
         ...(target === 'blank' ? ['noopener', 'noreferrer'] : []),
         ...(rel === 'nofollow' ? ['nofollow'] : []),
       ].join(' ')}
+      {...(compressStyle && tapStyle === 'compress'
+        ? { style: compressStyle }
+        : {})}
       role={role}
       target={target ? `_${target}` : null}
     >

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -74,6 +74,7 @@ function TapArea({
   } = useTapFeedback();
 
   const className = classnames(
+    styles.tapTransition,
     styles.touchable,
     getRoundingClassName(rounding),
     {

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -62,7 +62,12 @@ function TapArea({
   tapStyle = 'none',
   rounding = 0,
 }: Props) {
+  const innerRef = React.useRef(null);
+  // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
+  React.useImperativeHandle(forwardedRef, () => innerRef.current);
+
   const {
+    compressStyle,
     isTapping,
     handleBlur,
     handleMouseDown,
@@ -71,7 +76,10 @@ function TapArea({
     handleTouchMove,
     handleTouchCancel,
     handleTouchEnd,
-  } = useTapFeedback();
+  } = useTapFeedback({
+    height: innerRef?.current?.clientHeight,
+    width: innerRef?.current?.clientWidth,
+  });
 
   const className = classnames(
     styles.tapTransition,
@@ -135,8 +143,11 @@ function TapArea({
       onTouchMove={handleTouchMove}
       onTouchCancel={handleTouchCancel}
       onTouchEnd={handleTouchEnd}
-      ref={forwardedRef}
+      ref={innerRef}
       role="button"
+      {...(compressStyle && tapStyle === 'compress'
+        ? { style: compressStyle }
+        : {})}
       tabIndex={disabled ? null : '0'}
     >
       {children}

--- a/packages/gestalt/src/Touchable.css
+++ b/packages/gestalt/src/Touchable.css
@@ -47,6 +47,6 @@
 }
 
 .tapCompress {
-  transform: scale(0.98);
+  transform: scale(0.99);
   transform-origin: center;
 }

--- a/packages/gestalt/src/Touchable.css
+++ b/packages/gestalt/src/Touchable.css
@@ -1,6 +1,5 @@
 .touchable {
   composes: accessibilityOutline from "./Focus.css";
-  transition: transform 85ms ease-out;
 }
 
 .fullHeight {
@@ -43,7 +42,11 @@
   composes: grabbing from "./Cursor.css";
 }
 
+.tapTransition {
+  transition: transform 85ms ease-out;
+}
+
 .tapCompress {
-  transform: scale(0.99);
+  transform: scale(0.98);
   transform-origin: center;
 }

--- a/packages/gestalt/src/Touchable.css.flow
+++ b/packages/gestalt/src/Touchable.css.flow
@@ -10,6 +10,7 @@ declare module.exports: {|
   +'noDrop': string,
   +'pointer': string,
   +'tapCompress': string,
+  +'tapTransition': string,
   +'touchable': string,
   +'zoomIn': string,
   +'zoomOut': string,

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`IconButton renders with disabled state 1`] = `
 <button
   aria-label="Pinterest"
-  className="button disabled"
+  className="button tapTransition disabled"
   disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
@@ -12,6 +12,10 @@ exports[`IconButton renders with disabled state 1`] = `
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
   onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
   type="button"
 >
   <div
@@ -43,7 +47,7 @@ exports[`IconButton renders with disabled state 1`] = `
 exports[`IconButton renders with icon 1`] = `
 <button
   aria-label="Pinterest"
-  className="button enabled"
+  className="button tapTransition enabled"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -51,6 +55,10 @@ exports[`IconButton renders with icon 1`] = `
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
   onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
   type="button"
 >
   <div
@@ -82,7 +90,7 @@ exports[`IconButton renders with icon 1`] = `
 exports[`IconButton renders with svg 1`] = `
 <button
   aria-label="Pinterest"
-  className="button enabled"
+  className="button tapTransition enabled"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -90,6 +98,10 @@ exports[`IconButton renders with svg 1`] = `
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
   onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
   type="button"
 >
   <div

--- a/packages/gestalt/src/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`default 1`] = `
 <a
-  className="link touchable block rounding0 hoverUnderline"
+  className="link tapTransition touchable block rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -23,7 +23,7 @@ exports[`default 1`] = `
 
 exports[`inline 1`] = `
 <a
-  className="link touchable inlineBlock rounding0 hoverUnderline"
+  className="link tapTransition touchable inlineBlock rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -44,7 +44,7 @@ exports[`inline 1`] = `
 
 exports[`regular 1`] = `
 <a
-  className="link touchable block rounding0 hoverUnderline"
+  className="link tapTransition touchable block rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -65,7 +65,7 @@ exports[`regular 1`] = `
 
 exports[`target blank 1`] = `
 <a
-  className="link touchable block rounding0 hoverUnderline"
+  className="link tapTransition touchable block rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -86,7 +86,7 @@ exports[`target blank 1`] = `
 
 exports[`target null 1`] = `
 <a
-  className="link touchable block rounding0 hoverUnderline"
+  className="link tapTransition touchable block rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -107,7 +107,7 @@ exports[`target null 1`] = `
 
 exports[`target self 1`] = `
 <a
-  className="link touchable block rounding0 hoverUnderline"
+  className="link tapTransition touchable block rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -129,7 +129,7 @@ exports[`target self 1`] = `
 exports[`with accessibilitySelected and role 1`] = `
 <a
   aria-selected={true}
-  className="link touchable block rounding0 hoverUnderline"
+  className="link tapTransition touchable block rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -151,7 +151,7 @@ exports[`with accessibilitySelected and role 1`] = `
 
 exports[`with custom rounding, hoverStyle, and tapStyle 1`] = `
 <a
-  className="link touchable block pill"
+  className="link tapTransition touchable block pill"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -172,7 +172,7 @@ exports[`with custom rounding, hoverStyle, and tapStyle 1`] = `
 
 exports[`with nofollow 1`] = `
 <a
-  className="link touchable block rounding0 hoverUnderline"
+  className="link tapTransition touchable block rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -193,7 +193,7 @@ exports[`with nofollow 1`] = `
 
 exports[`with onTap 1`] = `
 <a
-  className="link touchable block rounding0 hoverUnderline"
+  className="link tapTransition touchable block rounding0 hoverUnderline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -10,7 +10,7 @@ exports[`renders correctly when active 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -69,7 +69,7 @@ exports[`renders correctly when inactive 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}

--- a/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
@@ -27,7 +27,7 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
       >
         <a
           aria-selected={true}
-          className="link touchable block pill"
+          className="link tapTransition touchable block pill"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -71,7 +71,7 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
       >
         <a
           aria-selected={false}
-          className="link touchable block pill"
+          className="link tapTransition touchable block pill"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -138,7 +138,7 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
       >
         <a
           aria-selected={true}
-          className="link touchable block pill"
+          className="link tapTransition touchable block pill"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -192,7 +192,7 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
       >
         <a
           aria-selected={false}
-          className="link touchable block pill"
+          className="link tapTransition touchable block pill"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -269,7 +269,7 @@ exports[`<Tabs /> matches snapshot with lg size and wrap 1`] = `
       >
         <a
           aria-selected={true}
-          className="link touchable block pill"
+          className="link tapTransition touchable block pill"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -313,7 +313,7 @@ exports[`<Tabs /> matches snapshot with lg size and wrap 1`] = `
       >
         <a
           aria-selected={false}
-          className="link touchable block pill"
+          className="link tapTransition touchable block pill"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/TapArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TapArea.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TapArea renders 1`] = `
 <div
   aria-disabled={false}
-  className="touchable rounding0 fullWidth pointer"
+  className="tapTransition touchable rounding0 fullWidth pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -27,7 +27,7 @@ exports[`TapArea renders 1`] = `
 exports[`TapArea sets correct mouse cursor 1`] = `
 <div
   aria-disabled={false}
-  className="touchable rounding0 fullWidth zoomIn"
+  className="tapTransition touchable rounding0 fullWidth zoomIn"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -51,7 +51,7 @@ exports[`TapArea sets correct mouse cursor 1`] = `
 exports[`TapArea sets correct rounding 1`] = `
 <div
   aria-disabled={false}
-  className="touchable circle fullWidth pointer"
+  className="tapTransition touchable circle fullWidth pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -75,7 +75,7 @@ exports[`TapArea sets correct rounding 1`] = `
 exports[`TapArea sets fullHeight correctly 1`] = `
 <div
   aria-disabled={false}
-  className="touchable rounding0 fullHeight fullWidth pointer"
+  className="tapTransition touchable rounding0 fullHeight fullWidth pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -99,7 +99,7 @@ exports[`TapArea sets fullHeight correctly 1`] = `
 exports[`TapArea sets fullWidth correctly 1`] = `
 <div
   aria-disabled={false}
-  className="touchable rounding0 pointer"
+  className="tapTransition touchable rounding0 pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -123,7 +123,7 @@ exports[`TapArea sets fullWidth correctly 1`] = `
 exports[`TapArea supports press style 1`] = `
 <div
   aria-disabled={false}
-  className="touchable rounding0 fullWidth pointer"
+  className="tapTransition touchable rounding0 fullWidth pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -73,7 +73,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
           Saved to
            
           <a
-            className="link touchable block rounding0 hoverUnderline"
+            className="link tapTransition touchable block rounding0 hoverUnderline"
             href="https://www.pinterest.com/search/pins/?q=home%20decor"
             onBlur={[Function]}
             onClick={[Function]}
@@ -96,9 +96,16 @@ exports[`<Toast /> Text + Image + Button 1`] = `
         className="box flexNone paddingX2"
       >
         <button
-          className="button lg solid gray enabled block"
+          className="button tapTransition lg solid gray enabled block"
           disabled={false}
+          onBlur={[Function]}
           onClick={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
           type="button"
         >
           <div
@@ -156,7 +163,7 @@ exports[`<Toast /> Text + Image 1`] = `
           Saved to
            
           <a
-            className="link touchable block rounding0 hoverUnderline"
+            className="link tapTransition touchable block rounding0 hoverUnderline"
             href="https://www.pinterest.com/search/pins/?q=home%20decor"
             onBlur={[Function]}
             onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -125,7 +125,7 @@ exports[`Video with children 1`] = `
       >
         <div
           aria-disabled={false}
-          className="touchable rounding0 pointer"
+          className="tapTransition touchable rounding0 pointer"
           onBlur={[Function]}
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -162,7 +162,7 @@ exports[`Video with children 1`] = `
       >
         <div
           aria-disabled={false}
-          className="touchable rounding0 pointer"
+          className="tapTransition touchable rounding0 pointer"
           onBlur={[Function]}
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -293,7 +293,7 @@ exports[`Video with children 1`] = `
       >
         <div
           aria-disabled={false}
-          className="touchable rounding0 pointer"
+          className="tapTransition touchable rounding0 pointer"
           onBlur={[Function]}
           onClick={[Function]}
           onContextMenu={[Function]}

--- a/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
@@ -9,7 +9,7 @@ exports[`VideoControls for double digit minutes 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -140,7 +140,7 @@ exports[`VideoControls for double digit minutes 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -184,7 +184,7 @@ exports[`VideoControls for double digit seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -315,7 +315,7 @@ exports[`VideoControls for double digit seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -359,7 +359,7 @@ exports[`VideoControls for single digit minutes 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -490,7 +490,7 @@ exports[`VideoControls for single digit minutes 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -534,7 +534,7 @@ exports[`VideoControls for single digit seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -665,7 +665,7 @@ exports[`VideoControls for single digit seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -709,7 +709,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -840,7 +840,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="touchable rounding0 pointer"
+      className="tapTransition touchable rounding0 pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}

--- a/packages/gestalt/src/useTapFeedback.js
+++ b/packages/gestalt/src/useTapFeedback.js
@@ -16,7 +16,14 @@ export const keyPressShouldTriggerTap = (
   event: SyntheticKeyboardEvent<TapTargetHTMLElement>
 ): boolean => [SPACE_CHAR_CODE, ENTER_CHAR_CODE].includes(event.charCode);
 
-export default function useTapFeedback(): {|
+export default function useTapFeedback({
+  height,
+  width,
+}: {|
+  height: ?number,
+  width: ?number,
+|}): {|
+  compressStyle: ?{| transform: string |},
   handleBlur: () => void,
   handleMouseDown: () => void,
   handleMouseUp: () => void,
@@ -31,7 +38,20 @@ export default function useTapFeedback(): {|
     x: 0,
     y: 0,
   });
+
+  const [compressStyle, setCompressStyle] = React.useState(null);
+
+  React.useEffect(() => {
+    if (height != null && width != null) {
+      const largestSize = width > height ? width : height;
+      setCompressStyle({
+        transform: isTapping ? `scale(${(largestSize - 4) / largestSize})` : '',
+      });
+    }
+  }, [height, width, isTapping]);
+
   return {
+    compressStyle,
     isTapping,
     handleBlur: () => setTapping(false),
     handleMouseDown: () => setTapping(true),


### PR DESCRIPTION
Follow up from #1054 which got merged by accident because of #1055 

Add compress styles to `Button` and `IconButton`

![button-iconbutton-compress](https://user-images.githubusercontent.com/127199/87693899-5b321800-c742-11ea-9bdd-88162fd3b024.gif)

## FAQ

### Why not make this conditional?
To enforce consistency on how buttons and icon buttons behave. We currently have it set conditionally on `Link` and `TapArea` but want to eventually make it consistent across all components.

### Why does the PR touch so many files?
We updated the class names in `Touchable.css` so the snapshots changed.

### How do you calculate the compress style?

`(width - 4)/width`. If the button is 100px wide: (100-4)/100 = 96%

## Test Plan

Try out the `Button` and `IconButton` out with the new compress style:
* https://deploy-preview-1056--gestalt.netlify.app/#/components/Button
* https://deploy-preview-1056--gestalt.netlify.app/#/components/IconButton