### PR TITLE
Modal: Prevent showing zoom out icon if closeOnOutsideClick is false

### DIFF
--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -35,6 +35,7 @@ card(
         type: 'boolean',
         description: 'Close the modal when you click outside of it',
         defaultValue: true,
+        href: 'closeOnOutsideClickExample',
       },
       {
         name: 'footer',
@@ -73,6 +74,50 @@ card(
         href: 'sizesExample',
       },
     ]}
+  />
+);
+
+card(
+  <Example
+    id="closeOnOutsideClickExample"
+    name="Prevent closing when clicking outside"
+    description={`
+      Sometimes we need the user to complete some required action at a Modal.
+      We can ensure that by preventing the user closing the modal.
+      For that you can set: \`closeOnOutsideClick\` to \`false\`.
+    `}
+    defaultCode={`
+function Example(props) {
+  const [showModal, setShowModal] = React.useState(false);
+  return (
+    <Box marginLeft={-1} marginRight={-1}>
+      <Box padding={1}>
+        <Button
+          text="Open modal"
+          onClick={() => { setShowModal(!showModal) }}
+        />
+        {showModal && (
+          <Layer>
+            <Modal
+              accessibilityModalLabel="Non closable modal"
+              closeOnOutsideClick={false}
+              heading="Heading"
+              onDismiss={() => { setShowModal(!showModal) }}
+            >
+              <Box padding={8}>
+                <Text align="center">Click on the button to close the modal</Text>
+                <Box marginTop={4}>
+                  <Button color="red" text="Close" onClick={() => { setShowModal(!showModal) }} />
+                </Box>
+              </Box>
+            </Modal>
+          </Layer>
+        )}
+      </Box>
+    </Box>
+  );
+}
+`}
   />
 );
 

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -79,50 +79,6 @@ card(
 
 card(
   <Example
-    id="closeOnOutsideClickExample"
-    name="Prevent closing when clicking outside"
-    description={`
-      Sometimes we need the user to complete some required action at a Modal.
-      We can ensure that by preventing the user closing the modal.
-      For that you can set: \`closeOnOutsideClick\` to \`false\`.
-    `}
-    defaultCode={`
-function Example(props) {
-  const [showModal, setShowModal] = React.useState(false);
-  return (
-    <Box marginLeft={-1} marginRight={-1}>
-      <Box padding={1}>
-        <Button
-          text="Open modal"
-          onClick={() => { setShowModal(!showModal) }}
-        />
-        {showModal && (
-          <Layer>
-            <Modal
-              accessibilityModalLabel="Non closable modal"
-              closeOnOutsideClick={false}
-              heading="Heading"
-              onDismiss={() => { setShowModal(!showModal) }}
-            >
-              <Box padding={8}>
-                <Text align="center">Click on the button to close the modal</Text>
-                <Box marginTop={4}>
-                  <Button color="red" text="Close" onClick={() => { setShowModal(!showModal) }} />
-                </Box>
-              </Box>
-            </Modal>
-          </Layer>
-        )}
-      </Box>
-    </Box>
-  );
-}
-`}
-  />
-);
-
-card(
-  <Example
     id="sizesExample"
     name="Sizes"
     description={`
@@ -154,7 +110,8 @@ function Example(props) {
     <Box marginLeft={-1} marginRight={-1}>
       <Box padding={1}>
         <Button
-          text="size='sm'"
+          inline
+          text="Small Modal"
           onClick={() => { dispatch({type: 'small'}) }}
         />
         {state.modal === 'small' && (
@@ -175,7 +132,8 @@ function Example(props) {
       </Box>
       <Box padding={1}>
         <Button
-          text="size='md'"
+          inline
+          text="Medium Modal"
           onClick={() => { dispatch({type: 'medium'}) }}
         />
         {state.modal === 'medium' && (
@@ -196,7 +154,8 @@ function Example(props) {
       </Box>
       <Box padding={1}>
         <Button
-          text="size='lg'"
+          inline
+          text="Large Modal"
           onClick={() => { dispatch({type: 'large'}) }}
         />
         {state.modal === 'large' && (
@@ -216,6 +175,49 @@ function Example(props) {
         )}
       </Box>
     </Box>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    id="closeOnOutsideClickExample"
+    name="Prevent close on outside click"
+    description={`
+      Sometimes we need the user to complete some required action at a Modal.
+      We can ensure that by preventing the user closing the modal.
+      For that you can set: \`closeOnOutsideClick\` to \`false\`.
+    `}
+    defaultCode={`
+function Example(props) {
+  const [showModal, setShowModal] = React.useState(false);
+  return (
+    <>
+      <Button
+        inline
+        text="Open modal"
+        onClick={() => { setShowModal(!showModal) }}
+      />
+      {showModal && (
+        <Layer>
+          <Modal
+            accessibilityModalLabel="Non closable modal"
+            closeOnOutsideClick={false}
+            heading="Heading"
+            onDismiss={() => { setShowModal(!showModal) }}
+          >
+            <Box padding={8}>
+              <Text align="center">Click on the button to close the modal</Text>
+              <Box marginTop={4}>
+                <Button color="red" text="Close" onClick={() => { setShowModal(!showModal) }} />
+              </Box>
+            </Box>
+          </Modal>
+        </Layer>
+      )}
+    </>
   );
 }
 `}

--- a/packages/gestalt/src/Modal.css
+++ b/packages/gestalt/src/Modal.css
@@ -6,7 +6,7 @@
   overflow-y: scroll;
 }
 
-.withZoomOut {
+.zoomOut {
   composes: zoomOut from "./Cursor.css";
 }
 

--- a/packages/gestalt/src/Modal.css
+++ b/packages/gestalt/src/Modal.css
@@ -1,10 +1,13 @@
 .backdrop {
   composes: absolute left0 top0 right0 bottom0 from "./Layout.css";
-  composes: zoomOut from "./Cursor.css";
   background: rgba(0, 0, 0, 0.4);
   height: 100%;
   opacity: 0.9;
   overflow-y: scroll;
+}
+
+.withZoomOut {
+  composes: zoomOut from "./Cursor.css";
 }
 
 .container {

--- a/packages/gestalt/src/Modal.css.flow
+++ b/packages/gestalt/src/Modal.css.flow
@@ -5,6 +5,6 @@ declare module.exports: {|
   +'container': string,
   +'shadow': string,
   +'shadowContainer': string,
-  +'withZoomOut': string,
   +'wrapper': string,
+  +'zoomOut': string,
 |};

--- a/packages/gestalt/src/Modal.css.flow
+++ b/packages/gestalt/src/Modal.css.flow
@@ -5,5 +5,6 @@ declare module.exports: {|
   +'container': string,
   +'shadow': string,
   +'shadowContainer': string,
+  +'withZoomOut': string,
   +'wrapper': string,
 |};

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -57,7 +57,7 @@ function Backdrop({
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
         className={classnames(styles.backdrop, {
-          [styles.withZoomOut]: closeOnOutsideClick,
+          [styles.zoomOut]: closeOnOutsideClick,
         })}
         onClick={handleClick}
       />

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -35,9 +35,11 @@ const ESCAPE_KEY_CODE = 27;
 
 function Backdrop({
   children,
+  closeOnOutsideClick,
   onClick,
 }: {|
   children?: Node,
+  closeOnOutsideClick: boolean,
   onClick?: (event: MouseEvent) => void,
 |}) {
   const handleClick = event => {
@@ -53,7 +55,12 @@ function Backdrop({
     <>
       {/* Disabling the linters below is fine, we don't want key event listeners (ESC handled elsewhere) */}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-      <div className={styles.backdrop} onClick={handleClick} />
+      <div
+        className={classnames(styles.backdrop, {
+          [styles.withZoomOut]: closeOnOutsideClick,
+        })}
+        onClick={handleClick}
+      />
       {children}
     </>
   );
@@ -145,7 +152,10 @@ const ModalWithForwardRef: React$AbstractComponent<
           className={styles.container}
           role={role}
         >
-          <Backdrop onClick={handleOutsideClick}>
+          <Backdrop
+            closeOnOutsideClick={closeOnOutsideClick}
+            onClick={handleOutsideClick}
+          >
             <div
               className={styles.wrapper}
               tabIndex={-1}

--- a/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
@@ -14,7 +14,7 @@ Object {
           role="dialog"
         >
           <div
-            class="backdrop withZoomOut"
+            class="backdrop zoomOut"
           />
           <div
             class="wrapper"
@@ -44,7 +44,7 @@ Object {
         role="dialog"
       >
         <div
-          class="backdrop withZoomOut"
+          class="backdrop zoomOut"
         />
         <div
           class="wrapper"

--- a/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
@@ -14,7 +14,7 @@ Object {
           role="dialog"
         >
           <div
-            class="backdrop"
+            class="backdrop withZoomOut"
           />
           <div
             class="wrapper"
@@ -44,7 +44,7 @@ Object {
         role="dialog"
       >
         <div
-          class="backdrop"
+          class="backdrop withZoomOut"
         />
         <div
           class="wrapper"


### PR DESCRIPTION
This fix the problem of showing the zoom out icon even when `closeOnOutsideClick` is set to `false`.
That behavior might confuse user thinking that if they click outside the modal this will be closed.

## Test Plan

Tested locally

<img width="1213" alt="Screen Shot 2020-09-01 at 3 11 42 PM" src="https://user-images.githubusercontent.com/7388586/91911415-e705f200-ec65-11ea-85a2-a165b239a6dc.png">
<img width="1213" alt="Screen Shot 2020-09-01 at 3 10 58 PM" src="https://user-images.githubusercontent.com/7388586/91911423-eb320f80-ec65-11ea-9519-f6298a1fab9c.png">

