### PR TITLE
Docs: Updated Required Props for Video

### DIFF
--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -25,6 +25,7 @@ card(
         type: 'string',
         description:
           'Accessibility label for the fullscreen maximize button if controls are shown',
+        required: true,
         href: 'videoControlsExample',
       },
       {
@@ -32,6 +33,7 @@ card(
         type: 'string',
         description:
           'Accessibility label for the fullscreen minimize button if controls are shown',
+        required: true,
         href: 'videoControlsExample',
       },
       {
@@ -39,6 +41,7 @@ card(
         type: 'string',
         description:
           'Accessibility label for the mute button if controls are shown',
+        required: true,
         href: 'videoControlsExample',
       },
       {
@@ -46,6 +49,7 @@ card(
         type: 'string',
         description:
           'Accessibility label for the pause button if controls are shown',
+        required: true,
         href: 'videoControlsExample',
       },
       {
@@ -53,6 +57,7 @@ card(
         type: 'string',
         description:
           'Accessibility label for the play button if controls are shown',
+        required: true,
         href: 'videoControlsExample',
       },
       {
@@ -60,6 +65,7 @@ card(
         type: 'string',
         description:
           'Accessibility label for the unmute button if controls are shown',
+        required: true,
         href: 'videoControlsExample',
       },
       {
@@ -169,6 +175,7 @@ card(
         type: 'number',
         description:
           'Specifies the speed at which the video plays: 1 for normal',
+        required: true,
         defaultValue: 1,
         href: 'videoUpdatesExample',
       },
@@ -176,6 +183,7 @@ card(
         name: 'playing',
         type: 'boolean',
         description: 'Specifies whether the video should play or not',
+        required: true,
         defaultValue: false,
         href: 'nativeVideoAttributesExample',
       },
@@ -196,9 +204,10 @@ card(
       {
         name: 'preload',
         type: `"auto" | "metadata" | "none"`,
-        defaultValue: 'auto',
         description:
           'Specifies how, if any, the video should be loaded when the page loads',
+        required: true,
+        defaultValue: 'auto',
       },
       {
         name: 'src',
@@ -214,6 +223,7 @@ card(
         type: 'number',
         description:
           'Specifies the volume of the video audio: 0 for muted, 1 for max',
+        required: true,
         defaultValue: 0,
         href: 'nativeVideoAttributesExample',
       },


### PR DESCRIPTION
Updated Video.doc.js so that the required props match the flow types in Video.js

Here are the required props for Video according to the docs:
![Screen Shot 2020-08-04 at 10 46 29 AM](https://user-images.githubusercontent.com/21958781/89326906-ee72b500-d63f-11ea-922a-a9c812d09a77.png)

Docs did not match with flowtyping from Video.js:
![Uploading Screen Shot 2020-08-04 at 10.47.06 AM.png…]()

## Test Plan
<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->