### PR TITLE
Docs: Add id to every heading (improves SEO & Search)

### DIFF
--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -210,7 +210,7 @@ function CheckboxExample() {
       <Label>
         <Row gap={1}>
           <Switch
-            onChange={() => { 
+            onChange={() => {
               setSize(size === "sm" ? "md" : "sm")
               setSwitched(!switched)}
             }
@@ -273,7 +273,7 @@ function CheckboxFlyoutExample() {
             positionRelativeToAnchor={false}
             shouldFocus={false}
             size="md"
-          >            
+          >
             <Box padding={3}>
               <Text
                 color="white"
@@ -300,7 +300,6 @@ card(
     disabled={[false, true]}
     indeterminate={[false, true]}
     size={['sm', 'md']}
-    heading={false}
   >
     {(props, i) => (
       <Checkbox id={`example-${i}`} onChange={() => {}} {...props} />

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -158,7 +158,7 @@ function RadioButtonExample() {
       <Label>
         <Row gap={1}>
           <Switch
-            onChange={() => { 
+            onChange={() => {
               setSize(size === "sm" ? "md" : "sm")
               setSwitched(!switched)}
             }
@@ -271,7 +271,6 @@ card(
     checked={[false, true]}
     disabled={[false, true]}
     size={['sm', 'md']}
-    heading={false}
   >
     {(props, i) => (
       <RadioButton

--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -90,7 +90,6 @@ card(
     id="switchCombinations"
     disabled={[false, true]}
     switched={[false, true]}
-    heading={false}
   >
     {(props, i) => (
       <Switch id={`example-${i}`} onChange={() => {}} {...props} />

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -1,12 +1,12 @@
 // @flow strict
 import React from 'react';
-import { Box, Heading } from 'gestalt';
+import { Box, Heading, Icon, Link, Row } from 'gestalt';
+import slugify from 'slugify';
 import Markdown from './Markdown.js';
 
 type Props = {|
   children?: React.Node,
   description?: string,
-  heading?: boolean,
   id: ?string,
   name: string,
   stacked?: boolean,
@@ -15,14 +15,28 @@ type Props = {|
 export default function Card({
   children,
   description,
-  heading = true,
   id,
   name,
   stacked = false,
 }: Props) {
+  const slugifiedId = id ?? slugify(name);
   return (
-    <Box id={id}>
-      {heading && <Heading size="md">{name}</Heading>}
+    <Box
+      id={slugifiedId}
+      dangerouslySetInlineStyle={{
+        __style: {
+          scrollMarginTop: 60,
+        },
+      }}
+    >
+      <Heading size="md">
+        <Row display="flex" alignItems="baseline" gap={1}>
+          {name}
+          <Link href={`#${slugifiedId}`} inline>
+            <Icon icon="link" accessibilityLabel="" size={12} />
+          </Link>
+        </Row>
+      </Heading>
       <Box
         marginLeft={-2}
         marginRight={-2}

--- a/docs/src/components/Combination.js
+++ b/docs/src/components/Combination.js
@@ -81,25 +81,18 @@ function layoutReducer(layout) {
 }
 
 export default function Combination({
-  name = '',
+  name = 'Combinations',
   description = '',
   layout = '2column',
   id,
   showValues = true,
   stacked = false,
-  heading = true,
   children,
   ...props
 }: Props) {
   const { column, mdColumn, lgColumn } = layoutReducer(layout);
   return (
-    <Card
-      name={name}
-      description={description}
-      id={id}
-      stacked={stacked}
-      heading={heading}
-    >
+    <Card name={name} description={description} id={id} stacked={stacked}>
       <Box display="flex" wrap>
         {combinations(props).map((combination, i) => (
           <Box

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -136,18 +136,7 @@ export default function PropTable({ props: properties, Component }: Props) {
                       <Box>
                         <Text overflow="normal" weight="bold">
                           {href ? (
-                            <Link
-                              href={`#${href}`}
-                              onClick={({ event }) => {
-                                event.preventDefault();
-                                const elem = document.getElementById(href);
-                                if (elem) {
-                                  elem.scrollIntoView({
-                                    block: 'start',
-                                  });
-                                }
-                              }}
-                            >
+                            <Link href={`#${href}`}>
                               <code>{name}</code>
                             </Link>
                           ) : (

--- a/docs/src/docs.css
+++ b/docs/src/docs.css
@@ -1,0 +1,16 @@
+body {
+  margin: 0;
+}
+
+@keyframes target-fade {
+  0% { background-color: rgba(0,0,0,.05); }
+
+  100% { background-color: rgba(255,255,255,0); }
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+  :target {
+    animation: 1.5s ease-in target-fade  1;
+  }
+}
+

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -7,7 +7,7 @@ import 'gestalt-datepicker/dist/gestalt-datepicker-future.css';
 import App from './components/App.js';
 import CardPage from './components/CardPage.js';
 import routes from './components/routes.js';
-import './reset.css';
+import './docs.css';
 import sidebarIndex from './components/sidebarIndex.js';
 
 const container = document.getElementById('root');

--- a/docs/src/reset.css
+++ b/docs/src/reset.css
@@ -1,3 +1,0 @@
-body {
-  margin: 0;
-}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "sane": "^4.1.0",
     "semver": "^7.3.2",
     "shelljs": "^0.8.4",
+    "slugify": "^1.4.5",
     "stylelint": "^13.6.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-standard": "^20.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17237,6 +17237,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+slugify@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.5.tgz#a7517acf5f4c02a4df41e735354b660a4ed1efcf"
+  integrity sha512-WpECLAgYaxHoEAJ8Q1Lo8HOs1ngn7LN7QjXgOLbmmfkcWvosyk4ZTXkTzKyhngK640USTZUlgoQJfED1kz5fnQ==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
Improve A11Y / SEO and search by adding an anchor to every heading on our docs. It becomes way easier to go to a certain example / section of the page.

![gestalt-docs-add-anchor-to-headings](https://user-images.githubusercontent.com/127199/89452340-598cbc00-d712-11ea-9523-a05998422d17.gif)

Note that the improved search functionality will only start working once the Algolia crawls our pages (every 24 hours).

## References
* Algolia DocSearch: [Add anchors to headings](https://docsearch.algolia.com/docs/tips/#add-anchors-to-headings)

## Test Plan

### Prop table links

1. Click on a reference in the prop table
2. Ensure the page scrolls to the correct section

### Direct links

1. Go to https://deploy-preview-1123--gestalt.netlify.app/data-display/Avatar#Fixed-Sizes
2. It should scroll to the correct location on the page
![image](https://user-images.githubusercontent.com/127199/89452464-8ccf4b00-d712-11ea-9ee0-f6ea1ad2c045.png)
