### PR TITLE
VSCode: add recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
+    "flowtype.flow-for-vscode",
+    "orta.vscode-jest"
+  ]
+}


### PR DESCRIPTION
In #1108 @ashleyseto ran into an issue where VSCode was incorrectly formatting code (not using prettier). The root cause is that the prettier extension is not installed.

![image](https://user-images.githubusercontent.com/127199/89231218-ba44b900-d599-11ea-8382-22769891df27.png)

After this lands, users will see the following upon restarting VSCode:
![image](https://user-images.githubusercontent.com/127199/89231297-e52f0d00-d599-11ea-9e42-327a5aff0986.png)

