### PR TITLE
Docs: remove sticky header

### DIFF
--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -7,7 +7,6 @@ import {
   IconButton,
   Tooltip,
   Link as GestaltLink,
-  Sticky,
 } from 'gestalt';
 import DocSearch from './DocSearch.js';
 import Link from './Link.js';
@@ -35,105 +34,103 @@ export default function Header({ colorScheme, onChangeColorScheme }: Props) {
   };
 
   return (
-    <Sticky top={0}>
-      <Box
-        paddingY={2}
-        paddingX={4}
-        mdPaddingX={6}
-        color="pine"
-        display="flex"
-        direction="row"
-        alignItems="center"
-      >
-        <Box marginStart={-2} marginEnd={-2}>
-          <Text color="white" weight="bold">
-            <Link to="/">
-              <Box padding={2}>
-                <Box
-                  display="flex"
-                  direction="row"
-                  alignItems="center"
-                  marginLeft={-1}
-                  marginRight={-1}
-                >
-                  <Box paddingX={1}>
-                    <Icon
-                      icon="pinterest"
-                      color="white"
-                      size={24}
-                      accessibilityLabel="Pinterest Logo"
-                    />
-                  </Box>
-                  <Box paddingX={1}>Gestalt</Box>
-                </Box>
-              </Box>
-            </Link>
-          </Text>
-        </Box>
-        <Box flex="grow" />
-        <Box display="flex" alignItems="center">
-          <DocSearch />
-
-          <Box display="none" mdDisplay="flex" alignItems="center">
-            <Tooltip
-              inline
-              text={isRTL ? 'Left-To-Right View' : 'Right-To-Left View'}
-            >
-              <IconButton
-                size="md"
-                accessibilityLabel="toggle page direction: Left-To-Right / Right-To-Left View"
-                iconColor="white"
-                dangerouslySetSvgPath={togglePageDirSvgPath}
-                onClick={toggleRTL}
-              />
-            </Tooltip>
-            <Tooltip
-              inline
-              text={
-                colorScheme === 'light' ? 'Dark-Mode View' : 'Light-Mode View'
-              }
-            >
-              <IconButton
-                size="md"
-                accessibilityLabel="toggle color scheme: light / dark mode views"
-                iconColor="white"
-                icon="workflow-status-in-progress"
-                onClick={() => onChangeColorScheme()}
-              />
-            </Tooltip>
-            <Tooltip
-              inline
-              text="Opens Codesandbox ready to start coding with Gestalt"
-            >
-              <Text color="white">
-                <GestaltLink
-                  href="https://codesandbox.io/s/k5plvp9v8v"
-                  target="blank"
-                >
-                  <Box padding={2}>Playground</Box>
-                </GestaltLink>
-              </Text>
-            </Tooltip>
-            <Text color="white">
-              <GestaltLink
-                href="https://github.com/pinterest/gestalt"
-                target="blank"
+    <Box
+      paddingY={2}
+      paddingX={4}
+      mdPaddingX={6}
+      color="pine"
+      display="flex"
+      direction="row"
+      alignItems="center"
+    >
+      <Box marginStart={-2} marginEnd={-2}>
+        <Text color="white" weight="bold">
+          <Link to="/">
+            <Box padding={2}>
+              <Box
+                display="flex"
+                direction="row"
+                alignItems="center"
+                marginLeft={-1}
+                marginRight={-1}
               >
-                <Box padding={2}>GitHub</Box>
-              </GestaltLink>
-            </Text>
-          </Box>
-          <Box display="flex" mdDisplay="none" alignItems="center">
+                <Box paddingX={1}>
+                  <Icon
+                    icon="pinterest"
+                    color="white"
+                    size={24}
+                    accessibilityLabel="Pinterest Logo"
+                  />
+                </Box>
+                <Box paddingX={1}>Gestalt</Box>
+              </Box>
+            </Box>
+          </Link>
+        </Text>
+      </Box>
+      <Box flex="grow" />
+      <Box display="flex" alignItems="center">
+        <DocSearch />
+
+        <Box display="none" mdDisplay="flex" alignItems="center">
+          <Tooltip
+            inline
+            text={isRTL ? 'Left-To-Right View' : 'Right-To-Left View'}
+          >
             <IconButton
               size="md"
-              accessibilityLabel={`${isSidebarOpen ? 'Hide' : 'Show'} Menu`}
+              accessibilityLabel="toggle page direction: Left-To-Right / Right-To-Left View"
               iconColor="white"
-              icon="menu"
-              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+              dangerouslySetSvgPath={togglePageDirSvgPath}
+              onClick={toggleRTL}
             />
-          </Box>
+          </Tooltip>
+          <Tooltip
+            inline
+            text={
+              colorScheme === 'light' ? 'Dark-Mode View' : 'Light-Mode View'
+            }
+          >
+            <IconButton
+              size="md"
+              accessibilityLabel="toggle color scheme: light / dark mode views"
+              iconColor="white"
+              icon="workflow-status-in-progress"
+              onClick={() => onChangeColorScheme()}
+            />
+          </Tooltip>
+          <Tooltip
+            inline
+            text="Opens Codesandbox ready to start coding with Gestalt"
+          >
+            <Text color="white">
+              <GestaltLink
+                href="https://codesandbox.io/s/k5plvp9v8v"
+                target="blank"
+              >
+                <Box padding={2}>Playground</Box>
+              </GestaltLink>
+            </Text>
+          </Tooltip>
+          <Text color="white">
+            <GestaltLink
+              href="https://github.com/pinterest/gestalt"
+              target="blank"
+            >
+              <Box padding={2}>GitHub</Box>
+            </GestaltLink>
+          </Text>
+        </Box>
+        <Box display="flex" mdDisplay="none" alignItems="center">
+          <IconButton
+            size="md"
+            accessibilityLabel={`${isSidebarOpen ? 'Hide' : 'Show'} Menu`}
+            iconColor="white"
+            icon="menu"
+            onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+          />
         </Box>
       </Box>
-    </Sticky>
+    </Box>
   );
 }


### PR DESCRIPTION
The `<Sticky />` header causes issues in our docs. It was introduced as part of #952 /cc @AlbertCarreras 

## Before
![Screen Shot 2020-07-23 at 2 22 06 PM](https://user-images.githubusercontent.com/127199/88340179-34e71c00-ccf0-11ea-9f96-2d6fdb36c286.png)

## After
![Screen Shot 2020-07-23 at 2 21 26 PM](https://user-images.githubusercontent.com/127199/88340184-37497600-ccf0-11ea-8cd7-de8003ebe0c8.png)

