### PR TITLE
Box: add test for flowtypes

### DIFF
--- a/packages/gestalt/src/Box.test.js
+++ b/packages/gestalt/src/Box.test.js
@@ -107,3 +107,12 @@ test('Box has correct zIndex', () => {
   const tree = create(<Box zIndex={zIndexStub} />).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Box is flowtyped correctly', () => {
+  // Disable console error output from proptypes package when running tests
+  jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+
+  // $FlowExpectedError[incompatible-type] Cannot create `Box` element because  number [1] is incompatible with  enum [2] in property `margin.
+  const IncorrectMargin = <Box margin={33} />;
+  expect(IncorrectMargin.type).toEqual(Box);
+});


### PR DESCRIPTION
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

In #986 we discovered `Box` was untyped for a while. In this PR we add an initial test to confirm Box is correctly typed.

Next steps:
* Add this kind of test to other components.

## Test Plan

* Flow & jest tests pass
* When changing `margin` on `Box` to a valid type, we should see an error:
![Screen Shot 2020-07-23 at 8 53 12 AM](https://user-images.githubusercontent.com/127199/88309080-b58f2380-ccc2-11ea-8fc5-f45d2ecc18b3.png)

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
