### PR TITLE
Datepicker: move gestalt to peerDependencies

### DIFF
--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -14,11 +14,11 @@
   ],
   "dependencies": {
     "classnames": "^2.2.6",
-    "gestalt": ">0.0.0",
     "prop-types": "^15.7.2",
     "react-datepicker": "2.15.0"
   },
   "peerDependencies": {
+    "gestalt": ">0.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },


### PR DESCRIPTION
Previously `gestalt` was listed under dependencies which causes a weird yarn.lock file for codebases that use `gestalt-datepicker`.

```
"gestalt-datepicker@https://registry.npmjs.org/gestalt-datepicker/-/gestalt-datepicker-11.4.0.tgz":
--
version "11.4.0"
resolved "https://registry.npmjs.org/gestalt-datepicker/-/gestalt-datepicker-11.4.0.tgz#a468b6bdf145d73c8a4051a3e32334770ad7e1b2"
dependencies:
classnames "^2.2.6"
gestalt ">0.0.0"
prop-types "^15.7.2"
react-datepicker "2.15.0"
 
gestalt@>0.0.0, "gestalt@https://registry.npmjs.org/gestalt/-/gestalt-11.4.0.tgz":
version "11.4.0"
resolved "https://registry.npmjs.org/gestalt/-/gestalt-11.4.0.tgz#6072a8a165bf5252973862f8fe4abe7dd069aa39"
dependencies:
classnames "^2.2.6"
prop-types "^15.7.2"
```

## Test Plan

```
rm -rf node_modules
yarn && yarn start
```