### PR TITLE
Typeahead: Fix prop type

### DIFF
--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -182,7 +182,7 @@ const InputField = ({
 InputField.displayName = InputField;
 
 InputField.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   id: PropTypes.string.isRequired,
   onBlur: PropTypes.func,
   onClear: PropTypes.func,


### PR DESCRIPTION
The label property is not required for the Typeahead component. This was not reflected in the proptypes.