### PR TITLE
Layer: add zIndex prop

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -212,6 +212,7 @@ card(
       },
       {
         name: 'zIndex',
+        href: 'zindex',
         type: 'interface Indexable { index(): number; }',
         description: `An object representing the zIndex value of the Box.`,
       },

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -23,6 +23,11 @@ card(
         type: 'React.Node',
         required: true,
       },
+      {
+        name: 'zIndex',
+        type: 'interface Indexable { index(): number; }',
+        description: `An object representing the zIndex value of the Layer.`,
+      },
     ]}
   />
 );
@@ -49,30 +54,72 @@ function Example() {
   const [showLayer, setShowLayer] = React.useState(false);
 
   return (
-    <Box marginLeft={-1} marginRight={-1}>
-      <Box padding={1}>
-        <Button
-          text="Show Layer"
-          onClick={() => setShowLayer(!showLayer)}
-        />
-        {showLayer && (
-          <Layer>
-            <Box color="darkWash" position="fixed" top left right bottom display="flex" alignItems="center" justifyContent="center">
-              <Box color="white" padding={3} display="flex" alignItems="center">
-                <Text>Layer Content</Text>
-                <Box marginStart={2}>
-                  <IconButton
-                    accessibilityLabel="Close"
-                    icon="cancel"
-                    onClick={() => setShowLayer(!showLayer)}
-                  />
-                </Box>
+    <>
+      <Button
+        inline
+        text="Show Layer"
+        onClick={() => setShowLayer(!showLayer)}
+      />
+      {showLayer && (
+        <Layer>
+          <Box color="darkWash" position="fixed" top left right bottom display="flex" alignItems="center" justifyContent="center">
+            <Box color="white" padding={3} display="flex" alignItems="center">
+              <Text>Layer Content</Text>
+              <Box marginStart={2}>
+                <IconButton
+                  accessibilityLabel="Close"
+                  icon="cancel"
+                  onClick={() => setShowLayer(!showLayer)}
+                />
               </Box>
             </Box>
-          </Layer>
-        )}
-      </Box>
-    </Box>
+          </Box>
+        </Layer>
+      )}
+    </>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    description="
+The example below shows using a \`FixedZIndex\` for the header zIndex and a \`CompositeZIndex\` to stack the Layer on top of it.
+    "
+    name="zIndex"
+    defaultCode={`
+function zIndexExample() {
+  const [showLayer, setShowLayer] = React.useState(false);
+  const HEADER_ZINDEX = new FixedZIndex(100);
+  // Results in a zIndex of 101
+  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+
+  return (
+    <>
+      <Button
+        inline
+        text="Show Layer"
+        onClick={() => setShowLayer(!showLayer)}
+      />
+      {showLayer && (
+        <Layer zIndex={zIndex}>
+          <Box color="darkWash" position="fixed" top left right bottom display="flex" alignItems="center" justifyContent="center">
+            <Box color="white" padding={3} display="flex" alignItems="center">
+              <Text>Layer Content</Text>
+              <Box marginStart={2}>
+                <IconButton
+                  accessibilityLabel="Close"
+                  icon="cancel"
+                  onClick={() => setShowLayer(!showLayer)}
+                />
+              </Box>
+            </Box>
+          </Box>
+        </Layer>
+      )}
+    </>
   );
 }
 `}

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -105,6 +105,8 @@ function Example(props) {
 
   const initialState = {modal: 'none'};
   const [state, dispatch] = React.useReducer(reducer, initialState);
+  const HEADER_ZINDEX = new FixedZIndex(1);
+  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
   return (
     <Box marginLeft={-1} marginRight={-1}>
@@ -115,7 +117,7 @@ function Example(props) {
           onClick={() => { dispatch({type: 'small'}) }}
         />
         {state.modal === 'small' && (
-          <Layer>
+          <Layer zIndex={zIndex}>
             <Modal
               accessibilityModalLabel="View default padding and styling"
               heading="Small modal"
@@ -137,7 +139,7 @@ function Example(props) {
           onClick={() => { dispatch({type: 'medium'}) }}
         />
         {state.modal === 'medium' && (
-          <Layer>
+          <Layer zIndex={zIndex}>
             <Modal
               accessibilityModalLabel="View default padding and styling"
               heading="Medium modal"
@@ -159,7 +161,7 @@ function Example(props) {
           onClick={() => { dispatch({type: 'large'}) }}
         />
         {state.modal === 'large' && (
-          <Layer>
+          <Layer zIndex={zIndex}>
             <Modal
               accessibilityModalLabel="View default padding and styling"
               heading="Large modal"

--- a/docs/src/components/DocSearch.css
+++ b/docs/src/components/DocSearch.css
@@ -25,7 +25,7 @@
   height: 100%;
   position: relative;
   width: 100%;
-  z-index: 999;
+  z-index: 1;
 }
 
 .searchbox__input {

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -1,11 +1,14 @@
 // @flow strict
 import { useRef, useState, type Portal, type Node, useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import { type Indexable } from './zIndex.js';
 
 export default function Layer({
   children,
+  zIndex,
 }: {|
   children: Node,
+  zIndex?: Indexable,
 |}): Portal | null {
   const [mounted, setMounted] = useState(false);
   const element = useRef<?HTMLDivElement>(null);
@@ -15,6 +18,8 @@ export default function Layer({
 
     if (typeof document !== 'undefined' && document.createElement) {
       element.current = document.createElement('div');
+      element.current.style.zIndex = zIndex ? `${zIndex.index()}` : '';
+      element.current.style.position = zIndex ? 'absolute' : '';
     }
 
     if (typeof document !== 'undefined' && document.body && element.current) {
@@ -26,10 +31,11 @@ export default function Layer({
         document.body.removeChild(element.current);
       }
     };
-  }, []);
+  }, [zIndex]);
 
   if (!mounted || !element.current) {
     return null;
   }
+
   return createPortal(children, element.current);
 }

--- a/packages/gestalt/src/Layer.jsdom.test.js
+++ b/packages/gestalt/src/Layer.jsdom.test.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Layer from './Layer.js';
+import { FixedZIndex } from './zIndex.js';
 
 describe('Layer in browser render', () => {
   if (typeof document !== 'undefined') {
@@ -18,6 +19,14 @@ describe('Layer in browser render', () => {
       const element = getByText('content');
       unmount();
       expect(body && body.contains(element)).toBeFalsy();
+    });
+
+    it('sets the zIndex if it is defined', () => {
+      const { getByText } = render(
+        <Layer zIndex={new FixedZIndex(200)}>content</Layer>
+      );
+      const element = getByText('content');
+      expect(element.style.zIndex).toEqual('200');
     });
   }
 });


### PR DESCRIPTION
Add `zIndex` as a prop to `<Layer />`.

## Why do we add zIndex as a prop?

In too many cases in the Pinterest codebase, we see the a `<Box />` with position: absolute & zIndex inside of a Layer, just to show the content on top: 

```
<Layer>
  <Box position="absolute" zIndex={MODAL_ZINDEX}>
    {children}
  </Box>
</Layer>
```

Instead, we would like to write the following:
```
<Layer zIndex={MODAL_ZINDEX}>
  {children}
</Layer>
```

## Test Plan

* Verify the `Layer` with zIndex shows on top of the sticky header (with zIndex of `1`) in the docs.

### Before
Sticky header is on top of the Layer

![Screen Shot 2020-09-17 at 9 25 06 AM](https://user-images.githubusercontent.com/127199/93500444-04bf9200-f8c9-11ea-944e-a5344f568b54.png)

### After
Sticky header is below the Layer

![Screen Shot 2020-09-17 at 9 24 56 AM](https://user-images.githubusercontent.com/127199/93500473-06895580-f8c9-11ea-9ebe-818e3430783b.png)