### PR TITLE
Docs: enable flow types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,8 +2,6 @@
 0.127.0
 
 [ignore]
-# Tracking https://github.com/facebook/flow/issues/4015
-<PROJECT_ROOT>/docs
 <PROJECT_ROOT>/packages/gestalt-codemods/.*/__testfixtures__
 
 [options]

--- a/docs/src/Avatar.doc.js
+++ b/docs/src/Avatar.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/AvatarPair.doc.js
+++ b/docs/src/AvatarPair.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(<PageHeader name="AvatarPair" description="Show avatars in pairs" />);

--- a/docs/src/Badge.doc.js
+++ b/docs/src/Badge.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Button } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
@@ -7,7 +7,7 @@ import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 const marginProps = [

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Button } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Card.doc.js
+++ b/docs/src/Card.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Checkbox } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Collage.doc.js
+++ b/docs/src/Collage.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Column.doc.js
+++ b/docs/src/Column.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Card from './components/Card.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Container.doc.js
+++ b/docs/src/Container.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/DatePicker.doc.js
+++ b/docs/src/DatePicker.doc.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import React from 'react';
+import React, { type Node } from 'react';
 import DatePicker from 'gestalt-datepicker';
 import {
   arSA,
@@ -40,7 +40,7 @@ import PageHeader from './components/PageHeader.js';
 import PropTable from './components/PropTable.js';
 import Combination from './components/Combination.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 const localeMap = {

--- a/docs/src/Development.doc.js
+++ b/docs/src/Development.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Heading, Link, Stack, Text } from 'gestalt';
 import Card from './components/Card.js';
 import Markdown from './components/Markdown.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(<Heading>Development</Heading>);

--- a/docs/src/Divider.doc.js
+++ b/docs/src/Divider.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Faq.doc.js
+++ b/docs/src/Faq.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Heading, Link, Stack, Text } from 'gestalt';
 import Markdown from './components/Markdown.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(<Heading>Frequently Asked Questions</Heading>);

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { GroupAvatar } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Icon } from 'gestalt';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(
@@ -37,6 +37,7 @@ card(
       },
       {
         name: 'icon',
+        // $FlowIssue[prop-missing]
         type: Icon.icons.map(name => `'${name}'`).join(' | '),
         description: `This allows us to type check for a valid icon name based on the keys from the list of icons shown below.`,
         href: 'iconCombinations',
@@ -81,6 +82,7 @@ card(
 );
 
 card(
+  // $FlowIssue[prop-missing]
   <Combination id="iconCombinations" name="Icon Combinations" icon={Icon.icons}>
     {props => (
       <Icon color="darkGray" accessibilityLabel="" size={32} {...props} />

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { IconButton } from 'gestalt';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Installation.doc.js
+++ b/docs/src/Installation.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Heading, Link, Row, Stack, Text } from 'gestalt';
 import Markdown from './components/Markdown.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(<Heading>Installation</Heading>);
@@ -87,7 +87,6 @@ card(
       <Text>
         Gestalt is a{' '}
         <Link
-          tapStyl="compress"
           inline
           href="https://yarnpkg.com/lang/en/docs/workspaces/"
           target="blank"
@@ -117,12 +116,7 @@ yarn start
       />
       <Text>
         Visit{' '}
-        <Link
-          tapStyl="compress"
-          inline
-          href="http://localhost:8888/"
-          target="blank"
-        >
+        <Link inline href="http://localhost:8888/" target="blank">
           <Text weight="bold">http://localhost:8888</Text>
         </Link>{' '}
         and click on a component to view the docs.
@@ -178,12 +172,7 @@ card(
       <Text>
         Every commit to master performs a release. As a reviewer, ensure the
         correct label is attached to every PR. Please follow{' '}
-        <Link
-          tapStyl="compress"
-          inline
-          href="https://semver.org/"
-          target="blank"
-        >
+        <Link inline href="https://semver.org/" target="blank">
           <Text weight="bold">semantic versioning</Text>
         </Link>
         .
@@ -226,7 +215,6 @@ card(
       <Text>
         Install the{' '}
         <Link
-          tapStyl="compress"
           inline
           href="https://www.npmjs.com/package/@types/gestalt"
           target="blank"

--- a/docs/src/Label.doc.js
+++ b/docs/src/Label.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Card from './components/Card.js';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Letterbox.doc.js
+++ b/docs/src/Letterbox.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Mask } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Masonry, Image, Text, MasonryUniformRowLayout } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(
@@ -112,7 +112,7 @@ card(
 
 type Props = {|
   flexible?: boolean,
-  layout?: Function,
+  layout?: () => {||},
 |};
 
 type State = {|
@@ -178,6 +178,7 @@ const getPins = () => {
 class ExampleMasonry extends React.Component<Props, State> {
   // ref on a component gets the mounted instance of the component
   // https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-class-component
+  // $FlowIssue[prop-missing]
   grid: ?Masonry<*>;
 
   scrollContainer: ?HTMLElement;
@@ -230,6 +231,7 @@ class ExampleMasonry extends React.Component<Props, State> {
           style={containerStyle}
         >
           {scrollContainer && (
+            // $FlowIssue[prop-missing]
             <Masonry
               columnWidth={170}
               comp={({ data }) => (
@@ -247,6 +249,7 @@ class ExampleMasonry extends React.Component<Props, State> {
               flexible={this.props.flexible}
               gutterWidth={5}
               items={this.state.pins}
+              // $FlowIssue[incompatible-type]
               layout={this.props.layout}
               minCols={1}
               ref={ref => {
@@ -321,6 +324,7 @@ card(
   `}
     name="Uniform row heights"
   >
+    {/* $FlowIssue[prop-missing] */}
     <ExampleMasonry layout={MasonryUniformRowLayout} />
   </Box>
 );

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Pog } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Provider.doc.js
+++ b/docs/src/Provider.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Pulsar.doc.js
+++ b/docs/src/Pulsar.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { RadioButton } from 'gestalt';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Row.doc.js
+++ b/docs/src/Row.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Row } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/SearchField.doc.js
+++ b/docs/src/SearchField.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
 
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(<PageHeader name="SearchField" />);
@@ -87,7 +87,6 @@ card(
     Be sure to internationalize your \`accessibilityLabel\`.
   `}
     name="Example: Accessibility"
-    useCheckerboard={false}
     defaultCode={`
   function SearchFieldExample() {
     const [value, setValue] = React.useState('');

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/SelectList.doc.js
+++ b/docs/src/SelectList.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Spinner.doc.js
+++ b/docs/src/Spinner.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(<PageHeader name="Spinner" />);

--- a/docs/src/Stack.doc.js
+++ b/docs/src/Stack.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Stack } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Sticky.doc.js
+++ b/docs/src/Sticky.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Switch } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Table } from 'gestalt';
 import Card from './components/Card.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 import PropTable from './components/PropTable.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(
@@ -92,6 +92,7 @@ card(<Card name="Table.Body" />);
 card(
   <PropTable
     showHeading={false}
+    // $FlowIssue[prop-missing]
     Component={Table.Body}
     props={[
       {
@@ -107,6 +108,7 @@ card(<Card name="Table.Cell" />);
 card(
   <PropTable
     showHeading={false}
+    // $FlowIssue[prop-missing]
     Component={Table.Cell}
     props={[
       {
@@ -132,6 +134,7 @@ card(<Card name="Table.Footer" />);
 card(
   <PropTable
     showHeading={false}
+    // $FlowIssue[prop-missing]
     Component={Table.Footer}
     props={[
       {
@@ -147,6 +150,7 @@ card(<Card name="Table.Header" />);
 card(
   <PropTable
     showHeading={false}
+    // $FlowIssue[prop-missing]
     Component={Table.Header}
     props={[
       {
@@ -205,6 +209,7 @@ card(<Card name="Table.HeaderCell" />);
 card(
   <PropTable
     showHeading={false}
+    // $FlowIssue[prop-missing]
     Component={Table.HeaderCell}
     props={[
       {
@@ -235,6 +240,7 @@ card(<Card name="Table.Row" />);
 card(
   <PropTable
     showHeading={false}
+    // $FlowIssue[prop-missing]
     Component={Table.Row}
     props={[
       {
@@ -255,6 +261,7 @@ card(
 card(
   <PropTable
     showHeading={false}
+    // $FlowIssue[prop-missing]
     Component={Table.SortableHeaderCell}
     props={[
       {

--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Tabs } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/TapArea.doc.js
+++ b/docs/src/TapArea.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Image, Mask, TapArea } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Combination from './components/Combination.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Button, Link, Image, Text, Toast } from 'gestalt';
 import Combination from './components/Combination.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 import PropTable from './components/PropTable.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -1,10 +1,10 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/ZIndexClasses.doc.js
+++ b/docs/src/ZIndexClasses.doc.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Icon, Row, Stack, Text } from 'gestalt';
 import Example from './components/Example.js';
 import Card from './components/Card.js';
 import PageHeader from './components/PageHeader.js';
 import Markdown from './components/Markdown.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(

--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { useState } from 'react';
+import React, { useState, type Node } from 'react';
 import { Box, Divider, Provider, Link, Text } from 'gestalt';
 import Header from './Header.js';
 import Navigation from './Navigation.js';
@@ -7,12 +7,12 @@ import useTracking from './useTracking.js';
 import { SidebarContextProvider } from './sidebarContext.js';
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
 |};
 
 const localStorageOrganizedByKey = 'gestalt-sidebar-organized-by';
 
-export default function App(props: Props) {
+export default function App(props: Props): Node {
   const { children } = props;
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [colorScheme, setColorScheme] = useState('light');
@@ -23,6 +23,7 @@ export default function App(props: Props) {
     'categorized' | 'alphabetical'
   >(() => {
     try {
+      // $FlowIssue[incompatible-call]
       return localStorage.getItem(localStorageOrganizedByKey) || 'categorized';
     } catch (error) {
       console.log(error); // eslint-disable-line no-console

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -1,14 +1,14 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Heading, Icon, Link, Row } from 'gestalt';
-import slugify from 'slugify';
+import slugify from 'slugify'; // flowlint-line untyped-import:off
 import Markdown from './Markdown.js';
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
   description?: string,
-  headingSize: 'sm' | 'md',
-  id: ?string,
+  headingSize?: 'sm' | 'md',
+  id?: string,
   name: string,
   stacked?: boolean,
   showHeading?: boolean,
@@ -22,7 +22,7 @@ export default function Card({
   name,
   stacked = false,
   showHeading = true,
-}: Props) {
+}: Props): Node {
   const slugifiedId = id ?? slugify(name);
   return (
     <>
@@ -37,7 +37,7 @@ export default function Card({
             id={slugifiedId}
             data-anchor
           >
-            <Row display="flex" alignItems="baseline" gap={1}>
+            <Row alignItems="baseline" gap={1}>
               {name}
               <Link href={`#${slugifiedId}`} inline>
                 <Icon icon="link" accessibilityLabel="" size={12} />

--- a/docs/src/components/CardPage.js
+++ b/docs/src/components/CardPage.js
@@ -1,15 +1,15 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, FixedZIndex, Link, Sticky, Row, Text } from 'gestalt';
 import SearchContent from './SearchContent.js';
 import Toc from './Toc.js';
 
 type Props = {|
-  cards: Array<React.Node>,
+  cards: Array<Node>,
   page: string,
 |};
 
-const CardPage = ({ cards, page }: Props) => {
+const CardPage = ({ cards, page }: Props): Node => {
   const editPageUrl = `https://github.com/pinterest/gestalt/tree/master/docs/src/${page}.doc.js`;
 
   return (

--- a/docs/src/components/Checkerboard.js
+++ b/docs/src/components/Checkerboard.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { useColorScheme } from 'gestalt';
 
 type Props = {|
   size?: number,
 |};
 
-export default function Checkerboard({ size = 8 }: Props) {
+export default function Checkerboard({ size = 8 }: Props): Node {
   const { colorGray400 } = useColorScheme();
   return (
     <svg

--- a/docs/src/components/Combination.js
+++ b/docs/src/components/Combination.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Text } from 'gestalt';
 import Checkerboard from './Checkerboard.js';
 import Card from './Card.js';
 
-type Props = {|
-  children: (Object, number) => React.Node,
+type Props = {
+  children: (Object, number) => Node, // flowlint-line unclear-type:off
   description?: string,
   heading?: boolean,
   id?: string,
@@ -14,7 +14,8 @@ type Props = {|
   showHeading?: boolean,
   showValues?: boolean,
   stacked?: boolean,
-|};
+  ...
+};
 
 const flatMap = (arr, fn) => arr.map(fn).reduce((a, b) => a.concat(b));
 const combinations = variationsByField => {
@@ -91,7 +92,7 @@ export default function Combination({
   stacked = false,
   children,
   ...props
-}: Props) {
+}: Props): Node {
   const { column, mdColumn, lgColumn } = layoutReducer(layout);
   return (
     <Card

--- a/docs/src/components/DocSearch.js
+++ b/docs/src/components/DocSearch.js
@@ -1,8 +1,8 @@
 // @flow strict
-import React, { useEffect } from 'react';
+import React, { useEffect, type Node } from 'react';
 import './DocSearch.css';
 
-export default function DocSearch() {
+export default function DocSearch(): Node {
   useEffect(() => {
     window.docsearch({
       apiKey: 'a22bd809b2fb174c5defd3c0f44cab8c',

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -1,9 +1,9 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import * as gestalt from 'gestalt'; // eslint-disable-line import/no-namespace
 import DatePicker from 'gestalt-datepicker';
-import LZString from 'lz-string';
-import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
+import LZString from 'lz-string'; // flowlint-line untyped-import:off
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'; // flowlint-line untyped-import:off
 import Card from './Card.js';
 import theme from './atomDark.js';
 
@@ -14,7 +14,7 @@ type Props = {|
   name: string,
   direction?: 'row' | 'column',
   showHeading?: boolean,
-  headingSize: 'sm' | 'md',
+  headingSize?: 'sm' | 'md',
 |};
 
 const { Box, Column, IconButton, Text, Tooltip } = gestalt;
@@ -82,6 +82,7 @@ const handleCodeSandbox = async ({ code, title }) => {
           dependencies: {
             react: 'latest',
             'react-dom': 'latest',
+            // $FlowIssue[exponential-spread]
             ...(baseComponents.length > 0 ? { gestalt: 'latest' } : {}),
             ...(additionalComponents.includes('DatePicker')
               ? { 'gestalt-datepicker': 'latest' }
@@ -144,7 +145,7 @@ const Example = ({
   direction = 'column',
   headingSize,
   showHeading,
-}: Props) => {
+}: Props): Node => {
   const code = defaultCode.trim();
   const scope = { ...gestalt, DatePicker };
   return (

--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import {
   Box,
   Text,
@@ -172,7 +172,7 @@ function Header({ colorScheme, onChangeColorScheme }: Props) {
 export default function StickyHeader({
   colorScheme,
   onChangeColorScheme,
-}: Props) {
+}: Props): Node {
   const isReducedHeight = () => window.innerHeight < 709;
   const [reducedHeight, setReducedHeight] = React.useState(isReducedHeight());
 

--- a/docs/src/components/Link.js
+++ b/docs/src/components/Link.js
@@ -1,16 +1,16 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Link as GestaltLink } from 'gestalt';
-import { createLocation } from 'history';
-import { withRouter } from 'react-router-dom';
+import { createLocation } from 'history'; // flowlint-line untyped-import:off
+import { withRouter } from 'react-router-dom'; // flowlint-line untyped-import:off
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
   history: *,
-  onClick: Function,
+  onClick: Function, // flowlint-line unclear-type:off
   replace?: boolean,
   target?: null | 'self' | 'blank',
-  to: string | Object,
+  to: string | Object, // flowlint-line unclear-type:off
 |};
 
 const isModifiedEvent = event =>
@@ -59,4 +59,5 @@ const Link = ({
   );
 };
 
+// $FlowIssue[signature-verification-failure]
 export default withRouter(Link);

--- a/docs/src/components/Markdown.js
+++ b/docs/src/components/Markdown.js
@@ -1,8 +1,8 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Text } from 'gestalt';
-import marked, { Renderer } from 'marked';
-import highlightjs from 'highlight.js';
+import marked, { Renderer } from 'marked'; // flowlint-line untyped-import:off
+import highlightjs from 'highlight.js'; // flowlint-line untyped-import:off
 import './Markdown.css';
 
 type Props = {|
@@ -27,7 +27,7 @@ const stripIndent = (str: string): string => {
   return str.replace(re, '');
 };
 
-export default function Markdown({ text }: Props) {
+export default function Markdown({ text }: Props): Node {
   const renderer = new Renderer();
 
   renderer.code = (code, language) => {

--- a/docs/src/components/NavLink.js
+++ b/docs/src/components/NavLink.js
@@ -1,16 +1,17 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Link, Text } from 'gestalt';
-import { withRouter, Route } from 'react-router-dom';
-import { createLocation } from 'history';
+import { withRouter, Route } from 'react-router-dom'; // flowlint-line untyped-import:off
+import { createLocation } from 'history'; // flowlint-line untyped-import:off
 import { useSidebarContext } from './sidebarContext.js';
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
   to: string,
   history: *,
 |};
 
+// $FlowIssue[prop-missing]
 const isLeftClickEvent = event => event.button === 0;
 const isModifiedEvent = event =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
@@ -44,4 +45,5 @@ const NavLink = ({ children, to, history }: Props) => {
   );
 };
 
+// $FlowIssue[signature-verification-failure]
 export default withRouter(NavLink);

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box } from 'gestalt';
 import SidebarSection from './SidebarSection.js';
 import SidebarSectionLink from './SidebarSectionLink.js';
@@ -17,7 +17,7 @@ function getAlphabetizedComponents() {
   );
 }
 
-export default function Navigation() {
+export default function Navigation(): Node {
   const { sidebarOrganisedBy, isSidebarOpen } = useSidebarContext();
 
   const navList = (

--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Badge, Box, Text, Tooltip, Heading, Link } from 'gestalt';
 import Markdown from './Markdown.js';
 
@@ -28,7 +28,7 @@ export default function ComponentHeader({
   name,
   description = '',
   fileName,
-}: Props) {
+}: Props): Node {
   return (
     <Box marginBottom={6}>
       <Box marginBottom={4}>

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -1,23 +1,25 @@
 // @flow strict
-import React from 'react';
+import React, { type Node, type ComponentType } from 'react';
 import { Box, Text, Icon, Link } from 'gestalt';
 import Card from './Card.js';
 
 type Props = {|
   props: Array<{|
+    // flowlint-next-line unclear-type:off
     defaultValue?: any,
     description?: ?string,
-    href: ?string,
+    href?: string,
     name: string,
     required?: boolean,
     responsive?: boolean,
     type: string,
   |}>,
   showHeading?: boolean,
-  Component?: React.ComponentType<any>,
+  // flowlint-next-line unclear-type:off
+  Component?: ComponentType<any>,
 |};
 
-const Th = ({ children }: {| children?: React.Node |}) => (
+const Th = ({ children }: {| children?: Node |}) => (
   <th style={{ borderBottom: '2px solid #ddd' }}>
     <Box padding={2}>
       <Text size="md" color="gray" overflow="normal" weight="bold">
@@ -35,7 +37,7 @@ const Td = ({
   color = 'darkGray',
 }: {|
   border?: boolean,
-  children?: React.Node,
+  children?: Node,
   colspan?: number,
   shrink?: boolean,
   color?: 'darkGray' | 'gray',
@@ -64,12 +66,12 @@ export default function PropTable({
   props: properties,
   Component,
   showHeading,
-}: Props) {
+}: Props): Node {
   const hasRequired = properties.some(prop => prop.required);
 
   if (process.env.NODE_ENV === 'development' && Component) {
-    // eslint-disable-next-line react/forbid-foreign-prop-types
-    const { displayName, propTypes } = Component;
+    // $FlowIssue[prop-missing]
+    const { displayName, propTypes } = Component; // eslint-disable-line react/forbid-foreign-prop-types
     const missingProps = Object.keys(propTypes || {}).reduce((acc, prop) => {
       if (!properties.find(p => p.name === prop)) {
         return acc.concat(prop);
@@ -167,7 +169,6 @@ export default function PropTable({
                       </Td>
                       <Td
                         shrink
-                        overflow="normal"
                         color={defaultValue != null ? 'darkGray' : 'gray'}
                         border={!description}
                       >
@@ -183,7 +184,7 @@ export default function PropTable({
                     acc.push(
                       <tr key={`${i}-description`}>
                         <Td colspan={hasRequired ? 2 : 1} />
-                        <Td colspan={2} overflow="normal" color="gray">
+                        <Td colspan={2} color="gray">
                           {description}
                         </Td>
                       </tr>

--- a/docs/src/components/SearchContent.js
+++ b/docs/src/components/SearchContent.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 
 type Props = {|
-  children?: React.Node,
+  children?: Node,
 |};
 
-const SearchContent = ({ children }: Props) => (
+const SearchContent = ({ children }: Props): Node => (
   <div className="docSearch-content">{children}</div>
 );
 

--- a/docs/src/components/SidebarSection.js
+++ b/docs/src/components/SidebarSection.js
@@ -1,10 +1,14 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Row, Text } from 'gestalt';
 import { type sidebarIndexType } from './sidebarIndex.js';
 import SidebarSectionLink from './SidebarSectionLink.js';
 
-export default function SidebarSection({ section }: sidebarIndexType) {
+export default function SidebarSection({
+  section,
+}: {|
+  section: sidebarIndexType,
+|}): Node {
   return (
     <>
       <Box padding={2} marginTop={4} role="list">

--- a/docs/src/components/SidebarSectionLink.js
+++ b/docs/src/components/SidebarSectionLink.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box } from 'gestalt';
 import NavLink from './NavLink.js';
 
@@ -7,7 +7,7 @@ type Props = {|
   componentName: string,
 |};
 
-export default function SideBarSectionLink({ componentName }: Props) {
+export default function SideBarSectionLink({ componentName }: Props): Node {
   return (
     <Box>
       <NavLink to={`/${componentName}`}>

--- a/docs/src/components/Toc.js
+++ b/docs/src/components/Toc.js
@@ -14,6 +14,7 @@ function throttle(func, wait) {
     }
     previous = Date.now();
     timeout = null;
+    // $FlowIssue[incompatible-type]
     result = func.apply(context, args);
     if (!timeout) {
       context = null;
@@ -61,7 +62,7 @@ function useThrottledOnScroll(callback, delay) {
   }, [throttledCallback]);
 }
 
-export default function Toc({ cards }: {| cards: Array<Node> |}) {
+export default function Toc({ cards }: {| cards: Array<Node> |}): Node {
   const [anchors, setAnchors] = useState([]);
   const [activeState, setActiveState] = React.useState(null);
   const clickedRef = React.useRef(false);
@@ -80,15 +81,19 @@ export default function Toc({ cards }: {| cards: Array<Node> |}) {
       .reverse()
       .every(anchor => {
         // No hash if we're near the top of the page
-        if (document.documentElement.scrollTop < 120) {
+        if (
+          document.documentElement &&
+          document.documentElement.scrollTop < 120
+        ) {
           active = { id: null };
           return false;
         }
 
         if (
+          document.documentElement &&
           anchor?.offsetTop <
-          document.documentElement.scrollTop +
-            document.documentElement.clientHeight / 8
+            document.documentElement.scrollTop +
+              document.documentElement.clientHeight / 8
         ) {
           active = anchor;
           return false;

--- a/docs/src/components/atomDark.js
+++ b/docs/src/components/atomDark.js
@@ -42,12 +42,6 @@ export default {
       },
     },
     {
-      types: [],
-      style: {
-        color: '#c6c5fe',
-      },
-    },
-    {
       types: ['operator', 'entity', 'url', 'string', 'variable'],
       style: {
         color: 'hsl(40, 90%, 60%)',

--- a/docs/src/components/routes.js
+++ b/docs/src/components/routes.js
@@ -1,6 +1,8 @@
 // @flow strict
+// $FlowIssue[signature-verification-failure]
 const routes = {};
 
+// $FlowIssue[prop-missing]
 const requireCard = require.context('..', true, /\.doc\.js$/);
 const paths = requireCard.keys();
 paths.sort((a, b) => a.localeCompare(b));

--- a/docs/src/components/sidebarContext.js
+++ b/docs/src/components/sidebarContext.js
@@ -1,8 +1,10 @@
 // @flow strict
 import React, { useContext } from 'react';
 
+// $FlowIssue
 const SidebarContext = React.createContext(true);
 
+// $FlowIssue[signature-verification-failure]
 const useSidebarContext = () => useContext(SidebarContext);
 const SidebarContextProvider = SidebarContext.Provider;
 

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -1,9 +1,9 @@
 // @flow strict
 
-export type sidebarIndexType = Array<{|
-  displayName: string,
+export type sidebarIndexType = {|
+  sectionName: string,
   pages: Array<string>,
-|}>;
+|};
 
 // sidebarIndex is the source of truth for the sidebar documentation menu.
 // sidebarIndex establishes the sidebar hierarchical menu order:
@@ -13,7 +13,7 @@ export type sidebarIndexType = Array<{|
 //    >>> page 2
 //    >>> page 3
 // Any new section/page must be added to sidebarIndex to be displayed.
-const sidebarIndex: sidebarIndexType = [
+const sidebarIndex: Array<sidebarIndexType> = [
   {
     sectionName: 'Getting Started',
     pages: ['Installation', 'Development', 'Faq'],

--- a/docs/src/components/useTracking.js
+++ b/docs/src/components/useTracking.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom'; // flowlint-line untyped-import:off
 
 export default function useTracking(trackingId: string) {
   const { listen } = useHistory();

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -1,7 +1,7 @@
 // @flow strict
 import React from 'react';
-import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
-import { render } from 'react-dom';
+import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom'; // flowlint-line untyped-import:off
+import { render } from 'react-dom'; // flowlint-line untyped-import:off
 import 'gestalt/dist/gestalt-future.css';
 import 'gestalt-datepicker/dist/gestalt-datepicker-future.css';
 import App from './components/App.js';

--- a/docs/src/useReducedMotion.doc.js
+++ b/docs/src/useReducedMotion.doc.js
@@ -1,9 +1,9 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 
-const cards = [];
+const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
 card(


### PR DESCRIPTION
Enable flow types on our Gestalt docs. Improves type safety and caught a couple of actual issues.

We previously did not enable these because of https://github.com/facebook/flow/issues/4015. It does mean we might have to restart the docs server when we make a change to Gestalt.

## Test Plan

`yarn flow` passes + checks the docs.
