### PR TITLE
Link/TapArea/DatePicker: Refactored forwardRef

### DIFF
--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -5,7 +5,7 @@ import React, {
   useRef,
   type AbstractComponent,
   type Node,
-  type Ref,
+  type Element,
 } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -23,7 +23,6 @@ import useFocusVisible from './useFocusVisible.js';
 type Props = {|
   accessibilitySelected?: boolean,
   children?: Node,
-  forwardedRef?: Ref<'a'>,
   hoverStyle?: 'none' | 'underline',
   href: string,
   id?: string,
@@ -41,26 +40,33 @@ type Props = {|
   target?: null | 'self' | 'blank',
 |};
 
-function Link({
-  accessibilitySelected,
-  children,
-  forwardedRef,
-  href,
-  id,
-  inline = false,
-  onBlur,
-  onClick,
-  onFocus,
-  rel = 'none',
-  role,
-  rounding = 0,
-  hoverStyle = 'underline',
-  tapStyle = 'none',
-  target = null,
-}: Props): Node {
+const LinkWithForwardRef: AbstractComponent<
+  Props,
+  HTMLAnchorElement
+> = forwardRef<Props, HTMLAnchorElement>(function Link(
+  props,
+  ref
+): Element<'a'> {
+  const {
+    accessibilitySelected,
+    children,
+    href,
+    id,
+    inline = false,
+    onBlur,
+    onClick,
+    onFocus,
+    rel = 'none',
+    role,
+    rounding = 0,
+    hoverStyle = 'underline',
+    tapStyle = 'none',
+    target = null,
+  } = props;
+
   const innerRef = useRef(null);
-  // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  useImperativeHandle(forwardedRef, () => innerRef.current);
+
+  useImperativeHandle(ref, () => innerRef.current);
 
   const {
     compressStyle,
@@ -141,17 +147,12 @@ function Link({
       {children}
     </a>
   );
-}
+});
 
-Link.propTypes = {
+// $FlowFixMe Flow(InferError)
+LinkWithForwardRef.propTypes = {
   accessibilitySelected: PropTypes.bool,
   children: PropTypes.node,
-  forwardedRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]),
   hoverStyle: (PropTypes.oneOf(['none', 'underline']): React$PropType$Primitive<
     'none' | 'underline'
   >),
@@ -173,15 +174,6 @@ Link.propTypes = {
     null | 'self' | 'blank'
   >),
 };
-
-function LinkWithRef(props, ref) {
-  return <Link {...props} forwardedRef={ref} />;
-}
-
-const LinkWithForwardRef: AbstractComponent<
-  Props,
-  HTMLAnchorElement
-> = forwardRef<Props, HTMLAnchorElement>(LinkWithRef);
 
 LinkWithForwardRef.displayName = 'Link';
 

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -3,8 +3,8 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useRef,
+  type Element,
   type Node,
-  type Ref,
 } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -18,8 +18,6 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import focusStyles from './Focus.css';
 import useFocusVisible from './useFocusVisible.js';
 
-type TapStyle = 'none' | 'compress';
-
 type Props = {|
   accessibilityControls?: string,
   accessibilityExpanded?: boolean,
@@ -27,7 +25,6 @@ type Props = {|
   accessibilityLabel?: string,
   children?: Node,
   disabled?: boolean,
-  forwardedRef?: Ref<'div'>,
   fullHeight?: boolean,
   fullWidth?: boolean,
   mouseCursor?:
@@ -46,32 +43,39 @@ type Props = {|
   onTap?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement>
   >,
-  tapStyle?: TapStyle,
+  tapStyle?: 'none' | 'compress',
   rounding?: Rounding,
 |};
 
-function TapArea({
-  accessibilityControls,
-  accessibilityExpanded,
-  accessibilityHaspopup,
-  accessibilityLabel,
-  children,
-  disabled = false,
-  forwardedRef,
-  fullHeight,
-  fullWidth = true,
-  mouseCursor = 'pointer',
-  onBlur,
-  onFocus,
-  onMouseEnter,
-  onMouseLeave,
-  onTap,
-  tapStyle = 'none',
-  rounding = 0,
-}: Props) {
+const TapAreaWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLDivElement
+> = forwardRef<Props, HTMLDivElement>(function TapArea(
+  props,
+  ref
+): Element<'div'> {
+  const {
+    accessibilityControls,
+    accessibilityExpanded,
+    accessibilityHaspopup,
+    accessibilityLabel,
+    children,
+    disabled = false,
+    fullHeight,
+    fullWidth = true,
+    mouseCursor = 'pointer',
+    onBlur,
+    onFocus,
+    onMouseEnter,
+    onMouseLeave,
+    onTap,
+    tapStyle = 'none',
+    rounding = 0,
+  } = props;
+
   const innerRef = useRef(null);
-  // $FlowFixMe Flow thinks forwardedRef is a number, which is incorrect
-  useImperativeHandle(forwardedRef, () => innerRef.current);
+
+  useImperativeHandle(ref, () => innerRef.current);
 
   const {
     compressStyle,
@@ -162,23 +166,16 @@ function TapArea({
       {children}
     </div>
   );
-}
+});
 
-export const TapAreaPropTypes = {
+// $FlowFixMe Flow(InferError)
+TapAreaWithForwardRef.propTypes = {
   accessibilityControls: PropTypes.string,
   accessibilityExpanded: PropTypes.bool,
   accessibilityHaspopup: PropTypes.bool,
   accessibilityLabel: PropTypes.string,
   children: PropTypes.node,
   disabled: PropTypes.bool,
-  forwardedRef: (PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({
-      current: PropTypes.any,
-    }),
-  ]): React$PropType$Primitive<
-    ((...a: Array<$FlowFixMe>) => mixed) | { current?: $FlowFixMe, ... }
-  >),
   fullHeight: PropTypes.bool,
   fullWidth: PropTypes.bool,
   mouseCursor: (PropTypes.oneOf([
@@ -210,15 +207,6 @@ export const TapAreaPropTypes = {
   >),
   rounding: RoundingPropType,
 };
-
-TapArea.propTypes = TapAreaPropTypes;
-
-const TapAreaWithForwardRef: React$AbstractComponent<
-  Props,
-  HTMLDivElement
-> = forwardRef<Props, HTMLDivElement>((props, ref) => (
-  <TapArea {...props} forwardedRef={ref} />
-));
 
 TapAreaWithForwardRef.displayName = 'TapArea';
 


### PR DESCRIPTION
- Refactored `forwardRef` implementation to prevent rendering 2 components and fix `displayName` in:

1. Link
2. TapArea
3. DatePicker

- Fixed  DatePicker `forwardRef` implementation

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
