### PR TITLE
Internal: avoid blank page on startup in dev + fix most docs exceptions in incremental builds

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -40,5 +40,16 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
+    <script>
+      (() => {
+        // On dev startup, we don't want to show a blank page, refresh until we do have content on the page
+        setInterval(() => {
+          const rootElement = document.querySelector('#root');
+          if (rootElement && rootElement.innerHTML === '') {
+            location.reload();
+          }
+        }, 5000);
+      })();
+    </script>
   </body>
 </html>

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -9,6 +9,9 @@ import PageHeader from './components/PageHeader.js';
 const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
+// $FlowIssue
+const icons: Array<string> = Icon?.icons ?? [];
+
 card(
   <PageHeader
     name="Icon"
@@ -37,8 +40,7 @@ card(
       },
       {
         name: 'icon',
-        // $FlowIssue[prop-missing]
-        type: Icon.icons.map(name => `'${name}'`).join(' | '),
+        type: icons.map(name => `'${name}'`).join(' | '),
         description: `This allows us to type check for a valid icon name based on the keys from the list of icons shown below.`,
         href: 'iconCombinations',
       },
@@ -82,8 +84,7 @@ card(
 );
 
 card(
-  // $FlowIssue[prop-missing]
-  <Combination id="iconCombinations" name="Icon Combinations" icon={Icon.icons}>
+  <Combination id="iconCombinations" name="Icon Combinations" icon={icons}>
     {props => (
       <Icon color="darkGray" accessibilityLabel="" size={32} {...props} />
     )}

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -93,7 +93,7 @@ card(
   <PropTable
     showHeading={false}
     // $FlowIssue[prop-missing]
-    Component={Table.Body}
+    Component={Table?.Body}
     props={[
       {
         name: 'children',
@@ -109,7 +109,7 @@ card(
   <PropTable
     showHeading={false}
     // $FlowIssue[prop-missing]
-    Component={Table.Cell}
+    Component={Table?.Cell}
     props={[
       {
         name: 'children',
@@ -135,7 +135,7 @@ card(
   <PropTable
     showHeading={false}
     // $FlowIssue[prop-missing]
-    Component={Table.Footer}
+    Component={Table?.Footer}
     props={[
       {
         name: 'children',
@@ -151,7 +151,7 @@ card(
   <PropTable
     showHeading={false}
     // $FlowIssue[prop-missing]
-    Component={Table.Header}
+    Component={Table?.Header}
     props={[
       {
         name: 'children',
@@ -210,7 +210,7 @@ card(
   <PropTable
     showHeading={false}
     // $FlowIssue[prop-missing]
-    Component={Table.HeaderCell}
+    Component={Table?.HeaderCell}
     props={[
       {
         name: 'children',
@@ -241,7 +241,7 @@ card(
   <PropTable
     showHeading={false}
     // $FlowIssue[prop-missing]
-    Component={Table.Row}
+    Component={Table?.Row}
     props={[
       {
         name: 'children',
@@ -262,7 +262,7 @@ card(
   <PropTable
     showHeading={false}
     // $FlowIssue[prop-missing]
-    Component={Table.SortableHeaderCell}
+    Component={Table?.SortableHeaderCell}
     props={[
       {
         name: 'children',


### PR DESCRIPTION
* We previously showed a blank page when running `yarn start`, this PR should fix that.
* During incremental builds, we were continuously seeing exceptions about `icons` not being defined on `Icon`.

## Test Plan

* Check out this branch
* Run `yarn start`
* Verify the docs show correctly (no blank page)