### PR TITLE
Docs: fix Divider overlap on bottom of the page

### DIFF
--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -65,10 +65,6 @@ export default function App(props: Props): Node {
               <Box padding={4} mdPadding={6} lgPadding={8} width="100%">
                 {children}
               </Box>
-            </Box>
-          </Box>
-          {document.location.href.includes('netlify') ? (
-            <Box>
               <Divider />
 
               <Box padding={4} mdPadding={6} lgPadding={8}>
@@ -79,7 +75,7 @@ export default function App(props: Props): Node {
                 </Link>
               </Box>
             </Box>
-          ) : null}
+          </Box>
         </Box>
       </Provider>
     </SidebarContextProvider>


### PR DESCRIPTION
### Before
See divider overlap on `SegmentedControl`

![Screen Shot 2020-08-31 at 10 02 43 AM](https://user-images.githubusercontent.com/127199/91746244-27d00f00-eb71-11ea-9455-16128dfcfb29.png)


### After
No divider overlap on `SegmentedControl`

![Screen Shot 2020-08-31 at 10 02 55 AM](https://user-images.githubusercontent.com/127199/91746249-2a326900-eb71-11ea-9c84-19bfc6029e83.png)

