### PR TITLE
Docs: update margin/padding for markdown elements

### DIFF
--- a/docs/src/components/Markdown.css
+++ b/docs/src/components/Markdown.css
@@ -1,20 +1,15 @@
-.Markdown p, pre, li {
-  margin-left: 30px;
-}
-
-.Markdown p, pre {
-  margin-bottom: 20px;
-  margin-top: 20px;
-}
-
-html[dir="rtl"] .Markdown p, pre, li {
-  margin-right: 30px;
-}
-
 .Markdown pre {
   background-color: rgb(236, 236, 236);
   overflow: auto;
   padding: 5px;
+}
+
+.Markdown ul + pre {
+  margin-left: 40px;
+}
+
+html[dir="rtl"] .Markdown ul + pre {
+  margin-right: 40px;
 }
 
 .Markdown li {


### PR DESCRIPTION
After #1145 the docs for each component look off (indented description):

![image](https://user-images.githubusercontent.com/127199/91059199-4321a400-e5de-11ea-90a2-d70156bfe9bd.png)

/cc @AlbertCarreras 

## Test Plan

### After
![image](https://user-images.githubusercontent.com/127199/91059310-68161700-e5de-11ea-85c7-b620b51beaa3.png)