### PR TITLE
Pulsar: update default size from 135px to 136px

### DIFF
--- a/docs/src/Pulsar.doc.js
+++ b/docs/src/Pulsar.doc.js
@@ -28,7 +28,7 @@ card(
         name: 'size',
         type: `number`,
         description: `Use numbers for pixel sizes`,
-        defaultValue: 120,
+        defaultValue: 136,
       },
     ]}
   />

--- a/packages/gestalt/src/Pulsar.js
+++ b/packages/gestalt/src/Pulsar.js
@@ -9,7 +9,7 @@ type Props = {|
   size?: number,
 |};
 
-export default function Pulsar({ paused, size = 135 }: Props): React.Node {
+export default function Pulsar({ paused, size = 136 }: Props): React.Node {
   return (
     <Box
       dangerouslySetInlineStyle={{

--- a/packages/gestalt/src/__snapshots__/Pulsar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pulsar.test.js.snap
@@ -7,9 +7,9 @@ exports[`Pulsar is hidden when paused 1`] = `
     Object {
       "animationIterationCount": 0,
       "boxShadow": "none",
-      "height": 135,
+      "height": 136,
       "outline": "none",
-      "width": 135,
+      "width": 136,
     }
   }
 >
@@ -30,9 +30,9 @@ exports[`Pulsar renders 1`] = `
     Object {
       "animationIterationCount": "infinite",
       "boxShadow": "none",
-      "height": 135,
+      "height": 136,
       "outline": "none",
-      "width": 135,
+      "width": 136,
     }
   }
 >


### PR DESCRIPTION
Changed the default size from 135px to 136px since our boint system encourages lengths to be multiple of 4px. We actually had 136px as the default initially until we changed the default to 120px in #126 and then to 135px in #169 

Also updated the doc, which had wrong default size.

## Test Plan

![Screenshot 2020-07-20 15 54 36](https://user-images.githubusercontent.com/5341184/87994274-5f8f6580-caa1-11ea-9b84-314893304c2d.png)
