### PR TITLE
Flowtests: Add more tests to components + fix GestaltProvider flowtype

### DIFF
--- a/packages/gestalt/src/Avatar.flowtest.js
+++ b/packages/gestalt/src/Avatar.flowtest.js
@@ -4,8 +4,8 @@ import Avatar from './Avatar.js';
 
 const Valid = <Avatar name="Yen-Wei" />;
 
-// $FlowExpectedError[prop-missing] Cannot create `Avatar` element because property `nonexisting` is missing in Props
+// $FlowExpectedError[prop-missing]
 const NonExistingProp = <Avatar nonexisting={33} />;
 
-// $FlowExpectedError[prop-missing] Cannot create `Avatar` element because property `name` is missing in Props
+// $FlowExpectedError[prop-missing]
 const MissingProp = <Avatar size="sm" />;

--- a/packages/gestalt/src/AvatarPair.flowtest.js
+++ b/packages/gestalt/src/AvatarPair.flowtest.js
@@ -12,8 +12,8 @@ const Valid = (
   />
 );
 
-// $FlowExpectedError[prop-missing] Cannot create `AvatarPair` element because property `nonexisting` is missing in props.
+// $FlowExpectedError[prop-missing]
 const NonExistingProp = <AvatarPair nonexisting={33} />;
 
-// $FlowExpectedError[prop-missing] Cannot create `AvatarPair` element because property `collaborators` is missing in props
+// $FlowExpectedError[prop-missing]
 const MissingProp = <AvatarPair />;

--- a/packages/gestalt/src/Badge.flowtest.js
+++ b/packages/gestalt/src/Badge.flowtest.js
@@ -4,8 +4,8 @@ import Badge from './Badge.js';
 
 const Valid = <Badge text="new" />;
 
-// $FlowExpectedError[prop-missing] Cannot create `Badge` element because property `nonexisting` is missing in  props.
+// $FlowExpectedError[prop-missing]
 const NonExistingProp = <Badge nonexisting={33} />;
 
-// $FlowExpectedError[prop-missing] Cannot create `Badge` element because property `text` is missing in props
+// $FlowExpectedError[prop-missing]
 const MissingProp = <Badge />;

--- a/packages/gestalt/src/Box.flowtest.js
+++ b/packages/gestalt/src/Box.flowtest.js
@@ -4,5 +4,5 @@ import Box from './Box.js';
 
 const Valid = <Box>Text</Box>;
 
-// $FlowExpectedError[incompatible-type] Cannot create `Box` element because  number [1] is incompatible with  enum [2] in property `margin.
+// $FlowExpectedError[incompatible-type]
 const IncorrectMargin = <Box margin={33} />;

--- a/packages/gestalt/src/Box.test.js
+++ b/packages/gestalt/src/Box.test.js
@@ -107,12 +107,3 @@ test('Box has correct zIndex', () => {
   const tree = create(<Box zIndex={zIndexStub} />).toJSON();
   expect(tree).toMatchSnapshot();
 });
-
-test('Box is flowtyped correctly', () => {
-  // Disable console error output from proptypes package when running tests
-  jest.spyOn(console, 'error').mockImplementationOnce(() => {});
-
-  // $FlowExpectedError[incompatible-type] Cannot create `Box` element because  number [1] is incompatible with  enum [2] in property `margin.
-  const IncorrectMargin = <Box margin={33} />;
-  expect(IncorrectMargin.type).toEqual(Box);
-});

--- a/packages/gestalt/src/Button.flowtest.js
+++ b/packages/gestalt/src/Button.flowtest.js
@@ -4,8 +4,8 @@ import Button from './Button.js';
 
 const Valid = <Button text="Next" />;
 
-// $FlowExpectedError[prop-missing] Cannot create `Button` element because property `nonexisting` is missing in  props.
+// $FlowExpectedError[prop-missing]
 const NonExistingProp = <Button nonexisting={33} />;
 
-// $FlowExpectedError[prop-missing] Cannot create `Button` element because property `text` is missing in props
+// $FlowExpectedError[prop-missing]
 const MissingProp = <Button />;

--- a/packages/gestalt/src/Callout.flowtest.js
+++ b/packages/gestalt/src/Callout.flowtest.js
@@ -10,8 +10,8 @@ const Valid = (
   />
 );
 
-// $FlowExpectedError[prop-missing] Cannot create `Callout` element because property `nonexisting` is missing in  props.
+// $FlowExpectedError[prop-missing]
 const NonExistingProp = <Callout nonexisting={33} />;
 
-// $FlowExpectedError[prop-missing] Cannot create `Callout` element because property `description` / `type` / `iconAccessiblityLabel` is missing in  props
+// $FlowExpectedError[prop-missing]
 const MissingProp = <Callout />;

--- a/packages/gestalt/src/Card.flowtest.js
+++ b/packages/gestalt/src/Card.flowtest.js
@@ -4,5 +4,5 @@ import Card from './Card.js';
 
 const Valid = <Card />;
 
-// $FlowExpectedError[prop-missing] Cannot create `Card` element because property `nonexisting` is missing in  props.
+// $FlowExpectedError[prop-missing]
 const NonExistingProp = <Card nonexisting={33} />;

--- a/packages/gestalt/src/Checkbox.flowtest.js
+++ b/packages/gestalt/src/Checkbox.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Checkbox from './Checkbox.js';
+
+const Valid = <Checkbox id="send-emails" onChange={() => {}} />;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Checkbox />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Checkbox nonexisting={33} />;

--- a/packages/gestalt/src/Column.flowtest.js
+++ b/packages/gestalt/src/Column.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Column from './Column.js';
+
+const Valid = <Column xs={1}>Hello world</Column>;
+
+// $FlowExpectedError[incompatible-type]
+const NonExistingProp = <Column nonexisting={33} />;

--- a/packages/gestalt/src/Container.flowtest.js
+++ b/packages/gestalt/src/Container.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Container from './Container.js';
+
+const Valid = <Container />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Container nonexisting={33} />;

--- a/packages/gestalt/src/Divider.flowtest.js
+++ b/packages/gestalt/src/Divider.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Divider from './Divider.js';
+
+const Valid = <Divider />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Divider nonexisting={33} />;

--- a/packages/gestalt/src/Flyout.flowtest.js
+++ b/packages/gestalt/src/Flyout.flowtest.js
@@ -1,0 +1,10 @@
+// @flow strict
+import React from 'react';
+import Flyout from './Flyout.js';
+
+const Valid = (
+  <Flyout anchor={document.createElement('div')} onDismiss={() => {}} />
+);
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Flyout nonexisting={33} />;

--- a/packages/gestalt/src/GestaltProvider.flowtest.js
+++ b/packages/gestalt/src/GestaltProvider.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import GestaltProvider from './GestaltProvider.js';
+
+const Valid = <GestaltProvider>Test</GestaltProvider>;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <GestaltProvider nonexisting={33} />;

--- a/packages/gestalt/src/GestaltProvider.js
+++ b/packages/gestalt/src/GestaltProvider.js
@@ -10,7 +10,7 @@ import {
 type Props = {|
   children: React.Node,
   colorScheme?: ColorScheme,
-  id: ?string,
+  id?: string,
 |};
 
 export default function GestaltProvider({

--- a/packages/gestalt/src/GroupAvatar.flowtest.js
+++ b/packages/gestalt/src/GroupAvatar.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import GroupAvatar from './GroupAvatar.js';
+
+const Valid = <GroupAvatar collaborators={[{ name: '💩 astral' }]} size="md" />;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <GroupAvatar />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <GroupAvatar nonexisting={33} />;

--- a/packages/gestalt/src/Heading.flowtest.js
+++ b/packages/gestalt/src/Heading.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Heading from './Heading.js';
+
+const Valid = <Heading size="sm">Heading</Heading>;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Heading nonexisting={33} />;

--- a/packages/gestalt/src/Icon.flowtest.js
+++ b/packages/gestalt/src/Icon.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Icon from './Icon.js';
+
+const Valid = <Icon icon="add" accessibilityLabel="Add" />;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Icon />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Icon nonexisting={33} />;

--- a/packages/gestalt/src/IconButton.flowtest.js
+++ b/packages/gestalt/src/IconButton.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import IconButton from './IconButton.js';
+
+const Valid = <IconButton icon="add" accessibilityLabel="Add" />;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <IconButton />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <IconButton nonexisting={33} />;

--- a/packages/gestalt/src/Image.flowtest.js
+++ b/packages/gestalt/src/Image.flowtest.js
@@ -1,0 +1,13 @@
+// @flow strict
+import React from 'react';
+import Image from './Image.js';
+
+const Valid = (
+  <Image alt="foo" naturalHeight={50} naturalWidth={50} src="foo.png" />
+);
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Image />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Image nonexisting={33} />;

--- a/packages/gestalt/src/Label.flowtest.js
+++ b/packages/gestalt/src/Label.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Label from './Label.js';
+
+const Valid = <Label htmlFor="foo" />;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Label />; // eslint-disable-line jsx-a11y/label-has-associated-control
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Label nonexisting={33} />; // eslint-disable-line jsx-a11y/label-has-associated-control

--- a/packages/gestalt/src/Layer.flowtest.js
+++ b/packages/gestalt/src/Layer.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Layer from './Layer.js';
+
+const Valid = <Layer>content</Layer>;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Layer />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Layer nonexisting={33} />;

--- a/packages/gestalt/src/LetterBox.flowtest.js
+++ b/packages/gestalt/src/LetterBox.flowtest.js
@@ -1,0 +1,15 @@
+// @flow strict
+import React from 'react';
+import Letterbox from './Letterbox.js';
+
+const Valid = (
+  <Letterbox width={50} height={50} contentAspectRatio={564 / 806}>
+    content
+  </Letterbox>
+);
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Letterbox />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Letterbox nonexisting={33} />;

--- a/packages/gestalt/src/Link.flowtest.js
+++ b/packages/gestalt/src/Link.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Link from './Link.js';
+
+const Valid = <Link href="https://example.com">content</Link>;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Link />; // eslint-disable-line jsx-a11y/anchor-is-valid
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Link nonexisting={33} />; // eslint-disable-line jsx-a11y/anchor-is-valid

--- a/packages/gestalt/src/Mask.flowtest.js
+++ b/packages/gestalt/src/Mask.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Mask from './Mask.js';
+
+const Valid = <Mask width={400}>content</Mask>;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Mask nonexisting={33} />;

--- a/packages/gestalt/src/Masonry.flowtest.js
+++ b/packages/gestalt/src/Masonry.flowtest.js
@@ -1,0 +1,12 @@
+// @flow strict
+import React from 'react';
+import Masonry from './Masonry.js';
+
+const Item = () => <div />;
+const Valid = <Masonry items={[]} comp={Item} />;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Masonry />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Masonry nonexisting={33} />;

--- a/packages/gestalt/src/Modal.flowtest.js
+++ b/packages/gestalt/src/Modal.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Modal from './Modal.js';
+
+const Valid = <Modal accessibilityModalLabel="Modal" onDismiss={() => {}} />;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Modal />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Modal nonexisting={33} />;

--- a/packages/gestalt/src/Pog.flowtest.js
+++ b/packages/gestalt/src/Pog.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Pog from './Pog.js';
+
+const Valid = <Pog icon="add" />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Pog nonexisting={33} />;

--- a/packages/gestalt/src/Pulsar.flowtest.js
+++ b/packages/gestalt/src/Pulsar.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Pulsar from './Pulsar.js';
+
+const Valid = <Pulsar size={400} />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Pulsar nonexisting={33} />;

--- a/packages/gestalt/src/Toast.flowtest.js
+++ b/packages/gestalt/src/Toast.flowtest.js
@@ -1,0 +1,11 @@
+// @flow strict
+import React from 'react';
+import Toast from './Toast.js';
+
+const Valid = <Toast text="Warning" />;
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Toast />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Toast nonexisting={33} />;

--- a/packages/gestalt/src/Typeahead.flowtest.js
+++ b/packages/gestalt/src/Typeahead.flowtest.js
@@ -1,0 +1,17 @@
+// @flow strict
+import React from 'react';
+import Typeahead from './Typeahead.js';
+
+const Valid = (
+  <Typeahead
+    id="Typeahead"
+    noResultText="No Result"
+    options={[{ value: '1', label: 'label' }]}
+  />
+);
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Typeahead />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Typeahead nonexisting={33} />;

--- a/packages/gestalt/src/Video.flowtest.js
+++ b/packages/gestalt/src/Video.flowtest.js
@@ -1,0 +1,23 @@
+// @flow strict
+import React from 'react';
+import Video from './Video.js';
+
+const Valid = (
+  <Video
+    accessibilityMaximizeLabel="Maximize"
+    accessibilityMinimizeLabel="Minimize"
+    accessibilityMuteLabel="Mute"
+    accessibilityPauseLabel="Pause"
+    accessibilityPlayLabel="Play"
+    accessibilityUnmuteLabel="Unmute"
+    aspectRatio={1}
+    captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+    src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+  />
+);
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <Video aspectRatio={1} />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Video nonexisting={33} />;


### PR DESCRIPTION
Add more flow tests to our Gestalt components.

We did find an issue with `GestaltProvider` where the flowtype was incorrect.