### PR TITLE
Avatar: Remove person icon fallback variant

### DIFF
--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -5,7 +5,6 @@ import Box from './Box.js';
 import Icon from './Icon.js';
 import Image from './Image.js';
 import Mask from './Mask.js';
-import PersonSvg from './icons/person.svg';
 import typography from './Typography.css';
 import { useColorScheme } from './contexts/ColorScheme.js';
 
@@ -24,11 +23,9 @@ const Square = (props: *) => (
 const DefaultAvatar = ({
   accessibilityLabel,
   name,
-  useDefaultIcon,
 }: {|
   accessibilityLabel?: string,
   name: string,
-  useDefaultIcon: boolean,
 |}) => {
   const { colorGray300 } = useColorScheme();
   const firstInitial = name ? [...name][0].toUpperCase() : '';
@@ -36,41 +33,28 @@ const DefaultAvatar = ({
 
   return (
     <Square color="lightGray" rounding="circle" overflow="hidden">
-      {useDefaultIcon || !firstInitial ? (
-        <svg
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          version="1.1"
-          viewBox="-3 -8 30 100"
-          xmlns="http://www.w3.org/2000/svg"
+      <svg
+        width="100%"
+        viewBox="-50 -50 100 100"
+        version="1.1"
+        preserveAspectRatio="xMidYMid meet"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <title>{title}</title>
+        <text
+          fontSize="40px"
+          fill={colorGray300}
+          dy="0.35em"
+          textAnchor="middle"
+          className={[
+            typography.antialiased,
+            typography.sansSerif,
+            typography.fontWeightBold,
+          ].join(' ')}
         >
-          {title && <title>{title}</title>}
-          <path d={PersonSvg} fill={colorGray300} />
-        </svg>
-      ) : (
-        <svg
-          width="100%"
-          viewBox="-50 -50 100 100"
-          version="1.1"
-          preserveAspectRatio="xMidYMid meet"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title>{title}</title>
-          <text
-            fontSize="40px"
-            fill={colorGray300}
-            dy="0.35em"
-            textAnchor="middle"
-            className={[
-              typography.antialiased,
-              typography.sansSerif,
-              typography.fontWeightBold,
-            ].join(' ')}
-          >
-            {firstInitial}
-          </text>
-        </svg>
-      )}
+          {firstInitial}
+        </text>
+      </svg>
     </Square>
   );
 };
@@ -82,7 +66,6 @@ type Props = {|
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'fit',
   src?: string,
   verified?: boolean,
-  __dangerouslyUseDefaultIcon?: boolean,
 |};
 
 const sizes = {
@@ -103,7 +86,6 @@ export default function Avatar(props: Props): Node {
     size = 'fit',
     src,
     verified,
-    __dangerouslyUseDefaultIcon: useDefaultIcon = false,
   } = props;
   const width = size === 'fit' ? '100%' : sizes[size];
   const height = size === 'fit' ? '' : sizes[size];
@@ -139,11 +121,7 @@ export default function Avatar(props: Props): Node {
           />
         </Mask>
       ) : (
-        <DefaultAvatar
-          accessibilityLabel={accessibilityLabel}
-          name={name}
-          useDefaultIcon={useDefaultIcon}
-        />
+        <DefaultAvatar accessibilityLabel={accessibilityLabel} name={name} />
       )}
 
       {verified && (

--- a/packages/gestalt/src/Avatar.jsdom.test.js
+++ b/packages/gestalt/src/Avatar.jsdom.test.js
@@ -14,12 +14,3 @@ test('Avatar handles Image error by rendering the default avatar', () => {
     getByText('T');
   }).toThrow('Unable to find an element with the text: T');
 });
-
-test('Avatar handles Image error by rendering the default icon if setted', () => {
-  const { getByAltText, getByRole } = render(
-    <Avatar name="Name" src="example.com" __dangerouslyUseDefaultIcon />
-  );
-  fireEvent.error(getByAltText('Name'));
-
-  expect(getByRole('img')).toBeTruthy();
-});

--- a/packages/gestalt/src/Avatar.test.js
+++ b/packages/gestalt/src/Avatar.test.js
@@ -4,7 +4,7 @@ import { create } from 'react-test-renderer';
 import Avatar from './Avatar.js';
 
 describe('Avatar', () => {
-  it('renders multi-byte character initials', () => {
+  it('renders multi-byte character initial', () => {
     const component = create(<Avatar name="💩 astral" />, {
       createNodeMock() {
         return { clientWidth: 100 };

--- a/packages/gestalt/src/Avatar.test.js
+++ b/packages/gestalt/src/Avatar.test.js
@@ -19,13 +19,6 @@ describe('Avatar', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders the default icon', () => {
-    const tree = create(
-      <Avatar name="Carlos" __dangerouslyUseDefaultIcon />
-    ).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-
   it('renders an outline', () => {
     const tree = create(<Avatar name="Jenny" outline />).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -451,50 +451,6 @@ exports[`Avatar renders the correct src 1`] = `
 </div>
 `;
 
-exports[`Avatar renders the default icon 1`] = `
-<div
-  className="box circle relative whiteBg"
-  style={
-    Object {
-      "height": "",
-      "width": "100%",
-    }
-  }
->
-  <div
-    className="box circle lightGrayBg overflowHidden relative"
-  >
-    <div
-      className="box relative"
-      style={
-        Object {
-          "paddingBottom": "100%",
-        }
-      }
-    />
-    <div
-      className="absolute bottom0 box left0 right0 top0"
-    >
-      <svg
-        preserveAspectRatio="xMidYMid meet"
-        role="img"
-        version="1.1"
-        viewBox="-3 -8 30 100"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <title>
-          Carlos
-        </title>
-        <path
-          d="test-file-stub"
-          fill="#111"
-        />
-      </svg>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Avatar renders the verified icon 1`] = `
 <div
   className="box circle relative whiteBg"
@@ -607,16 +563,23 @@ exports[`Avatar renders with an empty name shows default icon 1`] = `
     >
       <svg
         preserveAspectRatio="xMidYMid meet"
-        role="img"
         version="1.1"
-        viewBox="-3 -8 30 100"
+        viewBox="-50 -50 100 100"
+        width="100%"
         xmlns="http://www.w3.org/2000/svg"
       >
-        
-        <path
-          d="test-file-stub"
+        <title>
+          
+        </title>
+        <text
+          className="antialiased sansSerif fontWeightBold"
+          dy="0.35em"
           fill="#111"
-        />
+          fontSize="40px"
+          textAnchor="middle"
+        >
+          
+        </text>
       </svg>
     </div>
   </div>

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -50,7 +50,7 @@ exports[`Avatar renders an outline 1`] = `
 </div>
 `;
 
-exports[`Avatar renders multi-byte character initials 1`] = `
+exports[`Avatar renders multi-byte character initial 1`] = `
 <div
   className="box circle relative whiteBg"
   style={


### PR DESCRIPTION
We decided to move forward with the `first initial` version of the Avatar when the user has no profile pic

- Removes person icon fallback variant
- Removes `__dangerouslyUseDefaultIcon` prop

Before we had the possibility to choose between person icon or first initial variants for default avatar 
![Before](https://user-images.githubusercontent.com/7388586/89943090-85a4b300-dbd2-11ea-9e3e-517b919447af.png)

We decided to deprecate the person icon variant. So the first initial is the one to show when the user has no profile pic
![After](https://user-images.githubusercontent.com/7388586/89943220-b71d7e80-dbd2-11ea-9bc7-af717a84e020.png)


Tested locally