### PR TITLE
Video: add crossOrigin option

### DIFF
--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -89,6 +89,12 @@ card(
           Instead it serves to add overlays on top of the html video element, while still being under the video controls.`,
       },
       {
+        name: 'crossOrigin',
+        type: 'string',
+        description:
+          "Designate CORS behavior for the video element, one of 'use-credentials' or 'anonymous'. Note: when not passed in, CORS checks are disabled.",
+      },
+      {
         name: 'controls',
         type: 'boolean',
         description: 'Show the video player controls',

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -92,7 +92,7 @@ card(
         name: 'crossOrigin',
         type: "'use-credentials' | 'anonymous'",
         description:
-          "Designate CORS behavior for the video element. When not passed in, CORS checks are disabled.",
+          'Designate CORS behavior for the video element. When not passed in, CORS checks are disabled.',
       },
       {
         name: 'controls',

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -90,9 +90,9 @@ card(
       },
       {
         name: 'crossOrigin',
-        type: 'string',
+        type: "'use-credentials' | 'anonymous'",
         description:
-          "Designate CORS behavior for the video element, one of 'use-credentials' or 'anonymous'. Note: when not passed in, CORS checks are disabled.",
+          "Designate CORS behavior for the video element. When not passed in, CORS checks are disabled.",
       },
       {
         name: 'controls',

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -22,6 +22,7 @@ type Props = {|
   accessibilityUnmuteLabel: string,
   aspectRatio: number,
   captions: string,
+  crossOrigin?: 'anonymous' | 'use-credentials',
   children?: Node,
   controls?: boolean,
   loop?: boolean,

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -172,6 +172,7 @@ export default class Video extends PureComponent<Props, State> {
     aspectRatio: PropTypes.number.isRequired,
     captions: PropTypes.string.isRequired,
     children: PropTypes.node,
+    crossOrigin: PropTypes.string,
     controls: PropTypes.bool,
     loop: PropTypes.bool,
     onDurationChange: PropTypes.func,
@@ -203,11 +204,13 @@ export default class Video extends PureComponent<Props, State> {
   };
 
   static defaultProps: {|
+    crossOrigin?: 'use-credentials' | 'anonymous',
     playbackRate: number,
     playing: boolean,
     preload: 'auto' | 'metadata' | 'none',
     volume: number,
   |} = {
+    crossOrigin: undefined,
     playbackRate: 1,
     playing: false,
     preload: 'auto',
@@ -503,6 +506,7 @@ export default class Video extends PureComponent<Props, State> {
       aspectRatio,
       captions,
       children,
+      crossOrigin,
       loop,
       playing,
       playsInline,
@@ -538,6 +542,7 @@ export default class Video extends PureComponent<Props, State> {
             onSeeked={this.handleSeek}
             onTimeUpdate={this.handleTimeUpdate}
             onProgress={this.handleProgress}
+            {...(crossOrigin ? { crossOrigin } : null)}
           >
             {Array.isArray(src) &&
               src.map(source => (

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -173,7 +173,7 @@ export default class Video extends PureComponent<Props, State> {
     aspectRatio: PropTypes.number.isRequired,
     captions: PropTypes.string.isRequired,
     children: PropTypes.node,
-    crossOrigin: PropTypes.string,
+    crossOrigin: PropTypes.oneOf(['use-credentials', 'anonymous']),
     controls: PropTypes.bool,
     loop: PropTypes.bool,
     onDurationChange: PropTypes.func,
@@ -205,13 +205,11 @@ export default class Video extends PureComponent<Props, State> {
   };
 
   static defaultProps: {|
-    crossOrigin?: 'use-credentials' | 'anonymous',
     playbackRate: number,
     playing: boolean,
     preload: 'auto' | 'metadata' | 'none',
     volume: number,
   |} = {
-    crossOrigin: undefined,
     playbackRate: 1,
     playing: false,
     preload: 'auto',


### PR DESCRIPTION

What is the purpose of this PR?
  - Adding an option to choose the `crossOrigin` mode for videos so that users can use captions from a different domain if needed
  - Additional Context: I broke Gestalt video for [some folks](https://github.com/pinterest/gestalt/pull/1046#discussion_r454048460), and @simkessy [fixed them](https://github.com/pinterest/gestalt/pull/1077)
* What kind of feedback do you want?
  - Make sure changes seem reasonable

## Test Plan
  - [x] add captions and verify that they still work with `crossOrigin='anonymous'` passed in
  - [x] Make sure documentation Video still works locally