### PR TITLE
Internal: Script to generate a11y tests + add tests for 41 components

### DIFF
--- a/cypress/integration/accessibility_AvatarPair_spec.js
+++ b/cypress/integration/accessibility_AvatarPair_spec.js
@@ -1,0 +1,10 @@
+describe('AvatarPair Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/AvatarPair');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the AvatarPair page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Avatar_spec.js
+++ b/cypress/integration/accessibility_Avatar_spec.js
@@ -1,0 +1,10 @@
+describe('Avatar Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Avatar');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Avatar page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Badge_spec.js
+++ b/cypress/integration/accessibility_Badge_spec.js
@@ -1,0 +1,10 @@
+describe('Badge Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Badge');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Badge page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Box_spec.js
+++ b/cypress/integration/accessibility_Box_spec.js
@@ -1,0 +1,11 @@
+describe('Box Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Box');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Box page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_ButtonGroup_spec.js
+++ b/cypress/integration/accessibility_ButtonGroup_spec.js
@@ -1,0 +1,10 @@
+describe('ButtonGroup Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/ButtonGroup');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the ButtonGroup page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Callout_spec.js
+++ b/cypress/integration/accessibility_Callout_spec.js
@@ -1,0 +1,10 @@
+describe('Callout Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Callout');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Callout page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Card_spec.js
+++ b/cypress/integration/accessibility_Card_spec.js
@@ -1,0 +1,10 @@
+describe('Card Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Card');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Card page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Checkbox_spec.js
+++ b/cypress/integration/accessibility_Checkbox_spec.js
@@ -1,0 +1,11 @@
+describe('Checkbox Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Checkbox');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Checkbox page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Collage_spec.js
+++ b/cypress/integration/accessibility_Collage_spec.js
@@ -1,0 +1,10 @@
+describe('Collage Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Collage');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Collage page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Column_spec.js
+++ b/cypress/integration/accessibility_Column_spec.js
@@ -1,0 +1,10 @@
+describe('Column Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Column');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Column page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Container_spec.js
+++ b/cypress/integration/accessibility_Container_spec.js
@@ -1,0 +1,10 @@
+describe('Container Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Container');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Container page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_DatePicker_spec.js
+++ b/cypress/integration/accessibility_DatePicker_spec.js
@@ -1,0 +1,11 @@
+describe('DatePicker Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/DatePicker');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the DatePicker page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Development_spec.js
+++ b/cypress/integration/accessibility_Development_spec.js
@@ -1,0 +1,11 @@
+describe('Development Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Development');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Development page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Divider_spec.js
+++ b/cypress/integration/accessibility_Divider_spec.js
@@ -1,0 +1,10 @@
+describe('Divider Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Divider');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Divider page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Faq_spec.js
+++ b/cypress/integration/accessibility_Faq_spec.js
@@ -1,0 +1,11 @@
+describe('Faq Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Faq');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Faq page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Flyout_spec.js
+++ b/cypress/integration/accessibility_Flyout_spec.js
@@ -1,0 +1,10 @@
+describe('Flyout Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Flyout');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Flyout page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_GroupAvatar_spec.js
+++ b/cypress/integration/accessibility_GroupAvatar_spec.js
@@ -1,0 +1,10 @@
+describe('GroupAvatar Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/GroupAvatar');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the GroupAvatar page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Heading_spec.js
+++ b/cypress/integration/accessibility_Heading_spec.js
@@ -1,0 +1,10 @@
+describe('Heading Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Heading');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Heading page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_IconButton_spec.js
+++ b/cypress/integration/accessibility_IconButton_spec.js
@@ -1,0 +1,10 @@
+describe('IconButton Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/IconButton');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the IconButton page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Icon_spec.js
+++ b/cypress/integration/accessibility_Icon_spec.js
@@ -1,0 +1,10 @@
+describe('Icon Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Icon');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Icon page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Image_spec.js
+++ b/cypress/integration/accessibility_Image_spec.js
@@ -1,0 +1,11 @@
+describe('Image Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Image');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Image page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Installation_spec.js
+++ b/cypress/integration/accessibility_Installation_spec.js
@@ -1,0 +1,10 @@
+describe('Installation Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Installation');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Installation page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Label_spec.js
+++ b/cypress/integration/accessibility_Label_spec.js
@@ -1,0 +1,10 @@
+describe('Label Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Label');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Label page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Layer_spec.js
+++ b/cypress/integration/accessibility_Layer_spec.js
@@ -1,0 +1,10 @@
+describe('Layer Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Layer');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Layer page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Layouts_spec.js
+++ b/cypress/integration/accessibility_Layouts_spec.js
@@ -1,0 +1,10 @@
+describe('Layouts Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Layouts');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Layouts page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Letterbox_spec.js
+++ b/cypress/integration/accessibility_Letterbox_spec.js
@@ -1,0 +1,10 @@
+describe('Letterbox Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Letterbox');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Letterbox page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Link_spec.js
+++ b/cypress/integration/accessibility_Link_spec.js
@@ -1,0 +1,10 @@
+describe('Link Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Link');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Link page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Mask_spec.js
+++ b/cypress/integration/accessibility_Mask_spec.js
@@ -1,0 +1,10 @@
+describe('Mask Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Mask');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Mask page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Masonry_spec.js
+++ b/cypress/integration/accessibility_Masonry_spec.js
@@ -1,0 +1,11 @@
+describe('Masonry Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Masonry');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Masonry page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Modal_spec.js
+++ b/cypress/integration/accessibility_Modal_spec.js
@@ -1,0 +1,10 @@
+describe('Modal Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Modal');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Modal page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Pog_spec.js
+++ b/cypress/integration/accessibility_Pog_spec.js
@@ -1,0 +1,10 @@
+describe('Pog Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Pog');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Pog page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Provider_spec.js
+++ b/cypress/integration/accessibility_Provider_spec.js
@@ -1,0 +1,10 @@
+describe('Provider Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Provider');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Provider page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Pulsar_spec.js
+++ b/cypress/integration/accessibility_Pulsar_spec.js
@@ -1,0 +1,11 @@
+describe('Pulsar Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Pulsar');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Pulsar page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_RadioButton_spec.js
+++ b/cypress/integration/accessibility_RadioButton_spec.js
@@ -1,0 +1,11 @@
+describe('RadioButton Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/RadioButton');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the RadioButton page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Row_spec.js
+++ b/cypress/integration/accessibility_Row_spec.js
@@ -1,0 +1,10 @@
+describe('Row Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Row');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Row page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_SearchField_spec.js
+++ b/cypress/integration/accessibility_SearchField_spec.js
@@ -1,0 +1,10 @@
+describe('SearchField Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/SearchField');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the SearchField page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_SegmentedControl_spec.js
+++ b/cypress/integration/accessibility_SegmentedControl_spec.js
@@ -1,0 +1,11 @@
+describe('SegmentedControl Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/SegmentedControl');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the SegmentedControl page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_SelectList_spec.js
+++ b/cypress/integration/accessibility_SelectList_spec.js
@@ -1,0 +1,10 @@
+describe('SelectList Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/SelectList');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the SelectList page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Sheet_spec.js
+++ b/cypress/integration/accessibility_Sheet_spec.js
@@ -1,0 +1,10 @@
+describe('Sheet Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Sheet');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Sheet page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Spinner_spec.js
+++ b/cypress/integration/accessibility_Spinner_spec.js
@@ -1,0 +1,10 @@
+describe('Spinner Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Spinner');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Spinner page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Stack_spec.js
+++ b/cypress/integration/accessibility_Stack_spec.js
@@ -1,0 +1,10 @@
+describe('Stack Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Stack');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Stack page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Sticky_spec.js
+++ b/cypress/integration/accessibility_Sticky_spec.js
@@ -1,0 +1,11 @@
+describe('Sticky Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Sticky');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Sticky page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Switch_spec.js
+++ b/cypress/integration/accessibility_Switch_spec.js
@@ -1,0 +1,11 @@
+describe('Switch Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Switch');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Switch page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Table_spec.js
+++ b/cypress/integration/accessibility_Table_spec.js
@@ -1,0 +1,11 @@
+describe('Table Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Table');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Table page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Tabs_spec.js
+++ b/cypress/integration/accessibility_Tabs_spec.js
@@ -1,0 +1,11 @@
+describe('Tabs Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Tabs');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Tabs page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_TapArea_spec.js
+++ b/cypress/integration/accessibility_TapArea_spec.js
@@ -1,0 +1,10 @@
+describe('TapArea Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/TapArea');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the TapArea page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_TextArea_spec.js
+++ b/cypress/integration/accessibility_TextArea_spec.js
@@ -1,0 +1,10 @@
+describe('TextArea Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/TextArea');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the TextArea page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_TextField_spec.js
+++ b/cypress/integration/accessibility_TextField_spec.js
@@ -1,0 +1,10 @@
+describe('TextField Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/TextField');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the TextField page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Text_spec.js
+++ b/cypress/integration/accessibility_Text_spec.js
@@ -1,0 +1,10 @@
+describe('Text Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Text');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Text page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Toast_spec.js
+++ b/cypress/integration/accessibility_Toast_spec.js
@@ -1,0 +1,11 @@
+describe('Toast Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Toast');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Toast page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Tooltip_spec.js
+++ b/cypress/integration/accessibility_Tooltip_spec.js
@@ -1,0 +1,10 @@
+describe('Tooltip Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Tooltip');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Tooltip page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Typeahead_spec.js
+++ b/cypress/integration/accessibility_Typeahead_spec.js
@@ -1,0 +1,11 @@
+describe('Typeahead Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Typeahead');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the Typeahead page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_Video_spec.js
+++ b/cypress/integration/accessibility_Video_spec.js
@@ -1,0 +1,10 @@
+describe('Video Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Video');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the Video page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_ZIndexClasses_spec.js
+++ b/cypress/integration/accessibility_ZIndexClasses_spec.js
@@ -1,0 +1,11 @@
+describe('ZIndexClasses Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/ZIndexClasses');
+    cy.injectAxe();
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the ZIndexClasses page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_button_spec.js
+++ b/cypress/integration/accessibility_button_spec.js
@@ -1,4 +1,4 @@
-describe('Accessibility', () => {
+describe('Button Accessibility check', () => {
   beforeEach(() => {
     cy.visit('/Button');
     cy.injectAxe();

--- a/cypress/integration/accessibility_useFocusVisible_spec.js
+++ b/cypress/integration/accessibility_useFocusVisible_spec.js
@@ -1,0 +1,10 @@
+describe('useFocusVisible Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/useFocusVisible');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the useFocusVisible page', () => {
+    cy.checkA11y();
+  });
+});

--- a/cypress/integration/accessibility_useReducedMotion_spec.js
+++ b/cypress/integration/accessibility_useReducedMotion_spec.js
@@ -1,0 +1,10 @@
+describe('useReducedMotion Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/useReducedMotion');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the useReducedMotion page', () => {
+    cy.checkA11y();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-flow": "^7.10.4",
     "@babel/preset-react": "^7.10.4",
+    "@babel/register": "^7.11.5",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
@@ -74,6 +75,7 @@
     "bl": "4.0.3"
   },
   "scripts": {
+    "a11y:generate": "./scripts/generateAccessibilitySpecs.js",
     "build": "cd packages/gestalt && yarn build && cd ../gestalt-datepicker && yarn build",
     "codemod": "jscodeshift --ignore-pattern=**/node_modules/**",
     "css:validate": "./scripts/cssValidate.js",

--- a/scripts/generateAccessibilitySpecs.js
+++ b/scripts/generateAccessibilitySpecs.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+require('@babel/register');
+const fs = require('fs');
+const sidebarIndex = require('../docs/src/components/sidebarIndex.js');
+
+async function generate() {
+  const pages = sidebarIndex.default.reduce(
+    (acc, currentValue) => [...acc, ...currentValue.pages],
+    []
+  );
+
+  await Promise.all(
+    pages.map(async page => {
+      return await fs.promises.writeFile(
+        `./cypress/integration/accessibility_${page}_spec.js`,
+        `describe('${page} Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/${page}');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the ${page} page', () => {
+    cy.checkA11y();
+  });
+});
+`
+      );
+    })
+  );
+}
+
+(async function generateAccessibilitySpecs() {
+  try {
+    await generate();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    process.exit(1);
+  }
+
+  process.exit(0);
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,6 +1914,17 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/register@^7.11.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.11.5.tgz#79becf89e0ddd0fba8b92bc279bc0f5d2d7ce2ea"
+  integrity sha512-CAml0ioKX+kOAvBQDHa/+t1fgOt3qkTIz0TrRtRAT6XY0m5qYZXR85k6/sLCNPMGhYDlCFHCYuU0ybTJbvlC6w==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.19"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
+
 "@babel/runtime-corejs3@^7.10.2":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.3.tgz#931ed6941d3954924a7aa967ee440e60c507b91a"


### PR DESCRIPTION
## Changes

* `yarn a11y:generate` creates
 accessibility tests for each page in our docs
* Add tests for remaining components (we previously only had `/Installation` and `Button`)

![Screen Shot 2020-09-25 at 10 09 16 AM](https://user-images.githubusercontent.com/127199/94297248-0e747580-ff19-11ea-8603-072b86d20fc1.png)

## Notes

### Why not bundle these into 1 test?
That would not work with [Cypress Parallelization](https://github.com/cypress-io/github-action#parallel) which will speed up our test runs

### Why `.skip` a couple of these tests? 
Those tests were failing, we should address them in a follow up PR

### Why add `@babel/register`?
We need it to strip the flow types when importing the `sidebarIndex.js` file

### How do I run these tests locally?
Run `yarn cypress open` and hit `Run all tests`

## Test Plan

* Cypress CI step passes