### PR TITLE
Internal: Refactored imports from namespacing * to explicit Default Exports and Named Values Importing

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import * as React from 'react';
+import React, { forwardRef, useEffect, useState, type ElementRef } from 'react';
 import ReactDatePicker, { registerLocale } from 'react-datepicker';
 import classnames from 'classnames';
 import { Icon, Box, Label, Text } from 'gestalt';
@@ -12,7 +12,7 @@ type Props = {|
   disabled?: boolean,
   errorMessage?: string,
   excludeDates?: Array<Date>,
-  forwardedRef?: React.ElementRef<*>,
+  forwardedRef?: ElementRef<*>,
   helperText?: string,
   id: string,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
@@ -21,7 +21,7 @@ type Props = {|
   localeData?: LocaleData,
   maxDate?: Date,
   minDate?: Date,
-  nextRef?: React.ElementRef<*>,
+  nextRef?: ElementRef<*>,
   onChange: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
     value: Date,
@@ -58,19 +58,19 @@ function DatePicker(props: Props) {
 
   // We keep month in state to trigger a re-render when month changes since height will vary by where days fall
   // in the month and we need to keep the flyout pointed at the input correctly
-  const [selected, setSelected] = React.useState<?Date>(dateValue);
-  const [, setMonth] = React.useState<?number>();
-  const [dateFormat, setDateFormat] = React.useState<?string>();
-  const [updatedLocale, setUpdatedLocale] = React.useState<?string>();
-  const [initRangeHighlight, setInitRangeHighlight] = React.useState<?Date>();
+  const [selected, setSelected] = useState<?Date>(dateValue);
+  const [, setMonth] = useState<?number>();
+  const [dateFormat, setDateFormat] = useState<?string>();
+  const [updatedLocale, setUpdatedLocale] = useState<?string>();
+  const [initRangeHighlight, setInitRangeHighlight] = useState<?Date>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (rangeSelector) {
       setInitRangeHighlight(rangeStartDate || rangeEndDate);
     }
   }, [rangeStartDate, rangeEndDate, rangeSelector]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (localeData && localeData.code) {
       registerLocale(localeData.code, localeData);
       setUpdatedLocale(localeData.code);
@@ -189,7 +189,7 @@ function datePickerForwardRef(props, ref) {
 
 datePickerForwardRef.displayName = 'DatePickerForwardRef';
 
-export default (React.forwardRef<Props, HTMLInputElement>(
+export default (forwardRef<Props, HTMLInputElement>(
   datePickerForwardRef
 ): React$AbstractComponent<Props, HTMLInputElement>);
 

--- a/packages/gestalt-datepicker/src/DatePickerTextField.js
+++ b/packages/gestalt-datepicker/src/DatePickerTextField.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { forwardRef, type ElementRef } from 'react';
 import { Box, Icon, Label, TextField } from 'gestalt';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -22,7 +22,7 @@ type InjectedProps = {|
 
 type Props = {|
   id: string,
-  forwardedRef?: React.ElementRef<*>,
+  forwardedRef?: ElementRef<*>,
   ...InjectedProps,
 |};
 
@@ -87,7 +87,7 @@ function textFieldForwardRef(props, ref) {
 
 textFieldForwardRef.displayName = 'DatePickerTextFieldForwardRef';
 
-export default (React.forwardRef<Props, HTMLInputElement>(
+export default (forwardRef<Props, HTMLInputElement>(
   textFieldForwardRef
 ): React$AbstractComponent<Props, HTMLInputElement>);
 

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Icon from './Icon.js';
@@ -93,8 +93,8 @@ const sizes = {
   xl: 120,
 };
 
-export default function Avatar(props: Props): React.Node {
-  const [isImageLoaded, setIsImageLoaded] = React.useState(true);
+export default function Avatar(props: Props): Node {
+  const [isImageLoaded, setIsImageLoaded] = useState(true);
   const { colorGray0, colorGray100 } = useColorScheme();
   const {
     accessibilityLabel,

--- a/packages/gestalt/src/AvatarPair.js
+++ b/packages/gestalt/src/AvatarPair.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Avatar from './Avatar.js';
 import Box from './Box.js';
@@ -20,7 +20,7 @@ const sizes = {
 export default function AvatarPair({
   collaborators,
   size = 'fit',
-}: Props): React.Node {
+}: Props): Node {
   const width = size === 'fit' ? '100%' : sizes[size];
   return (
     <Box position="relative" width={width}>

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import styles from './Badge.css';
@@ -10,7 +10,7 @@ type Props = {|
   text: string,
 |};
 
-export default function Badge(props: Props): React.Node {
+export default function Badge(props: Props): Node {
   const { position = 'middle', text } = props;
 
   const cs = cx(styles.Badge, styles[position], colors.blueBg);

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -15,7 +15,7 @@ I'll explain each part as we go through. Just remember, if you want to make upda
 
 */
 
-import * as React from 'react';
+import React, { forwardRef, type Node, type AbstractComponent } from 'react';
 import PropTypes from 'prop-types';
 import styles from './Box.css';
 import borders from './Borders.css';
@@ -137,7 +137,7 @@ type ResponsiveProps = {|
 type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill';
 
 type PropType = {
-  children?: React.Node,
+  children?: Node,
   dangerouslySetInlineStyle?: {|
     __style: { [key: string]: string | number | void },
   |},
@@ -703,10 +703,10 @@ const omit = (keys, obj) =>
 // (className, style) or accessibility (onClick).
 const blacklistProps = ['onClick', 'className', 'style'];
 
-const BoxWithRef: React.AbstractComponent<
+const BoxWithRef: AbstractComponent<PropType, HTMLDivElement> = forwardRef<
   PropType,
   HTMLDivElement
-> = React.forwardRef<PropType, HTMLDivElement>(function Box(props, ref) {
+>(function Box(props, ref) {
   // Flow can't reason about the constant nature of Object.keys so we can't use
   // a functional (reduce) style here.
 

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -1,6 +1,12 @@
 // @flow strict
 
-import * as React from 'react';
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type Ref,
+  type Element,
+} from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
@@ -36,7 +42,7 @@ type Props = {|
   accessibilityLabel?: string,
   color?: 'gray' | 'red' | 'blue' | 'transparent' | 'white',
   disabled?: boolean,
-  forwardedRef?: React.Ref<'button'>,
+  forwardedRef?: Ref<'button'>,
   iconEnd?: $Keys<typeof icons>,
   inline?: boolean,
   name?: string,
@@ -48,7 +54,7 @@ type Props = {|
   type?: 'submit' | 'button',
 |};
 
-function Button(props: Props): React.Element<'button'> {
+function Button(props: Props): Element<'button'> {
   const {
     accessibilityControls,
     accessibilityExpanded,
@@ -67,11 +73,11 @@ function Button(props: Props): React.Element<'button'> {
     textColor: textColorProp,
     type = 'button',
   } = props;
-  const innerRef = React.useRef(null);
+  const innerRef = useRef(null);
   // When using both forwardedRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Button ref={inputRef} /> to call inputRef.current.focus()
   // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  React.useImperativeHandle(forwardedRef, () => innerRef.current);
+  useImperativeHandle(forwardedRef, () => innerRef.current);
 
   const {
     compressStyle,
@@ -205,7 +211,7 @@ ButtonWithRef.displayName = 'ForwardRef(Button)';
 const ButtonWithForwardRef: React$AbstractComponent<
   Props,
   HTMLButtonElement
-> = React.forwardRef<Props, HTMLButtonElement>(ButtonWithRef);
+> = forwardRef<Props, HTMLButtonElement>(ButtonWithRef);
 
 ButtonWithForwardRef.displayName = 'Button';
 

--- a/packages/gestalt/src/Card.js
+++ b/packages/gestalt/src/Card.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -8,14 +8,14 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type Props = {|
   active?: ?boolean,
-  children?: React.Node,
-  image?: React.Node,
+  children?: Node,
+  image?: Node,
   onMouseEnter?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
   onMouseLeave?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
 |};
 
-export default function Card(props: Props): React.Node {
-  const [hovered, setHovered] = React.useState(false);
+export default function Card(props: Props): Node {
+  const [hovered, setHovered] = useState(false);
   const { active, children, image, onMouseEnter, onMouseLeave } = props;
 
   const handleMouseEnter = event => {

--- a/packages/gestalt/src/Caret.js
+++ b/packages/gestalt/src/Caret.js
@@ -1,12 +1,12 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 
 type Props = {|
   direction?: ?'up' | 'right' | 'down' | 'left',
 |};
 
-export default function Caret(props: Props): React.Node {
+export default function Caret(props: Props): Node {
   const { direction } = props;
   let path;
   switch (direction) {

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -1,5 +1,13 @@
 // @flow strict
-import * as React from 'react';
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useEffect,
+  useRef,
+  useState,
+  type Node,
+  type Ref,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import colors from './Colors.css';
@@ -18,7 +26,7 @@ type Props = {|
   checked?: boolean,
   disabled?: boolean,
   errorMessage?: string,
-  forwardedRef?: React.Ref<'input'>,
+  forwardedRef?: Ref<'input'>,
   hasError?: boolean,
   id: string,
   indeterminate?: boolean,
@@ -35,7 +43,7 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
-function Checkbox(props: Props): React.Node {
+function Checkbox(props: Props): Node {
   const {
     checked = false,
     disabled = false,
@@ -51,16 +59,16 @@ function Checkbox(props: Props): React.Node {
     size = 'md',
   } = props;
 
-  const innerRef = React.useRef(null);
+  const innerRef = useRef(null);
   // When using both forwardedRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Checkbox ref={inputRef} /> to call inputRef.current.focus()
   // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  React.useImperativeHandle(forwardedRef, () => innerRef.current);
+  useImperativeHandle(forwardedRef, () => innerRef.current);
 
-  const [focused, setFocused] = React.useState(false);
-  const [hovered, setHover] = React.useState(false);
+  const [focused, setFocused] = useState(false);
+  const [hovered, setHover] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (innerRef && innerRef.current) {
       innerRef.current.indeterminate = indeterminate;
     }
@@ -213,7 +221,7 @@ CheckboxWithRef.displayName = 'ForwardRef(Checkbox)';
 const CheckboxWithForwardRef: React$AbstractComponent<
   Props,
   HTMLInputElement
-> = React.forwardRef<Props, HTMLInputElement>(CheckboxWithRef);
+> = forwardRef<Props, HTMLInputElement>(CheckboxWithRef);
 
 CheckboxWithForwardRef.displayName = 'Checkbox';
 

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Collection from './Collection.js';
 
@@ -151,11 +151,11 @@ type Props = {|
     width: number,
     height: number,
     index: number,
-  |}) => React.Node,
+  |}) => Node,
   width: number,
 |};
 
-export default function Collage(props: Props): React.Node {
+export default function Collage(props: Props): Node {
   const {
     columns,
     cover,

--- a/packages/gestalt/src/Collage.test.js
+++ b/packages/gestalt/src/Collage.test.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { create } from 'react-test-renderer';
 import Collage from './Collage.js';
 

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -39,12 +39,12 @@
   4. The viewport can be any size. Most windowing/recycling solutions implement some sort of overscanning, however Collection leaves this up the the parent.
 
 */
-import * as React from 'react';
+import React, { PureComponent, type Node } from 'react';
 import PropTypes from 'prop-types';
 import layoutStyles from './Layout.css';
 
 type Props = {|
-  Item: ({| idx: number |}) => React.Node,
+  Item: ({| idx: number |}) => Node,
   layout: Array<{|
     top: number,
     left: number,
@@ -57,7 +57,7 @@ type Props = {|
   viewportHeight?: number,
 |};
 
-export default class Collection extends React.PureComponent<Props, void> {
+export default class Collection extends PureComponent<Props, void> {
   static propTypes = {
     // eslint-disable-next-line react/forbid-prop-types
     Item: PropTypes.any,
@@ -90,7 +90,7 @@ export default class Collection extends React.PureComponent<Props, void> {
     viewportTop: 0,
   };
 
-  render(): React.Node {
+  render(): Node {
     const { Item, layout, viewportTop = 0, viewportLeft = 0 } = this.props;
 
     // Calculate the full dimensions of the item layer

--- a/packages/gestalt/src/Column.js
+++ b/packages/gestalt/src/Column.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './ColumnColumn.css';
@@ -9,21 +9,21 @@ type Columns = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 type ColumnProps =
   | {|
-      children?: React.Node,
+      children?: Node,
       span: Columns,
       smSpan?: Columns,
       mdSpan?: Columns,
       lgSpan?: Columns,
     |}
   | {|
-      children?: React.Node,
+      children?: Node,
       xs?: DeprecatedColumns,
       sm?: DeprecatedColumns,
       md?: DeprecatedColumns,
       lg?: DeprecatedColumns,
     |};
 
-export default function Column(props: ColumnProps): React.Node {
+export default function Column(props: ColumnProps): Node {
   const { children } = props;
   const cs = classnames(
     (props.xs !== undefined ||

--- a/packages/gestalt/src/Container.js
+++ b/packages/gestalt/src/Container.js
@@ -1,13 +1,13 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
 |};
 
-export default function Container(props: Props): React.Node {
+export default function Container(props: Props): Node {
   const { children } = props;
   return (
     <Box justifyContent="center" display="flex">

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { Component, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Caret from './Caret.js';
@@ -59,7 +59,7 @@ type OwnProps = {|
   bgColor: 'blue' | 'darkGray' | 'orange' | 'red' | 'white',
   border?: boolean,
   caret?: boolean,
-  children?: React.Node,
+  children?: Node,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onKeyDown: (event: {| keyCode: number |}) => void,
   onResize: () => void,
@@ -348,7 +348,7 @@ export function baseOffsets(
   return { top, left };
 }
 
-class WrappedContents extends React.Component<Props, State> {
+class WrappedContents extends Component<Props, State> {
   static propTypes = {
     bgColor: PropTypes.oneOf(['blue', 'darkGray', 'orange', 'red', 'white']),
     border: PropTypes.bool,
@@ -518,7 +518,7 @@ class WrappedContents extends React.Component<Props, State> {
     }
   };
 
-  render(): React.Node {
+  render(): Node {
     const {
       bgColor,
       border,
@@ -583,7 +583,7 @@ class WrappedContents extends React.Component<Props, State> {
   }
 }
 
-export default function Contents(props: OwnProps): React.Node {
+export default function Contents(props: OwnProps): Node {
   const { colorGray100, name: colorSchemeName } = useColorScheme();
   return (
     <WrappedContents

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { Component, type Node as ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import Contents from './Contents.js';
 import OutsideEventBehavior from './behaviors/OutsideEventBehavior.js';
@@ -9,7 +9,7 @@ type Props = {|
   bgColor: 'blue' | 'darkGray' | 'orange' | 'red' | 'white',
   border?: boolean,
   caret?: boolean,
-  children?: React.Node,
+  children?: ReactNode,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
   positionRelativeToAnchor: boolean,
@@ -69,7 +69,7 @@ function getTriggerRect(
   return { relativeOffset, triggerBoundingRect };
 }
 
-export default class Controller extends React.Component<Props, State> {
+export default class Controller extends Component<Props, State> {
   static propTypes = {
     anchor: PropTypes.shape({
       contains: PropTypes.func,
@@ -156,7 +156,7 @@ export default class Controller extends React.Component<Props, State> {
     this.setState({ relativeOffset, triggerBoundingRect });
   };
 
-  render(): React.Node {
+  render(): ReactNode {
     const {
       bgColor,
       border,

--- a/packages/gestalt/src/Divider.js
+++ b/packages/gestalt/src/Divider.js
@@ -1,7 +1,7 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import styles from './Divider.css';
 
-export default function Divider(): React.Node {
+export default function Divider(): Node {
   return <hr className={styles.divider} />;
 }

--- a/packages/gestalt/src/FetchItems.js
+++ b/packages/gestalt/src/FetchItems.js
@@ -11,7 +11,7 @@
  */
 
 // @flow strict
-import * as React from 'react';
+import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 type Props = {|
@@ -23,7 +23,7 @@ type Props = {|
   scrollTop: number,
 |};
 
-export default class FetchItems extends React.PureComponent<Props> {
+export default class FetchItems extends PureComponent<Props> {
   static propTypes = {
     containerHeight: PropTypes.number.isRequired,
     isAtEnd: PropTypes.bool,

--- a/packages/gestalt/src/FlexBox.js
+++ b/packages/gestalt/src/FlexBox.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box, {
   AlignContentPropType,
@@ -26,7 +26,7 @@ type Props = {|
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
-  children?: React.Node,
+  children?: Node,
   direction?: Direction,
   fit?: boolean,
   flex?: Flex,
@@ -59,7 +59,7 @@ type Props = {|
   wrap?: boolean,
 |};
 
-export default function FlexBox(props: Props): React.Node {
+export default function FlexBox(props: Props): Node {
   return <Box display="flex" {...props} />;
 }
 

--- a/packages/gestalt/src/Flyout.js
+++ b/packages/gestalt/src/Flyout.js
@@ -1,11 +1,11 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Controller from './Controller.js';
 
 type Props = {|
   anchor: ?HTMLElement,
-  children?: React.Node,
+  children?: Node,
   color?: 'blue' | 'orange' | 'red' | 'white' | 'darkGray',
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
@@ -15,7 +15,7 @@ type Props = {|
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number,
 |};
 
-export default function Flyout(props: Props): null | React.Node {
+export default function Flyout(props: Props): null | Node {
   const {
     anchor,
     children,

--- a/packages/gestalt/src/FormErrorMessage.js
+++ b/packages/gestalt/src/FormErrorMessage.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Text from './Text.js';
@@ -11,7 +11,7 @@ export default function FormErrorMessage({
 }: {|
   id: string,
   text?: string,
-|}): React.Node {
+|}): Node {
   return (
     <Box marginTop={2}>
       <Text color="red" size="sm">

--- a/packages/gestalt/src/FormHelperText.js
+++ b/packages/gestalt/src/FormHelperText.js
@@ -1,15 +1,11 @@
 // @flow strict
 
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Text from './Text.js';
 
-export default function FormHelperText({
-  text,
-}: {|
-  text: string,
-|}): React.Node {
+export default function FormHelperText({ text }: {| text: string |}): Node {
   return (
     <Box marginTop={2}>
       <Text color="gray" size="sm">

--- a/packages/gestalt/src/FormLabel.js
+++ b/packages/gestalt/src/FormLabel.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import styles from './FormLabel.css';
 import Text from './Text.js';
@@ -12,7 +12,7 @@ export default function FormLabel({
 }: {|
   id: string,
   label: string,
-|}): React.Node {
+|}): Node {
   return (
     <Label htmlFor={id}>
       <div className={styles.formLabel}>

--- a/packages/gestalt/src/GestaltProvider.js
+++ b/packages/gestalt/src/GestaltProvider.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import {
   ColorSchemeProvider,
@@ -8,7 +8,7 @@ import {
 } from './contexts/ColorScheme.js';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
   colorScheme?: ColorScheme,
   id?: string,
 |};
@@ -17,7 +17,7 @@ export default function GestaltProvider({
   children,
   colorScheme,
   id,
-}: Props): React.Node {
+}: Props): Node {
   return (
     <ColorSchemeProvider colorScheme={colorScheme} id={id}>
       {children}

--- a/packages/gestalt/src/GroupAvatar.js
+++ b/packages/gestalt/src/GroupAvatar.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import styles from './GroupAvatar.css';
 import Box from './Box.js';
@@ -170,7 +170,7 @@ const DefaultAvatar = (props: {|
   }
 };
 
-export default function GroupAvatar(props: Props): React.Node {
+export default function GroupAvatar(props: Props): Node {
   const { collaborators, outline, size = 'fit' } = props;
   const { colorGray0, colorGray100 } = useColorScheme();
   const avatarWidth = size === 'fit' ? '100%' : AVATAR_SIZES[size];

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import { createElement, type Node } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import colors from './Colors.css';
@@ -9,7 +9,7 @@ import typography from './Typography.css';
 type Props = {|
   align?: 'left' | 'right' | 'center' | 'justify',
   accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6,
-  children?: React.Node,
+  children?: Node,
   color?:
     | 'blue'
     | 'darkGray'
@@ -46,7 +46,7 @@ const SIZE_SCALE = {
   lg: 3,
 };
 
-export default function Heading(props: Props): React.Node {
+export default function Heading(props: Props): Node {
   const {
     accessibilityLevel,
     align = 'left',
@@ -78,7 +78,7 @@ export default function Heading(props: Props): React.Node {
   if (truncate && typeof children === 'string') {
     newProps = { ...newProps, title: children };
   }
-  return React.createElement(`h${headingLevel}`, newProps, children);
+  return createElement(`h${headingLevel}`, newProps, children);
 }
 
 Heading.propTypes = {

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './Icon.css';
@@ -58,7 +58,7 @@ const flipOnRtlIconNames = [
   'text-size',
 ];
 
-export default function Icon(props: Props): React.Node {
+export default function Icon(props: Props): Node {
   const {
     accessibilityLabel,
     color = 'gray',

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -1,5 +1,12 @@
 // @flow strict
-import * as React from 'react';
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  useRef,
+  type Node,
+  type Ref,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import icons from './icons/index.js';
@@ -25,7 +32,7 @@ type Props = {|
     | 'red',
   dangerouslySetSvgPath?: {| __path: string |},
   disabled?: boolean,
-  forwardedRef?: React.Ref<'button'>,
+  forwardedRef?: Ref<'button'>,
   icon?: $Keys<typeof icons>,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   onClick?: AbstractEventHandler<SyntheticMouseEvent<HTMLButtonElement>>,
@@ -49,12 +56,12 @@ function IconButton({
   padding,
   selected,
   size,
-}: Props): React.Node {
-  const innerRef = React.useRef(null);
+}: Props): Node {
+  const innerRef = useRef(null);
   // When using both forwardedRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <IconButton ref={inputRef} /> to call inputRef.current.focus()
   // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  React.useImperativeHandle(forwardedRef, () => innerRef.current);
+  useImperativeHandle(forwardedRef, () => innerRef.current);
 
   const {
     compressStyle,
@@ -71,9 +78,9 @@ function IconButton({
     width: innerRef?.current?.clientWidth,
   });
 
-  const [isActive, setActive] = React.useState(false);
-  const [isFocused, setFocused] = React.useState(false);
-  const [isHovered, setHovered] = React.useState(false);
+  const [isActive, setActive] = useState(false);
+  const [isFocused, setFocused] = useState(false);
+  const [isHovered, setHovered] = useState(false);
 
   const { isFocusVisible } = useFocusVisible();
 
@@ -175,7 +182,7 @@ IconButtonWithRef.displayName = 'ForwardRef(IconButton)';
 const IconButtonWithForwardRef: React$AbstractComponent<
   Props,
   HTMLButtonElement
-> = React.forwardRef<Props, HTMLButtonElement>(IconButtonWithRef);
+> = forwardRef<Props, HTMLButtonElement>(IconButtonWithRef);
 
 IconButtonWithForwardRef.displayName = 'IconButton';
 

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { PureComponent, type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import styles from './Image.css';
@@ -8,7 +8,7 @@ const shouldScaleImage = fit => fit === 'cover' || fit === 'contain';
 
 type Props = {|
   alt: string,
-  children?: React.Node,
+  children?: Node,
   color: string,
   fit?: 'contain' | 'cover' | 'none',
   importance?: 'high' | 'low' | 'auto',
@@ -22,7 +22,7 @@ type Props = {|
   srcSet?: string,
 |};
 
-export default class Image extends React.PureComponent<Props> {
+export default class Image extends PureComponent<Props> {
   static propTypes = {
     alt: PropTypes.string.isRequired,
     children: PropTypes.node,
@@ -85,7 +85,7 @@ export default class Image extends React.PureComponent<Props> {
     }
   }
 
-  render(): React.Node {
+  render(): Node {
     const {
       alt,
       color,

--- a/packages/gestalt/src/Label.js
+++ b/packages/gestalt/src/Label.js
@@ -1,14 +1,14 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import styles from './Label.css';
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
   htmlFor: string,
 |};
 
-export default function Label(props: Props): React.Node {
+export default function Label(props: Props): Node {
   const { children, htmlFor } = props;
 
   return (

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -1,17 +1,17 @@
 // @flow strict
-import * as React from 'react';
+import { Component, type Portal, type Node } from 'react';
 // flowlint-next-line untyped-import:off
 import { createPortal } from 'react-dom';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
 |};
 
 type State = {|
   mounted: boolean,
 |};
 
-export default class Layer extends React.Component<Props, State> {
+export default class Layer extends Component<Props, State> {
   state: State = {
     mounted: false,
   };
@@ -43,7 +43,7 @@ export default class Layer extends React.Component<Props, State> {
     }
   }
 
-  render(): React.Portal | null {
+  render(): Portal | null {
     const { children } = this.props;
     const { mounted } = this.state;
     if (!mounted) {

--- a/packages/gestalt/src/Letterbox.js
+++ b/packages/gestalt/src/Letterbox.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Mask from './Mask.js';
 
@@ -15,7 +15,7 @@ import Mask from './Mask.js';
 const aspectRatio = (width, height) => width / height;
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
   contentAspectRatio: number,
   height: number,
   width: number,
@@ -26,7 +26,7 @@ export default function Letterbox({
   contentAspectRatio,
   height,
   width,
-}: Props): React.Node {
+}: Props): Node {
   const viewportAspectRatio = aspectRatio(width, height);
 
   let contentHeight;

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -1,5 +1,12 @@
 // @flow strict
-import * as React from 'react';
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type AbstractComponent,
+  type Node,
+  type Ref,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import touchableStyles from './Touchable.css';
@@ -15,8 +22,8 @@ import useFocusVisible from './useFocusVisible.js';
 
 type Props = {|
   accessibilitySelected?: boolean,
-  children?: React.Node,
-  forwardedRef?: React.Ref<'a'>,
+  children?: Node,
+  forwardedRef?: Ref<'a'>,
   hoverStyle?: 'none' | 'underline',
   href: string,
   id?: string,
@@ -50,10 +57,10 @@ function Link({
   hoverStyle = 'underline',
   tapStyle = 'none',
   target = null,
-}: Props): React.Node {
-  const innerRef = React.useRef(null);
+}: Props): Node {
+  const innerRef = useRef(null);
   // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  React.useImperativeHandle(forwardedRef, () => innerRef.current);
+  useImperativeHandle(forwardedRef, () => innerRef.current);
 
   const {
     compressStyle,
@@ -171,10 +178,10 @@ function LinkWithRef(props, ref) {
   return <Link {...props} forwardedRef={ref} />;
 }
 
-const LinkWithForwardRef: React.AbstractComponent<
+const LinkWithForwardRef: AbstractComponent<
   Props,
   HTMLAnchorElement
-> = React.forwardRef<Props, HTMLAnchorElement>(LinkWithRef);
+> = forwardRef<Props, HTMLAnchorElement>(LinkWithRef);
 
 LinkWithForwardRef.displayName = 'Link';
 

--- a/packages/gestalt/src/Mask.js
+++ b/packages/gestalt/src/Mask.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import styles from './Mask.css';
@@ -8,7 +8,7 @@ import getRoundingClassName from './getRoundingClassName.js';
 type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle';
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
   height?: number | string,
   rounding?: Rounding,
   width?: number | string,
@@ -16,7 +16,7 @@ type Props = {|
   wash?: boolean,
 |};
 
-export default function Mask(props: Props): React.Node {
+export default function Mask(props: Props): Node {
   const {
     children,
     rounding = 0,

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -1,5 +1,9 @@
 // @flow strict
-import * as React from 'react';
+import React, {
+  Component as ReactComponent,
+  type ComponentType,
+  type Node,
+} from 'react';
 import PropTypes from 'prop-types';
 import debounce from './debounce.js';
 import FetchItems from './FetchItems.js';
@@ -36,7 +40,7 @@ type Layout =
 type Props<T> = {|
   columnWidth?: number,
   // eslint-disable-next-line flowtype/require-exact-type
-  comp: React.ComponentType<{
+  comp: ComponentType<{
     data: T,
     itemIdx: number,
     isMeasuring: boolean,
@@ -81,10 +85,7 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 const layoutNumberToCssDimension = n => (n !== Infinity ? n : undefined);
 
 // eslint-disable-next-line flowtype/require-exact-type
-export default class Masonry<T: {}> extends React.Component<
-  Props<T>,
-  State<T>
-> {
+export default class Masonry<T: {}> extends ReactComponent<Props<T>, State<T>> {
   // eslint-disable-next-line flowtype/require-exact-type
   static createMeasurementStore<T1: {}, T2>(): MeasurementStore<T1, T2> {
     return new MeasurementStore();
@@ -234,7 +235,6 @@ export default class Masonry<T: {}> extends React.Component<
     const measurementStore: Cache<T, *> =
       props.measurementStore || Masonry.createMeasurementStore();
 
-    // eslint-disable-next-line react/state-in-constructor
     this.state = {
       hasPendingMeasurements: props.items.some(
         item => !!item && !measurementStore.has(item)
@@ -484,7 +484,7 @@ export default class Masonry<T: {}> extends React.Component<
     return virtualize ? (isVisible && itemComponent) || null : itemComponent;
   };
 
-  render(): React.Node {
+  render(): Node {
     const {
       columnWidth,
       comp: Component,

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { useState, useEffect, useRef, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -10,10 +10,10 @@ import styles from './Modal.css';
 
 type Props = {|
   accessibilityModalLabel: string,
-  children?: React.Node,
+  children?: Node,
   closeOnOutsideClick?: boolean,
-  footer?: React.Node,
-  heading?: string | React.Node,
+  footer?: Node,
+  heading?: string | Node,
   onDismiss: () => void,
   role?: 'alertdialog' | 'dialog',
   size?: 'sm' | 'md' | 'lg' | number,
@@ -31,7 +31,7 @@ function Backdrop({
   children,
   onClick,
 }: {|
-  children?: React.Node,
+  children?: Node,
   onClick?: (event: MouseEvent) => void,
 |}) {
   const handleClick = event => {
@@ -53,7 +53,7 @@ function Backdrop({
   );
 }
 
-function Header({ heading }: {| heading: string | React.Node |}) {
+function Header({ heading }: {| heading: string | Node |}) {
   if (typeof heading !== 'string') {
     return heading;
   }
@@ -76,12 +76,12 @@ export default function Modal({
   heading,
   role = 'dialog',
   size = 'sm',
-}: Props): React.Node {
-  const [showTopShadow, setShowTopShadow] = React.useState(false);
-  const [showBottomShadow, setShowBottomShadow] = React.useState(false);
-  const content = React.useRef<?HTMLDivElement>(null);
+}: Props): Node {
+  const [showTopShadow, setShowTopShadow] = useState(false);
+  const [showBottomShadow, setShowBottomShadow] = useState(false);
+  const content = useRef<?HTMLDivElement>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     function handleKeyUp(event: {| keyCode: number |}) {
       if (event.keyCode === ESCAPE_KEY_CODE) {
         onDismiss();
@@ -113,14 +113,14 @@ export default function Modal({
     );
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener('resize', updateShadows);
     return () => {
       window.removeEventListener('resize', updateShadows);
     };
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     updateShadows();
   }, []);
 

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Icon from './Icon.js';
@@ -56,7 +56,7 @@ const defaultIconButtonIconColors = {
   white: 'gray',
 };
 
-export default function Pog(props: Props): React.Node {
+export default function Pog(props: Props): Node {
   const {
     accessibilityLabel = '',
     active = false,

--- a/packages/gestalt/src/Pulsar.js
+++ b/packages/gestalt/src/Pulsar.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import styles from './Pulsar.css';
@@ -9,7 +9,7 @@ type Props = {|
   size?: number,
 |};
 
-export default function Pulsar({ paused, size = 136 }: Props): React.Node {
+export default function Pulsar({ paused, size = 136 }: Props): Node {
   return (
     <Box
       dangerouslySetInlineStyle={{

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { forwardRef, useState, type Node, type Ref } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import controlStyles from './RadioButtonCheckbox.css';
@@ -14,7 +14,7 @@ import focusStyles from './Focus.css';
 type Props = {|
   checked?: boolean,
   disabled?: boolean,
-  forwardedRef?: React.Ref<'input'>,
+  forwardedRef?: Ref<'input'>,
   id: string,
   label?: string,
   name?: string,
@@ -26,7 +26,7 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
-function RadioButton(props: Props): React.Node {
+function RadioButton(props: Props): Node {
   const {
     checked = false,
     disabled = false,
@@ -39,8 +39,8 @@ function RadioButton(props: Props): React.Node {
     size = 'md',
   } = props;
 
-  const [focused, setFocused] = React.useState(false);
-  const [hovered, setHover] = React.useState(false);
+  const [focused, setFocused] = useState(false);
+  const [hovered, setHover] = useState(false);
 
   const handleChange: (
     event: SyntheticInputEvent<HTMLInputElement>
@@ -161,7 +161,7 @@ function RadioButtonWithRef(props, ref) {
 const RadioButtonWithForwardRef: React$AbstractComponent<
   Props,
   HTMLInputElement
-> = React.forwardRef<Props, HTMLInputElement>(RadioButtonWithRef);
+> = forwardRef<Props, HTMLInputElement>(RadioButtonWithRef);
 
 RadioButtonWithForwardRef.displayName = 'RadioButton';
 

--- a/packages/gestalt/src/Row.js
+++ b/packages/gestalt/src/Row.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { Children, type Node } from 'react';
 import PropTypes from 'prop-types';
 import FlexBox from './FlexBox.js';
 import Box, {
@@ -25,7 +25,7 @@ type Props = {|
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
-  children?: React.Node,
+  children?: Node,
   flex?: Flex,
   gap?: Padding,
   height?: Dimension,
@@ -47,7 +47,7 @@ export default function Row({
   justifyContent = 'start',
   width,
   ...rest
-}: Props): React.Node {
+}: Props): Node {
   return (
     <Box
       height={height}
@@ -63,7 +63,7 @@ export default function Row({
         width={width}
         {...rest}
       >
-        {React.Children.map(children, child =>
+        {Children.map(children, child =>
           child !== null && child !== undefined ? (
             <Box paddingX={gap}>{child}</Box>
           ) : null

--- a/packages/gestalt/src/ScrollContainer.js
+++ b/packages/gestalt/src/ScrollContainer.js
@@ -13,11 +13,11 @@
  */
 
 // @flow strict
-import * as React from 'react';
+import { Children, Component, type Node } from 'react';
 import PropTypes from 'prop-types';
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
   onScroll: (event: Event) => void,
   scrollContainer: ?HTMLElement | (() => ?HTMLElement),
 |};
@@ -28,7 +28,7 @@ function getScrollContainer(scrollContainer) {
     : scrollContainer;
 }
 
-export default class ScrollContainer extends React.Component<Props> {
+export default class ScrollContainer extends Component<Props> {
   scrollContainer: ?HTMLElement;
 
   static propTypes = {
@@ -74,6 +74,6 @@ export default class ScrollContainer extends React.Component<Props> {
   }
 
   render(): React$Node {
-    return React.Children.only(this.props.children);
+    return Children.only(this.props.children);
   }
 }

--- a/packages/gestalt/src/ScrollFetch.js
+++ b/packages/gestalt/src/ScrollFetch.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { PureComponent, type Node } from 'react';
 import PropTypes from 'prop-types';
 import FetchItems from './FetchItems.js';
 import ScrollContainer from './ScrollContainer.js';
@@ -24,7 +24,7 @@ type State = {|
   scrollTop: number,
 |};
 
-export default class ScrollFetch extends React.PureComponent<Props, State> {
+export default class ScrollFetch extends PureComponent<Props, State> {
   /**
    * Fetches additional items if needed.
    */
@@ -105,7 +105,7 @@ export default class ScrollFetch extends React.PureComponent<Props, State> {
     };
   }
 
-  render(): null | React.Node {
+  render(): null | Node {
     const { containerHeight, scrollHeight, scrollTop } = this.state;
     const { container, fetchMore, isAtEnd, isFetching } = this.props;
 

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import * as React from 'react';
+import React, { forwardRef, useState, type Ref } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import layout from './Layout.css';
@@ -25,7 +25,7 @@ type Props = {|
   placeholder?: string,
   size?: 'md' | 'lg',
   value?: string,
-  forwardedRef?: React.Ref<'input'>,
+  forwardedRef?: Ref<'input'>,
 |};
 
 const SearchField = ({
@@ -40,8 +40,8 @@ const SearchField = ({
   value,
   forwardedRef,
 }: Props) => {
-  const [hovered, setHovered] = React.useState<boolean>(false);
-  const [focused, setFocused] = React.useState<boolean>(false);
+  const [hovered, setHovered] = useState<boolean>(false);
+  const [focused, setFocused] = useState<boolean>(false);
 
   const handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
     onChange({
@@ -179,6 +179,6 @@ function forwardRefSearchField(props, ref) {
 }
 forwardRefSearchField.displayName = 'SearchField';
 
-export default (React.forwardRef<Props, HTMLInputElement>(
+export default (forwardRef<Props, HTMLInputElement>(
   forwardRefSearchField
 ): React$AbstractComponent<Props, HTMLInputElement>);

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -9,7 +9,7 @@ import styles from './SegmentedControl.css';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type Props = {|
-  items: Array<React.Node>,
+  items: Array<Node>,
   onChange: AbstractEventHandler<
     SyntheticMouseEvent<HTMLButtonElement>,
     {| activeIndex: number |}
@@ -19,7 +19,7 @@ type Props = {|
   size?: 'md' | 'lg',
 |};
 
-export default function SegmentedControl(props: Props): React.Node {
+export default function SegmentedControl(props: Props): Node {
   const { items, onChange, responsive, selectedItemIndex, size = 'md' } = props;
   const buttonWidth = responsive
     ? undefined

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { Component, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -37,7 +37,7 @@ type State = {|
   focused: boolean,
 |};
 
-export default class SelectList extends React.Component<Props, State> {
+export default class SelectList extends Component<Props, State> {
   select: ?HTMLSelectElement;
 
   static propTypes = {
@@ -90,7 +90,7 @@ export default class SelectList extends React.Component<Props, State> {
     }
   };
 
-  render(): React.Node {
+  render(): Node {
     const {
       disabled,
       errorMessage,

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -23,7 +23,7 @@ export default function Spinner({
   delay = true,
   show,
   size = 'md',
-}: Props): React.Node {
+}: Props): Node {
   return show ? (
     <Box display="flex" justifyContent="around" overflow="hidden">
       <div className={classnames(styles.icon, { [styles.delay]: delay })}>

--- a/packages/gestalt/src/Stack.js
+++ b/packages/gestalt/src/Stack.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { Children, type Node } from 'react';
 import PropTypes from 'prop-types';
 import FlexBox from './FlexBox.js';
 import Box, {
@@ -25,7 +25,7 @@ type Props = {|
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
-  children?: React.Node,
+  children?: Node,
   flex?: Flex,
   gap?: Padding,
   height?: Dimension,
@@ -47,7 +47,7 @@ export default function Stack({
   justifyContent = 'center',
   width,
   ...rest
-}: Props): React.Node {
+}: Props): Node {
   return (
     <Box
       height={height}
@@ -63,7 +63,7 @@ export default function Stack({
         width={width}
         {...rest}
       >
-        {React.Children.map(children, child =>
+        {Children.map(children, child =>
           child !== null && child !== undefined ? (
             <Box paddingY={gap}>{child}</Box>
           ) : null

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import layout from './Layout.css';
 import { type Indexable, FixedZIndex } from './zIndex.js';
@@ -20,7 +20,7 @@ type Threshold =
     |};
 
 type Props = {|
-  children: React.Node,
+  children: Node,
   zIndex?: Indexable,
   dangerouslySetZIndex?: {| __zIndex: number |},
   ...Threshold,
@@ -28,7 +28,7 @@ type Props = {|
 
 const DEFAULT_ZINDEX = new FixedZIndex(1);
 
-export default function Sticky(props: Props): React.Node {
+export default function Sticky(props: Props): Node {
   const { dangerouslySetZIndex, children } = props;
   const zIndex =
     props.zIndex ||

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import Box from './Box.js';
 import styles from './Table.css';
 import TableCell from './TableCell.js';
@@ -11,12 +11,12 @@ import TableRow from './TableRow.js';
 import TableSortableHeaderCell from './TableSortableHeaderCell.js';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
   borderSize?: 'sm' | 'none',
   maxHeight?: number | string,
 |};
 
-export default function Table(props: Props): React.Node {
+export default function Table(props: Props): Node {
   const { borderSize, children, maxHeight } = props;
 
   return (

--- a/packages/gestalt/src/TableBody.js
+++ b/packages/gestalt/src/TableBody.js
@@ -1,10 +1,10 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
 |};
 
-export default function TableBody(props: Props): React.Node {
+export default function TableBody(props: Props): Node {
   return <tbody>{props.children}</tbody>;
 }

--- a/packages/gestalt/src/TableCell.js
+++ b/packages/gestalt/src/TableCell.js
@@ -1,14 +1,14 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import styles from './Table.css';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
   colSpan?: number,
   rowSpan?: number,
 |};
 
-export default function TableCell(props: Props): React.Node {
+export default function TableCell(props: Props): Node {
   const { children, colSpan, rowSpan } = props;
 
   return (

--- a/packages/gestalt/src/TableFooter.js
+++ b/packages/gestalt/src/TableFooter.js
@@ -1,10 +1,10 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
 |};
 
-export default function TableFooter(props: Props): React.Node {
+export default function TableFooter(props: Props): Node {
   return <tfoot>{props.children}</tfoot>;
 }

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -1,14 +1,14 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import cx from 'classnames';
 import styles from './Table.css';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
   sticky?: boolean,
 |};
 
-export default function TableHeader(props: Props): React.Node {
+export default function TableHeader(props: Props): Node {
   const cs = cx(styles.thead, props.sticky && styles.sticky);
   return <thead className={cs}>{props.children}</thead>;
 }

--- a/packages/gestalt/src/TableHeaderCell.js
+++ b/packages/gestalt/src/TableHeaderCell.js
@@ -1,15 +1,15 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import styles from './Table.css';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
   colSpan?: number,
   rowSpan?: number,
   scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',
 |};
 
-export default function TableHeaderCell(props: Props): React.Node {
+export default function TableHeaderCell(props: Props): Node {
   const { children, colSpan, scope, rowSpan } = props;
 
   return (

--- a/packages/gestalt/src/TableRow.js
+++ b/packages/gestalt/src/TableRow.js
@@ -1,10 +1,10 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
 |};
 
-export default function TableRow(props: Props): React.Node {
+export default function TableRow(props: Props): Node {
   return <tr>{props.children}</tr>;
 }

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -1,12 +1,12 @@
 // @flow strict
-import * as React from 'react';
+import React, { useState, type Node } from 'react';
 import Box from './Box.js';
 import Icon from './Icon.js';
 import TableHeaderCell from './TableHeaderCell.js';
 import TapArea from './TapArea.js';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
   colSpan?: number,
   onSortChange: ({|
     event:
@@ -19,7 +19,7 @@ type Props = {|
   status: 'active' | 'inactive',
 |};
 
-export default function TableSortableHeaderCell(props: Props): React.Node {
+export default function TableSortableHeaderCell(props: Props): Node {
   const {
     children,
     colSpan,
@@ -30,8 +30,8 @@ export default function TableSortableHeaderCell(props: Props): React.Node {
     onSortChange,
   } = props;
 
-  const [isFocused, setFocused] = React.useState(false);
-  const [isHovered, setHovered] = React.useState(false);
+  const [isFocused, setFocused] = useState(false);
+  const [isHovered, setHovered] = useState(false);
 
   const shouldShowIcon = status === 'active' || isHovered || isFocused;
   const visibility = shouldShowIcon ? 'visible' : 'hidden';

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Row from './Row.js';
@@ -36,7 +36,7 @@ function Tab({
   isActive,
   onChange,
 }: {|
-  children: React.Node,
+  children: Node,
   size: 'md' | 'lg',
   isActive: boolean,
   href: string,
@@ -45,8 +45,8 @@ function Tab({
   id?: string,
   onChange: OnChangeHandler,
 |}) {
-  const [hovered, setHovered] = React.useState(false);
-  const [focused, setFocused] = React.useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
   return (
     <Box position={focused ? 'relative' : undefined}>
       <Link
@@ -100,7 +100,7 @@ type Props = {|
     href: string,
     id?: string,
     indicator?: 'dot',
-    text: React.Node,
+    text: Node,
   |}>,
   wrap?: boolean,
 |};
@@ -111,7 +111,7 @@ export default function Tabs({
   size = 'md',
   tabs,
   wrap,
-}: Props): React.Node {
+}: Props): Node {
   return (
     <Row wrap={wrap}>
       {tabs.map(({ id, href, text, indicator }, index) => (

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -1,5 +1,11 @@
 // @flow strict
-import * as React from 'react';
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type Node,
+  type Ref,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './Touchable.css';
@@ -19,9 +25,9 @@ type Props = {|
   accessibilityExpanded?: boolean,
   accessibilityHaspopup?: boolean,
   accessibilityLabel?: string,
-  children?: React.Node,
+  children?: Node,
   disabled?: boolean,
-  forwardedRef?: React.Ref<'div'>,
+  forwardedRef?: Ref<'div'>,
   fullHeight?: boolean,
   fullWidth?: boolean,
   mouseCursor?:
@@ -63,9 +69,9 @@ function TapArea({
   tapStyle = 'none',
   rounding = 0,
 }: Props) {
-  const innerRef = React.useRef(null);
+  const innerRef = useRef(null);
   // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  React.useImperativeHandle(forwardedRef, () => innerRef.current);
+  useImperativeHandle(forwardedRef, () => innerRef.current);
 
   const {
     compressStyle,
@@ -210,7 +216,7 @@ TapArea.propTypes = TapAreaPropTypes;
 const TapAreaWithForwardRef: React$AbstractComponent<
   Props,
   HTMLDivElement
-> = React.forwardRef<Props, HTMLDivElement>((props, ref) => (
+> = forwardRef<Props, HTMLDivElement>((props, ref) => (
   <TapArea {...props} forwardedRef={ref} />
 ));
 

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import colors from './Colors.css';
@@ -15,7 +15,7 @@ const SIZE_SCALE = {
 
 type Props = {|
   align?: 'left' | 'right' | 'center' | 'justify',
-  children?: React.Node,
+  children?: Node,
   color?:
     | 'green'
     | 'pine'
@@ -52,7 +52,7 @@ export default function Text({
   size = 'lg',
   truncate = false,
   weight = 'normal',
-}: Props): React.Node {
+}: Props): Node {
   const scale = SIZE_SCALE[size];
 
   const cs = cx(

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import * as React from 'react';
+import React, { forwardRef, useState, type Ref } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import formElement from './FormElement.css';
@@ -13,7 +13,7 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 type Props = {|
   errorMessage?: string,
   disabled?: boolean,
-  forwardedRef?: React.Ref<'textarea'>,
+  forwardedRef?: Ref<'textarea'>,
   hasError?: boolean,
   helperText?: string,
   id: string,
@@ -57,7 +57,7 @@ function TextArea({
   rows = 3,
   value,
 }: Props) {
-  const [focused, setFocused] = React.useState(false);
+  const [focused, setFocused] = useState(false);
 
   const handleChange = (event: SyntheticInputEvent<HTMLTextAreaElement>) => {
     onChange({ event, value: event.currentTarget.value });
@@ -151,7 +151,7 @@ TextAreaWithRef.displayName = 'ForwardRef(TextArea)';
 const TextAreaWithForwardRef: React$AbstractComponent<
   Props,
   HTMLTextAreaElement
-> = React.forwardRef<Props, HTMLTextAreaElement>(TextAreaWithRef);
+> = forwardRef<Props, HTMLTextAreaElement>(TextAreaWithRef);
 
 TextAreaWithForwardRef.displayName = 'TextArea';
 

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { forwardRef, useState, type Ref } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import formElement from './FormElement.css';
@@ -18,7 +18,7 @@ type Props = {|
     | 'username',
   disabled?: boolean,
   errorMessage?: string,
-  forwardedRef?: React.Ref<'input'>,
+  forwardedRef?: Ref<'input'>,
   hasError?: boolean,
   helperText?: string,
   id: string,
@@ -65,7 +65,7 @@ function TextField({
   type = 'text',
   value,
 }: Props) {
-  const [focused, setFocused] = React.useState(false);
+  const [focused, setFocused] = useState(false);
 
   const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
     onChange({ event, value: event.currentTarget.value });
@@ -163,11 +163,11 @@ TextField.propTypes = {
   value: PropTypes.string,
 };
 
-function forwardRef(props, ref) {
+function TextFieldWithRef(props, ref) {
   return <TextField {...props} forwardedRef={ref} />;
 }
-forwardRef.displayName = 'TextField';
+TextFieldWithRef.displayName = 'TextField';
 
-export default (React.forwardRef<Props, HTMLInputElement>(
-  forwardRef
+export default (forwardRef<Props, HTMLInputElement>(
+  TextFieldWithRef
 ): React$AbstractComponent<Props, HTMLInputElement>);

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -1,15 +1,15 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Element, type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Mask from './Mask.js';
 import Text from './Text.js';
 
 type Props = {|
-  button?: React.Node,
+  button?: Node,
   color?: 'darkGray' | 'red',
-  text: string | React.Element<*>,
-  thumbnail?: React.Node,
+  text: string | Element<*>,
+  thumbnail?: Node,
   thumbnailShape?: 'circle' | 'rectangle' | 'square',
 |};
 
@@ -19,7 +19,7 @@ export default function Toast({
   text,
   thumbnail,
   thumbnailShape = 'square',
-}: Props): React.Node {
+}: Props): Node {
   return (
     <Box marginBottom={3} paddingX={4} maxWidth={360} width="100vw">
       <Box color={color} fit padding={6} rounding="pill">

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -1,7 +1,6 @@
 // @flow strict
 
-import * as React from 'react';
-import { type Node } from 'react';
+import React, { forwardRef, useState, type Ref, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import layout from './Layout.css';
@@ -14,7 +13,7 @@ import FormLabel from './FormLabel.js';
 type DirectionOptionType = -1 | 0 | 1;
 
 type Props = {|
-  forwardedRef?: React.Ref<'input'>,
+  forwardedRef?: Ref<'input'>,
   id: string,
   label?: string,
   onBlur: ({|
@@ -53,7 +52,7 @@ const InputField = ({
   value,
   forwardedRef,
 }: Props): Node => {
-  const [hovered, setHovered] = React.useState<boolean>(false);
+  const [hovered, setHovered] = useState<boolean>(false);
 
   const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
     onChange({
@@ -204,6 +203,6 @@ const forwardRefInputField = (props, ref): Node => {
 };
 forwardRefInputField.displayName = 'InputField';
 
-export default (React.forwardRef<Props, HTMLInputElement>(
+export default (forwardRef<Props, HTMLInputElement>(
   forwardRefInputField
 ): React$AbstractComponent<Props, HTMLInputElement>);

--- a/packages/gestalt/src/TypeaheadOption.js
+++ b/packages/gestalt/src/TypeaheadOption.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -36,7 +36,7 @@ export default function TypeaheadOption({
   hoveredItem,
   setHoveredItem,
   setOptionRef,
-}: OptionProps): React.Node {
+}: OptionProps): Node {
   // Determine if the option is the current selected item
   const isSelectedItem = JSON.stringify(option) === JSON.stringify(selected);
 

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -1,6 +1,5 @@
 // @flow strict
-
-import * as React from 'react';
+import React, { PureComponent, type Node } from 'react';
 import PropTypes from 'prop-types';
 import VideoControls from './VideoControls.js';
 import { ColorSchemeProvider } from './contexts/ColorScheme.js';
@@ -23,7 +22,7 @@ type Props = {|
   accessibilityUnmuteLabel: string,
   aspectRatio: number,
   captions: string,
-  children?: React.Node,
+  children?: Node,
   controls?: boolean,
   loop?: boolean,
   onDurationChange?: ({|
@@ -156,7 +155,7 @@ const isNewSource = (oldSource: Source, newSource: Source): boolean => {
   return newSource !== oldSource;
 };
 
-export default class Video extends React.PureComponent<Props, State> {
+export default class Video extends PureComponent<Props, State> {
   video: ?HTMLVideoElement;
 
   player: ?HTMLDivElement;
@@ -499,7 +498,7 @@ export default class Video extends React.PureComponent<Props, State> {
     }
   };
 
-  render(): React.Node {
+  render(): Node {
     const {
       aspectRatio,
       captions,

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -1,6 +1,5 @@
 // @flow strict
-
-import * as React from 'react';
+import React, { Component, type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Icon from './Icon.js';
@@ -52,7 +51,7 @@ const timeToString = (time?: number) => {
   return `${minutesStr}:${secondsStr}`;
 };
 
-class VideoControls extends React.Component<Props> {
+class VideoControls extends Component<Props> {
   static propTypes = {
     accessibilityHideCaptionsLabel: PropTypes.string,
     accessibilityShowCaptionsLabel: PropTypes.string,
@@ -142,7 +141,7 @@ class VideoControls extends React.Component<Props> {
     onVolumeChange(event);
   };
 
-  render(): React.Node {
+  render(): Node {
     const {
       accessibilityHideCaptionsLabel,
       accessibilityShowCaptionsLabel,

--- a/packages/gestalt/src/VideoPlayhead.js
+++ b/packages/gestalt/src/VideoPlayhead.js
@@ -1,6 +1,5 @@
 // @flow strict
-
-import * as React from 'react';
+import React, { PureComponent, type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import styles from './Video.css';
@@ -17,7 +16,7 @@ type State = {|
   seeking: boolean,
 |};
 
-export default class VideoPlayhead extends React.PureComponent<Props, State> {
+export default class VideoPlayhead extends PureComponent<Props, State> {
   playhead: ?HTMLDivElement;
 
   static propTypes = {
@@ -89,7 +88,7 @@ export default class VideoPlayhead extends React.PureComponent<Props, State> {
     onPlayheadUp(event);
   };
 
-  render(): React.Node {
+  render(): Node {
     const { currentTime, duration } = this.props;
     const width = `${Math.floor((currentTime * 10000) / duration) / 100}%`;
     return (

--- a/packages/gestalt/src/behaviors/OutsideEventBehavior.js
+++ b/packages/gestalt/src/behaviors/OutsideEventBehavior.js
@@ -1,18 +1,18 @@
 // @flow strict
-import * as React from 'react';
+import React, { useEffect, useRef, type Node as ReactNode } from 'react';
 
 type Props = {|
-  children: React.Node,
+  children: ReactNode,
   onClick?: (event: MouseEvent) => void,
 |};
 
 export default function OutsideEventBehavior({
   children,
   onClick,
-}: Props): React.Node {
-  const element = React.useRef<?HTMLDivElement>(null);
+}: Props): ReactNode {
+  const element = useRef<?HTMLDivElement>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleClickEvent = (event: MouseEvent) => {
       if (
         !onClick ||

--- a/packages/gestalt/src/behaviors/StopScrollBehavior.js
+++ b/packages/gestalt/src/behaviors/StopScrollBehavior.js
@@ -1,11 +1,11 @@
 // @flow strict
-import * as React from 'react';
+import { Component, type Node } from 'react';
 
 type Props = {|
-  children: React.Node,
+  children: Node,
 |};
 
-export default class NoScrollBehavior extends React.Component<Props> {
+export default class NoScrollBehavior extends Component<Props> {
   prevOverflow: string | null;
 
   constructor(props: Props) {
@@ -26,7 +26,7 @@ export default class NoScrollBehavior extends React.Component<Props> {
     }
   }
 
-  render(): React.Node {
+  render(): Node {
     return this.props.children;
   }
 }

--- a/packages/gestalt/src/behaviors/TrapFocusBehavior.js
+++ b/packages/gestalt/src/behaviors/TrapFocusBehavior.js
@@ -1,8 +1,8 @@
 // @flow strict
-import * as React from 'react';
+import React, { Component, type Node as ReactNode } from 'react';
 
 type Props = {|
-  children?: React.Node,
+  children?: ReactNode,
 |};
 
 function queryFocusableAll(el: HTMLDivElement) {
@@ -32,7 +32,7 @@ const focusElement = (el: HTMLElement) => {
   }
 };
 
-export default class TrapFocusBehavior extends React.Component<Props> {
+export default class TrapFocusBehavior extends Component<Props> {
   el: ?HTMLDivElement;
 
   previouslyFocusedEl: ?HTMLElement;
@@ -76,7 +76,7 @@ export default class TrapFocusBehavior extends React.Component<Props> {
     }
   }
 
-  render(): React.Node {
+  render(): ReactNode {
     return <div ref={this.setElRef}>{this.props.children}</div>;
   }
 }

--- a/packages/gestalt/src/contexts/ColorScheme.js
+++ b/packages/gestalt/src/contexts/ColorScheme.js
@@ -1,5 +1,13 @@
 // @flow strict
-import * as React from 'react';
+import React, {
+  useContext,
+  useEffect,
+  useState,
+  createContext,
+  type Context,
+  type Element,
+  type Node,
+} from 'react';
 import PropTypes from 'prop-types';
 
 export type ColorScheme = 'light' | 'dark' | 'userPreference';
@@ -36,7 +44,7 @@ type Theme = {|
 |};
 
 type Props = {|
-  children: React.Node,
+  children: Node,
   colorScheme?: ColorScheme,
   id?: ?string,
 |};
@@ -95,9 +103,7 @@ const darkModeTheme = {
   blueActive: '#4a85c9',
 };
 
-const ThemeContext: React.Context<Theme> = React.createContext<Theme>(
-  lightModeTheme
-);
+const ThemeContext: Context<Theme> = createContext<Theme>(lightModeTheme);
 
 const themeToStyles = theme => {
   let styles = '';
@@ -122,14 +128,14 @@ export function ColorSchemeProvider({
   children,
   colorScheme,
   id,
-}: Props): React.Element<typeof ThemeContext.Provider> {
-  const [theme, setTheme] = React.useState(getTheme(colorScheme));
+}: Props): Element<typeof ThemeContext.Provider> {
+  const [theme, setTheme] = useState(getTheme(colorScheme));
   const className = id ? `__gestaltTheme${id}` : undefined;
   const selector = className ? `.${className}` : ':root';
   const handlePrefChange = e => {
     setTheme(getTheme(e.matches ? 'dark' : 'light'));
   };
-  React.useEffect(() => {
+  useEffect(() => {
     setTheme(getTheme(colorScheme));
     if (colorScheme === 'userPreference' && window.matchMedia) {
       window
@@ -168,6 +174,6 @@ ColorSchemeProvider.propTypes = {
 };
 
 export function useColorScheme(): Theme {
-  const theme = React.useContext(ThemeContext);
+  const theme = useContext(ThemeContext);
   return theme || lightModeTheme;
 }

--- a/packages/gestalt/src/useTapFeedback.js
+++ b/packages/gestalt/src/useTapFeedback.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import { useEffect, useState } from 'react';
 
 const SCROLL_DISTANCE = 10;
 const SPACE_CHAR_CODE = 32;
@@ -33,15 +33,15 @@ export default function useTapFeedback({
   handleTouchStart: (SyntheticTouchEvent<TapTargetHTMLElement>) => void,
   isTapping: boolean,
 |} {
-  const [isTapping, setTapping] = React.useState<boolean>(false);
-  const [coordinate, setCoordinate] = React.useState<Coordinate>({
+  const [isTapping, setTapping] = useState<boolean>(false);
+  const [coordinate, setCoordinate] = useState<Coordinate>({
     x: 0,
     y: 0,
   });
 
-  const [compressStyle, setCompressStyle] = React.useState(null);
+  const [compressStyle, setCompressStyle] = useState(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (height != null && width != null) {
       const largestSize = width > height ? width : height;
       setCompressStyle({


### PR DESCRIPTION
### Why are we moving from `import * as React` to `import React, { ... }`

- Consistency across Gestalt codebase.
- Explicit Default Imports and Named Values Importing is consistent with the importing format used in all other cases in our Pinboard/webapp codebase. 
- Explicit Default Imports and Named Values helps with readability; all used React features are listed on top. For instance, we only have to check the first line of code to know if a component is using `React.forwardRef` instead of scrolling all the way to the bottom of the file.

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
