### PR TITLE
Video: add `objectFill`  as a prop

### DIFF
--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -107,6 +107,12 @@ card(
         href: 'nativeVideoAttributesExample',
       },
       {
+        name: 'objectFit',
+        type: "'fill' | 'contain' | 'cover' | 'none' | 'scale-down'",
+        description:
+          'Sets how the content of the replaced <video> element should be resized to fit its container',
+      },
+      {
         name: 'onDurationChange',
         type:
           '({ event: SyntheticEvent<HTMLVideoElement>, duration: number }) => void',

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -11,6 +11,8 @@ type Source =
   | string
   | Array<{| type: 'video/m3u8' | 'video/mp4' | 'video/ogg', src: string |}>;
 
+type ObjectFit = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
+
 type Props = {|
   accessibilityHideCaptionsLabel?: string,
   accessibilityShowCaptionsLabel?: string,
@@ -26,6 +28,7 @@ type Props = {|
   children?: Node,
   controls?: boolean,
   loop?: boolean,
+  objectFit?: ObjectFit,
   onDurationChange?: ({|
     event: SyntheticEvent<HTMLVideoElement>,
     duration: number,
@@ -515,6 +518,7 @@ export default class Video extends PureComponent<Props, State> {
       children,
       crossOrigin,
       loop,
+      objectFit,
       playing,
       playsInline,
       poster,
@@ -523,9 +527,7 @@ export default class Video extends PureComponent<Props, State> {
       volume,
     } = this.props;
     const { currentTime, duration, fullscreen, captionsButton } = this.state;
-
     const paddingBottom = (fullscreen && '0') || `${(1 / aspectRatio) * 100}%`;
-
     return (
       <div
         ref={this.setPlayerRef}
@@ -549,6 +551,8 @@ export default class Video extends PureComponent<Props, State> {
             onSeeked={this.handleSeek}
             onTimeUpdate={this.handleTimeUpdate}
             onProgress={this.handleProgress}
+            // $FlowIssue facebook/flow#8448
+            {...(objectFit ? { style: { 'object-fit': objectFit } } : null)}
             {...(crossOrigin ? { crossOrigin } : null)}
           >
             {Array.isArray(src) &&

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -12,6 +12,7 @@ type Source =
   | Array<{| type: 'video/m3u8' | 'video/mp4' | 'video/ogg', src: string |}>;
 
 type ObjectFit = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
+type CrossOrigin = 'anonymous' | 'use-credentials';
 
 type Props = {|
   accessibilityHideCaptionsLabel?: string,
@@ -24,7 +25,7 @@ type Props = {|
   accessibilityUnmuteLabel: string,
   aspectRatio: number,
   captions: string,
-  crossOrigin?: 'anonymous' | 'use-credentials',
+  crossOrigin?: CrossOrigin,
   children?: Node,
   controls?: boolean,
   loop?: boolean,
@@ -551,9 +552,10 @@ export default class Video extends PureComponent<Props, State> {
             onSeeked={this.handleSeek}
             onTimeUpdate={this.handleTimeUpdate}
             onProgress={this.handleProgress}
-            // $FlowIssue facebook/flow#8448
             {...(objectFit ? { style: { 'object-fit': objectFit } } : null)}
-            {...(crossOrigin ? { crossOrigin } : null)}
+            {...((crossOrigin ? { crossOrigin } : { ...null }): {|
+              crossOrigin?: CrossOrigin,
+            |})}
           >
             {Array.isArray(src) &&
               src.map(source => (

--- a/packages/gestalt/src/Video.test.js
+++ b/packages/gestalt/src/Video.test.js
@@ -96,3 +96,29 @@ test('Video with children', () => {
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Video with crossOrigin', () => {
+  const tree = create(
+    <Video
+      {...A11Y_LABELS}
+      crossOrigin="anonymous"
+      aspectRatio={1}
+      captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+      src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+    />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Video with objectFit', () => {
+  const tree = create(
+    <Video
+      {...A11Y_LABELS}
+      objectFit="contain"
+      aspectRatio={1}
+      captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+      src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+    />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -346,6 +346,72 @@ exports[`Video with children 1`] = `
 </div>
 `;
 
+exports[`Video with crossOrigin 1`] = `
+<div
+  className="player"
+  style={
+    Object {
+      "height": 0,
+      "paddingBottom": "100%",
+    }
+  }
+>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": ".__gestaltThemeVideo {
+  --g-colorRed0: #ff5247;
+  --g-colorRed100: #e60023;
+  --g-colorRed100Active: #a3081a;
+  --g-colorRed100Hovered: #ad081b;
+  --g-colorGray0: #fff;
+  --g-colorGray0Active: #e0e0e0;
+  --g-colorGray0Hovered: #f0f0f0;
+  --g-colorGray50: #fff;
+  --g-colorGray100: #efefef;
+  --g-colorGray100Active: #dadada;
+  --g-colorGray100Hovered: #e2e2e2;
+  --g-colorGray150: #ddd;
+  --g-colorGray150Hovered: #d0d0d0;
+  --g-colorGray200: #767676;
+  --g-colorGray200Active: #828282;
+  --g-colorGray200Hovered: #878787;
+  --g-colorGray300: #111;
+  --g-colorGray400: #000;
+  --g-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+  --g-colorTransparentGray60: rgba(0, 0, 0, 0.06);
+  --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+  --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
+ }",
+      }
+    }
+  />
+  <div
+    className="__gestaltThemeVideo"
+  >
+    <video
+      autoPlay={false}
+      className="video"
+      crossOrigin="anonymous"
+      muted={true}
+      onCanPlay={[Function]}
+      onDurationChange={[Function]}
+      onEnded={[Function]}
+      onProgress={[Function]}
+      onSeeked={[Function]}
+      onTimeUpdate={[Function]}
+      preload="auto"
+      src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+    >
+      <track
+        kind="captions"
+        src="https://media.w3.org/2010/05/sintel/captions.vtt"
+      />
+    </video>
+  </div>
+</div>
+`;
+
 exports[`Video with media attributes 1`] = `
 <div
   className="player"
@@ -475,6 +541,76 @@ exports[`Video with multiple sources 1`] = `
         src="https://archive.org/download/ElephantsDream/ed_hd.ogv"
         type="video/ogg"
       />
+      <track
+        kind="captions"
+        src="https://media.w3.org/2010/05/sintel/captions.vtt"
+      />
+    </video>
+  </div>
+</div>
+`;
+
+exports[`Video with objectFit 1`] = `
+<div
+  className="player"
+  style={
+    Object {
+      "height": 0,
+      "paddingBottom": "100%",
+    }
+  }
+>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": ".__gestaltThemeVideo {
+  --g-colorRed0: #ff5247;
+  --g-colorRed100: #e60023;
+  --g-colorRed100Active: #a3081a;
+  --g-colorRed100Hovered: #ad081b;
+  --g-colorGray0: #fff;
+  --g-colorGray0Active: #e0e0e0;
+  --g-colorGray0Hovered: #f0f0f0;
+  --g-colorGray50: #fff;
+  --g-colorGray100: #efefef;
+  --g-colorGray100Active: #dadada;
+  --g-colorGray100Hovered: #e2e2e2;
+  --g-colorGray150: #ddd;
+  --g-colorGray150Hovered: #d0d0d0;
+  --g-colorGray200: #767676;
+  --g-colorGray200Active: #828282;
+  --g-colorGray200Hovered: #878787;
+  --g-colorGray300: #111;
+  --g-colorGray400: #000;
+  --g-colorTransparentDarkGray: rgba(51, 51, 51, 0.8);
+  --g-colorTransparentGray60: rgba(0, 0, 0, 0.06);
+  --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
+  --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
+ }",
+      }
+    }
+  />
+  <div
+    className="__gestaltThemeVideo"
+  >
+    <video
+      autoPlay={false}
+      className="video"
+      muted={true}
+      onCanPlay={[Function]}
+      onDurationChange={[Function]}
+      onEnded={[Function]}
+      onProgress={[Function]}
+      onSeeked={[Function]}
+      onTimeUpdate={[Function]}
+      preload="auto"
+      src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+      style={
+        Object {
+          "object-fit": "contain",
+        }
+      }
+    >
       <track
         kind="captions"
         src="https://media.w3.org/2010/05/sintel/captions.vtt"


### PR DESCRIPTION
## Background
When Story Pins started using the Gestalt `Video` component for MP4s (experiment gated), employees noticed that the "poster", or placeholder while the video loads, was being displayed distorted. 


## Repro
### Gif reproduction:
![distortion](https://user-images.githubusercontent.com/7406105/93834016-49339080-fc2f-11ea-9844-8172b8ca20a2.gif)

### Screenshot for emphasis.
![Screen Shot 2020-09-15 at 4 47 54 PM copy](https://user-images.githubusercontent.com/7406105/93833848-ada22000-fc2e-11ea-98ab-0a3ff831661d.png)


## Changes
Setting the style as 'object-fill: contain` seems to fix the issue, so this PR adds the specific `object-fill` part of the style as an optional prop.
![Screen Shot 2020-09-16 at 6 18 20 PM](https://user-images.githubusercontent.com/7406105/93834076-78e29880-fc2f-11ea-9c4b-8f5ca1578c0c.png)


## Test Plan
Internal e2e testing confirms this will be a fix, and you can locally observe the style is passed correctly:
![Screen Shot 2020-09-21 at 5 22 14 PM](https://user-images.githubusercontent.com/7406105/93833969-20130000-fc2f-11ea-8100-63ae0264e3f8.png)



