### PR TITLE
Internal: Add Cypress badge + link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gestalt
 
-[![NPM Version](https://img.shields.io/npm/v/gestalt.svg)](https://www.npmjs.com/package/gestalt)
+[![NPM Version](https://img.shields.io/npm/v/gestalt.svg)](https://www.npmjs.com/package/gestalt) [![gestalt](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/simple/x99ctf/master&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/x99ctf/runs)
 
 Gestalt is a set of React UI components that enforces Pinterest’s design language. We use it to streamline communication between designers and developers by enforcing a bunch of fundamental UI components. This common set of components helps raise the bar for UX & accessibility across Pinterest.
 


### PR DESCRIPTION
Adds a link + badge for Cypress to our README file.

![Screen Shot 2020-09-22 at 9 05 52 AM](https://user-images.githubusercontent.com/127199/93908055-ff8c8980-fcb2-11ea-9707-333505a740ab.png)

## Test Plan

- Badge + link show up in the readme