### PR TITLE
Docs: Fix UniformRowLayout example

### DIFF
--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -1,13 +1,6 @@
 // @flow strict
 import React, { type Node } from 'react';
-import {
-  Box,
-  Masonry,
-  Image,
-  Label,
-  Text,
-  MasonryUniformRowLayout,
-} from 'gestalt';
+import { Box, Masonry, Image, Label, Text } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
@@ -28,7 +21,7 @@ It contains performance optimizations like virtualization and support for infini
 type Props = {|
   flexible?: boolean,
   id?: string,
-  layout?: () => {||},
+  layout?: 'uniformRow',
 |};
 
 type State = {|
@@ -170,7 +163,6 @@ class ExampleMasonry extends React.Component<Props, State> {
               flexible={this.props.flexible}
               gutterWidth={5}
               items={this.state.pins}
-              // $FlowIssue[incompatible-type]
               layout={this.props.layout}
               minCols={1}
               ref={(ref) => {
@@ -245,8 +237,7 @@ card(
   `}
     name="Uniform row heights"
   >
-    {/* $FlowIssue[prop-missing] */}
-    <ExampleMasonry layout={MasonryUniformRowLayout} id="uniform" />
+    <ExampleMasonry layout="uniformRow" id="uniform" />
   </Card>
 );
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -493,6 +493,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<
     const { hasPendingMeasurements, measurementStore, width } = this.state;
 
     let getPositions;
+
     if ((flexible || layout === 'flexible') && width !== null) {
       getPositions = fullWidthLayout({
         gutter,


### PR DESCRIPTION
The UniformRowLayout example is not showing uniform rows

### Before
![image](https://user-images.githubusercontent.com/127199/97928479-febc2e00-1d1b-11eb-92a9-5214bdb90928.png)

### After
![image](https://user-images.githubusercontent.com/127199/97928353-bac92900-1d1b-11eb-802a-a92f76b8a05e.png)

