### PR TITLE
Datepicker: standardized date format & placeholder date format across…

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -14,7 +14,7 @@ import { Icon, Box, Label, Text } from 'gestalt';
 import PropTypes from 'prop-types';
 import DatePickerTextField from './DatePickerTextField.js';
 import styles from './DatePicker.css';
-import format from './format.js';
+import dateFormat from './dateFormat.js';
 import { LocaleDataPropTypes, type LocaleData } from './LocaleDataTypes.js';
 
 type Props = {|
@@ -76,7 +76,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<
   // in the month and we need to keep the flyout pointed at the input correctly
   const [selected, setSelected] = useState<?Date>(dateValue);
   const [, setMonth] = useState<?number>();
-  const [dateFormat, setDateFormat] = useState<?string>();
+  const [format, setFormat] = useState<?string>();
   const [updatedLocale, setUpdatedLocale] = useState<?string>();
   const [initRangeHighlight, setInitRangeHighlight] = useState<?Date>();
 
@@ -90,7 +90,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<
     if (localeData && localeData.code) {
       registerLocale(localeData.code, localeData);
       setUpdatedLocale(localeData.code);
-      setDateFormat(format[localeData.code || 'en-US']);
+      setFormat(dateFormat[localeData.code || 'en-US']);
     }
   }, [localeData]);
 
@@ -124,7 +124,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<
       <ReactDatePicker
         calendarClassName={classnames(styles['react-datepicker'])}
         customInput={<DatePickerTextField id={id} />}
-        dateFormat={dateFormat}
+        dateFormat={format}
         dayClassName={() => classnames(styles['react-datepicker__days'])}
         disabled={disabled}
         endDate={rangeEndDate}
@@ -155,9 +155,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<
         }}
         onKeyDown={event => updateNextRef(event.key === 'Enter')}
         onMonthChange={(newMonth: Date) => setMonth(newMonth.getMonth())}
-        placeholderText={
-          placeholder || dateFormat?.toUpperCase() || 'MM/DD/YYYY'
-        }
+        placeholderText={placeholder || format?.toUpperCase() || 'MM/DD/YYYY'}
         popperClassName={classnames(
           styles['react-datepicker-popper'],
           styles[`react-datepicker-popper-${popperPlacement[idealDirection]}`]

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -14,6 +14,7 @@ import { Icon, Box, Label, Text } from 'gestalt';
 import PropTypes from 'prop-types';
 import DatePickerTextField from './DatePickerTextField.js';
 import styles from './DatePicker.css';
+import format from './format.js';
 import { LocaleDataPropTypes, type LocaleData } from './LocaleDataTypes.js';
 
 type Props = {|
@@ -89,9 +90,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<
     if (localeData && localeData.code) {
       registerLocale(localeData.code, localeData);
       setUpdatedLocale(localeData.code);
-      setDateFormat(
-        localeData.formatLong && localeData.formatLong.date({ width: 'short' })
-      );
+      setDateFormat(format[localeData.code || 'en-US']);
     }
   }, [localeData]);
 
@@ -156,7 +155,9 @@ const DatePickerWithForwardRef: React$AbstractComponent<
         }}
         onKeyDown={event => updateNextRef(event.key === 'Enter')}
         onMonthChange={(newMonth: Date) => setMonth(newMonth.getMonth())}
-        placeholderText={placeholder || dateFormat || 'mm/dd/yyyy'}
+        placeholderText={
+          placeholder || dateFormat?.toUpperCase() || 'MM/DD/YYYY'
+        }
         popperClassName={classnames(
           styles['react-datepicker-popper'],
           styles[`react-datepicker-popper-${popperPlacement[idealDirection]}`]

--- a/packages/gestalt-datepicker/src/dateFormat.js
+++ b/packages/gestalt-datepicker/src/dateFormat.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-const format: { [string]: string } = {
+const dateFormat: { [string]: string } = {
   'ar-SA': 'MM/dd/yyyy', // Arabic (Saudi Arabia)
   cs: 'dd.MM.yyyy', // Czech
   da: 'dd/MM/yyyy', // Danish
@@ -33,4 +33,4 @@ const format: { [string]: string } = {
   'zh-TW': 'yyyy-MM-dd', // Chinese (Traditional)
 };
 
-export default format;
+export default dateFormat;

--- a/packages/gestalt-datepicker/src/format.js
+++ b/packages/gestalt-datepicker/src/format.js
@@ -1,0 +1,36 @@
+// @flow strict-local
+const format: { [string]: string } = {
+  'ar-SA': 'MM/dd/yyyy', // Arabic (Saudi Arabia)
+  cs: 'dd.MM.yyyy', // Czech
+  da: 'dd/MM/yyyy', // Danish
+  de: 'dd.MM.yyyy', // German
+  el: 'dd/MM/yyyy', // Greek
+  'en-GB': 'dd/MM/yyyy', // English (British)
+  'en-US': 'MM/dd/yyyy', // English
+  es: 'dd/MM/yyyy', // Spanish
+  fi: 'dd.MM.yyyy', // Finnish
+  fr: 'dd/MM/yyyy', // French
+  hi: 'dd/MM/yyyy', // Hindi
+  hu: 'yyyy. MM. dd', // Hungarian
+  id: 'dd/MM/yyyy', // Indonesian
+  it: 'dd/MM/yyyy', // Italian
+  ja: 'yyyy/MM/dd', // Japanese
+  ko: 'yyyy.MM.dd', // Korean
+  ms: 'dd/MM/yyyy', // Malay
+  nb: 'dd.MM.yyyy', // Norwegian (Bokm\u00e5l)
+  nl: 'dd-MM-yyyy', // Dutch
+  pl: 'dd.MM.yyyy', // Polish (Poland)
+  pt: 'dd/MM/yyyy', // Portuguese
+  ro: 'dd/MM/yyyy', // Romanian
+  ru: 'dd.MM.yyyy', // Russian
+  sk: 'dd. MM. yyyy', // Slovak
+  sv: 'yyyy-MM-dd', // Swedish
+  th: 'dd/MM/yyyy', // Thai
+  tr: 'dd.MM.yyyy', // Turkish
+  uk: 'dd.MM.yyyy', // Ukrainian
+  vi: 'dd/MM/yyyy', // Vietnamese
+  'zh-CN': 'yyyy-MM-dd', // Chinese (Simplified)
+  'zh-TW': 'yyyy-MM-dd', // Chinese (Traditional)
+};
+
+export default format;


### PR DESCRIPTION
… locale

- `date format` is used to format the displayed date and as default placeholder following [datepicker best practices]( https://uxplanet.org/date-picker-design-best-practices-41bd522f10a5).
- Locale format provided by `date-fns` was inconsistent across locales. 
- We added a small library to provide a consistent date format across locales.

### Before
![image](https://user-images.githubusercontent.com/10593890/89683327-33e7ea00-d8ad-11ea-9316-569053712f3b.png)
![image](https://user-images.githubusercontent.com/10593890/89683392-4cf09b00-d8ad-11ea-9f3e-7c5c35baed4d.png)

### After
![image](https://user-images.githubusercontent.com/10593890/89683349-3a766180-d8ad-11ea-84f4-d9a59e0b989d.png)
![image](https://user-images.githubusercontent.com/10593890/89683403-5548d600-d8ad-11ea-9728-b0b57005036b.png)

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
