### PR TITLE
Tooltip: Add zIndex prop

### DIFF
--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -153,6 +153,12 @@ card(
         required: false,
         description: 'A link which will show on the bottom of a tooltip',
       },
+      {
+        name: 'zIndex',
+        type: 'interface Indexable { index(): number; }',
+        required: false,
+        description: 'An object representing the zIndex value of the Tooltip.',
+      },
     ]}
   />
 );

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -5,6 +5,7 @@ import Controller from './Controller.js';
 import Text from './Text.js';
 import Box from './Box.js';
 import Layer from './Layer.js';
+import { type Indexable } from './zIndex.js';
 
 const noop = () => {};
 const TIMEOUT = 100;
@@ -15,6 +16,7 @@ type Props = {|
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   inline?: boolean,
   text: string,
+  zIndex?: Indexable,
 |};
 
 const initialState = { hoveredIcon: false, hoveredText: false, isOpen: false };
@@ -56,6 +58,7 @@ export default function Tooltip({
   idealDirection = 'down',
   inline,
   text,
+  zIndex,
 }: Props): Node {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const { isOpen } = state;
@@ -92,7 +95,7 @@ export default function Tooltip({
         {children}
       </Box>
       {isOpen && !!anchor && (
-        <Layer>
+        <Layer zIndex={zIndex}>
           <Controller
             anchor={anchor}
             caret={false}

--- a/packages/gestalt/src/Tooltip.jsdom.test.js
+++ b/packages/gestalt/src/Tooltip.jsdom.test.js
@@ -5,6 +5,7 @@ import { fireEvent, render } from '@testing-library/react';
 import Tooltip from './Tooltip.js';
 import Link from './Link.js';
 import Text from './Text.js';
+import { FixedZIndex } from './zIndex.js';
 
 test('Tooltip renders', () => {
   const component = create(
@@ -68,4 +69,25 @@ test('Tooltip renders with idealDirection', () => {
   );
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+test('Tooltip renders with zIndex', () => {
+  const fixedZIndex = new FixedZIndex(100);
+  const { container, getByText } = render(
+    <Tooltip text="This is a tooltip" zIndex={fixedZIndex}>
+      <div>Hi</div>
+    </Tooltip>
+  );
+  const ariaContainer = container.querySelector('[aria-label]');
+  expect(ariaContainer).not.toBe(null);
+
+  if (ariaContainer) {
+    fireEvent.mouseEnter(ariaContainer);
+  }
+
+  const { body } = document;
+  const tooltipText = getByText('This is a tooltip');
+  const layer = body && body.querySelector('.layer');
+  expect(layer && getComputedStyle(layer).zIndex).toEqual('100');
+  expect(body && body.contains(tooltipText)).toBe(true);
 });


### PR DESCRIPTION

This diff adds a zIndex prop to the Tooltip component, allowing users to set a zIndex value.

* What is the context surrounding this PR? Include links if possible.
Tooltip doesnt work well with modals as modals have a higher Z index. This enables developers to set a custom z index on the tooltip so it can show over the modals.

* What kind of feedback do you want? Code review

* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description` Yes

## Test Plan

How can reviewers verify this is good to merge?

* Is it tested? Yes, unit tests pass
* Is it accessible? No changes to accessibility
* Is it documented? Yes
* Have you involved other stakeholders (such as a Pinterest Designer)? yes
