### PR TITLE
Docs: add sidebar alphabetization toggle

### DIFF
--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -10,6 +10,8 @@ type Props = {|
   children?: React.Node,
 |};
 
+const localStorageOrganizedByKey = 'gestalt-sitebar-organized-by';
+
 export default function App(props: Props) {
   const { children } = props;
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -17,11 +19,32 @@ export default function App(props: Props) {
 
   useTracking('UA-12967896-44');
 
+  const [sidebarOrganisedBy, setSitebarOrganizedBy] = useState<
+    'categorized' | 'alphabetical'
+  >(() => {
+    try {
+      return localStorage.getItem(localStorageOrganizedByKey) || 'categorized';
+    } catch (error) {
+      console.log(error); // eslint-disable-line no-console
+    }
+    return 'categorized';
+  });
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(localStorageOrganizedByKey, sidebarOrganisedBy);
+    } catch (error) {
+      console.log(error); // eslint-disable-line no-console
+    }
+  }, [sidebarOrganisedBy]);
+
   return (
     <SidebarContextProvider
       value={{
         isSidebarOpen,
         setIsSidebarOpen,
+        sidebarOrganisedBy,
+        setSitebarOrganizedBy,
       }}
     >
       <Provider colorScheme={colorScheme}>

--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -20,7 +20,12 @@ type Props = {|
 
 function Header({ colorScheme, onChangeColorScheme }: Props) {
   const [isRTL, setIsRTL] = React.useState(false);
-  const { isSidebarOpen, setIsSidebarOpen } = useSidebarContext();
+  const {
+    isSidebarOpen,
+    setIsSidebarOpen,
+    sidebarOrganisedBy,
+    setSitebarOrganizedBy,
+  } = useSidebarContext();
 
   const toggleRTL = () => {
     if (document && document.documentElement) {
@@ -99,6 +104,34 @@ function Header({ colorScheme, onChangeColorScheme }: Props) {
               icon="workflow-status-in-progress"
               onClick={() => onChangeColorScheme()}
             />
+          </Tooltip>
+          <Tooltip
+            inline
+            text={`Sidebar: ${
+              sidebarOrganisedBy === 'categorized'
+                ? 'Alphabetical'
+                : 'Categorize'
+            }`}
+          >
+            <Box display="flex" alignItems="center">
+              <IconButton
+                size="md"
+                accessibilityLabel="Toggle side bar categorization"
+                iconColor="white"
+                icon={
+                  sidebarOrganisedBy === 'categorized'
+                    ? 'arrow-circle-down'
+                    : 'folder'
+                }
+                onClick={() =>
+                  setSitebarOrganizedBy(
+                    sidebarOrganisedBy === 'categorized'
+                      ? 'alphabetical'
+                      : 'categorized'
+                  )
+                }
+              />
+            </Box>
           </Tooltip>
           <Tooltip
             inline

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -1,19 +1,15 @@
 // @flow strict
-import React, { useState } from 'react';
-import { Box, SelectList } from 'gestalt';
+import React from 'react';
+import { Box } from 'gestalt';
 import SidebarSection from './SidebarSection.js';
 import SidebarSectionLink from './SidebarSectionLink.js';
 import sidebarIndex from './sidebarIndex.js';
 import { useSidebarContext } from './sidebarContext.js';
 
-const componentSections = sidebarIndex.filter(
-  indexItm => indexItm.sectionName !== 'Getting Started'
-);
-
 function getAlphabetizedComponents() {
   return Array.from(
     new Set(
-      componentSections
+      sidebarIndex
         .map(section => section.pages)
         .flat()
         .sort()
@@ -21,41 +17,13 @@ function getAlphabetizedComponents() {
   );
 }
 
-function gettingStartedSection() {
-  const gettingStarted = sidebarIndex.find(
-    itm => itm.sectionName === 'Getting Started'
-  );
-
-  return (
-    <SidebarSection section={gettingStarted} key={gettingStarted.sectionName} />
-  );
-}
-
 export default function Navigation() {
-  const { isSidebarOpen } = useSidebarContext();
-  const [organizedBy, setOrganizedBy] = useState('categorized');
+  const { sidebarOrganisedBy, isSidebarOpen } = useSidebarContext();
 
   const navList = (
     <>
-      {gettingStartedSection()}
-
-      <Box marginTop={4}>
-        <SelectList
-          id="organizedBy"
-          name="organizedBy"
-          onChange={({ value }) => setOrganizedBy(value)}
-          options={[
-            { label: 'Alpabetical', value: 'alphabetical' },
-            { label: 'Categorized', value: 'categorized' },
-          ]}
-          placeholder="Select component organization"
-          label="Component organization"
-          value={organizedBy}
-        />
-      </Box>
-
-      {organizedBy === 'categorized' ? (
-        componentSections.map(section => (
+      {sidebarOrganisedBy === 'categorized' ? (
+        sidebarIndex.map(section => (
           <SidebarSection section={section} key={section.sectionName} />
         ))
       ) : (

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -1,27 +1,95 @@
 // @flow strict
-import React from 'react';
-import { Box } from 'gestalt';
+import React, { useState } from 'react';
+import { Box, SelectList } from 'gestalt';
 import SidebarSection from './SidebarSection.js';
+import SidebarSectionLink from './SidebarSectionLink.js';
 import sidebarIndex from './sidebarIndex.js';
 import { useSidebarContext } from './sidebarContext.js';
 
+const componentSections = sidebarIndex.filter(
+  indexItm => indexItm.sectionPathname !== 'getting-started'
+);
+
+function getAlphabetizedComponents() {
+  return Array.from(
+    new Set(
+      componentSections
+        .map(section => section.pages)
+        .flat()
+        .sort()
+    )
+  ).map(page => {
+    const { sectionPathname } = sidebarIndex.find(sbi =>
+      sbi.pages.includes(page)
+    );
+    return { name: page, sectionPathname };
+  });
+}
+
+function gettingStartedSection() {
+  const gettingStarted = sidebarIndex.find(
+    itm => itm.sectionPathname === 'getting-started'
+  );
+
+  return (
+    <SidebarSection
+      section={gettingStarted}
+      key={gettingStarted.sectionPathname}
+    />
+  );
+}
+
 export default function Navigation() {
   const { isSidebarOpen } = useSidebarContext();
+  const [organizedBy, setOrganizedBy] = useState('categorized');
+
+  const navList = (
+    <>
+      {gettingStartedSection()}
+
+      <Box marginTop={4}>
+        <SelectList
+          id="organizedBy"
+          name="organizedBy"
+          onChange={({ value }) => setOrganizedBy(value)}
+          options={[
+            { label: 'Alpabetical', value: 'alphabetical' },
+            { label: 'Categorized', value: 'categorized' },
+          ]}
+          placeholder="Select component organization"
+          label="Component organization"
+          value={organizedBy}
+        />
+      </Box>
+
+      {organizedBy === 'categorized' ? (
+        componentSections.map(section => (
+          <SidebarSection section={section} key={section.sectionPathname} />
+        ))
+      ) : (
+        <Box marginTop={4}>
+          {getAlphabetizedComponents().map((component, i) => (
+            <SidebarSectionLink
+              key={i}
+              componentName={component.name}
+              sectionPathname={component.sectionPathname}
+            />
+          ))}
+        </Box>
+      )}
+    </>
+  );
 
   return (
     <>
       {isSidebarOpen && (
         <Box display="block" mdDisplay="none" padding={4}>
-          {sidebarIndex.map(section => (
-            <SidebarSection section={section} key={section.sectionName} />
-          ))}
+          {navList}
         </Box>
       )}
 
       <Box display="none" mdDisplay="block" padding={4}>
-        {sidebarIndex.map(section => (
-          <SidebarSection section={section} key={section.sectionName} />
-        ))}
+        {navList}
       </Box>
     </>
   );

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -7,7 +7,7 @@ import sidebarIndex from './sidebarIndex.js';
 import { useSidebarContext } from './sidebarContext.js';
 
 const componentSections = sidebarIndex.filter(
-  indexItm => indexItm.sectionPathname !== 'getting-started'
+  indexItm => indexItm.sectionName !== 'Getting Started'
 );
 
 function getAlphabetizedComponents() {
@@ -18,24 +18,16 @@ function getAlphabetizedComponents() {
         .flat()
         .sort()
     )
-  ).map(page => {
-    const { sectionPathname } = sidebarIndex.find(sbi =>
-      sbi.pages.includes(page)
-    );
-    return { name: page, sectionPathname };
-  });
+  );
 }
 
 function gettingStartedSection() {
   const gettingStarted = sidebarIndex.find(
-    itm => itm.sectionPathname === 'getting-started'
+    itm => itm.sectionName === 'Getting Started'
   );
 
   return (
-    <SidebarSection
-      section={gettingStarted}
-      key={gettingStarted.sectionPathname}
-    />
+    <SidebarSection section={gettingStarted} key={gettingStarted.sectionName} />
   );
 }
 
@@ -64,16 +56,12 @@ export default function Navigation() {
 
       {organizedBy === 'categorized' ? (
         componentSections.map(section => (
-          <SidebarSection section={section} key={section.sectionPathname} />
+          <SidebarSection section={section} key={section.sectionName} />
         ))
       ) : (
         <Box marginTop={4}>
-          {getAlphabetizedComponents().map((component, i) => (
-            <SidebarSectionLink
-              key={i}
-              componentName={component.name}
-              sectionPathname={component.sectionPathname}
-            />
+          {getAlphabetizedComponents().map((componentName, i) => (
+            <SidebarSectionLink key={i} componentName={componentName} />
           ))}
         </Box>
       )}

--- a/docs/src/components/SidebarSection.js
+++ b/docs/src/components/SidebarSection.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Box, Row, Text } from 'gestalt';
 import { type sidebarIndexType } from './sidebarIndex.js';
-import NavLink from './NavLink.js';
+import SidebarSectionLink from './SidebarSectionLink.js';
 
 export default function SidebarSection({ section }: sidebarIndexType) {
   return (
@@ -12,14 +12,9 @@ export default function SidebarSection({ section }: sidebarIndexType) {
           <Text size="sm">{section.sectionName}</Text>
         </Row>
       </Box>
-      {section.pages.map((component, i) => (
-        <Box key={i}>
-          <NavLink to={`/${component}`}>
-            <Box padding={2} role="listitem">
-              {component}
-            </Box>
-          </NavLink>
-        </Box>
+
+      {section.pages.map((componentName, i) => (
+        <SidebarSectionLink key={i} componentName={componentName} />
       ))}
     </>
   );

--- a/docs/src/components/SidebarSectionLink.js
+++ b/docs/src/components/SidebarSectionLink.js
@@ -1,0 +1,20 @@
+// @flow strict
+import React from 'react';
+import { Box } from 'gestalt';
+import NavLink from './NavLink.js';
+
+type Props = {|
+  componentName: string,
+|};
+
+export default function SideBarSectionLink({ componentName }: Props) {
+  return (
+    <Box>
+      <NavLink to={`/${componentName}`}>
+        <Box padding={2} role="listitem">
+          {componentName}
+        </Box>
+      </NavLink>
+    </Box>
+  );
+}


### PR DESCRIPTION
Based on #1128 from @mminute with the following changes:

* Move toggle to the header (where have have all the other toggles)
* Save sort preference in `localStorage` (so it stays consistent between refreshes)
* Don't exclude `Getting Started` (more scalable but does mean we don't only sort components / hooks)

## Test Plan

Test on netlify:
* Toggle the sort preference in the header
* Refresh the site + see that sort preference stays the same
