### PR TITLE
Button: Flow + name prop fixes

### DIFF
--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -69,7 +69,6 @@ type LinkButtonType = {|
   rel?: 'none' | 'nofollow',
   role: 'link',
   target?: null | 'self' | 'blank',
-  role: 'link',
 |};
 
 type unionProps = ButtonType | SubmitButtonType | LinkButtonType;
@@ -260,6 +259,7 @@ const ButtonWithForwardRef: React$AbstractComponent<
     accessibilityControls,
     accessibilityExpanded,
     accessibilityHaspopup,
+    name,
     type = 'button',
   } = props;
 
@@ -271,6 +271,7 @@ const ButtonWithForwardRef: React$AbstractComponent<
       aria-label={accessibilityLabel}
       className={classes}
       disabled={disabled}
+      name={name}
       onBlur={handleBlur}
       onClick={handleClick}
       onMouseDown={handleMouseDown}


### PR DESCRIPTION
`name` is a submit-type button attribute that will be deprecated. However, there are instances in Pinboard using it as an `id`. Initially, it was added just to the submit button and was not reintroduced to type-button buttons. Adding it back. It will be renamed as id in the future.


<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
