### PR TITLE
Internal: fail CI on ESLint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "greenkeeper-lockfile-update": "greenkeeper-lockfile-update",
     "greenkeeper-lockfile-upload": "greenkeeper-lockfile-upload",
     "lint:css": "stylelint \"packages/**/*.css\"",
-    "lint:js": "eslint .",
+    "lint:js": "eslint --max-warnings 0 .",
     "precommit": "lint-staged",
     "start": "netlify dev -c \"yarn dev\"",
     "test": "./scripts/test.sh"

--- a/scripts/generateComponent.js
+++ b/scripts/generateComponent.js
@@ -12,10 +12,12 @@ const gestaltPackages = path.join(root, 'packages/gestalt/src');
 const indexFile = path.join(gestaltPackages, 'index.js');
 
 function logError(message) {
+  // eslint-disable-next-line no-console
   console.log(chalk.red(`❌  Error: ${message}`));
 }
 
 function logSuccess(message) {
+  // eslint-disable-next-line no-console
   console.log(chalk.green(`✅ ${message}`));
 }
 


### PR DESCRIPTION
I noticed a couple of ESLint warnings sneaked in due to my PR: #1243. Let's:

* Disallow any ESLint warnings + fail CI if there are any
* Fix the current warnings with an ESLint disable

![Screen Shot 2020-10-07 at 11 11 06 AM](https://user-images.githubusercontent.com/127199/95372334-458b4500-0890-11eb-8883-49e860547025.png)

## Test Plan

* ESLint passes in CI
