### PR TITLE
Docs: Navigation- Add an option to list components alphabetically

### DIFF
--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -1,27 +1,95 @@
 // @flow strict
-import React from 'react';
-import { Box } from 'gestalt';
+import React, { useState } from 'react';
+import { Box, SelectList } from 'gestalt';
 import SidebarSection from './SidebarSection.js';
+import SidebarSectionLink from './SidebarSectionLink.js';
 import sidebarIndex from './sidebarIndex.js';
 import { useSidebarContext } from './sidebarContext.js';
 
+const componentSections = sidebarIndex.filter(
+  indexItm => indexItm.sectionPathname !== 'getting-started'
+);
+
+function getAlphabetizedComponents() {
+  return Array.from(
+    new Set(
+      componentSections
+        .map(section => section.pages)
+        .flat()
+        .sort()
+    )
+  ).map(page => {
+    const { sectionPathname } = sidebarIndex.find(sbi =>
+      sbi.pages.includes(page)
+    );
+    return { name: page, sectionPathname };
+  });
+}
+
+function gettingStartedSection() {
+  const gettingStarted = sidebarIndex.find(
+    itm => itm.sectionPathname === 'getting-started'
+  );
+
+  return (
+    <SidebarSection
+      section={gettingStarted}
+      key={gettingStarted.sectionPathname}
+    />
+  );
+}
+
 export default function Navigation() {
   const { isSidebarOpen } = useSidebarContext();
+  const [organizedBy, setOrganizedBy] = useState('categorized');
+
+  const navList = (
+    <>
+      {gettingStartedSection()}
+
+      <Box marginTop={4}>
+        <SelectList
+          id="organizedBy"
+          name="organizedBy"
+          onChange={({ value }) => setOrganizedBy(value)}
+          options={[
+            { label: 'Alpabetical', value: 'alphabetical' },
+            { label: 'Categorized', value: 'categorized' },
+          ]}
+          placeholder="Select component organization"
+          label="Component organization"
+          value={organizedBy}
+        />
+      </Box>
+
+      {organizedBy === 'categorized' ? (
+        componentSections.map(section => (
+          <SidebarSection section={section} key={section.sectionPathname} />
+        ))
+      ) : (
+        <Box marginTop={4}>
+          {getAlphabetizedComponents().map((component, i) => (
+            <SidebarSectionLink
+              key={i}
+              componentName={component.name}
+              sectionPathname={component.sectionPathname}
+            />
+          ))}
+        </Box>
+      )}
+    </>
+  );
 
   return (
     <>
       {isSidebarOpen && (
         <Box display="block" mdDisplay="none" padding={4}>
-          {sidebarIndex.map(section => (
-            <SidebarSection section={section} key={section.sectionName} />
-          ))}
+          {navList}
         </Box>
       )}
 
       <Box display="none" mdDisplay="block" padding={4}>
-        {sidebarIndex.map(section => (
-          <SidebarSection section={section} key={section.sectionName} />
-        ))}
+        {navList}
       </Box>
     </>
   );

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -7,7 +7,7 @@ import sidebarIndex from './sidebarIndex.js';
 import { useSidebarContext } from './sidebarContext.js';
 
 const componentSections = sidebarIndex.filter(
-  indexItm => indexItm.sectionPathname !== 'getting-started'
+  indexItm => indexItm.sectionName !== 'Getting Started'
 );
 
 function getAlphabetizedComponents() {
@@ -18,24 +18,16 @@ function getAlphabetizedComponents() {
         .flat()
         .sort()
     )
-  ).map(page => {
-    const { sectionPathname } = sidebarIndex.find(sbi =>
-      sbi.pages.includes(page)
-    );
-    return { name: page, sectionPathname };
-  });
+  );
 }
 
 function gettingStartedSection() {
   const gettingStarted = sidebarIndex.find(
-    itm => itm.sectionPathname === 'getting-started'
+    itm => itm.sectionName === 'Getting Started'
   );
 
   return (
-    <SidebarSection
-      section={gettingStarted}
-      key={gettingStarted.sectionPathname}
-    />
+    <SidebarSection section={gettingStarted} key={gettingStarted.sectionName} />
   );
 }
 
@@ -64,16 +56,12 @@ export default function Navigation() {
 
       {organizedBy === 'categorized' ? (
         componentSections.map(section => (
-          <SidebarSection section={section} key={section.sectionPathname} />
+          <SidebarSection section={section} key={section.sectionName} />
         ))
       ) : (
         <Box marginTop={4}>
-          {getAlphabetizedComponents().map((component, i) => (
-            <SidebarSectionLink
-              key={i}
-              componentName={component.name}
-              sectionPathname={component.sectionPathname}
-            />
+          {getAlphabetizedComponents().map((componentName, i) => (
+            <SidebarSectionLink key={i} componentName={componentName} />
           ))}
         </Box>
       )}

--- a/docs/src/components/SidebarSection.js
+++ b/docs/src/components/SidebarSection.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Box, Row, Text } from 'gestalt';
 import { type sidebarIndexType } from './sidebarIndex.js';
-import NavLink from './NavLink.js';
+import SidebarSectionLink from './SidebarSectionLink.js';
 
 export default function SidebarSection({ section }: sidebarIndexType) {
   return (
@@ -12,14 +12,9 @@ export default function SidebarSection({ section }: sidebarIndexType) {
           <Text size="sm">{section.sectionName}</Text>
         </Row>
       </Box>
-      {section.pages.map((component, i) => (
-        <Box key={i}>
-          <NavLink to={`/${component}`}>
-            <Box padding={2} role="listitem">
-              {component}
-            </Box>
-          </NavLink>
-        </Box>
+
+      {section.pages.map((componentName, i) => (
+        <SidebarSectionLink key={i} componentName={componentName} />
       ))}
     </>
   );

--- a/docs/src/components/SidebarSectionLink.js
+++ b/docs/src/components/SidebarSectionLink.js
@@ -1,0 +1,20 @@
+// @flow strict
+import React from 'react';
+import { Box } from 'gestalt';
+import NavLink from './NavLink.js';
+
+type Props = {|
+  componentName: string,
+|};
+
+export default function SideBarSectionLink({ componentName }: Props) {
+  return (
+    <Box>
+      <NavLink to={`/${componentName}`}>
+        <Box padding={2} role="listitem">
+          {componentName}
+        </Box>
+      </NavLink>
+    </Box>
+  );
+}


### PR DESCRIPTION
Add a select list to the documentation navigation bar to allow users to choose whether the Gestalt components are organized by category or alphabetically.

## Test Plan
Go to the Gestalt documentation.  In the side nav bar observe that there is a select list with `Categorized` selected.
The components listed below the select list should be organized by category (ex. Foundation: [Heading, Icon, Text])
Select `Alphabetical` in the select list.
The components should update to be alphabetical.

![GestaltAlpha](https://user-images.githubusercontent.com/10646092/89466860-6bc62480-d729-11ea-9829-71f6acda2b71.gif)


