### PR TITLE
RadioButton: Add forward ref (BREAKING CHANGE)

### DIFF
--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -55,6 +55,12 @@ card(
         type: 'string',
       },
       {
+        name: 'ref',
+        type: "React.Ref<'input'>",
+        description: 'Forward the ref to the underlying input element',
+        href: 'refExample',
+      },
+      {
         name: 'size',
         type: `"sm" | "md"`,
         description: `sm: 16px, md: 24px`,
@@ -124,6 +130,128 @@ function RadioButtonExample() {
           value="other"
         />
       </Box>
+    </Box>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    id="ref"
+    name="Example: ref"
+    description={`A \`RadioButton\` can be focused via \`ref\``}
+    defaultCode={`
+function RadioButtonExample() {
+  const ref = React.useRef();
+  const [option, setOption] = React.useState();
+
+  return (
+    <Row gap={2}>
+      <Button
+        text="Focus the RadioButton"
+        onClick={() => ref.current.focus()}
+      />
+      <Stack gap={2}>
+        <RadioButton
+          id="proceed"
+          checked={option === "proceed"}
+          label="Proceed"
+          onChange={() => setOption("proceed")}
+          value="usa"
+          ref={ref}
+        />
+        <RadioButton
+          id="notProceed"
+          checked={option === "notProceed"}
+          label="Do Not Proceed"
+          onChange={() => setOption("notProceed")}
+          value="usa"
+        />
+      </Stack>
+    </Row>
+  );
+}`}
+  />
+);
+
+card(
+  <Example
+    name="Example: RadioButton and Flyout"
+    description={`
+    A \`RadioButton\` with an anchor ref to a Flyout component doesn't pass the correct positioning to the Flyout. Instead set the anchor ref to the parent container.
+  `}
+    defaultCode={`
+
+function ErrorFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const [option, setOption] = React.useState(false);
+  const anchorCatRef = React.useRef();
+  const anchorDogRef = React.useRef();
+
+  return (
+    <Box>
+      <Stack gap={2}>
+        <Box display="inlineBlock" ref={anchorCatRef}>
+          <RadioButton
+            id="cat"
+            checked={option === "cat"}
+            label="I'm a cat person"
+            onChange={() => {
+              setOpen(true)
+              setOption("cat")}
+            }
+            value="cat"
+          />
+        </Box>
+        <Box display="inlineBlock" ref={anchorDogRef}>
+          <RadioButton
+            id="dog"
+            checked={option === "dog"}
+            label="I'm a dog person"
+            onChange={() => {
+              setOpen(true)
+              setOption('dog')}
+            }
+            value="dog"
+          />
+        </Box>
+      </Stack>
+      {open &&
+        <Layer>
+          <Flyout
+            anchor={option === "cat" ? anchorCatRef.current  : anchorDogRef.current}
+            color="red"
+            idealDirection="right"
+            onDismiss={() => setOpen(false)}
+            positionRelativeToAnchor={false}
+            shouldFocus={false}
+            size="md"
+          >
+            <Link
+              href={
+                option === "cat"
+                  ? "https://www.pinterest.com/search/pins/?q=cats"
+                  : "https://www.pinterest.com/search/pins/?q=dogs"
+              }
+              target='blank'
+            >
+              <Box padding={3}>
+                <Text
+                  color="white"
+                  weight="bold"
+                >
+                { option === "cat"
+                    ? "Check cats on Pinterest!"
+                    : "Check dogs on Pinterest!"
+                }
+                </Text>
+              </Box>
+            </Link>
+          </Flyout>
+        </Layer>
+      }
     </Box>
   );
 }

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -12,6 +12,7 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 type Props = {|
   checked?: boolean,
   disabled?: boolean,
+  forwardedRef?: React.Ref<'input'>,
   id: string,
   label?: string,
   name?: string,
@@ -23,136 +24,140 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
-type State = {|
-  focused: boolean,
-  hovered: boolean,
-|};
+function RadioButton(props: Props): React.Node {
+  const {
+    checked = false,
+    disabled = false,
+    id,
+    forwardedRef,
+    label,
+    name,
+    onChange,
+    value,
+    size = 'md',
+  } = props;
 
-export default class RadioButton extends React.Component<Props, State> {
-  static propTypes = {
-    checked: PropTypes.bool,
-    disabled: PropTypes.bool,
-    id: PropTypes.string.isRequired,
-    label: PropTypes.string,
-    name: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
-    value: PropTypes.string.isRequired,
-    size: PropTypes.oneOf(['sm', 'md']),
-  };
+  const [focused, setFocused] = React.useState(false);
+  const [hovered, setHover] = React.useState(false);
 
-  static defaultProps: {|
-    checked: boolean,
-    disabled: boolean,
-    size?: 'sm' | 'md',
-  |} = {
-    checked: false,
-    disabled: false,
-    size: 'md',
-  };
-
-  state: State = {
-    focused: false,
-    hovered: false,
-  };
-
-  handleChange: (
+  const handleChange: (
     event: SyntheticInputEvent<HTMLInputElement>
-  ) => mixed = event => {
-    const { onChange } = this.props;
-    const { checked } = event.target;
-    onChange({ checked, event });
-  };
+  ) => mixed = event => onChange({ checked: event.target.checked, event });
 
-  handleBlur: () => void = () => this.setState({ focused: false });
+  const handleBlur: () => void = () => setFocused(false);
 
-  handleFocus: () => void = () => this.setState({ focused: true });
+  const handleFocus: () => void = () => setFocused(true);
 
-  handleHover: (hovered: boolean) => void = (hovered: boolean) => {
-    this.setState({ hovered });
-  };
+  const handleHover: (isHovered: boolean) => void = (isHovered: boolean) =>
+    setHover(isHovered);
 
-  render(): React.Node {
-    const { checked, disabled, id, label, name, size, value } = this.props;
-    const { focused, hovered } = this.state;
+  let borderStyle = styles.Border;
+  if (disabled && checked) {
+    borderStyle = styles.BorderDisabledChecked;
+  } else if (!disabled && checked) {
+    borderStyle = styles.BorderDarkGray;
+  } else if (!disabled && hovered) {
+    borderStyle = styles.BorderHovered;
+  }
 
-    let borderStyle = styles.Border;
-    if (disabled && checked) {
-      borderStyle = styles.BorderDisabledChecked;
-    } else if (!disabled && checked) {
-      borderStyle = styles.BorderDarkGray;
-    } else if (!disabled && hovered) {
-      borderStyle = styles.BorderHovered;
-    }
+  let borderWidth = styles.BorderUnchecked;
+  if (disabled && !checked) {
+    borderWidth = styles.BorderDisabled;
+  } else if (checked && size === 'sm') {
+    borderWidth = styles.BorderCheckedSm;
+  } else if (checked && size === 'md') {
+    borderWidth = styles.BorderCheckedMd;
+  }
 
-    let borderWidth = styles.BorderUnchecked;
-    if (disabled && !checked) {
-      borderWidth = styles.BorderDisabled;
-    } else if (checked && size === 'sm') {
-      borderWidth = styles.BorderCheckedSm;
-    } else if (checked && size === 'md') {
-      borderWidth = styles.BorderCheckedMd;
-    }
+  const styleSize = size === 'sm' ? controlStyles.sizeSm : controlStyles.sizeMd;
 
-    const styleSize =
-      size === 'sm' ? controlStyles.sizeSm : controlStyles.sizeMd;
+  const bgStyle = disabled && !checked ? styles.BgDisabled : styles.BgEnabled;
 
-    const bgStyle = disabled && !checked ? styles.BgDisabled : styles.BgEnabled;
+  return (
+    <Box
+      alignItems="center"
+      display="flex"
+      justifyContent="start"
+      marginLeft={-1}
+      marginRight={-1}
+    >
+      <Label htmlFor={id}>
+        <Box paddingX={1}>
+          <div
+            className={classnames(
+              bgStyle,
+              borderStyle,
+              borderWidth,
+              styleSize,
+              styles.RadioButton,
+              {
+                [styles.RadioButtonIsFocused]: focused,
+              }
+            )}
+          >
+            <input
+              checked={checked}
+              className={classnames(controlStyles.input, styleSize, {
+                [styles.InputEnabled]: !disabled,
+              })}
+              disabled={disabled}
+              id={id}
+              name={name}
+              onBlur={handleBlur}
+              onChange={handleChange}
+              onFocus={handleFocus}
+              onMouseEnter={() => handleHover(true)}
+              onMouseLeave={() => handleHover(false)}
+              ref={forwardedRef}
+              type="radio"
+              value={value}
+            />
+          </div>
+        </Box>
+      </Label>
 
-    return (
-      <Box
-        alignItems="center"
-        display="flex"
-        justifyContent="start"
-        marginLeft={-1}
-        marginRight={-1}
-      >
+      {label && (
         <Label htmlFor={id}>
           <Box paddingX={1}>
-            <div
-              className={classnames(
-                bgStyle,
-                borderStyle,
-                borderWidth,
-                styleSize,
-                styles.RadioButton,
-                {
-                  [styles.RadioButtonIsFocused]: focused,
-                }
-              )}
+            <Text
+              color={disabled ? 'gray' : undefined}
+              size={size === 'sm' ? 'md' : 'lg'}
             >
-              <input
-                checked={checked}
-                className={classnames(controlStyles.input, styleSize, {
-                  [styles.InputEnabled]: !disabled,
-                })}
-                disabled={disabled}
-                id={id}
-                name={name}
-                onBlur={this.handleBlur}
-                onChange={this.handleChange}
-                onFocus={this.handleFocus}
-                onMouseEnter={() => this.handleHover(true)}
-                onMouseLeave={() => this.handleHover(false)}
-                type="radio"
-                value={value}
-              />
-            </div>
+              {label}
+            </Text>
           </Box>
         </Label>
-
-        {label && (
-          <Label htmlFor={id}>
-            <Box paddingX={1}>
-              <Text
-                color={disabled ? 'gray' : undefined}
-                size={size === 'sm' ? 'md' : 'lg'}
-              >
-                {label}
-              </Text>
-            </Box>
-          </Label>
-        )}
-      </Box>
-    );
-  }
+      )}
+    </Box>
+  );
 }
+
+RadioButton.propTypes = {
+  checked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.any,
+    }),
+  ]),
+  label: PropTypes.string,
+  name: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
+  size: PropTypes.oneOf(['sm', 'md']),
+};
+
+function RadioButtonWithRef(props, ref) {
+  return <RadioButton {...props} forwardedRef={ref} />;
+}
+
+const RadioButtonWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLInputElement
+> = React.forwardRef<Props, HTMLInputElement>(RadioButtonWithRef);
+
+RadioButtonWithForwardRef.displayName = 'RadioButton';
+
+export default RadioButtonWithForwardRef;

--- a/packages/gestalt/src/RadioButton.jsdom.test.js
+++ b/packages/gestalt/src/RadioButton.jsdom.test.js
@@ -1,0 +1,22 @@
+// @flow strict
+import React from 'react';
+import { render } from '@testing-library/react';
+import RadioButton from './RadioButton.js';
+
+const mockOnChange = jest.fn();
+
+describe('RadioButton', () =>
+  it('forwards a ref to <Box ref={ref}><input/></Box>', () => {
+    const ref = React.createRef();
+    render(
+      <RadioButton
+        value="test"
+        checked
+        id="testRadioButton"
+        onChange={mockOnChange}
+        ref={ref}
+      />
+    );
+    expect(ref.current instanceof HTMLInputElement).toEqual(true);
+    expect(ref.current?.checked).toEqual(true);
+  }));


### PR DESCRIPTION
- refactored to function component
- Adds ref forwarding to RadioButton
- Added ref example to Docs
- Added test for ref 

Link to same issue as Checkbox https://github.com/pinterest/gestalt/issues/1068

### Why?

Without forwardedRefs, refs are set on the component's instance, not the actual input. So in each of those cases, people drill down to get the input.

That is pretty hacky, so let's add a way for them to get it in a cleaner way.

### Why is this a breaking change?
[https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers
)
> When you start using forwardRef in a component library, you should treat it as a breaking change and release a new major version of your library. This is because your library likely has an observably different behavior (such as what refs get assigned to, and what types are exported), and this can break apps and other libraries that depend on the old behavior.

### Can I get more documentation around this feature?
https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components