### PR TITLE
GestaltProvider: rename to Provider & move under configuration section

### DIFF
--- a/docs/src/Provider.doc.js
+++ b/docs/src/Provider.doc.js
@@ -9,8 +9,8 @@ const card = c => cards.push(c);
 
 card(
   <PageHeader
-    name="GestaltProvider"
-    description="An app may optionally have a `GestaltProvider` to set up context for components further down the tree. The first usecase is setting the color scheme, but other uses such as right to left support will be added in the future."
+    name="Provider"
+    description="An app may optionally have a `Provider` to set up context for components further down the tree. The first usecase is setting the color scheme, but other uses such as right to left support will be added in the future."
   />
 );
 
@@ -58,7 +58,7 @@ function Example(props) {
     }
   ];
   return (
-    <GestaltProvider colorScheme={scheme} id="docsExample">
+    <Provider colorScheme={scheme} id="docsExample">
       <Box color="white" padding={2}>
         <SelectList
           id="scheme"
@@ -74,7 +74,7 @@ function Example(props) {
         </Box>
         <Button text="Example button" inline /> <Button color="red" text="Red Button" inline />
       </Box>
-    </GestaltProvider>
+    </Provider>
   );
 }`}
   />

--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React, { useState } from 'react';
-import { Box, Divider, GestaltProvider, Link, Text } from 'gestalt';
+import { Box, Divider, Provider, Link, Text } from 'gestalt';
 import Header from './Header.js';
 import Navigation from './Navigation.js';
 import { SidebarContextProvider } from './sidebarContext.js';
@@ -21,7 +21,7 @@ export default function App(props: Props) {
         setIsSidebarOpen,
       }}
     >
-      <GestaltProvider colorScheme={colorScheme}>
+      <Provider colorScheme={colorScheme}>
         <Box minHeight="100vh" color="white">
           <Header
             colorScheme={colorScheme}
@@ -54,7 +54,7 @@ export default function App(props: Props) {
             </Box>
           ) : null}
         </Box>
-      </GestaltProvider>
+      </Provider>
     </SidebarContextProvider>
   );
 }

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -27,9 +27,9 @@ const sidebarIndex: sidebarIndexType = [
   },
 
   {
-    sectionName: 'Setup',
-    sectionPathname: 'setup',
-    pages: ['GestaltProvider'],
+    sectionName: 'Configuration',
+    sectionPathname: 'configuration',
+    pages: ['Provider'],
   },
   {
     sectionName: 'Data Display',

--- a/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/.eslintrc.json
+++ b/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "prettier/prettier": "off",
+    "react/jsx-fragments": "off",
+    "no-undef": "off"
+  }
+}

--- a/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-1.input.js
+++ b/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-1.input.js
@@ -1,0 +1,7 @@
+// @flow strict
+import React from 'react';
+import { GestaltProvider } from 'gestalt';
+
+export default function TestGestaltProvider() {
+  return <GestaltProvider onTouch={() => {}}>Hello</GestaltProvider>;
+}

--- a/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-1.output.js
+++ b/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-1.output.js
@@ -1,0 +1,7 @@
+// @flow strict
+import React from 'react';
+import { Provider } from 'gestalt';
+
+export default function TestGestaltProvider() {
+  return <Provider onTouch={() => {}}>Hello</Provider>;
+}

--- a/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-2.input.js
+++ b/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-2.input.js
@@ -1,0 +1,7 @@
+// @flow strict
+import React from 'react';
+import { GestaltProvider as RenamedGestaltProvider } from 'gestalt';
+
+export default function TestGestaltProvider() {
+  return <RenamedGestaltProvider onTouch={() => {}}>Hello</RenamedGestaltProvider>;
+}

--- a/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-2.output.js
+++ b/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-2.output.js
@@ -1,0 +1,7 @@
+// @flow strict
+import React from 'react';
+import { Provider } from 'gestalt';
+
+export default function TestGestaltProvider() {
+  return <Provider onTouch={() => {}}>Hello</Provider>;
+}

--- a/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-3.input.js
+++ b/packages/gestalt-codemods/11.5.5-12.0.0/__testfixtures__/gestaltprovider-to-provider-3.input.js
@@ -1,0 +1,6 @@
+// @flow strict
+import React, { Fragment } from 'react';
+
+export default function TestGestaltProvider() {
+  return <><Fragment><React.Fragment>test</React.Fragment></Fragment></>;
+}

--- a/packages/gestalt-codemods/11.5.5-12.0.0/__tests__/gestaltprovider-to-provider.test.js
+++ b/packages/gestalt-codemods/11.5.5-12.0.0/__tests__/gestaltprovider-to-provider.test.js
@@ -1,0 +1,22 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../gestaltprovider-to-provider', () => {
+  return Object.assign(jest.requireActual('../gestaltprovider-to-provider'), {
+    parser: 'flow',
+  });
+});
+
+describe('gestaltprovider-to-provider', () => {
+  [
+    'gestaltprovider-to-provider-1',
+    'gestaltprovider-to-provider-2',
+    'gestaltprovider-to-provider-3',
+  ].forEach(test => {
+    defineTest(
+      __dirname,
+      'gestaltprovider-to-provider',
+      { quote: 'single' },
+      test
+    );
+  });
+});

--- a/packages/gestalt-codemods/11.5.5-12.0.0/gestaltprovider-to-provider.js
+++ b/packages/gestalt-codemods/11.5.5-12.0.0/gestaltprovider-to-provider.js
@@ -1,0 +1,76 @@
+/**
+ * Converts
+ *  <GestaltProvider />
+ * to
+ *  <Provider />
+ */
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let gestaltProviderLocalIdentifierName;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return;
+    }
+    const gestaltProviderSpecifier = decl.specifiers.find(
+      node => node.imported.name === 'GestaltProvider'
+    );
+
+    if (!gestaltProviderSpecifier) {
+      return;
+    }
+
+    gestaltProviderLocalIdentifierName =
+      gestaltProviderSpecifier && gestaltProviderSpecifier.local.name;
+
+    const newSpecifiers = [
+      // Strip out GestaltProvider import
+      ...decl.specifiers.filter(
+        node => node.imported.name !== 'GestaltProvider'
+      ),
+      // Only add the new Provider import if it is not already imported
+      decl.specifiers.every(node => node.imported.name !== 'Provider') &&
+        j.importSpecifier(j.identifier('Provider')),
+    ].filter(Boolean);
+
+    // Sort all the imports alphabetically
+    newSpecifiers.sort((a, b) =>
+      a.imported.name.localeCompare(b.imported.name)
+    );
+
+    const newNode = j.importDeclaration(newSpecifiers, j.literal('gestalt'));
+
+    j(path).replaceWith(newNode);
+  });
+
+  if (!gestaltProviderLocalIdentifierName) {
+    // Not imported
+    return null;
+  }
+
+  let hasModifications = false;
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach(path => {
+      const { node } = path;
+
+      if (
+        node.openingElement.name.name !== gestaltProviderLocalIdentifierName
+      ) {
+        return;
+      }
+
+      node.openingElement.name = 'Provider';
+      node.closingElement.name = 'Provider';
+
+      j(path).replaceWith(node);
+
+      hasModifications = true;
+    })
+    .toSource({ quote: 'single' });
+
+  return hasModifications ? transform : null;
+}

--- a/packages/gestalt/src/GestaltProvider.flowtest.js
+++ b/packages/gestalt/src/GestaltProvider.flowtest.js
@@ -1,8 +1,0 @@
-// @flow strict
-import React from 'react';
-import GestaltProvider from './GestaltProvider.js';
-
-const Valid = <GestaltProvider>Test</GestaltProvider>;
-
-// $FlowExpectedError[prop-missing]
-const NonExistingProp = <GestaltProvider nonexisting={33} />;

--- a/packages/gestalt/src/Provider.flowtest.js
+++ b/packages/gestalt/src/Provider.flowtest.js
@@ -1,0 +1,8 @@
+// @flow strict
+import React from 'react';
+import Provider from './Provider.js';
+
+const Valid = <Provider>Test</Provider>;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <Provider nonexisting={33} />;

--- a/packages/gestalt/src/Provider.js
+++ b/packages/gestalt/src/Provider.js
@@ -13,11 +13,7 @@ type Props = {|
   id?: string,
 |};
 
-export default function GestaltProvider({
-  children,
-  colorScheme,
-  id,
-}: Props): Node {
+export default function Provider({ children, colorScheme, id }: Props): Node {
   return (
     <ColorSchemeProvider colorScheme={colorScheme} id={id}>
       {children}
@@ -25,7 +21,7 @@ export default function GestaltProvider({
   );
 }
 
-GestaltProvider.propTypes = {
+Provider.propTypes = {
   children: PropTypes.node,
   colorScheme: ColorSchemePropType,
 };

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -13,7 +13,7 @@ import Column from './Column.js';
 import Container from './Container.js';
 import Divider from './Divider.js';
 import Flyout from './Flyout.js';
-import GestaltProvider from './GestaltProvider.js';
+import Provider from './Provider.js';
 import GroupAvatar from './GroupAvatar.js';
 import Heading from './Heading.js';
 import Icon from './Icon.js';
@@ -70,7 +70,7 @@ export {
   Divider,
   FixedZIndex,
   Flyout,
-  GestaltProvider,
+  Provider,
   GroupAvatar,
   Heading,
   Icon,


### PR DESCRIPTION
Request by Kelly (UX Writer) to rename `GestaltProvider` to `Provider` & move the component under the configuration section.

## Test Plan

Test on Netlify

![image](https://user-images.githubusercontent.com/127199/89312994-ca59a880-d62c-11ea-83f2-c90471a6f059.png)

