### PR TITLE
[Pog]: Add red to prop type

### DIFF
--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -115,6 +115,7 @@ Pog.propTypes = {
     'gray',
     'lightGray',
     'white',
+    'red',
   ]),
   dangerouslySetSvgPath: PropTypes.shape({
     __path: PropTypes.string,


### PR DESCRIPTION
The color red was missing in the prop types causing an erorr:

![image](https://user-images.githubusercontent.com/5871660/89829050-33eb2280-db17-11ea-9faa-647a56774646.png)

 