### PR TITLE
Docs: add ability to expand code examples

### DIFF
--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { useEffect, useRef, useState, type Node } from 'react';
 import * as gestalt from 'gestalt'; // eslint-disable-line import/no-namespace
 import DatePicker from 'gestalt-datepicker';
 import LZString from 'lz-string';
@@ -17,7 +17,7 @@ type Props = {|
   headingSize?: 'sm' | 'md',
 |};
 
-const { Box, Column, IconButton, Text, Tooltip } = gestalt;
+const { Box, Button, Column, IconButton, Stack, Text, Tooltip } = gestalt;
 
 const compress = object =>
   LZString.compressToBase64(JSON.stringify(object))
@@ -148,6 +148,17 @@ const Example = ({
 }: Props): Node => {
   const code = defaultCode.trim();
   const scope = { ...gestalt, DatePicker };
+  const [expanded, setExpanded] = useState(true);
+  const codeExampleRef = useRef(null);
+  const CODE_EXAMPLE_HEIGHT = 100;
+
+  useEffect(() => {
+    const height = codeExampleRef?.current?.clientHeight ?? 0;
+    if (height - 80 > CODE_EXAMPLE_HEIGHT) {
+      setExpanded(false);
+    }
+  }, [code]);
+
   return (
     <Card
       name={name}
@@ -195,35 +206,56 @@ const Example = ({
 
           <Column span={direction === 'column' ? 12 : 6}>
             <Box paddingX={2}>
-              <Box paddingY={2}>
+              <Stack gap={2}>
                 <Text size="md" color="gray">
                   Editor
                 </Text>
-              </Box>
-              <Box position="relative" display="flex" color="darkGray">
-                <Box flex="grow">
-                  {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
-                  {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                  <label>
-                    <LiveEditor padding={16} />
-                  </label>
+
+                <Box display="flex" direction="column">
+                  <Box
+                    position="relative"
+                    display="flex"
+                    color="darkGray"
+                    ref={codeExampleRef}
+                    {...(expanded
+                      ? {}
+                      : { maxHeight: CODE_EXAMPLE_HEIGHT, overflow: 'hidden' })}
+                  >
+                    <Box flex="grow">
+                      {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
+                      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                      <label>
+                        <LiveEditor padding={16} />
+                      </label>
+                    </Box>
+                    <Box padding={2}>
+                      <Tooltip inline text="Open in CodeSandbox">
+                        <IconButton
+                          dangerouslySetSvgPath={{
+                            __path:
+                              'M9.365 21.17v-8.645L1.93 8.248v4.928l3.405 1.974v3.705l4.029 2.314zm1.93.05l4.104-2.363v-3.794l3.427-1.986V8.211l-7.53 4.348v8.661zm6.54-14.666L13.878 4.26l-3.475 2.017L6.9 4.257 2.907 6.583l7.452 4.288 7.477-4.316zM0 18.017V6.04L10.377 0l10.38 6.015v11.983l-10.38 5.98L0 18.018z',
+                          }}
+                          accessibilityLabel="Open in CodeSandbox"
+                          iconColor="white"
+                          onClick={() => {
+                            handleCodeSandbox({ code, title: name });
+                          }}
+                        />
+                      </Tooltip>
+                    </Box>
+                  </Box>
+                  {expanded ? null : (
+                    <Box alignSelf="end" marginTop={2}>
+                      <Button
+                        onClick={() => setExpanded(true)}
+                        accessibilityLabel={`Expand code for ${name}`}
+                        inline
+                        text="Expand code"
+                      />
+                    </Box>
+                  )}
                 </Box>
-                <Box padding={2}>
-                  <Tooltip inline text="Open in CodeSandbox">
-                    <IconButton
-                      dangerouslySetSvgPath={{
-                        __path:
-                          'M9.365 21.17v-8.645L1.93 8.248v4.928l3.405 1.974v3.705l4.029 2.314zm1.93.05l4.104-2.363v-3.794l3.427-1.986V8.211l-7.53 4.348v8.661zm6.54-14.666L13.878 4.26l-3.475 2.017L6.9 4.257 2.907 6.583l7.452 4.288 7.477-4.316zM0 18.017V6.04L10.377 0l10.38 6.015v11.983l-10.38 5.98L0 18.018z',
-                      }}
-                      accessibilityLabel="Open in CodeSandbox"
-                      iconColor="white"
-                      onClick={() => {
-                        handleCodeSandbox({ code, title: name });
-                      }}
-                    />
-                  </Tooltip>
-                </Box>
-              </Box>
+              </Stack>
             </Box>
           </Column>
         </Box>

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -1,11 +1,11 @@
 // @flow strict
-import React, { useEffect, useRef, useState, type Node } from 'react';
+import React, { type Node } from 'react';
 import * as gestalt from 'gestalt'; // eslint-disable-line import/no-namespace
 import DatePicker from 'gestalt-datepicker';
-import LZString from 'lz-string';
-import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
+import { LiveProvider, LiveError, LivePreview } from 'react-live';
 import Card from './Card.js';
 import theme from './atomDark.js';
+import ExampleCode from './ExampleCode.js';
 
 type Props = {|
   defaultCode: string,
@@ -17,125 +17,7 @@ type Props = {|
   headingSize?: 'sm' | 'md',
 |};
 
-const { Box, Button, Column, IconButton, Stack, Text, Tooltip } = gestalt;
-
-const compress = object =>
-  LZString.compressToBase64(JSON.stringify(object))
-    .replace(/\+/g, '-') // Convert '+' to '-'
-    .replace(/\//g, '_') // Convert '/' to '_'
-    .replace(/=+$/, ''); // Remove ending '='
-
-const exportDefaultMaybe = ({ code }) =>
-  code.startsWith('function') || code.startsWith('class')
-    ? `export default ${code}`
-    : `const Demo = () => (
-  ${code}
-);
-
-export default Demo;`;
-
-const dedupeArray = <T>(arr: Array<T>): Array<T> => [...new Set(arr)];
-
-const handleCodeSandbox = async ({ code, title }) => {
-  const gestaltComponents = Object.keys(gestalt);
-  const additionalGestaltComponents = ['DatePicker'];
-
-  const usedComponents = dedupeArray([
-    ...(code.match(/<((\w+))/g) || []).map(component =>
-      component.replace('<', '')
-    ),
-    ...(
-      code.match(/(new FixedZIndex)|(new CompositeZIndex)/g) || []
-    ).map(component => component.replace('new ', '')),
-  ]);
-
-  const baseComponents = gestaltComponents.filter(x =>
-    usedComponents.includes(x)
-  );
-
-  const additionalComponents = additionalGestaltComponents.filter(x =>
-    usedComponents.includes(x)
-  );
-
-  const getPackagedComponents = () => {
-    const imports = [`import "../node_modules/gestalt/dist/gestalt.css"`];
-    if (additionalComponents.includes('DatePicker')) {
-      imports.push(
-        'import "../node_modules/gestalt-datepicker/dist/gestalt-datepicker.css";',
-        'import DatePicker from "gestalt-datepicker";'
-      );
-    }
-    if (baseComponents.length > 0) {
-      imports.push(`import { ${baseComponents.join(', ')} } from "gestalt";`);
-    }
-
-    return imports.join('\n');
-  };
-
-  const parameters = compress({
-    module: '/example.js',
-    files: {
-      'package.json': {
-        content: {
-          title,
-          // description: demoConfig.description
-          dependencies: {
-            react: 'latest',
-            'react-dom': 'latest',
-            // $FlowIssue[exponential-spread]
-            ...(baseComponents.length > 0 ? { gestalt: 'latest' } : {}),
-            ...(additionalComponents.includes('DatePicker')
-              ? { 'gestalt-datepicker': 'latest' }
-              : {}),
-          },
-          devDependencies: {
-            'react-scripts': 'latest',
-          },
-          main: 'index.js',
-          scripts: {
-            start: 'react-scripts start',
-          },
-        },
-      },
-      'index.js': {
-        content: `import React from "react";
-import { render } from "react-dom";
-import Example from "./example";
-render(<Example />, document.querySelector("#root"));`,
-      },
-      'example.js': {
-        content: `import React from "react";
-${getPackagedComponents()}
-
-${exportDefaultMaybe({ code })}`,
-      },
-      'index.html': {
-        content: `<body>
-  <div id="root"></div>
-</body>
-`,
-      },
-    },
-  });
-
-  const formData = new FormData();
-  formData.append('parameters', parameters);
-
-  const url = await fetch(
-    'https://codesandbox.io/api/v1/sandboxes/define?json=1',
-    {
-      method: 'post',
-      body: formData,
-      mode: 'cors',
-    }
-  )
-    .then(response => response.json())
-    .then(({ errors, sandbox_id: id }) => {
-      if (errors) throw errors;
-      return `https://codesandbox.io/s/${id}?module=/example.js`;
-    });
-  window.open(url);
-};
+const { Box, Column, Text } = gestalt;
 
 const Example = ({
   defaultCode,
@@ -148,16 +30,6 @@ const Example = ({
 }: Props): Node => {
   const code = defaultCode.trim();
   const scope = { ...gestalt, DatePicker };
-  const [expanded, setExpanded] = useState(true);
-  const codeExampleRef = useRef(null);
-  const CODE_EXAMPLE_HEIGHT = 100;
-
-  useEffect(() => {
-    const height = codeExampleRef?.current?.clientHeight ?? 0;
-    if (height - 80 > CODE_EXAMPLE_HEIGHT) {
-      setExpanded(false);
-    }
-  }, [code]);
 
   return (
     <Card
@@ -203,60 +75,8 @@ const Example = ({
               </Box>
             </Box>
           </Column>
-
           <Column span={direction === 'column' ? 12 : 6}>
-            <Box paddingX={2}>
-              <Stack gap={2}>
-                <Text size="md" color="gray">
-                  Editor
-                </Text>
-
-                <Box display="flex" direction="column">
-                  <Box
-                    position="relative"
-                    display="flex"
-                    color="darkGray"
-                    ref={codeExampleRef}
-                    {...(expanded
-                      ? {}
-                      : { maxHeight: CODE_EXAMPLE_HEIGHT, overflow: 'hidden' })}
-                  >
-                    <Box flex="grow">
-                      {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
-                      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                      <label>
-                        <LiveEditor padding={16} />
-                      </label>
-                    </Box>
-                    <Box padding={2}>
-                      <Tooltip inline text="Open in CodeSandbox">
-                        <IconButton
-                          dangerouslySetSvgPath={{
-                            __path:
-                              'M9.365 21.17v-8.645L1.93 8.248v4.928l3.405 1.974v3.705l4.029 2.314zm1.93.05l4.104-2.363v-3.794l3.427-1.986V8.211l-7.53 4.348v8.661zm6.54-14.666L13.878 4.26l-3.475 2.017L6.9 4.257 2.907 6.583l7.452 4.288 7.477-4.316zM0 18.017V6.04L10.377 0l10.38 6.015v11.983l-10.38 5.98L0 18.018z',
-                          }}
-                          accessibilityLabel="Open in CodeSandbox"
-                          iconColor="white"
-                          onClick={() => {
-                            handleCodeSandbox({ code, title: name });
-                          }}
-                        />
-                      </Tooltip>
-                    </Box>
-                  </Box>
-                  {expanded ? null : (
-                    <Box alignSelf="end" marginTop={2}>
-                      <Button
-                        onClick={() => setExpanded(true)}
-                        accessibilityLabel={`Expand code for ${name}`}
-                        inline
-                        text="Expand code"
-                      />
-                    </Box>
-                  )}
-                </Box>
-              </Stack>
-            </Box>
+            <ExampleCode code={code} name={name} />
           </Column>
         </Box>
 

--- a/docs/src/components/ExampleCode.js
+++ b/docs/src/components/ExampleCode.js
@@ -1,0 +1,79 @@
+// @flow strict
+import React, { useEffect, useRef, useState, type Node } from 'react';
+import { Box, Button, IconButton, Stack, Text, Tooltip } from 'gestalt';
+import { LiveEditor } from 'react-live';
+import handleCodeSandbox from './handleCodeSandbox.js';
+
+export default function ExampleCode({
+  code,
+  name,
+}: {|
+  code: string,
+  name: string,
+|}): Node {
+  const [expanded, setExpanded] = useState(true);
+  const codeExampleRef = useRef(null);
+  const CODE_EXAMPLE_HEIGHT = 100;
+
+  useEffect(() => {
+    const height = codeExampleRef?.current?.clientHeight ?? 0;
+    if (height - 80 > CODE_EXAMPLE_HEIGHT) {
+      setExpanded(false);
+    }
+  }, [code]);
+
+  return (
+    <Box paddingX={2}>
+      <Stack gap={2}>
+        <Text size="md" color="gray">
+          Editor
+        </Text>
+
+        <Box display="flex" direction="column">
+          <Box
+            position="relative"
+            display="flex"
+            color="darkGray"
+            ref={codeExampleRef}
+            {...(expanded
+              ? {}
+              : { maxHeight: CODE_EXAMPLE_HEIGHT, overflow: 'hidden' })}
+          >
+            <Box flex="grow">
+              {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label>
+                <LiveEditor padding={16} />
+              </label>
+            </Box>
+            <Box padding={2}>
+              <Tooltip inline text="Open in CodeSandbox">
+                <IconButton
+                  dangerouslySetSvgPath={{
+                    __path:
+                      'M9.365 21.17v-8.645L1.93 8.248v4.928l3.405 1.974v3.705l4.029 2.314zm1.93.05l4.104-2.363v-3.794l3.427-1.986V8.211l-7.53 4.348v8.661zm6.54-14.666L13.878 4.26l-3.475 2.017L6.9 4.257 2.907 6.583l7.452 4.288 7.477-4.316zM0 18.017V6.04L10.377 0l10.38 6.015v11.983l-10.38 5.98L0 18.018z',
+                  }}
+                  accessibilityLabel="Open in CodeSandbox"
+                  iconColor="white"
+                  onClick={() => {
+                    handleCodeSandbox({ code, title: name });
+                  }}
+                />
+              </Tooltip>
+            </Box>
+          </Box>
+          {expanded ? null : (
+            <Box alignSelf="end" marginTop={2}>
+              <Button
+                onClick={() => setExpanded(true)}
+                accessibilityLabel={`Expand code for ${name}`}
+                inline
+                text="Expand code"
+              />
+            </Box>
+          )}
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/docs/src/components/handleCodeSandbox.js
+++ b/docs/src/components/handleCodeSandbox.js
@@ -1,0 +1,129 @@
+// @flow strict
+import * as gestalt from 'gestalt'; // eslint-disable-line import/no-namespace
+import LZString from 'lz-string';
+
+const compress = object =>
+  LZString.compressToBase64(JSON.stringify(object))
+    .replace(/\+/g, '-') // Convert '+' to '-'
+    .replace(/\//g, '_') // Convert '/' to '_'
+    .replace(/=+$/, ''); // Remove ending '='
+
+const exportDefaultMaybe = ({ code }) =>
+  code.startsWith('function') || code.startsWith('class')
+    ? `export default ${code}`
+    : `const Demo = () => (
+${code}
+);
+
+export default Demo;`;
+
+const dedupeArray = <T>(arr: Array<T>): Array<T> => [...new Set(arr)];
+
+const handleCodeSandbox = async ({
+  code,
+  title,
+}: {|
+  code: string,
+  title: string,
+|}) => {
+  const gestaltComponents = Object.keys(gestalt);
+  const additionalGestaltComponents = ['DatePicker'];
+
+  const usedComponents = dedupeArray([
+    ...(code.match(/<((\w+))/g) || []).map(component =>
+      component.replace('<', '')
+    ),
+    ...(
+      code.match(/(new FixedZIndex)|(new CompositeZIndex)/g) || []
+    ).map(component => component.replace('new ', '')),
+  ]);
+
+  const baseComponents = gestaltComponents.filter(x =>
+    usedComponents.includes(x)
+  );
+
+  const additionalComponents = additionalGestaltComponents.filter(x =>
+    usedComponents.includes(x)
+  );
+
+  const getPackagedComponents = () => {
+    const imports = [`import "../node_modules/gestalt/dist/gestalt.css"`];
+    if (additionalComponents.includes('DatePicker')) {
+      imports.push(
+        'import "../node_modules/gestalt-datepicker/dist/gestalt-datepicker.css";',
+        'import DatePicker from "gestalt-datepicker";'
+      );
+    }
+    if (baseComponents.length > 0) {
+      imports.push(`import { ${baseComponents.join(', ')} } from "gestalt";`);
+    }
+
+    return imports.join('\n');
+  };
+
+  const parameters = compress({
+    module: '/example.js',
+    files: {
+      'package.json': {
+        content: {
+          title,
+          // description: demoConfig.description
+          dependencies: {
+            react: 'latest',
+            'react-dom': 'latest',
+            // $FlowIssue[exponential-spread]
+            ...(baseComponents.length > 0 ? { gestalt: 'latest' } : {}),
+            ...(additionalComponents.includes('DatePicker')
+              ? { 'gestalt-datepicker': 'latest' }
+              : {}),
+          },
+          devDependencies: {
+            'react-scripts': 'latest',
+          },
+          main: 'index.js',
+          scripts: {
+            start: 'react-scripts start',
+          },
+        },
+      },
+      'index.js': {
+        content: `import React from "react";
+import { render } from "react-dom";
+import Example from "./example";
+render(<Example />, document.querySelector("#root"));`,
+      },
+      'example.js': {
+        content: `import React from "react";
+${getPackagedComponents()}
+
+${exportDefaultMaybe({ code })}`,
+      },
+      'index.html': {
+        content: `<body>
+  <div id="root"></div>
+</body>
+`,
+      },
+    },
+  });
+
+  const formData = new FormData();
+  formData.append('parameters', parameters);
+
+  const url = await fetch(
+    'https://codesandbox.io/api/v1/sandboxes/define?json=1',
+    {
+      method: 'post',
+      body: formData,
+      mode: 'cors',
+    }
+  )
+    .then(response => response.json())
+    .then(({ errors, sandbox_id: id }) => {
+      if (errors) throw errors;
+      return `https://codesandbox.io/s/${id}?module=/example.js`;
+    });
+  window.open(url);
+};
+
+export default handleCodeSandbox;


### PR DESCRIPTION
While scrolling through our component docs, the amount of code we see is overwhelming. This PR adds an `Expand code` button which expands the code when required.

![gestalt-docs-expand-code-exampe](https://user-images.githubusercontent.com/127199/93911571-6ca21e00-fcb7-11ea-9273-54656f2b4814.gif)

### Notes
* The max height of the code is `100` with a threshold of `80`. So we will only show the expand button when the height is > 180px.
* This is a first stab - definitely open for design suggestions.

## Test Plan

* On the netlify preview, we see `Expand code` on all code examples which have a height of + 180px.
