### PR TITLE
Button/Checkbox/IconButton/Link/RadioButton/Switch/TapArea: useFocusVisible

### DIFF
--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -4,16 +4,16 @@ import * as React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
+import focusStyles from './Focus.css';
 import Icon from './Icon.js';
 import icons from './icons/index.js';
 import styles from './Button.css';
 import Text from './Text.js';
-import { useColorScheme } from './contexts/ColorScheme.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import touchableStyles from './Touchable.css';
 import useFocusVisible from './useFocusVisible.js';
 import useTapFeedback from './useTapFeedback.js';
-import touchableStyles from './Touchable.css';
-import focusStyles from './Focus.css';
+import { useColorScheme } from './contexts/ColorScheme.js';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 const DEFAULT_TEXT_COLORS = {
   blue: 'white',

--- a/packages/gestalt/src/Checkbox.css
+++ b/packages/gestalt/src/Checkbox.css
@@ -36,10 +36,6 @@
   composes: solid from "./Borders.css";
 }
 
-.checkFocused {
-  composes: accessibilityOutlineFocus from "./Focus.css";
-}
-
 .inputEnabled {
   composes: pointer from "./Cursor.css";
 }

--- a/packages/gestalt/src/Checkbox.css.flow
+++ b/packages/gestalt/src/Checkbox.css.flow
@@ -9,6 +9,5 @@ declare module.exports: {|
   +'borderRadiusMd': string,
   +'borderRadiusSm': string,
   +'check': string,
-  +'checkFocused': string,
   +'inputEnabled': string,
 |};

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -11,6 +11,8 @@ import Icon from './Icon.js';
 import Label from './Label.js';
 import Text from './Text.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import useFocusVisible from './useFocusVisible.js';
+import focusStyles from './Focus.css';
 
 type Props = {|
   checked?: boolean,
@@ -103,6 +105,8 @@ function Checkbox(props: Props): React.Node {
 
   const styleSize = size === 'sm' ? controlStyles.sizeSm : controlStyles.sizeMd;
 
+  const { isFocusVisible } = useFocusVisible();
+
   return (
     <Box>
       <Box
@@ -139,7 +143,8 @@ function Checkbox(props: Props): React.Node {
                 styleSize,
                 styles.check,
                 {
-                  [styles.checkFocused]: focused,
+                  [focusStyles.accessibilityOutlineFocus]:
+                    focused && isFocusVisible,
                 }
               )}
             >

--- a/packages/gestalt/src/Focus.css
+++ b/packages/gestalt/src/Focus.css
@@ -7,3 +7,7 @@
   box-shadow: 0 0 0 4px rgba(0, 132, 255, 0.5);
   outline: 0;
 }
+
+.hideOutline {
+  outline: 0;
+}

--- a/packages/gestalt/src/Focus.css.flow
+++ b/packages/gestalt/src/Focus.css.flow
@@ -3,4 +3,5 @@
 declare module.exports: {|
   +'accessibilityOutline': string,
   +'accessibilityOutlineFocus': string,
+  +'hideOutline': string,
 |};

--- a/packages/gestalt/src/IconButton.css
+++ b/packages/gestalt/src/IconButton.css
@@ -5,6 +5,10 @@
   background: transparent;
 }
 
+.button:focus {
+  outline: 0;
+}
+
 .enabled {
   composes: pointer from "./Cursor.css";
 }
@@ -12,8 +16,4 @@
 .disabled {
   cursor: default;
   opacity: 0.5;
-}
-
-.button:focus {
-  outline: 0;
 }

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -8,6 +8,7 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './IconButton.css';
 import touchableStyles from './Touchable.css';
 import useTapFeedback from './useTapFeedback.js';
+import useFocusVisible from './useFocusVisible.js';
 
 type Props = {|
   accessibilityControls?: string,
@@ -74,6 +75,8 @@ function IconButton({
   const [isFocused, setFocused] = React.useState(false);
   const [isHovered, setHovered] = React.useState(false);
 
+  const { isFocusVisible } = useFocusVisible();
+
   const classes = classnames(styles.button, touchableStyles.tapTransition, {
     [styles.disabled]: disabled,
     [styles.enabled]: !disabled,
@@ -119,7 +122,7 @@ function IconButton({
         active={!disabled && isActive}
         bgColor={bgColor}
         dangerouslySetSvgPath={dangerouslySetSvgPath}
-        focused={!disabled && isFocused}
+        focused={!disabled && isFocusVisible && isFocused}
         hovered={!disabled && isHovered}
         icon={icon}
         iconColor={iconColor}

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -10,6 +10,8 @@ import getRoundingClassName, {
   type Rounding,
 } from './getRoundingClassName.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import focusStyles from './Focus.css';
+import useFocusVisible from './useFocusVisible.js';
 
 type Props = {|
   accessibilitySelected?: boolean,
@@ -68,14 +70,16 @@ function Link({
     width: innerRef?.current?.clientWidth,
   });
 
+  const { isFocusVisible } = useFocusVisible();
+
   const className = classnames(
     styles.link,
     touchableStyles.tapTransition,
-    touchableStyles.touchable,
     inline ? styles.inlineBlock : styles.block,
     getRoundingClassName(rounding),
     {
       [styles.hoverUnderline]: hoverStyle === 'underline',
+      [focusStyles.accessibilityOutline]: isFocusVisible,
       [touchableStyles.tapCompress]: tapStyle === 'compress' && isTapping,
     }
   );

--- a/packages/gestalt/src/RadioButton.css
+++ b/packages/gestalt/src/RadioButton.css
@@ -14,10 +14,6 @@
   composes: solid from "./Borders.css";
 }
 
-.RadioButtonIsFocused {
-  composes: accessibilityOutlineFocus from "./Focus.css";
-}
-
 .Border {
   composes: borderColorLightGray from "./Borders.css";
 }

--- a/packages/gestalt/src/RadioButton.css.flow
+++ b/packages/gestalt/src/RadioButton.css.flow
@@ -13,5 +13,4 @@ declare module.exports: {|
   +'BorderUnchecked': string,
   +'InputEnabled': string,
   +'RadioButton': string,
-  +'RadioButtonIsFocused': string,
 |};

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -8,6 +8,8 @@ import Box from './Box.js';
 import Label from './Label.js';
 import Text from './Text.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import useFocusVisible from './useFocusVisible.js';
+import focusStyles from './Focus.css';
 
 type Props = {|
   checked?: boolean,
@@ -73,6 +75,8 @@ function RadioButton(props: Props): React.Node {
 
   const bgStyle = disabled && !checked ? styles.BgDisabled : styles.BgEnabled;
 
+  const { isFocusVisible } = useFocusVisible();
+
   return (
     <Box
       alignItems="center"
@@ -91,7 +95,8 @@ function RadioButton(props: Props): React.Node {
               styleSize,
               styles.RadioButton,
               {
-                [styles.RadioButtonIsFocused]: focused,
+                [focusStyles.accessibilityOutlineFocus]:
+                  focused && isFocusVisible,
               }
             )}
           >

--- a/packages/gestalt/src/Switch.css
+++ b/packages/gestalt/src/Switch.css
@@ -22,10 +22,6 @@ html[dir="rtl"] .switch {
   transform: rotateY(180deg);
 }
 
-.focused {
-  composes: accessibilityOutlineFocus from "./Focus.css";
-}
-
 .switchDarkGray {
   composes: darkGrayBg from "./Colors.css";
   composes: borderColorDarkGray from "./Borders.css";

--- a/packages/gestalt/src/Switch.css.flow
+++ b/packages/gestalt/src/Switch.css.flow
@@ -3,7 +3,6 @@
 declare module.exports: {|
   +'checkbox': string,
   +'checkboxEnabled': string,
-  +'focused': string,
   +'slider': string,
   +'sliderDark': string,
   +'sliderLeft': string,

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -1,7 +1,9 @@
 // @flow strict
-import * as React from 'react';
+import React, { useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import useFocusVisible from './useFocusVisible.js';
+import focusStyles from './Focus.css';
 import styles from './Switch.css';
 
 type Props = {|
@@ -12,83 +14,71 @@ type Props = {|
   switched?: boolean,
 |};
 
-type State = {|
-  focused: boolean,
-|};
+export default function Switch({
+  disabled = false,
+  id,
+  name,
+  onChange,
+  switched = false,
+}: Props): Node {
+  const [focused, setFocused] = useState(false);
 
-export default class Switch extends React.Component<Props, State> {
-  static propTypes = {
-    disabled: PropTypes.bool,
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
-    switched: PropTypes.bool,
-  };
-
-  static defaultProps: {| disabled: boolean, switched: boolean |} = {
-    disabled: false,
-    switched: false,
-  };
-
-  state: State = {
-    focused: false,
-  };
-
-  handleBlur: () => void = () => this.setState({ focused: false });
-
-  handleFocus: () => void = () => this.setState({ focused: true });
-
-  handleChange: (event: SyntheticInputEvent<>) => void = (
+  const handleChange: (event: SyntheticInputEvent<>) => void = (
     event: SyntheticInputEvent<>
   ) => {
-    const { onChange } = this.props;
     const { checked } = event.target;
     onChange({ event, value: checked });
   };
 
-  render(): React.Node {
-    const { disabled, id, name, switched } = this.props;
+  const { isFocusVisible } = useFocusVisible();
 
-    const switchStyles = classnames(
-      styles.switch,
-      {
-        [styles.focused]: this.state.focused,
-      },
-      // eslint-disable-next-line no-nested-ternary
-      disabled
-        ? switched
-          ? styles.switchGray
-          : styles.switchLightGray
-        : switched
-        ? styles.switchDarkGray
-        : styles.switchWhite
-    );
+  const switchStyles = classnames(
+    styles.switch,
+    {
+      [focusStyles.accessibilityOutlineFocus]: focused && isFocusVisible,
+    },
+    // eslint-disable-next-line no-nested-ternary
+    disabled
+      ? switched
+        ? styles.switchGray
+        : styles.switchLightGray
+      : switched
+      ? styles.switchDarkGray
+      : styles.switchWhite
+  );
 
-    const sliderStyles = classnames(
-      styles.slider,
-      switched ? styles.sliderRight : styles.sliderLeft,
-      switched && !disabled ? styles.sliderDark : styles.sliderLight
-    );
+  const sliderStyles = classnames(
+    styles.slider,
+    switched ? styles.sliderRight : styles.sliderLeft,
+    switched && !disabled ? styles.sliderDark : styles.sliderLight
+  );
 
-    const inputStyles = classnames(styles.checkbox, {
-      [styles.checkboxEnabled]: !disabled,
-    });
+  const inputStyles = classnames(styles.checkbox, {
+    [styles.checkboxEnabled]: !disabled,
+  });
 
-    return (
-      <div className={switchStyles}>
-        <input
-          checked={switched}
-          className={inputStyles}
-          disabled={disabled}
-          id={id}
-          name={name}
-          onBlur={this.handleBlur}
-          onChange={this.handleChange}
-          onFocus={this.handleFocus}
-          type="checkbox"
-        />
-        <div className={sliderStyles} />
-      </div>
-    );
-  }
+  return (
+    <div className={switchStyles}>
+      <input
+        checked={switched}
+        className={inputStyles}
+        disabled={disabled}
+        id={id}
+        name={name}
+        onBlur={() => setFocused(false)}
+        onChange={handleChange}
+        onFocus={() => setFocused(true)}
+        type="checkbox"
+      />
+      <div className={sliderStyles} />
+    </div>
+  );
 }
+
+Switch.propTypes = {
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  switched: PropTypes.bool,
+};

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -9,6 +9,8 @@ import getRoundingClassName, {
   type Rounding,
 } from './getRoundingClassName.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import focusStyles from './Focus.css';
+import useFocusVisible from './useFocusVisible.js';
 
 type TapStyle = 'none' | 'compress';
 
@@ -80,11 +82,14 @@ function TapArea({
     width: innerRef?.current?.clientWidth,
   });
 
+  const { isFocusVisible } = useFocusVisible();
+
   const className = classnames(
+    focusStyles.hideOutline,
     styles.tapTransition,
-    styles.touchable,
     getRoundingClassName(rounding),
     {
+      [focusStyles.accessibilityOutline]: !disabled && isFocusVisible,
       [styles.fullHeight]: fullHeight,
       [styles.fullWidth]: fullWidth,
       [styles[mouseCursor]]: !disabled,
@@ -116,7 +121,6 @@ function TapArea({
         if (!disabled && onFocus) {
           onFocus({ event });
         }
-        event.stopPropagation();
       }}
       onMouseEnter={event => {
         if (!disabled && onMouseEnter) {

--- a/packages/gestalt/src/Touchable.css
+++ b/packages/gestalt/src/Touchable.css
@@ -1,7 +1,3 @@
-.touchable {
-  composes: accessibilityOutline from "./Focus.css";
-}
-
 .fullHeight {
   height: 100%;
 }

--- a/packages/gestalt/src/Touchable.css.flow
+++ b/packages/gestalt/src/Touchable.css.flow
@@ -11,7 +11,6 @@ declare module.exports: {|
   +'pointer': string,
   +'tapCompress': string,
   +'tapTransition': string,
-  +'touchable': string,
   +'zoomIn': string,
   +'zoomOut': string,
 |};

--- a/packages/gestalt/src/TypeaheadOption.js
+++ b/packages/gestalt/src/TypeaheadOption.js
@@ -7,6 +7,8 @@ import Text from './Text.js';
 import styles from './Touchable.css';
 import getRoundingClassName from './getRoundingClassName.js';
 import Icon from './Icon.js';
+import focusStyles from './Focus.css';
+import useFocusVisible from './useFocusVisible.js';
 
 type OptionObject = {|
   label: string,
@@ -42,7 +44,10 @@ export default function TypeaheadOption({
     if (handleSelect) handleSelect({ event, item: option });
   };
 
-  const className = classnames(styles.touchable, getRoundingClassName(2), {
+  const { isFocusVisible } = useFocusVisible();
+
+  const className = classnames(getRoundingClassName(2), {
+    [focusStyles.accessibilityOutline]: isFocusVisible,
     [styles.fullWidth]: true,
     [styles.pointer]: true,
   });

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -185,7 +185,7 @@ exports[`<Callout /> description + title + primaryLink + dismissButton 1`] = `
       className="box flexNone paddingX4 paddingY4 pill whiteBg"
     >
       <a
-        className="link tapTransition touchable block rounding0 hoverUnderline"
+        className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
         href="pinterest.com"
         onBlur={[Function]}
         onClick={[Function]}
@@ -311,7 +311,7 @@ exports[`<Callout /> description + title + primaryLink + secondaryLink 1`] = `
       className="box flexNone paddingX4 paddingY4"
     >
       <a
-        className="link tapTransition touchable block rounding0 hoverUnderline"
+        className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
         href="pinterest.com/help"
         onBlur={[Function]}
         onClick={[Function]}
@@ -341,7 +341,7 @@ exports[`<Callout /> description + title + primaryLink + secondaryLink 1`] = `
       className="box flexNone paddingX4 paddingY4 pill whiteBg"
     >
       <a
-        className="link tapTransition touchable block rounding0 hoverUnderline"
+        className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
         href="pinterest.com"
         onBlur={[Function]}
         onClick={[Function]}
@@ -423,7 +423,7 @@ exports[`<Callout /> description + title + primaryLink 1`] = `
       className="box flexNone paddingX4 paddingY4 pill whiteBg"
     >
       <a
-        className="link tapTransition touchable block rounding0 hoverUnderline"
+        className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
         href="pinterest.com"
         onBlur={[Function]}
         onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`default 1`] = `
 <a
-  className="link tapTransition touchable block rounding0 hoverUnderline"
+  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -23,7 +23,7 @@ exports[`default 1`] = `
 
 exports[`inline 1`] = `
 <a
-  className="link tapTransition touchable inlineBlock rounding0 hoverUnderline"
+  className="link tapTransition inlineBlock rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -44,7 +44,7 @@ exports[`inline 1`] = `
 
 exports[`regular 1`] = `
 <a
-  className="link tapTransition touchable block rounding0 hoverUnderline"
+  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -65,7 +65,7 @@ exports[`regular 1`] = `
 
 exports[`target blank 1`] = `
 <a
-  className="link tapTransition touchable block rounding0 hoverUnderline"
+  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -86,7 +86,7 @@ exports[`target blank 1`] = `
 
 exports[`target null 1`] = `
 <a
-  className="link tapTransition touchable block rounding0 hoverUnderline"
+  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -107,7 +107,7 @@ exports[`target null 1`] = `
 
 exports[`target self 1`] = `
 <a
-  className="link tapTransition touchable block rounding0 hoverUnderline"
+  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -129,7 +129,7 @@ exports[`target self 1`] = `
 exports[`with accessibilitySelected and role 1`] = `
 <a
   aria-selected={true}
-  className="link tapTransition touchable block rounding0 hoverUnderline"
+  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -151,7 +151,7 @@ exports[`with accessibilitySelected and role 1`] = `
 
 exports[`with custom rounding, hoverStyle, and tapStyle 1`] = `
 <a
-  className="link tapTransition touchable block pill"
+  className="link tapTransition block pill accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -172,7 +172,7 @@ exports[`with custom rounding, hoverStyle, and tapStyle 1`] = `
 
 exports[`with nofollow 1`] = `
 <a
-  className="link tapTransition touchable block rounding0 hoverUnderline"
+  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -193,7 +193,7 @@ exports[`with nofollow 1`] = `
 
 exports[`with onTap 1`] = `
 <a
-  className="link tapTransition touchable block rounding0 hoverUnderline"
+  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -10,7 +10,7 @@ exports[`renders correctly when active 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -69,7 +69,7 @@ exports[`renders correctly when inactive 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}

--- a/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
@@ -27,7 +27,7 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
       >
         <a
           aria-selected={true}
-          className="link tapTransition touchable block pill"
+          className="link tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -71,7 +71,7 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
       >
         <a
           aria-selected={false}
-          className="link tapTransition touchable block pill"
+          className="link tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -138,7 +138,7 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
       >
         <a
           aria-selected={true}
-          className="link tapTransition touchable block pill"
+          className="link tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -192,7 +192,7 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
       >
         <a
           aria-selected={false}
-          className="link tapTransition touchable block pill"
+          className="link tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -269,7 +269,7 @@ exports[`<Tabs /> matches snapshot with lg size and wrap 1`] = `
       >
         <a
           aria-selected={true}
-          className="link tapTransition touchable block pill"
+          className="link tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -313,7 +313,7 @@ exports[`<Tabs /> matches snapshot with lg size and wrap 1`] = `
       >
         <a
           aria-selected={false}
-          className="link tapTransition touchable block pill"
+          className="link tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/TapArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TapArea.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TapArea renders 1`] = `
 <div
   aria-disabled={false}
-  className="tapTransition touchable rounding0 fullWidth pointer"
+  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -27,7 +27,7 @@ exports[`TapArea renders 1`] = `
 exports[`TapArea sets correct mouse cursor 1`] = `
 <div
   aria-disabled={false}
-  className="tapTransition touchable rounding0 fullWidth zoomIn"
+  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth zoomIn"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -51,7 +51,7 @@ exports[`TapArea sets correct mouse cursor 1`] = `
 exports[`TapArea sets correct rounding 1`] = `
 <div
   aria-disabled={false}
-  className="tapTransition touchable circle fullWidth pointer"
+  className="hideOutline tapTransition circle accessibilityOutline fullWidth pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -75,7 +75,7 @@ exports[`TapArea sets correct rounding 1`] = `
 exports[`TapArea sets fullHeight correctly 1`] = `
 <div
   aria-disabled={false}
-  className="tapTransition touchable rounding0 fullHeight fullWidth pointer"
+  className="hideOutline tapTransition rounding0 accessibilityOutline fullHeight fullWidth pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -99,7 +99,7 @@ exports[`TapArea sets fullHeight correctly 1`] = `
 exports[`TapArea sets fullWidth correctly 1`] = `
 <div
   aria-disabled={false}
-  className="tapTransition touchable rounding0 pointer"
+  className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}
@@ -123,7 +123,7 @@ exports[`TapArea sets fullWidth correctly 1`] = `
 exports[`TapArea supports press style 1`] = `
 <div
   aria-disabled={false}
-  className="tapTransition touchable rounding0 fullWidth pointer"
+  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
   onBlur={[Function]}
   onClick={[Function]}
   onContextMenu={[Function]}

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -73,7 +73,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
           Saved to
            
           <a
-            className="link tapTransition touchable block rounding0 hoverUnderline"
+            className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
             href="https://www.pinterest.com/search/pins/?q=home%20decor"
             onBlur={[Function]}
             onClick={[Function]}
@@ -163,7 +163,7 @@ exports[`<Toast /> Text + Image 1`] = `
           Saved to
            
           <a
-            className="link tapTransition touchable block rounding0 hoverUnderline"
+            className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
             href="https://www.pinterest.com/search/pins/?q=home%20decor"
             onBlur={[Function]}
             onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -139,7 +139,7 @@ exports[`Video with children 1`] = `
       >
         <div
           aria-disabled={false}
-          className="tapTransition touchable rounding0 pointer"
+          className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
           onBlur={[Function]}
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -176,7 +176,7 @@ exports[`Video with children 1`] = `
       >
         <div
           aria-disabled={false}
-          className="tapTransition touchable rounding0 pointer"
+          className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
           onBlur={[Function]}
           onClick={[Function]}
           onContextMenu={[Function]}
@@ -307,7 +307,7 @@ exports[`Video with children 1`] = `
       >
         <div
           aria-disabled={false}
-          className="tapTransition touchable rounding0 pointer"
+          className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
           onBlur={[Function]}
           onClick={[Function]}
           onContextMenu={[Function]}

--- a/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
@@ -9,7 +9,7 @@ exports[`VideoControls for double digit minutes 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -140,7 +140,7 @@ exports[`VideoControls for double digit minutes 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -184,7 +184,7 @@ exports[`VideoControls for double digit seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -315,7 +315,7 @@ exports[`VideoControls for double digit seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -359,7 +359,7 @@ exports[`VideoControls for single digit minutes 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -490,7 +490,7 @@ exports[`VideoControls for single digit minutes 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -534,7 +534,7 @@ exports[`VideoControls for single digit seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -665,7 +665,7 @@ exports[`VideoControls for single digit seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -709,7 +709,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -840,7 +840,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
   >
     <div
       aria-disabled={false}
-      className="tapTransition touchable rounding0 pointer"
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}


### PR DESCRIPTION
Follow up from #1073 where we only show the blue outline (focus ring) when using the keyboard.

Other changes:
* Convert Switch to React hooks (in order to use `useFocusVisible`)
* TapArea: no longer prevent bubbling up /cc @jackhsu978 in #906 

## Test Plan

For each of these components:

* Button
* Checkbox
* IconButton
* Link
* RadioButton
* Switch
* TapArea

Verify the following:

* Click on the component => You should see no focus style
* Tab to set the focus on the component => You should see the focus style
