### PR TITLE
Button/IconButton/CheckBox/RadioButton: refactored forwardRef

### DIFF
--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -369,7 +369,7 @@ function A11yExPopup() {
           </Box>
         </Flyout>
       )}
-    <>
+    </>
   );
 }
 `}

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -191,7 +191,7 @@ function CheckboxExample() {
 
 card(
   <Example
-    id="ref"
+    id="refExample"
     name="Example: ref"
     description={`The innermost \`Checkbox\` element can be accessed via \`ref\``}
     defaultCode={`

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -191,44 +191,100 @@ function CheckboxExample() {
 
 card(
   <Example
-    id="refExample"
+    id="ref"
     name="Example: ref"
+    description={`The innermost \`Checkbox\` element can be accessed via \`ref\``}
+    defaultCode={`
+function CheckboxExample() {
+  const ref = React.useRef();
+  const [label, setLabel] = React.useState("24px Checkbox");
+  const [size, setSize] = React.useState('md');
+  const [switched, setSwitched] = React.useState(false);
+
+  React.useEffect(() => {
+      setLabel(ref.current && ref.current.offsetHeight)
+  }, [size]);
+
+  return (
+    <Row gap={2}>
+      <Label>
+        <Row gap={1}>
+          <Switch
+            onChange={() => { 
+              setSize(size === "sm" ? "md" : "sm")
+              setSwitched(!switched)}
+            }
+            id="emailNotifications"
+            switched={switched}
+          />
+          <Text>Toggle Checkbox to small size</Text>
+        </Row>
+      </Label>
+        <Checkbox
+          id="sizing"
+          checked={true}
+          label={label + 'px Checkbox'}
+          onChange={() => {} }
+          value="value"
+          ref={ref}
+          size={size}
+        />
+    </Row>
+  );
+}`}
+  />
+);
+
+card(
+  <Example
+    name="Example: Checkbox and Flyout"
     description={`
-    A \`Checkbox\` with an anchor ref to a Flyout component
+    A \`Checkbox\` with an anchor ref to a Flyout component doesn't pass the correct positioning to the Flyout. Instead set the anchor ref to the parent container.
   `}
     defaultCode={`
+
 function CheckboxFlyoutExample() {
   const [open, setOpen] = React.useState(false);
   const [checked, setChecked] = React.useState(false);
-
-  const anchorRef = React.useRef();
+  const termsA = React.useRef();
 
   return (
-    <Box >
-      <Checkbox
-        checked={checked}
-        id="ref"
-        label="Private Board"
-        name="privacy"
-        ref={anchorRef}
-        onChange={({ checked }) => {
-          setOpen(true)
-          setChecked(checked);
-        }}
-      />
-      {open && (
-        <Flyout
-          anchor={anchorRef.current}
-          idealDirection="up"
-          onDismiss={() => setOpen(false)}
-          shouldFocus={false}
-        >
-          <Box padding={3}>
-            <Text weight="bold">Your board is now </Text>
-            <Text weight="bold">{checked ? 'private': 'public'}</Text>
-          </Box>
-        </Flyout>
-      )}
+    <Box>
+        <Box display="inlineBlock" ref={termsA}>
+          <Checkbox
+            id="a"
+            checked={checked}
+            label="Email me a notification"
+            onChange={() => {
+              setOpen(!checked)
+              setChecked(!checked)
+              }
+            }
+            value="A"
+          />
+        </Box>
+      {open &&
+        <Layer>
+          <Flyout
+            anchor={termsA.current}
+            color="red"
+            idealDirection="right"
+            onDismiss={() => setOpen(false)}
+            positionRelativeToAnchor={false}
+            shouldFocus={false}
+            size="md"
+          >            
+            <Box padding={3}>
+              <Text
+                color="white"
+                weight="bold"
+              >
+                  Change your primary email in Settings
+              </Text>
+            </Box>
+          </Flyout>
+        </Layer>
+      }
     </Box>
   );
 }

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -141,35 +141,42 @@ card(
   <Example
     id="ref"
     name="Example: ref"
-    description={`A \`RadioButton\` can be focused via \`ref\``}
+    description={`The innermost \`RadioButton\` element can be accessed via \`ref\``}
     defaultCode={`
 function RadioButtonExample() {
   const ref = React.useRef();
-  const [option, setOption] = React.useState();
+  const [label, setLabel] = React.useState("24 px RadioButton");
+  const [size, setSize] = React.useState('md');
+  const [switched, setSwitched] = React.useState(false);
+
+  React.useEffect(() => {
+      setLabel(ref.current && ref.current.offsetHeight)
+  }, [size]);
 
   return (
     <Row gap={2}>
-      <Button
-        text="Focus the RadioButton"
-        onClick={() => ref.current.focus()}
-      />
-      <Stack gap={2}>
+      <Label>
+        <Row gap={1}>
+          <Switch
+            onChange={() => { 
+              setSize(size === "sm" ? "md" : "sm")
+              setSwitched(!switched)}
+            }
+            id="emailNotifications"
+            switched={switched}
+          />
+          <Text>Toggle RadioButton to small size</Text>
+        </Row>
+      </Label>
         <RadioButton
-          id="proceed"
-          checked={option === "proceed"}
-          label="Proceed"
-          onChange={() => setOption("proceed")}
-          value="usa"
+          id="sizing"
+          checked={false}
+          label={label + 'px RadioButton'}
+          onChange={() => {} }
+          value="value"
           ref={ref}
+          size={size}
         />
-        <RadioButton
-          id="notProceed"
-          checked={option === "notProceed"}
-          label="Do Not Proceed"
-          onChange={() => setOption("notProceed")}
-          value="usa"
-        />
-      </Stack>
     </Row>
   );
 }`}
@@ -184,7 +191,7 @@ card(
   `}
     defaultCode={`
 
-function ErrorFlyoutExample() {
+function RadioButtonFlyoutExample() {
   const [open, setOpen] = React.useState(false);
   const [option, setOption] = React.useState(false);
   const anchorCatRef = React.useRef();

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -4,7 +4,6 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useRef,
-  type Ref,
   type Element,
 } from 'react';
 import classnames from 'classnames';
@@ -42,7 +41,6 @@ type Props = {|
   accessibilityLabel?: string,
   color?: 'gray' | 'red' | 'blue' | 'transparent' | 'white',
   disabled?: boolean,
-  forwardedRef?: Ref<'button'>,
   iconEnd?: $Keys<typeof icons>,
   inline?: boolean,
   name?: string,
@@ -54,7 +52,13 @@ type Props = {|
   type?: 'submit' | 'button',
 |};
 
-function Button(props: Props): Element<'button'> {
+const ButtonWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLButtonElement
+> = forwardRef<Props, HTMLButtonElement>(function Button(
+  props,
+  ref
+): Element<'button'> {
   const {
     accessibilityControls,
     accessibilityExpanded,
@@ -62,7 +66,6 @@ function Button(props: Props): Element<'button'> {
     accessibilityLabel,
     color = 'gray',
     disabled = false,
-    forwardedRef,
     iconEnd,
     inline = false,
     name,
@@ -74,10 +77,9 @@ function Button(props: Props): Element<'button'> {
     type = 'button',
   } = props;
   const innerRef = useRef(null);
-  // When using both forwardedRef and innerRef, React.useimperativehandle() allows a parent component
+  // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Button ref={inputRef} /> to call inputRef.current.focus()
-  // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  useImperativeHandle(forwardedRef, () => innerRef.current);
+  useImperativeHandle(ref, () => innerRef.current);
 
   const {
     compressStyle,
@@ -181,21 +183,16 @@ function Button(props: Props): Element<'button'> {
     </button>
   );
   /* eslint-enable react/button-has-type */
-}
+});
 
-Button.propTypes = {
+// $FlowFixMe Flow(InferError)
+ButtonWithForwardRef.propTypes = {
   accessibilityControls: PropTypes.string,
   accessibilityExpanded: PropTypes.bool,
   accessibilityHaspopup: PropTypes.bool,
   accessibilityLabel: PropTypes.string,
   color: PropTypes.oneOf(['blue', 'gray', 'red', 'transparent', 'white']),
   disabled: PropTypes.bool,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
   iconEnd: PropTypes.oneOf(Object.keys(icons)),
   inline: PropTypes.bool,
   name: PropTypes.string,
@@ -206,17 +203,6 @@ Button.propTypes = {
   textColor: PropTypes.oneOf(['white', 'darkGray', 'blue', 'red']),
   type: PropTypes.oneOf(['button', 'submit']),
 };
-
-function ButtonWithRef(props, ref) {
-  return <Button {...props} forwardedRef={ref} />;
-}
-
-ButtonWithRef.displayName = 'ForwardRef(Button)';
-
-const ButtonWithForwardRef: React$AbstractComponent<
-  Props,
-  HTMLButtonElement
-> = forwardRef<Props, HTMLButtonElement>(ButtonWithRef);
 
 ButtonWithForwardRef.displayName = 'Button';
 

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -6,7 +6,6 @@ import React, {
   useRef,
   useState,
   type Node,
-  type Ref,
 } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -26,7 +25,6 @@ type Props = {|
   checked?: boolean,
   disabled?: boolean,
   errorMessage?: string,
-  forwardedRef?: Ref<'input'>,
   hasError?: boolean,
   id: string,
   indeterminate?: boolean,
@@ -43,12 +41,14 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
-function Checkbox(props: Props): Node {
+const CheckboxWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLInputElement
+> = forwardRef<Props, HTMLInputElement>(function Checkbox(props, ref): Node {
   const {
     checked = false,
     disabled = false,
     errorMessage,
-    forwardedRef,
     hasError = false,
     id,
     indeterminate = false,
@@ -60,10 +60,9 @@ function Checkbox(props: Props): Node {
   } = props;
 
   const innerRef = useRef(null);
-  // When using both forwardedRef and innerRef, React.useimperativehandle() allows a parent component
+  // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Checkbox ref={inputRef} /> to call inputRef.current.focus()
-  // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  useImperativeHandle(forwardedRef, () => innerRef.current);
+  useImperativeHandle(ref, () => innerRef.current);
 
   const [focused, setFocused] = useState(false);
   const [hovered, setHover] = useState(false);
@@ -190,18 +189,13 @@ function Checkbox(props: Props): Node {
       )}
     </Box>
   );
-}
+});
 
-Checkbox.propTypes = {
+// $FlowFixMe Flow(InferError)
+CheckboxWithForwardRef.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   errorMessage: PropTypes.string,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
   hasError: PropTypes.bool,
   id: PropTypes.string.isRequired,
   indeterminate: PropTypes.bool,
@@ -211,17 +205,6 @@ Checkbox.propTypes = {
   onClick: PropTypes.func,
   size: PropTypes.oneOf(['sm', 'md']),
 };
-
-function CheckboxWithRef(props, ref) {
-  return <Checkbox {...props} forwardedRef={ref} />;
-}
-
-CheckboxWithRef.displayName = 'ForwardRef(Checkbox)';
-
-const CheckboxWithForwardRef: React$AbstractComponent<
-  Props,
-  HTMLInputElement
-> = forwardRef<Props, HTMLInputElement>(CheckboxWithRef);
 
 CheckboxWithForwardRef.displayName = 'Checkbox';
 

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -5,7 +5,6 @@ import React, {
   useState,
   useRef,
   type Node,
-  type Ref,
 } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -32,7 +31,6 @@ type Props = {|
     | 'red',
   dangerouslySetSvgPath?: {| __path: string |},
   disabled?: boolean,
-  forwardedRef?: Ref<'button'>,
   icon?: $Keys<typeof icons>,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   onClick?: AbstractEventHandler<SyntheticMouseEvent<HTMLButtonElement>>,
@@ -41,27 +39,29 @@ type Props = {|
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
-function IconButton({
-  accessibilityControls,
-  accessibilityExpanded,
-  accessibilityHaspopup,
-  accessibilityLabel,
-  bgColor,
-  dangerouslySetSvgPath,
-  disabled,
-  forwardedRef,
-  icon,
-  iconColor,
-  onClick,
-  padding,
-  selected,
-  size,
-}: Props): Node {
+const IconButtonWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLButtonElement
+> = forwardRef<Props, HTMLButtonElement>(function IconButton(props, ref): Node {
+  const {
+    accessibilityControls,
+    accessibilityExpanded,
+    accessibilityHaspopup,
+    accessibilityLabel,
+    bgColor,
+    dangerouslySetSvgPath,
+    disabled,
+    icon,
+    iconColor,
+    onClick,
+    padding,
+    selected,
+    size,
+  } = props;
   const innerRef = useRef(null);
-  // When using both forwardedRef and innerRef, React.useimperativehandle() allows a parent component
+  // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <IconButton ref={inputRef} /> to call inputRef.current.focus()
-  // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  useImperativeHandle(forwardedRef, () => innerRef.current);
+  useImperativeHandle(ref, () => innerRef.current);
 
   const {
     compressStyle,
@@ -139,9 +139,10 @@ function IconButton({
       />
     </button>
   );
-}
+});
 
-IconButton.propTypes = {
+// $FlowFixMe Flow(InferError)
+IconButtonWithForwardRef.propTypes = {
   accessibilityControls: PropTypes.string,
   accessibilityExpanded: PropTypes.bool,
   accessibilityHaspopup: PropTypes.bool,
@@ -159,12 +160,6 @@ IconButton.propTypes = {
     __path: PropTypes.string,
   }),
   disabled: PropTypes.bool,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
   icon: PropTypes.oneOf(Object.keys(icons)),
   iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'white']),
   onClick: PropTypes.func,
@@ -172,17 +167,6 @@ IconButton.propTypes = {
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
 };
-
-function IconButtonWithRef(props, ref) {
-  return <IconButton {...props} forwardedRef={ref} />;
-}
-
-IconButtonWithRef.displayName = 'ForwardRef(IconButton)';
-
-const IconButtonWithForwardRef: React$AbstractComponent<
-  Props,
-  HTMLButtonElement
-> = forwardRef<Props, HTMLButtonElement>(IconButtonWithRef);
 
 IconButtonWithForwardRef.displayName = 'IconButton';
 

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { forwardRef, useState, type Node, type Ref } from 'react';
+import React, { forwardRef, useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import controlStyles from './RadioButtonCheckbox.css';
@@ -14,7 +14,6 @@ import focusStyles from './Focus.css';
 type Props = {|
   checked?: boolean,
   disabled?: boolean,
-  forwardedRef?: Ref<'input'>,
   id: string,
   label?: string,
   name?: string,
@@ -26,12 +25,14 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
-function RadioButton(props: Props): Node {
+const RadioButtonWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLInputElement
+> = forwardRef<Props, HTMLInputElement>(function RadioButton(props, ref): Node {
   const {
     checked = false,
     disabled = false,
     id,
-    forwardedRef,
     label,
     name,
     onChange,
@@ -113,7 +114,7 @@ function RadioButton(props: Props): Node {
               onFocus={handleFocus}
               onMouseEnter={() => handleHover(true)}
               onMouseLeave={() => handleHover(false)}
-              ref={forwardedRef}
+              ref={ref}
               type="radio"
               value={value}
             />
@@ -135,33 +136,19 @@ function RadioButton(props: Props): Node {
       )}
     </Box>
   );
-}
+});
 
-RadioButton.propTypes = {
+// $FlowFixMe Flow(InferError)
+RadioButtonWithForwardRef.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
   label: PropTypes.string,
   name: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,
   size: PropTypes.oneOf(['sm', 'md']),
 };
-
-function RadioButtonWithRef(props, ref) {
-  return <RadioButton {...props} forwardedRef={ref} />;
-}
-
-const RadioButtonWithForwardRef: React$AbstractComponent<
-  Props,
-  HTMLInputElement
-> = forwardRef<Props, HTMLInputElement>(RadioButtonWithRef);
 
 RadioButtonWithForwardRef.displayName = 'RadioButton';
 


### PR DESCRIPTION
- Refactored `forwardRef` implementation to prevent rendering 2 components and fix `displayName` in:

1. Button
2. IconButton
3. CheckBox
4. RadioButton

- Fix Doc examples for  CheckBox, RadioButton


<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
