### PR TITLE
[Docs] Update port number for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Build and watch Gestalt & run the docs server:
 yarn start
 ```
 
-Visit [http://localhost:3000/](http://localhost:3000) and click on a component to view the docs.
+Visit [http://localhost:8888/](http://localhost:8888) and click on a component to view the docs.
 
 ## Codemods
 

--- a/docs/src/Installation.doc.js
+++ b/docs/src/Installation.doc.js
@@ -128,10 +128,10 @@ yarn start
       <Link
         tapStyl="compress"
         inline
-        href="http://localhost:3000/"
+        href="http://localhost:8888/"
         target="blank"
       >
-        <Text weight="bold">http://localhost:3000</Text>
+        <Text weight="bold">http://localhost:8888</Text>
       </Link>{' '}
       and click on a component to view the docs.
     </Text>


### PR DESCRIPTION
Running `yarn start` serves the docs at http://localhost:8888 after #1115

## Test Plan

Confirm this is the right port to use
