### PR TITLE
Sheet: Add subHeading prop [Depends on #1236]

### DIFF
--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -555,7 +555,7 @@ function RefExample() {
             >
               <Box color="white" minHeight={400} padding={8}>
                 <Box marginBottom={4}>
-                  <Heading size="md">Focused content</Heading>                
+                  <Heading size="md">Focused content</Heading>
                 </Box>
                 <Button 
                   inline 

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -77,7 +77,7 @@ function SizesExample(props) {
             onDismiss={() => { dispatch({ type: 'none' }) }}
             size={state.size}
           >
-            <Heading size="md">Content</Heading>
+            <Heading size="md">Children</Heading>
           </Sheet>
         </Layer>
       )}
@@ -128,10 +128,11 @@ card(
 
     In the example below, please notice all the following animations:
     - **in** (on show): from the "Open sheet" button entrypoint.
-    - **out** (on dismiss): from these 7 exitpoints:
+    - **out** (on dismiss): from these 8 exitpoints:
       - ESC key
       - Click on outside
-      - X button (header)
+      - X button (heading)
+      - Close button (subHeading)
       - Right arrow icon red button (children)
       - Done red button (children)
       - Left arrow red icon button (children)
@@ -157,12 +158,17 @@ function AnimationExample() {
             accessibilitySheetLabel="Animated sheet"
             footer={({ onDismissStart }) => (
               <Heading size="md">
-                <Button inline onClick={onDismissStart} text="Close" />
+                <Button inline onClick={onDismissStart} text="Close on Footer" />
               </Heading>
             )}
             heading="Animated Sheet"
             onDismiss={() => setShouldShow(false)}
             size="md"
+            subHeading={({ onDismissStart }) => (
+              <Box marginBottom={4} marginStart={8} marginEnd={8}>
+                <Button color="blue" inline onClick={onDismissStart} text="Close on Sub-heading" />
+              </Box>
+            )}
           >
             {({ onDismissStart }) => (
               <Row justifyContent="center" alignItems="center" height="100%">
@@ -174,7 +180,7 @@ function AnimationExample() {
                   onClick={onDismissStart} 
                   size="lg"                     
                 />
-                <Button color="red" inline onClick={onDismissStart} size="lg" text="Done" />
+                <Button color="red" inline onClick={onDismissStart} size="lg" text="Done on Children" />
                 <IconButton 
                   accessibilityLabel="Done icon right"
                   icon="directional-arrow-left" 
@@ -353,6 +359,164 @@ function DefaultPaddingExample(props) {
 
 card(
   <Example
+    id="subHeadingExample"
+    name="Sub-heading"
+    description={`
+      Specifies a sub-heading component to be docked under the heading. 
+      The shadow (when scrolling) between the \`subHeading\`, \`children\`, and \`footer\` are included as well. Please try scrolling up and down the children to verify the shadow.
+    `}
+    defaultCode={`
+function SubheadingExample(props) {
+  const SheetWithSubheading = ({
+    onDismiss,
+  }) => {
+    const [activeTabIndex, setActiveTabIndex] = React.useState(0);
+    const enRef = React.useRef();
+    const esRef = React.useRef();
+    const ptRef = React.useRef();
+    const chRef = React.useRef();
+    const refs = [enRef, esRef, ptRef, chRef];
+  
+    const handleChangeTab = ({ activeTabIndex, event }) => {
+      event.preventDefault();
+      setActiveTabIndex(activeTabIndex);
+      refs[activeTabIndex].current.scrollIntoView({
+        behavior: 'smooth'
+      });
+    }
+
+    return (
+      <Sheet
+        accessibilityDismissButtonLabel="Close"
+        accessibilitySheetLabel="Example sheet to demonstrate subHeading"
+        heading="Sheet with subHeading"
+        onDismiss={onDismiss}
+        footer={<Heading size="md">Footer</Heading>}
+        size="md"
+        subHeading={
+          <Box marginBottom={4} marginStart={8} marginEnd={8}>
+            <Tabs
+              tabs={[
+                {
+                  text: "English",
+                  href: "#"
+                },
+                {
+                  text: "Español",
+                  href: "#"
+                },
+                {
+                  text: "Português",
+                  href: "#"
+                },
+                {
+                  text: '普通话',
+                  href: '#'
+                }
+              ]}
+              activeTabIndex={activeTabIndex}
+              onChange={handleChangeTab}
+            />
+          </Box>
+        }
+      >
+        <Box marginBottom={8} ref={enRef}>
+          <Text weight="bold">English</Text>
+          <Text>
+            <ol>
+              <li>One</li>
+              <li>Two</li>
+              <li>Three</li>
+              <li>Four</li>
+              <li>Five</li>
+              <li>Six</li>
+              <li>Seven</li>
+              <li>Eight</li>
+              <li>Nine</li>
+              <li>Ten</li>
+            </ol>
+          </Text>
+        </Box>
+        <Box marginBottom={8} ref={esRef}>
+          <Text weight="bold">Español</Text>
+          <Text>
+            <ol>
+              <li>Uno</li>
+              <li>Dos</li>
+              <li>Tres</li>
+              <li>Cuatro</li>
+              <li>Cinco</li>
+              <li>Seis</li>
+              <li>Siete</li>
+              <li>Ocho</li>
+              <li>Nueve</li>
+              <li>Diez</li>
+            </ol>
+          </Text>
+        </Box>
+        <Box marginBottom={8} ref={ptRef}>
+          <Text weight="bold">Português</Text>
+          <Text>
+            <ol>
+              <li>Um</li>
+              <li>Dois</li>
+              <li>Três</li>
+              <li>Quatro</li>
+              <li>Cinco</li>
+              <li>Seis</li>
+              <li>Sete</li>
+              <li>Oito</li>
+              <li>Nove</li>
+              <li>Dez</li>
+            </ol>
+          </Text>
+        </Box>  
+        <Box marginBottom={8} ref={chRef}>
+          <Text weight="bold">普通话</Text>
+          <Text>
+            <ol>
+              <li>一</li>
+              <li>二</li>
+              <li>三</li>
+              <li>四</li>
+              <li>五</li>
+              <li>六</li>
+              <li>七</li>
+              <li>八</li>
+              <li>九</li>
+              <li>十</li>
+            </ol>
+          </Text>
+        </Box>            
+      </Sheet>
+    );
+  };
+
+  const [shouldShow, setShouldShow] = React.useState(false);
+  const HEADER_ZINDEX = new FixedZIndex(10);
+  const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
+
+  return (
+    <>
+      <Button
+        inline
+        text="View subheading"
+        onClick={() => setShouldShow(true)}
+      />
+      {shouldShow && (
+        <Layer zIndex={sheetZIndex}>
+          <SheetWithSubheading onDismiss={() => setShouldShow(false)} />}
+        </Layer>
+      )}
+    </>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
     id="refExample"
     name="Example: ref"
     description={`
@@ -469,7 +633,8 @@ card(
         required: false,
         defaultValue: null,
         description: [
-          'Supply the container element that is going to be used as the Sheet main content.',
+          'Supply the container element or render prop that is going to be used as the Sheet main content.',
+          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
           'Obs: This element will be padded by 32px, differently than <Modal>.',
         ],
         href: 'defaultPaddingAndStylingExample',
@@ -493,7 +658,8 @@ card(
         required: false,
         defaultValue: null,
         description: [
-          'Supply the container element that is going to be used as the Sheet custom footer.',
+          'Supply the container element or render prop that is going to be used as the Sheet custom footer.',
+          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
           'Obs: This element will be padded by 32px, similarly to <Modal>.',
         ],
         href: 'defaultPaddingAndStylingExample',
@@ -541,6 +707,18 @@ card(
           '- lg: 900px',
         ],
         href: 'sizesExample',
+      },
+      {
+        name: 'subHeading',
+        type: 'React.Node | (({| onDismissStart: () => void |}) => React.Node)',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply the container element or the render prop that is going to be used as the Sheet sub-heading docked under the heading.',
+          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
+          'It can only be provided when a heading is also provided.',
+        ],
+        href: 'subHeadingExample',
       },
     ]}
   />

--- a/packages/gestalt/src/Sheet.flowtest.js
+++ b/packages/gestalt/src/Sheet.flowtest.js
@@ -12,6 +12,7 @@ const ValidWithNodeProps = (
     onDismiss={() => {}}
     ref={React.createRef()}
     size="sm"
+    subHeading={<nav />}
   >
     <section />
   </Sheet>
@@ -27,27 +28,45 @@ const ValidWithRenderProps = (
     onDismiss={() => {}}
     ref={React.createRef()}
     size="sm"
+    subHeading={({ onDismissStart }) => <nav />}
   >
     {({ onDismissStart }) => <section />}
   </Sheet>
 );
 
-const InvalidChildren = (
+const InvalidWithRenderProps = (
   <Sheet
     accessibilityDismissButtonLabel="Dismiss"
     accessibilitySheetLabel="Sheet"
+    // $FlowExpectedError[prop-missing]
+    footer={({ onDismiss }) => <footer />}
+    heading="Sheet title"
     onDismiss={() => {}}
+    // $FlowExpectedError[prop-missing]
+    subHeading={({ onDismiss }) => <nav />}
   >
     {/* $FlowExpectedError[prop-missing] */}
     {({ onDismiss }) => <section />}
   </Sheet>
 );
 
-// $FlowExpectedError[prop-missing]
+const NoSubHeadingWithoutHeading = (
+  // $FlowExpectedError[incompatible-type]
+  <Sheet
+    accessibilityDismissButtonLabel="Dismiss"
+    accessibilitySheetLabel="Sheet"
+    onDismiss={() => {}}
+    subHeading={<nav />}
+  >
+    <section />
+  </Sheet>
+);
+
+// $FlowExpectedError[incompatible-type]
 const MissingProp = <Sheet />;
 
 const NonExistingProp = (
-  // $FlowExpectedError[prop-missing]
+  // $FlowExpectedError[incompatible-type]
   <Sheet
     accessibilityDismissButtonLabel="Dismiss"
     accessibilitySheetLabel="Sheet"
@@ -59,11 +78,11 @@ const NonExistingProp = (
 );
 
 const InvalidTypeProp = (
+  // $FlowExpectedError[incompatible-type]
   <Sheet
     accessibilityDismissButtonLabel="Dismiss"
     accessibilitySheetLabel="Sheet"
     onDismiss={() => {}}
-    // $FlowExpectedError[incompatible-type]
     size="xxl"
   >
     <section />

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -44,24 +44,39 @@ import StopScrollBehavior from './behaviors/StopScrollBehavior.js';
 import sheetStyles from './Sheet.css';
 import TrapFocusBehavior from './behaviors/TrapFocusBehavior.js';
 
-type SheetProps = {|
+type SheetMainProps = {|
   accessibilityDismissButtonLabel: string,
   accessibilitySheetLabel: string,
   children: Node,
   closeOnOutsideClick?: boolean,
   footer?: Node,
-  heading?: string,
   onDismiss: () => void,
   size?: 'sm' | 'md' | 'lg',
 |};
 
+type SheetProps = {|
+  ...SheetMainProps,
+  heading?: string,
+  subHeading?: Node,
+|};
+
 type NodeOrRenderProp = Node | (({| onDismissStart: () => void |}) => Node);
 
-type AnimatedSheetProps = {|
-  ...SheetProps,
+type AnimatedSheetMainProps = {|
+  ...SheetMainProps,
   children: NodeOrRenderProp,
   footer?: NodeOrRenderProp,
 |};
+
+type AnimatedSheetWithHeadingProps = {|
+  ...AnimatedSheetMainProps,
+  heading: string,
+  subHeading?: NodeOrRenderProp,
+|};
+
+type AnimatedSheetProps =
+  | AnimatedSheetMainProps
+  | AnimatedSheetWithHeadingProps;
 
 const SIZE_WIDTH_MAP = {
   sm: 540,
@@ -116,10 +131,11 @@ const SheetWithForwardRef: React$AbstractComponent<
     accessibilitySheetLabel,
     children,
     closeOnOutsideClick = true,
-    onDismiss,
     footer,
-    heading,
+    heading = undefined,
+    onDismiss,
     size = 'sm',
+    subHeading = undefined,
   } = props;
 
   const [showTopShadow, setShowTopShadow] = useState<boolean>(false);
@@ -222,6 +238,7 @@ const SheetWithForwardRef: React$AbstractComponent<
                         />
                       </Box>
                     </Row>
+                    {subHeading}
                   </div>
                 )}
                 {!heading && (
@@ -284,8 +301,9 @@ SheetWithForwardRef.propTypes = {
   closeOnOutsideClick: PropTypes.bool,
   footer: PropTypes.node,
   heading: PropTypes.string,
-  onDismiss: PropTypes.func,
+  onDismiss: PropTypes.func.isRequired,
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  subHeading: PropTypes.node,
 };
 
 /*
@@ -308,8 +326,9 @@ const AnimatedSheetWithForwardRef: React$AbstractComponent<
     closeOnOutsideClick,
     onDismiss,
     footer,
-    heading,
+    heading = undefined,
     size,
+    subHeading = undefined,
   } = props;
 
   return (
@@ -326,6 +345,11 @@ const AnimatedSheetWithForwardRef: React$AbstractComponent<
           onDismiss={onDismissStart}
           ref={sheetRef}
           size={size}
+          subHeading={
+            typeof subHeading === 'function'
+              ? subHeading({ onDismissStart })
+              : subHeading
+          }
         >
           {typeof children === 'function'
             ? children({ onDismissStart })
@@ -345,6 +369,7 @@ AnimatedSheetWithForwardRef.propTypes = {
   ...SheetWithForwardRef.propTypes,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   footer: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  subHeading: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
 
 export default AnimatedSheetWithForwardRef;

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -132,10 +132,10 @@ const SheetWithForwardRef: React$AbstractComponent<
     children,
     closeOnOutsideClick = true,
     footer,
-    heading = undefined,
+    heading,
     onDismiss,
     size = 'sm',
-    subHeading = undefined,
+    subHeading,
   } = props;
 
   const [showTopShadow, setShowTopShadow] = useState<boolean>(false);

--- a/packages/gestalt/src/Sheet.jsdom.test.js
+++ b/packages/gestalt/src/Sheet.jsdom.test.js
@@ -27,6 +27,7 @@ describe('Sheet', () => {
         onDismiss={jest.fn()}
         ref={sheetRef}
         size="sm"
+        subHeading={<nav />}
       >
         <section />
       </Sheet>
@@ -49,6 +50,9 @@ describe('Sheet', () => {
         onDismiss={jest.fn()}
         ref={sheetRef}
         size="sm"
+        subHeading={({ onDismissStart }) => (
+          <button onClick={onDismissStart} type="submit" />
+        )}
       >
         {({ onDismissStart }) => (
           <button onClick={onDismissStart} type="submit" />
@@ -223,6 +227,57 @@ describe('Sheet', () => {
             Submit
           </button>
         )}
+      </Sheet>
+    );
+    const button = getByText('Submit');
+    fireEvent.click(button);
+    fireEvent.animationEnd(container.querySelector('div[role="dialog"]'));
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dismiss from clicking on the footer content', () => {
+    const mockOnDismiss = jest.fn();
+
+    const { container, getByText } = render(
+      <Sheet
+        accessibilityDismissButtonLabel="Dismiss"
+        accessibilitySheetLabel="Test Sheet"
+        closeOnOutsideClick
+        footer={({ onDismissStart }) => (
+          <button onClick={onDismissStart} type="submit">
+            Submit
+          </button>
+        )}
+        onDismiss={mockOnDismiss}
+      >
+        <section />
+      </Sheet>
+    );
+    const button = getByText('Submit');
+    fireEvent.click(button);
+    fireEvent.animationEnd(container.querySelector('div[role="dialog"]'));
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dismiss from clicking on the subHeading content', () => {
+    const mockOnDismiss = jest.fn();
+
+    const { container, getByText } = render(
+      <Sheet
+        accessibilityDismissButtonLabel="Dismiss"
+        accessibilitySheetLabel="Test Sheet"
+        closeOnOutsideClick
+        heading="Test Sheet"
+        onDismiss={mockOnDismiss}
+        subHeading={({ onDismissStart }) => (
+          <button onClick={onDismissStart} type="submit">
+            Submit
+          </button>
+        )}
+      >
+        <section />
       </Sheet>
     );
     const button = getByText('Submit');

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -80,6 +80,7 @@ exports[`Sheet should render all props with nodes 1`] = `
                 </div>
               </div>
             </div>
+            <nav />
           </div>
           <div
             class="box flexGrow overflowAuto paddingX8 paddingY8"
@@ -182,6 +183,9 @@ exports[`Sheet should render all props with render props 1`] = `
                 </div>
               </div>
             </div>
+            <button
+              type="submit"
+            />
           </div>
           <div
             class="box flexGrow overflowAuto paddingX8 paddingY8"


### PR DESCRIPTION
Depends on https://github.com/pinterest/gestalt/pull/1236

This PR adds a new prop "subHeading" to support a use case where certain designs ask for a sub-heading docked under the heading.

This "subHeading" prop shall take a Node or a Render prop to behave similar to "footer" and "children" so it can contain exitpoints which may trigger "out" animations.

## Test Plan
Tested on <Sheet> docs
Tested with OS reduced motion activated
