### PR TITLE
SegmentedControl: make use of useFocusVisible

### DIFF
--- a/packages/gestalt/src/SegmentedControl.css
+++ b/packages/gestalt/src/SegmentedControl.css
@@ -9,7 +9,6 @@
 }
 
 .item {
-  composes: accessibilityOutline from "./Focus.css";
   composes: flexGrow from "./Layout.css";
   composes: m0 from "./Whitespace.css";
   composes: noBorder from "./Borders.css";

--- a/packages/gestalt/src/__snapshots__/SegmentedControl.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SegmentedControl.test.js.snap
@@ -7,7 +7,7 @@ exports[`SegmentedControl renders 1`] = `
 >
   <button
     aria-selected={true}
-    className="item itemIsSelected"
+    className="item hideOutline itemIsSelected accessibilityOutline"
     onClick={[Function]}
     role="tab"
     style={
@@ -25,7 +25,7 @@ exports[`SegmentedControl renders 1`] = `
   </button>
   <button
     aria-selected={false}
-    className="item itemIsNotSelected"
+    className="item hideOutline itemIsNotSelected accessibilityOutline"
     onClick={[Function]}
     role="tab"
     style={
@@ -43,7 +43,7 @@ exports[`SegmentedControl renders 1`] = `
   </button>
   <button
     aria-selected={false}
-    className="item itemIsNotSelected"
+    className="item hideOutline itemIsNotSelected accessibilityOutline"
     onClick={[Function]}
     role="tab"
     style={
@@ -61,7 +61,7 @@ exports[`SegmentedControl renders 1`] = `
   </button>
   <button
     aria-selected={false}
-    className="item itemIsNotSelected"
+    className="item hideOutline itemIsNotSelected accessibilityOutline"
     onClick={[Function]}
     role="tab"
     style={
@@ -87,7 +87,7 @@ exports[`SegmentedControl with responsive widths renders 1`] = `
 >
   <button
     aria-selected={true}
-    className="item itemIsSelected"
+    className="item hideOutline itemIsSelected accessibilityOutline"
     onClick={[Function]}
     role="tab"
     style={
@@ -105,7 +105,7 @@ exports[`SegmentedControl with responsive widths renders 1`] = `
   </button>
   <button
     aria-selected={false}
-    className="item itemIsNotSelected"
+    className="item hideOutline itemIsNotSelected accessibilityOutline"
     onClick={[Function]}
     role="tab"
     style={


### PR DESCRIPTION
Make use of `useFocusVisible` in SegmentedControl

## Before
![segmented-control-before](https://user-images.githubusercontent.com/127199/90910832-d9f72200-e38c-11ea-855e-069fcf2d69b9.gif)

## After
![segmented-control-after](https://user-images.githubusercontent.com/127199/90910841-dbc0e580-e38c-11ea-8542-631679855fb4.gif)

## Test Plan

### Mouse interaction: no outline
1. Go to https://deploy-preview-1157--gestalt.netlify.app/SegmentedControl
2. Click on each SegmentedControl item
3. No outline is visible

### Keyboard interaction: outline shows
1. Go to https://deploy-preview-1157--gestalt.netlify.app/SegmentedControl
2. Tab through each SegmentedControl item
3. Outline is visible