### PR TITLE
Internal: Add integration test retries

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,12 @@
 {
+  "$schema": "https://on.cypress.io/cypress.schema.json",
   "baseUrl": "http://localhost:3000",
   "projectId": "x99ctf",
   "viewportHeight": 1080,
   "viewportWidth": 1920,
-  "defaultCommandTimeout": 8000
+  "defaultCommandTimeout": 8000,
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }


### PR DESCRIPTION
## Goal

Avoid flaky test runs by adding retries. We had a few instances where we had to re-run the whole test suite in GitHub CI just to fix 1 flaky test.

## Changes

* Add retries: https://docs.cypress.io/guides/guides/test-retries.html#Global-Configuration
* Add JSON schema to show a description of each property on hover (in VSCode)
https://www.cypress.io/blog/2020/06/18/extending-the-cypress-config-file/
![image](https://user-images.githubusercontent.com/127199/98125025-c4ac7280-1e68-11eb-8e44-6ce8abf1d3e5.png)
![image](https://user-images.githubusercontent.com/127199/98125105-e3ab0480-1e68-11eb-89f9-30bb88025aa0.png)

## Test Plan

* Cypress integration tests pass