### PR TITLE
Docs: remove heading for multiple Combination sections on Box

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -524,7 +524,7 @@ card(
     id="border"
     name="Borders"
   >
-    <Combination borderSize={['sm', 'lg']}>
+    <Combination borderSize={['sm', 'lg']} showHeading={false}>
       {props => (
         <Box
           width={60}
@@ -578,7 +578,10 @@ card(
     id="rounding"
     name="Rounding"
   >
-    <Combination rounding={['pill', 'circle', 0, 1, 2, 3, 4, 5, 6, 7, 8]}>
+    <Combination
+      rounding={['pill', 'circle', 0, 1, 2, 3, 4, 5, 6, 7, 8]}
+      showHeading={false}
+    >
       {props => (
         <Box
           color="gray"
@@ -599,7 +602,10 @@ card(
     id="opacity"
     name="Opacity"
   >
-    <Combination opacity={[0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]}>
+    <Combination
+      opacity={[0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]}
+      showHeading={false}
+    >
       {props => <Box color="darkGray" width={60} height={60} {...props} />}
     </Combination>
   </Card>

--- a/docs/src/components/Combination.js
+++ b/docs/src/components/Combination.js
@@ -11,6 +11,7 @@ type Props = {|
   id?: string,
   layout?: '2column' | '4column' | '12column',
   name?: string,
+  showHeading?: boolean,
   showValues?: boolean,
   stacked?: boolean,
 |};
@@ -85,6 +86,7 @@ export default function Combination({
   description = '',
   layout = '2column',
   id,
+  showHeading,
   showValues = true,
   stacked = false,
   children,
@@ -92,7 +94,13 @@ export default function Combination({
 }: Props) {
   const { column, mdColumn, lgColumn } = layoutReducer(layout);
   return (
-    <Card name={name} description={description} id={id} stacked={stacked}>
+    <Card
+      name={name}
+      description={description}
+      id={id}
+      stacked={stacked}
+      showHeading={showHeading}
+    >
       <Box display="flex" wrap>
         {combinations(props).map((combination, i) => (
           <Box


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/127199/91503286-edb7f200-e87e-11ea-837b-74b343262a53.png)

After
![image](https://user-images.githubusercontent.com/127199/91503299-f6a8c380-e87e-11ea-8e55-e7f2baf59e3d.png)

