### PR TITLE
Sticky: remove deprecated dangerouslySetZIndex

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 [ignore]
 <PROJECT_ROOT>/packages/gestalt-codemods/.*/__testfixtures__
 <PROJECT_ROOT>/cypress
+<PROJECT_ROOT>/node_modules/cypress/
 
 [options]
 esproposal.optional_chaining=enable

--- a/packages/gestalt-codemods/13.14.0-14.0.0/sticky-find-deprecated-dangerouslySetZIndex.js
+++ b/packages/gestalt-codemods/13.14.0-14.0.0/sticky-find-deprecated-dangerouslySetZIndex.js
@@ -1,0 +1,50 @@
+/*
+ * Log an error when `dangerouslySetZIndex` is specified on `<Sticky />`
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+
+  src.find(j.ImportDeclaration).forEach(path => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter(node => node.imported.name === 'Sticky')
+      .map(node => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  src
+    .find(j.JSXElement)
+    .forEach(jsxElement => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      attrs.forEach(attr => {
+        if (attr.name && attr.name.name === 'dangerouslySetZIndex') {
+          // eslint-disable-next-line no-console
+          console.error(
+            `Replace legacy dangerouslySetZIndex with zIndex on Sticky: ${file.path}:${attr.loc.start.line}:${attr.loc.start.column}`
+          );
+        }
+      });
+      return null;
+    })
+    .toSource();
+
+  return null;
+}

--- a/packages/gestalt/src/Sticky.flowtest.js
+++ b/packages/gestalt/src/Sticky.flowtest.js
@@ -1,0 +1,29 @@
+// @flow strict
+import React from 'react';
+import Sticky from './Sticky.js';
+import { FixedZIndex } from './zIndex.js';
+
+const ValidDefaultStickyType = <Sticky top={0}>Content</Sticky>;
+
+const ValidZIndex = (
+  <Sticky top={0} zIndex={new FixedZIndex(1)}>
+    Content
+  </Sticky>
+);
+
+const InValidZIndex = (
+  // $FlowExpectedError[incompatible-type]
+  <Sticky top={0} zIndex={1}>
+    Content
+  </Sticky>
+);
+
+// $FlowExpectedError[incompatible-type]
+const MissingProp = <Sticky />;
+
+const IncompatibleLegacyZIndexProp = (
+  // $FlowExpectedError[incompatible-type]
+  <Sticky top={0} dangerouslySetZIndex={1}>
+    Content
+  </Sticky>
+);

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -22,7 +22,6 @@ type Threshold =
 type Props = {|
   ...Threshold,
   children: Node,
-  dangerouslySetZIndex?: {| __zIndex: number |},
   height?: number,
   zIndex?: Indexable,
 |};
@@ -30,14 +29,8 @@ type Props = {|
 const DEFAULT_ZINDEX = new FixedZIndex(1);
 
 export default function Sticky(props: Props): Node {
-  const { dangerouslySetZIndex, children, height } = props;
-  const zIndex =
-    props.zIndex ||
-    (dangerouslySetZIndex &&
-    Object.prototype.hasOwnProperty.call(dangerouslySetZIndex, '__zIndex')
-      ? // eslint-disable-next-line no-underscore-dangle
-        new FixedZIndex(dangerouslySetZIndex.__zIndex)
-      : DEFAULT_ZINDEX);
+  const { children, height } = props;
+  const zIndex = props.zIndex || DEFAULT_ZINDEX;
   const style = {
     ...(height !== undefined ? { height } : {}),
     top: props.top != null ? props.top : undefined,
@@ -55,9 +48,6 @@ export default function Sticky(props: Props): Node {
 
 Sticky.propTypes = {
   children: PropTypes.node,
-  dangerouslySetZIndex: PropTypes.exact({
-    __zIndex: PropTypes.number,
-  }),
   top: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   left: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),


### PR DESCRIPTION
`dangerouslySetZIndex` has been removed from the Pinterest codebase.

## Changes

* Remove `dangerouslySetZIndex` from `<Sticky />`
* Add a codemod to find legacy usages when other people upgrade
* Add flow test for `<Sticky />`

## Test Plan

* `dangerouslySetZIndex` is no longer available on Sticky
