### PR TITLE
Sticky: add height prop

### DIFF
--- a/docs/src/Sticky.doc.js
+++ b/docs/src/Sticky.doc.js
@@ -42,6 +42,11 @@ card(
         description: `Use numbers for pixels: top={100} and strings for percentages: top="100%"`,
       },
       {
+        name: 'height',
+        type: 'number',
+        description: `Use numbers for pixels: height={100}. This is only useful when the sticky container and its content need to have different heights.`,
+      },
+      {
         name: 'zIndex',
         type: 'interface Indexable { index(): number; }',
         description: `An object representing the zIndex value of the Sticky.`,

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -20,16 +20,17 @@ type Threshold =
     |};
 
 type Props = {|
-  children: Node,
-  zIndex?: Indexable,
-  dangerouslySetZIndex?: {| __zIndex: number |},
   ...Threshold,
+  children: Node,
+  dangerouslySetZIndex?: {| __zIndex: number |},
+  height?: number,
+  zIndex?: Indexable,
 |};
 
 const DEFAULT_ZINDEX = new FixedZIndex(1);
 
 export default function Sticky(props: Props): Node {
-  const { dangerouslySetZIndex, children } = props;
+  const { dangerouslySetZIndex, children, height } = props;
   const zIndex =
     props.zIndex ||
     (dangerouslySetZIndex &&
@@ -38,6 +39,7 @@ export default function Sticky(props: Props): Node {
         new FixedZIndex(dangerouslySetZIndex.__zIndex)
       : DEFAULT_ZINDEX);
   const style = {
+    ...(height !== undefined ? { height } : {}),
     top: props.top != null ? props.top : undefined,
     left: props.left != null ? props.left : undefined,
     right: props.right != null ? props.right : undefined,
@@ -60,6 +62,7 @@ Sticky.propTypes = {
   left: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   right: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  height: PropTypes.number,
   // eslint-disable-next-line react/forbid-prop-types
   zIndex: PropTypes.any,
 };

--- a/packages/gestalt/src/Sticky.test.js
+++ b/packages/gestalt/src/Sticky.test.js
@@ -26,6 +26,15 @@ test('Sticky correctly sets thresholds for string values', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Sticky correctly sets height', () => {
+  const tree = create(
+    <Sticky top={1} height={100}>
+      Sticky
+    </Sticky>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Sticky correctly sets zIndex', () => {
   const zIndexStub = {
     index() {

--- a/packages/gestalt/src/__snapshots__/Sticky.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sticky.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Sticky correctly sets height 1`] = `
+<div
+  className="sticky"
+  style={
+    Object {
+      "bottom": undefined,
+      "height": 100,
+      "left": undefined,
+      "right": undefined,
+      "top": 1,
+      "zIndex": 1,
+    }
+  }
+>
+  Sticky
+</div>
+`;
+
 exports[`Sticky correctly sets thresholds for number values 1`] = `
 <div
   className="sticky"


### PR DESCRIPTION
`<Sticky>` container always have the same height has the height of its content. This adds the `height` prop which allows the container to have a different height than its content.

![Screen Shot 2020-08-07 at 2 12 17 PM](https://user-images.githubusercontent.com/5341184/89692910-cdb99200-d8c1-11ea-975f-a2755ca72023.png)
