### PR TITLE
Docs: use PageHeader on all pages

### DIFF
--- a/docs/src/Development.doc.js
+++ b/docs/src/Development.doc.js
@@ -3,11 +3,12 @@ import React, { type Node } from 'react';
 import { Heading, Link, Stack, Text } from 'gestalt';
 import Card from './components/Card.js';
 import Markdown from './components/Markdown.js';
+import PageHeader from './components/PageHeader.js';
 
 const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
-card(<Heading>Development</Heading>);
+card(<PageHeader name="Development" showSourceLink={false} />);
 
 card(
   <Card name="Set up your laptop">

--- a/docs/src/Faq.doc.js
+++ b/docs/src/Faq.doc.js
@@ -3,11 +3,12 @@ import React, { type Node } from 'react';
 import { Box, Heading, Link, Stack, Text } from 'gestalt';
 import Markdown from './components/Markdown.js';
 import Card from './components/Card.js';
+import PageHeader from './components/PageHeader.js';
 
 const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
-card(<Heading>Frequently Asked Questions</Heading>);
+card(<PageHeader name="Frequently Asked Questions" showSourceLink={false} />);
 
 card(
   <Card name="Component Usage">

--- a/docs/src/Installation.doc.js
+++ b/docs/src/Installation.doc.js
@@ -3,11 +3,12 @@ import React, { type Node } from 'react';
 import { Heading, Link, Row, Stack, Text } from 'gestalt';
 import Markdown from './components/Markdown.js';
 import Card from './components/Card.js';
+import PageHeader from './components/PageHeader.js';
 
 const cards: Array<Node> = [];
 const card = c => cards.push(c);
 
-card(<Heading>Installation</Heading>);
+card(<PageHeader name="Installation" showSourceLink={false} />);
 
 card(
   <Stack gap={2}>

--- a/docs/src/Layouts.doc.js
+++ b/docs/src/Layouts.doc.js
@@ -10,6 +10,7 @@ card(
   <PageHeader
     name="Layouts"
     description="A list of easy-to-copy layouts which have been battle tested."
+    showSourceLink={false}
   />
 );
 

--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -8,6 +8,7 @@ type Props = {|
   description?: string,
   beta?: boolean,
   fileName?: string, // only use if name !== file name
+  showSourceLink?: boolean,
 |};
 
 const gestaltPath = component => {
@@ -28,6 +29,7 @@ export default function ComponentHeader({
   name,
   description = '',
   fileName,
+  showSourceLink = true,
 }: Props): Node {
   return (
     <Box marginBottom={6}>
@@ -40,11 +42,13 @@ export default function ComponentHeader({
             </Tooltip>
           ) : null}
         </Heading>
-        <Text color="gray">
-          <Link href={githubUrl(fileName || name)} inline>
-            Source
-          </Link>
-        </Text>
+        {showSourceLink && (
+          <Text color="gray">
+            <Link href={githubUrl(fileName || name)} inline>
+              Source
+            </Link>
+          </Text>
+        )}
       </Box>
       {description && <Markdown text={description} />}
     </Box>


### PR DESCRIPTION
Use `<PageHeader />` on all pages + remove the `View Source` on non-component pages

## Test Plan

* All page headers look consistent
* Layouts page doesn't show a `View Source` link
