### PR TITLE
Internal: improve package.json with repository / keywords + exports information

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,5 +141,9 @@
       "stylelint",
       "flow-generate:css && flow"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pinterest/gestalt"
   }
 }

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -8,6 +8,14 @@
   "jsnext:main": "dist/gestalt-datepicker.es.js",
   "module": "dist/gestalt-datepicker.es.js",
   "style": "dist/gestalt-datepicker.css",
+  "exports": {
+    ".": {
+      "import": "./dist/gestalt-datepicker.es.js"
+    },
+    "./css": {
+      "import": "./dist/gestalt-datepicker.css"
+    }
+  },
   "files": [
     "dist",
     "src"
@@ -31,5 +39,16 @@
     "last 2 versions",
     "not IE < 11",
     "not <1%"
-  ]
+  ],
+  "keywords": [
+    "react",
+    "react component",
+    "pinterest",
+    "ui library",
+    "datepicker"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pinterest/gestalt"
+  }
 }

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -8,6 +8,14 @@
   "jsnext:main": "dist/gestalt.es.js",
   "module": "dist/gestalt.es.js",
   "style": "dist/gestalt.css",
+  "exports": {
+    ".": {
+      "import": "./dist/gestalt.es.js"
+    },
+    "./css": {
+      "import": "./dist/gestalt.css"
+    }
+  },
   "files": [
     "dist",
     "src"
@@ -31,5 +39,15 @@
     "last 2 versions",
     "not IE < 11",
     "not <1%"
-  ]
+  ],
+  "keywords": [
+    "react",
+    "react component",
+    "pinterest",
+    "ui library"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pinterest/gestalt"
+  }
 }


### PR DESCRIPTION
https://www.skypack.dev/view/gestalt surfaced a couple of fields we should add to our `package.json` file:

* `repository`: Make it easy to see where the code lives when you've install the package
* `keywords`: Improves discoverability of the the package
* `exports`: Explicitly states which files are meant to be imported:

Before
```
import "../node_modules/gestalt/dist/gestalt.css";
```

After
```
import "gestalt/css";
```

## Test Plan

CI Passes
