### PR TITLE
Focus Styles: override CSS outline if a global one is specified

### DIFF
--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -17,7 +17,6 @@
   composes: borderBox minWidth60 from "./Layout.css";
   composes: noBorder from "./Borders.css";
   border-radius: 24px;
-  outline: 0;
 }
 
 .sm {

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -109,19 +109,24 @@ function Button(props: Props): Element<'button'> {
 
   const { isFocusVisible } = useFocusVisible();
 
-  const classes = classnames(styles.button, touchableStyles.tapTransition, {
-    [styles.sm]: size === 'sm',
-    [styles.md]: size === 'md',
-    [styles.lg]: size === 'lg',
-    [styles[colorClass]]: !disabled && !selected,
-    [styles.selected]: !disabled && selected,
-    [styles.disabled]: disabled,
-    [styles.enabled]: !disabled,
-    [styles.inline]: inline,
-    [styles.block]: !inline,
-    [touchableStyles.tapCompress]: !disabled && isTapping,
-    [focusStyles.accessibilityOutline]: !disabled && isFocusVisible,
-  });
+  const classes = classnames(
+    styles.button,
+    focusStyles.hideOutline,
+    touchableStyles.tapTransition,
+    {
+      [styles.sm]: size === 'sm',
+      [styles.md]: size === 'md',
+      [styles.lg]: size === 'lg',
+      [styles[colorClass]]: !disabled && !selected,
+      [styles.selected]: !disabled && selected,
+      [styles.disabled]: disabled,
+      [styles.enabled]: !disabled,
+      [styles.inline]: inline,
+      [styles.block]: !inline,
+      [touchableStyles.tapCompress]: !disabled && isTapping,
+      [focusStyles.accessibilityOutline]: !disabled && isFocusVisible,
+    }
+  );
 
   const textColor =
     (disabled && 'gray') ||

--- a/packages/gestalt/src/Focus.css
+++ b/packages/gestalt/src/Focus.css
@@ -8,6 +8,6 @@
   outline: 0;
 }
 
-.hideOutline {
+.hideOutline:focus {
   outline: 0;
 }

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -81,6 +81,7 @@ function Link({
 
   const className = classnames(
     styles.link,
+    focusStyles.hideOutline,
     touchableStyles.tapTransition,
     inline ? styles.inlineBlock : styles.block,
     getRoundingClassName(rounding),

--- a/packages/gestalt/src/TypeaheadOption.js
+++ b/packages/gestalt/src/TypeaheadOption.js
@@ -46,11 +46,15 @@ export default function TypeaheadOption({
 
   const { isFocusVisible } = useFocusVisible();
 
-  const className = classnames(getRoundingClassName(2), {
-    [focusStyles.accessibilityOutline]: isFocusVisible,
-    [styles.fullWidth]: true,
-    [styles.pointer]: true,
-  });
+  const className = classnames(
+    getRoundingClassName(2),
+    focusStyles.hideOutline,
+    {
+      [focusStyles.accessibilityOutline]: isFocusVisible,
+      [styles.fullWidth]: true,
+      [styles.pointer]: true,
+    }
+  );
 
   // Default option color
   let optionStateColor = 'transparent';

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -198,7 +198,7 @@ exports[`<Callout /> description + title + primaryLink + dismissButton 1`] = `
     className="box itemsCenter marginBottomAuto marginEndAuto marginStartAuto mdMarginEnd0 mdMarginTopAuto paddingX4 paddingY4 pill whiteBg"
   >
     <a
-      className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+      className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
       href="pinterest.com"
       onBlur={[Function]}
       onClick={[Function]}
@@ -324,7 +324,7 @@ exports[`<Callout /> description + title + primaryLink + secondaryLink 1`] = `
     className="box itemsCenter marginBottomAuto marginEndAuto marginStartAuto mdMarginEnd0 mdMarginTopAuto paddingX4 paddingY4"
   >
     <a
-      className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+      className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
       href="pinterest.com/help"
       onBlur={[Function]}
       onClick={[Function]}
@@ -350,7 +350,7 @@ exports[`<Callout /> description + title + primaryLink + secondaryLink 1`] = `
     className="box itemsCenter marginBottomAuto marginEndAuto marginStartAuto marginTop2 mdMarginEnd0 mdMarginTopAuto paddingX4 paddingY4 pill whiteBg"
   >
     <a
-      className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+      className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
       href="pinterest.com"
       onBlur={[Function]}
       onClick={[Function]}
@@ -432,7 +432,7 @@ exports[`<Callout /> description + title + primaryLink 1`] = `
     className="box itemsCenter marginBottomAuto marginEndAuto marginStartAuto mdMarginEnd0 mdMarginTopAuto paddingX4 paddingY4 pill whiteBg"
   >
     <a
-      className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+      className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
       href="pinterest.com"
       onBlur={[Function]}
       onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`default 1`] = `
 <a
-  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -23,7 +23,7 @@ exports[`default 1`] = `
 
 exports[`inline 1`] = `
 <a
-  className="link tapTransition inlineBlock rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition inlineBlock rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -44,7 +44,7 @@ exports[`inline 1`] = `
 
 exports[`regular 1`] = `
 <a
-  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -65,7 +65,7 @@ exports[`regular 1`] = `
 
 exports[`target blank 1`] = `
 <a
-  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -86,7 +86,7 @@ exports[`target blank 1`] = `
 
 exports[`target null 1`] = `
 <a
-  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -107,7 +107,7 @@ exports[`target null 1`] = `
 
 exports[`target self 1`] = `
 <a
-  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -129,7 +129,7 @@ exports[`target self 1`] = `
 exports[`with accessibilitySelected and role 1`] = `
 <a
   aria-selected={true}
-  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -151,7 +151,7 @@ exports[`with accessibilitySelected and role 1`] = `
 
 exports[`with custom rounding, hoverStyle, and tapStyle 1`] = `
 <a
-  className="link tapTransition block pill accessibilityOutline"
+  className="link hideOutline tapTransition block pill accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -172,7 +172,7 @@ exports[`with custom rounding, hoverStyle, and tapStyle 1`] = `
 
 exports[`with nofollow 1`] = `
 <a
-  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
@@ -193,7 +193,7 @@ exports[`with nofollow 1`] = `
 
 exports[`with onTap 1`] = `
 <a
-  className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+  className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
@@ -27,7 +27,7 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
       >
         <a
           aria-selected={true}
-          className="link tapTransition block pill accessibilityOutline"
+          className="link hideOutline tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -71,7 +71,7 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
       >
         <a
           aria-selected={false}
-          className="link tapTransition block pill accessibilityOutline"
+          className="link hideOutline tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -138,7 +138,7 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
       >
         <a
           aria-selected={true}
-          className="link tapTransition block pill accessibilityOutline"
+          className="link hideOutline tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -192,7 +192,7 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
       >
         <a
           aria-selected={false}
-          className="link tapTransition block pill accessibilityOutline"
+          className="link hideOutline tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -269,7 +269,7 @@ exports[`<Tabs /> matches snapshot with lg size and wrap 1`] = `
       >
         <a
           aria-selected={true}
-          className="link tapTransition block pill accessibilityOutline"
+          className="link hideOutline tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}
@@ -313,7 +313,7 @@ exports[`<Tabs /> matches snapshot with lg size and wrap 1`] = `
       >
         <a
           aria-selected={false}
-          className="link tapTransition block pill accessibilityOutline"
+          className="link hideOutline tapTransition block pill accessibilityOutline"
           href="#"
           onBlur={[Function]}
           onClick={[Function]}

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -73,7 +73,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
           Saved to
            
           <a
-            className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+            className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
             href="https://www.pinterest.com/search/pins/?q=home%20decor"
             onBlur={[Function]}
             onClick={[Function]}
@@ -96,7 +96,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
         className="box flexNone paddingX2"
       >
         <button
-          className="button tapTransition lg gray enabled block accessibilityOutline"
+          className="button hideOutline tapTransition lg gray enabled block accessibilityOutline"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -163,7 +163,7 @@ exports[`<Toast /> Text + Image 1`] = `
           Saved to
            
           <a
-            className="link tapTransition block rounding0 hoverUnderline accessibilityOutline"
+            className="link hideOutline tapTransition block rounding0 hoverUnderline accessibilityOutline"
             href="https://www.pinterest.com/search/pins/?q=home%20decor"
             onBlur={[Function]}
             onClick={[Function]}


### PR DESCRIPTION
## Before
![button-focus-outline-before](https://user-images.githubusercontent.com/127199/89330707-82934b00-d645-11ea-8812-aad86b273b7a.gif)

## After
![button-focus-outline-after](https://user-images.githubusercontent.com/127199/89330711-84f5a500-d645-11ea-9396-cb12066421cb.gif)



## Test Plan

1) Add the following global CSS to the docs CSS (e.g. `DocSearch.css`)
```
:focus {
  outline: 1px auto #d1d1d1;
}
```
2) Ensure you don't see a double / light gray focus style