### PR TITLE
SelectList: Add disabled to options prop

### DIFF
--- a/docs/src/SelectList.doc.js
+++ b/docs/src/SelectList.doc.js
@@ -56,7 +56,7 @@ card(
       },
       {
         name: 'options',
-        type: 'Array<{ label: string, value: string }>',
+        type: 'Array<{ label: string, value: string, disabled?: boolean }>',
         required: true,
         href: 'basicExample',
       },

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -27,6 +27,7 @@ type Props = {|
   options: Array<{
     label: string,
     value: string,
+    disabled?: boolean,
   }>,
   placeholder?: string,
   size?: 'md' | 'lg',
@@ -52,6 +53,7 @@ export default class SelectList extends Component<Props, State> {
       PropTypes.exact({
         label: PropTypes.string.isRequired,
         value: PropTypes.string.isRequired,
+        disabled: PropTypes.bool,
       })
     ),
     placeholder: PropTypes.string,
@@ -162,7 +164,11 @@ export default class SelectList extends Component<Props, State> {
               </option>
             )}
             {options.map(option => (
-              <option key={option.value} value={option.value}>
+              <option
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled || false}
+              >
                 {option.label}
               </option>
             ))}

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -167,7 +167,7 @@ export default class SelectList extends Component<Props, State> {
               <option
                 key={option.value}
                 value={option.value}
-                disabled={option.disabled || false}
+                disabled={option.disabled}
               >
                 {option.label}
               </option>

--- a/packages/gestalt/src/SelectList.jsdom.test.js
+++ b/packages/gestalt/src/SelectList.jsdom.test.js
@@ -73,6 +73,20 @@ describe('<SelectList />', () => {
     expect(container.querySelector('option')).toBeDisabled();
   });
 
+  it('SelectList with disabled option', () => {
+    const { container } = render(
+      <SelectList
+        id="test"
+        onChange={jest.fn()}
+        options={[
+          ...options,
+          { label: 'option4', value: 'value4', disabled: true },
+        ]}
+      />
+    );
+    expect(container.querySelector('option[value="value4"]')).toBeDisabled();
+  });
+
   it('shows a label for the select list', () => {
     const { getByText } = render(
       <SelectList

--- a/packages/gestalt/src/SelectList.jsdom.test.js
+++ b/packages/gestalt/src/SelectList.jsdom.test.js
@@ -73,7 +73,7 @@ describe('<SelectList />', () => {
     expect(container.querySelector('option')).toBeDisabled();
   });
 
-  it('SelectList with disabled option', () => {
+  it('SelectList with disabled options', () => {
     const { container } = render(
       <SelectList
         id="test"

--- a/packages/gestalt/src/SelectList.test.js
+++ b/packages/gestalt/src/SelectList.test.js
@@ -44,6 +44,22 @@ describe('SelectList', () => {
     ).toEqual(['Placeholder text']);
   });
 
+  it('Renders a disabled option if options includes disabled option', () => {
+    const component = create(
+      <SelectList
+        id="test"
+        onChange={jest.fn()}
+        options={[
+          ...options,
+          { label: 'option4', value: 'value4', disabled: true },
+        ]}
+      />
+    );
+    expect(component.root.findByProps({ disabled: true }).children).toEqual([
+      'option4',
+    ]);
+  });
+
   it('SelectList normal', () => {
     const tree = create(
       <SelectList id="test" onChange={jest.fn()} options={options} />

--- a/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
@@ -45,16 +45,19 @@ exports[`SelectList SelectList normal 1`] = `
       onChange={[Function]}
     >
       <option
+        disabled={false}
         value="value1"
       >
         option1
       </option>
       <option
+        disabled={false}
         value="value2"
       >
         option2
       </option>
       <option
+        disabled={false}
         value="value3"
       >
         option3

--- a/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
@@ -45,19 +45,16 @@ exports[`SelectList SelectList normal 1`] = `
       onChange={[Function]}
     >
       <option
-        disabled={false}
         value="value1"
       >
         option1
       </option>
       <option
-        disabled={false}
         value="value2"
       >
         option2
       </option>
       <option
-        disabled={false}
         value="value3"
       >
         option3


### PR DESCRIPTION
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible. 
This is an update allow for disabling options within SelectList as supported in the native select https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
We would like to add in this change so that we may disable options on analytics.pinterest.com. For example, if a user has no paid content, the filter should have the paid option disabled.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->
This is an update adding in the ability to disable options within SelectList as supported in the native select https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option

## Test Plan
Tested locally to verify that it works as expected and added two tests.

<img width="833" alt="Screen Shot 2020-08-10 at 5 04 22 PM" src="https://user-images.githubusercontent.com/46180742/89842799-8e8e7980-db2b-11ea-8fac-408c3a51ae0c.png">

<!--
How can reviewers verify this is good to merge?

* Is it tested? Yes
* Is it accessible? I believe so
* Is it documented? Yes
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
