### PR TITLE
Docs: nest anchor inside of heading

### DIFF
--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -21,21 +21,23 @@ export default function Card({
 }: Props) {
   const slugifiedId = id ?? slugify(name);
   return (
-    <Box
-      id={slugifiedId}
-      dangerouslySetInlineStyle={{
-        __style: {
-          scrollMarginTop: 60,
-        },
-      }}
-    >
+    <>
       <Heading size="md">
-        <Row display="flex" alignItems="baseline" gap={1}>
-          {name}
-          <Link href={`#${slugifiedId}`} inline>
-            <Icon icon="link" accessibilityLabel="" size={12} />
-          </Link>
-        </Row>
+        <Box
+          dangerouslySetInlineStyle={{
+            __style: {
+              scrollMarginTop: 60,
+            },
+          }}
+          id={slugifiedId}
+        >
+          <Row display="flex" alignItems="baseline" gap={1}>
+            {name}
+            <Link href={`#${slugifiedId}`} inline>
+              <Icon icon="link" accessibilityLabel="" size={12} />
+            </Link>
+          </Row>
+        </Box>
       </Heading>
       <Box
         marginLeft={-2}
@@ -48,6 +50,6 @@ export default function Card({
           {children}
         </Box>
       </Box>
-    </Box>
+    </>
   );
 }


### PR DESCRIPTION
Algolia was able to re-index our pages but the search doesn't look good. Let's try to improve it by nesting the anchor inside of the heading.

![image](https://user-images.githubusercontent.com/127199/89673837-ec0c9700-d89b-11ea-9e30-3993ffb4db09.png)

## Test Plan

Search improves on the next crawl
