### PR TITLE
Layouts: Add form layout example

### DIFF
--- a/docs/src/Layouts.doc.js
+++ b/docs/src/Layouts.doc.js
@@ -1,0 +1,122 @@
+// @flow strict
+import React, { type Node } from 'react';
+import Example from './components/Example.js';
+import PageHeader from './components/PageHeader.js';
+
+const cards: Array<Node> = [];
+const card = c => cards.push(c);
+
+card(
+  <PageHeader
+    name="Layouts"
+    description="A list of easy-to-copy layouts which have been battle tested."
+  />
+);
+
+card(
+  <Example
+    description="Responsive &amp; RTL friendly form layout."
+    name="Form Layout"
+    defaultCode={`
+<Box
+  display="flex"
+  marginLeft={-3}
+  marginRight={-3}
+  marginBottom={-3}
+  marginTop={-3}
+  wrap
+  width="100%"
+  padding={3}
+  direction="column"
+  maxWidth={800}
+>
+  <Box flex="grow" paddingX={3} paddingY={3}>
+    <Heading size="sm" accessibilityLevel={2}>
+      Form Title
+    </Heading>
+  </Box>
+
+  <Box flex="grow" paddingX={3} paddingY={3}>
+    <TextField
+      label="TextField 1"
+      id="textfield1"
+      onChange={() => {}}
+      placeholder="Placeholder"
+    />
+  </Box>
+
+  <Box flex="grow" paddingX={3} paddingY={3}>
+    <Box
+      display="flex"
+      wrap
+      marginLeft={-3}
+      marginRight={-3}
+      marginBottom={-3}
+      marginTop={-3}
+    >
+      <Box flex="grow" paddingX={3} paddingY={3}>
+        <TextField
+          label="TextField 2"
+          id="textfield2"
+          onChange={() => {}}
+          placeholder="Placeholder"
+        />
+      </Box>
+      <Box flex="grow" paddingX={3} paddingY={3}>
+        <TextField
+          label="TextField 3"
+          id="textfield3"
+          onChange={() => {}}
+          placeholder="Placeholder"
+        />
+      </Box>
+    </Box>
+  </Box>
+
+  <Box flex="grow" paddingX={3} paddingY={3}>
+    <SelectList
+      label="SelectList"
+      id="selectlist"
+      options={[
+        {
+          value: 'belgium',
+          label: 'Belgium',
+        },
+        {
+          value: 'france',
+          label: 'France',
+        },
+        {
+          value: 'usa',
+          label: 'USA',
+        },
+      ]}
+      placeholder="Placeholder"
+      onChange={() => {}}
+    />
+  </Box>
+
+  <Box flex="grow" paddingX={3} paddingY={3}>
+    <Box
+      justifyContent="end"
+      marginStart={-1}
+      marginRight={-1}
+      marginTop={-1}
+      marginBottom={-1}
+      display="flex"
+      wrap
+    >
+      <Box paddingX={1} paddingY={1}>
+        <Button text="Cancel" size="lg" inline />
+      </Box>
+      <Box paddingX={1} paddingY={1}>
+        <Button text="Submit" color="red" size="lg" type="submit" />
+      </Box>
+    </Box>
+  </Box>
+</Box>
+`}
+  />
+);
+
+export default cards;

--- a/docs/src/Layouts.doc.js
+++ b/docs/src/Layouts.doc.js
@@ -26,7 +26,6 @@ card(
   marginTop={-3}
   wrap
   width="100%"
-  padding={3}
   direction="column"
   maxWidth={800}
 >

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -16,7 +16,7 @@ export type sidebarIndexType = {|
 const sidebarIndex: Array<sidebarIndexType> = [
   {
     sectionName: 'Getting Started',
-    pages: ['Installation', 'Development', 'Faq'],
+    pages: ['Installation', 'Development', 'Layouts', 'Faq'],
   },
   {
     sectionName: 'Foundation',


### PR DESCRIPTION
# Layouts

* Add a "Layouts" page
* Add a `Form Layout` example which is responsive, works with RTL and dark mode

![layouts-form-layout](https://user-images.githubusercontent.com/127199/92136894-6a882600-edc1-11ea-95e1-97c056e28b66.gif)

## Test Plan

- [ ] Test on netlify as soon as the preview goes out
- [ ] Approved by design /cc @ashleyseto @anniemochi 