### PR TITLE
Switch: Implemented forwardRef (BREAKING CHANGE)

### DIFF
--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -35,6 +35,10 @@ card(
         href: 'basicExample',
       },
       {
+        name: 'label',
+        type: 'string',
+      },
+      {
         name: 'name',
         type: 'string',
         href: 'basicExample',
@@ -44,6 +48,12 @@ card(
         type: '({ event: SyntheticInputEvent<>, value: boolean }) => void',
         required: true,
         href: 'basicExample',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'input'>",
+        description: 'Forward the ref to the underlying input element',
+        href: 'refExample',
       },
       {
         name: 'switched',
@@ -57,28 +67,74 @@ card(
 
 card(
   <Example
-    id="basicExample"
-    description={`
-    Whenever you are using a \`Switch\` component, you should use a [Label](#/Label) with it to make your component accessible.
-  `}
-    name="Example: Using a label"
+    id="Example"
+    name="Example"
     defaultCode={`
 function SwitchExample() {
   const [switched, setSwitched] = React.useState(false);
 
   return (
-    <Box display="flex" alignItems="center">
-      <Box paddingX={2} flex="grow">
-        <Label htmlFor="emailNotifications">
-          <Text>Airplane mode</Text>
-        </Label>
-      </Box>
       <Switch
-        onChange={() => setSwitched(!switched)}
         id="emailNotifications"
+        label='Turn on your notifications'
+        onChange={() => setSwitched(!switched)}
         switched={switched}
       />
-    </Box>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    name="Example: Switch and Flyout"
+    description={`
+    A \`Switch\` with an anchor ref to a Flyout component.
+  `}
+    id="refExample"
+    defaultCode={`
+function SwitchFlyoutExample() {
+  const [open, setOpen] = React.useState(false);
+  const [switched, setSwitched] = React.useState(false);
+  const anchorRef = React.useRef();
+
+  return (
+    <>
+      <Switch
+        id="emailNotifications"
+        label="Turn on your notifications"
+        onChange={() => {
+            setOpen(!switched);
+            setSwitched(!switched);
+          }
+        }
+        switched={switched}
+        ref={anchorRef}
+      />
+      {open &&
+        <Layer>
+          <Flyout
+            anchor={anchorRef.current}
+            color="red"
+            idealDirection="up"
+            onDismiss={() => setOpen(false)}
+            positionRelativeToAnchor={false}
+            shouldFocus={false}
+            size="md"
+          >            
+            <Box padding={3}>
+              <Text
+                color="white"
+                weight="bold"
+              >
+                  Your notifications are on!
+              </Text>
+            </Box>
+          </Flyout>
+        </Layer>
+      }
+    </>
   );
 }
 `}

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -1,26 +1,36 @@
 // @flow strict
-import React, { useState, type Node } from 'react';
+import React, { forwardRef, useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import useFocusVisible from './useFocusVisible.js';
 import focusStyles from './Focus.css';
 import styles from './Switch.css';
+import Label from './Label.js';
+import Row from './Row.js';
+import Text from './Text.js';
 
 type Props = {|
   disabled?: boolean,
   id: string,
+  label?: string,
   name?: string,
   onChange: ({| event: SyntheticInputEvent<>, value: boolean |}) => void,
   switched?: boolean,
 |};
 
-export default function Switch({
-  disabled = false,
-  id,
-  name,
-  onChange,
-  switched = false,
-}: Props): Node {
+const SwitchWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLInputElement
+> = forwardRef<Props, HTMLInputElement>(function Switch(props, ref): Node {
+  const {
+    disabled = false,
+    id,
+    name,
+    label,
+    onChange,
+    switched = false,
+  } = props;
+
   const [focused, setFocused] = useState(false);
 
   const handleChange: (event: SyntheticInputEvent<>) => void = (
@@ -58,27 +68,43 @@ export default function Switch({
   });
 
   return (
-    <div className={switchStyles}>
-      <input
-        checked={switched}
-        className={inputStyles}
-        disabled={disabled}
-        id={id}
-        name={name}
-        onBlur={() => setFocused(false)}
-        onChange={handleChange}
-        onFocus={() => setFocused(true)}
-        type="checkbox"
-      />
-      <div className={sliderStyles} />
-    </div>
+    <Row gap={1}>
+      <Label htmlFor={id}>
+        <div className={switchStyles}>
+          <input
+            checked={switched}
+            className={inputStyles}
+            disabled={disabled}
+            id={id}
+            name={name}
+            onBlur={() => setFocused(false)}
+            onChange={handleChange}
+            onFocus={() => setFocused(true)}
+            ref={ref}
+            type="checkbox"
+          />
+          <div className={sliderStyles} />
+        </div>
+      </Label>
+      {label && (
+        <Label htmlFor={id}>
+          <Text color={disabled ? 'gray' : undefined}>{label}</Text>
+        </Label>
+      )}
+    </Row>
   );
-}
+});
 
-Switch.propTypes = {
+// $FlowFixMe Flow(InferError)
+SwitchWithForwardRef.propTypes = {
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
+  label: PropTypes.string,
   name: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   switched: PropTypes.bool,
 };
+
+SwitchWithForwardRef.displayName = 'Switch';
+
+export default SwitchWithForwardRef;

--- a/packages/gestalt/src/Switch.jsdom.test.js
+++ b/packages/gestalt/src/Switch.jsdom.test.js
@@ -1,0 +1,15 @@
+// @flow strict
+import React from 'react';
+import { render } from '@testing-library/react';
+import Switch from './Switch.js';
+
+const mockOnChange = jest.fn();
+
+describe('Switch', () => {
+  it('forwards a ref to innermost input', () => {
+    const ref = React.createRef();
+    render(<Switch id="test" onChange={mockOnChange} ref={ref} switched />);
+    expect(ref.current instanceof HTMLInputElement).toEqual(true);
+    expect(ref.current?.checked).toEqual(true);
+  });
+});

--- a/packages/gestalt/src/__snapshots__/Switch.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Switch.test.js.snap
@@ -2,80 +2,196 @@
 
 exports[`Switch 1`] = `
 <div
-  className="switch switchWhite"
+  className="box marginEndN1 marginStartN1"
+  style={
+    Object {
+      "height": undefined,
+      "width": undefined,
+    }
+  }
 >
-  <input
-    checked={false}
-    className="checkbox checkboxEnabled"
-    disabled={false}
-    id="test"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    type="checkbox"
-  />
   <div
-    className="slider sliderLeft sliderLight"
-  />
+    className="box itemsCenter xsDirectionRow xsDisplayFlex"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="box paddingX1"
+    >
+      <label
+        className="label"
+        htmlFor="test"
+      >
+        <div
+          className="switch switchWhite"
+        >
+          <input
+            checked={false}
+            className="checkbox checkboxEnabled"
+            disabled={false}
+            id="test"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="slider sliderLeft sliderLight"
+          />
+        </div>
+      </label>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Switch disabled 1`] = `
 <div
-  className="switch switchLightGray"
+  className="box marginEndN1 marginStartN1"
+  style={
+    Object {
+      "height": undefined,
+      "width": undefined,
+    }
+  }
 >
-  <input
-    checked={false}
-    className="checkbox"
-    disabled={true}
-    id="test"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    type="checkbox"
-  />
   <div
-    className="slider sliderLeft sliderLight"
-  />
+    className="box itemsCenter xsDirectionRow xsDisplayFlex"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="box paddingX1"
+    >
+      <label
+        className="label"
+        htmlFor="test"
+      >
+        <div
+          className="switch switchLightGray"
+        >
+          <input
+            checked={false}
+            className="checkbox"
+            disabled={true}
+            id="test"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="slider sliderLeft sliderLight"
+          />
+        </div>
+      </label>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Switch switched & disabled 1`] = `
 <div
-  className="switch switchLightGray"
+  className="box marginEndN1 marginStartN1"
+  style={
+    Object {
+      "height": undefined,
+      "width": undefined,
+    }
+  }
 >
-  <input
-    checked={false}
-    className="checkbox"
-    disabled={true}
-    id="test"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    type="checkbox"
-  />
   <div
-    className="slider sliderLeft sliderLight"
-  />
+    className="box itemsCenter xsDirectionRow xsDisplayFlex"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="box paddingX1"
+    >
+      <label
+        className="label"
+        htmlFor="test"
+      >
+        <div
+          className="switch switchLightGray"
+        >
+          <input
+            checked={false}
+            className="checkbox"
+            disabled={true}
+            id="test"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="slider sliderLeft sliderLight"
+          />
+        </div>
+      </label>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Switch switched 1`] = `
 <div
-  className="switch switchWhite"
+  className="box marginEndN1 marginStartN1"
+  style={
+    Object {
+      "height": undefined,
+      "width": undefined,
+    }
+  }
 >
-  <input
-    checked={false}
-    className="checkbox checkboxEnabled"
-    disabled={false}
-    id="test"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    type="checkbox"
-  />
   <div
-    className="slider sliderLeft sliderLight"
-  />
+    className="box itemsCenter xsDirectionRow xsDisplayFlex"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="box paddingX1"
+    >
+      <label
+        className="label"
+        htmlFor="test"
+      >
+        <div
+          className="switch switchWhite"
+        >
+          <input
+            checked={false}
+            className="checkbox checkboxEnabled"
+            disabled={false}
+            id="test"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <div
+            className="slider sliderLeft sliderLight"
+          />
+        </div>
+      </label>
+    </div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
- Adds ref forwarding to Switch
- Added ref example to Docs
- Added test for ref 

- Added Label prop to Switch. The Docs example was demoing how to add a Label for accessibility. Implemented Label prop following CheckBox/RadioButton pattern.

### Why?

Without forwardedRefs, refs are set on the component's instance, not the actual input. So in each of those cases, people drill down to get the input.

That is pretty hacky, so let's add a way for them to get it in a cleaner way.

### Why is this a breaking change?
[https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers
)
> When you start using forwardRef in a component library, you should treat it as a breaking change and release a new major version of your library. This is because your library likely has an observably different behavior (such as what refs get assigned to, and what types are exported), and this can break apps and other libraries that depend on the old behavior.

### Can I get more documentation around this feature?
https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
