### PR TITLE
Checkbox: Add forward ref (BREAKING CHANGE)

### DIFF
--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -76,9 +76,8 @@ a checkbox and its indeterminism are independent.`,
       },
       {
         name: 'ref',
-        type: "React.Ref<'div'>",
-        description:
-          'Forward the ref to the underlying Box component wrapping the input element',
+        type: "React.Ref<'input'>",
+        description: 'Forward the ref to the underlying input element',
         href: 'refExample',
       },
       {

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -75,6 +75,13 @@ a checkbox and its indeterminism are independent.`,
         type: `({ event: SyntheticInputEvent<HTMLInputElement>, checked: boolean }) => void`,
       },
       {
+        name: 'ref',
+        type: "React.Ref<'div'>",
+        description:
+          'Forward the ref to the underlying Box component wrapping the input element',
+        href: 'refExample',
+      },
+      {
         name: 'size',
         type: `"sm" | "md"`,
         defaultValue: 'md',
@@ -177,6 +184,53 @@ function CheckboxExample() {
         name="error"
         onChange={() => {}}
       />
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    id="refExample"
+    name="Example: ref"
+    description={`
+    A \`Checkbox\` with an anchor ref to a Flyout component
+  `}
+    defaultCode={`
+function CheckboxFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const [checked, setChecked] = React.useState(false);
+
+  const anchorRef = React.useRef();
+
+  return (
+    <Box >
+      <Checkbox
+        checked={checked}
+        id="ref"
+        label="Private Board"
+        name="privacy"
+        ref={anchorRef}
+        onChange={({ checked }) => {
+          setOpen(true)
+          setChecked(checked);
+        }}
+      />
+      {open && (
+        <Flyout
+          anchor={anchorRef.current}
+          idealDirection="up"
+          onDismiss={() => setOpen(false)}
+          shouldFocus={false}
+        >
+          <Box padding={3}>
+            <Text weight="bold">Your board is now </Text>
+            <Text weight="bold">{checked ? 'private': 'public'}</Text>
+          </Box>
+        </Flyout>
+      )}
+    </Box>
   );
 }
 `}

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -16,6 +16,7 @@ type Props = {|
   checked?: boolean,
   disabled?: boolean,
   errorMessage?: string,
+  forwardedRef?: React.Ref<'div'>,
   hasError?: boolean,
   id: string,
   indeterminate?: boolean,
@@ -32,10 +33,11 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
-export default function Checkbox({
+function Checkbox({
   checked = false,
   disabled = false,
   errorMessage,
+  forwardedRef,
   hasError = false,
   id,
   indeterminate = false,
@@ -104,7 +106,7 @@ export default function Checkbox({
         marginRight={-1}
       >
         <Label htmlFor={id}>
-          <Box paddingX={1} position="relative">
+          <Box ref={forwardedRef} paddingX={1} position="relative">
             <input
               checked={checked}
               className={classnames(controlStyles.input, styleSize, {
@@ -174,6 +176,12 @@ Checkbox.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   errorMessage: PropTypes.string,
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.any,
+    }),
+  ]),
   hasError: PropTypes.bool,
   id: PropTypes.string.isRequired,
   indeterminate: PropTypes.bool,
@@ -183,3 +191,18 @@ Checkbox.propTypes = {
   onClick: PropTypes.func,
   size: PropTypes.oneOf(['sm', 'md']),
 };
+
+function CheckboxWithRef(props, ref) {
+  return <Checkbox {...props} forwardedRef={ref} />;
+}
+
+CheckboxWithRef.displayName = 'ForwardRef(Checkbox)';
+
+const CheckboxWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLDivElement
+> = React.forwardRef<Props, HTMLDivElement>(CheckboxWithRef);
+
+CheckboxWithForwardRef.displayName = 'Checkbox';
+
+export default CheckboxWithForwardRef;

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -48,19 +48,21 @@ function Checkbox(props: Props): React.Node {
     onClick,
     size = 'md',
   } = props;
-  const inputElement = React.useRef<?HTMLInputElement>(null);
+
+  const innerRef = React.useRef(null);
+  // When using both forwardedRef and innerRef, React.useimperativehandle() allows a parent component
+  // that renders <Checkbox ref={inputRef} /> to call inputRef.current.focus()
+  // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
+  React.useImperativeHandle(forwardedRef, () => innerRef.current);
+
   const [focused, setFocused] = React.useState(false);
   const [hovered, setHover] = React.useState(false);
 
   React.useEffect(() => {
-    // $FlowFixMe
-    if (forwardedRef && forwardedRef.current) {
-      // $FlowFixMe
-      forwardedRef.current.indeterminate = indeterminate;
-    } else if (inputElement && inputElement.current) {
-      inputElement.current.indeterminate = indeterminate;
+    if (innerRef && innerRef.current) {
+      innerRef.current.indeterminate = indeterminate;
     }
-  }, [forwardedRef, indeterminate]);
+  }, [indeterminate]);
 
   const handleChange = event => {
     if (onChange) {
@@ -126,7 +128,7 @@ function Checkbox(props: Props): React.Node {
               onFocus={() => setFocused(true)}
               onMouseEnter={handleHover}
               onMouseLeave={handleHover}
-              ref={forwardedRef || inputElement}
+              ref={innerRef}
               type="checkbox"
             />
             <div

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -16,7 +16,7 @@ type Props = {|
   checked?: boolean,
   disabled?: boolean,
   errorMessage?: string,
-  forwardedRef?: React.Ref<'div'>,
+  forwardedRef?: React.Ref<'input'>,
   hasError?: boolean,
   id: string,
   indeterminate?: boolean,
@@ -33,29 +33,34 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
-function Checkbox({
-  checked = false,
-  disabled = false,
-  errorMessage,
-  forwardedRef,
-  hasError = false,
-  id,
-  indeterminate = false,
-  label,
-  name,
-  onChange,
-  onClick,
-  size = 'md',
-}: Props): React.Node {
+function Checkbox(props: Props): React.Node {
+  const {
+    checked = false,
+    disabled = false,
+    errorMessage,
+    forwardedRef,
+    hasError = false,
+    id,
+    indeterminate = false,
+    label,
+    name,
+    onChange,
+    onClick,
+    size = 'md',
+  } = props;
   const inputElement = React.useRef<?HTMLInputElement>(null);
   const [focused, setFocused] = React.useState(false);
   const [hovered, setHover] = React.useState(false);
 
   React.useEffect(() => {
-    if (inputElement && inputElement.current) {
+    // $FlowFixMe
+    if (forwardedRef && forwardedRef.current) {
+      // $FlowFixMe
+      forwardedRef.current.indeterminate = indeterminate;
+    } else if (inputElement && inputElement.current) {
       inputElement.current.indeterminate = indeterminate;
     }
-  }, [indeterminate]);
+  }, [forwardedRef, indeterminate]);
 
   const handleChange = event => {
     if (onChange) {
@@ -106,7 +111,7 @@ function Checkbox({
         marginRight={-1}
       >
         <Label htmlFor={id}>
-          <Box ref={forwardedRef} paddingX={1} position="relative">
+          <Box paddingX={1}>
             <input
               checked={checked}
               className={classnames(controlStyles.input, styleSize, {
@@ -121,7 +126,7 @@ function Checkbox({
               onFocus={() => setFocused(true)}
               onMouseEnter={handleHover}
               onMouseLeave={handleHover}
-              ref={inputElement}
+              ref={forwardedRef || inputElement}
               type="checkbox"
             />
             <div
@@ -200,8 +205,8 @@ CheckboxWithRef.displayName = 'ForwardRef(Checkbox)';
 
 const CheckboxWithForwardRef: React$AbstractComponent<
   Props,
-  HTMLDivElement
-> = React.forwardRef<Props, HTMLDivElement>(CheckboxWithRef);
+  HTMLInputElement
+> = React.forwardRef<Props, HTMLInputElement>(CheckboxWithRef);
 
 CheckboxWithForwardRef.displayName = 'Checkbox';
 

--- a/packages/gestalt/src/Checkbox.jsdom.test.js
+++ b/packages/gestalt/src/Checkbox.jsdom.test.js
@@ -26,7 +26,32 @@ describe('Checkbox', () => {
 
   it('forwards a ref to <Box ref={ref}><input/></Box>', () => {
     const ref = React.createRef();
-    render(<Checkbox id="testcheckbox" onChange={mockOnChange} ref={ref} />);
-    expect(ref.current instanceof HTMLDivElement).toEqual(true);
+    render(
+      <Checkbox checked id="testcheckbox" onChange={mockOnChange} ref={ref} />
+    );
+    expect(ref.current instanceof HTMLInputElement).toEqual(true);
+    expect(ref.current?.checked).toEqual(true);
+  });
+
+  it('sets the innermost input to indeterminate with ref', () => {
+    const ref = React.createRef();
+    render(
+      <Checkbox
+        indeterminate
+        id="testcheckbox"
+        onChange={mockOnChange}
+        ref={ref}
+      />
+    );
+    expect(ref.current instanceof HTMLInputElement).toEqual(true);
+    expect(ref.current?.indeterminate).toEqual(true);
+  });
+
+  it('sets the innermost input to indeterminate without ref', () => {
+    const { container } = render(
+      <Checkbox indeterminate id="testcheckbox" onChange={mockOnChange} />
+    );
+    const input = container.querySelector('input');
+    expect(input?.indeterminate).toBe(true);
   });
 });

--- a/packages/gestalt/src/Checkbox.jsdom.test.js
+++ b/packages/gestalt/src/Checkbox.jsdom.test.js
@@ -3,21 +3,30 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import Checkbox from './Checkbox.js';
 
-test('Checkbox handles click', () => {
-  const mockOnClick = jest.fn();
-  const mockOnChange = jest.fn();
-  const { getByLabelText } = render(
-    <form>
-      <label htmlFor="testcheckbox">Label</label>
-      <Checkbox
-        size="sm"
-        id="testcheckbox"
-        onChange={mockOnChange}
-        onClick={mockOnClick}
-      />
-    </form>
-  );
-  getByLabelText('Label').click();
-  expect(mockOnClick).toHaveBeenCalled();
-  expect(mockOnChange).toHaveBeenCalled();
+const mockOnClick = jest.fn();
+const mockOnChange = jest.fn();
+
+describe('Checkbox', () => {
+  it('Checkbox handles click', () => {
+    const { getByLabelText } = render(
+      <form>
+        <label htmlFor="testcheckbox">Label</label>
+        <Checkbox
+          size="sm"
+          id="testcheckbox"
+          onChange={mockOnChange}
+          onClick={mockOnClick}
+        />
+      </form>
+    );
+    getByLabelText('Label').click();
+    expect(mockOnClick).toHaveBeenCalled();
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it('forwards a ref to <Box ref={ref}><input/></Box>', () => {
+    const ref = React.createRef();
+    render(<Checkbox id="testcheckbox" onChange={mockOnChange} ref={ref} />);
+    expect(ref.current instanceof HTMLDivElement).toEqual(true);
+  });
 });

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -12,7 +12,7 @@ exports[`Checkbox 1`] = `
       htmlFor="id"
     >
       <div
-        className="box paddingX1 relative"
+        className="box paddingX1"
       >
         <input
           checked={false}
@@ -62,7 +62,7 @@ exports[`Checkbox checked 1`] = `
       htmlFor="id"
     >
       <div
-        className="box paddingX1 relative"
+        className="box paddingX1"
       >
         <input
           checked={true}
@@ -126,7 +126,7 @@ exports[`Checkbox disabled & checked 1`] = `
       htmlFor="id"
     >
       <div
-        className="box paddingX1 relative"
+        className="box paddingX1"
       >
         <input
           checked={true}
@@ -190,7 +190,7 @@ exports[`Checkbox disabled 1`] = `
       htmlFor="id"
     >
       <div
-        className="box paddingX1 relative"
+        className="box paddingX1"
       >
         <input
           checked={false}
@@ -240,7 +240,7 @@ exports[`Checkbox indeterminate 1`] = `
       htmlFor="id"
     >
       <div
-        className="box paddingX1 relative"
+        className="box paddingX1"
       >
         <input
           checked={false}
@@ -304,7 +304,7 @@ exports[`Checkbox small 1`] = `
       htmlFor="id"
     >
       <div
-        className="box paddingX1 relative"
+        className="box paddingX1"
       >
         <input
           checked={false}
@@ -354,7 +354,7 @@ exports[`Checkbox with error 1`] = `
       htmlFor="id"
     >
       <div
-        className="box paddingX1 relative"
+        className="box paddingX1"
       >
         <input
           checked={false}
@@ -425,7 +425,7 @@ exports[`Checkbox without label 1`] = `
       htmlFor="id"
     >
       <div
-        className="box paddingX1 relative"
+        className="box paddingX1"
       >
         <input
           checked={false}


### PR DESCRIPTION
- Adds ref forwarding to Checkbox
- Added ref example to Docs
- Added test for ref 

### Why?

We have use cases in the Pinterest codebase where we set a ref on a wrapping container for Checkbox in order to anchor other components on it.
<Box><Checkbox/></Box>
 
To abstract this implementation, let's add a way for them to get it in a dryer way.

Moreover, without forwardedRefs, refs are set on the component's instance, not the actual input. So in each of those cases, people drill down to get the <input />.

That is pretty hacky, so let's add a way for them to get it in a cleaner way.

### Why is this a breaking change?
[https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers
)
> When you start using forwardRef in a component library, you should treat it as a breaking change and release a new major version of your library. This is because your library likely has an observably different behavior (such as what refs get assigned to, and what types are exported), and this can break apps and other libraries that depend on the old behavior.

### Can I get more documentation around this feature?
https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components

## Test Plan

* Is it tested? YES
~~* Is it accessible?~~
* Is it documented? YES
~~* Have you involved other stakeholders (such as a Pinterest Designer)?~~

Browser | validating the click target is still correct | validating layout looks good | it's accessible (you can hit space to toggle the checkbox) | Demo
------------ | ------------- | ------------- | ------------- | -------------
Chrome | CORRECT | CORRECT | CORRECT | ![Kapture 2020-07-17 at 11 22 34](https://user-images.githubusercontent.com/10593890/87818666-d5849a00-c81f-11ea-891e-462ca32df401.gif)
Safari | CORRECT | CORRECT | FAILS unrelated to this change |![Kapture 2020-07-17 at 11 25 12](https://user-images.githubusercontent.com/10593890/87818888-39a75e00-c820-11ea-9b85-63a6b707a5e9.gif)
IE11 | CORRECT | CORRECT | CORRECT |  ![Kapture 2020-07-17 at 11 21 04](https://user-images.githubusercontent.com/10593890/87818591-a66e2880-c81f-11ea-844f-7dabce1e77e2.gif)

