### PR TITLE
Row, Stack: Update `children` type

### DIFF
--- a/docs/src/Installation.doc.js
+++ b/docs/src/Installation.doc.js
@@ -37,7 +37,7 @@ card(
       developers by enforcing a bunch of fundamental UI components. This common
       set of components helps raise the bar for UX & accessibility across
       Pinterest.
-    </Text>{' '}
+    </Text>
   </Stack>
 );
 

--- a/docs/src/Row.doc.js
+++ b/docs/src/Row.doc.js
@@ -26,7 +26,9 @@ card(
     props={[
       {
         name: 'children',
-        type: 'React.Node',
+        type: 'React.Element',
+        description:
+          'All children must be Elements — unwrapped strings and other non-Element Nodes are not allowed',
       },
       {
         name: 'alignContent',

--- a/docs/src/Stack.doc.js
+++ b/docs/src/Stack.doc.js
@@ -26,7 +26,9 @@ card(
     props={[
       {
         name: 'children',
-        type: 'React.Node',
+        type: 'React.Element',
+        description:
+          'All children must be Elements — unwrapped strings and other non-Element Nodes are not allowed',
       },
       {
         name: 'alignContent',

--- a/packages/gestalt/src/Row.flowtest.js
+++ b/packages/gestalt/src/Row.flowtest.js
@@ -1,0 +1,24 @@
+// @flow strict
+import React from 'react';
+import Row from './Row.js';
+
+const ValidSingle = (
+  <Row gap={1}>
+    <div />
+  </Row>
+);
+
+const ValidMultiple = (
+  <Row gap={1}>
+    <div />
+    <div />
+    <div />
+    <div />
+  </Row>
+);
+
+const test = true;
+const Testing = <Row>{test ? <div /> : null}</Row>;
+
+// $FlowExpectedError[incompatible-type]
+const MissingProp = <Row gap={1}>test</Row>;

--- a/packages/gestalt/src/Row.js
+++ b/packages/gestalt/src/Row.js
@@ -28,8 +28,7 @@ type Props = {|
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
-  // $FlowExpectedError[unclear-type]
-  children?: ChildrenArray<Element<any>>,
+  children?: ChildrenArray<?Element<*>>,
   flex?: Flex,
   gap?: Padding,
   height?: Dimension,

--- a/packages/gestalt/src/Row.js
+++ b/packages/gestalt/src/Row.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { type ChildrenArray, type Element, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import disallowedProps from './stackDisallowedProps.js';
@@ -28,7 +28,8 @@ type Props = {|
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
-  children?: Node,
+  // $FlowExpectedError[unclear-type]
+  children?: ChildrenArray<Element<any>>,
   flex?: Flex,
   gap?: Padding,
   height?: Dimension,

--- a/packages/gestalt/src/Stack.flowtest.js
+++ b/packages/gestalt/src/Stack.flowtest.js
@@ -1,0 +1,24 @@
+// @flow strict
+import React from 'react';
+import Stack from './Stack.js';
+
+const ValidSingle = (
+  <Stack gap={1}>
+    <div />
+  </Stack>
+);
+
+const ValidMultiple = (
+  <Stack gap={1}>
+    <div />
+    <div />
+    <div />
+    <div />
+  </Stack>
+);
+
+const test = true;
+const Testing = <Stack>{test ? <div /> : null}</Stack>;
+
+// $FlowExpectedError[incompatible-type]
+const MissingProp = <Stack gap={1}>test</Stack>;

--- a/packages/gestalt/src/Stack.js
+++ b/packages/gestalt/src/Stack.js
@@ -28,8 +28,7 @@ type Props = {|
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
-  // $FlowExpectedError[unclear-type]
-  children?: ChildrenArray<Element<any>>,
+  children?: ChildrenArray<?Element<*>>,
   flex?: Flex,
   gap?: Padding,
   height?: Dimension,

--- a/packages/gestalt/src/Stack.js
+++ b/packages/gestalt/src/Stack.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { type ChildrenArray, type Element, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import disallowedProps from './stackDisallowedProps.js';
@@ -28,7 +28,8 @@ type Props = {|
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
-  children?: Node,
+  // $FlowExpectedError[unclear-type]
+  children?: ChildrenArray<Element<any>>,
   flex?: Flex,
   gap?: Padding,
   height?: Dimension,


### PR DESCRIPTION
Given how Row/Stack implement `gap` on their children, each child needs to be a React Element — styles won't be applied if given an unwrapped string or other non-Element Nodes.

This PR updates the `children` type for both components, and fixes one non-standard usage in the docs (no visual change that I can detect in the [preview](https://deploy-preview-1216--gestalt.netlify.app/Installation)). The Flow suppressions aren't ideal, but we really don't care what kind of Element we're getting, just that each child is an Element.