### PR TITLE
Modal: Add forwardRef

### DIFF
--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -54,6 +54,12 @@ card(
         href: 'sizesExample',
       },
       {
+        name: 'ref',
+        type: "React.Ref<'div'>",
+        description: 'Forward the ref to the underlying div element',
+        href: 'refExample',
+      },
+      {
         name: 'role',
         type: `"alertdialog" | "dialog"`,
         defaultValue: 'dialog',
@@ -286,6 +292,54 @@ function HeadingExample(props) {
   );
 }
 `}
+  />
+);
+
+card(
+  <Example
+    id="refExample"
+    name="Example: ref"
+    description={`
+    A \`Modal\` with focus using refs
+  `}
+    defaultCode={`
+function ModalRefExample() {
+  const [showModal, setShowModal] = React.useState(false);
+
+  const modalRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (showModal && modalRef.current) {
+      // this is just an example of accessing the ref, Modal already traps focus on rendering
+      modalRef.current.focus();
+    }
+  }, [showModal, modalRef]);
+
+  return (
+    <Box marginLeft={-1} marginRight={-1}>
+      <Box padding={1}>
+        <Button
+          text="Open modal"
+          onClick={() => { setShowModal(!showModal) }}
+        />
+        <Layer>
+          {showModal && (
+            <Modal
+              accessibilityModalLabel="Focused modal"
+              onDismiss={() => { setShowModal(!showModal) }}
+              ref={modalRef}
+              size="md"
+            >
+              <Box color="lightGray" minHeight={400} padding={4}>
+                <Heading size="md">Focused modal</Heading>
+              </Box>
+            </Modal>
+          )}
+        </Layer>
+      </Box>
+    </Box>
+  );
+}`}
   />
 );
 

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -1,5 +1,11 @@
 // @flow strict
-import React, { useState, useEffect, useRef, type Node } from 'react';
+import React, {
+  forwardRef,
+  useState,
+  useEffect,
+  useRef,
+  type Node,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -67,16 +73,21 @@ function Header({ heading }: {| heading: string | Node |}) {
   );
 }
 
-export default function Modal({
-  accessibilityModalLabel,
-  children,
-  closeOnOutsideClick = true,
-  onDismiss,
-  footer,
-  heading,
-  role = 'dialog',
-  size = 'sm',
-}: Props): Node {
+const ModalWithForwardRef: React$AbstractComponent<
+  Props,
+  HTMLDivElement
+> = forwardRef<Props, HTMLDivElement>(function Modal(props, ref): Node {
+  const {
+    accessibilityModalLabel,
+    children,
+    closeOnOutsideClick = true,
+    onDismiss,
+    footer,
+    heading,
+    role = 'dialog',
+    size = 'sm',
+  } = props;
+
   const [showTopShadow, setShowTopShadow] = useState(false);
   const [showBottomShadow, setShowBottomShadow] = useState(false);
   const content = useRef<?HTMLDivElement>(null);
@@ -135,7 +146,12 @@ export default function Modal({
           role={role}
         >
           <Backdrop onClick={handleOutsideClick}>
-            <div className={styles.wrapper} tabIndex={-1} style={{ width }}>
+            <div
+              className={styles.wrapper}
+              tabIndex={-1}
+              style={{ width }}
+              ref={ref}
+            >
               <Box
                 flex="grow"
                 position="relative"
@@ -176,9 +192,10 @@ export default function Modal({
       </TrapFocusBehavior>
     </StopScrollBehavior>
   );
-}
+});
 
-Modal.propTypes = {
+// $FlowFixMe Flow(InferError)
+ModalWithForwardRef.propTypes = {
   accessibilityModalLabel: PropTypes.string.isRequired,
   children: PropTypes.node,
   closeOnOutsideClick: PropTypes.bool,
@@ -191,3 +208,7 @@ Modal.propTypes = {
     PropTypes.oneOf(['sm', 'md', 'lg']),
   ]),
 };
+
+ModalWithForwardRef.displayName = 'Modal';
+
+export default ModalWithForwardRef;

--- a/packages/gestalt/src/Modal.jsdom.test.js
+++ b/packages/gestalt/src/Modal.jsdom.test.js
@@ -1,0 +1,26 @@
+// @flow strict
+import React from 'react';
+import { render } from '@testing-library/react';
+import Modal from './Modal.js';
+
+const mockOnDismiss = jest.fn();
+
+describe('Modal', () => {
+  if (typeof document !== 'undefined') {
+    test('Modal renders with ref', () => {
+      const modalRef = React.createRef();
+      const modal = render(
+        <Modal
+          accessibilityModalLabel="Test modal"
+          onDismiss={mockOnDismiss}
+          ref={modalRef}
+        >
+          Modal content
+        </Modal>
+      );
+
+      expect(modal).toMatchSnapshot();
+      expect(modalRef.current instanceof HTMLDivElement).toEqual(true);
+    });
+  }
+});

--- a/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
@@ -1,0 +1,120 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal Modal renders with ref 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body
+    style="overflow: hidden;"
+  >
+    <div>
+      <div>
+        <div
+          aria-label="Test modal"
+          class="container"
+          role="dialog"
+        >
+          <div
+            class="backdrop"
+          />
+          <div
+            class="wrapper"
+            style="width: 540px;"
+            tabindex="-1"
+          >
+            <div
+              class="box flexGrow relative xsDirectionColumn xsDisplayFlex"
+              style="width: 100%;"
+            >
+              <div
+                class="box flexGrow overflowAuto"
+              >
+                Modal content
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div>
+      <div
+        aria-label="Test modal"
+        class="container"
+        role="dialog"
+      >
+        <div
+          class="backdrop"
+        />
+        <div
+          class="wrapper"
+          style="width: 540px;"
+          tabindex="-1"
+        >
+          <div
+            class="box flexGrow relative xsDirectionColumn xsDisplayFlex"
+            style="width: 100%;"
+          >
+            <div
+              class="box flexGrow overflowAuto"
+            >
+              Modal content
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;


### PR DESCRIPTION
The purpose of this PR is to add React `forwardRef` to `Modal` in order to be able to reference the Modal container from parent components

## Test Plan

Tested locally
There are no UI changes
Renders as expected

<img width="1436" alt="Screen Shot 2020-08-28 at 3 40 04 PM" src="https://user-images.githubusercontent.com/7388586/91620432-ca577a80-e944-11ea-9b7d-5b6a7efd7456.png">

