### PR TITLE
Internal: fix `flowtype/require-exact-type` errors

### DIFF
--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -178,7 +178,6 @@ const getPins = () => {
 class ExampleMasonry extends React.Component<Props, State> {
   // ref on a component gets the mounted instance of the component
   // https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-class-component
-  // $FlowIssue[prop-missing]
   grid: ?Masonry<*>;
 
   scrollContainer: ?HTMLElement;
@@ -231,7 +230,6 @@ class ExampleMasonry extends React.Component<Props, State> {
           style={containerStyle}
         >
           {scrollContainer && (
-            // $FlowIssue[prop-missing]
             <Masonry
               columnWidth={170}
               comp={({ data }) => (

--- a/packages/gestalt-datepicker/src/LocaleDataTypes.js
+++ b/packages/gestalt-datepicker/src/LocaleDataTypes.js
@@ -4,39 +4,37 @@ import PropTypes from 'prop-types';
 // flowlint unclear-type:off
 
 // LocaleData type from https://github.com/date-fns/date-fns/blob/81ab18785146405ca2ae28710cdfbb13a294ec50/src/locale/af/index.js.flow
-/* eslint-disable flowtype/require-exact-type */
-export type LocaleData = {
+export type LocaleData = {|
   code?: string,
   formatDistance?: (...args: Array<any>) => any,
 
   formatRelative?: (...args: Array<any>) => any,
-  localize?: {
+  localize?: {|
     ordinalNumber: (...args: Array<any>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
     month: (...args: Array<any>) => any,
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any,
-  },
-  formatLong?: {
+  |},
+  formatLong?: {|
     date: (...args: Array<any>) => any,
     time: (...args: Array<any>) => any,
     dateTime: (...args: Array<any>) => any,
-  },
-  match?: {
+  |},
+  match?: {|
     ordinalNumber: (...args: Array<string>) => any,
     era: (...args: Array<any>) => any,
     quarter: (...args: Array<any>) => any,
     month: (...args: Array<any>) => any,
     day: (...args: Array<any>) => any,
     dayPeriod: (...args: Array<any>) => any,
-  },
-  options?: {
+  |},
+  options?: {|
     weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6,
     firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
-  },
-};
-/* eslint-enable flowtype/require-exact-type */
+  |},
+|};
 
 // $FlowFixMe[signature-verification-failure]
 export const LocaleDataPropTypes = PropTypes.shape({

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -84,10 +84,11 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 
 const layoutNumberToCssDimension = n => (n !== Infinity ? n : undefined);
 
-// eslint-disable-next-line flowtype/require-exact-type
-export default class Masonry<T: {}> extends ReactComponent<Props<T>, State<T>> {
-  // eslint-disable-next-line flowtype/require-exact-type
-  static createMeasurementStore<T1: {}, T2>(): MeasurementStore<T1, T2> {
+export default class Masonry<T: { ... }> extends ReactComponent<
+  Props<T>,
+  State<T>
+> {
+  static createMeasurementStore<T1: { ... }, T2>(): MeasurementStore<T1, T2> {
     return new MeasurementStore();
   }
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -58,7 +58,7 @@ type Props<T> = {|
         ?{|
           from: number,
         |}
-      ) => void | boolean | {||}),
+      ) => void | boolean | { ... }),
   scrollContainer?: () => HTMLElement,
   virtualBoundsTop?: number,
   virtualBoundsBottom?: number,

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -39,12 +39,11 @@ type Layout =
 
 type Props<T> = {|
   columnWidth?: number,
-  // eslint-disable-next-line flowtype/require-exact-type
-  comp: ComponentType<{
+  comp: ComponentType<{|
     data: T,
     itemIdx: number,
     isMeasuring: boolean,
-  }>,
+  |}>,
   flexible?: boolean,
   gutterWidth?: number,
   items: Array<T>,
@@ -56,12 +55,10 @@ type Props<T> = {|
   loadItems?:
     | false
     | ((
-        // eslint-disable-next-line flowtype/require-exact-type
-        ?{
+        ?{|
           from: number,
-        }
-        // eslint-disable-next-line flowtype/require-exact-type
-      ) => void | boolean | {}),
+        |}
+      ) => void | boolean | {||}),
   scrollContainer?: () => HTMLElement,
   virtualBoundsTop?: number,
   virtualBoundsBottom?: number,
@@ -211,12 +208,10 @@ export default class Masonry<T: { ... }> extends ReactComponent<
     loadItems?:
       | false
       | ((
-          // eslint-disable-next-line flowtype/require-exact-type
-          ?{
+          ?{|
             from: number,
-          }
-          // eslint-disable-next-line flowtype/require-exact-type
-        ) => void | boolean | {}),
+          |}
+        ) => void | boolean | { ... }),
     minCols: number,
     virtualize?: boolean,
   |} = {

--- a/packages/gestalt/src/MeasurementStore.js
+++ b/packages/gestalt/src/MeasurementStore.js
@@ -1,8 +1,7 @@
 // @flow strict
 import type { Cache } from './Cache.js';
 
-// eslint-disable-next-line flowtype/require-exact-type
-export default class MeasurementStore<T: {} | $ReadOnlyArray<mixed>, V>
+export default class MeasurementStore<T: { ... } | $ReadOnlyArray<mixed>, V>
   implements Cache<T, V> {
   map: WeakMap<T, V> = new WeakMap();
 

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -12,12 +12,11 @@ import Icon from './Icon.js';
 import styles from './SelectList.css';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
-// eslint-disable-next-line flowtype/require-exact-type
-type Options = Array<{
+type Options = Array<{|
   label: string,
   value: string,
   disabled?: boolean,
-}>;
+|}>;
 
 type Props = {|
   errorMessage?: string,


### PR DESCRIPTION
We added the linter `flowtype/require-exact-type` in #946, but we disable the linter in several places. 

For the same reasons we added the `flowtype/require-exact-type` linter, disabling these errors is actually very bad because the downstream projects do not really respect the exact-by-default logic and would still treat `{ }` as inexact. We should avoid using `{ }` to flow running in downstream projects correctly know whether object type is exact and inexact without any ambiguity. 

This PR fixes all linter errors. Note that in some cases we actually meant to use inexact types. I have made sure that they are correctly typed as inexact.

## Test Plan

Flow