### PR TITLE
Docs: Add 'edit this page' link to every doc page

### DIFF
--- a/docs/src/components/CardPage.js
+++ b/docs/src/components/CardPage.js
@@ -1,48 +1,61 @@
 // @flow strict
 import React from 'react';
-import { Box, FixedZIndex, Sticky } from 'gestalt';
+import { Box, FixedZIndex, Link, Sticky, Row, Text } from 'gestalt';
 import SearchContent from './SearchContent.js';
 import Toc from './Toc.js';
 
 type Props = {|
   cards: Array<React.Node>,
+  page: string,
 |};
 
-const CardPage = ({ cards }: Props) => (
-  <Box display="flex">
-    <Box flex="grow" maxWidth={1200}>
-      <SearchContent>
-        {cards.map((card, i) => (
-          <Box
-            marginBottom={4}
-            id={`card-${i}`}
-            key={i}
-            dangerouslySetInlineStyle={{
-              __style: {
-                scrollMarginTop: 60,
-              },
-            }}
-          >
-            {card}
-          </Box>
-        ))}
-      </SearchContent>
+const CardPage = ({ cards, page }: Props) => {
+  const editPageUrl = `https://github.com/pinterest/gestalt/tree/master/docs/src/${page}.doc.js`;
+
+  return (
+    <Box display="flex">
+      <Box flex="grow" maxWidth={1200}>
+        <SearchContent>
+          {cards.map((card, i) => (
+            <Box
+              marginBottom={4}
+              id={`card-${i}`}
+              key={i}
+              dangerouslySetInlineStyle={{
+                __style: {
+                  scrollMarginTop: 60,
+                },
+              }}
+            >
+              {card}
+            </Box>
+          ))}
+        </SearchContent>
+
+        <Box marginTop={12} display="flex">
+          <Link href={editPageUrl} target="blank" inline>
+            <Row gap={1}>
+              <Text weight="bold">Edit page on GitHub</Text>
+            </Row>
+          </Link>
+        </Box>
+      </Box>
+      <Box
+        minWidth={200}
+        maxWidth={240}
+        marginStart={4}
+        mdMarginStart={6}
+        lgMarginStart={8}
+        display="none"
+        lgDisplay="block"
+        flex="none"
+      >
+        <Sticky top={90} zIndex={new FixedZIndex(0)}>
+          <Toc cards={cards} />
+        </Sticky>
+      </Box>
     </Box>
-    <Box
-      minWidth={200}
-      maxWidth={240}
-      marginStart={4}
-      mdMarginStart={6}
-      lgMarginStart={8}
-      display="none"
-      lgDisplay="block"
-      flex="none"
-    >
-      <Sticky top={90} zIndex={new FixedZIndex(0)}>
-        <Toc cards={cards} />
-      </Sticky>
-    </Box>
-  </Box>
-);
+  );
+};
 
 export default CardPage;

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -16,7 +16,7 @@ const mapRoutes = pages =>
     <Route
       path={`/${page}`}
       key={i}
-      render={() => <CardPage cards={routes[page]} />}
+      render={() => <CardPage cards={routes[page]} page={page} />}
     />
   ));
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/127199/91502771-c3196980-e87d-11ea-97f0-eed2c2419c3b.png)


Makes it easier for people to make updates to a specific page. They only have to click the link on that page + make the updates on GitHub.

## Test Plan

1. Go to `/Box` in the Gestalt Docs: https://deploy-preview-1170--gestalt.netlify.app/Box
2. Scroll down to the bottom of the page
3. Click on `Edit this page`
4. It opens https://github.com/pinterest/gestalt/blob/master/docs/src/Box.doc.js