### PR TITLE
Callout: Update info callout icon

### DIFF
--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -12,24 +12,24 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type LinkData = {|
   href: string,
-    label: string,
-      onClick ?: AbstractEventHandler <
+  label: string,
+  onClick?: AbstractEventHandler<
     | SyntheticMouseEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent < HTMLAnchorElement >
+    | SyntheticKeyboardEvent<HTMLAnchorElement>
   >,
 |};
 
 type Props = {|
   description: string,
-    dismissButton ?: {|
-      accessibilityLabel: string,
-        onDismiss: () => void,
+  dismissButton?: {|
+    accessibilityLabel: string,
+    onDismiss: () => void,
   |},
-iconAccessibilityLabel: string,
-  primaryLink ?: LinkData,
-  secondaryLink ?: LinkData,
+  iconAccessibilityLabel: string,
+  primaryLink?: LinkData,
+  secondaryLink?: LinkData,
   type: 'error' | 'info' | 'warning',
-    title ?: string,
+  title?: string,
 |};
 
 const CALLOUT_TYPE_ATTRIBUTES = {
@@ -56,8 +56,8 @@ const CalloutLink = ({
   type,
 }: {|
   data: LinkData,
-    stacked ?: boolean,
-    type: string,
+  stacked?: boolean,
+  type: string,
 |}): Node => {
   const { name } = useColorScheme();
   const colorDarkMode = name === 'darkMode' ? 'white' : 'darkGray';

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -12,29 +12,29 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type LinkData = {|
   href: string,
-  label: string,
-  onClick?: AbstractEventHandler<
+    label: string,
+      onClick ?: AbstractEventHandler <
     | SyntheticMouseEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent < HTMLAnchorElement >
   >,
 |};
 
 type Props = {|
   description: string,
-  dismissButton?: {|
-    accessibilityLabel: string,
-    onDismiss: () => void,
+    dismissButton ?: {|
+      accessibilityLabel: string,
+        onDismiss: () => void,
   |},
-  iconAccessibilityLabel: string,
-  primaryLink?: LinkData,
-  secondaryLink?: LinkData,
+iconAccessibilityLabel: string,
+  primaryLink ?: LinkData,
+  secondaryLink ?: LinkData,
   type: 'error' | 'info' | 'warning',
-  title?: string,
+    title ?: string,
 |};
 
 const CALLOUT_TYPE_ATTRIBUTES = {
   info: {
-    icon: 'check-circle',
+    icon: 'info-circle',
     color: 'blue',
     backgroundColor: '#EBF4FE',
   },
@@ -56,8 +56,8 @@ const CalloutLink = ({
   type,
 }: {|
   data: LinkData,
-  stacked?: boolean,
-  type: string,
+    stacked ?: boolean,
+    type: string,
 |}): Node => {
   const { name } = useColorScheme();
   const colorDarkMode = name === 'darkMode' ? 'white' : 'darkGray';


### PR DESCRIPTION
Monetization design requested a change to the info callout icon. They wanted it to be the info icon rather than the check circle. Also VS code seems to have made adjustments in how the code layout automatically on save.

**Before**

<img width="1436" alt="Screen Shot 2020-08-03 at 2 11 07 PM" src="https://user-images.githubusercontent.com/2187170/89227865-4f907f00-d593-11ea-8801-50f354f9dc7f.png">

**After**

<img width="1438" alt="Screen Shot 2020-08-03 at 2 10 48 PM" src="https://user-images.githubusercontent.com/2187170/89227886-59b27d80-d593-11ea-8e70-99cc96eb5c50.png">