### PR TITLE
Internal: enforce disallow namespace/wildcard imports + apply on docs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
     ],
     "import/extensions": ["error", "always", { "ignorePackages": true }],
     "import/no-extraneous-dependencies": "off",
+    "import/no-namespace": "error",
     "import/no-relative-parent-imports": "error",
     "import/no-unresolved": "off",
     "jsx-a11y/label-has-associated-control": [

--- a/docs/src/Avatar.doc.js
+++ b/docs/src/Avatar.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/AvatarPair.doc.js
+++ b/docs/src/AvatarPair.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Badge.doc.js
+++ b/docs/src/Badge.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Button } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Button } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Card.doc.js
+++ b/docs/src/Card.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Checkbox } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Collage.doc.js
+++ b/docs/src/Collage.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Column.doc.js
+++ b/docs/src/Column.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Card from './components/Card.js';
 import Example from './components/Example.js';

--- a/docs/src/Container.doc.js
+++ b/docs/src/Container.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/DatePicker.doc.js
+++ b/docs/src/DatePicker.doc.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import * as React from 'react';
+import React from 'react';
 import DatePicker from 'gestalt-datepicker';
 import {
   arSA,

--- a/docs/src/Divider.doc.js
+++ b/docs/src/Divider.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/GestaltProvider.doc.js
+++ b/docs/src/GestaltProvider.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { GroupAvatar } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Icon } from 'gestalt';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Installation.doc.js
+++ b/docs/src/Installation.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Heading, Link, Row, Stack, Text, Tooltip } from 'gestalt';
 import Markdown from './components/Markdown.js';
 

--- a/docs/src/Label.doc.js
+++ b/docs/src/Label.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Card from './components/Card.js';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Letterbox.doc.js
+++ b/docs/src/Letterbox.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Mask } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Masonry, Image, Text, MasonryUniformRowLayout } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Pog } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { RadioButton } from 'gestalt';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';

--- a/docs/src/Row.doc.js
+++ b/docs/src/Row.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Row } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/SearchField.doc.js
+++ b/docs/src/SearchField.doc.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/SelectList.doc.js
+++ b/docs/src/SelectList.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Spinner.doc.js
+++ b/docs/src/Spinner.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Stack.doc.js
+++ b/docs/src/Stack.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Stack } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Switch } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Table } from 'gestalt';
 import Card from './components/Card.js';
 import Example from './components/Example.js';

--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Tabs } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Button, Link, Image, Text, Toast } from 'gestalt';
 import Combination from './components/Combination.js';
 import Example from './components/Example.js';

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/ZIndexClasses.doc.js
+++ b/docs/src/ZIndexClasses.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Heading, Stack, Text } from 'gestalt';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Heading } from 'gestalt';
 import Markdown from './Markdown.js';
 

--- a/docs/src/components/CardPage.js
+++ b/docs/src/components/CardPage.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box } from 'gestalt';
 import SearchContent from './SearchContent.js';
 

--- a/docs/src/components/Combination.js
+++ b/docs/src/components/Combination.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Text } from 'gestalt';
 import Checkerboard from './Checkerboard.js';
 import Card from './Card.js';

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React from 'react';
-import * as gestalt from 'gestalt';
+import * as gestalt from 'gestalt'; // eslint-disable-line import/no-namespace
 import DatePicker from 'gestalt-datepicker';
 import LZString from 'lz-string';
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';

--- a/docs/src/components/Link.js
+++ b/docs/src/components/Link.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Link as GestaltLink } from 'gestalt';
 import { createLocation } from 'history';
 import { withRouter } from 'react-router-dom';

--- a/docs/src/components/NavLink.js
+++ b/docs/src/components/NavLink.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Link, Text } from 'gestalt';
 import { withRouter, Route } from 'react-router-dom';
 import { createLocation } from 'history';

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 import { Box, Text, Icon, Link } from 'gestalt';
 
 type Props = {|

--- a/docs/src/components/SearchContent.js
+++ b/docs/src/components/SearchContent.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React from 'react';
 
 type Props = {|
   children?: React.Node,


### PR DESCRIPTION
Follow up from #1103
Lint rule documentation: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-namespace.md

## Test Plan

* ESLint passes
* `import * from ...` results in an error: 
![Screen Shot 2020-08-03 at 10 29 21 AM](https://user-images.githubusercontent.com/127199/89210199-84410e00-d574-11ea-8006-34c0897780b9.png)
