### PR TITLE
Internal: Validate that each doc page has an a11y test

### DIFF
--- a/cypress/integration/accessibility_ActivationCard_spec.js
+++ b/cypress/integration/accessibility_ActivationCard_spec.js
@@ -1,0 +1,10 @@
+describe('ActivationCard Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/ActivationCard');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the ActivationCard page', () => {
+    cy.checkA11y();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "scripts": {
     "a11y:generate": "./scripts/generateAccessibilitySpecs.js",
+    "a11y:validate": "./scripts/validateAccessibilitySpecs.js",
     "build": "cd packages/gestalt && yarn build && cd ../gestalt-datepicker && yarn build",
     "codemod": "jscodeshift --ignore-pattern=**/node_modules/**",
     "css:validate": "./scripts/cssValidate.js",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,6 +14,9 @@ yarn stylelint "**/*.css"
 echo "jest"
 yarn jest --coverage
 
+echo "a11y:validate"
+yarn a11y:validate
+
 echo "flow"
 yarn flow check --max-warnings 0
 

--- a/scripts/validateAccessibilitySpecs.js
+++ b/scripts/validateAccessibilitySpecs.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+require('@babel/register');
+const globby = require('globby');
+const sidebarIndex = require('../docs/src/components/sidebarIndex.js');
+
+const cypressSpecFile = 'cypress/integration/accessibility_*_spec.js';
+
+async function validate() {
+  const pages = sidebarIndex.default.reduce(
+    (acc, currentValue) => [...acc, ...currentValue.pages],
+    []
+  );
+
+  const a11ySpecFiles = await globby([cypressSpecFile]);
+
+  const pagesWithoutA11ySpecFiles = pages.filter(
+    page => !a11ySpecFiles.includes(cypressSpecFile.replace('*', page))
+  );
+
+  if (pagesWithoutA11ySpecFiles.length) {
+    throw new Error(
+      `❌ The following doc ${
+        pagesWithoutA11ySpecFiles.length > 1
+          ? 'pages do not have'
+          : 'page does not have'
+      } an accessibility integration test: ${pagesWithoutA11ySpecFiles.join(
+        ','
+      )}`
+    );
+  }
+  // eslint-disable-next-line no-console
+  console.log(`✅ All doc pages have an accessibility integration test`);
+}
+
+/**
+ * Validate that we have an accessibility integration test for each docs page.
+ */
+(async function validateAccessibilitySpecs() {
+  try {
+    await validate();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    process.exit(1);
+  }
+
+  process.exit(0);
+})();

--- a/scripts/validateAccessibilitySpecs.js
+++ b/scripts/validateAccessibilitySpecs.js
@@ -11,10 +11,15 @@ async function validate() {
     []
   );
 
-  const a11ySpecFiles = await globby([cypressSpecFile]);
+  const a11ySpecFiles = (await globby([cypressSpecFile])).map(file =>
+    file.toLocaleLowerCase()
+  );
 
   const pagesWithoutA11ySpecFiles = pages.filter(
-    page => !a11ySpecFiles.includes(cypressSpecFile.replace('*', page))
+    page =>
+      !a11ySpecFiles.includes(
+        cypressSpecFile.replace('*', page.toLocaleLowerCase())
+      )
   );
 
   if (pagesWithoutA11ySpecFiles.length) {


### PR DESCRIPTION
Adds a test to CI to ensure every page in our docs has an accessibility integration test /cc @AlbertCarreras @ayeshakmaz 

### When it finds a page without an accessibility integration test
![Screen Shot 2020-10-08 at 9 15 20 AM](https://user-images.githubusercontent.com/127199/95486191-8eea9b80-0947-11eb-8c5b-504725bf60ed.png)


### When each page has an accessibility integration test
![Screen Shot 2020-10-08 at 9 18 14 AM](https://user-images.githubusercontent.com/127199/95486182-8c884180-0947-11eb-9965-95eb0e63d91d.png)


## Test Plan

CI passes

