### PR TITLE
Internal: Parallelize Cypress integration tests (2x speed improvement)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,6 +35,6 @@ jobs:
         env:
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: 'b63ae79f-fb3e-439f-b588-4946a6593370'
           # pass GitHub token to allow accurately detecting a build vs a re-run build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,15 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving the Dashboard hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run copies of the current job in parallel
+        containers: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -20,6 +29,7 @@ jobs:
           wait-on: 'http://localhost:3000'
           group: ci
           record: true
+          parallel: true
           # tag will be either "push" or "pull_request"
           tag: ${{ github.event_name }}
         env:

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}


### PR DESCRIPTION
Since we added more Cypress integration tests in #1233, the builds now take +11 minutes to complete. Let's see what the impact is of parallelizing these tests.

![image](https://user-images.githubusercontent.com/127199/94452748-b92ca400-0164-11eb-89af-50cefd2d5629.png)

### Before
![image](https://user-images.githubusercontent.com/127199/94460924-488a8500-016e-11eb-9ed0-d8541f503f83.png)

### After
![image](https://user-images.githubusercontent.com/127199/94460969-56d8a100-016e-11eb-8cd9-59be54642dab.png)

## Notes

This does expose the cypress record key since it's [required for parallelization](https://docs.cypress.io/guides/guides/parallelization.html#CI-parallelization-interactions). The risk is that others would pollute our dashboard runs (unlikely) but the benefits are:
* Forked runs are recorded in the dashboard
* Parallelization should work 

## Test Plan

* Integration tests pass
* Total time to run is < 11 minutes
