### PR TITLE
Table: Add onExpand function prop to RowExpandable

### DIFF
--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -335,7 +335,8 @@ card(
       },
       {
         name: 'onExpand',
-        type: `({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>, expanded: boolean }) => void`,
+        type: `({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement> expanded: boolean }) => void`,
         description: [
           'Callback fired when the expand arrow-down button component is clicked with a mouse or keyboard.',
         ],

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -349,17 +349,10 @@ card(
     name="Example: Table Row Expandable"
     defaultCode={`
     function RowExpandableExample() {
-      const [iconShown, setIconShown] = React.useState(false);
-      const icon = () => {
-        return(
-            <Icon
-              icon="face-happy"
-              color="darkGray"
-              size={24}
-              accessibilityLabel="Pinterest Logo"
-            />
-          )
-      }
+      const [textShown, setTextShown] = React.useState(false);
+      const showTextOnExpand = () => {
+        return <Text>Row expanded</Text>;
+      };
 
       return(
         <Table>
@@ -386,7 +379,7 @@ card(
               accessibilityExpandLabel="Expand"
               accessibilityCollapseLabel="Collapse"
               id="row1"
-              onExpand={() => setIconShown(!iconShown)}
+              onExpand={() => setTextShown(!textShown)}
               expandedContents={
                 <Box maxWidth={236} padding={2} column={12}>
                   <Card
@@ -404,7 +397,7 @@ card(
                         </Box>
                       </Link>
                     </Text>
-                    {iconShown && icon()}
+                    {textShown && showTextOnExpand()}
                   </Card>
                 </Box>
               }

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -338,7 +338,7 @@ card(
         type: `({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement>
           | SyntheticKeyboardEvent<HTMLAnchorElement> expanded: boolean }) => void`,
         description: [
-          'Callback fired when the expand arrow-down button component is clicked with a mouse or keyboard.',
+          'Callback fired when the expand button component is clicked',
         ],
       },
     ]}

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -333,6 +333,13 @@ card(
         type: 'string',
         required: true,
       },
+      {
+        name: 'onExpand',
+        type: `({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>, expanded: boolean }) => void`,
+        description: [
+          'Callback fired when the expand arrow-down button component is clicked with a mouse or keyboard.',
+        ],
+      },
     ]}
   />
 );
@@ -341,71 +348,27 @@ card(
   <Example
     name="Example: Table Row Expandable"
     defaultCode={`
-<Table>
-  <Table.Header>
-    <Table.Row>
-      <Table.HeaderCell>
-        <Box display="visuallyHidden">
-          <Text weight="bold">Open/Close row</Text>
-        </Box>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">Name</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">House</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">Birthday</Text>
-      </Table.HeaderCell>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.RowExpandable
-      accessibilityExpandLabel="Expand"
-      accessibilityCollapseLabel="Collapse"
-      id="row1"
-      expandedContents={
-        <Box maxWidth={236} padding={2} column={12}>
-          <Card
-            image={
-              <Avatar
-                name="luna avatar"
-                src="https://i.ibb.co/QY9qR7h/luna.png"
-              />
-            }
-          >
-            <Text align="center" weight="bold">
-              <Link href="https://pinterest.com">
-                <Box paddingX={3} paddingY={2}>
-                  Luna's Info
-                </Box>
-              </Link>
-            </Text>
-          </Card>
-        </Box>
+    function RowExpandableExample() {
+      const [iconShown, setIconShown] = React.useState(false);
+      const icon = () => {
+        return(
+            <Icon
+              icon="face-happy"
+              color="darkGray"
+              size={24}
+              accessibilityLabel="Pinterest Logo"
+            />
+          )
       }
-    >
-      <Table.Cell>
-        <Text>Luna Lovegood</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Ravenclaw</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>June 25, 1993</Text>
-      </Table.Cell>
-    </Table.RowExpandable>
-    <Table.RowExpandable
-      accessibilityExpandLabel="Expand"
-      accessibilityCollapseLabel="Collapse"
-      id="row2"
-      expandedContents={
-        <Table maxWidth={800} maxHeight={500}>
-          <Table.Header sticky>
+
+      return(
+        <Table>
+          <Table.Header>
             <Table.Row>
               <Table.HeaderCell>
-                <Text weight="bold">Image</Text>
+                <Box display="visuallyHidden">
+                  <Text weight="bold">Open/Close row</Text>
+                </Box>
               </Table.HeaderCell>
               <Table.HeaderCell>
                 <Text weight="bold">Name</Text>
@@ -413,121 +376,183 @@ card(
               <Table.HeaderCell>
                 <Text weight="bold">House</Text>
               </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Birthday</Text>
+              </Table.HeaderCell>
             </Table.Row>
           </Table.Header>
           <Table.Body>
-            <Table.Row colSpan={10}>
-              <Table.Cell>
-                <Box width={50}>
-                  <Mask rounding="circle">
-                    <Image
-                      alt="Luna"
-                      src="https://i.ibb.co/QY9qR7h/luna.png"
-                      naturalHeight={50}
-                      naturalWidth={50}
-                    />
-                  </Mask>
+            <Table.RowExpandable
+              accessibilityExpandLabel="Expand"
+              accessibilityCollapseLabel="Collapse"
+              id="row1"
+              onExpand={() => setIconShown(!iconShown)}
+              expandedContents={
+                <Box maxWidth={236} padding={2} column={12}>
+                  <Card
+                    image={
+                      <Avatar
+                        name="luna avatar"
+                        src="https://i.ibb.co/QY9qR7h/luna.png"
+                      />
+                    }
+                  >
+                    <Text align="center" weight="bold">
+                      <Link href="https://pinterest.com">
+                        <Box paddingX={3} paddingY={2}>
+                          Luna's Info
+                        </Box>
+                      </Link>
+                    </Text>
+                    {iconShown && icon()}
+                  </Card>
                 </Box>
-              </Table.Cell>
+              }
+            >
               <Table.Cell>
-                <Text>Lun Lovegood</Text>
+                <Text>Luna Lovegood</Text>
               </Table.Cell>
               <Table.Cell>
                 <Text>Ravenclaw</Text>
               </Table.Cell>
-            </Table.Row>
-            <Table.Row>
               <Table.Cell>
-                <Box width={50}>
-                  <Mask rounding="circle">
-                    <Image
-                      alt="Draco"
-                      src="https://i.ibb.co/Hzcfxjt/draco.png"
-                      naturalHeight={50}
-                      naturalWidth={50}
-                    />
-                  </Mask>
-                </Box>
+                <Text>June 25, 1993</Text>
               </Table.Cell>
+            </Table.RowExpandable>
+            <Table.RowExpandable
+              accessibilityExpandLabel="Expand"
+              accessibilityCollapseLabel="Collapse"
+              id="row2"
+              expandedContents={
+                <Table maxWidth={800} maxHeight={500}>
+                  <Table.Header sticky>
+                    <Table.Row>
+                      <Table.HeaderCell>
+                        <Text weight="bold">Image</Text>
+                      </Table.HeaderCell>
+                      <Table.HeaderCell>
+                        <Text weight="bold">Name</Text>
+                      </Table.HeaderCell>
+                      <Table.HeaderCell>
+                        <Text weight="bold">House</Text>
+                      </Table.HeaderCell>
+                    </Table.Row>
+                  </Table.Header>
+                  <Table.Body>
+                    <Table.Row colSpan={10}>
+                      <Table.Cell>
+                        <Box width={50}>
+                          <Mask rounding="circle">
+                            <Image
+                              alt="Luna"
+                              src="https://i.ibb.co/QY9qR7h/luna.png"
+                              naturalHeight={50}
+                              naturalWidth={50}
+                            />
+                          </Mask>
+                        </Box>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text>Lun Lovegood</Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text>Ravenclaw</Text>
+                      </Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>
+                        <Box width={50}>
+                          <Mask rounding="circle">
+                            <Image
+                              alt="Draco"
+                              src="https://i.ibb.co/Hzcfxjt/draco.png"
+                              naturalHeight={50}
+                              naturalWidth={50}
+                            />
+                          </Mask>
+                        </Box>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text>Draco Malfoy</Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text>Slytherin</Text>
+                      </Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>
+                        <Box width={50}>
+                          <Mask rounding="circle">
+                            <Image
+                              alt="Neville"
+                              src="https://i.ibb.co/JvY9DKK/neville.png"
+                              naturalHeight={50}
+                              naturalWidth={50}
+                            />
+                          </Mask>
+                        </Box>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text>Neville Longbottom</Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text>Gryffindor</Text>
+                      </Table.Cell>
+                    </Table.Row>
+                  </Table.Body>
+                </Table>
+              }
+            >
               <Table.Cell>
                 <Text>Draco Malfoy</Text>
               </Table.Cell>
               <Table.Cell>
                 <Text>Slytherin</Text>
               </Table.Cell>
-            </Table.Row>
-            <Table.Row>
               <Table.Cell>
-                <Box width={50}>
-                  <Mask rounding="circle">
-                    <Image
-                      alt="Neville"
-                      src="https://i.ibb.co/JvY9DKK/neville.png"
-                      naturalHeight={50}
-                      naturalWidth={50}
-                    />
-                  </Mask>
-                </Box>
+                <Text>December 3, 1992</Text>
               </Table.Cell>
+            </Table.RowExpandable>
+            <Table.RowExpandable
+              accessibilityExpandLabel="Expand"
+              accessibilityCollapseLabel="Collapse"
+              id="row3"
+              expandedContents={
+                <Box maxWidth={236} padding={2} column={12}>
+                  <Card
+                    image={
+                      <Avatar
+                        name="luna avatar"
+                        src="https://i.ibb.co/JvY9DKK/neville.png"
+                      />
+                    }
+                  >
+                    <Text align="center" weight="bold">
+                      <Link href="https://pinterest.com">
+                        <Box paddingX={3} paddingY={2}>
+                          Neville's Info
+                        </Box>
+                      </Link>
+                    </Text>
+                  </Card>
+                </Box>
+              }
+            >
               <Table.Cell>
                 <Text>Neville Longbottom</Text>
               </Table.Cell>
               <Table.Cell>
                 <Text>Gryffindor</Text>
               </Table.Cell>
-            </Table.Row>
+              <Table.Cell>
+                <Text>July 30, 1980</Text>
+              </Table.Cell>
+            </Table.RowExpandable>
           </Table.Body>
         </Table>
-      }
-    >
-      <Table.Cell>
-        <Text>Draco Malfoy</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Slytherin</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>December 3, 1992</Text>
-      </Table.Cell>
-    </Table.RowExpandable>
-    <Table.RowExpandable
-      accessibilityExpandLabel="Expand"
-      accessibilityCollapseLabel="Collapse"
-      id="row3"
-      expandedContents={
-        <Box maxWidth={236} padding={2} column={12}>
-          <Card
-            image={
-              <Avatar
-                name="luna avatar"
-                src="https://i.ibb.co/JvY9DKK/neville.png"
-              />
-            }
-          >
-            <Text align="center" weight="bold">
-              <Link href="https://pinterest.com">
-                <Box paddingX={3} paddingY={2}>
-                  Neville's Info
-                </Box>
-              </Link>
-            </Text>
-          </Card>
-        </Box>
-      }
-    >
-      <Table.Cell>
-        <Text>Neville Longbottom</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Gryffindor</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>July 30, 1980</Text>
-      </Table.Cell>
-    </Table.RowExpandable>
-  </Table.Body>
-</Table>;
-`}
+      );
+    }
+    `}
   />
 );
 

--- a/packages/gestalt/src/TableRowExpandable.flowtest.js
+++ b/packages/gestalt/src/TableRowExpandable.flowtest.js
@@ -23,6 +23,8 @@ const InvalidTypeProp = (
     // $FlowExpectedError[incompatible-type]
     hoverStyle={2}
     id="expandableRow"
+    // $FlowExpectedError[incompatible-type]
+    onExpand="gray"
   >
     <div>row cells</div>
   </TableRowExpandable>

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -34,7 +34,11 @@ export default function TableRowExpandable(props: Props): Node {
   const hoverStyle = props.hoverStyle || 'gray';
   const cs = hoverStyle === 'gray' ? cx(styles.hoverShadeGray) : null;
 
-  const handleButtonClick = event => {
+  const handleButtonClick = (
+    event:
+      | SyntheticMouseEvent<HTMLButtonElement>
+      | SyntheticKeyboardEvent<HTMLButtonElement>
+  ) => {
     setExpanded(!expanded);
     if (onExpand) {
       onExpand({ event, expanded });

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -37,7 +37,7 @@ export default function TableRowExpandable(props: Props): Node {
   const handleButtonClick = event => {
     setExpanded(!expanded);
     if (onExpand) {
-      onExpand({ event });
+      onExpand({ event, expanded });
     }
   };
 

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -36,13 +36,7 @@ export default function TableRowExpandable(props: Props): Node {
   const hoverStyle = props.hoverStyle || 'gray';
   const cs = hoverStyle === 'gray' ? cx(styles.hoverShadeGray) : null;
 
-  const handleButtonClick = (
-    event:
-      | SyntheticMouseEvent<HTMLButtonElement>
-      | SyntheticKeyboardEvent<HTMLButtonElement>
-      | SyntheticMouseEvent<HTMLAnchorElement>
-      | SyntheticKeyboardEvent<HTMLAnchorElement>
-  ) => {
+  const handleButtonClick = ({ event }) => {
     setExpanded(!expanded);
     if (onExpand) {
       onExpand({ event, expanded });

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -5,12 +5,18 @@ import styles from './Table.css';
 import Box from './Box.js';
 import IconButton from './IconButton.js';
 import TableCell from './TableCell.js';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type Props = {|
   accessibilityExpandLabel: string,
   accessibilityCollapseLabel: string,
   children: Node,
   expandedContents: Node,
+  onExpand?: AbstractEventHandler<
+    | SyntheticMouseEvent<HTMLButtonElement>
+    | SyntheticKeyboardEvent<HTMLButtonElement>,
+    {| expanded: boolean |}
+  >,
   hoverStyle?: 'gray' | 'none',
   id: string,
 |};
@@ -21,11 +27,19 @@ export default function TableRowExpandable(props: Props): Node {
     accessibilityExpandLabel,
     children,
     expandedContents,
+    onExpand,
     id,
   } = props;
   const [expanded, setExpanded] = useState(false);
   const hoverStyle = props.hoverStyle || 'gray';
   const cs = hoverStyle === 'gray' ? cx(styles.hoverShadeGray) : null;
+
+  const handleButtonClick = event => {
+    setExpanded(!expanded);
+    if (onExpand) {
+      onExpand({ event });
+    }
+  };
 
   return (
     <>
@@ -39,7 +53,7 @@ export default function TableRowExpandable(props: Props): Node {
             }
             icon={expanded ? 'arrow-up' : 'arrow-down'}
             iconColor="darkGray"
-            onClick={() => setExpanded(!expanded)}
+            onClick={handleButtonClick}
             size="xs"
           />
         </TableCell>

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -14,7 +14,9 @@ type Props = {|
   expandedContents: Node,
   onExpand?: AbstractEventHandler<
     | SyntheticMouseEvent<HTMLButtonElement>
-    | SyntheticKeyboardEvent<HTMLButtonElement>,
+    | SyntheticKeyboardEvent<HTMLButtonElement>
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>,
     {| expanded: boolean |}
   >,
   hoverStyle?: 'gray' | 'none',
@@ -38,6 +40,8 @@ export default function TableRowExpandable(props: Props): Node {
     event:
       | SyntheticMouseEvent<HTMLButtonElement>
       | SyntheticKeyboardEvent<HTMLButtonElement>
+      | SyntheticMouseEvent<HTMLAnchorElement>
+      | SyntheticKeyboardEvent<HTMLAnchorElement>
   ) => {
     setExpanded(!expanded);
     if (onExpand) {

--- a/packages/gestalt/src/TableRowExpandable.jsdom.test.js
+++ b/packages/gestalt/src/TableRowExpandable.jsdom.test.js
@@ -8,7 +8,9 @@ import TableCell from './TableCell.js';
 import TableRowExpandable from './TableRowExpandable.js';
 import Text from './Text.js';
 
-test('TableRowExpandable handles onMouseEnter callback', () => {
+const mockOnExpand = jest.fn();
+
+test('TableRowExpandable handles expand contents call', () => {
   const { getByText } = render(
     <Table>
       <TableBody>
@@ -30,5 +32,33 @@ test('TableRowExpandable handles onMouseEnter callback', () => {
   }).toThrow('Unable to find an element with the text: Hello');
   const button = screen.getByRole('button');
   fireEvent.click(button);
+  expect(mockOnExpand).toHaveBeenCalledTimes(0);
+  expect(getByText('Hello')).toBeTruthy();
+});
+
+test('TableRowExpandable handles onExpand callback', () => {
+  const { getByText } = render(
+    <Table>
+      <TableBody>
+        <TableRowExpandable
+          accessibilityExpandLabel="Expand"
+          accessibilityCollapseLabel="Collapse"
+          expandedContents={<Box>Hello</Box>}
+          id="expandableRow"
+          onExpand={mockOnExpand}
+        >
+          <TableCell>
+            <Text>Row Info</Text>
+          </TableCell>
+        </TableRowExpandable>
+      </TableBody>
+    </Table>
+  );
+  expect(() => {
+    getByText('Hello');
+  }).toThrow('Unable to find an element with the text: Hello');
+  const button = screen.getByRole('button');
+  fireEvent.click(button);
+  expect(mockOnExpand).toHaveBeenCalled();
   expect(getByText('Hello')).toBeTruthy();
 });

--- a/packages/gestalt/src/TableRowExpandable.test.js
+++ b/packages/gestalt/src/TableRowExpandable.test.js
@@ -11,6 +11,7 @@ test('renders correctly', () => {
         accessibilityCollapseLabel="Collapse"
         expandedContents={<div>Expanded Contents</div>}
         id="expandableRow"
+        onExpand={() => {}}
       >
         <div>row cells</div>
       </TableRowExpandable>
@@ -28,6 +29,7 @@ test('renders correctly with explicit hover', () => {
         hoverStyle="gray"
         expandedContents={<div>Expanded Contents</div>}
         id="expandableRow"
+        onExpand={() => {}}
       >
         <div>row cells</div>
       </TableRowExpandable>
@@ -45,6 +47,7 @@ test('renders correctly without hover', () => {
         hoverStyle="none"
         expandedContents={<div>Expanded Contents</div>}
         id="expandableRow"
+        onExpand={() => {}}
       >
         <div>row cells</div>
       </TableRowExpandable>


### PR DESCRIPTION
## Summary
The purpose of this PR is to add the onExpand function prop to the Table.RowExpandable component. 

An example use case for this prop would be if a user wanted to request an API call **only** when the row is expanded. 

## Test Plan
I used the docs and created more tests to make sure the function prop works as needed.
