### PR TITLE
SelectList: convert to function component

### DIFF
--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { Component, type Node } from 'react';
+import React, { useState, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -36,147 +36,128 @@ type Props = {|
   value?: ?string,
 |};
 
-type State = {|
-  focused: boolean,
-|};
+export default function SelectList({
+  disabled = false,
+  errorMessage,
+  helperText,
+  id,
+  label,
+  name,
+  onChange,
+  options = [],
+  placeholder,
+  size = 'md',
+  value,
+}: Props): Node {
+  const [focused, setFocused] = useState(false);
 
-export default class SelectList extends Component<Props, State> {
-  select: ?HTMLSelectElement;
-
-  static propTypes = {
-    disabled: PropTypes.bool,
-    errorMessage: PropTypes.string,
-    helperText: PropTypes.string,
-    id: PropTypes.string.isRequired,
-    label: PropTypes.string,
-    name: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
-    options: PropTypes.arrayOf(
-      PropTypes.exact({
-        label: PropTypes.string.isRequired,
-        value: PropTypes.string.isRequired,
-        disabled: PropTypes.bool,
-      })
-    ),
-    placeholder: PropTypes.string,
-    size: PropTypes.oneOf(['md', 'lg']),
-    value: PropTypes.string,
-  };
-
-  static defaultProps: {|
-    disabled: boolean,
-    options: Options,
-    size?: 'md' | 'lg',
-  |} = {
-    disabled: false,
-    size: 'md',
-    options: [],
-  };
-
-  state: State = {
-    focused: false,
-  };
-
-  setSelectListRef: (ref: ?HTMLSelectElement) => void = ref => {
-    this.select = ref;
-  };
-
-  handleOnChange: (
+  const handleOnChange: (
     event: SyntheticInputEvent<HTMLSelectElement>
   ) => void = event => {
-    const { onChange, value } = this.props;
     if (value !== event.target.value) {
       onChange({ event, value: event.target.value });
     }
   };
 
-  render(): Node {
-    const {
-      disabled,
-      errorMessage,
-      helperText,
-      id,
-      label,
-      name,
-      options,
-      placeholder,
-      size,
-      value,
-    } = this.props;
+  const handleBlur = (event: SyntheticInputEvent<HTMLSelectElement>) => {
+    setFocused(false);
+    handleOnChange(event);
+  };
 
-    const { focused } = this.state;
+  const handleFocus = () => {
+    setFocused(true);
+  };
 
-    const classes = classnames(
-      styles.select,
-      formElement.base,
-      disabled ? formElement.disabled : formElement.enabled,
-      errorMessage ? formElement.errored : formElement.normal,
-      size === 'md' ? layout.medium : layout.large
-    );
+  const classes = classnames(
+    styles.select,
+    formElement.base,
+    disabled ? formElement.disabled : formElement.enabled,
+    errorMessage ? formElement.errored : formElement.normal,
+    size === 'md' ? layout.medium : layout.large
+  );
 
-    const showPlaceholder = placeholder && !value;
+  const showPlaceholder = placeholder && !value;
 
-    return (
-      <Box>
-        {label && <FormLabel id={id} label={label} />}
+  return (
+    <Box>
+      {label && <FormLabel id={id} label={label} />}
+      <Box
+        color={disabled ? 'lightGray' : 'white'}
+        display="flex"
+        position="relative"
+        rounding={4}
+        width="100%"
+      >
         <Box
-          color={disabled ? 'lightGray' : 'white'}
+          alignItems="center"
+          bottom
+          dangerouslySetInlineStyle={{
+            __style: { paddingRight: 14, paddingTop: 2 },
+          }}
           display="flex"
-          position="relative"
-          rounding={4}
-          width="100%"
+          position="absolute"
+          right
+          top
         >
-          <Box
-            alignItems="center"
-            bottom
-            dangerouslySetInlineStyle={{
-              __style: { paddingRight: 14, paddingTop: 2 },
-            }}
-            display="flex"
-            position="absolute"
-            right
-            top
-          >
-            <Icon
-              icon="arrow-down"
-              size={12}
-              color={disabled ? 'gray' : 'darkGray'}
-              accessibilityLabel=""
-            />
-          </Box>
-          <select
-            aria-describedby={errorMessage && focused ? `${id}-error` : null}
-            aria-invalid={errorMessage ? 'true' : 'false'}
-            className={classes}
-            disabled={disabled}
-            id={id}
-            name={name}
-            onBlur={this.handleOnChange}
-            onChange={this.handleOnChange}
-            ref={this.setSelectListRef}
-            value={showPlaceholder ? placeholder : value}
-          >
-            {showPlaceholder && (
-              <option disabled value={placeholder} hidden>
-                {placeholder}
-              </option>
-            )}
-            {options.map(option => (
-              <option
-                key={option.value}
-                value={option.value}
-                disabled={option.disabled}
-              >
-                {option.label}
-              </option>
-            ))}
-          </select>
+          <Icon
+            icon="arrow-down"
+            size={12}
+            color={disabled ? 'gray' : 'darkGray'}
+            accessibilityLabel=""
+          />
         </Box>
-        {helperText && !errorMessage ? (
-          <FormHelperText text={helperText} />
-        ) : null}
-        {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
+        <select
+          aria-describedby={errorMessage && focused ? `${id}-error` : null}
+          aria-invalid={errorMessage ? 'true' : 'false'}
+          className={classes}
+          disabled={disabled}
+          id={id}
+          name={name}
+          onBlur={handleBlur}
+          onChange={handleOnChange}
+          onFocus={handleFocus}
+          value={showPlaceholder ? placeholder : value}
+        >
+          {showPlaceholder && (
+            <option disabled value={placeholder} hidden>
+              {placeholder}
+            </option>
+          )}
+          {options.map(option => (
+            <option
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+            >
+              {option.label}
+            </option>
+          ))}
+        </select>
       </Box>
-    );
-  }
+      {helperText && !errorMessage ? (
+        <FormHelperText text={helperText} />
+      ) : null}
+      {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
+    </Box>
+  );
 }
+
+SelectList.propTypes = {
+  disabled: PropTypes.bool,
+  errorMessage: PropTypes.string,
+  helperText: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  name: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.exact({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+      disabled: PropTypes.bool,
+    })
+  ),
+  placeholder: PropTypes.string,
+  size: PropTypes.oneOf(['md', 'lg']),
+  value: PropTypes.string,
+};

--- a/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
@@ -43,6 +43,7 @@ exports[`SelectList SelectList normal 1`] = `
       id="test"
       onBlur={[Function]}
       onChange={[Function]}
+      onFocus={[Function]}
     >
       <option
         value="value1"


### PR DESCRIPTION
Convert `SelectList` to a function component. Main reason is to get rid of the duplicated flow types in `defaultProps`. This recently caused an issue with `SelectList` in #1151 

## Test Plan
* SelectList tests pass
* SelectList works as expected in the docs
