### PR TITLE
Docs: single subdirectory URLs

### DIFF
--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -13,14 +13,14 @@ export default function Navigation() {
       {isSidebarOpen && (
         <Box display="block" mdDisplay="none" padding={4}>
           {sidebarIndex.map(section => (
-            <SidebarSection section={section} key={section.sectionPathname} />
+            <SidebarSection section={section} key={section.sectionName} />
           ))}
         </Box>
       )}
 
       <Box display="none" mdDisplay="block" padding={4}>
         {sidebarIndex.map(section => (
-          <SidebarSection section={section} key={section.sectionPathname} />
+          <SidebarSection section={section} key={section.sectionName} />
         ))}
       </Box>
     </>

--- a/docs/src/components/SidebarSection.js
+++ b/docs/src/components/SidebarSection.js
@@ -14,7 +14,7 @@ export default function SidebarSection({ section }: sidebarIndexType) {
       </Box>
       {section.pages.map((component, i) => (
         <Box key={i}>
-          <NavLink to={`/${section.sectionPathname}/${component}`}>
+          <NavLink to={`/${component}`}>
             <Box padding={2} role="listitem">
               {component}
             </Box>

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -1,7 +1,6 @@
 // @flow strict
 
 export type sidebarIndexType = Array<{|
-  sectionPathname: string,
   displayName: string,
   pages: Array<string>,
 |}>;
@@ -16,40 +15,33 @@ export type sidebarIndexType = Array<{|
 // Any new section/page must be added to sidebarIndex to be displayed.
 const sidebarIndex: sidebarIndexType = [
   {
-    sectionPathname: 'getting-started',
     sectionName: 'Getting Started',
     pages: ['Installation'],
   },
   {
-    sectionPathname: 'foundation',
     sectionName: 'Foundation',
     pages: ['Heading', 'Icon', 'Text'],
   },
 
   {
     sectionName: 'Configuration',
-    sectionPathname: 'configuration',
     pages: ['Provider'],
   },
   {
     sectionName: 'Accessibility',
-    sectionPathname: 'accessibility',
     pages: ['useReducedMotion'],
   },
   {
     sectionName: 'Data Display',
-    sectionPathname: 'data-display',
     pages: ['Avatar', 'AvatarPair', 'Badge', 'GroupAvatar', 'Table'],
   },
   {
     sectionName: 'Feedback',
-    sectionPathname: 'feedback',
     pages: ['Callout', 'Modal', 'Pulsar', 'Spinner', 'Toast', 'Tooltip'],
   },
 
   {
     sectionName: 'Forms',
-    sectionPathname: 'forms',
     pages: [
       'Button',
       'Checkbox',
@@ -71,7 +63,6 @@ const sidebarIndex: sidebarIndexType = [
   },
   {
     sectionName: 'Layout',
-    sectionPathname: 'layout',
     pages: [
       'Box',
       'Card',
@@ -89,12 +80,10 @@ const sidebarIndex: sidebarIndexType = [
   },
   {
     sectionName: 'Media',
-    sectionPathname: 'media',
     pages: ['Image', 'Letterbox', 'Mask', 'Video'],
   },
   {
     sectionName: 'Navigation',
-    sectionPathname: 'navigation',
     pages: ['Link', 'SegmentedControl', 'Tabs'],
   },
 ];

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -11,10 +11,10 @@ import './docs.css';
 import sidebarIndex from './components/sidebarIndex.js';
 
 const container = document.getElementById('root');
-const mapRoutes = (pages, pathname) =>
+const mapRoutes = pages =>
   pages.map((page, i) => (
     <Route
-      path={`/${pathname}/${page}`}
+      path={`/${page}`}
       key={i}
       render={() => <CardPage cards={routes[page]} />}
     />
@@ -29,11 +29,9 @@ if (container instanceof Element) {
             <Route
               exact
               path="/"
-              render={() => <Redirect to="/getting-started/Installation" />}
+              render={() => <Redirect to="/Installation" />}
             />
-            {sidebarIndex.map(section =>
-              mapRoutes(section.pages, section.sectionPathname)
-            )}
+            {sidebarIndex.map(section => mapRoutes(section.pages))}
           </Switch>
         </App>
       </BrowserRouter>


### PR DESCRIPTION
Internal request by couple of developers.

Before
`https://gestalt.netlify.app/layout/Box`
After
`https://gestalt.netlify.app/Box`

Pros
* Allows developers to quickly go to a component without knowing which subsection it is in.

Cons
* Means that every section in itself needs to be unique. E.g. we can't do `layout/Box` and `forms/Box`.