### PR TITLE
useFocusVisible: Only show focus ring on keyboard input

### DIFF
--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -5,11 +5,9 @@
 
 .button {
   composes: borderBox minWidth60 from "./Layout.css";
-  border-radius: 24px;
-}
-
-.solid {
   composes: noBorder from "./Borders.css";
+  border-radius: 24px;
+  outline: 0;
 }
 
 .sm {
@@ -40,7 +38,6 @@
 }
 
 .enabled {
-  composes: accessibilityOutline from "./Focus.css";
   composes: pointer from "./Cursor.css";
 }
 

--- a/packages/gestalt/src/Button.css.flow
+++ b/packages/gestalt/src/Button.css.flow
@@ -15,7 +15,6 @@ declare module.exports: {|
   +'red': string,
   +'selected': string,
   +'sm': string,
-  +'solid': string,
   +'transparent': string,
   +'white': string,
 |};

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -10,8 +10,10 @@ import styles from './Button.css';
 import Text from './Text.js';
 import { useColorScheme } from './contexts/ColorScheme.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import useFocusVisible from './useFocusVisible.js';
 import useTapFeedback from './useTapFeedback.js';
 import touchableStyles from './Touchable.css';
+import focusStyles from './Focus.css';
 
 const DEFAULT_TEXT_COLORS = {
   blue: 'white',
@@ -99,23 +101,21 @@ function Button(props: Props): React.Element<'button'> {
     colorClass = 'darkModeGray';
   }
 
-  const classes = classnames(
-    styles.button,
-    styles.solid,
-    touchableStyles.tapTransition,
-    {
-      [styles.sm]: size === 'sm',
-      [styles.md]: size === 'md',
-      [styles.lg]: size === 'lg',
-      [styles[colorClass]]: !disabled && !selected,
-      [styles.selected]: !disabled && selected,
-      [styles.disabled]: disabled,
-      [styles.enabled]: !disabled,
-      [styles.inline]: inline,
-      [styles.block]: !inline,
-      [touchableStyles.tapCompress]: !disabled && isTapping,
-    }
-  );
+  const { isFocusVisible } = useFocusVisible();
+
+  const classes = classnames(styles.button, touchableStyles.tapTransition, {
+    [styles.sm]: size === 'sm',
+    [styles.md]: size === 'md',
+    [styles.lg]: size === 'lg',
+    [styles[colorClass]]: !disabled && !selected,
+    [styles.selected]: !disabled && selected,
+    [styles.disabled]: disabled,
+    [styles.enabled]: !disabled,
+    [styles.inline]: inline,
+    [styles.block]: !inline,
+    [touchableStyles.tapCompress]: !disabled && isTapping,
+    [focusStyles.accessibilityOutline]: !disabled && isFocusVisible,
+  });
 
   const textColor =
     (disabled && 'gray') ||

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -96,7 +96,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
         className="box flexNone paddingX2"
       >
         <button
-          className="button solid tapTransition lg gray enabled block"
+          className="button tapTransition lg gray enabled block accessibilityOutline"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}

--- a/packages/gestalt/src/useFocusVisible.js
+++ b/packages/gestalt/src/useFocusVisible.js
@@ -1,0 +1,131 @@
+// @flow strict
+
+// Portions of the code in this file are based on code from react & react-spectrum:
+// https://github.com/facebook/react/blob/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
+// https://github.com/adobe/react-spectrum/blob/c700898916bbd076bcc63e49d77c16d80623a8e7/packages/@react-aria/interactions/src/useFocusVisible.ts
+
+import { useState, useEffect } from 'react';
+
+type Modality = 'keyboard' | 'pointer';
+type HandlerEvent = PointerEvent | MouseEvent | KeyboardEvent | FocusEvent;
+type Handler = (modality: Modality, e: HandlerEvent) => void;
+
+let hasSetupGlobalListeners = false;
+let currentModality = null;
+const changeHandlers = new Set<Handler>();
+let hasEventBeforeFocus = false;
+
+const isMac =
+  typeof window !== 'undefined' && window.navigator != null
+    ? /^Mac/.test(window.navigator.platform)
+    : false;
+
+function isValidKey(e: KeyboardEvent) {
+  return !(e.metaKey || (!isMac && e.altKey) || e.ctrlKey);
+}
+
+function triggerChangeHandlers(modality: Modality, e: HandlerEvent) {
+  changeHandlers.forEach(handler => {
+    handler(modality, e);
+  });
+}
+
+function handleKeyboardEvent(e: KeyboardEvent) {
+  hasEventBeforeFocus = true;
+  if (isValidKey(e)) {
+    currentModality = 'keyboard';
+    triggerChangeHandlers('keyboard', e);
+  }
+}
+
+function handlePointerEvent(e: PointerEvent | MouseEvent) {
+  currentModality = 'pointer';
+  if (e.type === 'mousedown' || e.type === 'pointerdown') {
+    hasEventBeforeFocus = true;
+    triggerChangeHandlers('pointer', e);
+  }
+}
+
+function handleFocusEvent(e: FocusEvent) {
+  // Firefox fires two extra focus events when the user first clicks into an iframe:
+  // first on the window, then on the document. We ignore these events so they don't
+  // cause keyboard focus rings to appear.
+  if (e.target === window || e.target === document) {
+    return;
+  }
+
+  // If a focus event occurs without a preceding keyboard or pointer event, switch to keyboard modality.
+  // This occurs, for example, when navigating a form with the next/previous buttons on iOS.
+  if (!hasEventBeforeFocus) {
+    currentModality = 'keyboard';
+    triggerChangeHandlers('keyboard', e);
+  }
+
+  hasEventBeforeFocus = false;
+}
+
+function handleWindowBlur() {
+  // When the window is blurred, reset state. This is necessary when tabbing out of the window,
+  // for example, since a subsequent focus event won't be fired.
+  hasEventBeforeFocus = false;
+}
+
+function isFocusVisible(): boolean {
+  return currentModality !== 'pointer';
+}
+
+function setupGlobalFocusEvents() {
+  if (typeof window === 'undefined' || hasSetupGlobalListeners) {
+    return;
+  }
+
+  // Programmatic focus() calls shouldn't affect the current input modality.
+  // However, we need to detect other cases when a focus event occurs without
+  // a preceding user event (e.g. screen reader focus). Overriding the focus
+  // method on HTMLElement.prototype is a bit hacky, but works.
+  const { focus } = HTMLElement.prototype;
+  // $FlowIssue[cannot-write]
+  HTMLElement.prototype.focus = function focusElement(...args) {
+    hasEventBeforeFocus = true;
+    focus.apply(this, args);
+  };
+
+  document.addEventListener('keydown', handleKeyboardEvent, true);
+  document.addEventListener('keyup', handleKeyboardEvent, true);
+
+  // Register focus events on the window so they are sure to happen
+  // before React's event listeners (registered on the document).
+  window.addEventListener('focus', handleFocusEvent, true);
+  window.addEventListener('blur', handleWindowBlur, false);
+
+  if (typeof PointerEvent !== 'undefined') {
+    document.addEventListener('pointerdown', handlePointerEvent, true);
+    document.addEventListener('pointermove', handlePointerEvent, true);
+    document.addEventListener('pointerup', handlePointerEvent, true);
+  } else {
+    document.addEventListener('mousedown', handlePointerEvent, true);
+    document.addEventListener('mousemove', handlePointerEvent, true);
+    document.addEventListener('mouseup', handlePointerEvent, true);
+  }
+
+  hasSetupGlobalListeners = true;
+}
+
+export default function useFocusVisible(): {|
+  isFocusVisible: boolean,
+|} {
+  setupGlobalFocusEvents();
+  const [isFocusVisibleState, setFocusVisible] = useState(isFocusVisible());
+  useEffect(() => {
+    const handler = () => {
+      setFocusVisible(isFocusVisible());
+    };
+
+    changeHandlers.add(handler);
+    return () => {
+      changeHandlers.delete(handler);
+    };
+  }, []);
+
+  return { isFocusVisible: isFocusVisibleState };
+}


### PR DESCRIPTION
Adds `useFocusVisible` a React hook we can use in all of our components to only show the blue outline (focus ring) when using the keyboard.

In this first PR we only apply it to `<Button />`

![focus-outline-keyboard-only](https://user-images.githubusercontent.com/127199/88440462-d63ea280-cdc2-11ea-9416-0e4e84bf0ee0.gif)


## Test Plan

### Click on a `<Button />` and don't see a focus ring:
![useFocusVisible-mouse](https://user-images.githubusercontent.com/127199/88343731-e8530f00-ccf6-11ea-8d30-fa6f63039322.gif)

### Use the `TAB` key to get to a button and do see the focus ring:
![useFocusVisible-keyboard](https://user-images.githubusercontent.com/127199/88343736-ec7f2c80-ccf6-11ea-9098-c465d5f8ba85.gif)
