### PR TITLE
Internal: BREAKING only build css file with css vars

### DIFF
--- a/docs/src/Faq.doc.js
+++ b/docs/src/Faq.doc.js
@@ -115,16 +115,17 @@ import { Button, Text } from 'gestalt';
         set the polyfill up in the docs which should go in the &lt;head /&gt; of
         your html.
         <Markdown
-          text="
+          text={`
 ~~~js
 // Load polyfills for IE 11
-if (/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
-document.write(
-'<script src=https://polyfill.io/v3/polyfill.min.js?features=default><\/script>' +
-'<script src=https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js><\/script>'
-);
+if (/MSIE \\d|Trident.*rv:/.test(navigator.userAgent)) {
+  document.write(
+    '<script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>' +
+    '<script src="https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js"></script>'
+  );
 }
-~~~"
+~~~
+          `}
         />
       </Text>
     </Stack>

--- a/docs/src/Faq.doc.js
+++ b/docs/src/Faq.doc.js
@@ -102,8 +102,28 @@ padding 0 .. 12
         Add the following to your import declarations:
         <Markdown
           text="
-~~~bash
+~~~js
 import { Button, Text } from 'gestalt';
+~~~"
+        />
+      </Text>
+
+      <Heading size="sm">What&apos;s required to support IE11?</Heading>
+      <Text>
+        Gestalt supports IE11 currently, but you will need to use a polyfill
+        because the css file uses css variables. Below is an example of how we
+        set the polyfill up in the docs which should go in the &lt;head /&gt; of
+        your html.
+        <Markdown
+          text="
+~~~js
+// Load polyfills for IE 11
+if (/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
+document.write(
+'<script src=https://polyfill.io/v3/polyfill.min.js?features=default><\/script>' +
+'<script src=https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js><\/script>'
+);
+}
 ~~~"
         />
       </Text>

--- a/docs/src/components/Markdown.js
+++ b/docs/src/components/Markdown.js
@@ -4,6 +4,7 @@ import { Text } from 'gestalt';
 import marked, { Renderer } from 'marked';
 import highlightjs from 'highlight.js';
 import './Markdown.css';
+import 'highlight.js/styles/github.css';
 
 type Props = {|
   text: string,
@@ -30,11 +31,6 @@ const stripIndent = (str: string): string => {
 export default function Markdown({ text }: Props): Node {
   const renderer = new Renderer();
 
-  renderer.code = (code, language) => {
-    const highlight = highlightjs.highlight(language, code).value;
-    return `<pre><code class="hljs ${language}">${highlight}</code></pre>`;
-  };
-
   renderer.heading = (input, level) => {
     const escapedText = input.toLowerCase().replace(/[^\w]+/g, '-');
 
@@ -55,6 +51,13 @@ export default function Markdown({ text }: Props): Node {
 
   const html = marked(stripIndent(text), {
     renderer,
+    highlight(code, language) {
+      const validLanguage = highlightjs.getLanguage(language)
+        ? language
+        : 'plaintext';
+      return highlightjs.highlight(validLanguage, code).value;
+    },
+    breaks: true,
   });
 
   return (

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import { render } from 'react-dom';
-import 'gestalt/dist/gestalt-future.css';
-import 'gestalt-datepicker/dist/gestalt-datepicker-future.css';
+import 'gestalt/dist/gestalt.css';
+import 'gestalt-datepicker/dist/gestalt-datepicker.css';
 import App from './components/App.js';
 import CardPage from './components/CardPage.js';
 import routes from './components/routes.js';

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -1,15 +1,5 @@
 :root {
-  /* fix colors for higher contrast in middle grays */
-  --g-colorGray300: #111;
-
-  /* primary colors */
-  --g-colorGray50: #fff;
-  --g-colorGray200: #767676;
-  --g-colorGray300: #111;
-  --g-colorGray400: #000;
-
   /* transparent colors */
-  --g-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --g-color-focus: rgba(0, 132, 255, 0.5);
 
   /* border & dimensions */

--- a/packages/gestalt/src/Borders.css
+++ b/packages/gestalt/src/Borders.css
@@ -1,17 +1,6 @@
 :root {
   --g-border-width: 1px;
   --g-border-width-lg: 2px;
-  --g-boint: 4px;
-
-  /* primary colors */
-  --g-colorGray100: #efefef;
-  --g-colorGray150: #ddd;
-  --g-colorGray200: #767676;
-  --g-colorGray300: #111;
-  --g-colorRed100: #e60023;
-
-  /* hover colors */
-  --g-colorGray150Hovered: #d0d0d0;
 }
 
 

--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -1,17 +1,3 @@
-:root {
-  --g-colorGray0Hovered: #f0f0f0;
-  --g-colorGray0Active: #e0e0e0;
-  --g-colorGray100: #efefef;
-  --g-colorGray100Hovered: #e2e2e2;
-  --g-colorGray100Active: #dadada;
-  --g-colorRed100Hovered: #ad081b;
-  --g-colorRed100Active: #a3081a;
-  --g-blueHovered: #4a8ad4;
-  --g-blueActive: #4a85c9;
-  --g-colorTransparentGray60: rgba(0, 0, 0, 0.06);
-  --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-}
-
 .button {
   composes: borderBox minWidth60 from "./Layout.css";
   composes: noBorder from "./Borders.css";

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -42,6 +42,8 @@
   /* transparent colors */
   --g-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
   --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
+  --g-colorTransparentGray60: rgba(0, 0, 0, 0.06);
+  --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
 }
 
 /** PRIMARY COLORS **/

--- a/packages/gestalt/src/FormElement.css
+++ b/packages/gestalt/src/FormElement.css
@@ -1,12 +1,3 @@
-:root {
-  /* primary colors */
-  --g-colorGray150: #ddd;
-
-  /* hover colors */
-  --g-colorGray150Hovered: #d0d0d0;
-  --g-colorRed100Hovered: #ad081b;
-}
-
 .base {
   composes: accessibilityOutline from "./Focus.css";
   appearance: none;

--- a/packages/gestalt/src/Pog.css
+++ b/packages/gestalt/src/Pog.css
@@ -1,17 +1,3 @@
-:root {
-  --g-colorGray0Hovered: #f0f0f0;
-  --g-colorGray0Active: #e0e0e0;
-  --g-colorGray300: #111;
-  --g-colorTransparentGray60: rgba(0, 0, 0, 0.06);
-  --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-  --g-colorGray100Hovered: #e2e2e2;
-  --g-colorGray100Active: #dadada;
-  --g-colorGray200Hovered: #878787;
-  --g-colorGray200Active: #828282;
-  --g-colorRed100Hovered: #ad081b;
-  --g-colorRed100Active: #a3081a;
-}
-
 .pog {
   composes: circle from "./Borders.css";
   composes: flex from "./Layout.css";

--- a/packages/gestalt/src/SearchField.css
+++ b/packages/gestalt/src/SearchField.css
@@ -1,10 +1,3 @@
-:root {
-  --g-boint: 4px;
-  --g-colorGray0: #fff;
-  --g-colorGray100: #efefef;
-  --g-colorGray200: #767676;
-}
-
 .input {
   composes: accessibilityOutline from "./Focus.css";
   composes: border pill sizeLg from "./Borders.css";

--- a/packages/gestalt/src/Table.css
+++ b/packages/gestalt/src/Table.css
@@ -1,9 +1,3 @@
-:root {
-  /* primary colors */
-  --g-colorGray0: #fff;
-  --g-colorGray150: #ddd;
-}
-
 .table {
   border-collapse: separate;
   border-spacing: 0;

--- a/packages/gestalt/src/TextArea.css
+++ b/packages/gestalt/src/TextArea.css
@@ -1,7 +1,3 @@
-:root {
-  --g-colorGray200: #767676;
-}
-
 .textArea {
   composes: borderBox from "./Layout.css";
   composes: Text fontSize3 from "./Text.css";

--- a/packages/gestalt/src/TextField.css
+++ b/packages/gestalt/src/TextField.css
@@ -1,7 +1,3 @@
-:root {
-  --g-colorGray200: #767676;
-}
-
 .textField {
   composes: borderBox from "./Layout.css";
   composes: Text fontSize3 from "./Text.css";

--- a/scripts/cssValidate.js
+++ b/scripts/cssValidate.js
@@ -20,7 +20,7 @@ const duplicateVariablesDifferentValues = async () => {
   const astRoot = postcss.parse(combined);
 
   const lookup = {};
-  astRoot.walkDecls(/^--gestalt/, ({ prop, value }) => {
+  astRoot.walkDecls(/^--g/, ({ prop, value }) => {
     if (lookup[prop] && lookup[prop] !== value) {
       throw new Error(
         `CSS Validate error: ${prop} is defined multiple times with different values: ${lookup[prop]} & ${value}.\nPlease make these the same`
@@ -30,41 +30,9 @@ const duplicateVariablesDifferentValues = async () => {
   });
 };
 
-const noVarInLegacyCSS = async () => {
-  const combined = (
-    await Promise.all(
-      [
-        'packages/gestalt/dist/gestalt.css',
-        'packages/gestalt-datepicker/dist/gestalt-datepicker.css',
-      ].map(async file => {
-        return await fs.promises.readFile(file, 'utf8');
-      })
-    )
-  ).join('');
-
-  const astRoot = postcss.parse(combined);
-
-  // Define a CSS variable
-  astRoot.walkDecls(/^--gestalt/, ({ prop, value }) => {
-    throw new Error(
-      `CSS Validate error: ${prop} CSS variable with value ${value} is defined in the legacy CSS - this will break IE and older browsers`
-    );
-  });
-
-  // Use a CSS variable
-  astRoot.walkDecls(({ prop, value }) => {
-    if (value.startsWith('var(')) {
-      throw new Error(
-        `CSS Validate error: ${prop} property with CSS variable ${value} is used in the legacy CSS - this will break IE and older browsers`
-      );
-    }
-  });
-};
-
 (async function cssValidate() {
   try {
     await duplicateVariablesDifferentValues();
-    await noVarInLegacyCSS();
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);


### PR DESCRIPTION
After experimenting in the main repo with the gestalt-future.css file that has css vars in it, we've determined this is safe to ship. I'm marking this as a breaking change because any app using gestalt that needs to support older browsers such as IE11 will need to use a polyfill. I've already added this one to our app's build for legacy browsers: https://github.com/nuxodin/ie11CustomProperties

Possible improvement: We still have `:root` declarations spread across a few css files. This is nice from a code organization perspective (border width vars defined in Borders.css, color vars defined in Colors.css for example) but makes less sense in the output css file. Perhaps we could combine the declarations into one Variables.css file? Some vars like the ones specific to the datepicker could be scoped to a specific class rather than globally as well. This PR is safe to ship, so I could make these changes in a follow up.

I also noticed markdown syntax highlighting wasn't working when I added documentation for the polyfill. This fixes that too.

## Test Plan
The docs are using the new css file. I've confirmed the docs look as expected and I can see the css vars in the built css file. Switching to dark mode works correctly indicating the css vars are being overwritten by the color scheme provider properly.
