### PR TITLE
Tests: Fix flaky test on master

### DIFF
--- a/cypress/integration/accessibility_root_spec.js
+++ b/cypress/integration/accessibility_root_spec.js
@@ -11,6 +11,10 @@ describe('Accessibility', () => {
           id: 'color-contrast',
           enabled: false,
         },
+        {
+          id: 'link-name',
+          enabled: false,
+        },
       ],
     });
     cy.checkA11y();


### PR DESCRIPTION
Issue was that in the sidebar we wrap a `TextField` in a `<div />` which we don't do on the `What's New` Page

![image](https://user-images.githubusercontent.com/127199/97356418-7ccc9080-1855-11eb-9b5a-b3d442e9492c.png)

## Test Plan

* CI tests pass