### PR TITLE
Docs: separate sidebar scrolling

### DIFF
--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -44,8 +44,16 @@ export default function Navigation() {
         </Box>
       )}
 
-      <Box display="none" mdDisplay="block" padding={4}>
-        {navList}
+      <Box display="none" mdDisplay="block">
+        <Box
+          padding={4}
+          position="fixed"
+          overflow="auto"
+          maxHeight="calc(100% - 60px)"
+          minWidth={240}
+        >
+          {navList}
+        </Box>
       </Box>
     </>
   );


### PR DESCRIPTION
Add scrolling to the sidebar, separate from the main content. Allows you to navigate between pages without losing the navigation context. 

### Before 
![gestalt-docs-before-jump](https://user-images.githubusercontent.com/127199/91106870-ae906380-e628-11ea-8416-c172f5c88d4c.gif)

### After

![gestalt-docs-after-no-jump](https://user-images.githubusercontent.com/127199/91106877-b6e89e80-e628-11ea-9b1b-fbdf1df40061.gif)
