### PR TITLE
Box: fix docs for Layout section

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -135,6 +135,7 @@ card(
     name="Layout"
     justifyContent={['start', 'end', 'center', 'between', 'around']}
     alignItems={['start', 'end', 'center', 'baseline', 'stretch']}
+    layout="4column"
   >
     {props => (
       <Box display="flex" width={96} {...props}>


### PR DESCRIPTION
## Before
![Screen Shot 2020-10-14 at 3 33 22 PM](https://user-images.githubusercontent.com/127199/96052615-c5865180-0e32-11eb-8361-275f6e073bcd.png)

## After
![Screen Shot 2020-10-14 at 3 33 02 PM](https://user-images.githubusercontent.com/127199/96052621-c7e8ab80-0e32-11eb-86d8-bd023211bf0c.png)

