### PR TITLE
useFocusVisible: export hook & add docs

### DIFF
--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -29,7 +29,7 @@ const sidebarIndex: Array<sidebarIndexType> = [
   },
   {
     sectionName: 'Accessibility',
-    pages: ['useReducedMotion'],
+    pages: ['useFocusVisible', 'useReducedMotion'],
   },
   {
     sectionName: 'Data Display',

--- a/docs/src/useFocusVisible.doc.js
+++ b/docs/src/useFocusVisible.doc.js
@@ -1,0 +1,67 @@
+// @flow strict
+import React, { type Node } from 'react';
+import Example from './components/Example.js';
+import PageHeader from './components/PageHeader.js';
+
+const cards: Array<Node> = [];
+const card = c => cards.push(c);
+
+card(
+  <PageHeader
+    name="useFocusVisible"
+    description={`
+    \`useFocusVisible\` manages focus interactions on the page and determines whether a focus ring should be shown. If a user interacts with a mouse/touch, then the focus is not visible. When the user interacts with the keyboard, then the focus is visible.
+
+    References:
+    <ul>
+      <li><a href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html">WCAG 2.4.7: Focus Visible</a></li>
+      <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible">:focus-visible CSS pseudo-class</a></li>
+    </ul>
+    `}
+  />
+);
+
+card(
+  <Example
+    name="Example"
+    defaultCode={`
+function Example() {
+  const { isFocusVisible } = useFocusVisible();
+  const [ focussedButton1, setFocussedButton1 ] = React.useState(false);
+  const [ focussedButton2, setFocussedButton2 ] = React.useState(false);
+
+  return (
+    <Stack gap={2}>
+      <Row gap={2}>
+        <Text>With focus visible</Text>
+        <button
+          onBlur={() => setFocussedButton1(false)}
+          onFocus={() => setFocussedButton1(true)}
+          style={{
+            outline: 'none',
+            boxShadow: isFocusVisible && focussedButton1 ? "0 0 0 4px rgba(0, 132, 255, 0.5)" : null
+          }}
+        >
+          <Text>Button 1</Text>
+        </button>
+      </Row>
+      <Row gap={2}>
+        <Text>Without focus visible</Text>
+        <button
+          onBlur={() => setFocussedButton2(false)}
+          onFocus={() => setFocussedButton2(true)}
+          style={{
+            outline: 'none',
+            boxShadow: focussedButton2 ? "0 0 0 4px rgba(0, 132, 255, 0.5)" : null
+          }}
+        >
+          <Text>Button 2</Text>
+        </button>
+      </Row>
+    </Stack>
+  );
+}`}
+  />
+);
+
+export default cards;

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -48,6 +48,7 @@ import TextArea from './TextArea.js';
 import TextField from './TextField.js';
 import Toast from './Toast.js';
 import Tooltip from './Tooltip.js';
+import useFocusVisible from './useFocusVisible.js';
 import useReducedMotion from './useReducedMotion.js';
 import Video from './Video.js';
 import Typeahead from './Typeahead.js';
@@ -108,6 +109,7 @@ export {
   Tooltip,
   Typeahead,
   useColorScheme,
+  useFocusVisible,
   useReducedMotion,
   Video,
 };


### PR DESCRIPTION
Export the a11y `useFocusVisible` hook which can be used to only show a focus style when tabbing through with a keyboard.

## Test Plan

### Click

1. Go to `/useFocusVisible`
2. Click on `Button 1` and `Button 2`
3. Only `Button 2` shows the focus style

![useFVclick](https://user-images.githubusercontent.com/127199/91737918-99559080-eb64-11ea-9226-49d006131a85.gif)

### Tab

1. Go to `/useFocusVisible`
2. Tab through `Button 1` and `Button 2`
3. Both buttons the focus style

![useFVtab](https://user-images.githubusercontent.com/127199/91737974-af635100-eb64-11ea-90e5-aca1b58f526e.gif)
