### PR TITLE
InputButton/Button: Add forward ref (BREAKING CHANGE)

### DIFF
--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -89,6 +89,12 @@ card(
         type: '({ event: SyntheticMouseEvent<> }) => void',
       },
       {
+        name: 'ref',
+        type: "React.Ref<'button'>",
+        description: 'Forward the ref to the underlying button element',
+        href: 'refExample',
+      },
+      {
         name: 'size',
         type: `"sm" | "md" | "lg"`,
         defaultValue: 'md',
@@ -337,7 +343,7 @@ function A11yExPopup() {
   const anchorRef = React.useRef(null);
 
   return (
-    <Box>
+    <>
       <Box
         color="lightGray"
         display="inlineBlock"
@@ -363,7 +369,7 @@ function A11yExPopup() {
           </Box>
         </Flyout>
       )}
-    </Box>
+    <>
   );
 }
 `}
@@ -387,7 +393,7 @@ function A11yExDisclosure() {
   const [isOpen, setOpen] = React.useState(false);
 
   return (
-    <Box>
+    <>
       <Box
         color="lightGray"
         display="inlineBlock"
@@ -407,10 +413,51 @@ function A11yExDisclosure() {
           <Text>I am an accordion panel.</Text>
         </Box>
       )}
-    </Box>
+    </>
   );
 }
 `}
+  />
+);
+
+card(
+  <Example
+    id="refExample"
+    name="Example: ref"
+    description={`
+    A \`Button\` with an anchor ref to a Flyout component
+  `}
+    defaultCode={`
+function ButtonFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const [checked, setChecked] = React.useState(false);
+
+  const anchorRef = React.useRef(null);
+
+  return (
+    <>
+      <Button
+        inline
+        color="red"
+        onClick={() => setOpen(true)}
+        ref={anchorRef}
+        text="Submit"
+      />
+      {open && (
+        <Flyout
+          anchor={anchorRef.current}
+          idealDirection="right"
+          onDismiss={() => setOpen(false)}
+          shouldFocus={false}
+        >
+          <Box padding={3}>
+            <Text weight="bold">Your message was submitted!</Text>
+          </Box>
+        </Flyout>
+      )}
+    </>
+  );
+}`}
   />
 );
 

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -89,6 +89,12 @@ card(
         href: 'paddingCombinations',
       },
       {
+        name: 'ref',
+        type: "React.Ref<'button'>",
+        description: 'Forward the ref to the underlying button element',
+        href: 'refExample',
+      },
+      {
         name: 'selected',
         type: 'boolean',
         defaultValue: false,
@@ -135,7 +141,7 @@ function A11yExPopup() {
   const anchorRef = React.useRef(null);
 
   return (
-    <Box>
+    <>
       <Box display="inlineBlock" ref={anchorRef}>
         <IconButton
           accessibilityLabel="see more"
@@ -156,7 +162,7 @@ function A11yExPopup() {
           </Box>
         </Flyout>
       )}
-    </Box>
+    </>
   );
 }
 `}
@@ -180,7 +186,7 @@ function A11yExDisclosure() {
   const [isOpen, setOpen] = React.useState(false);
 
   return (
-    <Box>
+    <>
       <Box display="inlineBlock">
         <IconButton
           accessibilityControls="accordion-panel"
@@ -201,10 +207,52 @@ function A11yExDisclosure() {
           <Text>I am an accordion panel.</Text>
         </Box>
       )}
-    </Box>
+    </>
   );
 }
 `}
+  />
+);
+
+card(
+  <Example
+    id="refExample"
+    name="Example: ref"
+    description={`
+    A \`IconButton\` with an anchor ref to a Flyout component
+  `}
+    defaultCode={`
+function IconButtonFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const [checked, setChecked] = React.useState(false);
+
+  const anchorRef = React.useRef(null);
+
+  return (
+    <>
+      <IconButton
+        accessibilityLabel="Love Reaction"
+        bgColor="white"
+        icon="heart"
+        iconColor="red"
+        onClick={() => setOpen(true)}
+        ref={anchorRef}
+      />
+      {open && (
+        <Flyout
+          anchor={anchorRef.current}
+          idealDirection="right"
+          onDismiss={() => setOpen(false)}
+          shouldFocus={false}
+        >
+          <Box padding={3}>
+            <Text weight="bold">You loved this pin!</Text>
+          </Box>
+        </Flyout>
+      )}
+    </>
+  );
+}`}
   />
 );
 

--- a/packages/gestalt/src/Button.jsdom.test.js
+++ b/packages/gestalt/src/Button.jsdom.test.js
@@ -3,11 +3,20 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import Button from './Button.js';
 
-test('Button handles click', () => {
-  const mockOnClick = jest.fn();
-  const { getByText } = render(
-    <Button text="ButtonText" onClick={mockOnClick} />
-  );
-  getByText('ButtonText').click();
-  expect(mockOnClick).toHaveBeenCalled();
+describe('Button', () => {
+  it('handles click', () => {
+    const mockOnClick = jest.fn();
+    const { getByText } = render(
+      <Button text="ButtonText" onClick={mockOnClick} />
+    );
+    getByText('ButtonText').click();
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it('forwards a ref to the innermost button element', () => {
+    const ref = React.createRef();
+    render(<Button disabled text="test" ref={ref} />);
+    expect(ref.current instanceof HTMLButtonElement).toEqual(true);
+    expect(ref.current?.disabled).toEqual(true);
+  });
 });

--- a/packages/gestalt/src/Checkbox.jsdom.test.js
+++ b/packages/gestalt/src/Checkbox.jsdom.test.js
@@ -24,7 +24,7 @@ describe('Checkbox', () => {
     expect(mockOnChange).toHaveBeenCalled();
   });
 
-  it('forwards a ref to <Box ref={ref}><input/></Box>', () => {
+  it('forwards a ref to the innermost input element', () => {
     const ref = React.createRef();
     render(
       <Checkbox checked id="testcheckbox" onChange={mockOnChange} ref={ref} />

--- a/packages/gestalt/src/IconButton.jsdom.test.js
+++ b/packages/gestalt/src/IconButton.jsdom.test.js
@@ -1,0 +1,13 @@
+// @flow strict
+import React from 'react';
+import { render } from '@testing-library/react';
+import IconButton from './IconButton.js';
+
+describe('IconButton', () => {
+  it('forwards a ref to the innermost button element', () => {
+    const ref = React.createRef();
+    render(<IconButton disabled accessibilityLabel="test" ref={ref} />);
+    expect(ref.current instanceof HTMLButtonElement).toEqual(true);
+    expect(ref.current?.disabled).toEqual(true);
+  });
+});


### PR DESCRIPTION
- Adds ref forwarding to `IconButton` & `Button`
- Added ref example to Docs
- Added test for ref 

+ Cleaned examples to use empty tags when needed.

### Why?

We have use cases in the Pinterest codebase where we set a ref on a wrapping container for `IconButton`/`Button` in order to anchor other components on it.
`<Box><IconButton/></Box>`
 
To abstract this implementation, let's add a way for them to get it in a dryer way.

Moreover, without `forwardedRef`s, refs are set on the component's instance, not the actual input. So in each of those cases, people drill down to get the innermost `<button />` element.

That is pretty hacky, so let's add a way for them to get it in a cleaner way.

### Why is this a breaking change?
[https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers
)
> When you start using `forwardRef` in a component library, you should treat it as a breaking change and release a new major version of your library. This is because your library likely has an observably different behavior (such as what refs get assigned to, and what types are exported), and this can break apps and other libraries that depend on the old behavior.

### Can I get more documentation around this feature?
https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components

## Test Plan

* Is it tested? YES
~~* Is it accessible?~~
* Is it documented? YES
~~* Have you involved other stakeholders (such as a Pinterest Designer)?~~

