### PR TITLE
Table.Header: fix stacking context on sticky header

### DIFF
--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -196,9 +196,12 @@ card(
     id="stickyHeader"
     name="Example: Sticky header"
     defaultCode={`
-<Table maxHeight={110}>
+<Table maxHeight={200}>
   <Table.Header sticky>
     <Table.Row>
+      <Table.HeaderCell>
+        <Text weight="bold">Image</Text>
+      </Table.HeaderCell>
       <Table.HeaderCell>
         <Text weight="bold">Name</Text>
       </Table.HeaderCell>
@@ -209,14 +212,50 @@ card(
   </Table.Header>
   <Table.Body>
     <Table.Row>
+      <Table.Cell>
+        <Box width={50}>
+          <Mask rounding="circle">
+            <Image
+              alt="Luna"
+              src="https://i.ibb.co/QY9qR7h/luna.png"
+              naturalHeight={50}
+              naturalWidth={50}
+            />
+          </Mask>
+        </Box>
+      </Table.Cell>
       <Table.Cell><Text>Luna Lovegood</Text></Table.Cell>
       <Table.Cell><Text>Ravenclaw</Text></Table.Cell>
     </Table.Row>
     <Table.Row>
+      <Table.Cell>
+        <Box width={50}>
+          <Mask rounding="circle">
+            <Image
+              alt="Draco"
+              src="https://i.ibb.co/Hzcfxjt/draco.png"
+              naturalHeight={50}
+              naturalWidth={50}
+            />
+          </Mask>
+        </Box>
+      </Table.Cell>
       <Table.Cell><Text>Draco Malfoy</Text></Table.Cell>
       <Table.Cell><Text>Slytherin</Text></Table.Cell>
     </Table.Row>
     <Table.Row>
+      <Table.Cell>
+        <Box width={50}>
+          <Mask rounding="circle">
+            <Image
+              alt="Neville"
+              src="https://i.ibb.co/JvY9DKK/neville.png"
+              naturalHeight={50}
+              naturalWidth={50}
+            />
+          </Mask>
+        </Box>
+      </Table.Cell>
       <Table.Cell><Text>Neville Longbottom</Text></Table.Cell>
       <Table.Cell><Text>Gryffindor</Text></Table.Cell>
     </Table.Row>

--- a/packages/gestalt/src/Table.css
+++ b/packages/gestalt/src/Table.css
@@ -19,6 +19,7 @@
   background-color: var(--g-colorGray0);
   position: sticky;
   top: 0;
+  z-index: 1;
 }
 
 .thead tr:last-child th {


### PR DESCRIPTION
### Before
![table-header-sticky-before](https://user-images.githubusercontent.com/127199/92811190-10fc9a00-f373-11ea-961c-7bbaad58e099.gif)

### After
![table-header-sticky-after](https://user-images.githubusercontent.com/127199/92811204-13f78a80-f373-11ea-9a87-c699c9fbfb0c.gif)

## Test Plan

1. Go to `/Table#stickyHeader` in the gestalt docs
2. Scroll down the table
3. Ensure the header is always on top
