### PR TITLE
Box: Extract types and transforms, cleanup

### DIFF
--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -7,7 +7,7 @@
 This guide will help you navigate and understand its design. This file is roughly organized like:
 
   1. Flow Types
-  2. Prop transformers
+  2. Prop transformers -> moved to ./boxTransforms.js
   3. Box itself
   4. PropTypes
 
@@ -23,30 +23,54 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import styles from './Box.css';
-import borders from './Borders.css';
-import colors from './Colors.css';
-import layout from './Layout.css';
-import whitespace from './boxWhitespace.css';
-import {
-  concat,
-  fromClassName,
-  fromInlineStyle,
-  identity,
-  mapClassName,
-  toProps,
-  type Style,
-} from './style.js';
-import {
-  union,
-  bind,
-  range,
-  toggle,
-  mapping,
-  rangeWithZero,
-  rangeWithoutZero,
-} from './transforms.js';
-import { getRoundingStyle } from './getRoundingClassName.js';
+import { buildStyles } from './boxTransforms.js';
 import { type Indexable } from './zIndex.js';
+import {
+  type DangerouslySetInlineStyle,
+  type AlignContent,
+  type AlignItems,
+  type AlignSelf,
+  type BorderSize,
+  type Bottom,
+  type Column,
+  type Color,
+  type Dimension,
+  type Display,
+  type Direction,
+  type Fit,
+  type Flex,
+  type JustifyContent,
+  type Left,
+  type Margin,
+  type Opacity,
+  type Overflow,
+  type Padding,
+  type Position,
+  type Right,
+  type Role,
+  type Rounding,
+  type Top,
+  type UserSelect,
+  type Wrap,
+  AlignContentPropType,
+  AlignItemsPropType,
+  AlignSelfPropType,
+  BorderSizePropType,
+  ColorPropType,
+  ColumnPropType,
+  DimensionPropType,
+  DirectionPropType,
+  DisplayPropType,
+  FlexPropType,
+  JustifyContentPropType,
+  MarginPropType,
+  OpacityPropType,
+  OverflowPropType,
+  PaddingPropType,
+  PositionPropType,
+  RoundingPropType,
+  UserSelectPropType,
+} from './boxTypes.js';
 
 /*
 
@@ -59,88 +83,9 @@ extra runtime typechecks in the transformers for performance.
 
 */
 
-export type AlignContent =
-  | 'start'
-  | 'end'
-  | 'center'
-  | 'between'
-  | 'around'
-  | 'evenly'
-  | 'stretch';
-
-export type AlignItems = 'start' | 'end' | 'center' | 'baseline' | 'stretch';
-
-export type AlignSelf =
-  | 'auto'
-  | 'start'
-  | 'end'
-  | 'center'
-  | 'baseline'
-  | 'stretch';
-
-type Column = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
-
-export type Dimension = number | string;
-
-type Display = 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden';
-
-export type Direction = 'row' | 'column';
-
-export type Flex = 'grow' | 'shrink' | 'none';
-
-export type JustifyContent =
-  | 'start'
-  | 'end'
-  | 'center'
-  | 'between'
-  | 'around'
-  | 'evenly';
-
-export type Margin =
-  | -12
-  | -11
-  | -10
-  | -9
-  | -8
-  | -7
-  | -6
-  | -5
-  | -4
-  | -3
-  | -2
-  | -1
-  | 0
-  | 1
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 7
-  | 8
-  | 9
-  | 10
-  | 11
-  | 12
-  | 'auto';
-
-export type Overflow =
-  | 'visible'
-  | 'hidden'
-  | 'scroll'
-  | 'scrollX'
-  | 'scrollY'
-  | 'auto';
-
-export type Padding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
-
-type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill';
-
-type PropType = {
+type Props = {
   children?: Node,
-  dangerouslySetInlineStyle?: {|
-    __style: { [key: string]: string | number | void },
-  |},
+  dangerouslySetInlineStyle?: DangerouslySetInlineStyle,
 
   display?: Display,
   column?: Column,
@@ -158,35 +103,14 @@ type PropType = {
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
-  bottom?: boolean,
-  borderSize?: 'sm' | 'lg' | 'none',
-  color?:
-    | 'blue'
-    | 'darkGray'
-    | 'darkWash'
-    | 'eggplant'
-    | 'gray'
-    | 'green'
-    | 'lightGray'
-    | 'lightWash'
-    | 'maroon'
-    | 'midnight'
-    | 'navy'
-    | 'olive'
-    | 'orange'
-    | 'orchid'
-    | 'pine'
-    | 'purple'
-    | 'red'
-    | 'transparent'
-    | 'transparentDarkGray'
-    | 'watermelon'
-    | 'white',
-  fit?: boolean,
+  bottom?: Bottom,
+  borderSize?: BorderSize,
+  color?: Color,
+  fit?: Fit,
   flex?: Flex,
   height?: Dimension,
   justifyContent?: JustifyContent,
-  left?: boolean,
+  left?: Left,
 
   margin?: Margin,
   marginTop?: Margin,
@@ -225,7 +149,7 @@ type PropType = {
   minHeight?: Dimension,
   minWidth?: Dimension,
 
-  opacity?: 0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1,
+  opacity?: Opacity,
 
   overflow?: Overflow,
 
@@ -244,16 +168,16 @@ type PropType = {
   mdPaddingY?: Padding,
   lgPaddingY?: Padding,
 
-  position?: 'static' | 'absolute' | 'relative' | 'fixed',
-  right?: boolean,
+  position?: Position,
+  right?: Right,
   rounding?: Rounding,
-  top?: boolean,
+  top?: Top,
   width?: Dimension,
-  wrap?: boolean,
+  wrap?: Wrap,
 
-  userSelect?: 'auto' | 'none',
+  userSelect?: UserSelect,
 
-  role?: string,
+  role?: Role,
 
   zIndex?: Indexable,
   ...
@@ -263,346 +187,9 @@ type PropType = {
 
 /*
 
-# Transformers
-
-This is where the meat and the bones of Box's transforms are. You can read more about the DSL in `./transforms.js`, but basically they are a small declarative way of specifying how a property (i.e. `marginTop={4}`) gets turned into a CSS class (`marginTop4`).
-
-There's a little preamble here, but it culminates in a big object mapping the actual property names to the transformer values.
-
-*/
-
-const transformNumberOrPassthrough = (selector: string) => (
-  m: Margin
-): Style => {
-  if (typeof m === 'number') {
-    return bind(rangeWithZero(selector), whitespace)(m);
-  }
-
-  if (m === 'auto') {
-    return fromClassName(whitespace[`${selector}Auto`]);
-  }
-
-  return identity();
-};
-
-const marginStart = transformNumberOrPassthrough('marginStart');
-const marginEnd = transformNumberOrPassthrough('marginEnd');
-const marginTop = transformNumberOrPassthrough('marginTop');
-const marginRight = transformNumberOrPassthrough('marginRight');
-const marginBottom = transformNumberOrPassthrough('marginBottom');
-const marginLeft = transformNumberOrPassthrough('marginLeft');
-const margin = union(marginTop, marginBottom, marginLeft, marginRight);
-
-const smMarginStart = transformNumberOrPassthrough('smMarginStart');
-const smMarginEnd = transformNumberOrPassthrough('smMarginEnd');
-const smMarginTop = transformNumberOrPassthrough('smMarginTop');
-const smMarginRight = transformNumberOrPassthrough('smMarginRight');
-const smMarginBottom = transformNumberOrPassthrough('smMarginBottom');
-const smMarginLeft = transformNumberOrPassthrough('smMarginLeft');
-const smMargin = union(
-  smMarginTop,
-  smMarginBottom,
-  smMarginLeft,
-  smMarginRight,
-  smMarginStart,
-  smMarginEnd
-);
-
-const mdMarginStart = transformNumberOrPassthrough('mdMarginStart');
-const mdMarginEnd = transformNumberOrPassthrough('mdMarginEnd');
-const mdMarginTop = transformNumberOrPassthrough('mdMarginTop');
-const mdMarginRight = transformNumberOrPassthrough('mdMarginRight');
-const mdMarginBottom = transformNumberOrPassthrough('mdMarginBottom');
-const mdMarginLeft = transformNumberOrPassthrough('mdMarginLeft');
-const mdMargin = union(
-  mdMarginTop,
-  mdMarginBottom,
-  mdMarginLeft,
-  mdMarginRight,
-  mdMarginStart,
-  mdMarginEnd
-);
-
-const lgMarginStart = transformNumberOrPassthrough('lgMarginStart');
-const lgMarginEnd = transformNumberOrPassthrough('lgMarginEnd');
-const lgMarginTop = transformNumberOrPassthrough('lgMarginTop');
-const lgMarginRight = transformNumberOrPassthrough('lgMarginRight');
-const lgMarginBottom = transformNumberOrPassthrough('lgMarginBottom');
-const lgMarginLeft = transformNumberOrPassthrough('lgMarginLeft');
-const lgMargin = union(
-  lgMarginTop,
-  lgMarginBottom,
-  lgMarginLeft,
-  lgMarginRight,
-  lgMarginStart,
-  lgMarginEnd
-);
-
-const paddingX = bind(rangeWithoutZero('paddingX'), whitespace);
-const paddingY = bind(rangeWithoutZero('paddingY'), whitespace);
-const padding = union(paddingX, paddingY);
-
-const smPaddingX = bind(rangeWithoutZero('smPaddingX'), whitespace);
-const smPaddingY = bind(rangeWithoutZero('smPaddingY'), whitespace);
-const smPadding = union(smPaddingX, smPaddingY);
-
-const mdPaddingX = bind(rangeWithoutZero('mdPaddingX'), whitespace);
-const mdPaddingY = bind(rangeWithoutZero('mdPaddingY'), whitespace);
-const mdPadding = union(mdPaddingX, mdPaddingY);
-
-const lgPaddingX = bind(rangeWithoutZero('lgPaddingX'), whitespace);
-const lgPaddingY = bind(rangeWithoutZero('lgPaddingY'), whitespace);
-const lgPadding = union(lgPaddingX, lgPaddingY);
-
-const opacityMap = mapClassName(name => styles[name]);
-const opacity = val => {
-  if (val > 0 && val < 1) {
-    return opacityMap(range('opacity0')(val * 10));
-  }
-  return opacityMap(range('opacity')(val));
-};
-
-/*
-
-It's preferable to put new properties into that object directly just so it's easier to read.
-
-*/
-
-const propToFn = {
-  display: mapping({
-    none: styles.xsDisplayNone,
-    flex: styles.xsDisplayFlex,
-    block: styles.xsDisplayBlock,
-    inlineBlock: styles.xsDisplayInlineBlock,
-    visuallyHidden: styles.xsDisplayVisuallyHidden,
-  }),
-  column: bind(range('xsCol'), styles),
-  direction: mapping({
-    row: styles.xsDirectionRow,
-    column: styles.xsDirectionColumn,
-  }),
-
-  smDisplay: mapping({
-    none: styles.smDisplayNone,
-    flex: styles.smDisplayFlex,
-    block: styles.smDisplayBlock,
-    inlineBlock: styles.smDisplayInlineBlock,
-    visuallyHidden: styles.smDisplayVisuallyHidden,
-  }),
-  smColumn: bind(range('smCol'), styles),
-  smDirection: mapping({
-    row: styles.smDirectionRow,
-    column: styles.smDirectionColumn,
-  }),
-
-  mdDisplay: mapping({
-    none: styles.mdDisplayNone,
-    flex: styles.mdDisplayFlex,
-    block: styles.mdDisplayBlock,
-    inlineBlock: styles.mdDisplayInlineBlock,
-    visuallyHidden: styles.mdDisplayVisuallyHidden,
-  }),
-  mdColumn: bind(range('mdCol'), styles),
-  mdDirection: mapping({
-    row: styles.mdDirectionRow,
-    column: styles.mdDirectionColumn,
-  }),
-
-  lgDisplay: mapping({
-    none: styles.lgDisplayNone,
-    flex: styles.lgDisplayFlex,
-    block: styles.lgDisplayBlock,
-    inlineBlock: styles.lgDisplayInlineBlock,
-    visuallyHidden: styles.lgDisplayVisuallyHidden,
-  }),
-  lgColumn: bind(range('lgCol'), styles),
-  lgDirection: mapping({
-    row: styles.lgDirectionRow,
-    column: styles.lgDirectionColumn,
-  }),
-
-  alignContent: mapping({
-    start: layout.contentStart,
-    end: layout.contentEnd,
-    center: layout.contentCenter,
-    between: layout.contentBetween,
-    around: layout.contentAround,
-    evenly: layout.contentEvenly,
-    // default: stretch
-  }),
-  alignItems: mapping({
-    start: layout.itemsStart,
-    end: layout.itemsEnd,
-    center: layout.itemsCenter,
-    baseline: layout.itemsBaseline,
-    // default: stretch
-  }),
-  alignSelf: mapping({
-    start: layout.selfStart,
-    end: layout.selfEnd,
-    center: layout.selfCenter,
-    baseline: layout.selfBaseline,
-    stretch: layout.selfStretch,
-    // default: auto
-  }),
-  bottom: toggle(layout.bottom0),
-  borderSize: value => {
-    const borderProps =
-      value !== 'none'
-        ? [
-            fromClassName(borders.solid),
-            fromClassName(borders.borderColorLightGray),
-          ]
-        : [];
-    return concat([
-      mapping({
-        sm: borders.sizeSm,
-        lg: borders.sizeLg,
-        // default: none
-      })(value),
-      ...borderProps,
-    ]);
-  },
-  color: mapping({
-    blue: colors.blueBg,
-    darkGray: colors.darkGrayBg,
-    pine: colors.pineBg,
-    gray: colors.grayBg,
-    red: colors.redBg,
-    olive: colors.oliveBg,
-    lightGray: colors.lightGrayBg,
-    white: colors.whiteBg,
-    orange: colors.orangeBg,
-    green: colors.greenBg,
-    navy: colors.navyBg,
-    midnight: colors.midnightBg,
-    purple: colors.purpleBg,
-    orchid: colors.orchidBg,
-    eggplant: colors.eggplantBg,
-    maroon: colors.maroonBg,
-    watermelon: colors.watermelonBg,
-    lightWash: colors.lightWashBg,
-    darkWash: colors.darkWashBg,
-    transparentDarkGray: colors.transparentDarkGrayBg,
-    // default: transparent
-  }),
-  fit: toggle(layout.fit),
-  flex: mapping({
-    grow: layout.flexGrow,
-    none: layout.flexNone,
-    // default: shrink
-  }),
-  height: height => fromInlineStyle({ height }),
-  justifyContent: mapping({
-    end: layout.justifyEnd,
-    center: layout.justifyCenter,
-    between: layout.justifyBetween,
-    around: layout.justifyAround,
-    evenly: layout.justifyEvenly,
-    // default: start
-  }),
-  left: toggle(layout.left0),
-  margin,
-  marginTop,
-  marginRight,
-  marginBottom,
-  marginLeft,
-  marginStart,
-  marginEnd,
-
-  smMargin,
-  smMarginTop,
-  smMarginRight,
-  smMarginBottom,
-  smMarginLeft,
-  smMarginStart,
-  smMarginEnd,
-
-  mdMargin,
-  mdMarginTop,
-  mdMarginRight,
-  mdMarginBottom,
-  mdMarginLeft,
-  mdMarginStart,
-  mdMarginEnd,
-
-  lgMargin,
-  lgMarginTop,
-  lgMarginRight,
-  lgMarginBottom,
-  lgMarginLeft,
-  lgMarginStart,
-  lgMarginEnd,
-
-  maxHeight: maxHeight => fromInlineStyle({ maxHeight }),
-  maxWidth: maxWidth => fromInlineStyle({ maxWidth }),
-  minHeight: minHeight => fromInlineStyle({ minHeight }),
-  minWidth: minWidth => fromInlineStyle({ minWidth }),
-  opacity,
-  overflow: mapping({
-    hidden: layout.overflowHidden,
-    scroll: layout.overflowScroll,
-    auto: layout.overflowAuto,
-    scrollX: layout.overflowScrollX,
-    scrollY: layout.overflowScrollY,
-    // default: visible
-  }),
-  padding,
-  paddingX,
-  paddingY,
-  smPadding,
-  smPaddingX,
-  smPaddingY,
-  mdPadding,
-  mdPaddingX,
-  mdPaddingY,
-  lgPadding,
-  lgPaddingX,
-  lgPaddingY,
-  position: mapping({
-    absolute: layout.absolute,
-    relative: layout.relative,
-    fixed: layout.fixed,
-    // default: static
-  }),
-  right: toggle(layout.right0),
-  rounding: getRoundingStyle,
-  top: toggle(layout.top0),
-  userSelect: mapping({
-    none: styles.userSelectNone,
-    // default: auto
-  }),
-  width: width => fromInlineStyle({ width }),
-  wrap: toggle(layout.flexWrap),
-  dangerouslySetInlineStyle: value => {
-    // eslint-disable-next-line no-underscore-dangle
-    return value && value.__style ? fromInlineStyle(value.__style) : identity();
-  },
-  zIndex: (value: ?Indexable) => {
-    if (!value) {
-      return identity();
-    }
-    return fromInlineStyle({ zIndex: value.index() });
-  },
-};
-
-/*
-
 # The Component
 
 */
-
-const contains = (key, arr) => arr.indexOf(key) >= 0;
-const omit = (keys, obj) =>
-  Object.keys(obj).reduce((acc, k: string) => {
-    if (contains(k, keys)) {
-      return acc;
-    }
-    return {
-      ...acc,
-      [k]: obj[k],
-    };
-  }, {});
 
 // Box is a "pass-through" component, meaning that if you pass properties to it
 // that it doesn't know about (`aria-label` for instance) it passes directly
@@ -611,45 +198,18 @@ const omit = (keys, obj) =>
 // (className, style) or accessibility (onClick).
 const disallowedProps = ['onClick', 'className', 'style'];
 
-const BoxWithForwardRef: AbstractComponent<
-  PropType,
+const BoxWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwardRef<
+  Props,
   HTMLDivElement
-> = forwardRef<PropType, HTMLDivElement>(function Box(
-  props,
-  ref
-): Element<'div'> {
-  // Flow can't reason about the constant nature of Object.keys so we can't use
-  // a functional (reduce) style here.
-
-  // All Box's are box-sized by default, so we start off building up the styles
-  // to be applied with a Box base class.
-  let s = fromClassName(styles.box);
-
-  // Init the list of props we'll omit from passthrough. We'll add to this
-  // list as we match props against the transforms list.
-  const omitProps = [...disallowedProps];
-
-  // This loops through each property and if it exists in the previously
-  // defined transform map, concatentes the resulting styles to the base
-  // styles. If there's a match, we also don't pass through that property. This
-  // means Box's runtime is only dependent on the number of properties passed
-  // to it (which is typically small) instead of the total number of possible
-  // properties (~30 or so). While it may ~feel~ like Box is innefficient, its
-  // biggest performance impact is on startup time because there's so much code
-  // here.
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const prop in props) {
-    if (Object.prototype.hasOwnProperty.call(propToFn, prop)) {
-      const fn = propToFn[prop];
-      const value = props[prop];
-      omitProps.push(prop);
-      s = concat([s, fn(value)]);
-    }
-  }
+>(function Box(props, ref): Element<'div'> {
+  const { passthroughProps, propsStyles } = buildStyles<Props>(
+    styles.box,
+    props,
+    disallowedProps
+  );
 
   // And... magic!
-  return <div {...omit(omitProps, props)} {...toProps(s)} ref={ref} />;
+  return <div {...passthroughProps} {...propsStyles} ref={ref} />;
 });
 
 BoxWithForwardRef.displayName = 'Box';
@@ -663,151 +223,6 @@ export default BoxWithForwardRef;
 And we're done here :)
 
 */
-
-export const AlignContentPropType: React$PropType$Primitive<
-  'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch'
-> = PropTypes.oneOf([
-  'start',
-  'end',
-  'center',
-  'between',
-  'around',
-  'evenly',
-  'stretch',
-]);
-
-export const AlignItemsPropType: React$PropType$Primitive<
-  'start' | 'end' | 'center' | 'baseline' | 'stretch'
-> = PropTypes.oneOf(['start', 'end', 'center', 'baseline', 'stretch']);
-
-export const AlignSelfPropType: React$PropType$Primitive<
-  'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch'
-> = PropTypes.oneOf(['auto', 'start', 'end', 'center', 'baseline', 'stretch']);
-
-const ColumnPropType = PropTypes.oneOf([
-  0,
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  10,
-  11,
-  12,
-]);
-
-export const DimensionPropType: React$PropType$Primitive<
-  number | string
-> = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
-
-export const DirectionPropType: React$PropType$Primitive<
-  'row' | 'column'
-> = PropTypes.oneOf(['row', 'column']);
-
-const DisplayPropType = PropTypes.oneOf([
-  'none',
-  'flex',
-  'block',
-  'inlineBlock',
-  'visuallyHidden',
-]);
-
-export const FlexPropType: React$PropType$Primitive<
-  'grow' | 'shrink' | 'none'
-> = PropTypes.oneOf(['grow', 'shrink', 'none']);
-
-export const JustifyContentPropType: React$PropType$Primitive<
-  'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'
-> = PropTypes.oneOf(['start', 'end', 'center', 'between', 'around', 'evenly']);
-
-export const MarginPropType: React$PropType$Primitive<
-  | -12
-  | -11
-  | -10
-  | -9
-  | -8
-  | -7
-  | -6
-  | -5
-  | -4
-  | -3
-  | -2
-  | -1
-  | 0
-  | 1
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 7
-  | 8
-  | 9
-  | 10
-  | 11
-  | 12
-  | 'auto'
-> = PropTypes.oneOf([
-  -12,
-  -11,
-  -10,
-  -9,
-  -8,
-  -7,
-  -6,
-  -5,
-  -4,
-  -3,
-  -2,
-  -1,
-  0,
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  10,
-  11,
-  12,
-  'auto',
-]);
-
-export const OverflowPropType: React$PropType$Primitive<
-  'visible' | 'hidden' | 'scroll' | 'scrollX' | 'scrollY' | 'auto'
-> = PropTypes.oneOf([
-  'visible',
-  'hidden',
-  'scroll',
-  'scrollX',
-  'scrollY',
-  'auto',
-]);
-
-export const PaddingPropType: React$PropType$Primitive<
-  0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
-> = PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-
-const RoundingPropType = PropTypes.oneOf([
-  0,
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  'circle',
-  'pill',
-]);
 
 // $FlowFixMe Flow(InferError)
 BoxWithForwardRef.propTypes = {
@@ -836,30 +251,8 @@ BoxWithForwardRef.propTypes = {
   alignItems: AlignItemsPropType,
   alignSelf: AlignSelfPropType,
   bottom: PropTypes.bool,
-  borderSize: PropTypes.oneOf(['sm', 'lg', 'none']),
-  color: PropTypes.oneOf([
-    'blue',
-    'darkGray',
-    'darkWash',
-    'eggplant',
-    'gray',
-    'green',
-    'lightGray',
-    'lightWash',
-    'maroon',
-    'midnight',
-    'navy',
-    'olive',
-    'orange',
-    'orchid',
-    'pine',
-    'purple',
-    'red',
-    'transparent',
-    'transparentDarkGray',
-    'watermelon',
-    'white',
-  ]),
+  borderSize: BorderSizePropType,
+  color: ColorPropType,
   fit: PropTypes.bool,
   flex: FlexPropType,
   height: DimensionPropType,
@@ -903,7 +296,7 @@ BoxWithForwardRef.propTypes = {
   minHeight: DimensionPropType,
   minWidth: DimensionPropType,
 
-  opacity: PropTypes.oneOf([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]),
+  opacity: OpacityPropType,
 
   overflow: OverflowPropType,
 
@@ -923,14 +316,14 @@ BoxWithForwardRef.propTypes = {
   lgPaddingX: PaddingPropType,
   lgPaddingY: PaddingPropType,
 
-  position: PropTypes.oneOf(['static', 'absolute', 'relative', 'fixed']),
+  position: PositionPropType,
   right: PropTypes.bool,
   rounding: RoundingPropType,
   top: PropTypes.bool,
   width: DimensionPropType,
   wrap: PropTypes.bool,
 
-  userSelect: PropTypes.oneOf(['auto', 'none']),
+  userSelect: UserSelectPropType,
 
   role: PropTypes.string,
 

--- a/packages/gestalt/src/FlexBox.js
+++ b/packages/gestalt/src/FlexBox.js
@@ -1,7 +1,8 @@
 // @flow strict
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
-import Box, {
+import Box from './Box.js';
+import {
   AlignContentPropType,
   AlignItemsPropType,
   AlignSelfPropType,
@@ -20,7 +21,7 @@ import Box, {
   type JustifyContent,
   type Overflow,
   type Padding,
-} from './Box.js';
+} from './boxTypes.js';
 
 type Props = {|
   alignContent?: AlignContent,

--- a/packages/gestalt/src/Row.js
+++ b/packages/gestalt/src/Row.js
@@ -2,7 +2,8 @@
 import React, { Children, type Node } from 'react';
 import PropTypes from 'prop-types';
 import FlexBox from './FlexBox.js';
-import Box, {
+import Box from './Box.js';
+import {
   AlignContentPropType,
   AlignItemsPropType,
   AlignSelfPropType,
@@ -19,7 +20,7 @@ import Box, {
   type JustifyContent,
   type Overflow,
   type Padding,
-} from './Box.js';
+} from './boxTypes.js';
 
 type Props = {|
   alignContent?: AlignContent,

--- a/packages/gestalt/src/Stack.js
+++ b/packages/gestalt/src/Stack.js
@@ -2,7 +2,8 @@
 import React, { Children, type Node } from 'react';
 import PropTypes from 'prop-types';
 import FlexBox from './FlexBox.js';
-import Box, {
+import Box from './Box.js';
+import {
   AlignContentPropType,
   AlignItemsPropType,
   AlignSelfPropType,
@@ -19,7 +20,7 @@ import Box, {
   type JustifyContent,
   type Overflow,
   type Padding,
-} from './Box.js';
+} from './boxTypes.js';
 
 type Props = {|
   alignContent?: AlignContent,

--- a/packages/gestalt/src/boxTransforms.js
+++ b/packages/gestalt/src/boxTransforms.js
@@ -1,0 +1,560 @@
+// @flow strict
+import styles from './Box.css';
+import borders from './Borders.css';
+import colors from './Colors.css';
+import layout from './Layout.css';
+import whitespace from './boxWhitespace.css';
+import {
+  concat,
+  fromClassName,
+  fromInlineStyle,
+  identity,
+  mapClassName,
+  toProps,
+  type ToPropsOutput,
+} from './style.js';
+import omit from './utils/omit.js';
+import {
+  union,
+  bind,
+  range,
+  toggle,
+  mapping,
+  rangeWithZero,
+  rangeWithoutZero,
+  type Functor,
+} from './transforms.js';
+import { getRoundingStyle } from './getRoundingClassName.js';
+import { type Indexable } from './zIndex.js';
+import {
+  type AlignContent,
+  type AlignItems,
+  type AlignSelf,
+  type BorderSize,
+  type Column,
+  type Color,
+  type DangerouslySetInlineStyle,
+  type Dimension,
+  type Display,
+  type Direction,
+  type Flex,
+  type JustifyContent,
+  type Margin,
+  type Opacity,
+  type Overflow,
+  type Padding,
+  type Position,
+  type UserSelect,
+} from './boxTypes.js';
+
+/*
+
+# Transformers
+
+This is where the meat and the bones of Box's transforms are. You can read more about the DSL in `./transforms.js`, but basically they are a small declarative way of specifying how a property (i.e. `marginTop={4}`) gets turned into a CSS class (`marginTop4`).
+
+There's a little preamble here, but it culminates in a big object mapping the actual property names to the transformer values.
+
+*/
+
+const display: Functor<Display> = mapping({
+  none: styles.xsDisplayNone,
+  flex: styles.xsDisplayFlex,
+  block: styles.xsDisplayBlock,
+  inlineBlock: styles.xsDisplayInlineBlock,
+  visuallyHidden: styles.xsDisplayVisuallyHidden,
+});
+const column: Functor<Column> = bind(range('xsCol'), styles);
+const direction: Functor<Direction> = mapping({
+  row: styles.xsDirectionRow,
+  column: styles.xsDirectionColumn,
+});
+
+const smDisplay: Functor<Display> = mapping({
+  none: styles.smDisplayNone,
+  flex: styles.smDisplayFlex,
+  block: styles.smDisplayBlock,
+  inlineBlock: styles.smDisplayInlineBlock,
+  visuallyHidden: styles.smDisplayVisuallyHidden,
+});
+const smColumn: Functor<Column> = bind(range('smCol'), styles);
+const smDirection: Functor<Direction> = mapping({
+  row: styles.smDirectionRow,
+  column: styles.smDirectionColumn,
+});
+
+const mdDisplay: Functor<Display> = mapping({
+  none: styles.mdDisplayNone,
+  flex: styles.mdDisplayFlex,
+  block: styles.mdDisplayBlock,
+  inlineBlock: styles.mdDisplayInlineBlock,
+  visuallyHidden: styles.mdDisplayVisuallyHidden,
+});
+const mdColumn: Functor<Column> = bind(range('mdCol'), styles);
+const mdDirection: Functor<Direction> = mapping({
+  row: styles.mdDirectionRow,
+  column: styles.mdDirectionColumn,
+});
+
+const lgDisplay: Functor<Display> = mapping({
+  none: styles.lgDisplayNone,
+  flex: styles.lgDisplayFlex,
+  block: styles.lgDisplayBlock,
+  inlineBlock: styles.lgDisplayInlineBlock,
+  visuallyHidden: styles.lgDisplayVisuallyHidden,
+});
+const lgColumn: Functor<Column> = bind(range('lgCol'), styles);
+const lgDirection: Functor<Direction> = mapping({
+  row: styles.lgDirectionRow,
+  column: styles.lgDirectionColumn,
+});
+
+/* ***************************************** */
+
+const alignContent: Functor<AlignContent> = mapping({
+  start: layout.contentStart,
+  end: layout.contentEnd,
+  center: layout.contentCenter,
+  between: layout.contentBetween,
+  around: layout.contentAround,
+  evenly: layout.contentEvenly,
+  // default: stretch
+});
+const alignItems: Functor<AlignItems> = mapping({
+  start: layout.itemsStart,
+  end: layout.itemsEnd,
+  center: layout.itemsCenter,
+  baseline: layout.itemsBaseline,
+  // default: stretch
+});
+const alignSelf: Functor<AlignSelf> = mapping({
+  start: layout.selfStart,
+  end: layout.selfEnd,
+  center: layout.selfCenter,
+  baseline: layout.selfBaseline,
+  stretch: layout.selfStretch,
+  // default: auto
+});
+const bottom: Functor<boolean> = toggle(layout.bottom0);
+const borderSize: Functor<BorderSize> = value => {
+  const borderProps =
+    value !== 'none'
+      ? [
+          fromClassName(borders.solid),
+          fromClassName(borders.borderColorLightGray),
+        ]
+      : [];
+  return concat([
+    mapping({
+      sm: borders.sizeSm,
+      lg: borders.sizeLg,
+      // default: none
+    })(value),
+    ...borderProps,
+  ]);
+};
+const color: Functor<Color> = mapping({
+  blue: colors.blueBg,
+  darkGray: colors.darkGrayBg,
+  pine: colors.pineBg,
+  gray: colors.grayBg,
+  red: colors.redBg,
+  olive: colors.oliveBg,
+  lightGray: colors.lightGrayBg,
+  white: colors.whiteBg,
+  orange: colors.orangeBg,
+  green: colors.greenBg,
+  navy: colors.navyBg,
+  midnight: colors.midnightBg,
+  purple: colors.purpleBg,
+  orchid: colors.orchidBg,
+  eggplant: colors.eggplantBg,
+  maroon: colors.maroonBg,
+  watermelon: colors.watermelonBg,
+  lightWash: colors.lightWashBg,
+  darkWash: colors.darkWashBg,
+  transparentDarkGray: colors.transparentDarkGrayBg,
+  // default: transparent
+});
+const fit: Functor<boolean> = toggle(layout.fit);
+const flex: Functor<Flex> = mapping({
+  grow: layout.flexGrow,
+  none: layout.flexNone,
+  // default: shrink
+});
+const height: Functor<Dimension> = h => fromInlineStyle({ height: h });
+const justifyContent: Functor<JustifyContent> = mapping({
+  end: layout.justifyEnd,
+  center: layout.justifyCenter,
+  between: layout.justifyBetween,
+  around: layout.justifyAround,
+  evenly: layout.justifyEvenly,
+  // default: start
+});
+const left: Functor<boolean> = toggle(layout.left0);
+
+/* ***************************************** */
+
+type MarginFunctorType = Functor<Margin>;
+
+const transformNumberOrPassthrough = (
+  selector: string
+): MarginFunctorType => m => {
+  if (typeof m === 'number') {
+    return bind(rangeWithZero(selector), whitespace)(m);
+  }
+
+  if (m === 'auto') {
+    return fromClassName(whitespace[`${selector}Auto`]);
+  }
+
+  return identity();
+};
+
+const marginStart: MarginFunctorType = transformNumberOrPassthrough(
+  'marginStart'
+);
+const marginEnd: MarginFunctorType = transformNumberOrPassthrough('marginEnd');
+const marginTop: MarginFunctorType = transformNumberOrPassthrough('marginTop');
+const marginRight: MarginFunctorType = transformNumberOrPassthrough(
+  'marginRight'
+);
+const marginBottom: MarginFunctorType = transformNumberOrPassthrough(
+  'marginBottom'
+);
+const marginLeft: MarginFunctorType = transformNumberOrPassthrough(
+  'marginLeft'
+);
+const margin: MarginFunctorType = union(
+  marginTop,
+  marginBottom,
+  marginLeft,
+  marginRight
+);
+
+const smMarginStart: MarginFunctorType = transformNumberOrPassthrough(
+  'smMarginStart'
+);
+const smMarginEnd: MarginFunctorType = transformNumberOrPassthrough(
+  'smMarginEnd'
+);
+const smMarginTop: MarginFunctorType = transformNumberOrPassthrough(
+  'smMarginTop'
+);
+const smMarginRight: MarginFunctorType = transformNumberOrPassthrough(
+  'smMarginRight'
+);
+const smMarginBottom: MarginFunctorType = transformNumberOrPassthrough(
+  'smMarginBottom'
+);
+const smMarginLeft: MarginFunctorType = transformNumberOrPassthrough(
+  'smMarginLeft'
+);
+const smMargin: MarginFunctorType = union(
+  smMarginTop,
+  smMarginBottom,
+  smMarginLeft,
+  smMarginRight,
+  smMarginStart,
+  smMarginEnd
+);
+
+const mdMarginStart: MarginFunctorType = transformNumberOrPassthrough(
+  'mdMarginStart'
+);
+const mdMarginEnd: MarginFunctorType = transformNumberOrPassthrough(
+  'mdMarginEnd'
+);
+const mdMarginTop: MarginFunctorType = transformNumberOrPassthrough(
+  'mdMarginTop'
+);
+const mdMarginRight: MarginFunctorType = transformNumberOrPassthrough(
+  'mdMarginRight'
+);
+const mdMarginBottom: MarginFunctorType = transformNumberOrPassthrough(
+  'mdMarginBottom'
+);
+const mdMarginLeft: MarginFunctorType = transformNumberOrPassthrough(
+  'mdMarginLeft'
+);
+const mdMargin: MarginFunctorType = union(
+  mdMarginTop,
+  mdMarginBottom,
+  mdMarginLeft,
+  mdMarginRight,
+  mdMarginStart,
+  mdMarginEnd
+);
+
+const lgMarginStart: MarginFunctorType = transformNumberOrPassthrough(
+  'lgMarginStart'
+);
+const lgMarginEnd: MarginFunctorType = transformNumberOrPassthrough(
+  'lgMarginEnd'
+);
+const lgMarginTop: MarginFunctorType = transformNumberOrPassthrough(
+  'lgMarginTop'
+);
+const lgMarginRight: MarginFunctorType = transformNumberOrPassthrough(
+  'lgMarginRight'
+);
+const lgMarginBottom: MarginFunctorType = transformNumberOrPassthrough(
+  'lgMarginBottom'
+);
+const lgMarginLeft: MarginFunctorType = transformNumberOrPassthrough(
+  'lgMarginLeft'
+);
+const lgMargin: MarginFunctorType = union(
+  lgMarginTop,
+  lgMarginBottom,
+  lgMarginLeft,
+  lgMarginRight,
+  lgMarginStart,
+  lgMarginEnd
+);
+
+/* ***************************************** */
+
+const maxHeight: Functor<Dimension> = d => fromInlineStyle({ maxHeight: d });
+const maxWidth: Functor<Dimension> = d => fromInlineStyle({ maxWidth: d });
+const minHeight: Functor<Dimension> = d => fromInlineStyle({ minHeight: d });
+const minWidth: Functor<Dimension> = d => fromInlineStyle({ minWidth: d });
+const opacityMap = mapClassName(name => styles[name]);
+const opacity: Functor<Opacity> = val => {
+  if (val > 0 && val < 1) {
+    return opacityMap(range('opacity0')(val * 10));
+  }
+  return opacityMap(range('opacity')(val));
+};
+const overflow: Functor<Overflow> = mapping({
+  hidden: layout.overflowHidden,
+  scroll: layout.overflowScroll,
+  auto: layout.overflowAuto,
+  scrollX: layout.overflowScrollX,
+  scrollY: layout.overflowScrollY,
+  // default: visible
+});
+
+/* ***************************************** */
+
+type PaddingFunctor = Functor<Padding>;
+
+const paddingX: PaddingFunctor = bind(rangeWithoutZero('paddingX'), whitespace);
+const paddingY: PaddingFunctor = bind(rangeWithoutZero('paddingY'), whitespace);
+const padding: PaddingFunctor = union(paddingX, paddingY);
+
+const smPaddingX: PaddingFunctor = bind(
+  rangeWithoutZero('smPaddingX'),
+  whitespace
+);
+const smPaddingY: PaddingFunctor = bind(
+  rangeWithoutZero('smPaddingY'),
+  whitespace
+);
+const smPadding: PaddingFunctor = union(smPaddingX, smPaddingY);
+
+const mdPaddingX: PaddingFunctor = bind(
+  rangeWithoutZero('mdPaddingX'),
+  whitespace
+);
+const mdPaddingY: PaddingFunctor = bind(
+  rangeWithoutZero('mdPaddingY'),
+  whitespace
+);
+const mdPadding: PaddingFunctor = union(mdPaddingX, mdPaddingY);
+
+const lgPaddingX: PaddingFunctor = bind(
+  rangeWithoutZero('lgPaddingX'),
+  whitespace
+);
+const lgPaddingY: PaddingFunctor = bind(
+  rangeWithoutZero('lgPaddingY'),
+  whitespace
+);
+const lgPadding: PaddingFunctor = union(lgPaddingX, lgPaddingY);
+
+/* ***************************************** */
+
+const position: Functor<Position> = mapping({
+  absolute: layout.absolute,
+  relative: layout.relative,
+  fixed: layout.fixed,
+  // default: static
+});
+const right: Functor<boolean> = toggle(layout.right0);
+const rounding = getRoundingStyle;
+const top: Functor<boolean> = toggle(layout.top0);
+const userSelect: Functor<UserSelect> = mapping({
+  none: styles.userSelectNone,
+  // default: auto
+});
+const width: Functor<Dimension> = w => fromInlineStyle({ width: w });
+const wrap: Functor<boolean> = toggle(layout.flexWrap);
+const dangerouslySetInlineStyle: Functor<DangerouslySetInlineStyle> = value => {
+  // eslint-disable-next-line no-underscore-dangle
+  return value && value.__style ? fromInlineStyle(value.__style) : identity();
+};
+const zIndex: Functor<?Indexable> = value => {
+  if (!value) {
+    return identity();
+  }
+  return fromInlineStyle({ zIndex: value.index() });
+};
+
+/*
+
+It's preferable to put new properties into that object directly just so it's easier to read.
+Unfortunately Flow doesn't like that for the vast majority of the fields. :(
+
+*/
+
+export const propToFn = {
+  display,
+  column,
+  direction,
+
+  smDisplay,
+  smColumn,
+  smDirection,
+
+  mdDisplay,
+  mdColumn,
+  mdDirection,
+
+  lgDisplay,
+  lgColumn,
+  lgDirection,
+
+  alignContent,
+  alignItems,
+  alignSelf,
+  bottom,
+  borderSize,
+  color,
+  fit,
+  flex,
+  height,
+  justifyContent,
+  left,
+
+  margin,
+  marginTop,
+  marginRight,
+  marginBottom,
+  marginLeft,
+  marginStart,
+  marginEnd,
+
+  smMargin,
+  smMarginTop,
+  smMarginRight,
+  smMarginBottom,
+  smMarginLeft,
+  smMarginStart,
+  smMarginEnd,
+
+  mdMargin,
+  mdMarginTop,
+  mdMarginRight,
+  mdMarginBottom,
+  mdMarginLeft,
+  mdMarginStart,
+  mdMarginEnd,
+
+  lgMargin,
+  lgMarginTop,
+  lgMarginRight,
+  lgMarginBottom,
+  lgMarginLeft,
+  lgMarginStart,
+  lgMarginEnd,
+
+  maxHeight,
+  maxWidth,
+  minHeight,
+  minWidth,
+  opacity,
+  overflow,
+
+  padding,
+  paddingX,
+  paddingY,
+  smPadding,
+  smPaddingX,
+  smPaddingY,
+  mdPadding,
+  mdPaddingX,
+  mdPaddingY,
+  lgPadding,
+  lgPaddingX,
+  lgPaddingY,
+
+  position,
+  right,
+  rounding,
+  top,
+  userSelect,
+  width,
+  wrap,
+  dangerouslySetInlineStyle,
+  zIndex,
+};
+
+/*
+
+# Style Builder
+
+This is where it all comes together. This function takes the base styles for the component,
+the component's props, and any disallowed props. It outputs the passthrough props (after
+removing disallowed and given props), as well as an object with the combined classNames
+and styles from the given props.
+
+*/
+
+// $FlowExpectedError[unclear-type]
+export function buildStyles<T: Object>(
+  baseStyles: string,
+  props: T,
+  disallowedProps?: Array<string>
+): {|
+  passthroughProps: T,
+  propsStyles: ToPropsOutput,
+|} {
+  // Flow can't reason about the constant nature of Object.keys so we can't use
+  // a functional (reduce) style here.
+
+  // All Box's are box-sized by default, so we start off building up the styles
+  // to be applied with a Box base class.
+  let s = fromClassName(baseStyles);
+
+  // Init the list of props we'll omit from passthrough. We'll add to this
+  // list as we match props against the transforms list.
+  const omitProps = [...(disallowedProps ?? [])];
+
+  // This loops through each property and if it exists in the previously
+  // defined transform map, concatenates the resulting styles to the base
+  // styles. If there's a match, we also don't pass through that property. This
+  // means Box's runtime is only dependent on the number of properties passed
+  // to it (which is typically small) instead of the total number of possible
+  // properties (~30 or so). While it may ~feel~ like Box is inefficient, its
+  // biggest performance impact is on startup time because there's so much code
+  // here.
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const prop in props) {
+    if (
+      Object.prototype.hasOwnProperty.call(propToFn, prop) &&
+      !omitProps.includes(prop)
+    ) {
+      const fn = propToFn[prop];
+      const value = props[prop];
+      omitProps.push(prop);
+      s = concat([s, fn(value)]);
+    }
+  }
+
+  return {
+    passthroughProps: omit(omitProps, props),
+    propsStyles: toProps(s),
+  };
+}

--- a/packages/gestalt/src/boxTypes.js
+++ b/packages/gestalt/src/boxTypes.js
@@ -1,0 +1,237 @@
+// @flow strict
+import PropTypes from 'prop-types';
+
+/*
+
+FLOW TYPES
+
+*/
+
+export type DangerouslySetInlineStyle = {|
+  __style: { [key: string]: string | number | void },
+|};
+
+export type AlignContent =
+  | 'start'
+  | 'end'
+  | 'center'
+  | 'between'
+  | 'around'
+  | 'evenly'
+  | 'stretch';
+export type AlignItems = 'start' | 'end' | 'center' | 'baseline' | 'stretch';
+export type AlignSelf =
+  | 'auto'
+  | 'start'
+  | 'end'
+  | 'center'
+  | 'baseline'
+  | 'stretch';
+export type Bottom = boolean;
+export type BorderSize = 'sm' | 'lg' | 'none';
+export type Color =
+  | 'blue'
+  | 'darkGray'
+  | 'darkWash'
+  | 'eggplant'
+  | 'gray'
+  | 'green'
+  | 'lightGray'
+  | 'lightWash'
+  | 'maroon'
+  | 'midnight'
+  | 'navy'
+  | 'olive'
+  | 'orange'
+  | 'orchid'
+  | 'pine'
+  | 'purple'
+  | 'red'
+  | 'transparent'
+  | 'transparentDarkGray'
+  | 'watermelon'
+  | 'white';
+export type Column = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type Dimension = number | string;
+export type Display =
+  | 'none'
+  | 'flex'
+  | 'block'
+  | 'inlineBlock'
+  | 'visuallyHidden';
+export type Direction = 'row' | 'column';
+export type Flex = 'grow' | 'shrink' | 'none';
+export type Fit = boolean;
+export type JustifyContent =
+  | 'start'
+  | 'end'
+  | 'center'
+  | 'between'
+  | 'around'
+  | 'evenly';
+export type Left = boolean;
+export type Margin =
+  | -12
+  | -11
+  | -10
+  | -9
+  | -8
+  | -7
+  | -6
+  | -5
+  | -4
+  | -3
+  | -2
+  | -1
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 'auto';
+
+export type Opacity =
+  | 0
+  | 0.1
+  | 0.2
+  | 0.3
+  | 0.4
+  | 0.5
+  | 0.6
+  | 0.7
+  | 0.8
+  | 0.9
+  | 1;
+export type Overflow =
+  | 'visible'
+  | 'hidden'
+  | 'scroll'
+  | 'scrollX'
+  | 'scrollY'
+  | 'auto';
+export type Padding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type Position = 'static' | 'absolute' | 'relative' | 'fixed';
+export type Right = boolean;
+export type Role = string;
+export type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill';
+export type Top = boolean;
+export type UserSelect = 'auto' | 'none';
+export type Wrap = boolean;
+
+/*
+
+PROPTYPES
+
+*/
+
+export const AlignContentPropType: React$PropType$Primitive<AlignContent> = PropTypes.oneOf(
+  ['start', 'end', 'center', 'between', 'around', 'evenly', 'stretch']
+);
+export const AlignItemsPropType: React$PropType$Primitive<AlignItems> = PropTypes.oneOf(
+  ['start', 'end', 'center', 'baseline', 'stretch']
+);
+export const AlignSelfPropType: React$PropType$Primitive<AlignSelf> = PropTypes.oneOf(
+  ['auto', 'start', 'end', 'center', 'baseline', 'stretch']
+);
+export const BorderSizePropType: React$PropType$Primitive<BorderSize> = PropTypes.oneOf(
+  ['sm', 'lg', 'none']
+);
+export const ColorPropType: React$PropType$Primitive<Color> = PropTypes.oneOf([
+  'blue',
+  'darkGray',
+  'darkWash',
+  'eggplant',
+  'gray',
+  'green',
+  'lightGray',
+  'lightWash',
+  'maroon',
+  'midnight',
+  'navy',
+  'olive',
+  'orange',
+  'orchid',
+  'pine',
+  'purple',
+  'red',
+  'transparent',
+  'transparentDarkGray',
+  'watermelon',
+  'white',
+]);
+export const ColumnPropType: React$PropType$Primitive<Column> = PropTypes.oneOf(
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+);
+export const DimensionPropType: React$PropType$Primitive<Dimension> = PropTypes.oneOfType(
+  [PropTypes.number, PropTypes.string]
+);
+export const DirectionPropType: React$PropType$Primitive<Direction> = PropTypes.oneOf(
+  ['row', 'column']
+);
+export const DisplayPropType: React$PropType$Primitive<Display> = PropTypes.oneOf(
+  ['none', 'flex', 'block', 'inlineBlock', 'visuallyHidden']
+);
+export const FlexPropType: React$PropType$Primitive<Flex> = PropTypes.oneOf([
+  'grow',
+  'shrink',
+  'none',
+]);
+export const JustifyContentPropType: React$PropType$Primitive<JustifyContent> = PropTypes.oneOf(
+  ['start', 'end', 'center', 'between', 'around', 'evenly']
+);
+export const MarginPropType: React$PropType$Primitive<Margin> = PropTypes.oneOf(
+  [
+    -12,
+    -11,
+    -10,
+    -9,
+    -8,
+    -7,
+    -6,
+    -5,
+    -4,
+    -3,
+    -2,
+    -1,
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    'auto',
+  ]
+);
+export const OpacityPropType: React$PropType$Primitive<Opacity> = PropTypes.oneOf(
+  [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+);
+export const OverflowPropType: React$PropType$Primitive<Overflow> = PropTypes.oneOf(
+  ['visible', 'hidden', 'scroll', 'scrollX', 'scrollY', 'auto']
+);
+export const PaddingPropType: React$PropType$Primitive<Padding> = PropTypes.oneOf(
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+);
+export const PositionPropType: React$PropType$Primitive<Position> = PropTypes.oneOf(
+  ['static', 'absolute', 'relative', 'fixed']
+);
+export const RoundingPropType: React$PropType$Primitive<Rounding> = PropTypes.oneOf(
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 'circle', 'pill']
+);
+export const UserSelectPropType: React$PropType$Primitive<UserSelect> = PropTypes.oneOf(
+  ['auto', 'none']
+);

--- a/packages/gestalt/src/style.js
+++ b/packages/gestalt/src/style.js
@@ -60,10 +60,9 @@ export const mapClassName = (fn: (x: string) => string): (Style => Style) => ({
   inlineStyle,
 });
 
-export const toProps = ({
-  className,
-  inlineStyle,
-}: Style): { className: string, style: InlineStyle, ... } => {
+export type ToPropsOutput = {| className: string, style: InlineStyle |};
+
+export const toProps = ({ className, inlineStyle }: Style): ToPropsOutput => {
   const props = {};
 
   if (className.size > 0) {
@@ -79,5 +78,6 @@ export const toProps = ({
     props.style = inlineStyle;
   }
 
+  // $FlowFixMe[incompatible-exact]
   return props;
 };

--- a/packages/gestalt/src/transforms.js
+++ b/packages/gestalt/src/transforms.js
@@ -1,5 +1,4 @@
 // @flow strict
-
 import {
   concat,
   fromClassName,
@@ -16,7 +15,7 @@ These are a collection of a few functors that take values and returns Style's. O
 
 */
 
-type Functor<T> = (n: T) => Style;
+export type Functor<T> = (n: T) => Style;
 
 // Adds a classname when a property is present.
 //

--- a/packages/gestalt/src/utils/omit.js
+++ b/packages/gestalt/src/utils/omit.js
@@ -1,0 +1,16 @@
+// @flow strict
+
+const contains = (key, arr) => arr.indexOf(key) >= 0;
+// $FlowExpectedError[unclear-type]
+const omit = (keys: Array<string>, obj: Object): Object =>
+  Object.keys(obj).reduce((acc, k: string) => {
+    if (contains(k, keys)) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [k]: obj[k],
+    };
+  }, {});
+
+export default omit;


### PR DESCRIPTION
After [yet another failed attempt](https://github.com/pinterest/gestalt/pull/1221) at improving Row/Stack, I'm putting that work on the back burner for a month or so. But I don't want to lose the work put into extracting types, transforms, and general cleanup to Box, so here are those changes. This should be a pure refactor, with no visual or API differences.