### PR TITLE
Button/TapArea/IconButton: add tabIndex prop

### DIFF
--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -31,18 +31,40 @@ card(
     defaultCode={`
 function Example() {
   const [disabled, setDisabled] = React.useState(false);
+  const [tabIndex, setTabIndex] = React.useState(false);
 
   return (
     <Stack gap={3}>
       <Row gap={1}>
         <Tooltip text="Default button">
-          <Button onClick={() => {}} text="Clear search history" inline disabled={disabled} />
+          <Button
+            onClick={() => {}}
+            text="Clear search history"
+            inline
+            disabled={disabled}
+            tabIndex={tabIndex ? -1 : 0}
+          />
         </Tooltip>
         <Tooltip text="Submit button">
-          <Button type="submit" name="satisfaction-questionaire" text="Submit your response" inline disabled={disabled} />
+          <Button
+            type="submit"
+            name="satisfaction-questionaire"
+            text="Submit your response"
+            inline
+            disabled={disabled}
+            tabIndex={tabIndex ? -1 : 0}
+          />
         </Tooltip>
         <Tooltip text="Link button">
-          <Button role="link" target="blank" href="https://www.pinterest.com" text="Visit pinterest.com" inline disabled={disabled} />
+          <Button
+            role="link"
+            target="blank"
+            href="https://www.pinterest.com"
+            text="Visit pinterest.com"
+            inline
+            disabled={disabled}
+            tabIndex={tabIndex ? -1 : 0}
+          />
         </Tooltip>
       </Row>
       <Row gap={1}>
@@ -54,6 +76,18 @@ function Example() {
         <Box paddingX={2} flex="grow">
           <Label htmlFor="disable-buttons">
             <Text>Disable buttons</Text>
+          </Label>
+        </Box>
+      </Row>
+      <Row gap={1}>
+        <Switch
+          onChange={() => setTabIndex(!tabIndex)}
+          id="unreachable-buttons"
+          switched={tabIndex}
+        />
+        <Box paddingX={2} flex="grow">
+          <Label htmlFor="unreachable-buttons">
+            <Text>Remove from keyboard navigation with tabIndex</Text>
           </Label>
         </Box>
       </Row>
@@ -459,6 +493,18 @@ card(
         description:
           'Forward the ref to the underlying button or anchor element.',
         href: 'ref',
+      },
+      {
+        name: 'tabIndex',
+        type: `-1 | 0`,
+        required: false,
+        defaultValue: 0,
+        description: [
+          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
+          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
+          `If component is disabled, the component is also unreachable from keyboard navigation.`,
+        ],
+        href: 'type-roles',
       },
       {
         name: 'role',

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -36,6 +36,8 @@ card(
     defaultCode={`
 function Example() {
   const [disabled, setDisabled] = React.useState(false);
+  const [tabIndex, setTabIndex] = React.useState(false);
+
   return (
     <Stack gap={3}>
       <Row gap={1}>
@@ -45,6 +47,7 @@ function Example() {
             icon="share"
             onClick={() => {}}
             disabled={disabled}
+            tabIndex={tabIndex ? -1 : 0}
           />
         </Tooltip>
         <Tooltip text="Link IconButton">
@@ -55,6 +58,7 @@ function Example() {
             target="blank"
             href="https://www.pinterest.com"
             disabled={disabled}
+            tabIndex={tabIndex ? -1 : 0}
           />
         </Tooltip>
       </Row>
@@ -67,6 +71,18 @@ function Example() {
         <Box paddingX={2} flex="grow">
           <Label htmlFor="disable-buttons">
             <Text>Disable buttons</Text>
+          </Label>
+        </Box>
+      </Row>
+      <Row gap={1}>
+        <Switch
+          onChange={() => setTabIndex(!tabIndex)}
+          id="unreachable-buttons"
+          switched={tabIndex}
+        />
+        <Box paddingX={2} flex="grow">
+          <Label htmlFor="unreachable-buttons">
+            <Text>Remove from keyboard navigation with tabIndex</Text>
           </Label>
         </Box>
       </Row>
@@ -432,6 +448,18 @@ card(
         description:
           'Forward the ref to the underlying button or anchor element',
         href: 'ref',
+      },
+      {
+        name: 'tabIndex',
+        type: `-1 | 0`,
+        required: false,
+        defaultValue: 0,
+        description: [
+          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
+          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
+          `If component is disabled, the component is also unreachable from keyboard navigation.`,
+        ],
+        href: 'roles',
       },
       {
         name: 'role',

--- a/docs/src/TapArea.doc.js
+++ b/docs/src/TapArea.doc.js
@@ -104,6 +104,7 @@ function Example() {
   const [disabled, setDisabled] = React.useState(false);
   const [compressed, setCompressed] = React.useState('compress');
   const [touches, setTouches] = React.useState(0);
+  const [tabIndex, setTabIndex] = React.useState(false);
 
   return (
     <Stack gap={3}>
@@ -113,6 +114,7 @@ function Example() {
             tapStyle={compressed}
             disabled={disabled}
             onTap={() => setTouches(touches + 1)}
+            tabIndex={tabIndex ? -1 : 0}
           >
             <Box padding={3} column={12} borderSize="lg" width={200}>
               <Mask rounding={2}>
@@ -134,6 +136,7 @@ function Example() {
             role="link"
             target="blank"
             href="https://www.pinterest.com"
+            tabIndex={tabIndex ? -1 : 0}
           >
             <Box padding={3} column={12} borderSize="lg" width={200}>
               <Mask rounding={2}>
@@ -170,6 +173,18 @@ function Example() {
         <Box paddingX={2} flex="grow">
           <Label htmlFor="disable-buttons">
             <Text>Disable TapArea</Text>
+          </Label>
+        </Box>
+      </Row>
+      <Row gap={1}>
+        <Switch
+          onChange={() => setTabIndex(!tabIndex)}
+          id="unreachable-buttons"
+          switched={tabIndex}
+        />
+        <Box paddingX={2} flex="grow">
+          <Label htmlFor="unreachable-buttons">
+            <Text>Remove from keyboard navigation with tabIndex</Text>
           </Label>
         </Box>
       </Row>
@@ -521,6 +536,18 @@ card(
         defaultValue: null,
         description: 'Forward the ref to the underlying div or anchor element.',
         href: 'ref',
+      },
+      {
+        name: 'tabIndex',
+        type: `-1 | 0`,
+        required: false,
+        defaultValue: 0,
+        description: [
+          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
+          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
+          `If component is disabled, the component is also unreachable from keyboard navigation.`,
+        ],
+        href: 'roles',
       },
       {
         name: 'rounding',

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -55,6 +55,7 @@ type BaseButton = {|
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>
   >,
+  tabIndex?: -1 | 0,
   size?: 'sm' | 'md' | 'lg',
   text: string,
 |};
@@ -122,6 +123,7 @@ const ButtonWithForwardRef: React$AbstractComponent<
     inline = false,
     iconEnd,
     onClick,
+    tabIndex = 0,
     selected = false,
     size = 'md',
     text,
@@ -214,6 +216,7 @@ const ButtonWithForwardRef: React$AbstractComponent<
         onClick={handleLinkClick}
         ref={innerRef}
         rel={rel}
+        tabIndex={tabIndex}
         size={size}
         target={target}
         wrappedComponent="button"
@@ -251,6 +254,7 @@ const ButtonWithForwardRef: React$AbstractComponent<
         onTouchStart={handleTouchStart}
         ref={innerRef}
         style={compressStyle || undefined}
+        tabIndex={disabled ? null : tabIndex}
         type="submit"
       >
         {iconEnd ? (
@@ -292,8 +296,9 @@ const ButtonWithForwardRef: React$AbstractComponent<
       onTouchMove={handleTouchMove}
       onTouchStart={handleTouchStart}
       ref={innerRef}
-      type="button"
       style={compressStyle || undefined}
+      tabIndex={disabled ? null : tabIndex}
+      type="button"
     >
       {iconEnd ? (
         <IconEnd
@@ -332,6 +337,7 @@ ButtonWithForwardRef.propTypes = {
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<
     'none' | 'nofollow'
   >),
+  tabIndex: PropTypes.oneOf([-1, 0]),
   role: PropTypes.oneOf(['button', 'link']),
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['sm', 'md', 'lg']),

--- a/packages/gestalt/src/Button.jsdom.test.js
+++ b/packages/gestalt/src/Button.jsdom.test.js
@@ -20,14 +20,17 @@ describe('Button', () => {
     expect(ref.current?.type).toEqual('submit');
   });
 
-  it('renders a default button and forwards a ref to the innermost <button> element', () => {
+  it('renders a default button with sequential keyboard navigation and forwards a ref to the innermost <button> element', () => {
     const ref = createRef();
     render(<Button text="test" ref={ref} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current?.type).toEqual('button');
+    expect(
+      ref.current instanceof HTMLButtonElement && ref.current?.tabIndex
+    ).toEqual(0);
   });
 
-  it('renders a link button and forwards a ref to the innermost <a> element', () => {
+  it('renders a link button with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {
     const ref = createRef();
     render(
       <Button
@@ -42,6 +45,18 @@ describe('Button', () => {
     expect(
       ref.current instanceof HTMLAnchorElement && ref.current?.href
     ).toEqual('http://www.pinterest.com/');
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(0);
+  });
+
+  it('renders a disabled button', () => {
+    const ref = createRef();
+    render(<Button text="test" disabled ref={ref} />);
+    expect(ref.current instanceof HTMLButtonElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLButtonElement && ref.current?.tabIndex
+    ).toEqual(-1);
   });
 
   it('renders a disabled link button', () => {
@@ -60,5 +75,35 @@ describe('Button', () => {
     expect(
       ref.current instanceof HTMLAnchorElement && ref.current?.href
     ).toEqual('');
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
+
+  it('renders a button removed from sequential keyboard navigation via tabIndex', () => {
+    const ref = createRef();
+    render(<Button text="test" ref={ref} tabIndex={-1} />);
+    expect(ref.current instanceof HTMLButtonElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLButtonElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
+
+  it('renders a link button removed from sequential keyboard navigation via tabIndex', () => {
+    const ref = createRef();
+    render(
+      <Button
+        text="test"
+        role="link"
+        href="http://www.pinterest.com"
+        ref={ref}
+        tabIndex={-1}
+        target="blank"
+      />
+    );
+    expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(-1);
   });
 });

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -38,6 +38,7 @@ type BaseIconButton = {|
   >,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   padding?: 1 | 2 | 3 | 4 | 5,
+  tabIndex?: -1 | 0,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
@@ -75,6 +76,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<
     iconColor,
     onClick,
     padding,
+    tabIndex = 0,
     size,
   } = props;
 
@@ -184,6 +186,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<
         onMouseLeave={handleOnMouseLeave}
         ref={innerRef}
         rel={rel}
+        tabIndex={tabIndex}
         target={target}
         wrappedComponent="iconButton"
       >
@@ -229,6 +232,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<
       onTouchStart={handleTouchStart}
       ref={innerRef}
       style={compressStyle || undefined}
+      tabIndex={disabled ? null : tabIndex}
       type="button"
     >
       {renderPogComponent(selected)}
@@ -263,6 +267,7 @@ IconButtonWithForwardRef.propTypes = {
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<
     'none' | 'nofollow'
   >),
+  tabIndex: PropTypes.oneOf([-1, 0]),
   role: PropTypes.oneOf(['button', 'link']),
   selected: PropTypes.bool,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),

--- a/packages/gestalt/src/IconButton.jsdom.test.js
+++ b/packages/gestalt/src/IconButton.jsdom.test.js
@@ -13,16 +13,16 @@ describe('IconButton', () => {
     expect(mockOnClick).toHaveBeenCalled();
   });
 
-  it('renders a button and forwards a ref to the innermost <button> element', () => {
+  it('renders a button with sequential keyboard navigation and forwards a ref to the innermost <button> element', () => {
     const ref = createRef();
-    render(<IconButton disabled accessibilityLabel="test" ref={ref} />);
+    render(<IconButton accessibilityLabel="test" ref={ref} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(
-      ref.current instanceof HTMLButtonElement && ref.current?.disabled
-    ).toEqual(true);
+      ref.current instanceof HTMLButtonElement && ref.current?.tabIndex
+    ).toEqual(0);
   });
 
-  it('renders a link button and forwards a ref to the innermost <a> element', () => {
+  it('renders a link button with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {
     const ref = createRef();
     render(
       <IconButton
@@ -38,6 +38,9 @@ describe('IconButton', () => {
     expect(
       ref.current instanceof HTMLAnchorElement && ref.current?.href
     ).toEqual('http://www.pinterest.com/');
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(0);
   });
 
   it('renders a disabled link button', () => {
@@ -57,5 +60,54 @@ describe('IconButton', () => {
     expect(
       ref.current instanceof HTMLAnchorElement && ref.current?.href
     ).toEqual('');
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
+
+  it('renders a disabled button', () => {
+    const ref = createRef();
+    render(
+      <IconButton disabled accessibilityLabel="test" icon="add" ref={ref} />
+    );
+    expect(ref.current instanceof HTMLButtonElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLButtonElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
+
+  it('renders an IconButton removed from sequential keyboard navigation via tabIndex', () => {
+    const ref = createRef();
+    render(
+      <IconButton
+        accessibilityLabel="test"
+        icon="add"
+        ref={ref}
+        tabIndex={-1}
+      />
+    );
+    expect(ref.current instanceof HTMLButtonElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLButtonElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
+
+  it('renders a link IconButton removed from sequential keyboard navigation via tabIndex', () => {
+    const ref = createRef();
+    render(
+      <IconButton
+        accessibilityLabel="test"
+        icon="add"
+        role="link"
+        href="http://www.pinterest.com"
+        ref={ref}
+        tabIndex={-1}
+        target="blank"
+      />
+    );
+    expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(-1);
   });
 });

--- a/packages/gestalt/src/InternalLink.flowtest.js
+++ b/packages/gestalt/src/InternalLink.flowtest.js
@@ -3,7 +3,11 @@ import React from 'react';
 import InternalLink from './InternalLink.js';
 
 const Valid = (
-  <InternalLink wrappedComponent="button" href="https://example.com">
+  <InternalLink
+    tabIndex={0}
+    wrappedComponent="button"
+    href="https://example.com"
+  >
     content
   </InternalLink>
 );

--- a/packages/gestalt/src/InternalLink.js
+++ b/packages/gestalt/src/InternalLink.js
@@ -52,6 +52,7 @@ type Props = {|
   onMouseUp?: AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement>>,
   onMouseLeave?: AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement>>,
   rel?: 'none' | 'nofollow',
+  tabIndex: -1 | 0,
   rounding?: Rounding,
   size?: 'sm' | 'md' | 'lg',
   tapStyle?: 'none' | 'compress',
@@ -85,6 +86,7 @@ const InternalLinkWithForwardRef: AbstractComponent<
     onMouseDown,
     onMouseUp,
     rel,
+    tabIndex = 0,
     rounding,
     size,
     tapStyle = 'compress',
@@ -224,10 +226,10 @@ const InternalLinkWithForwardRef: AbstractComponent<
         ...(target === 'blank' ? ['noopener', 'noreferrer'] : []),
         ...(rel === 'nofollow' ? ['nofollow'] : []),
       ].join(' ')}
+      tabIndex={disabled ? null : tabIndex}
       {...(tapStyle === 'compress' && compressStyle && !disabled
         ? { style: compressStyle }
         : {})}
-      tabIndex={isTapArea && !disabled ? '0' : null}
       target={target ? `_${target}` : null}
     >
       {children}
@@ -266,6 +268,7 @@ InternalLinkWithForwardRef.propTypes = {
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<
     'none' | 'nofollow'
   >),
+  tabIndex: PropTypes.oneOf([-1, 0]),
   rounding: RoundingPropType,
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   tapStyle: (PropTypes.oneOf(['none', 'compress']): React$PropType$Primitive<

--- a/packages/gestalt/src/InternalLink.jsdom.test.js
+++ b/packages/gestalt/src/InternalLink.jsdom.test.js
@@ -10,6 +10,7 @@ test('InternalLink handles onClick callback', () => {
       wrappedComponent="button"
       href="https://example.com"
       onClick={mockOnClick}
+      tabIndex={0}
     >
       InternalLink
     </InternalLink>

--- a/packages/gestalt/src/InternalLink.test.js
+++ b/packages/gestalt/src/InternalLink.test.js
@@ -7,7 +7,11 @@ it('default', () =>
   expect(
     renderer
       .create(
-        <InternalLink wrappedComponent="button" href="https://example.com">
+        <InternalLink
+          wrappedComponent="button"
+          href="https://example.com"
+          tabIndex={0}
+        >
           InternalLink
         </InternalLink>
       )
@@ -22,6 +26,7 @@ it('inline', () =>
           wrappedComponent="button"
           href="https://example.com"
           inline
+          tabIndex={0}
         >
           InternalLink
         </InternalLink>
@@ -37,6 +42,7 @@ it('target null', () =>
           wrappedComponent="button"
           href="https://example.com"
           target={null}
+          tabIndex={0}
         >
           InternalLink
         </InternalLink>
@@ -52,6 +58,7 @@ it('target self', () =>
           wrappedComponent="button"
           href="https://example.com"
           target="self"
+          tabIndex={0}
         >
           InternalLink
         </InternalLink>
@@ -67,6 +74,7 @@ it('target blank', () =>
           wrappedComponent="button"
           href="https://example.com"
           target="blank"
+          tabIndex={0}
         >
           InternalLink
         </InternalLink>
@@ -82,6 +90,7 @@ it('with nofollow', () =>
           wrappedComponent="button"
           href="https://example.com"
           rel="nofollow"
+          tabIndex={0}
         >
           InternalLink
         </InternalLink>
@@ -97,6 +106,7 @@ it('with onTap', () =>
           wrappedComponent="button"
           href="https://example.com"
           onClick={() => {}}
+          tabIndex={0}
         >
           InternalLink
         </InternalLink>

--- a/packages/gestalt/src/Link.jsdom.test.js
+++ b/packages/gestalt/src/Link.jsdom.test.js
@@ -3,13 +3,15 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import Link from './Link.js';
 
-test('Link handles onClick callback', () => {
-  const mockOnClick = jest.fn();
-  const { getByText } = render(
-    <Link href="https://example.com" onClick={mockOnClick}>
-      Link
-    </Link>
-  );
-  getByText('Link').click();
-  expect(mockOnClick).toHaveBeenCalled();
+describe('Link', () => {
+  test('Link handles onClick callback', () => {
+    const mockOnClick = jest.fn();
+    const { getByText } = render(
+      <Link href="https://example.com" onClick={mockOnClick}>
+        Link
+      </Link>
+    );
+    getByText('Link').click();
+    expect(mockOnClick).toHaveBeenCalled();
+  });
 });

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -51,6 +51,7 @@ type BaseTapArea = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
   >,
+  tabIndex?: -1 | 0,
   rounding?: Rounding,
   tapStyle?: 'none' | 'compress',
 |};
@@ -89,6 +90,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<
     onMouseEnter,
     onMouseLeave,
     onTap,
+    tabIndex = 0,
     rounding = 0,
     tapStyle = 'none',
   } = props;
@@ -189,6 +191,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<
         onMouseLeave={handleLinkOnMouseLeave}
         ref={innerRef}
         rel={rel}
+        tabIndex={tabIndex}
         rounding={rounding}
         tapStyle={tapStyle}
         target={target}
@@ -240,7 +243,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<
       {...(tapStyle === 'compress' && compressStyle && !disabled
         ? { style: compressStyle }
         : {})}
-      tabIndex={disabled ? null : '0'}
+      tabIndex={disabled ? null : tabIndex}
     >
       {children}
     </div>
@@ -285,6 +288,7 @@ TapAreaWithForwardRef.propTypes = {
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<
     'none' | 'nofollow'
   >),
+  tabIndex: PropTypes.oneOf([-1, 0]),
   role: PropTypes.oneOf(['tapArea', 'link']),
   rounding: RoundingPropType,
   tapStyle: (PropTypes.oneOf(['none', 'compress']): React$PropType$Primitive<

--- a/packages/gestalt/src/TapArea.jsdom.test.js
+++ b/packages/gestalt/src/TapArea.jsdom.test.js
@@ -3,85 +3,139 @@ import React, { createRef } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import TapArea from './TapArea.js';
 
-test('TapArea handles onTap callback', () => {
-  const mockOnTap = jest.fn();
-  const { getByText } = render(<TapArea onTap={mockOnTap}>TapArea</TapArea>);
-  getByText('TapArea').click();
-  expect(mockOnTap).toHaveBeenCalled();
-});
+describe('TapArea', () => {
+  it('TapArea handles onTap callback', () => {
+    const mockOnTap = jest.fn();
+    const { getByText } = render(<TapArea onTap={mockOnTap}>TapArea</TapArea>);
+    getByText('TapArea').click();
+    expect(mockOnTap).toHaveBeenCalled();
+  });
 
-test('TapArea handles onBlur callback', () => {
-  const mockOnBlur = jest.fn();
-  const { getByText } = render(<TapArea onBlur={mockOnBlur}>TapArea</TapArea>);
-  fireEvent.focus(getByText('TapArea'));
-  fireEvent.blur(getByText('TapArea'));
-  expect(mockOnBlur).toHaveBeenCalled();
-});
+  it('TapArea handles onBlur callback', () => {
+    const mockOnBlur = jest.fn();
+    const { getByText } = render(
+      <TapArea onBlur={mockOnBlur}>TapArea</TapArea>
+    );
+    fireEvent.focus(getByText('TapArea'));
+    fireEvent.blur(getByText('TapArea'));
+    expect(mockOnBlur).toHaveBeenCalled();
+  });
 
-test('TapArea handles onFocus callback', () => {
-  const mockOnFocus = jest.fn();
-  const { getByText } = render(
-    <TapArea onFocus={mockOnFocus}>TapArea</TapArea>
-  );
-  fireEvent.focus(getByText('TapArea'));
-  expect(mockOnFocus).toHaveBeenCalled();
-});
+  it('TapArea handles onFocus callback', () => {
+    const mockOnFocus = jest.fn();
+    const { getByText } = render(
+      <TapArea onFocus={mockOnFocus}>TapArea</TapArea>
+    );
+    fireEvent.focus(getByText('TapArea'));
+    expect(mockOnFocus).toHaveBeenCalled();
+  });
 
-test('TapArea handles onMouseEnter callback', () => {
-  const mockOnMouseEnter = jest.fn();
-  const { getByText } = render(
-    <TapArea onMouseEnter={mockOnMouseEnter}>TapArea</TapArea>
-  );
-  fireEvent.mouseEnter(getByText('TapArea'));
-  expect(mockOnMouseEnter).toHaveBeenCalled();
-});
+  it('TapArea handles onMouseEnter callback', () => {
+    const mockOnMouseEnter = jest.fn();
+    const { getByText } = render(
+      <TapArea onMouseEnter={mockOnMouseEnter}>TapArea</TapArea>
+    );
+    fireEvent.mouseEnter(getByText('TapArea'));
+    expect(mockOnMouseEnter).toHaveBeenCalled();
+  });
 
-test('TapArea handles onMouseLeave callback', () => {
-  const mockOnMouseLeave = jest.fn();
-  const { getByText } = render(
-    <TapArea onMouseLeave={mockOnMouseLeave}>TapArea</TapArea>
-  );
-  fireEvent.mouseLeave(getByText('TapArea'));
-  expect(mockOnMouseLeave).toHaveBeenCalled();
-});
+  it('TapArea handles onMouseLeave callback', () => {
+    const mockOnMouseLeave = jest.fn();
+    const { getByText } = render(
+      <TapArea onMouseLeave={mockOnMouseLeave}>TapArea</TapArea>
+    );
+    fireEvent.mouseLeave(getByText('TapArea'));
+    expect(mockOnMouseLeave).toHaveBeenCalled();
+  });
 
-test('TapArea handles key press event', () => {
-  const mockOnTap = jest.fn();
-  const { getByText } = render(<TapArea onTap={mockOnTap}>TapArea</TapArea>);
-  const mockEvent = { charCode: 32, preventDefault: jest.fn() };
-  fireEvent.keyPress(getByText('TapArea'), mockEvent);
-  expect(mockOnTap).toHaveBeenCalled();
-});
+  it('TapArea handles key press event', () => {
+    const mockOnTap = jest.fn();
+    const { getByText } = render(<TapArea onTap={mockOnTap}>TapArea</TapArea>);
+    const mockEvent = { charCode: 32, preventDefault: jest.fn() };
+    fireEvent.keyPress(getByText('TapArea'), mockEvent);
+    expect(mockOnTap).toHaveBeenCalled();
+  });
 
-it('renders a link TapArea and forwards a ref to the innermost <a> element', () => {
-  const ref = createRef();
-  render(
-    <TapArea
-      role="link"
-      href="http://www.pinterest.com"
-      ref={ref}
-      target="blank"
-    />
-  );
-  expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
-  expect(ref.current instanceof HTMLAnchorElement && ref.current?.href).toEqual(
-    'http://www.pinterest.com/'
-  );
-});
+  it('renders a TapArea with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {
+    const ref = createRef();
+    render(<TapArea ref={ref} />);
+    expect(ref.current instanceof HTMLDivElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLDivElement && ref.current?.tabIndex
+    ).toEqual(0);
+  });
 
-it('renders a disabled link TapArea', () => {
-  const ref = createRef();
-  render(
-    <TapArea
-      role="link"
-      href="http://www.pinterest.com"
-      disabled
-      ref={ref}
-      target="blank"
-    />
-  );
-  expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
-  expect(ref.current instanceof HTMLAnchorElement && ref.current?.href).toEqual(
-    ''
-  );
+  it('renders a link TapArea with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {
+    const ref = createRef();
+    render(
+      <TapArea
+        role="link"
+        href="http://www.pinterest.com"
+        ref={ref}
+        target="blank"
+      />
+    );
+    expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.href
+    ).toEqual('http://www.pinterest.com/');
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(0);
+  });
+
+  it('renders a disabled TapArea', () => {
+    const ref = createRef();
+    render(<TapArea disabled ref={ref} />);
+    expect(ref.current instanceof HTMLDivElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLDivElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
+
+  it('renders a disabled link TapArea', () => {
+    const ref = createRef();
+    render(
+      <TapArea
+        role="link"
+        href="http://www.pinterest.com"
+        disabled
+        ref={ref}
+        target="blank"
+      />
+    );
+    expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.href
+    ).toEqual('');
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
+
+  it('renders a TapArea removed from sequential keyboard navigation via tabIndex', () => {
+    const ref = createRef();
+    render(<TapArea tabIndex={-1} ref={ref} />);
+    expect(ref.current instanceof HTMLDivElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLDivElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
+
+  it('renders a link TapArea removed from sequential keyboard navigation via tabIndex', () => {
+    const ref = createRef();
+    render(
+      <TapArea
+        role="link"
+        href="http://www.pinterest.com"
+        tabIndex={-1}
+        ref={ref}
+        target="blank"
+      />
+    );
+    expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
+    expect(
+      ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex
+    ).toEqual(-1);
+  });
 });

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
@@ -327,7 +327,7 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         rel=""
-        tabIndex={null}
+        tabIndex={0}
         target={null}
       >
         <div
@@ -355,6 +355,7 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
       onTouchEnd={[Function]}
       onTouchMove={[Function]}
       onTouchStart={[Function]}
+      tabIndex={0}
       type="button"
     >
       <div
@@ -471,7 +472,7 @@ exports[`<ActivationCard /> message + title + link 1`] = `
         onTouchMove={[Function]}
         onTouchStart={[Function]}
         rel=""
-        tabIndex={null}
+        tabIndex={0}
         target={null}
       >
         <div

--- a/packages/gestalt/src/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ButtonGroup.test.js.snap
@@ -18,6 +18,7 @@ exports[`ButtonGroup Renders container with children when multiple children are 
       onTouchEnd={[Function]}
       onTouchMove={[Function]}
       onTouchStart={[Function]}
+      tabIndex={0}
       type="button"
     >
       <div
@@ -41,6 +42,7 @@ exports[`ButtonGroup Renders container with children when multiple children are 
       onTouchEnd={[Function]}
       onTouchMove={[Function]}
       onTouchStart={[Function]}
+      tabIndex={0}
       type="button"
     >
       <div
@@ -67,6 +69,7 @@ exports[`ButtonGroup Renders the child without container when 1 child is passed 
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
+  tabIndex={0}
   type="button"
 >
   <div

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -214,7 +214,7 @@ exports[`<Callout /> message + title + primaryLink + dismissButton 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       rel=""
-      tabIndex={null}
+      tabIndex={0}
       target={null}
     >
       <div
@@ -241,6 +241,7 @@ exports[`<Callout /> message + title + primaryLink + dismissButton 1`] = `
       onTouchEnd={[Function]}
       onTouchMove={[Function]}
       onTouchStart={[Function]}
+      tabIndex={0}
       type="button"
     >
       <div
@@ -344,7 +345,7 @@ exports[`<Callout /> message + title + primaryLink + secondaryLink 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       rel=""
-      tabIndex={null}
+      tabIndex={0}
       target={null}
     >
       <div
@@ -374,7 +375,7 @@ exports[`<Callout /> message + title + primaryLink + secondaryLink 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       rel=""
-      tabIndex={null}
+      tabIndex={0}
       target={null}
     >
       <div
@@ -460,7 +461,7 @@ exports[`<Callout /> message + title + primaryLink 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       rel=""
-      tabIndex={null}
+      tabIndex={0}
       target={null}
     >
       <div

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -16,6 +16,7 @@ exports[`IconButton renders with disabled state 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
+  tabIndex={null}
   type="button"
 >
   <div
@@ -59,6 +60,7 @@ exports[`IconButton renders with icon 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
+  tabIndex={0}
   type="button"
 >
   <div
@@ -102,6 +104,7 @@ exports[`IconButton renders with svg 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
+  tabIndex={0}
   type="button"
 >
   <div

--- a/packages/gestalt/src/__snapshots__/InternalLink.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/InternalLink.test.js.snap
@@ -18,7 +18,7 @@ exports[`default 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
-  tabIndex={null}
+  tabIndex={0}
   target={null}
 >
   InternalLink
@@ -43,7 +43,7 @@ exports[`inline 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
-  tabIndex={null}
+  tabIndex={0}
   target={null}
 >
   InternalLink
@@ -68,7 +68,7 @@ exports[`target blank 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel="noopener noreferrer"
-  tabIndex={null}
+  tabIndex={0}
   target="_blank"
 >
   InternalLink
@@ -93,7 +93,7 @@ exports[`target null 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
-  tabIndex={null}
+  tabIndex={0}
   target={null}
 >
   InternalLink
@@ -118,7 +118,7 @@ exports[`target self 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
-  tabIndex={null}
+  tabIndex={0}
   target="_self"
 >
   InternalLink
@@ -143,7 +143,7 @@ exports[`with nofollow 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel="nofollow"
-  tabIndex={null}
+  tabIndex={0}
   target={null}
 >
   InternalLink
@@ -168,7 +168,7 @@ exports[`with onTap 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
-  tabIndex={null}
+  tabIndex={0}
   target={null}
 >
   InternalLink

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -55,6 +55,7 @@ exports[`Sheet should render all props with nodes 1`] = `
                     <button
                       aria-label="Dismiss"
                       class="button tapTransition enabled"
+                      tabindex="0"
                       type="button"
                     >
                       <div
@@ -158,6 +159,7 @@ exports[`Sheet should render all props with render props 1`] = `
                     <button
                       aria-label="Dismiss"
                       class="button tapTransition enabled"
+                      tabindex="0"
                       type="button"
                     >
                       <div
@@ -241,6 +243,7 @@ exports[`Sheet should render animation in 1`] = `
               <button
                 aria-label="Dismiss"
                 class="button tapTransition enabled"
+                tabindex="0"
                 type="button"
               >
                 <div
@@ -305,6 +308,7 @@ exports[`Sheet should render animation out 1`] = `
               <button
                 aria-label="Dismiss"
                 class="button tapTransition enabled"
+                tabindex="0"
                 type="button"
               >
                 <div

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -25,7 +25,7 @@ exports[`renders correctly when active 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <div
         className="box itemsCenter xsDisplayFlex"
@@ -84,7 +84,7 @@ exports[`renders correctly when inactive 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <div
         className="box itemsCenter xsDisplayFlex"

--- a/packages/gestalt/src/__snapshots__/TapArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TapArea.test.js.snap
@@ -18,7 +18,7 @@ exports[`Link-role tapArea supports press style 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   rel=""
-  tabIndex="0"
+  tabIndex={0}
   target={null}
 >
   TapArea
@@ -43,7 +43,7 @@ exports[`TapArea renders 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   role="button"
-  tabIndex="0"
+  tabIndex={0}
 >
   TapArea
 </div>
@@ -67,7 +67,7 @@ exports[`TapArea sets correct mouse cursor 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   role="button"
-  tabIndex="0"
+  tabIndex={0}
 >
   TapArea
 </div>
@@ -91,7 +91,7 @@ exports[`TapArea sets correct rounding 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   role="button"
-  tabIndex="0"
+  tabIndex={0}
 >
   TapArea
 </div>
@@ -115,7 +115,7 @@ exports[`TapArea sets fullHeight correctly 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   role="button"
-  tabIndex="0"
+  tabIndex={0}
 >
   TapArea
 </div>
@@ -139,7 +139,7 @@ exports[`TapArea sets fullWidth correctly 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   role="button"
-  tabIndex="0"
+  tabIndex={0}
 >
   TapArea
 </div>
@@ -163,7 +163,7 @@ exports[`TapArea supports press style 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   role="button"
-  tabIndex="0"
+  tabIndex={0}
 >
   TapArea
 </div>

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -106,6 +106,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          tabIndex={0}
           type="button"
         >
           <div

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -156,7 +156,7 @@ exports[`Video with children 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="button"
-          tabIndex="0"
+          tabIndex={0}
         >
           <svg
             aria-hidden={null}
@@ -193,7 +193,7 @@ exports[`Video with children 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="button"
-          tabIndex="0"
+          tabIndex={0}
         >
           <svg
             aria-hidden={true}
@@ -324,7 +324,7 @@ exports[`Video with children 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="button"
-          tabIndex="0"
+          tabIndex={0}
         >
           <svg
             aria-hidden={null}

--- a/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
@@ -24,7 +24,7 @@ exports[`VideoControls for double digit minutes 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -155,7 +155,7 @@ exports[`VideoControls for double digit minutes 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -199,7 +199,7 @@ exports[`VideoControls for double digit seconds 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -330,7 +330,7 @@ exports[`VideoControls for double digit seconds 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -374,7 +374,7 @@ exports[`VideoControls for single digit minutes 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -505,7 +505,7 @@ exports[`VideoControls for single digit minutes 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -549,7 +549,7 @@ exports[`VideoControls for single digit seconds 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -680,7 +680,7 @@ exports[`VideoControls for single digit seconds 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -724,7 +724,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}
@@ -855,7 +855,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       role="button"
-      tabIndex="0"
+      tabIndex={0}
     >
       <svg
         aria-hidden={null}


### PR DESCRIPTION
For accessibility reasons, sometimes we have to remove components from the sequential keyboard navigation.

We use implement `tabIndex` https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex in `Button`, `TapArea`, and `IconButton`.

Added tests and updated documentation for each component to cover all tabIndex combinations.
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan
- Added test coverage to check for tabIndex in the innermost component
- Tested in Docs https://www.loom.com/share/91f4c25c87bb4be69579084ff5199446
<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
