### PR TITLE
TapArea: implemented href with InternalLink

### DIFF
--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -61,7 +61,7 @@ card(
         required: false,
         defaultValue: null,
         description: [
-          'Indicate that a button component controls the appearance of menus and expose whether they are currently opened or closed.',
+          'Indicate that a button component controls the appearance of interactive popup elements, such as menu or dialog.',
           'Optional with button-role + button-type buttons.',
           'Accessibility: It populates aria-haspopup.',
         ],
@@ -224,7 +224,7 @@ card(
 
 card(
   <Example
-    name="Basic button"
+    name="Basic Button"
     id="basic-button"
     defaultCode={`<Button text="Medium-sized button" inline />`}
   />
@@ -458,6 +458,7 @@ function MenuButtonExample() {
     <>
       <Box display="inlineBlock" ref={anchorRef}>
         <Button
+          accessibilityControls="menu"
           accessibilityExpanded={selected}
           accessibilityHaspopup
           selected={selected}
@@ -476,7 +477,7 @@ function MenuButtonExample() {
             positionRelativeToAnchor={false}
             size="md"
           >
-            <Box direction="column" display="flex" padding={2}>
+            <Box id="menu" direction="column" display="flex" padding={2}>
               <Box padding={2}>
                 <Text weight="bold">
                   Option 1

--- a/docs/src/TapArea.doc.js
+++ b/docs/src/TapArea.doc.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Box, Image, Mask, TapArea } from 'gestalt';
+import { Box, TapArea, Text } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import Combination from './components/Combination.js';
 import Example from './components/Example.js';
@@ -12,7 +12,7 @@ const card = c => cards.push(c);
 card(
   <PageHeader
     name="TapArea"
-    description="TapArea allows for elements to be clickable / touched in an accessible way. We add cursor & focus styles, trigger the `onTap` when hitting Space / Enter and correct aria roles."
+    description="TapArea allows components to be clickable & touchable in an accessible way."
   />
 );
 
@@ -20,142 +20,281 @@ card(
   <PropTable
     props={[
       {
+        name: 'accessibilityLabel',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply a short, descriptive label for screen-readers to replace TapArea texts that do not provide sufficient context about the button component behavior.',
+          'Accessibility: It populates aria-label.',
+        ],
+        href: 'accessibility',
+      },
+      {
         name: 'accessibilityControls',
         type: 'string',
-        description:
-          'Identifies the element whose contents or presence are controlled by the current element. Populates aria-controls.',
-        href: 'accessibility-disclosure',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Specify the `id` of an associated element (or elements) whose contents or visibility are controlled by a button component so that screen reader users can identify the relationship between elements.',
+          'Optional with button-role.',
+          'Accessibility: It populates aria-controls.',
+        ],
+        href: 'accessibility',
       },
       {
         name: 'accessibilityExpanded',
         type: 'boolean',
-        description:
-          'Use this property on elements that can expand to reveal additional information. Populates aria-expanded.',
-        href: 'accessibility-disclosure',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Indicate that a button component hides or exposes collapsible components and expose whether they are currently expanded or collapsed.',
+          'Optional with button-role.',
+          'Accessibility: It populates aria-expanded.',
+        ],
+        href: 'accessibility',
       },
       {
         name: 'accessibilityHaspopup',
         type: 'boolean',
-        description:
-          'Indicates that the element has a popup context menu or sub-level menu. Populates aria-haspopup.',
-        href: 'accessibility-popup',
-      },
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        description:
-          'String that clients such as VoiceOver will read to describe the element. Populates aria-label.',
-        href: 'accessibility-popup',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Indicate that a button component controls the appearance of interactive popup elements, such as menu or dialog.',
+          'Optional with button-role.',
+          'Accessibility: It populates aria-haspopup.',
+        ],
+        href: 'accessibility',
       },
       {
         name: 'children',
         type: 'React.Node',
+        required: true,
+        defaultValue: null,
+        description:
+          'TapArea is a wrapper around non-button components (or children) that provides clicking / touching functionality as if they were a unified button area.',
+        href: 'basic-taparea',
       },
       {
         name: 'disabled',
         type: 'boolean',
+        required: false,
+        defaultValue: null,
         description:
-          'Disables the TapArea area, prevents the events, remove the element from the tab order and populates aria-label.',
-        defaultValue: false,
-        href: 'disabled',
+          'Set disabled state so TapArea cannot be interacted with and actions are not available.',
+        href: 'roles',
       },
       {
         name: 'fullHeight',
         type: 'boolean',
-        description: 'Expands to the full height of the parent.',
-        href: 'fullHeightWidthExample',
+        required: false,
+        defaultValue: null,
+        description:
+          'Set the TapArea height to expand to the full height of the parent.',
+        href: 'fullHeightWidth',
       },
       {
         name: 'fullWidth',
         type: 'boolean',
-        description: 'Expands to the full width of the parent.',
+        required: false,
         defaultValue: true,
-        href: 'fullHeightWidthExample',
+        description:
+          'Set the TapArea width to expand to the full width of the parent.',
+        href: 'fullHeightWidth',
       },
       {
         name: 'mouseCursor',
         type: `"copy" | "grab" | "grabbing" | "move" | "noDrop" | "pointer" | "zoomIn" | "zoomOut"`,
+        required: false,
         defaultValue: 'pointer',
-        href: 'basicExample',
+        description: [
+          'Select a mouse cursor type to convey the TapArea expected behavior .',
+        ],
+        href: 'mouseCursor',
       },
       {
         name: 'onBlur',
-        type: '({ event: SyntheticFocusEvent<HTMLDivElement> }) => void',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLButtonElement> | SyntheticFocusEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: ['Callback fired when a TapArea component loses focus.'],
+        href: 'basicExample',
       },
       {
         name: 'onFocus',
-        type: '({ event: SyntheticFocusEvent<HTMLDivElement> }) => void',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLButtonElement> | SyntheticFocusEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a TapArea component gets focus via keyboard navigation, mouse click (pressed), or focus method',
+        ],
+        href: 'basicExample',
       },
       {
         name: 'onMouseEnter',
-        type: '({ event: SyntheticMouseEvent<HTMLDivElement> }) => void',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a mouse pointer moves onto a TapArea component.',
+        ],
+        href: 'basicExample',
       },
       {
         name: 'onMouseLeave',
-        type: '({ event: SyntheticMouseEvent<HTMLDivElement> }) => void',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a mouse pointer moves out a TapArea component.',
+        ],
+        href: 'basicExample',
       },
       {
         name: 'onTap',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> }) => void',
-        href: 'basicExample',
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a TapArea component is clicked (pressed and released) with a mouse or keyboard.',
+        ],
+        href: 'basic-taparea',
       },
       {
         name: 'ref',
-        type: "React.Ref<'div'>",
-        description: 'Forward the ref to the underlying div element',
-      },
-      {
-        name: 'tapStyle',
-        type: `"none" | "compress"`,
-        description: `Style when the TapArea is clicked / touched. Value "compress" scales down by 1%.`,
-        defaultValue: 'none',
-        href: 'tapStyleCombinations',
+        type: `React.Ref<'div'> | React.Ref<'a'>`,
+        required: false,
+        defaultValue: null,
+        description: 'Forward the ref to the underlying div or anchor element.',
+        href: 'ref',
       },
       {
         name: 'rounding',
         type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
-        href: 'basicExample',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Sets a border radius for the TapArea. Select a rounding option that aligns with its children.',
+          'Options are "circle" or "pill" for fully rounded corners or 0-8 representing the radius in boints.',
+        ],
+        href: 'rounding',
+      },
+      {
+        name: 'href',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: ['Specify a link URL.', 'Required with role=link.'],
+        href: 'roles',
+      },
+      {
+        name: 'role',
+        type: `'button' | 'link'`,
+        required: false,
+        defaultValue: 'button',
+        description: [
+          `Select a TapArea variant:`,
+          `- 'button': Use for TapArea to act like buttons. The TapArea is rendered as a '<div>'.`,
+          `- 'link': Use for TapArea to act like links. The button is rendered as an '<a>'.`,
+          `Required with role=link.`,
+        ],
+        href: 'roles',
+      },
+      {
+        name: 'rel',
+        type: `'none' | 'nofollow'`,
+        required: false,
+        defaultValue: 'none',
+        description: 'Optional with role=link.',
+        href: 'roles',
+      },
+      {
+        name: 'target',
+        type: `null | 'self' | 'blank'`,
+        required: false,
+        defaultValue: 'null',
+        description: [
+          'Define the frame or window to open the anchor defined on `href`:',
+          '- `null` opens the anchor in the same window.',
+          '- `blank` opens the anchor in a new window.',
+          '- `self` opens an anchor in the same frame.',
+          'Optional with role=link.',
+        ],
+        href: 'roles',
       },
     ]}
   />
 );
 
 card(
-  <Example
-    id="basicExample"
-    description={`
-    For a generic container to be clickable, use the TapArea component.
-
-    If you have a \`Link\` or \`Button\` inside of TapArea, you can apply \`e.stopPropagation()\` so the \`onTap\` doesn't get triggered.
+  <>
+    <Example
+      name="Basic TapArea"
+      id="basic-taparea"
+      defaultCode={`
+function TapAreaExample() {
+  return (
+    <Box rounding={4} borderSize="sm" column={2}>
+      <TapArea rounding={4}>
+        <Box
+          alignItems="center"
+          direction="column"
+          display="flex"
+          padding={3}
+        >
+          <Avatar
+            name="Alberto"
+            size="xl"
+            src="https://i.ibb.co/NsK2w5y/Alberto.jpg"
+            verified
+          />
+          <Text weight="bold">Alberto's Profile</Text>
+        </Box>
+      </TapArea>
+    </Box>
+  );
+}
+`}
+    />
+    <Example
+      id="link_buttons"
+      description={`If you have a \`Link\` or \`Button\` inside of TapArea, you can apply \`e.stopPropagation()\` so the \`onTap\` doesn't get triggered.
   `}
-    name="Example"
-    defaultCode={`
+      name="TapArea with Link/Buttons"
+      defaultCode={`
 function TapAreaExample() {
   const [touches, setTouches] = React.useState(0);
 
   return (
-    <Box width={130}>
+    <Box column={2}>
       <TapArea
-        mouseCursor="zoomIn"
         onTap={() => setTouches(touches + 1)}
         rounding={2}
       >
-        <Mask rounding={2}>
-          <Image
-            alt="Antelope Canyon"
-            naturalHeight={1}
-            naturalWidth={1}
-            src="https://i.ibb.co/DwYrGy6/stock14.jpg"
-          />
-        </Mask>
-        <Box paddingY={2}>
-          <Link
-            href="https://en.wikipedia.org/wiki/Antelope_Canyon"
-            onClick={({ event }) => event.stopPropagation()}
-          >
-            <Text align="center">Wiki Link</Text>
-          </Link>
+        <Box color='darkGray' rounding={4} borderSize="sm">
+          <Mask rounding={2}>
+            <Image
+              alt="Antelope Canyon"
+              naturalHeight={1}
+              naturalWidth={1}
+              src="https://i.ibb.co/DwYrGy6/stock14.jpg"
+            />
+          </Mask>
+          <Box paddingY={2}>
+            <Link
+              href="https://www.pinterest.com/search/pins/?rs=ac&len=2&q=antelope%20canyon%20arizona&eq=Antelope%20Canyon"
+              onClick={({ event }) => event.stopPropagation()}
+              rounding="pill"
+              target="blank"
+            >
+              <Text align="center" color="white">Find More on Pinterest</Text>
+            </Link>
+          </Box>
         </Box>
       </TapArea>
       <Box paddingY={2}>
@@ -163,7 +302,69 @@ function TapAreaExample() {
           Touched {touches} {touches === 1 ? 'time' : 'times'}
         </Text>
       </Box>
-    </Box>
+    </Box>  );
+}
+`}
+    />
+  </>
+);
+
+card(
+  <Example
+    name="Roles"
+    id="roles"
+    defaultCode={`
+function Example() {
+  const [disabled, setDisabled] = React.useState(false);
+  const [touches, setTouches] = React.useState(0);
+
+  return (
+    <Stack gap={3}>
+      <Row gap={3}>
+        <Tooltip text="Default TapArea">
+          <TapArea disabled={disabled} onTap={() => setTouches(touches + 1)} >
+            <Box padding={3} column={12} borderSize="lg" width={200}>
+              <Mask rounding={2}>
+                <Image
+                  alt="Antelope Canyon"
+                  naturalHeight={1}
+                  naturalWidth={1}
+                  src="https://i.ibb.co/DwYrGy6/stock14.jpg"
+                />
+              </Mask>
+              <Text align="center">Touched {touches} {touches === 1 ? 'time' : 'times'}</Text>
+            </Box>
+          </TapArea>
+        </Tooltip>
+        <Tooltip text="Link TapArea">
+          <TapArea disabled={disabled} role="link" target="blank" href="https://www.pinterest.com" >
+            <Box padding={3} column={12} borderSize="lg" width={200}>
+              <Mask rounding={2}>
+                <Image
+                  alt="Antelope Canyon"
+                  naturalHeight={1}
+                  naturalWidth={1}
+                  src="https://i.ibb.co/DwYrGy6/stock14.jpg"
+                />
+              </Mask>
+              <Text align="center">Visit Pinterest.com</Text>
+            </Box>
+          </TapArea>
+        </Tooltip>
+      </Row>
+      <Row gap={1}>
+        <Switch
+          onChange={() => setDisabled(!disabled)}
+          id="disable-buttons"
+          switched={disabled}
+        />
+        <Box paddingX={2} flex="grow">
+          <Label htmlFor="disable-buttons">
+            <Text>Disable TapArea</Text>
+          </Label>
+        </Box>
+      </Row>
+    </Stack>
   );
 }
 `}
@@ -172,12 +373,8 @@ function TapAreaExample() {
 
 card(
   <Example
-    id="fullHeightWidthExample"
-    description={`
-    \`fullWidth\` and \`fullHeight\` are flags on \`TapArea\` controlling how it is sized relative to the parent container.
-    If one is set to \`true\`, the \`TapArea\` component will expand to the full size of its parent in that direction.
-  `}
-    name="Full width and full height"
+    name="Height & Width"
+    id="fullHeightWidth"
     defaultCode={`
 <Box color="olive" display="flex" width={500} height={250}>
   <Box borderSize="sm" margin={3} column={6}>
@@ -204,176 +401,63 @@ card(
 );
 
 card(
-  <Example
-    id="accessibility-popup"
-    description={`
-      We want to make sure every TapArea on the page is unique when being read by screenreader.
-      - \`accessibilityHaspopup\` specifies that the button has associated content (i.e. Flyout).
-      - \`accessibilityLabel\` updates the spoken text.
-  `}
-    name="Example: Accessibility (Popup)"
-    defaultCode={`
-function AccessibilityExamplePopup() {
-  const [isOpen, setOpen] = React.useState(false);
-  const anchorRef = React.useRef(null);
-
-  return (
-    <Box display="inlineBlock" ref={anchorRef}>
-      <TapArea
-        accessibilityHaspopup
-        accessibilityLabel="see more"
-        onTap={() => setOpen(!isOpen)}
-        rounding="pill"
-      >
-        <Box
-          borderSize="sm"
-          padding={2}
-          rounding="pill"
-        >
-          <Row gap={1}>
-            <Text weight="bold">See more</Text>
-            <Icon accessibilityLabel="ellipsis icon" color="darkGray" icon="ellipsis" />
-          </Row>
+  <Combination
+    id="mouseCursor"
+    name="Mouse Cursor"
+    mouseCursor={[
+      'copy',
+      'grab',
+      'grabbing',
+      'move',
+      'noDrop',
+      'pointer',
+      'zoomIn',
+      'zoomOut',
+    ]}
+  >
+    {(props, i) => (
+      <TapArea id={`example-${i}`} {...props}>
+        <Box borderSize="lg" padding={3} color="white">
+          <Text>{props.mouseCursor}</Text>
         </Box>
       </TapArea>
-      {isOpen && (
-        <Flyout
-          anchor={anchorRef && anchorRef.current}
-          idealDirection="right"
-          onDismiss={() => {}}
-        >
-          <Box alignItems="center" display="flex" padding={2}>
-            <Text>I am a popup.</Text>
-          </Box>
-        </Flyout>
-      )}
-    </Box>
-  );
-}
-`}
-  />
-);
-
-card(
-  <Example
-    id="accessibility-disclosure"
-    description={`
-      We want to make sure every TapArea area on the page is unique when being read by screenreader.
-      - \`accessibilityControls\` specifies the \`id\` of an associated content element (i.e. Accordion panel) which is controlled by this TapArea area.
-      - \`accessibilityExpanded\` specifies that the associated content (i.e. Accordion panel) is open.
-      - \`accessibilityLabel\` updates the spoken text.
-
-      Be sure to internationalize your \`accessibilityLabel\`.
-  `}
-    name="Example: Accessibility (Disclosure)"
-    defaultCode={`
-function AccessibilityExampleDisclosure() {
-  const [isOpen, setOpen] = React.useState(false);
-
-  return (
-    <Box width={200}>
-      <TapArea
-        accessibilityControls="accordion-panel"
-        accessibilityExpanded={isOpen}
-        onTap={() => setOpen(!isOpen)}
-        rounding="pill"
-      >
-        <Box borderSize="sm" padding={2} rounding="pill">
-          <Row justifyContent="between">
-            <Text weight="bold">{isOpen ? 'Collapse' : 'Expand'}</Text>
-            <Icon
-              accessibilityLabel=""
-              icon={isOpen ? 'arrow-up' : 'arrow-down'}
-              color="darkGray"
-            />
-          </Row>
-        </Box>
-      </TapArea>
-      {isOpen && (
-        <Box id="accordion-panel" role="region" padding={2}>
-          <Text>I am an accordion panel.</Text>
-        </Box>
-      )}
-    </Box>
-  );
-}`}
-  />
-);
-
-card(
-  <Example
-    id="disabled"
-    description={`Set \`disable\` on a \`TapArea\` to prevent event propagation, remove the element from tab order, and populate \`aria-label\`.`}
-    name="Example: Disabled"
-    defaultCode={`
-function DisabledExample() {
-  const [clickCount, setClickCount] = React.useState(0);
-  const hasReachedLimit = clickCount === 5;
-  const bgColor = hasReachedLimit ? 'lightGray' : 'white';
-  const icon = hasReachedLimit ? 'face-sad' : 'face-happy';
-
-  return (
-    <Box width={200}>
-      <TapArea
-        accessibilityControls="count-panel"
-        disabled={hasReachedLimit}
-        onTap={() => setClickCount(clickCount + 1)}
-      >
-        <Box
-          borderSize="sm"
-          color={bgColor}
-          padding={2}
-          rounding="pill"
-        >
-          <Row justifyContent="between">
-            <Text weight="bold">Click me</Text>
-            <Icon accessibilityLabel="" icon={icon} color="darkGray" />
-          </Row>
-        </Box>
-      </TapArea>
-      <Box id="count-panel" role="region" padding={2}>
-        <Text>Number of touches: {clickCount}</Text>
-      </Box>
-    </Box>
-  );
-}
-`}
-  />
+    )}
+  </Combination>
 );
 
 card(
   <Combination
-    id="tapStyleCombinations"
-    name="Combinations: tapStyle"
-    description={`\`tapStyle\` "compress" scales down by 1% on click / touch.`}
-    tapStyle={['none', 'compress']}
+    id="rounding"
+    name="Rounding"
+    rounding={[0, 1, 2, 3, 4, 5, 6, 7, 8, 'circle', 'pill']}
   >
-    {props => (
-      <Box padding={2} width={150}>
-        <TapArea {...props} rounding="circle">
-          <Mask rounding="circle">
-            <Image
-              alt="Antelope Canyon"
-              naturalHeight={1}
-              naturalWidth={1}
-              src="https://i.ibb.co/DwYrGy6/stock14.jpg"
-            />
-          </Mask>
-        </TapArea>
-      </Box>
+    {(props, i) => (
+      <TapArea id={`example-${i}`} {...props}>
+        <Box
+          color="white"
+          borderSize="lg"
+          width={props.rounding === 'pill' ? 120 : 70}
+          height={70}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          {...props}
+        >
+          <Text>{props.rounding}</Text>
+        </Box>
+      </TapArea>
     )}
   </Combination>
 );
 
 card(
   <Example
-    id="ref example"
-    name="Example: ref"
-    description={`A \`TapArea\` can be focused via \`ref\``}
+    id="ref"
+    name="ref"
     defaultCode={`
 function TapAreaRefExample() {
   const ref = React.useRef();
-  const [touches, setTouches] = React.useState(0);
+  const [focus, setFocus] = React.useState(0);
 
   return (
     <Row gap={1}>
@@ -381,22 +465,94 @@ function TapAreaRefExample() {
         text="Focus the TapArea"
         onClick={() => ref.current.focus()}
       />
-        <TapArea
-          ref={ref}
+      <TapArea
+        ref={ref}
+        rounding="pill"
+        onFocus={() => setFocus(focus + 1)}
+      >
+        <Box
+          borderSize="sm"
+          padding={2}
           rounding="pill"
-          onTap={() => setTouches(touches + 1)}
         >
-          <Box
-            borderSize="sm"
-            padding={2}
-            rounding="pill"
-          >
-            <Text>TapArea is touched {touches} times</Text>
-          </Box>
-        </TapArea>
+          <Text>TapArea is focused {focus} times</Text>
+        </Box>
+      </TapArea>
     </Row>
   );
 }`}
+  />
+);
+
+card(
+  <Example
+    name="Accessibility: label, controls, expanded, & popup"
+    id="accessibility"
+    defaultCode={`
+function MenuButtonExample() {
+  const [selected, setSelected] = React.useState(false);
+  const anchorRef = React.useRef();
+
+  return (
+    <>
+        <TapArea
+          accessibilityLabel="Open the options menu"
+          accessibilityControls="menu"
+          accessibilityExpanded={selected}
+          accessibilityHaspopup
+          onTap={() => setSelected(!selected)}
+        >
+          <Box
+            ref={anchorRef}
+            borderSize="sm"
+            display="inlineBlock"
+            alignItems="center"
+            rounding={1}
+            padding={2}
+          >
+            <Row gap={1}>
+              <Box height={50} width={50}>
+                <Mask rounding={1}>
+                  <Image
+                    alt="Antelope Canyon"
+                    naturalHeight={1}
+                    naturalWidth={1}
+                    src="https://i.ibb.co/FY2MKr5/stock6.jpg"
+                  />
+                </Mask>
+              </Box>
+              <Text weight="bold" align="center">Menu</Text>
+            </Row>
+          </Box>
+      </TapArea>
+      {selected && (
+        <Layer>
+          <Flyout
+            anchor={anchorRef.current}
+            idealDirection="down"
+            onDismiss={() => setSelected(false)}
+            positionRelativeToAnchor={false}
+            size="md"
+          >
+            <Box id="menu" direction="column" display="flex" padding={2}>
+              <Box padding={2}>
+                <Text weight="bold">
+                  Option 1
+                </Text>
+              </Box>
+              <Box padding={2}>
+                <Text weight="bold">
+                  Option 2
+                </Text>
+              </Box>
+            </Box>
+          </Flyout>
+        </Layer>
+      )}
+    </>
+  );
+}
+`}
   />
 );
 

--- a/packages/gestalt-codemods/13.2.0-13.3.0/__testfixtures__/tapArea-remove-tapStyle-prop.input.js
+++ b/packages/gestalt-codemods/13.2.0-13.3.0/__testfixtures__/tapArea-remove-tapStyle-prop.input.js
@@ -1,0 +1,12 @@
+// @flow strict
+import React from 'react';
+import { Box, TapArea, TapArea as Renamed } from 'gestalt';
+
+export default function TestBox() {
+  return (
+    <Box>
+      <TapArea tapStyle="none"/>
+      <Renamed tapStyle="none"/>
+    </Box>
+  );
+}

--- a/packages/gestalt-codemods/13.2.0-13.3.0/__testfixtures__/tapArea-remove-tapStyle-prop.output.js
+++ b/packages/gestalt-codemods/13.2.0-13.3.0/__testfixtures__/tapArea-remove-tapStyle-prop.output.js
@@ -1,0 +1,12 @@
+// @flow strict
+import React from 'react';
+import { Box, TapArea, TapArea as Renamed } from 'gestalt';
+
+export default function TestBox() {
+  return (
+    <Box>
+      <TapArea />
+      <Renamed />
+    </Box>
+  );
+}

--- a/packages/gestalt-codemods/13.2.0-13.3.0/__tests__/tapArea-remove-tapStyle-prop.test.js
+++ b/packages/gestalt-codemods/13.2.0-13.3.0/__tests__/tapArea-remove-tapStyle-prop.test.js
@@ -1,0 +1,18 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../tapArea-remove-tapStyle-prop', () => {
+  return Object.assign(jest.requireActual('../tapArea-remove-tapStyle-prop'), {
+    parser: 'flow',
+  });
+});
+
+describe('tapArea-remove-tapStyle-prop', () => {
+  ['tapArea-remove-tapStyle-prop'].forEach(test => {
+    defineTest(
+      __dirname,
+      'tapArea-remove-tapStyle-prop',
+      { quote: 'single' },
+      test
+    );
+  });
+});

--- a/packages/gestalt-codemods/13.2.0-13.3.0/tapArea-remove-tapStyle-prop.js
+++ b/packages/gestalt-codemods/13.2.0-13.3.0/tapArea-remove-tapStyle-prop.js
@@ -1,0 +1,66 @@
+/*
+ * Converts
+ *  <TapArea tapStyle='compress' /> to <TapArea />
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter(node => node.imported.name === 'TapArea')
+      .map(node => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach(jsxElement => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some(attr => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove Dynamic Text properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`
+        );
+      }
+
+      let tempAttr;
+      let newAttribute;
+      const newAttrs = attrs
+        .map(attr =>
+          attr?.name?.name && attr.name.name === 'tapStyle' ? null : attr
+        )
+        .filter(Boolean);
+
+      fileHasModifications = true;
+
+      let appendedAttr = tempAttr || false;
+      appendedAttr = tempAttr && newAttribute ? newAttribute : tempAttr;
+
+      node.openingElement.attributes = appendedAttr
+        ? [...newAttrs, ...appendedAttr]
+        : newAttrs;
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -11,7 +11,9 @@ type Props = {|
   onSortChange: ({|
     event:
       | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
+      | SyntheticKeyboardEvent<HTMLDivElement>
+      | SyntheticMouseEvent<HTMLAnchorElement>
+      | SyntheticKeyboardEvent<HTMLAnchorElement>,
   |}) => void,
   rowSpan?: number,
   scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',

--- a/packages/gestalt/src/TapArea.flowtest.js
+++ b/packages/gestalt/src/TapArea.flowtest.js
@@ -1,0 +1,22 @@
+// @flow strict
+import React from 'react';
+import TapArea from './TapArea.js';
+
+const ValidDefaultTapAreaType = <TapArea />;
+
+const ValidLinkRole = <TapArea role="link" href="http://www.pinterest.com" />;
+
+const NonExistingProp = (
+  // $FlowExpectedError[incompatible-type]
+  <TapArea nonexisting={33} />
+);
+
+const IncompatibleLinkProps = (
+  // $FlowExpectedError[incompatible-type]
+  <TapArea role="link" accessibilityHasPop />
+);
+
+const IncompatibleDefaultTapAreaProps = (
+  // $FlowExpectedError[incompatible-type]
+  <TapArea type="button" target="blank" />
+);

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -3,12 +3,12 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useRef,
-  type Element,
   type Node,
 } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './Touchable.css';
+import InternalLink from './InternalLink.js';
 import useTapFeedback, { keyPressShouldTriggerTap } from './useTapFeedback.js';
 import getRoundingClassName, {
   RoundingPropType,
@@ -18,10 +18,15 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import focusStyles from './Focus.css';
 import useFocusVisible from './useFocusVisible.js';
 
-type Props = {|
-  accessibilityControls?: string,
-  accessibilityExpanded?: boolean,
-  accessibilityHaspopup?: boolean,
+type FocusEventHandler = AbstractEventHandler<
+  SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement>
+>;
+
+type MouseEventHandler = AbstractEventHandler<
+  SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>
+>;
+
+type BaseTapArea = {|
   accessibilityLabel?: string,
   children?: Node,
   disabled?: boolean,
@@ -36,28 +41,42 @@ type Props = {|
     | 'pointer'
     | 'zoomIn'
     | 'zoomOut',
-  onBlur?: AbstractEventHandler<SyntheticFocusEvent<HTMLDivElement>>,
-  onFocus?: AbstractEventHandler<SyntheticFocusEvent<HTMLDivElement>>,
-  onMouseEnter?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
-  onMouseLeave?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
+  onBlur?: FocusEventHandler,
+  onFocus?: FocusEventHandler,
+  onMouseEnter?: MouseEventHandler,
+  onMouseLeave?: MouseEventHandler,
   onTap?: AbstractEventHandler<
-    SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement>
+    | SyntheticMouseEvent<HTMLDivElement>
+    | SyntheticKeyboardEvent<HTMLDivElement>
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>
   >,
-  tapStyle?: 'none' | 'compress',
   rounding?: Rounding,
 |};
+type TapAreaType = {|
+  ...BaseTapArea,
+  accessibilityControls?: string,
+  accessibilityExpanded?: boolean,
+  accessibilityHaspopup?: boolean,
+  role?: 'button',
+|};
+
+type LinkTapAreaType = {|
+  ...BaseTapArea,
+  href: string,
+  rel?: 'none' | 'nofollow',
+  role: 'link',
+  target?: null | 'self' | 'blank',
+|};
+
+type unionProps = TapAreaType | LinkTapAreaType;
+type unionRefs = HTMLDivElement | HTMLAnchorElement;
 
 const TapAreaWithForwardRef: React$AbstractComponent<
-  Props,
-  HTMLDivElement
-> = forwardRef<Props, HTMLDivElement>(function TapArea(
-  props,
-  ref
-): Element<'div'> {
+  unionProps,
+  unionRefs
+> = forwardRef<unionProps, unionRefs>(function TapArea(props, ref): Node {
   const {
-    accessibilityControls,
-    accessibilityExpanded,
-    accessibilityHaspopup,
     accessibilityLabel,
     children,
     disabled = false,
@@ -69,7 +88,6 @@ const TapAreaWithForwardRef: React$AbstractComponent<
     onMouseEnter,
     onMouseLeave,
     onTap,
-    tapStyle = 'none',
     rounding = 0,
   } = props;
 
@@ -94,7 +112,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<
 
   const { isFocusVisible } = useFocusVisible();
 
-  const className = classnames(
+  const buttonRoleClasses = classnames(
     focusStyles.hideOutline,
     styles.tapTransition,
     getRoundingClassName(rounding),
@@ -103,10 +121,82 @@ const TapAreaWithForwardRef: React$AbstractComponent<
       [styles.fullHeight]: fullHeight,
       [styles.fullWidth]: fullWidth,
       [styles[mouseCursor]]: !disabled,
-      [styles.tapCompress]: !disabled && tapStyle === 'compress' && isTapping,
+      [styles.tapCompress]: props.role !== 'link' && !disabled && isTapping,
     }
   );
 
+  const handleClick = event => {
+    if (!disabled && onTap) {
+      onTap({ event });
+    }
+  };
+
+  const handleLinkClick = ({ event }) => handleClick(event);
+
+  const handleOnBlur = event => {
+    if (!disabled && onBlur) {
+      onBlur({ event });
+    }
+  };
+
+  const handleLinkOnBlur = ({ event }) => handleOnBlur(event);
+
+  const handleOnFocus = event => {
+    if (!disabled && onFocus) {
+      onFocus({ event });
+    }
+  };
+
+  const handleLinkOnFocus = ({ event }) => handleOnFocus(event);
+
+  const handleOnMouseEnter = event => {
+    if (!disabled && onMouseEnter) {
+      onMouseEnter({ event });
+    }
+  };
+
+  const handleLinkOnMouseEnter = ({ event }) => handleOnMouseEnter(event);
+
+  const handleOnMouseLeave = event => {
+    if (!disabled && onMouseLeave) {
+      onMouseLeave({ event });
+    }
+  };
+
+  const handleLinkOnMouseLeave = ({ event }) => handleOnMouseLeave(event);
+
+  if (props.role === 'link') {
+    const { href, rel = 'none', target = null } = props;
+
+    return (
+      <InternalLink
+        accessibilityLabel={accessibilityLabel}
+        disabled={disabled}
+        href={href}
+        fullHeight={fullHeight}
+        fullWidth={fullWidth}
+        mouseCursor={mouseCursor}
+        onClick={handleLinkClick}
+        onBlur={handleLinkOnBlur}
+        onFocus={handleLinkOnFocus}
+        onMouseEnter={handleLinkOnMouseEnter}
+        onMouseLeave={handleLinkOnMouseLeave}
+        ref={innerRef}
+        rel={rel}
+        rounding={rounding}
+        target={target}
+        wrappedComponent="tapArea"
+      >
+        {children}
+      </InternalLink>
+    );
+  }
+
+  const {
+    accessibilityControls,
+    accessibilityExpanded,
+    accessibilityHaspopup,
+  } = props;
   return (
     <div
       aria-controls={accessibilityControls}
@@ -114,34 +204,16 @@ const TapAreaWithForwardRef: React$AbstractComponent<
       aria-expanded={accessibilityExpanded}
       aria-haspopup={accessibilityHaspopup}
       aria-label={accessibilityLabel}
-      className={className}
+      className={buttonRoleClasses}
       onContextMenu={event => event.preventDefault()}
-      onClick={event => {
-        if (!disabled && onTap) {
-          onTap({ event });
-        }
-      }}
+      onClick={handleClick}
       onBlur={event => {
-        if (!disabled && onBlur) {
-          onBlur({ event });
-        }
+        handleOnBlur(event);
         handleBlur();
       }}
-      onFocus={event => {
-        if (!disabled && onFocus) {
-          onFocus({ event });
-        }
-      }}
-      onMouseEnter={event => {
-        if (!disabled && onMouseEnter) {
-          onMouseEnter({ event });
-        }
-      }}
-      onMouseLeave={event => {
-        if (!disabled && onMouseLeave) {
-          onMouseLeave({ event });
-        }
-      }}
+      onFocus={handleOnFocus}
+      onMouseEnter={handleOnMouseEnter}
+      onMouseLeave={handleOnMouseLeave}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
       onKeyPress={event => {
@@ -158,9 +230,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<
       onTouchEnd={handleTouchEnd}
       ref={innerRef}
       role="button"
-      {...(compressStyle && tapStyle === 'compress'
-        ? { style: compressStyle }
-        : {})}
+      style={compressStyle || undefined}
       tabIndex={disabled ? null : '0'}
     >
       {children}
@@ -178,6 +248,7 @@ TapAreaWithForwardRef.propTypes = {
   disabled: PropTypes.bool,
   fullHeight: PropTypes.bool,
   fullWidth: PropTypes.bool,
+  href: PropTypes.string,
   mouseCursor: (PropTypes.oneOf([
     'copy',
     'grab',
@@ -202,8 +273,12 @@ TapAreaWithForwardRef.propTypes = {
   onTap: PropTypes.func,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
-  tapStyle: (PropTypes.oneOf(['none', 'compress']): React$PropType$Primitive<
-    'none' | 'compress'
+  rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<
+    'none' | 'nofollow'
+  >),
+  role: PropTypes.oneOf(['tapArea', 'link']),
+  target: (PropTypes.oneOf([null, 'self', 'blank']): React$PropType$Primitive<
+    null | 'self' | 'blank'
   >),
   rounding: RoundingPropType,
 };

--- a/packages/gestalt/src/TapArea.jsdom.test.js
+++ b/packages/gestalt/src/TapArea.jsdom.test.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import React, { createRef } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import TapArea from './TapArea.js';
 
@@ -51,4 +51,37 @@ test('TapArea handles key press event', () => {
   const mockEvent = { charCode: 32, preventDefault: jest.fn() };
   fireEvent.keyPress(getByText('TapArea'), mockEvent);
   expect(mockOnTap).toHaveBeenCalled();
+});
+
+it('renders a link TapArea and forwards a ref to the innermost <a> element', () => {
+  const ref = createRef();
+  render(
+    <TapArea
+      role="link"
+      href="http://www.pinterest.com"
+      ref={ref}
+      target="blank"
+    />
+  );
+  expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+  expect(ref.current instanceof HTMLAnchorElement && ref.current?.href).toEqual(
+    'http://www.pinterest.com/'
+  );
+});
+
+it('renders a disabled link TapArea', () => {
+  const ref = createRef();
+  render(
+    <TapArea
+      role="link"
+      href="http://www.pinterest.com"
+      disabled
+      ref={ref}
+      target="blank"
+    />
+  );
+  expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+  expect(ref.current instanceof HTMLAnchorElement && ref.current?.href).toEqual(
+    ''
+  );
 });

--- a/packages/gestalt/src/TapArea.test.js
+++ b/packages/gestalt/src/TapArea.test.js
@@ -44,15 +44,6 @@ test('TapArea sets fullHeight correctly', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('TapArea supports press style', () => {
-  const tree = create(
-    <TapArea onTap={() => {}} tapStyle="compress">
-      TapArea
-    </TapArea>
-  ).toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
 test('accessibilityControls', () => {
   const instance = create(
     <TapArea onTap={() => {}} accessibilityControls="another-element">

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -36,10 +36,14 @@ type Props = {|
     SyntheticEvent<HTMLVideoElement>,
     {| loaded: number |}
   >,
-  onPlay?: AbstractEventHandler<SyntheticEvent<HTMLDivElement>>,
+  onPlay?: AbstractEventHandler<
+    SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
+  >,
   onPlayheadDown?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
   onPlayheadUp?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
-  onPause?: AbstractEventHandler<SyntheticEvent<HTMLDivElement>>,
+  onPause?: AbstractEventHandler<
+    SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
+  >,
   onReady?: AbstractEventHandler<SyntheticEvent<HTMLVideoElement>>,
   onSeek?: AbstractEventHandler<SyntheticEvent<HTMLVideoElement>>,
   onTimeChange?: AbstractEventHandler<
@@ -47,7 +51,7 @@ type Props = {|
     {| time: number |}
   >,
   onVolumeChange?: AbstractEventHandler<
-    SyntheticEvent<HTMLDivElement>,
+    SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
     {| volume: number |}
   >,
   playbackRate: number,
@@ -415,7 +419,9 @@ export default class Video extends PureComponent<Props, State> {
   };
 
   // Sent when playback of the media starts after having been paused.
-  handlePlay: (event: SyntheticEvent<HTMLDivElement>) => void = event => {
+  handlePlay: (
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
+  ) => void = event => {
     const { onPlay } = this.props;
 
     if (onPlay) {
@@ -446,7 +452,9 @@ export default class Video extends PureComponent<Props, State> {
   };
 
   // Sent when playback is paused.
-  handlePause: (event: SyntheticEvent<HTMLDivElement>) => void = event => {
+  handlePause: (
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
+  ) => void = event => {
     const { onPause } = this.props;
 
     if (onPause) {
@@ -490,7 +498,7 @@ export default class Video extends PureComponent<Props, State> {
 
   // Sent when the audio volume changes
   handleVolumeChange: (
-    event: SyntheticEvent<HTMLDivElement>
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
   ) => void = event => {
     const { onVolumeChange } = this.props;
     const muted = (this.video && this.video.muted) || false;

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -21,13 +21,21 @@ type Props = {|
   currentTime: number,
   duration: number,
   fullscreen: boolean,
-  onCaptionsChange: (event: SyntheticEvent<HTMLDivElement>) => void,
+  onCaptionsChange: (
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
+  ) => void,
   onFullscreenChange: () => void,
-  onPause: (event: SyntheticEvent<HTMLDivElement>) => void,
-  onPlay: (event: SyntheticEvent<HTMLDivElement>) => void,
+  onPause: (
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
+  ) => void,
+  onPlay: (
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
+  ) => void,
   onPlayheadDown: (event: SyntheticMouseEvent<HTMLDivElement>) => void,
   onPlayheadUp: (event: SyntheticMouseEvent<HTMLDivElement>) => void,
-  onVolumeChange: (event: SyntheticEvent<HTMLDivElement>) => void,
+  onVolumeChange: (
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>
+  ) => void,
   playing: boolean,
   seek: (time: number) => void,
   volume: number,
@@ -75,32 +83,12 @@ function VideoControls({
   seek,
   volume,
 }: Props): Node {
-  const handleFullscreenChange: ({|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
-  |}) => void = ({
-    event,
-  }: {|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
-  |}) => {
+  const handleFullscreenChange = ({ event }) => {
     event.stopPropagation();
     onFullscreenChange();
   };
 
-  const handlePlayingChange: ({|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
-  |}) => void = ({
-    event,
-  }: {|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
-  |}) => {
+  const handlePlayingChange = ({ event }) => {
     if (playing) {
       onPause(event);
     } else {
@@ -108,32 +96,12 @@ function VideoControls({
     }
   };
 
-  const handleCaptionsChange: ({|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
-  |}) => void = ({
-    event,
-  }: {|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
-  |}) => {
+  const handleCaptionsChange = ({ event }) => {
     event.stopPropagation();
     onCaptionsChange(event);
   };
 
-  const handleVolumeChange: ({|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
-  |}) => void = ({
-    event,
-  }: {|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>,
-  |}) => {
+  const handleVolumeChange = ({ event }) => {
     onVolumeChange(event);
   };
 

--- a/packages/gestalt/src/__snapshots__/InternalLink.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/InternalLink.test.js.snap
@@ -6,14 +6,19 @@ exports[`default 1`] = `
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
+  onContextMenu={null}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onMouseUp={[Function]}
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
+  tabIndex={null}
   target={null}
 >
   InternalLink
@@ -26,14 +31,19 @@ exports[`inline 1`] = `
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
+  onContextMenu={null}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onMouseUp={[Function]}
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
+  tabIndex={null}
   target={null}
 >
   InternalLink
@@ -46,14 +56,19 @@ exports[`target blank 1`] = `
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
+  onContextMenu={null}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onMouseUp={[Function]}
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel="noopener noreferrer"
+  tabIndex={null}
   target="_blank"
 >
   InternalLink
@@ -66,14 +81,19 @@ exports[`target null 1`] = `
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
+  onContextMenu={null}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onMouseUp={[Function]}
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
+  tabIndex={null}
   target={null}
 >
   InternalLink
@@ -86,14 +106,19 @@ exports[`target self 1`] = `
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
+  onContextMenu={null}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onMouseUp={[Function]}
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
+  tabIndex={null}
   target="_self"
 >
   InternalLink
@@ -106,14 +131,19 @@ exports[`with nofollow 1`] = `
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
+  onContextMenu={null}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onMouseUp={[Function]}
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel="nofollow"
+  tabIndex={null}
   target={null}
 >
   InternalLink
@@ -126,14 +156,19 @@ exports[`with onTap 1`] = `
   href="https://example.com"
   onBlur={[Function]}
   onClick={[Function]}
+  onContextMenu={null}
+  onFocus={[Function]}
   onKeyPress={[Function]}
   onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   onMouseUp={[Function]}
   onTouchCancel={[Function]}
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
+  tabIndex={null}
   target={null}
 >
   InternalLink

--- a/packages/gestalt/src/__snapshots__/TapArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TapArea.test.js.snap
@@ -119,27 +119,3 @@ exports[`TapArea sets fullWidth correctly 1`] = `
   TapArea
 </div>
 `;
-
-exports[`TapArea supports press style 1`] = `
-<div
-  aria-disabled={false}
-  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onFocus={[Function]}
-  onKeyPress={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  role="button"
-  tabIndex="0"
->
-  TapArea
-</div>
-`;


### PR DESCRIPTION
- TapArea: implemented href with InternalLink.
- Improved test coverage
- Updated Docs
- Codemod to remove deprecated tapStyle prop

Codemod helper, run
`yarn codemod --parser=flow -t=packages/gestalt-codemods/13.2.0-13.3.0/tapArea-remove-tapStyle-prop.js relative/path/to/your/code
`
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

Go to Docs, check all new and previous functionality works

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
