### PR TITLE
Docs: Fix Header to remove sticky header on reduced window size

### DIFF
--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -18,7 +18,7 @@ type Props = {|
   onChangeColorScheme: () => void,
 |};
 
-export default function Header({ colorScheme, onChangeColorScheme }: Props) {
+function Header({ colorScheme, onChangeColorScheme }: Props) {
   const [isRTL, setIsRTL] = React.useState(false);
   const { isSidebarOpen, setIsSidebarOpen } = useSidebarContext();
 
@@ -35,105 +35,134 @@ export default function Header({ colorScheme, onChangeColorScheme }: Props) {
   };
 
   return (
-    <Sticky top={0}>
-      <Box
-        paddingY={2}
-        paddingX={4}
-        mdPaddingX={6}
-        color="pine"
-        display="flex"
-        direction="row"
-        alignItems="center"
-      >
-        <Box marginStart={-2} marginEnd={-2}>
-          <Text color="white" weight="bold">
-            <Link to="/">
-              <Box padding={2}>
-                <Box
-                  display="flex"
-                  direction="row"
-                  alignItems="center"
-                  marginLeft={-1}
-                  marginRight={-1}
-                >
-                  <Box paddingX={1}>
-                    <Icon
-                      icon="pinterest"
-                      color="white"
-                      size={24}
-                      accessibilityLabel="Pinterest Logo"
-                    />
-                  </Box>
-                  <Box paddingX={1}>Gestalt</Box>
-                </Box>
-              </Box>
-            </Link>
-          </Text>
-        </Box>
-        <Box flex="grow" />
-        <Box display="flex" alignItems="center">
-          <DocSearch />
-
-          <Box display="none" mdDisplay="flex" alignItems="center">
-            <Tooltip
-              inline
-              text={isRTL ? 'Left-To-Right View' : 'Right-To-Left View'}
-            >
-              <IconButton
-                size="md"
-                accessibilityLabel="toggle page direction: Left-To-Right / Right-To-Left View"
-                iconColor="white"
-                dangerouslySetSvgPath={togglePageDirSvgPath}
-                onClick={toggleRTL}
-              />
-            </Tooltip>
-            <Tooltip
-              inline
-              text={
-                colorScheme === 'light' ? 'Dark-Mode View' : 'Light-Mode View'
-              }
-            >
-              <IconButton
-                size="md"
-                accessibilityLabel="toggle color scheme: light / dark mode views"
-                iconColor="white"
-                icon="workflow-status-in-progress"
-                onClick={() => onChangeColorScheme()}
-              />
-            </Tooltip>
-            <Tooltip
-              inline
-              text="Opens Codesandbox ready to start coding with Gestalt"
-            >
-              <Text color="white">
-                <GestaltLink
-                  href="https://codesandbox.io/s/k5plvp9v8v"
-                  target="blank"
-                >
-                  <Box padding={2}>Playground</Box>
-                </GestaltLink>
-              </Text>
-            </Tooltip>
-            <Text color="white">
-              <GestaltLink
-                href="https://github.com/pinterest/gestalt"
-                target="blank"
+    <Box
+      paddingY={2}
+      paddingX={4}
+      mdPaddingX={6}
+      color="pine"
+      display="flex"
+      direction="row"
+      alignItems="center"
+    >
+      <Box marginStart={-2} marginEnd={-2}>
+        <Text color="white" weight="bold">
+          <Link to="/">
+            <Box padding={2}>
+              <Box
+                display="flex"
+                direction="row"
+                alignItems="center"
+                marginLeft={-1}
+                marginRight={-1}
               >
-                <Box padding={2}>GitHub</Box>
-              </GestaltLink>
-            </Text>
-          </Box>
-          <Box display="flex" mdDisplay="none" alignItems="center">
+                <Box paddingX={1}>
+                  <Icon
+                    icon="pinterest"
+                    color="white"
+                    size={24}
+                    accessibilityLabel="Pinterest Logo"
+                  />
+                </Box>
+                <Box paddingX={1}>Gestalt</Box>
+              </Box>
+            </Box>
+          </Link>
+        </Text>
+      </Box>
+      <Box flex="grow" />
+      <Box display="flex" alignItems="center">
+        <DocSearch />
+
+        <Box display="none" mdDisplay="flex" alignItems="center">
+          <Tooltip
+            inline
+            text={isRTL ? 'Left-To-Right View' : 'Right-To-Left View'}
+          >
             <IconButton
               size="md"
-              accessibilityLabel={`${isSidebarOpen ? 'Hide' : 'Show'} Menu`}
+              accessibilityLabel="toggle page direction: Left-To-Right / Right-To-Left View"
               iconColor="white"
-              icon="menu"
-              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+              dangerouslySetSvgPath={togglePageDirSvgPath}
+              onClick={toggleRTL}
             />
-          </Box>
+          </Tooltip>
+          <Tooltip
+            inline
+            text={
+              colorScheme === 'light' ? 'Dark-Mode View' : 'Light-Mode View'
+            }
+          >
+            <IconButton
+              size="md"
+              accessibilityLabel="toggle color scheme: light / dark mode views"
+              iconColor="white"
+              icon="workflow-status-in-progress"
+              onClick={() => onChangeColorScheme()}
+            />
+          </Tooltip>
+          <Tooltip
+            inline
+            text="Opens Codesandbox ready to start coding with Gestalt"
+          >
+            <Text color="white">
+              <GestaltLink
+                href="https://codesandbox.io/s/k5plvp9v8v"
+                target="blank"
+              >
+                <Box padding={2}>Playground</Box>
+              </GestaltLink>
+            </Text>
+          </Tooltip>
+          <Text color="white">
+            <GestaltLink
+              href="https://github.com/pinterest/gestalt"
+              target="blank"
+            >
+              <Box padding={2}>GitHub</Box>
+            </GestaltLink>
+          </Text>
+        </Box>
+        <Box display="flex" mdDisplay="none" alignItems="center">
+          <IconButton
+            size="md"
+            accessibilityLabel={`${isSidebarOpen ? 'Hide' : 'Show'} Menu`}
+            iconColor="white"
+            icon="menu"
+            onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+          />
         </Box>
       </Box>
+    </Box>
+  );
+}
+
+export default function StickyHeader({
+  colorScheme,
+  onChangeColorScheme,
+}: Props) {
+  const isReducedHeight = () => window.innerHeight < 709;
+  const [reducedHeight, setReducedHeight] = React.useState(isReducedHeight());
+
+  React.useEffect(() => {
+    function handleResizeHeight() {
+      if (isReducedHeight() !== reducedHeight) {
+        setReducedHeight(isReducedHeight());
+      }
+    }
+    window.addEventListener('resize', handleResizeHeight);
+  });
+
+  return reducedHeight ? (
+    <Header
+      colorScheme={colorScheme}
+      onChangeColorScheme={onChangeColorScheme}
+    />
+  ) : (
+    <Sticky top={0}>
+      <Header
+        colorScheme={colorScheme}
+        onChangeColorScheme={onChangeColorScheme}
+      />
     </Sticky>
   );
 }


### PR DESCRIPTION
The `<Sticky />` header causes issues in our docs. It was introduced as part of #952 /cc @AlbertCarreras 

However,  it is convenient to have a sticky header on Gestalt Docs due to the amount of scrolling that is required when reading the Docs. 

A proposed solution is to keep the sticky header on full windows and remove it when windows downsize to a size that doesn't allow the correct display of Modals.

## Before
![Screen Shot 2020-07-23 at 2 22 06 PM](https://user-images.githubusercontent.com/127199/88340179-34e71c00-ccf0-11ea-9f96-2d6fdb36c286.png)

## After
![Kapture 2020-07-23 at 18 19 17](https://user-images.githubusercontent.com/10593890/88353092-12b1c600-cd11-11ea-8344-f3712060a9fa.gif)

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
