### PR TITLE
useReducedMotion: fix in Safari/Edge

### DIFF
--- a/packages/gestalt/src/useReducedMotion.js
+++ b/packages/gestalt/src/useReducedMotion.js
@@ -1,6 +1,22 @@
 // @flow strict
 import { useState, useEffect } from 'react';
 
+function addListener(mediaQuery, callback) {
+  // addEventListener on mediaQuery is not supported in all browsers (Edge / Safari)
+  if (mediaQuery.addEventListener) {
+    mediaQuery.addEventListener('change', callback);
+  } else if (mediaQuery.addListener) {
+    mediaQuery.addListener(callback);
+  }
+}
+function removeListener(mediaQuery, callback) {
+  if (mediaQuery.removeEventListener) {
+    mediaQuery.removeEventListener('change', callback);
+  } else if (mediaQuery.removeListener) {
+    mediaQuery.removeListener(callback);
+  }
+}
+
 export default function useReducedMotion(): boolean {
   const supportsMatchMedia = typeof window !== 'undefined' && window.matchMedia;
 
@@ -18,9 +34,9 @@ export default function useReducedMotion(): boolean {
       setMatch(mediaQuery.matches);
     };
     handleChange();
-    mediaQuery.addEventListener('change', handleChange);
+    addListener(mediaQuery, handleChange);
     return () => {
-      mediaQuery.removeEventListener('change', handleChange);
+      removeListener(mediaQuery, handleChange);
     };
   }, [supportsMatchMedia]);
   return matches;


### PR DESCRIPTION
`addEventListener` is not supported in Safari / Edge on the Media Query object

![image](https://user-images.githubusercontent.com/127199/89681620-1feeb900-d8aa-11ea-9ae0-47027a7a82c7.png)

https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#Methods mentions we should use `addEventListener` with the `change` event when possible. So we use that before trying `addListener`

![image](https://user-images.githubusercontent.com/127199/89681763-6f34e980-d8aa-11ea-8bc1-42b7e768f96c.png)


## Test Plan

1. Open Safari
2. Go to the `useReducedMotion` page
3. Ensure there are no exceptions in the console
