### PR TITLE
ActivationCard: Add shadow border and polish docs

### DIFF
--- a/docs/src/ActivationCard.doc.js
+++ b/docs/src/ActivationCard.doc.js
@@ -19,7 +19,7 @@ card(
     name="Not started and Pending Cards"
     defaultCode={`
 <Box display="flex" marginStart={-1} marginEnd={-1}>
-  <Box paddingX={1}>
+  <Box paddingX={1} column={6}>
     <ActivationCard
       status="notStarted"
       statusMessage="Not started"
@@ -32,7 +32,7 @@ card(
       }}
     />
   </Box>
-  <Box paddingX={1}>
+  <Box paddingX={1} column={6}>
     <ActivationCard
       status="pending"
       statusMessage="Pending"
@@ -55,7 +55,7 @@ card(
     name="Needs attention and Complete Cards"
     defaultCode={`
 <Box display="flex" marginStart={-1} marginEnd={-1}>
-  <Box paddingX={1}>
+  <Box paddingX={1} column={6}>
     <ActivationCard
       status="needsAttention"
       statusMessage="Needs attention"
@@ -68,7 +68,7 @@ card(
       }}
     />
   </Box>
-  <Box paddingX={1}>
+  <Box paddingX={1} column={6}>
     <ActivationCard
       status="complete"
       statusMessage="Completed"

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -200,7 +200,7 @@ export default function ActivationCard({
     <Box
       display="flex"
       flex="grow"
-      borderStyle="sm"
+      borderStyle="shadow"
       rounding={4}
       padding={6}
       maxWidth={400}
@@ -208,6 +208,7 @@ export default function ActivationCard({
       direction="column"
       justifyContent="center"
       height="100%"
+      width="100%"
     >
       {isCompleted ? (
         <CompletedCard

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
@@ -2,11 +2,12 @@
 
 exports[`<ActivationCard /> Needs attention ActivationCard 1`] = `
 <div
-  className="borderColorLightGray box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 sizeSm solid xsDirectionColumn xsDisplayFlex"
+  className="box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
       "maxWidth": 400,
+      "width": "100%",
     }
   }
 >
@@ -68,11 +69,12 @@ exports[`<ActivationCard /> Needs attention ActivationCard 1`] = `
 
 exports[`<ActivationCard /> Not started ActivationCard 1`] = `
 <div
-  className="borderColorLightGray box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 sizeSm solid xsDirectionColumn xsDisplayFlex"
+  className="box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
       "maxWidth": 400,
+      "width": "100%",
     }
   }
 >
@@ -117,11 +119,12 @@ exports[`<ActivationCard /> Not started ActivationCard 1`] = `
 
 exports[`<ActivationCard /> Pending ActivationCard 1`] = `
 <div
-  className="borderColorLightGray box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 sizeSm solid xsDirectionColumn xsDisplayFlex"
+  className="box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
       "maxWidth": 400,
+      "width": "100%",
     }
   }
 >
@@ -183,11 +186,12 @@ exports[`<ActivationCard /> Pending ActivationCard 1`] = `
 
 exports[`<ActivationCard /> complete ActivationCard 1`] = `
 <div
-  className="borderColorLightGray box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 sizeSm solid xsDirectionColumn xsDisplayFlex"
+  className="box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
       "maxWidth": 400,
+      "width": "100%",
     }
   }
 >
@@ -243,11 +247,12 @@ exports[`<ActivationCard /> complete ActivationCard 1`] = `
 
 exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
 <div
-  className="borderColorLightGray box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 sizeSm solid xsDirectionColumn xsDisplayFlex"
+  className="box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
       "maxWidth": 400,
+      "width": "100%",
     }
   }
 >
@@ -388,11 +393,12 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
 
 exports[`<ActivationCard /> message + title + link 1`] = `
 <div
-  className="borderColorLightGray box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 sizeSm solid xsDirectionColumn xsDisplayFlex"
+  className="box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
       "maxWidth": 400,
+      "width": "100%",
     }
   }
 >
@@ -488,11 +494,12 @@ exports[`<ActivationCard /> message + title + link 1`] = `
 
 exports[`<ActivationCard /> message + title 1`] = `
 <div
-  className="borderColorLightGray box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 sizeSm solid xsDirectionColumn xsDisplayFlex"
+  className="box flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
       "maxWidth": 400,
+      "width": "100%",
     }
   }
 >


### PR DESCRIPTION
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

Now that Box supports drop shadow, this PR updates activation card to use the the shadow border per original designs. Also included in this PR is an update to the docs to ensure that the activation cards within a group are the same width.

Before:
<img width="826" alt="Screen Shot 2020-10-20 at 2 49 12 PM" src="https://user-images.githubusercontent.com/46180742/96647947-71241b80-12e3-11eb-9677-d58331c127df.png">

After:
<img width="830" alt="Screen Shot 2020-10-20 at 2 45 28 PM" src="https://user-images.githubusercontent.com/46180742/96647958-75e8cf80-12e3-11eb-9cf6-b212cbb7a413.png">


<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
