### PR TITLE
Flowtest: Add flow specific test files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,6 +88,12 @@
       }
     },
     {
+      "files": ["**/*.flowtest.js"],
+      "rules": {
+        "no-unused-vars": "off"
+      }
+    },
+    {
       "files": ["scripts/danger/*.js"],
       "globals": {
         "danger": true,

--- a/packages/gestalt/src/Avatar.flowtest.js
+++ b/packages/gestalt/src/Avatar.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Avatar from './Avatar.js';
+
+const Valid = <Avatar name="Yen-Wei" />;
+
+// $FlowExpectedError[prop-missing] Cannot create `Avatar` element because property `nonexisting` is missing in Props
+const NonExistingProp = <Avatar nonexisting={33} />;
+
+// $FlowExpectedError[prop-missing] Cannot create `Avatar` element because property `name` is missing in Props
+const MissingProp = <Avatar size="sm" />;

--- a/packages/gestalt/src/AvatarPair.flowtest.js
+++ b/packages/gestalt/src/AvatarPair.flowtest.js
@@ -1,0 +1,19 @@
+// @flow strict
+import React from 'react';
+import AvatarPair from './AvatarPair.js';
+
+const Valid = (
+  <AvatarPair
+    collaborators={[
+      {
+        name: 'Jenny',
+      },
+    ]}
+  />
+);
+
+// $FlowExpectedError[prop-missing] Cannot create `AvatarPair` element because property `nonexisting` is missing in props.
+const NonExistingProp = <AvatarPair nonexisting={33} />;
+
+// $FlowExpectedError[prop-missing] Cannot create `AvatarPair` element because property `collaborators` is missing in props
+const MissingProp = <AvatarPair />;

--- a/packages/gestalt/src/Badge.flowtest.js
+++ b/packages/gestalt/src/Badge.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Badge from './Badge.js';
+
+const Valid = <Badge text="new" />;
+
+// $FlowExpectedError[prop-missing] Cannot create `Badge` element because property `nonexisting` is missing in  props.
+const NonExistingProp = <Badge nonexisting={33} />;
+
+// $FlowExpectedError[prop-missing] Cannot create `Badge` element because property `text` is missing in props
+const MissingProp = <Badge />;

--- a/packages/gestalt/src/Box.flowtest.js
+++ b/packages/gestalt/src/Box.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Box from './Box.js';
+
+const Valid = <Box>Text</Box>;
+
+// $FlowExpectedError[incompatible-type] Cannot create `Box` element because  number [1] is incompatible with  enum [2] in property `margin.
+const IncorrectMargin = <Box margin={33} />;

--- a/packages/gestalt/src/Button.flowtest.js
+++ b/packages/gestalt/src/Button.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Button from './Button.js';
+
+const Valid = <Button text="Next" />;
+
+// $FlowExpectedError[prop-missing] Cannot create `Button` element because property `nonexisting` is missing in  props.
+const NonExistingProp = <Button nonexisting={33} />;
+
+// $FlowExpectedError[prop-missing] Cannot create `Button` element because property `text` is missing in props
+const MissingProp = <Button />;

--- a/packages/gestalt/src/Callout.flowtest.js
+++ b/packages/gestalt/src/Callout.flowtest.js
@@ -1,0 +1,17 @@
+// @flow strict
+import React from 'react';
+import Callout from './Callout.js';
+
+const Valid = (
+  <Callout
+    description="Callout error message"
+    iconAccessibilityLabel="error"
+    type="error"
+  />
+);
+
+// $FlowExpectedError[prop-missing] Cannot create `Callout` element because property `nonexisting` is missing in  props.
+const NonExistingProp = <Callout nonexisting={33} />;
+
+// $FlowExpectedError[prop-missing] Cannot create `Callout` element because property `description` / `type` / `iconAccessiblityLabel` is missing in  props
+const MissingProp = <Callout />;

--- a/packages/gestalt/src/Card.flowtest.js
+++ b/packages/gestalt/src/Card.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Card from './Card.js';
+
+const Valid = <Card />;
+
+// $FlowExpectedError[prop-missing] Cannot create `Card` element because property `nonexisting` is missing in  props.
+const NonExistingProp = <Card nonexisting={33} />;


### PR DESCRIPTION
Instead of add flow tests to `.test.js` files and having to add a useless `expect` statement, let's create flow specific test files

## Test Plan

* Flow passed on CI