### PR TITLE
Docs: persist dark mode and RTL settings across refreshes

### DIFF
--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -1,43 +1,44 @@
 // @flow strict
-import React, { useState, type Node } from 'react';
+import React, { useState, type Node, useEffect } from 'react';
 import { Box, Divider, Provider, Link, Text } from 'gestalt';
 import Header from './Header.js';
 import Navigation from './Navigation.js';
 import useTracking from './useTracking.js';
 import { SidebarContextProvider } from './sidebarContext.js';
+import useLocalStorage from './useLocalStorage.js';
 
 type Props = {|
   children?: Node,
 |};
 
 const localStorageOrganizedByKey = 'gestalt-sidebar-organized-by';
+const localStorageColorSchemeKey = 'gestalt-color-scheme';
+const localStorageTextDirectionKey = 'gestalt-text-direction';
 
 export default function App(props: Props): Node {
   const { children } = props;
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [colorScheme, setColorScheme] = useState('light');
 
   useTracking('UA-12967896-44');
 
-  const [sidebarOrganisedBy, setSidebarOrganizedBy] = useState<
+  const [sidebarOrganisedBy, setSidebarOrganizedBy] = useLocalStorage<
     'categorized' | 'alphabetical'
-  >(() => {
-    try {
-      // $FlowIssue[incompatible-call]
-      return localStorage.getItem(localStorageOrganizedByKey) || 'categorized';
-    } catch (error) {
-      console.log(error); // eslint-disable-line no-console
-    }
-    return 'categorized';
-  });
+  >(localStorageOrganizedByKey, 'categorized');
 
-  React.useEffect(() => {
-    try {
-      localStorage.setItem(localStorageOrganizedByKey, sidebarOrganisedBy);
-    } catch (error) {
-      console.log(error); // eslint-disable-line no-console
+  const [colorScheme, setColorScheme] = useLocalStorage<
+    'light' | 'dark' | 'userPreference'
+  >(localStorageColorSchemeKey, 'light');
+
+  const [textDirection, setTextDirection] = useLocalStorage<'ltr' | 'rtl'>(
+    localStorageTextDirectionKey,
+    'ltr'
+  );
+
+  useEffect(() => {
+    if (document && document.documentElement) {
+      document.documentElement.dir = textDirection;
     }
-  }, [sidebarOrganisedBy]);
+  }, [textDirection]);
 
   return (
     <SidebarContextProvider
@@ -54,6 +55,10 @@ export default function App(props: Props): Node {
             colorScheme={colorScheme}
             onChangeColorScheme={() =>
               setColorScheme(colorScheme === 'light' ? 'dark' : 'light')
+            }
+            textDirection={textDirection}
+            onTextDirectionChange={() =>
+              setTextDirection(textDirection === 'rtl' ? 'ltr' : 'rtl')
             }
           />
           <Box mdDisplay="flex" direction="row">

--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -17,10 +17,16 @@ import { useSidebarContext } from './sidebarContext.js';
 type Props = {|
   colorScheme: string,
   onChangeColorScheme: () => void,
+  textDirection: 'ltr' | 'rtl',
+  onTextDirectionChange: () => void,
 |};
 
-function Header({ colorScheme, onChangeColorScheme }: Props) {
-  const [isRTL, setIsRTL] = React.useState(false);
+function Header({
+  colorScheme,
+  onChangeColorScheme,
+  textDirection,
+  onTextDirectionChange,
+}: Props) {
   const {
     isSidebarOpen,
     setIsSidebarOpen,
@@ -28,16 +34,11 @@ function Header({ colorScheme, onChangeColorScheme }: Props) {
     setSidebarOrganizedBy,
   } = useSidebarContext();
 
-  const toggleRTL = () => {
-    if (document && document.documentElement) {
-      document.documentElement.dir = isRTL ? 'ltr' : 'rtl';
-      setIsRTL(!isRTL);
-    }
-  };
   const togglePageDirSvgPath = {
-    __path: isRTL
-      ? 'M9 10v5h2V4h2v11h2V4h2V2H9C6.79 2 5 3.79 5 6s1.79 4 4 4zm12 8l-4-4v3H5v2h12v3l4-4z'
-      : 'M10 10v5h2V4h2v11h2V4h2V2h-8C7.79 2 6 3.79 6 6s1.79 4 4 4zm-2 7v-3l-4 4 4 4v-3h12v-2H8z',
+    __path:
+      textDirection === 'rtl'
+        ? 'M9 10v5h2V4h2v11h2V4h2V2H9C6.79 2 5 3.79 5 6s1.79 4 4 4zm12 8l-4-4v3H5v2h12v3l4-4z'
+        : 'M10 10v5h2V4h2v11h2V4h2V2h-8C7.79 2 6 3.79 6 6s1.79 4 4 4zm-2 7v-3l-4 4 4 4v-3h12v-2H8z',
   };
 
   return (
@@ -83,14 +84,18 @@ function Header({ colorScheme, onChangeColorScheme }: Props) {
         <Box display="none" mdDisplay="flex" alignItems="center">
           <Tooltip
             inline
-            text={isRTL ? 'Left-To-Right View' : 'Right-To-Left View'}
+            text={
+              textDirection === 'rtl'
+                ? 'Left-To-Right View'
+                : 'Right-To-Left View'
+            }
           >
             <IconButton
               size="md"
               accessibilityLabel="toggle page direction: Left-To-Right / Right-To-Left View"
               iconColor="white"
               dangerouslySetSvgPath={togglePageDirSvgPath}
-              onClick={toggleRTL}
+              onClick={() => onTextDirectionChange()}
             />
           </Tooltip>
           <Tooltip
@@ -174,6 +179,8 @@ function Header({ colorScheme, onChangeColorScheme }: Props) {
 export default function StickyHeader({
   colorScheme,
   onChangeColorScheme,
+  textDirection,
+  onTextDirectionChange,
 }: Props): Node {
   const isReducedHeight = () => window.innerHeight < 709;
   const [reducedHeight, setReducedHeight] = React.useState(isReducedHeight());
@@ -191,12 +198,16 @@ export default function StickyHeader({
     <Header
       colorScheme={colorScheme}
       onChangeColorScheme={onChangeColorScheme}
+      textDirection={textDirection}
+      onTextDirectionChange={onTextDirectionChange}
     />
   ) : (
     <Sticky zIndex={new FixedZIndex(10)} top={0}>
       <Header
         colorScheme={colorScheme}
         onChangeColorScheme={onChangeColorScheme}
+        textDirection={textDirection}
+        onTextDirectionChange={onTextDirectionChange}
       />
     </Sticky>
   );

--- a/docs/src/components/useLocalStorage.js
+++ b/docs/src/components/useLocalStorage.js
@@ -1,0 +1,44 @@
+// @flow strict
+import { useState } from 'react';
+
+// Forked from https://usehooks.com/useLocalStorage/
+export default function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (((T) => T) | T) => void] {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item || initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      // eslint-disable-next-line no-console
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  // Return a wrapped version of useState's setter function that
+  // persists the new value to localStorage.
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        // $FlowIssue[prop-missing]
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      window.localStorage.setItem(key, valueToStore);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
+  };
+
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
## Changes

* Persist dark mode and RTL settings across refreshes (using local storage)
* Introduces `useLocalStorage` to make it easier to work with local storage in our docs. Forked from https://usehooks.com/useLocalStorage/

## Test Plan

1. Go to `/`
2. Switch to dark mode
3. Reload

Expected result: dark mode is still enabled.
