### PR TITLE
Flyout: Update docs to mention that size is max width

### DIFF
--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -75,7 +75,7 @@ card(
       {
         name: 'size',
         type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number`,
-        description: `xs: 180px, sm: 230px, md: 284px, lg: 320px, xl: 360px, flexible: no inherent sizing from flyout`,
+        description: `xs: 180px, sm: 230px, md: 284px, lg: 320px, xl: 360px, flexible: no inherent sizing from flyout. Sets the maximum width of the Flyout.`,
         defaultValue: 'sm',
         href: 'basicExample',
       },


### PR DESCRIPTION
I recently added a `Flyout` and couldn't figure out why it wasn't using the `size` I set for the width. After reading the code, I saw that `size` actually sets the **max** width for the `Flyout` so I needed to make my content at least that wide. I'm updating the docs to make it more clear for the next person.

## Test Plan
Confirm updated documentation makes sense
