### PR TITLE
[WIP] IconButton: Added support for href and segmented Flow type

### DIFF
--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -79,6 +79,17 @@ card(
         Icon.`,
       },
       {
+        name: 'href',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Specify a link URL.',
+          'Required with link-role buttons.',
+        ],
+        href: 'roles',
+      },
+      {
         name: 'onClick',
         type: '({ event: SyntheticMouseEvent<> }) => void',
       },
@@ -89,10 +100,31 @@ card(
         href: 'paddingCombinations',
       },
       {
+        name: 'rel',
+        type: `'none' | 'nofollow'`,
+        required: false,
+        defaultValue: 'none',
+        description: 'Optional with link-role buttons.',
+        href: 'roles',
+      },
+      {
         name: 'ref',
-        type: "React.Ref<'button'>",
+        type: `React.Ref<'button'> | React.Ref<'a'>`,
         description: 'Forward the ref to the underlying button element',
         href: 'refExample',
+      },
+      {
+        name: 'role',
+        type: `'button' | 'link'`,
+        required: false,
+        defaultValue: 'button',
+        description: [
+          `Select a button variant:`,
+          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a '<button>'.`,
+          `- 'link': Use for buttons to act like links. The button is rendered as an '<a>'.`,
+          `Required with link-role buttons.`,
+        ],
+        href: 'roles',
       },
       {
         name: 'selected',
@@ -106,6 +138,20 @@ card(
         description: `xs: 24px, sm: 32px, md: 40px, lg: 48px, xl: 56px`,
         defaultValue: 'md',
         href: 'sizeCombinations',
+      },
+      {
+        name: 'target',
+        type: `null | 'self' | 'blank'`,
+        required: false,
+        defaultValue: 'null',
+        description: [
+          'Define the frame or window to open the anchor defined on `href`:',
+          '- `null` opens the anchor in the same window.',
+          '- `blank` opens the anchor in a new window.',
+          '- `self` opens an anchor in the same frame.',
+          'Optional with link-role buttons.',
+        ],
+        href: 'roles',
       },
     ]}
   />
@@ -122,6 +168,43 @@ card(
   iconColor="red"
   onClick={() => { console.log('❤️')}}
 />
+`}
+  />
+);
+
+card(
+  <Example
+    name="Roles"
+    id="roles"
+    defaultCode={`
+function Example() {
+  const [disabled, setDisabled] = React.useState(false);
+
+  return (
+    <Stack gap={3}>
+      <Row gap={1}>
+        <Tooltip text="Default IconButton">
+          <IconButton accessibilityLabel='Default IconButton' icon='share' onClick={() => {}} disabled={disabled} />
+        </Tooltip>
+        <Tooltip text="Link IconButton">
+          <IconButton accessibilityLabel='Link IconButton' icon='link' role="link" target="blank" href="https://www.pinterest.com" disabled={disabled} />
+        </Tooltip>
+      </Row>
+      <Row gap={1}>
+        <Switch
+          onChange={() => setDisabled(!disabled)}
+          id="disable-buttons"
+          switched={disabled}
+        />
+        <Box paddingX={2} flex="grow">
+          <Label htmlFor="disable-buttons">
+            <Text>Disable buttons</Text>
+          </Label>
+        </Box>
+      </Row>
+    </Stack>
+  );
+}
 `}
   />
 );

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -204,7 +204,6 @@ const ButtonWithForwardRef: React$AbstractComponent<
     }
   }
 
-  /* eslint-disable react/button-has-type */
   if (props.role === 'link') {
     const { href, rel, target } = props;
 
@@ -248,7 +247,7 @@ const ButtonWithForwardRef: React$AbstractComponent<
         onTouchStart={handleTouchStart}
         ref={innerRef}
         style={compressStyle}
-        type={type}
+        type={type} // eslint-disable-line react/button-has-type
       >
         {iconEnd ? iconEndComponent() : buttonText}
       </button>
@@ -281,13 +280,12 @@ const ButtonWithForwardRef: React$AbstractComponent<
       onTouchMove={handleTouchMove}
       onTouchStart={handleTouchStart}
       ref={innerRef}
-      type={type}
+      type={type} // eslint-disable-line react/button-has-type
       {...(compressStyle ? { style: compressStyle } : {})}
     >
       {iconEnd ? iconEndComponent() : buttonText}
     </button>
   );
-  /* eslint-enable react/button-has-type */
 });
 
 // $FlowFixMe Flow(InferError)

--- a/packages/gestalt/src/IconButton.flowtest.js
+++ b/packages/gestalt/src/IconButton.flowtest.js
@@ -2,10 +2,43 @@
 import React from 'react';
 import IconButton from './IconButton.js';
 
-const Valid = <IconButton icon="add" accessibilityLabel="Add" />;
+const ValidDefaultIconButton = (
+  <IconButton icon="add" accessibilityLabel="Add" />
+);
 
-// $FlowExpectedError[prop-missing]
+const ValidLinkRoleIconButton = (
+  <IconButton
+    icon="add"
+    accessibilityLabel="Add"
+    role="link"
+    href="http://www.pinterest.com"
+  />
+);
+
+// $FlowExpectedError[incompatible-type]
 const MissingProp = <IconButton />;
 
-// $FlowExpectedError[prop-missing]
+// $FlowExpectedError[incompatible-type]
 const NonExistingProp = <IconButton nonexisting={33} />;
+
+const IncompatibleLinkRoleProps = (
+  // $FlowExpectedError[incompatible-type]
+  <IconButton
+    accessibilityExpanded
+    icon="add"
+    accessibilityLabel="Add"
+    role="link"
+    href="http://www.pinterest.com"
+  />
+);
+
+const IncompatibleButtonRoleProps = (
+  // $FlowExpectedError[incompatible-type]
+  <IconButton
+    accessibilityExpanded
+    icon="add"
+    accessibilityLabel="Add"
+    role="button"
+    target="blank"
+  />
+);

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -9,6 +9,7 @@ import React, {
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import icons from './icons/index.js';
+import Link from './Link.js';
 import Pog from './Pog.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './IconButton.css';
@@ -16,10 +17,7 @@ import touchableStyles from './Touchable.css';
 import useTapFeedback from './useTapFeedback.js';
 import useFocusVisible from './useFocusVisible.js';
 
-type Props = {|
-  accessibilityControls?: string,
-  accessibilityExpanded?: boolean,
-  accessibilityHaspopup?: boolean,
+type BaseIconButton = {|
   accessibilityLabel: string,
   bgColor?:
     | 'transparent'
@@ -32,21 +30,43 @@ type Props = {|
   dangerouslySetSvgPath?: {| __path: string |},
   disabled?: boolean,
   icon?: $Keys<typeof icons>,
+  onClick?: AbstractEventHandler<
+    | SyntheticMouseEvent<HTMLButtonElement>
+    | SyntheticKeyboardEvent<HTMLButtonElement>
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>
+  >,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
-  onClick?: AbstractEventHandler<SyntheticMouseEvent<HTMLButtonElement>>,
   padding?: 1 | 2 | 3 | 4 | 5,
-  selected?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
+type IconButtonType = {|
+  ...BaseIconButton,
+  accessibilityControls?: string,
+  accessibilityExpanded?: boolean,
+  accessibilityHaspopup?: boolean,
+  role?: 'button',
+  selected?: boolean,
+|};
+
+type LinkIconButtonType = {|
+  ...BaseIconButton,
+  href: string,
+  rel?: 'none' | 'nofollow',
+  role: 'link',
+  target?: null | 'self' | 'blank',
+|};
+
+type unionProps = IconButtonType | LinkIconButtonType;
+
+type unionRefs = HTMLButtonElement | HTMLAnchorElement;
+
 const IconButtonWithForwardRef: React$AbstractComponent<
-  Props,
-  HTMLButtonElement
-> = forwardRef<Props, HTMLButtonElement>(function IconButton(props, ref): Node {
+  unionProps,
+  unionRefs
+> = forwardRef<unionProps, unionRefs>(function IconButton(props, ref): Node {
   const {
-    accessibilityControls,
-    accessibilityExpanded,
-    accessibilityHaspopup,
     accessibilityLabel,
     bgColor,
     dangerouslySetSvgPath,
@@ -55,9 +75,9 @@ const IconButtonWithForwardRef: React$AbstractComponent<
     iconColor,
     onClick,
     padding,
-    selected,
     size,
   } = props;
+
   const innerRef = useRef(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <IconButton ref={inputRef} /> to call inputRef.current.focus()
@@ -87,8 +107,74 @@ const IconButtonWithForwardRef: React$AbstractComponent<
   const classes = classnames(styles.button, touchableStyles.tapTransition, {
     [styles.disabled]: disabled,
     [styles.enabled]: !disabled,
-    [touchableStyles.tapCompress]: !disabled && isTapping,
+    [touchableStyles.tapCompress]:
+      props.role !== 'link' && !disabled && isTapping,
   });
+
+  function handleClick(event) {
+    if (onClick) {
+      onClick({ event });
+    }
+  }
+
+  function handleLinkClick({ event }) {
+    handleClick(event);
+  }
+
+  const renderPogComponent = (selected?: boolean): Node => {
+    return (
+      <Pog
+        active={!disabled && isActive}
+        bgColor={bgColor}
+        dangerouslySetSvgPath={dangerouslySetSvgPath}
+        focused={!disabled && isFocusVisible && isFocused}
+        hovered={!disabled && isHovered}
+        icon={icon}
+        iconColor={iconColor}
+        padding={padding}
+        selected={selected}
+        size={size}
+      />
+    );
+  };
+
+  if (props.role === 'link') {
+    const { href, rel, target } = props;
+
+    return (
+      <Link
+        accessibilityLabel={accessibilityLabel}
+        disabled={disabled}
+        inline
+        href={href}
+        onClick={handleLinkClick}
+        ref={innerRef}
+        rel={rel}
+        rounding="circle"
+        tapStyle={disabled ? undefined : 'compress'}
+        target={target}
+      >
+        <div
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => {
+            setActive(false);
+            setHovered(false);
+          }}
+          className={classes}
+        >
+          {renderPogComponent()}
+        </div>
+      </Link>
+    );
+  }
+
+  const {
+    accessibilityControls,
+    accessibilityExpanded,
+    accessibilityHaspopup,
+    selected,
+    role = 'button',
+  } = props;
 
   return (
     <button
@@ -102,7 +188,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<
         handleBlur();
         setFocused(false);
       }}
-      onClick={event => onClick && onClick({ event })}
+      onClick={handleClick}
       onFocus={() => setFocused(true)}
       onMouseDown={() => {
         handleMouseDown();
@@ -122,21 +208,10 @@ const IconButtonWithForwardRef: React$AbstractComponent<
       onTouchMove={handleTouchMove}
       onTouchStart={handleTouchStart}
       ref={innerRef}
-      type="button"
-      {...(compressStyle ? { style: compressStyle } : {})}
+      style={compressStyle || undefined}
+      type={role} // eslint-disable-line react/button-has-type
     >
-      <Pog
-        active={!disabled && isActive}
-        bgColor={bgColor}
-        dangerouslySetSvgPath={dangerouslySetSvgPath}
-        focused={!disabled && isFocusVisible && isFocused}
-        hovered={!disabled && isHovered}
-        icon={icon}
-        iconColor={iconColor}
-        padding={padding}
-        selected={selected}
-        size={size}
-      />
+      {renderPogComponent(selected)}
     </button>
   );
 });
@@ -160,12 +235,20 @@ IconButtonWithForwardRef.propTypes = {
     __path: PropTypes.string,
   }),
   disabled: PropTypes.bool,
+  href: PropTypes.string,
   icon: PropTypes.oneOf(Object.keys(icons)),
   iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'white']),
   onClick: PropTypes.func,
   padding: PropTypes.oneOf([1, 2, 3, 4, 5]),
+  rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<
+    'none' | 'nofollow'
+  >),
+  role: PropTypes.oneOf(['button', 'link']),
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
+  target: (PropTypes.oneOf([null, 'self', 'blank']): React$PropType$Primitive<
+    null | 'self' | 'blank'
+  >),
 };
 
 IconButtonWithForwardRef.displayName = 'IconButton';

--- a/packages/gestalt/src/IconButton.jsdom.test.js
+++ b/packages/gestalt/src/IconButton.jsdom.test.js
@@ -1,13 +1,58 @@
 // @flow strict
-import React from 'react';
+import React, { createRef } from 'react';
 import { render } from '@testing-library/react';
 import IconButton from './IconButton.js';
 
 describe('IconButton', () => {
-  it('forwards a ref to the innermost button element', () => {
-    const ref = React.createRef();
+  it('handles click', () => {
+    const mockOnClick = jest.fn();
+    const { getByRole } = render(
+      <IconButton accessibilityLabel="test" icon="add" onClick={mockOnClick} />
+    );
+    getByRole('button').click();
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it('renders a button and forwards a ref to the innermost <button> element', () => {
+    const ref = createRef();
     render(<IconButton disabled accessibilityLabel="test" ref={ref} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
+    // $FlowIgnore[prop-missing]
     expect(ref.current?.disabled).toEqual(true);
+  });
+
+  it('renders a link button and forwards a ref to the innermost <a> element', () => {
+    const ref = createRef();
+    render(
+      <IconButton
+        accessibilityLabel="test"
+        icon="add"
+        role="link"
+        href="http://www.pinterest.com"
+        ref={ref}
+        target="blank"
+      />
+    );
+    expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+    // $FlowIgnore[prop-missing]
+    expect(ref.current?.href).toEqual('http://www.pinterest.com/');
+  });
+
+  it('renders a disabled link button', () => {
+    const ref = createRef();
+    render(
+      <IconButton
+        disabled
+        accessibilityLabel="test"
+        icon="add"
+        role="link"
+        href="http://www.pinterest.com"
+        ref={ref}
+        target="blank"
+      />
+    );
+    expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+    // $FlowIgnore[prop-missing]
+    expect(ref.current?.href).toEqual('');
   });
 });


### PR DESCRIPTION
- Added support to href to IconButton.
- Segmented Flow for each IconButton type to make Flow Type stricter in IconButton.
- Upgraded IconButton Docs to add new props. >> There will be follow up
- Added test.


<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
