### PR TITLE
Image: convert to function component

### DIFF
--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -1,15 +1,16 @@
 // @flow strict
-import React, { PureComponent, type Node } from 'react';
+import React, { type Node, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import styles from './Image.css';
+import usePrevious from './usePrevious.js';
 
 const shouldScaleImage = fit => fit === 'cover' || fit === 'contain';
 
 type Props = {|
   alt: string,
   children?: Node,
-  color: string,
+  color?: string,
   fit?: 'contain' | 'cover' | 'none',
   importance?: 'high' | 'low' | 'auto',
   loading?: 'eager' | 'lazy' | 'auto',
@@ -22,126 +23,107 @@ type Props = {|
   srcSet?: string,
 |};
 
-export default class Image extends PureComponent<Props> {
-  static propTypes = {
-    alt: PropTypes.string.isRequired,
-    children: PropTypes.node,
-    color: PropTypes.string,
-    fit: PropTypes.oneOf(['contain', 'cover', 'none']),
-    importance: PropTypes.oneOf(['high', 'low', 'auto']),
-    loading: PropTypes.oneOf(['eager', 'lazy', 'auto']),
-    naturalHeight: PropTypes.number.isRequired,
-    naturalWidth: PropTypes.number.isRequired,
-    onError: PropTypes.func,
-    onLoad: PropTypes.func,
-    sizes: PropTypes.string,
-    src: PropTypes.string.isRequired,
-    srcSet: PropTypes.string,
-  };
-
-  static defaultProps: {|
-    color: string,
-    fit?: 'contain' | 'cover' | 'none',
-    importance?: 'high' | 'low' | 'auto',
-    loading?: 'eager' | 'lazy' | 'auto',
-  |} = {
-    color: 'transparent',
-    fit: 'none',
-    importance: 'auto',
-    loading: 'auto',
-  };
-
-  componentDidMount() {
-    if (shouldScaleImage(this.props.fit)) {
-      this.loadImage();
+export default function Image({
+  alt,
+  children,
+  color = 'transparent',
+  fit = 'none',
+  importance = 'auto',
+  loading = 'auto',
+  naturalHeight,
+  naturalWidth,
+  onError,
+  onLoad,
+  sizes,
+  src,
+  srcSet,
+}: Props): Node {
+  const handleLoad: () => void = useCallback(() => {
+    if (onLoad) {
+      onLoad();
     }
-  }
+  }, [onLoad]);
 
-  componentDidUpdate(prevProps: Props) {
-    const { fit, src } = this.props;
-    if (shouldScaleImage(fit) && prevProps.src !== src) {
-      this.loadImage();
+  const handleError: () => void = useCallback(() => {
+    if (onError) {
+      onError();
     }
-  }
+  }, [onError]);
 
-  handleLoad: () => void = () => {
-    if (this.props.onLoad) {
-      this.props.onLoad();
-    }
-  };
-
-  handleError: () => void = () => {
-    if (this.props.onError) {
-      this.props.onError();
-    }
-  };
-
-  loadImage() {
+  const loadImage = useCallback(() => {
     if (typeof window !== 'undefined') {
       const image = new window.Image();
-      image.onload = this.handleLoad;
-      image.onerror = this.handleError;
-      image.src = this.props.src;
+      image.onload = handleLoad;
+      image.onerror = handleError;
+      image.src = src;
     }
-  }
+  }, [handleError, handleLoad, src]);
 
-  render(): Node {
-    const {
-      alt,
-      color,
-      children,
-      fit,
-      importance,
-      loading,
-      naturalHeight,
-      naturalWidth,
-      sizes,
-      src,
-      srcSet,
-    } = this.props;
+  const previousSrc = usePrevious(src);
 
-    const isScaledImage = shouldScaleImage(fit);
-    const childContent = children ? (
-      <Box position="absolute" top left bottom right overflow="hidden">
-        {children}
-      </Box>
-    ) : null;
+  useEffect(() => {
+    if (shouldScaleImage(fit) && previousSrc !== src) {
+      loadImage();
+    }
+  }, [fit, src, previousSrc, loadImage]);
 
-    return isScaledImage ? (
-      <div
-        aria-label={alt}
-        className={fit === 'contain' || fit === 'cover' ? styles[fit] : null}
-        style={{
+  const isScaledImage = shouldScaleImage(fit);
+  const childContent = children ? (
+    <Box position="absolute" top left bottom right overflow="hidden">
+      {children}
+    </Box>
+  ) : null;
+
+  return isScaledImage ? (
+    <div
+      aria-label={alt}
+      className={fit === 'contain' || fit === 'cover' ? styles[fit] : null}
+      style={{
+        backgroundColor: color,
+        backgroundImage: `url('${src}')`,
+      }}
+      role="img"
+    >
+      {childContent}
+    </div>
+  ) : (
+    <Box
+      position="relative"
+      dangerouslySetInlineStyle={{
+        __style: {
           backgroundColor: color,
-          backgroundImage: `url('${src}')`,
-        }}
-        role="img"
-      >
-        {childContent}
-      </div>
-    ) : (
-      <Box
-        position="relative"
-        dangerouslySetInlineStyle={{
-          __style: {
-            backgroundColor: color,
-            paddingBottom: `${(naturalHeight / naturalWidth) * 100}%`,
-          },
-        }}
-      >
-        <img
-          alt={alt}
-          className={styles.img}
-          importance={importance}
-          loading={loading}
-          onError={this.handleError}
-          onLoad={this.handleLoad}
-          sizes={sizes}
-          src={src}
-          srcSet={srcSet}
-        />
-        {childContent}
-      </Box>
-    );
-  }
+          paddingBottom: `${(naturalHeight / naturalWidth) * 100}%`,
+        },
+      }}
+    >
+      <img
+        alt={alt}
+        className={styles.img}
+        importance={importance}
+        loading={loading}
+        onError={handleError}
+        onLoad={handleLoad}
+        sizes={sizes}
+        src={src}
+        srcSet={srcSet}
+      />
+      {childContent}
+    </Box>
+  );
 }
+
+Image.propTypes = {
+  alt: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  color: PropTypes.string,
+  fit: PropTypes.oneOf(['contain', 'cover', 'none']),
+  importance: PropTypes.oneOf(['high', 'low', 'auto']),
+  loading: PropTypes.oneOf(['eager', 'lazy', 'auto']),
+  naturalHeight: PropTypes.number.isRequired,
+  naturalWidth: PropTypes.number.isRequired,
+  onError: PropTypes.func,
+  onLoad: PropTypes.func,
+  sizes: PropTypes.string,
+  src: PropTypes.string.isRequired,
+  srcSet: PropTypes.string,
+};

--- a/packages/gestalt/src/usePrevious.js
+++ b/packages/gestalt/src/usePrevious.js
@@ -1,0 +1,14 @@
+// @flow strict
+import { useEffect, useRef } from 'react';
+
+export default function usePrevious(
+  value: string | number
+): void | string | number {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}


### PR DESCRIPTION
Convert `Image` to a function component. Main reason is to get rid of the duplicated flow types in `defaultProps`. This recently caused an issue with `SelectList` in #1151 

## Test Plan

Image renders correctly