### PR TITLE
Doc: update Text size example

### DIFF
--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -125,7 +125,7 @@ card(
     </span>
   </Row>
   <Row gap={1}>
-    <Text inline size="md">Medium (default size)</Text>
+    <Text inline size="md">Medium</Text>
     <span lang="ja">
       <Text inline size="md">
         こんにちは
@@ -133,7 +133,7 @@ card(
     </span>
   </Row>
   <Row gap={1}>
-    <Text inline size="lg">Large</Text>
+    <Text inline size="lg">Large (default size)</Text>
     <span lang="ja">
       <Text inline size="lg">
         こんにちは


### PR DESCRIPTION
The default value of `size` prop of the `<Text>` component has been changed from "md" to "lg", but the [code example](https://gestalt.netlify.app/Text#size) in the doc hasn't been updated. This PR updates the code example.

Before:
![Screen Shot 2020-09-29 at 11 28 09 AM](https://user-images.githubusercontent.com/5341184/94600602-f23d4500-0246-11eb-80c8-db987e764840.png)

After:
![Screen Shot 2020-09-29 at 11 31 17 AM](https://user-images.githubusercontent.com/5341184/94600805-4fd19180-0247-11eb-98b4-980acce11145.png)
