### PR TITLE
Docs: update Text wrap/overflow example

### DIFF
--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -137,7 +137,7 @@ card(
     id="overflow"
     name="Overflow"
     defaultCode={`
-<Box maxWidth={240}>
+<Box maxWidth={180}>
   <Box marginBottom={2}>
     <Text weight="bold">normal:</Text>
     <Text overflow="normal">


### PR DESCRIPTION
Raised by @rootvar - the current example is not so helpful. Let's reduce the width so it does become more helpful.

### Before
![Screen Shot 2020-09-11 at 10 52 50 AM](https://user-images.githubusercontent.com/127199/92957273-24fcd600-f41d-11ea-99d8-486a54b26d97.png)

### After
![Screen Shot 2020-09-11 at 10 52 42 AM](https://user-images.githubusercontent.com/127199/92957276-26c69980-f41d-11ea-90ef-56477183b4c5.png)
