### PR TITLE
RadioButton: fix warning in jest test

### DIFF
--- a/packages/gestalt/src/RadioButton.jsdom.test.js
+++ b/packages/gestalt/src/RadioButton.jsdom.test.js
@@ -5,7 +5,7 @@ import RadioButton from './RadioButton.js';
 
 const mockOnChange = jest.fn();
 
-describe('RadioButton', () =>
+describe('RadioButton', () => {
   it('forwards a ref to <Box ref={ref}><input/></Box>', () => {
     const ref = React.createRef();
     render(
@@ -19,4 +19,5 @@ describe('RadioButton', () =>
     );
     expect(ref.current instanceof HTMLInputElement).toEqual(true);
     expect(ref.current?.checked).toEqual(true);
-  }));
+  });
+});


### PR DESCRIPTION
Issue was introduced in #1057 @AlbertCarreras 

```
A "describe" callback must not return a value.
          Returning a value from "describe" will fail the test in a future version of Jest.
```

![Screen Shot 2020-07-30 at 2 25 51 PM](https://user-images.githubusercontent.com/127199/88976550-1beee580-d271-11ea-9813-c316c932931b.png)
