### PR TITLE
Button: add accessibility integration tests

### DIFF
--- a/cypress/integration/accessibility_button_spec.js
+++ b/cypress/integration/accessibility_button_spec.js
@@ -1,10 +1,10 @@
 describe('Accessibility', () => {
   beforeEach(() => {
-    cy.visit('/');
+    cy.visit('/Button');
     cy.injectAxe();
   });
 
-  it('Tests accessibility on the root page page', () => {
+  it('Tests accessibility on the Button page', () => {
     cy.checkA11y();
   });
 });

--- a/cypress/integration/accessibility_root_spec.js
+++ b/cypress/integration/accessibility_root_spec.js
@@ -1,0 +1,10 @@
+describe('Accessibility', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the root page', () => {
+    cy.checkA11y();
+  });
+});

--- a/docs/src/components/Checkerboard.js
+++ b/docs/src/components/Checkerboard.js
@@ -1,48 +1,30 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { useColorScheme } from 'gestalt';
+import { Box, useColorScheme } from 'gestalt';
 
-type Props = {|
-  size?: number,
-|};
-
-export default function Checkerboard({ size = 8 }: Props): Node {
-  const { colorGray400 } = useColorScheme();
+export default function Checkerboard(): Node {
+  const { colorGray300 } = useColorScheme();
+  const colorGray300Encoded = colorGray300.replace('#', '%23');
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      version="1.1"
-      width="100%"
+    <Box
       height="100%"
-      style={{ display: 'flex' }}
-      preserveAspectRatio="none"
-    >
-      <pattern
-        id="pattern"
-        x={0}
-        y={0}
-        width={size * 2}
-        height={size * 2}
-        patternUnits="userSpaceOnUse"
-      >
-        <rect
-          fill={colorGray400}
-          fillOpacity="0.1"
-          x={0}
-          width={size}
-          height={size}
-          y={0}
-        />
-        <rect
-          fill={colorGray400}
-          fillOpacity="0.1"
-          x={size}
-          width={size}
-          height={size}
-          y={size}
-        />
-      </pattern>
-      <rect fill="url(#pattern)" x={0} y={0} width="100%" height="100%" />
-    </svg>
+      width="100%"
+      dangerouslySetInlineStyle={{
+        __style: {
+          backgroundImage: `
+          url('data:image/svg+xml;utf8,
+            <svg preserveAspectRatio="none"  viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+              <rect x="0" y="0" width="5" height="5" fill-opacity="0.1" fill="${colorGray300Encoded}" />
+              <rect x="5" y="5" width="5" height="5" fill-opacity="0.1" fill="${colorGray300Encoded}" />
+              <rect x="5" y="0" width="5" height="5" fill-opacity="0.1" fill="transparent" />
+              <rect x="0" y="5" width="5" height="5" fill-opacity="0.1" fill="transparent" />
+            </svg>
+          ')`
+            .split('\n')
+            .join(''),
+          backgroundSize: '16px 16px',
+        },
+      }}
+    />
   );
 }

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -202,7 +202,11 @@ const Example = ({
               </Box>
               <Box position="relative" display="flex" color="darkGray">
                 <Box flex="grow">
-                  <LiveEditor padding={16} />
+                  {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
+                  {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                  <label>
+                    <LiveEditor padding={16} />
+                  </label>
                 </Box>
                 <Box padding={2}>
                   <Tooltip inline text="Open in CodeSandbox">


### PR DESCRIPTION
Add accessibility tests to the Button tests. This is our first test for a component page so it should set the foundation for other pages as well.

## Fixed exceptions
![Screen Shot 2020-09-21 at 7 56 26 AM](https://user-images.githubusercontent.com/127199/93792124-f4215b80-fbe9-11ea-8aba-c1ce4dc06b8e.png)

## Test Plan

* CI tests (especially the cypress one) passes

