### PR TITLE
Docs: fix borderSize to borderStyle for Example

### DIFF
--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -41,7 +41,7 @@ const Example = ({
       <LiveProvider code={code} scope={scope} theme={theme}>
         <Box display="flex" direction="column" marginLeft={-2} marginRight={-2}>
           <Box padding={2} height="100%">
-            <Box position="relative" padding={4} borderSize="sm" rounding={2}>
+            <Box position="relative" padding={4} borderStyle="sm" rounding={2}>
               <LivePreview />
             </Box>
           </Box>


### PR DESCRIPTION
We landed #1245 after #1248 which used `borderSize` instead of the new `borderStyle`

### Before

![image](https://user-images.githubusercontent.com/127199/95396044-d96f0800-08b4-11eb-9d29-9dbf5a4e13ee.png)


### After

![image](https://user-images.githubusercontent.com/127199/95395960-b04e7780-08b4-11eb-9694-02b7ce93256e.png)



