### PR TITLE
Docs: fix blank installation page

### DIFF
--- a/docs/src/components/Markdown.js
+++ b/docs/src/components/Markdown.js
@@ -34,6 +34,7 @@ export default function Markdown({
   text,
   size = 'lg',
 }: Props) {
+  console.log('/// Markdown - fetchfile', fetchFile);
   const [fetchedText, setFetchedText] = useState(null);
   const renderer = new Renderer();
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,8 @@
   from = "/*"
   to = "/"
   status = 200
+
+[[headers]]
+  for = "/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
https://gestalt.netlify.app/Installation is currently blank because of a CORS issue. Netlify tries to make a request from https://gestalt.netlify.app/ to https://master--gestalt.netlify.app/ which is not allowed.

![image](https://user-images.githubusercontent.com/127199/90420436-cdad5500-e06c-11ea-8974-016de8dfdf4b.png)


Fixes #1147 

## Test Plan
1. Go to https://gestalt.netlify.app/Installation
2. Ensure the page loads & shows content
