### PR TITLE
SearchField/Typeahead/TypeaheadInputField/TextField/TextArea: refactored forwardRef

### DIFF
--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import React, { forwardRef, useState, type Ref } from 'react';
+import React, { forwardRef, useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import layout from './Layout.css';
@@ -25,21 +25,24 @@ type Props = {|
   placeholder?: string,
   size?: 'md' | 'lg',
   value?: string,
-  forwardedRef?: Ref<'input'>,
 |};
 
-const SearchField = ({
-  accessibilityLabel,
-  autoComplete,
-  id,
-  onBlur,
-  onChange,
-  onFocus,
-  placeholder,
-  size = 'md',
-  value,
-  forwardedRef,
-}: Props) => {
+const SearchFieldWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLInputElement
+> = forwardRef<Props, HTMLInputElement>(function SearchField(props, ref): Node {
+  const {
+    accessibilityLabel,
+    autoComplete,
+    id,
+    onBlur,
+    onChange,
+    onFocus,
+    placeholder,
+    size = 'md',
+    value,
+  } = props;
+
   const [hovered, setHovered] = useState<boolean>(false);
   const [focused, setFocused] = useState<boolean>(false);
 
@@ -117,7 +120,7 @@ const SearchField = ({
         </Box>
       )}
       <input
-        ref={forwardedRef}
+        ref={ref}
         aria-label={accessibilityLabel}
         autoComplete={autoComplete}
         className={className}
@@ -155,10 +158,12 @@ const SearchField = ({
       )}
     </Box>
   );
-};
+});
 
-SearchField.propTypes = {
+// $FlowFixMe Flow(InferError)
+SearchFieldWithForwardRef.propTypes = {
   accessibilityLabel: PropTypes.string.isRequired,
+  autoComplete: PropTypes.oneOf(['on', 'off', 'username', 'name']),
   id: PropTypes.string.isRequired,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
@@ -166,19 +171,8 @@ SearchField.propTypes = {
   placeholder: PropTypes.string,
   size: PropTypes.oneOf(['md', 'lg']),
   value: PropTypes.string,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
 };
 
-function forwardRefSearchField(props, ref) {
-  return <SearchField {...props} forwardedRef={ref} />;
-}
-forwardRefSearchField.displayName = 'SearchField';
+SearchFieldWithForwardRef.displayName = 'SearchField';
 
-export default (forwardRef<Props, HTMLInputElement>(
-  forwardRefSearchField
-): React$AbstractComponent<Props, HTMLInputElement>);
+export default SearchFieldWithForwardRef;

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import React, { forwardRef, useState, type Ref } from 'react';
+import React, { forwardRef, useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import formElement from './FormElement.css';
@@ -13,7 +13,6 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 type Props = {|
   errorMessage?: string,
   disabled?: boolean,
-  forwardedRef?: Ref<'textarea'>,
   hasError?: boolean,
   helperText?: string,
   id: string,
@@ -40,23 +39,26 @@ type Props = {|
   value?: string,
 |};
 
-function TextArea({
-  errorMessage,
-  disabled = false,
-  forwardedRef,
-  hasError = false,
-  helperText,
-  id,
-  label,
-  name,
-  onBlur,
-  onChange,
-  onFocus,
-  onKeyDown,
-  placeholder,
-  rows = 3,
-  value,
-}: Props) {
+const TextAreaWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLTextAreaElement
+> = forwardRef<Props, HTMLTextAreaElement>(function TextArea(props, ref): Node {
+  const {
+    errorMessage,
+    disabled = false,
+    hasError = false,
+    helperText,
+    id,
+    label,
+    name,
+    onBlur,
+    onChange,
+    onFocus,
+    onKeyDown,
+    placeholder,
+    rows = 3,
+    value,
+  } = props;
   const [focused, setFocused] = useState(false);
 
   const handleChange = (event: SyntheticInputEvent<HTMLTextAreaElement>) => {
@@ -107,7 +109,7 @@ function TextArea({
         onFocus={handleFocus}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        ref={forwardedRef}
+        ref={ref}
         rows={rows}
         value={value}
       />
@@ -117,17 +119,12 @@ function TextArea({
       {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
     </span>
   );
-}
+});
 
-TextArea.propTypes = {
+// $FlowFixMe Flow(InferError)
+TextAreaWithForwardRef.propTypes = {
   disabled: PropTypes.bool,
   errorMessage: PropTypes.string,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
   hasError: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,
@@ -141,17 +138,6 @@ TextArea.propTypes = {
   rows: PropTypes.number,
   value: PropTypes.string,
 };
-
-function TextAreaWithRef(props, ref) {
-  return <TextArea {...props} forwardedRef={ref} />;
-}
-
-TextAreaWithRef.displayName = 'ForwardRef(TextArea)';
-
-const TextAreaWithForwardRef: React$AbstractComponent<
-  Props,
-  HTMLTextAreaElement
-> = forwardRef<Props, HTMLTextAreaElement>(TextAreaWithRef);
 
 TextAreaWithForwardRef.displayName = 'TextArea';
 

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { forwardRef, useState, type Ref } from 'react';
+import React, { forwardRef, useState, type Node } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import formElement from './FormElement.css';
@@ -18,7 +18,6 @@ type Props = {|
     | 'username',
   disabled?: boolean,
   errorMessage?: string,
-  forwardedRef?: Ref<'input'>,
   hasError?: boolean,
   helperText?: string,
   id: string,
@@ -46,25 +45,28 @@ type Props = {|
   value?: string,
 |};
 
-function TextField({
-  autoComplete,
-  disabled = false,
-  errorMessage,
-  forwardedRef,
-  hasError = false,
-  helperText,
-  id,
-  label,
-  name,
-  onBlur,
-  onChange,
-  onFocus,
-  onKeyDown,
-  placeholder,
-  size = 'md',
-  type = 'text',
-  value,
-}: Props) {
+const TextFieldWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLInputElement
+> = forwardRef<Props, HTMLInputElement>(function TextField(props, ref): Node {
+  const {
+    autoComplete,
+    disabled = false,
+    errorMessage,
+    hasError = false,
+    helperText,
+    id,
+    label,
+    name,
+    onBlur,
+    onChange,
+    onFocus,
+    onKeyDown,
+    placeholder,
+    size = 'md',
+    type = 'text',
+    value,
+  } = props;
   const [focused, setFocused] = useState(false);
 
   const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
@@ -120,7 +122,7 @@ function TextField({
         onKeyDown={handleKeyDown}
         pattern={pattern}
         placeholder={placeholder}
-        ref={forwardedRef}
+        ref={ref}
         type={type}
         value={value}
       />
@@ -130,9 +132,10 @@ function TextField({
       {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
     </span>
   );
-}
+});
 
-TextField.propTypes = {
+// $FlowFixMe Flow(InferError)
+TextFieldWithForwardRef.propTypes = {
   autoComplete: PropTypes.oneOf([
     'current-password',
     'new-password',
@@ -142,12 +145,6 @@ TextField.propTypes = {
   ]),
   disabled: PropTypes.bool,
   errorMessage: PropTypes.string,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
   hasError: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,
@@ -163,11 +160,6 @@ TextField.propTypes = {
   value: PropTypes.string,
 };
 
-function TextFieldWithRef(props, ref) {
-  return <TextField {...props} forwardedRef={ref} />;
-}
-TextFieldWithRef.displayName = 'TextField';
+TextFieldWithForwardRef.displayName = 'TextField';
 
-export default (forwardRef<Props, HTMLInputElement>(
-  TextFieldWithRef
-): React$AbstractComponent<Props, HTMLInputElement>);
+export default TextFieldWithForwardRef;

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -1,11 +1,11 @@
 // @flow strict
 import React, {
+  forwardRef,
   useState,
   useEffect,
   useRef,
   useImperativeHandle,
   type Node,
-  type Ref,
 } from 'react';
 import PropTypes from 'prop-types';
 import TypeaheadInputField from './TypeaheadInputField.js';
@@ -21,7 +21,6 @@ type OptionObject = {|
 |};
 
 type Props = {|
-  forwardedRef?: Ref<'input'>,
   id: string,
   label?: string,
   noResultText: string,
@@ -54,10 +53,11 @@ type Props = {|
   value?: string,
 |};
 
-const Typeahead = (props: Props): Node => {
+const TypeaheadWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLInputElement
+> = forwardRef<Props, HTMLInputElement>(function Typeahead(props, ref): Node {
   const {
-    options,
-    value = null,
     id,
     label,
     noResultText,
@@ -65,9 +65,10 @@ const Typeahead = (props: Props): Node => {
     onChange,
     onFocus,
     onSelect,
+    options,
     placeholder,
     size,
-    forwardedRef,
+    value = null,
   } = props;
 
   // Store original data
@@ -108,7 +109,7 @@ const Typeahead = (props: Props): Node => {
   // Ref to the input
   const inputRef = useRef(null);
   // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  useImperativeHandle(forwardedRef, () => inputRef.current);
+  useImperativeHandle(ref, () => inputRef.current);
 
   const [containerOpen, setContainerOpen] = useState<boolean>(false);
 
@@ -171,8 +172,8 @@ const Typeahead = (props: Props): Node => {
   };
 
   let selectedElement;
-  const setOptionRef = ref => {
-    selectedElement = ref;
+  const setOptionRef = optionRef => {
+    selectedElement = optionRef;
   };
 
   const containerRef = useRef();
@@ -323,21 +324,17 @@ const Typeahead = (props: Props): Node => {
       )}
     </Box>
   );
-};
+});
 
-Typeahead.displayName = 'Typeahead';
-
-Typeahead.propTypes = {
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
+// $FlowFixMe Flow(InferError)
+TypeaheadWithForwardRef.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string,
-  value: PropTypes.string,
+  noResultText: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onSelect: PropTypes.func,
   options: PropTypes.arrayOf(
     PropTypes.exact({
       label: PropTypes.string.isRequired,
@@ -346,18 +343,9 @@ Typeahead.propTypes = {
   ).isRequired,
   placeholder: PropTypes.string,
   size: PropTypes.oneOf(['md', 'lg']),
-  onBlur: PropTypes.func,
-  onFocus: PropTypes.func,
-  onSelect: PropTypes.func,
-  noResultText: PropTypes.string.isRequired,
+  value: PropTypes.string,
 };
 
-const forwardRefTypeaheadField = (props, ref): Node => {
-  return <Typeahead {...props} forwardedRef={ref} />;
-};
+TypeaheadWithForwardRef.displayName = 'Typeahead';
 
-forwardRefTypeaheadField.displayName = 'Typeahead';
-
-export default (React.forwardRef<Props, HTMLInputElement>(
-  forwardRefTypeaheadField
-): React$AbstractComponent<Props, HTMLInputElement>);
+export default TypeaheadWithForwardRef;

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -38,20 +38,24 @@ type Props = {|
   value?: string,
 |};
 
-const InputField = ({
-  id,
-  label,
-  onBlur,
-  onChange,
-  onClear,
-  onKeyNavigation,
-  onFocus,
-  setContainer,
-  placeholder,
-  size = 'md',
-  value,
-  forwardedRef,
-}: Props): Node => {
+const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLInputElement
+> = forwardRef<Props, HTMLInputElement>(function InputField(props, ref): Node {
+  const {
+    id,
+    label,
+    onBlur,
+    onChange,
+    onClear,
+    onKeyNavigation,
+    onFocus,
+    setContainer,
+    placeholder,
+    size = 'md',
+    value,
+  } = props;
+
   const [hovered, setHovered] = useState<boolean>(false);
 
   const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
@@ -133,7 +137,7 @@ const InputField = ({
         position="relative"
       >
         <input
-          ref={forwardedRef}
+          ref={ref}
           autoComplete="off"
           aria-label={label}
           className={className}
@@ -176,33 +180,23 @@ const InputField = ({
       </Box>
     </>
   );
-};
+});
 
-InputField.displayName = InputField;
-
-InputField.propTypes = {
+// $FlowFixMe Flow(InferError)
+TypeaheadInputFieldWithForwardRef.propTypes = {
   label: PropTypes.string,
   id: PropTypes.string.isRequired,
   onBlur: PropTypes.func,
   onClear: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
+  onKeyNavigation: PropTypes.func,
   placeholder: PropTypes.string,
   size: PropTypes.oneOf(['md', 'lg']),
+  setContainer: PropTypes.func,
   value: PropTypes.string,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
 };
 
-const forwardRefInputField = (props, ref): Node => {
-  return <InputField {...props} forwardedRef={ref} />;
-};
-forwardRefInputField.displayName = 'InputField';
+TypeaheadInputFieldWithForwardRef.displayName = 'TypeaheadInputField';
 
-export default (forwardRef<Props, HTMLInputElement>(
-  forwardRefInputField
-): React$AbstractComponent<Props, HTMLInputElement>);
+export default TypeaheadInputFieldWithForwardRef;


### PR DESCRIPTION
- Refactored `forwardRef` implementation to prevent rendering 2 components and fix `displayName` in:

1. TextArea
2. TextField
3. Typeahead & TypeaheadInputField
4. SeachField

- Fix Proptypes for  SeachField, Typeahead



<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
