### PR TITLE
Layer: convert to function component

### DIFF
--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -1,54 +1,36 @@
 // @flow strict
-import { Component, type Portal, type Node } from 'react';
+import { useRef, useState, type Portal, type Node, useEffect } from 'react';
 // flowlint-next-line untyped-import:off
 import { createPortal } from 'react-dom';
 
-type Props = {|
+export default function Layer({
+  children,
+}: {|
   children: Node,
-|};
+|}): Portal | null {
+  const [mounted, setMounted] = useState(false);
+  const element = useRef<?HTMLDivElement>(null);
 
-type State = {|
-  mounted: boolean,
-|};
+  useEffect(() => {
+    setMounted(true);
 
-export default class Layer extends Component<Props, State> {
-  state: State = {
-    mounted: false,
-  };
-
-  el: HTMLDivElement;
-
-  constructor(props: Props) {
-    super(props);
     if (typeof document !== 'undefined' && document.createElement) {
-      this.el = document.createElement('div');
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Using Layer without document present. Children will not be rendered.'
-      );
+      element.current = document.createElement('div');
     }
-  }
 
-  componentDidMount() {
-    if (typeof document !== 'undefined' && document.body) {
-      document.body.appendChild(this.el);
-      this.setState({ mounted: true });
+    if (typeof document !== 'undefined' && document.body && element.current) {
+      document.body.appendChild(element.current);
     }
-  }
 
-  componentWillUnmount() {
-    if (document.body) {
-      document.body.removeChild(this.el);
-    }
-  }
+    return () => {
+      if (typeof document !== 'undefined' && document.body && element.current) {
+        document.body.removeChild(element.current);
+      }
+    };
+  }, []);
 
-  render(): Portal | null {
-    const { children } = this.props;
-    const { mounted } = this.state;
-    if (!mounted) {
-      return null;
-    }
-    return createPortal(children, this.el);
+  if (!mounted || !element.current) {
+    return null;
   }
+  return createPortal(children, element.current);
 }

--- a/packages/gestalt/src/Layer.test.js
+++ b/packages/gestalt/src/Layer.test.js
@@ -11,11 +11,7 @@ describe('Layer in server render', () => {
       return;
     }
 
-    const warnSpy = jest.spyOn(console, 'warn');
     const tree = create(<Layer>content</Layer>).toJSON();
     expect(tree).toEqual(null);
-    expect(warnSpy).toHaveBeenCalledWith(
-      'Using Layer without document present. Children will not be rendered.'
-    );
   });
 });


### PR DESCRIPTION
Convert `<Layer />` to a function component. Makes the code more readable + consistent with other components in our codebase.

## Test Plan

1. Jest tests pass for `<Layer />`
2. Go to `/Layer` in the docs & verify the layer shows + hides correctly

![image](https://user-images.githubusercontent.com/127199/92261535-6c6beb00-ee8e-11ea-9d82-9b9c2960d834.png)

