### PR TITLE
Box: Refactored forwardRef logic + forwardRef test + forwardRef example in Docs

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -184,6 +184,12 @@ card(
         href: 'absolutePositioning',
       },
       {
+        name: 'ref',
+        type: "React.Ref<'div'>",
+        description: 'Forward the ref to the underlying div element',
+        href: 'refExample',
+      },
+      {
         name: 'role',
         type: 'string',
       },
@@ -304,17 +310,6 @@ card(
       </Box>
     )}
   </Combination>
-);
-
-card(
-  <Card
-    description={`
-    As of Gestalt v0.86.0, \`Box\` supports React's new [\`forwardRef\`](https://reactjs.org/docs/forwarding-refs.html) functionality.
-    This allows you to set a \`ref\` on the actual \`<Box />\` component and it will be passed down to the underlying \`<div>\` element.
-    The \`ref\` can be set through any of the supported React methods and accessing it will yield the \`<div>\` that \`Box\` implements.
-  `}
-    name="Refs"
-  />
 );
 
 card(
@@ -608,6 +603,52 @@ card(
       {props => <Box color="darkGray" width={60} height={60} {...props} />}
     </Combination>
   </Card>
+);
+
+card(
+  <Example
+    id="refExample"
+    name="Example: ref"
+    description={`
+    A \`Box\` with an anchor ref to a Flyout component
+  `}
+    defaultCode={`
+function ButtonFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const [checked, setChecked] = React.useState(false);
+
+  const anchorRef = React.useRef(null);
+
+  return (
+    <>
+      <Stack gap={3}>
+        <Button
+          inline
+          color="red"
+          onClick={() => setOpen(true)}
+          size="sm"
+          text="Anchor a Flyout to Box"
+        />
+        <Box borderSize='sm' padding={3} ref={anchorRef} rounding={1}>
+          <Text>I'm a Box</Text>
+        </Box>
+      </Stack>
+      {open && (
+        <Flyout
+          anchor={anchorRef.current}
+          idealDirection="right"
+          onDismiss={() => setOpen(false)}
+          shouldFocus={false}
+        >
+          <Box padding={3}>
+            <Text weight="bold">I'm a Flyout anchored to a Box</Text>
+          </Box>
+        </Flyout>
+      )}
+    </>
+  );
+}`}
+  />
 );
 
 card(

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -15,7 +15,12 @@ I'll explain each part as we go through. Just remember, if you want to make upda
 
 */
 
-import React, { forwardRef, type Node, type AbstractComponent } from 'react';
+import React, {
+  forwardRef,
+  type Node,
+  type AbstractComponent,
+  type Element,
+} from 'react';
 import PropTypes from 'prop-types';
 import styles from './Box.css';
 import borders from './Borders.css';
@@ -703,10 +708,13 @@ const omit = (keys, obj) =>
 // (className, style) or accessibility (onClick).
 const blacklistProps = ['onClick', 'className', 'style'];
 
-const BoxWithRef: AbstractComponent<PropType, HTMLDivElement> = forwardRef<
+const BoxWithForwardRef: AbstractComponent<
   PropType,
   HTMLDivElement
->(function Box(props, ref) {
+> = forwardRef<PropType, HTMLDivElement>(function Box(
+  props,
+  ref
+): Element<'div'> {
   // Flow can't reason about the constant nature of Object.keys so we can't use
   // a functional (reduce) style here.
 
@@ -741,11 +749,9 @@ const BoxWithRef: AbstractComponent<PropType, HTMLDivElement> = forwardRef<
   return <div {...omit(omitProps, props)} {...toProps(s)} ref={ref} />;
 });
 
-// This is a legacy backport around tools external to Gestalt (*waves hands*)
-// expecting Boxes' displayName to be just "Box" and not "ForwardRef(Box)".
-BoxWithRef.displayName = 'Box';
+BoxWithForwardRef.displayName = 'Box';
 
-export default BoxWithRef;
+export default BoxWithForwardRef;
 
 /*
 
@@ -906,8 +912,8 @@ const SizeDisplayPropType = PropTypes.oneOf([
   'inlineBlock',
 ]);
 
-// $FlowFixMe
-BoxWithRef.propTypes = {
+// $FlowFixMe Flow(InferError)
+BoxWithForwardRef.propTypes = {
   children: PropTypes.node,
   dangerouslySetInlineStyle: PropTypes.exact({
     __style: PropTypes.object,

--- a/packages/gestalt/src/Box.jsdom.test.js
+++ b/packages/gestalt/src/Box.jsdom.test.js
@@ -1,0 +1,13 @@
+// @flow strict
+import React from 'react';
+import { render } from '@testing-library/react';
+import Box from './Box.js';
+
+describe('Box', () => {
+  it('forwards a ref to the innermost div element', () => {
+    const ref = React.createRef();
+    render(<Box title="test" ref={ref} />);
+    expect(ref.current instanceof HTMLDivElement).toEqual(true);
+    expect(ref.current?.title).toEqual('test');
+  });
+});


### PR DESCRIPTION
- Refactored forwardRef logic to a [proposed standard](https://paper.dropbox.com/doc/Gestalt-forwardRefs--A43M3_lujiEigRQ81g_pZJqoAg-Mp93uiR5uRp7Hb9iLwbiW) for consolidation inside Gestalt components


- forwardRef test
- forwardRef example in Docs


<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
