### PR TITLE
CompositeZIndex: Update deps array type

### DIFF
--- a/packages/gestalt/src/zIndex.js
+++ b/packages/gestalt/src/zIndex.js
@@ -18,9 +18,9 @@ export class FixedZIndex implements Indexable {
 }
 
 export class CompositeZIndex implements Indexable {
-  +deps: Array<Indexable>;
+  +deps: Array<FixedZIndex | CompositeZIndex>;
 
-  constructor(deps: Array<Indexable>) {
+  constructor(deps: Array<FixedZIndex | CompositeZIndex>) {
     this.deps = deps;
   }
 


### PR DESCRIPTION
The current type of Indexable leaks an implementation detail with a very unhelpful Flow error message if a user tries to pass integers in the deps array.

Users shouldn't need to know about Indexable; they should only need to know about the exported classes FixedZIndex and CompositeZIndex. While using the Indexable interface for that type is technically correct, it leaks out via the error message. Since we don't anticipate adding many (or any) further implementations of Indexable, it's fine to be explicit with the deps array type to provide a more useful error message.