### PR TITLE
Docs: Move props back to the top + make collapsible

### DIFF
--- a/docs/src/ActivationCard.doc.js
+++ b/docs/src/ActivationCard.doc.js
@@ -15,73 +15,6 @@ card(
 );
 
 card(
-  <Example
-    name="Not started and Pending Cards"
-    defaultCode={`
-<Box display="flex" marginStart={-1} marginEnd={-1}>
-  <Box paddingX={1} column={6}>
-    <ActivationCard
-      status="notStarted"
-      statusMessage="Not started"
-      title="Claim your website"
-      message="Grow distribution and track Pins linked to your website"
-      link={{href: "https://pinterest.com", label:"Claim your website now"}}
-      dismissButton={{
-        accessibilityLabel: 'Dismiss card',
-        onDismiss: ()=>{},
-      }}
-    />
-  </Box>
-  <Box paddingX={1} column={6}>
-    <ActivationCard
-      status="pending"
-      statusMessage="Pending"
-      title="Claim your website"
-      message="We will notify you via email as soon as your site has been successfully claimed."
-      link={{href: "https://pinterest.com", label:"Learn more"}}
-      dismissButton={{
-        accessibilityLabel: 'Dismiss card',
-        onDismiss: ()=>{},
-      }}
-    />
-  </Box>
-</Box>
-  `}
-  />
-);
-
-card(
-  <Example
-    name="Needs attention and Complete Cards"
-    defaultCode={`
-<Box display="flex" marginStart={-1} marginEnd={-1}>
-  <Box paddingX={1} column={6}>
-    <ActivationCard
-      status="needsAttention"
-      statusMessage="Needs attention"
-      title="Tag is unhealthy"
-      message="Oops! Your tag must be healthy to continue."
-      link={{accessibilityLabel:"Learn more about tag health", href: "https://pinterest.com", label:"Learn more"}}
-      dismissButton={{
-        accessibilityLabel: 'Dismiss card',
-        onDismiss: ()=>{},
-      }}
-    />
-  </Box>
-  <Box paddingX={1} column={6}>
-    <ActivationCard
-      status="complete"
-      statusMessage="Completed"
-      title="Nice work"
-      message="Tag is installed and healthy"
-    />
-  </Box>
-</Box>
-  `}
-  />
-);
-
-card(
   <PropTable
     props={[
       {
@@ -156,6 +89,73 @@ card(
         href: '',
       },
     ]}
+  />
+);
+
+card(
+  <Example
+    name="Not started and Pending Cards"
+    defaultCode={`
+<Box display="flex" marginStart={-1} marginEnd={-1}>
+  <Box paddingX={1} column={6}>
+    <ActivationCard
+      status="notStarted"
+      statusMessage="Not started"
+      title="Claim your website"
+      message="Grow distribution and track Pins linked to your website"
+      link={{href: "https://pinterest.com", label:"Claim your website now"}}
+      dismissButton={{
+        accessibilityLabel: 'Dismiss card',
+        onDismiss: ()=>{},
+      }}
+    />
+  </Box>
+  <Box paddingX={1} column={6}>
+    <ActivationCard
+      status="pending"
+      statusMessage="Pending"
+      title="Claim your website"
+      message="We will notify you via email as soon as your site has been successfully claimed."
+      link={{href: "https://pinterest.com", label:"Learn more"}}
+      dismissButton={{
+        accessibilityLabel: 'Dismiss card',
+        onDismiss: ()=>{},
+      }}
+    />
+  </Box>
+</Box>
+  `}
+  />
+);
+
+card(
+  <Example
+    name="Needs attention and Complete Cards"
+    defaultCode={`
+<Box display="flex" marginStart={-1} marginEnd={-1}>
+  <Box paddingX={1} column={6}>
+    <ActivationCard
+      status="needsAttention"
+      statusMessage="Needs attention"
+      title="Tag is unhealthy"
+      message="Oops! Your tag must be healthy to continue."
+      link={{accessibilityLabel:"Learn more about tag health", href: "https://pinterest.com", label:"Learn more"}}
+      dismissButton={{
+        accessibilityLabel: 'Dismiss card',
+        onDismiss: ()=>{},
+      }}
+    />
+  </Box>
+  <Box paddingX={1} column={6}>
+    <ActivationCard
+      status="complete"
+      statusMessage="Completed"
+      title="Nice work"
+      message="Tag is installed and healthy"
+    />
+  </Box>
+</Box>
+  `}
   />
 );
 

--- a/docs/src/Avatar.doc.js
+++ b/docs/src/Avatar.doc.js
@@ -15,6 +15,46 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibilityLabel',
+        type: 'string',
+        description:
+          'String that clients such as VoiceOver will read to describe the element. Will default to `name` prop if not provided.',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+      },
+      {
+        name: 'outline',
+        type: 'boolean',
+        defaultValue: false,
+        description: `Adds a white border around Avatar so it's visible when displayed on other images`,
+      },
+      {
+        name: 'size',
+        type: `"xs" | "sm" | "md" | "lg" | "xl" | "fit"`,
+        defaultValue: 'fit',
+        description:
+          'xs: 24px, sm: 32px, md: 48px, lg: 64px, xl: 120px. If size is `fit`, Avatar will fill 100% of the parent container width',
+      },
+      {
+        name: 'src',
+        type: 'string',
+      },
+      {
+        name: 'verified',
+        type: 'boolean',
+        defaultValue: false,
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description={`
     There are 5 sizes you can choose for an \`Avatar\`. For certain designs you may need a container-based size. More information on that option is below.
@@ -118,46 +158,6 @@ card(
   verified
 />
   `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        description:
-          'String that clients such as VoiceOver will read to describe the element. Will default to `name` prop if not provided.',
-      },
-      {
-        name: 'name',
-        type: 'string',
-        required: true,
-      },
-      {
-        name: 'outline',
-        type: 'boolean',
-        defaultValue: false,
-        description: `Adds a white border around Avatar so it's visible when displayed on other images`,
-      },
-      {
-        name: 'size',
-        type: `"xs" | "sm" | "md" | "lg" | "xl" | "fit"`,
-        defaultValue: 'fit',
-        description:
-          'xs: 24px, sm: 32px, md: 48px, lg: 64px, xl: 120px. If size is `fit`, Avatar will fill 100% of the parent container width',
-      },
-      {
-        name: 'src',
-        type: 'string',
-      },
-      {
-        name: 'verified',
-        type: 'boolean',
-        defaultValue: false,
-      },
-    ]}
   />
 );
 

--- a/docs/src/AvatarPair.doc.js
+++ b/docs/src/AvatarPair.doc.js
@@ -10,6 +10,25 @@ const card = (c) => cards.push(c);
 card(<PageHeader name="AvatarPair" description="Show avatars in pairs" />);
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'collaborators',
+        type: 'Array<{| name: string, src?: string |}>',
+        required: true,
+      },
+      {
+        name: 'size',
+        type: `"md" | "lg" | "fit"`,
+        defaultValue: 'fit',
+        description:
+          'md: 48px, lg: 64px. If size is `fit`, AvatarPair will fill 100% of the parent container width',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Example: Basic"
     defaultCode={`
@@ -51,25 +70,6 @@ card(
   />
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'collaborators',
-        type: 'Array<{| name: string, src?: string |}>',
-        required: true,
-      },
-      {
-        name: 'size',
-        type: `"md" | "lg" | "fit"`,
-        defaultValue: 'fit',
-        description:
-          'md: 48px, lg: 64px. If size is `fit`, AvatarPair will fill 100% of the parent container width',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Badge.doc.js
+++ b/docs/src/Badge.doc.js
@@ -16,6 +16,26 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'text',
+        type: `string`,
+        required: true,
+        description:
+          'Text displayed inside of the Badge. Sentence case is best.',
+      },
+      {
+        name: 'position',
+        type: `"middle" | "top"`,
+        defaultValue: 'middle',
+        description: 'Badge position relative to its parent element.',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description="
     The `Badge` component is rendered inline within parent element."
@@ -34,26 +54,6 @@ card(
     defaultCode={`
   <Heading>Heading <Badge text="Beta" position="top"/></Heading>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'text',
-        type: `string`,
-        required: true,
-        description:
-          'Text displayed inside of the Badge. Sentence case is best.',
-      },
-      {
-        name: 'position',
-        type: `"middle" | "top"`,
-        defaultValue: 'middle',
-        description: 'Badge position relative to its parent element.',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -54,6 +54,173 @@ card(
 );
 
 card(
+  <PropTable
+    Component={Box}
+    props={[
+      {
+        name: 'dangerouslySetInlineStyle',
+        type: '{ __style: { [key: string]: string | number | void } }',
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'display',
+        type: `"none" | "flex" | "block" | "inlineBlock" | "visuallyHidden"`,
+        defaultValue: 'block',
+        responsive: true,
+        href: 'display',
+      },
+      {
+        name: 'direction',
+        type: `"row" | "column"`,
+        defaultValue: 'row',
+        responsive: true,
+        description:
+          'Establishes the main-axis, thus defining the direction flex items are placed in the flex container.',
+      },
+      {
+        name: 'alignContent',
+        type: `"start" | "end" | "center" | "between" | "around" | "evenly" | "stretch"`,
+        defaultValue: 'stretch',
+        description:
+          "Aligns a flex container's lines within when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.",
+      },
+      {
+        name: 'alignItems',
+        type: `"start" | "end" | "center" | "baseline" | "stretch"`,
+        defaultValue: 'stretch',
+        description:
+          'Defines the default behaviour for how flex items are laid out along the cross-axis on the current line. Think of it as the justify-content version for the cross-axis (perpendicular to the main-axis).',
+        href: 'layout',
+      },
+      {
+        name: 'alignSelf',
+        type: `"auto" | "start" | "end" | "center" | "baseline" | "stretch"`,
+        defaultValue: 'stretch',
+        description:
+          'Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items.',
+      },
+      {
+        name: 'borderStyle',
+        type: `"sm" | "lg" | "shadow" | "none"`,
+        defaultValue: 'none',
+        description:
+          'Specify a border style for the box. For sizes, "sm" is 1px and "lg" is 2px. Setting a size will always default the border style to solid and color to lightGray. Alternatively, "shadow" can be specified to add a box shadow instead of a solid border',
+        href: 'border',
+      },
+      {
+        name: 'color',
+        type: `"blue" | "darkGray" | "darkWash" | "eggplant" | "gray" | "green" | "lightGray" | "lightWash" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "transparent" | "transparentDarkGray" | "watermelon" | "white"`,
+        defaultValue: 'transparent',
+        href: 'color',
+      },
+      { name: 'fit', type: 'boolean', defaultValue: false },
+      {
+        name: 'flex',
+        type: '"grow" | "shrink" | "none"',
+        defaultValue: 'shrink',
+        description: `Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size the Box relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows the Box to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves the Box's size based on child content regardless of its container's size.`,
+      },
+      {
+        name: 'justifyContent',
+        type: `"start" | "end" | "center" | "between" | "around" | "evenly"`,
+        defaultValue: 'start',
+        description:
+          'Defines the alignment along the main axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.',
+        href: 'layout',
+      },
+      ...absolutePositioningProps,
+      ...marginProps,
+      {
+        name: 'column',
+        type: `0 .. 12`,
+        responsive: true,
+      },
+      {
+        name: 'maxHeight',
+        type: `number | string`,
+      },
+      {
+        name: 'maxWidth',
+        type: `number | string`,
+        description: `Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%"`,
+      },
+      {
+        name: 'minHeight',
+        type: `number | string`,
+        description: `Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%"`,
+      },
+      {
+        name: 'minWidth',
+        type: `number | string`,
+        description: `Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%"`,
+      },
+      {
+        name: 'height',
+        type: `number | string`,
+        description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
+      },
+      {
+        name: 'width',
+        type: `number | string`,
+        description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
+      },
+      {
+        name: 'opacity',
+        type: `0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1`,
+      },
+      {
+        name: 'overflow',
+        type: `"visible" | "hidden" | "scroll" | "scrollX" | "scrollY" | "auto"`,
+        defaultValue: 'visible',
+      },
+      ...paddingProps,
+      {
+        name: 'position',
+        type: `"static" | "absolute" | "relative" | "fixed"`,
+        defaultValue: 'static',
+        href: 'absolutePositioning',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'div'>",
+        description: 'Forward the ref to the underlying div element',
+        href: 'refExample',
+      },
+      {
+        name: 'role',
+        type: 'string',
+      },
+      {
+        name: 'rounding',
+        type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
+        href: 'rounding',
+      },
+      {
+        name: 'userSelect',
+        type: `"auto" | "none"`,
+        defaultValue: 'auto',
+        description: `controls whether or not user can select text`,
+      },
+      {
+        name: 'wrap',
+        type: 'boolean',
+        defaultValue: false,
+        description: `By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.`,
+      },
+      {
+        name: 'zIndex',
+        href: 'zindex',
+        type: 'interface Indexable { index(): number; }',
+        description: `An object representing the zIndex value of the Box.`,
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description={`
     The [media object](http://www.stubbornella.org/content/2010/06/25/the-media-object-saves-hundreds-of-lines-of-code/) is a common pattern for displaying data. What's interesting about this example is the use of \`flex\` to align the items. If you try changing the size of the \`Avatar\` or the number of lines of \`Text\`, both will stay aligned because they are center aligned.
@@ -515,173 +682,6 @@ function Example() {
   return <Box color="blue" width={60} height={60} zIndex={zIndex} />
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    Component={Box}
-    props={[
-      {
-        name: 'dangerouslySetInlineStyle',
-        type: '{ __style: { [key: string]: string | number | void } }',
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'display',
-        type: `"none" | "flex" | "block" | "inlineBlock" | "visuallyHidden"`,
-        defaultValue: 'block',
-        responsive: true,
-        href: 'display',
-      },
-      {
-        name: 'direction',
-        type: `"row" | "column"`,
-        defaultValue: 'row',
-        responsive: true,
-        description:
-          'Establishes the main-axis, thus defining the direction flex items are placed in the flex container.',
-      },
-      {
-        name: 'alignContent',
-        type: `"start" | "end" | "center" | "between" | "around" | "evenly" | "stretch"`,
-        defaultValue: 'stretch',
-        description:
-          "Aligns a flex container's lines within when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.",
-      },
-      {
-        name: 'alignItems',
-        type: `"start" | "end" | "center" | "baseline" | "stretch"`,
-        defaultValue: 'stretch',
-        description:
-          'Defines the default behaviour for how flex items are laid out along the cross-axis on the current line. Think of it as the justify-content version for the cross-axis (perpendicular to the main-axis).',
-        href: 'layout',
-      },
-      {
-        name: 'alignSelf',
-        type: `"auto" | "start" | "end" | "center" | "baseline" | "stretch"`,
-        defaultValue: 'stretch',
-        description:
-          'Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items.',
-      },
-      {
-        name: 'borderStyle',
-        type: `"sm" | "lg" | "shadow" | "none"`,
-        defaultValue: 'none',
-        description:
-          'Specify a border style for the box. For sizes, "sm" is 1px and "lg" is 2px. Setting a size will always default the border style to solid and color to lightGray. Alternatively, "shadow" can be specified to add a box shadow instead of a solid border',
-        href: 'border',
-      },
-      {
-        name: 'color',
-        type: `"blue" | "darkGray" | "darkWash" | "eggplant" | "gray" | "green" | "lightGray" | "lightWash" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "transparent" | "transparentDarkGray" | "watermelon" | "white"`,
-        defaultValue: 'transparent',
-        href: 'color',
-      },
-      { name: 'fit', type: 'boolean', defaultValue: false },
-      {
-        name: 'flex',
-        type: '"grow" | "shrink" | "none"',
-        defaultValue: 'shrink',
-        description: `Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size the Box relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows the Box to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves the Box's size based on child content regardless of its container's size.`,
-      },
-      {
-        name: 'justifyContent',
-        type: `"start" | "end" | "center" | "between" | "around" | "evenly"`,
-        defaultValue: 'start',
-        description:
-          'Defines the alignment along the main axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.',
-        href: 'layout',
-      },
-      ...absolutePositioningProps,
-      ...marginProps,
-      {
-        name: 'column',
-        type: `0 .. 12`,
-        responsive: true,
-      },
-      {
-        name: 'maxHeight',
-        type: `number | string`,
-      },
-      {
-        name: 'maxWidth',
-        type: `number | string`,
-        description: `Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%"`,
-      },
-      {
-        name: 'minHeight',
-        type: `number | string`,
-        description: `Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%"`,
-      },
-      {
-        name: 'minWidth',
-        type: `number | string`,
-        description: `Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%"`,
-      },
-      {
-        name: 'height',
-        type: `number | string`,
-        description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
-      },
-      {
-        name: 'width',
-        type: `number | string`,
-        description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
-      },
-      {
-        name: 'opacity',
-        type: `0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1`,
-      },
-      {
-        name: 'overflow',
-        type: `"visible" | "hidden" | "scroll" | "scrollX" | "scrollY" | "auto"`,
-        defaultValue: 'visible',
-      },
-      ...paddingProps,
-      {
-        name: 'position',
-        type: `"static" | "absolute" | "relative" | "fixed"`,
-        defaultValue: 'static',
-        href: 'absolutePositioning',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'div'>",
-        description: 'Forward the ref to the underlying div element',
-        href: 'refExample',
-      },
-      {
-        name: 'role',
-        type: 'string',
-      },
-      {
-        name: 'rounding',
-        type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
-        href: 'rounding',
-      },
-      {
-        name: 'userSelect',
-        type: `"auto" | "none"`,
-        defaultValue: 'auto',
-        description: `controls whether or not user can select text`,
-      },
-      {
-        name: 'wrap',
-        type: 'boolean',
-        defaultValue: false,
-        description: `By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.`,
-      },
-      {
-        name: 'zIndex',
-        href: 'zindex',
-        type: 'interface Indexable { index(): number; }',
-        description: `An object representing the zIndex value of the Box.`,
-      },
-    ]}
   />
 );
 

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -17,6 +17,224 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibilityLabel',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply a short, descriptive label for screen-readers to replace button texts that do not provide sufficient context about the button component behavior. Texts like `Click Here,` `Follow,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the button text.',
+          'Use IconButton if you only need a button with an icon and no text.',
+          'Accessibility: It populates aria-label. Screen readers read the `accessibilityLabel` prop, if present, instead of `text`.',
+        ],
+        href: 'accessibilityLabel',
+      },
+      {
+        name: 'accessibilityControls',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Specify the `id` of an associated element (or elements) whose contents or visibility are controlled by a button component so that screen reader users can identify the relationship between elements.',
+          'Optional with button-role + button-type buttons.',
+          'Accessibility: It populates aria-controls.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'accessibilityExpanded',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Indicate that a button component hides or exposes collapsible components and expose whether they are currently expanded or collapsed.',
+          'Optional with button-role + button-type buttons.',
+          'Accessibility: It populates aria-expanded.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'accessibilityHaspopup',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Indicate that a button component controls the appearance of interactive popup elements, such as menu or dialog.',
+          'Optional with button-role + button-type buttons.',
+          'Accessibility: It populates aria-haspopup.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'color',
+        type: `'gray' | 'red' | 'blue' | 'transparent' | 'transparentWhiteText' | 'white'`,
+        required: false,
+        defaultValue: 'gray',
+        description: [
+          'Primary colors to apply to the button background.',
+          'Accessibility: Use `transparentWhiteText` to increase the contrast between a dark background and a transparent-Button text.',
+        ],
+        href: 'color',
+      },
+      {
+        name: 'disabled',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description:
+          'Set disabled state so buttons look inactive, cannot be interacted with, and actions are not available.',
+        href: 'type-roles',
+      },
+      {
+        name: 'iconEnd',
+        type: '$Keys<typeof icons>',
+        required: false,
+        defaultValue: false,
+        description: [
+          'Add a Gestalt icon to be displayed after the button text. Sometimes an icon can help clarify the usage of a button. Menus are a common use case.',
+          'Accessibility: Icons on buttons are not accessible for screen readers.',
+          'Use IconButton if you only need buttons with icons and no text.',
+        ],
+        href: 'iconEnd',
+      },
+      {
+        name: 'inline',
+        type: 'boolean',
+        required: false,
+        defaultValue: false,
+        description:
+          'Display a button as an inline element so that it does not start on a new line breaking the flow of the content. Inline buttons are sized by the text within the button, whereas the default block buttons expand to the full width of their container.',
+        href: 'width',
+      },
+      {
+        name: 'onClick',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a button component is clicked (pressed and released) with a mouse or keyboard.',
+          'Required with button-role + button-type buttons.',
+        ],
+        href: 'selected',
+      },
+      {
+        name: 'size',
+        type: `'sm' | 'md' | 'lg'`,
+        required: false,
+        defaultValue: 'md',
+        description:
+          'Display a button in different sizes. Size changes the component padding modifying its fixed height: sm (32px), md (40px), lg (48px).',
+        href: 'size',
+      },
+      {
+        name: 'text',
+        type: 'string',
+        required: true,
+        defaultValue: null,
+        description: [
+          'Text to render inside the button to convey the function and purpose of the button. The button text has a fixed size.',
+          'Accessibility: Screen readers read the `accessibilityLabel` prop, if present, instead of the `text` prop. See `accessibilityLabel` for more info.',
+        ],
+        href: 'basic-button',
+      },
+      {
+        name: 'type',
+        type: `'submit' | 'button'`,
+        required: false,
+        defaultValue: 'button',
+        description: [
+          'Select a type of button-role button:',
+          '-`button`: Use to render simple push buttons with no default behavior and control custom functionality inside the `onClick` callback.',
+          '-`submit`: Use to submit forms. The button is inside/associated with a form.',
+        ],
+        href: 'type-roles',
+      },
+      {
+        name: 'selected',
+        type: 'boolean',
+        required: false,
+        defaultValue: false,
+        description: [
+          'Control the "selected" state of a button component to toggle binary states.',
+          'Optional with button-role + button-type buttons.',
+        ],
+        href: 'selected',
+      },
+      {
+        name: 'href',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Specify a link URL.',
+          'Required with link-role buttons.',
+        ],
+        href: 'type-roles',
+      },
+      {
+        name: 'ref',
+        type: `React.Ref<'button'> | React.Ref<'a'>`,
+        required: false,
+        defaultValue: null,
+        description:
+          'Forward the ref to the underlying button or anchor element.',
+        href: 'ref',
+      },
+      {
+        name: 'tabIndex',
+        type: `-1 | 0`,
+        required: false,
+        defaultValue: 0,
+        description: [
+          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
+          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
+          `If component is disabled, the component is also unreachable from keyboard navigation.`,
+        ],
+        href: 'type-roles',
+      },
+      {
+        name: 'role',
+        type: `'button' | 'link'`,
+        required: false,
+        defaultValue: 'button',
+        description: [
+          `Select a button variant:`,
+          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a '<button>'.`,
+          `- 'link': Use for buttons to act like links. The button is rendered as an '<a>'.`,
+          `Required with link-role buttons.`,
+        ],
+        href: 'type-roles',
+      },
+      {
+        name: 'rel',
+        type: `'none' | 'nofollow'`,
+        required: false,
+        defaultValue: 'none',
+        description: 'Optional with link-role buttons.',
+        href: 'type-roles',
+      },
+      {
+        name: 'target',
+        type: `null | 'self' | 'blank'`,
+        required: false,
+        defaultValue: 'null',
+        description: [
+          'Define the frame or window to open the anchor defined on `href`:',
+          '- `null` opens the anchor in the same window.',
+          '- `blank` opens the anchor in a new window.',
+          '- `self` opens an anchor in the same frame.',
+          'Optional with link-role buttons.',
+        ],
+        href: 'type-roles',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Basic Button"
     id="basic-button"
@@ -26,7 +244,7 @@ card(
 
 card(
   <Example
-    name="Types & Roles"
+    name="Types &amp; Roles"
     id="type-roles"
     defaultCode={`
 function Example() {
@@ -324,224 +542,6 @@ function MenuButtonExample() {
   );
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Supply a short, descriptive label for screen-readers to replace button texts that do not provide sufficient context about the button component behavior. Texts like `Click Here,` `Follow,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the button text.',
-          'Use IconButton if you only need a button with an icon and no text.',
-          'Accessibility: It populates aria-label. Screen readers read the `accessibilityLabel` prop, if present, instead of `text`.',
-        ],
-        href: 'accessibilityLabel',
-      },
-      {
-        name: 'accessibilityControls',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Specify the `id` of an associated element (or elements) whose contents or visibility are controlled by a button component so that screen reader users can identify the relationship between elements.',
-          'Optional with button-role + button-type buttons.',
-          'Accessibility: It populates aria-controls.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'accessibilityExpanded',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Indicate that a button component hides or exposes collapsible components and expose whether they are currently expanded or collapsed.',
-          'Optional with button-role + button-type buttons.',
-          'Accessibility: It populates aria-expanded.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'accessibilityHaspopup',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Indicate that a button component controls the appearance of interactive popup elements, such as menu or dialog.',
-          'Optional with button-role + button-type buttons.',
-          'Accessibility: It populates aria-haspopup.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'color',
-        type: `'gray' | 'red' | 'blue' | 'transparent' | 'transparentWhiteText' | 'white'`,
-        required: false,
-        defaultValue: 'gray',
-        description: [
-          'Primary colors to apply to the button background.',
-          'Accessibility: Use `transparentWhiteText` to increase the contrast between a dark background and a transparent-Button text.',
-        ],
-        href: 'color',
-      },
-      {
-        name: 'disabled',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description:
-          'Set disabled state so buttons look inactive, cannot be interacted with, and actions are not available.',
-        href: 'type-roles',
-      },
-      {
-        name: 'iconEnd',
-        type: '$Keys<typeof icons>',
-        required: false,
-        defaultValue: false,
-        description: [
-          'Add a Gestalt icon to be displayed after the button text. Sometimes an icon can help clarify the usage of a button. Menus are a common use case.',
-          'Accessibility: Icons on buttons are not accessible for screen readers.',
-          'Use IconButton if you only need buttons with icons and no text.',
-        ],
-        href: 'iconEnd',
-      },
-      {
-        name: 'inline',
-        type: 'boolean',
-        required: false,
-        defaultValue: false,
-        description:
-          'Display a button as an inline element so that it does not start on a new line breaking the flow of the content. Inline buttons are sized by the text within the button, whereas the default block buttons expand to the full width of their container.',
-        href: 'width',
-      },
-      {
-        name: 'onClick',
-        type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Callback fired when a button component is clicked (pressed and released) with a mouse or keyboard.',
-          'Required with button-role + button-type buttons.',
-        ],
-        href: 'selected',
-      },
-      {
-        name: 'size',
-        type: `'sm' | 'md' | 'lg'`,
-        required: false,
-        defaultValue: 'md',
-        description:
-          'Display a button in different sizes. Size changes the component padding modifying its fixed height: sm (32px), md (40px), lg (48px).',
-        href: 'size',
-      },
-      {
-        name: 'text',
-        type: 'string',
-        required: true,
-        defaultValue: null,
-        description: [
-          'Text to render inside the button to convey the function and purpose of the button. The button text has a fixed size.',
-          'Accessibility: Screen readers read the `accessibilityLabel` prop, if present, instead of the `text` prop. See `accessibilityLabel` for more info.',
-        ],
-        href: 'basic-button',
-      },
-      {
-        name: 'type',
-        type: `'submit' | 'button'`,
-        required: false,
-        defaultValue: 'button',
-        description: [
-          'Select a type of button-role button:',
-          '-`button`: Use to render simple push buttons with no default behavior and control custom functionality inside the `onClick` callback.',
-          '-`submit`: Use to submit forms. The button is inside/associated with a form.',
-        ],
-        href: 'type-roles',
-      },
-      {
-        name: 'selected',
-        type: 'boolean',
-        required: false,
-        defaultValue: false,
-        description: [
-          'Control the "selected" state of a button component to toggle binary states.',
-          'Optional with button-role + button-type buttons.',
-        ],
-        href: 'selected',
-      },
-      {
-        name: 'href',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Specify a link URL.',
-          'Required with link-role buttons.',
-        ],
-        href: 'type-roles',
-      },
-      {
-        name: 'ref',
-        type: `React.Ref<'button'> | React.Ref<'a'>`,
-        required: false,
-        defaultValue: null,
-        description:
-          'Forward the ref to the underlying button or anchor element.',
-        href: 'ref',
-      },
-      {
-        name: 'tabIndex',
-        type: `-1 | 0`,
-        required: false,
-        defaultValue: 0,
-        description: [
-          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
-          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
-          `If component is disabled, the component is also unreachable from keyboard navigation.`,
-        ],
-        href: 'type-roles',
-      },
-      {
-        name: 'role',
-        type: `'button' | 'link'`,
-        required: false,
-        defaultValue: 'button',
-        description: [
-          `Select a button variant:`,
-          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a '<button>'.`,
-          `- 'link': Use for buttons to act like links. The button is rendered as an '<a>'.`,
-          `Required with link-role buttons.`,
-        ],
-        href: 'type-roles',
-      },
-      {
-        name: 'rel',
-        type: `'none' | 'nofollow'`,
-        required: false,
-        defaultValue: 'none',
-        description: 'Optional with link-role buttons.',
-        href: 'type-roles',
-      },
-      {
-        name: 'target',
-        type: `null | 'self' | 'blank'`,
-        required: false,
-        defaultValue: 'null',
-        description: [
-          'Define the frame or window to open the anchor defined on `href`:',
-          '- `null` opens the anchor in the same window.',
-          '- `blank` opens the anchor in a new window.',
-          '- `self` opens an anchor in the same frame.',
-          'Optional with link-role buttons.',
-        ],
-        href: 'type-roles',
-      },
-    ]}
   />
 );
 

--- a/docs/src/ButtonGroup.doc.js
+++ b/docs/src/ButtonGroup.doc.js
@@ -12,6 +12,19 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'Node',
+        description: `List of Button's or IconButton's`,
+        href: 'accessibilityLabel',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Example"
     id="example"
@@ -38,19 +51,6 @@ card(
   </ButtonGroup>
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'Node',
-        description: `List of Button's or IconButton's`,
-        href: 'accessibilityLabel',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -15,57 +15,6 @@ card(
 );
 
 card(
-  <Example
-    name="Info Example"
-    defaultCode={`
-<Callout
-  type="info"
-  iconAccessibilityLabel="Info icon"
-  title="Your business account was created!"
-  message="Apply to the Verified Merchant Program!"
-  primaryLink={{href: "https://pinterest.com", label:"Get started"}}
-  secondaryLink={{href: "https://pinterest.com", label:"Learn more"}}
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: ()=>{},
-  }}
-/>
-`}
-  />
-);
-
-card(
-  <Example
-    name="Warning Example"
-    defaultCode={`
-<Callout
-  type="warning"
-  iconAccessibilityLabel="Warning icon"
-  message="This feature will be removed in two weeks."
-  primaryLink={{href: "https://pinterest.com", label:"Learn more"}}
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: ()=>{},
-  }}
-/>
-  `}
-  />
-);
-
-card(
-  <Example
-    name="Error Example"
-    defaultCode={`
-<Callout
-  type="error"
-  iconAccessibilityLabel="Error icon"
-  message="This action can't be undone."
-/>
-  `}
-  />
-);
-
-card(
   <PropTable
     props={[
       {
@@ -156,6 +105,57 @@ card(
         href: '',
       },
     ]}
+  />
+);
+
+card(
+  <Example
+    name="Info Example"
+    defaultCode={`
+<Callout
+  type="info"
+  iconAccessibilityLabel="Info icon"
+  title="Your business account was created!"
+  message="Apply to the Verified Merchant Program!"
+  primaryLink={{href: "https://pinterest.com", label:"Get started"}}
+  secondaryLink={{href: "https://pinterest.com", label:"Learn more"}}
+  dismissButton={{
+    accessibilityLabel: 'Dismiss banner',
+    onDismiss: ()=>{},
+  }}
+/>
+`}
+  />
+);
+
+card(
+  <Example
+    name="Warning Example"
+    defaultCode={`
+<Callout
+  type="warning"
+  iconAccessibilityLabel="Warning icon"
+  message="This feature will be removed in two weeks."
+  primaryLink={{href: "https://pinterest.com", label:"Learn more"}}
+  dismissButton={{
+    accessibilityLabel: 'Dismiss banner',
+    onDismiss: ()=>{},
+  }}
+/>
+  `}
+  />
+);
+
+card(
+  <Example
+    name="Error Example"
+    defaultCode={`
+<Callout
+  type="error"
+  iconAccessibilityLabel="Error icon"
+  message="This action can't be undone."
+/>
+  `}
   />
 );
 

--- a/docs/src/Card.doc.js
+++ b/docs/src/Card.doc.js
@@ -17,6 +17,34 @@ The Card component is meant to highlight content in grids. It visually shows tha
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'active',
+        type: '?boolean',
+        defaultValue: false,
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'image',
+        type: 'React.Node',
+      },
+      {
+        name: 'onMouseEnter',
+        type: '({ event: SyntheticMouseEvent<HTMLDivElement> })',
+      },
+      {
+        name: 'onMouseLeave',
+        type: '({ event: SyntheticMouseEvent<HTMLDivElement> })',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description={`
     Using \`Card\` is as easy as it can be, simply wrap your component(s) with it. Ideally all of the children should be clickable and cover 100% of the area
@@ -44,34 +72,6 @@ function CardExample() {
   );
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'active',
-        type: '?boolean',
-        defaultValue: false,
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'image',
-        type: 'React.Node',
-      },
-      {
-        name: 'onMouseEnter',
-        type: '({ event: SyntheticMouseEvent<HTMLDivElement> })',
-      },
-      {
-        name: 'onMouseLeave',
-        type: '({ event: SyntheticMouseEvent<HTMLDivElement> })',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -17,6 +17,93 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'checked',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'combinations',
+      },
+      {
+        name: 'disabled',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'combinations',
+      },
+      {
+        name: 'errorMessage',
+        type: 'string',
+      },
+      {
+        name: 'hasError',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'hasError',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+      },
+      {
+        name: 'image',
+        type: 'React.Node',
+        href: 'images',
+        description:
+          'An optional <Image/> component can be supplied to add an image to each checkbox. Spacing is already accounted for, simply specify the width and height.',
+      },
+      {
+        name: 'indeterminate',
+        type: 'boolean',
+        defaultValue: false,
+        description: `Indeterminism is
+purely presentational - the value of
+a checkbox and its indeterminism are independent.`,
+        href: 'combinations',
+      },
+      {
+        name: 'label',
+        type: 'string',
+      },
+      {
+        name: 'name',
+        type: 'string',
+      },
+      {
+        name: 'onChange',
+        type: `({ event: SyntheticInputEvent<>, checked: boolean }) => void`,
+        required: true,
+      },
+      {
+        name: 'onClick',
+        type: `({ event: SyntheticInputEvent<HTMLInputElement>, checked: boolean }) => void`,
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'input'>",
+        description: 'Forward the ref to the underlying input element',
+        href: 'refExample',
+      },
+      {
+        name: 'size',
+        type: `"sm" | "md"`,
+        defaultValue: 'md',
+        description: `"sm" is 16px & "md" is 24px`,
+        href: 'combinations',
+      },
+      {
+        name: 'subtext',
+        type: 'string',
+        href: 'subtext',
+        description:
+          'Optional description for the checkbox, used to provide more detail about an option',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="single"
     name="Example"
@@ -338,93 +425,6 @@ card(
       />
     )}
   </Combination>
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'checked',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'combinations',
-      },
-      {
-        name: 'disabled',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'combinations',
-      },
-      {
-        name: 'errorMessage',
-        type: 'string',
-      },
-      {
-        name: 'hasError',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'hasError',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-      },
-      {
-        name: 'image',
-        type: 'React.Node',
-        href: 'images',
-        description:
-          'An optional <Image/> component can be supplied to add an image to each checkbox. Spacing is already accounted for, simply specify the width and height.',
-      },
-      {
-        name: 'indeterminate',
-        type: 'boolean',
-        defaultValue: false,
-        description: `Indeterminism is
-purely presentational - the value of
-a checkbox and its indeterminism are independent.`,
-        href: 'combinations',
-      },
-      {
-        name: 'label',
-        type: 'string',
-      },
-      {
-        name: 'name',
-        type: 'string',
-      },
-      {
-        name: 'onChange',
-        type: `({ event: SyntheticInputEvent<>, checked: boolean }) => void`,
-        required: true,
-      },
-      {
-        name: 'onClick',
-        type: `({ event: SyntheticInputEvent<HTMLInputElement>, checked: boolean }) => void`,
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'input'>",
-        description: 'Forward the ref to the underlying input element',
-        href: 'refExample',
-      },
-      {
-        name: 'size',
-        type: `"sm" | "md"`,
-        defaultValue: 'md',
-        description: `"sm" is 16px & "md" is 24px`,
-        href: 'combinations',
-      },
-      {
-        name: 'subtext',
-        type: 'string',
-        href: 'subtext',
-        description:
-          'Optional description for the checkbox, used to provide more detail about an option',
-      },
-    ]}
-  />
 );
 
 export default cards;

--- a/docs/src/Collage.doc.js
+++ b/docs/src/Collage.doc.js
@@ -17,6 +17,66 @@ Like Masonry, Collage creates a deterministic grid layout that can absolutely po
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'columns',
+        type: 'number',
+        description: 'Number of columns (2 - 4)',
+        required: true,
+        href: 'columns',
+      },
+      {
+        name: 'cover',
+        type: 'boolean',
+        description: 'Whether or not the first image is a cover image',
+        defaultValue: false,
+        href: 'coverImage',
+      },
+      {
+        name: 'gutter',
+        type: 'number',
+        description: 'The amount of vertical & horizontal space between images',
+        defaultValue: 0,
+        href: 'gutter',
+      },
+      {
+        name: 'height',
+        type: 'number',
+        description: 'Height of the collage',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'layoutKey',
+        type: 'number',
+        description: `
+        Depending on the number of columns of the collage, there may be multiple layouts available.
+        If there are N layouts available, (layoutKey % N) will determine which layout is used.
+        `,
+        defaultValue: 0,
+        href: 'layoutKey',
+      },
+      {
+        name: 'renderImage',
+        type:
+          '({ width: number, height: number, index: number }) => React.Node',
+        description: 'Render prop for the collage images',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'width',
+        type: 'number',
+        description: 'Width of the collage',
+        required: true,
+        href: 'basicExample',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="basicExample"
     name="Basic example"
@@ -449,66 +509,6 @@ card(
   ))}
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'columns',
-        type: 'number',
-        description: 'Number of columns (2 - 4)',
-        required: true,
-        href: 'columns',
-      },
-      {
-        name: 'cover',
-        type: 'boolean',
-        description: 'Whether or not the first image is a cover image',
-        defaultValue: false,
-        href: 'coverImage',
-      },
-      {
-        name: 'gutter',
-        type: 'number',
-        description: 'The amount of vertical & horizontal space between images',
-        defaultValue: 0,
-        href: 'gutter',
-      },
-      {
-        name: 'height',
-        type: 'number',
-        description: 'Height of the collage',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'layoutKey',
-        type: 'number',
-        description: `
-        Depending on the number of columns of the collage, there may be multiple layouts available.
-        If there are N layouts available, (layoutKey % N) will determine which layout is used.
-        `,
-        defaultValue: 0,
-        href: 'layoutKey',
-      },
-      {
-        name: 'renderImage',
-        type:
-          '({ width: number, height: number, index: number }) => React.Node',
-        description: 'Render prop for the collage images',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'width',
-        type: 'number',
-        description: 'Width of the collage',
-        required: true,
-        href: 'basicExample',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Column.doc.js
+++ b/docs/src/Column.doc.js
@@ -16,6 +16,23 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'span',
+        type: '0 .. 12',
+        required: true,
+        responsive: true,
+      },
+    ]}
+  />
+);
+
+card(
   <Card
     description={`
     Column is a basic layout component to help you size your UI. A full width is composed
@@ -253,23 +270,6 @@ card(
   </Box>
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'span',
-        type: '0 .. 12',
-        required: true,
-        responsive: true,
-      },
-    ]}
   />
 );
 

--- a/docs/src/Container.doc.js
+++ b/docs/src/Container.doc.js
@@ -15,6 +15,17 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description="
     On small screens, the container is the width of the screen. On large screens, it centers the content with a max-width of 800px.
@@ -29,17 +40,6 @@ card(
   </Container>
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-    ]}
   />
 );
 

--- a/docs/src/DatePicker.doc.js
+++ b/docs/src/DatePicker.doc.js
@@ -86,6 +86,113 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      { name: 'id', required: true, type: 'string' },
+      {
+        name: 'onChange',
+        required: true,
+        type: '({event: SyntheticInputEvent<>, value: Date }) => void',
+      },
+      { name: 'disabled', type: 'boolean', href: 'disabled' },
+      { name: 'errorMessage', type: 'string', href: 'errorMessage' },
+      {
+        name: 'excludeDates',
+        type: 'Array<Date>',
+        description: 'Array of disabled dates.',
+        href: 'exclude',
+      },
+      {
+        name: 'helperText',
+        type: 'string',
+        description:
+          'More information about how to complete the date picker field.',
+        href: 'helperText',
+      },
+      {
+        name: 'idealDirection',
+        type: `'up'|'right'|'down'|'left'`,
+        description: 'Preferred direction for the calendar flyout to open.',
+        href: 'idealDirection',
+        defaultValue: 'down',
+      },
+      {
+        name: 'includeDates',
+        type: 'Array<Date>',
+        description: 'Array of enabled dates.',
+        href: 'include',
+      },
+      { name: 'label', type: 'string' },
+      {
+        name: 'localeData',
+        type: 'date-fns locale objects',
+        description: `DatePicker accepts imported locales from the open source date utility library date-fns.`,
+        href: 'localeData',
+      },
+      {
+        name: 'maxDate',
+        type: 'Date',
+        description: 'Disable dates outside a max date.',
+        href: 'maxMinDates',
+      },
+      {
+        name: 'minDate',
+        type: 'Date',
+        description: 'Disable dates outside a min date.',
+        href: 'maxMinDates',
+      },
+      {
+        name: 'nextRef',
+        type: 'React.ElementRef',
+        description:
+          'Required for date range selection. Pass the complimentary range date picker ref object to DatePicker to autofocus on the unselected date range field.',
+        href: 'rangePicker',
+      },
+      {
+        name: 'placeholder',
+        type: 'string',
+        defaultValue: 'date format for locale',
+      },
+      {
+        name: 'rangeEndDate',
+        type: 'Date',
+        description:
+          'Required for date range selection. End date on a date range selection.',
+        href: 'disabled-past',
+      },
+
+      {
+        name: 'rangeSelector',
+        type: `'start'|'end'`,
+        description:
+          'Required for date range selection. Defines the datepicker start/end role in a date range selection.',
+        href: 'rangePicker',
+      },
+      {
+        name: 'rangeStartDate',
+        type: 'Date',
+        description:
+          'Required for date range selection. Start date on a date range selection.',
+        href: 'disabled-past',
+      },
+      {
+        name: 'ref',
+        type: 'React.ElementRef',
+        description:
+          'Required for date range selection. Pass a ref object to DatePicker to autofocus on the unselected date range field.',
+        href: 'rangePicker',
+      },
+      {
+        name: 'value',
+        type: 'Date',
+        description: 'Pre-selected date value.',
+        href: 'preselectedValue',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description="
     Use DatePicker to select date inputs.
@@ -374,113 +481,6 @@ import { it } from 'date-fns/locale';
       );
     }}
   </Combination>
-);
-
-card(
-  <PropTable
-    props={[
-      { name: 'id', required: true, type: 'string' },
-      {
-        name: 'onChange',
-        required: true,
-        type: '({event: SyntheticInputEvent<>, value: Date }) => void',
-      },
-      { name: 'disabled', type: 'boolean', href: 'disabled' },
-      { name: 'errorMessage', type: 'string', href: 'errorMessage' },
-      {
-        name: 'excludeDates',
-        type: 'Array<Date>',
-        description: 'Array of disabled dates.',
-        href: 'exclude',
-      },
-      {
-        name: 'helperText',
-        type: 'string',
-        description:
-          'More information about how to complete the date picker field.',
-        href: 'helperText',
-      },
-      {
-        name: 'idealDirection',
-        type: `'up'|'right'|'down'|'left'`,
-        description: 'Preferred direction for the calendar flyout to open.',
-        href: 'idealDirection',
-        defaultValue: 'down',
-      },
-      {
-        name: 'includeDates',
-        type: 'Array<Date>',
-        description: 'Array of enabled dates.',
-        href: 'include',
-      },
-      { name: 'label', type: 'string' },
-      {
-        name: 'localeData',
-        type: 'date-fns locale objects',
-        description: `DatePicker accepts imported locales from the open source date utility library date-fns.`,
-        href: 'localeData',
-      },
-      {
-        name: 'maxDate',
-        type: 'Date',
-        description: 'Disable dates outside a max date.',
-        href: 'maxMinDates',
-      },
-      {
-        name: 'minDate',
-        type: 'Date',
-        description: 'Disable dates outside a min date.',
-        href: 'maxMinDates',
-      },
-      {
-        name: 'nextRef',
-        type: 'React.ElementRef',
-        description:
-          'Required for date range selection. Pass the complimentary range date picker ref object to DatePicker to autofocus on the unselected date range field.',
-        href: 'rangePicker',
-      },
-      {
-        name: 'placeholder',
-        type: 'string',
-        defaultValue: 'date format for locale',
-      },
-      {
-        name: 'rangeEndDate',
-        type: 'Date',
-        description:
-          'Required for date range selection. End date on a date range selection.',
-        href: 'disabled-past',
-      },
-
-      {
-        name: 'rangeSelector',
-        type: `'start'|'end'`,
-        description:
-          'Required for date range selection. Defines the datepicker start/end role in a date range selection.',
-        href: 'rangePicker',
-      },
-      {
-        name: 'rangeStartDate',
-        type: 'Date',
-        description:
-          'Required for date range selection. Start date on a date range selection.',
-        href: 'disabled-past',
-      },
-      {
-        name: 'ref',
-        type: 'React.ElementRef',
-        description:
-          'Required for date range selection. Pass a ref object to DatePicker to autofocus on the unselected date range field.',
-        href: 'rangePicker',
-      },
-      {
-        name: 'value',
-        type: 'Date',
-        description: 'Pre-selected date value.',
-        href: 'preselectedValue',
-      },
-    ]}
-  />
 );
 
 export default cards;

--- a/docs/src/Divider.doc.js
+++ b/docs/src/Divider.doc.js
@@ -14,6 +14,8 @@ card(
   />
 );
 
+card(<PropTable props={[]} />);
+
 card(
   <Example
     description="
@@ -33,7 +35,5 @@ card(
 `}
   />
 );
-
-card(<PropTable props={[]} />);
 
 export default cards;

--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -17,6 +17,73 @@ or to make the interaction feel faster."
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'anchor',
+        type: '?HTMLElement',
+        required: true,
+        description: 'Ref for the element that the Flyout will attach to',
+        href: 'anchor',
+      },
+      {
+        name: 'idealDirection',
+        type: `'up' | 'right' | 'down' | 'left'`,
+        description: 'Preferred direction for the Flyout to open',
+        href: 'idealDirection',
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'onDismiss',
+        type: '() => void',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'positionRelativeToAnchor',
+        type: 'boolean',
+        defaultValue: true,
+        description:
+          'Depicts if the Flyout shares a relative root with the anchor element',
+        href: 'anchor',
+      },
+      {
+        name: 'color',
+        type: `"blue" | "orange" | "red" | "white" | "darkGray"`,
+        defaultValue: 'white',
+        description:
+          'The background color of the Flyout; red matches other default error messaging',
+        href: 'errorFlyout',
+      },
+      {
+        name: 'shouldFocus',
+        type: 'boolean',
+        defaultValue: true,
+        description: 'Focus on the flyout when opened',
+        href: 'errorFlyout',
+      },
+      {
+        name: 'showCaret',
+        type: 'boolean',
+        defaultValue: false,
+        description: 'Show the caret on the flyout',
+        href: 'showCaret',
+      },
+      {
+        name: 'size',
+        type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number`,
+        description: `xs: 180px, sm: 230px, md: 284px, lg: 320px, xl: 360px, flexible: no inherent sizing from flyout. Sets the maximum width of the Flyout.`,
+        defaultValue: 'sm',
+        href: 'basicExample',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="basicExample"
     name="Example"
@@ -190,73 +257,6 @@ card(
     * \`aria-expanded\` informs the screenreader whether the flyout is currently open or closed.
   `}
     name="Accessibility"
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'anchor',
-        type: '?HTMLElement',
-        required: true,
-        description: 'Ref for the element that the Flyout will attach to',
-        href: 'anchor',
-      },
-      {
-        name: 'idealDirection',
-        type: `'up' | 'right' | 'down' | 'left'`,
-        description: 'Preferred direction for the Flyout to open',
-        href: 'idealDirection',
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'onDismiss',
-        type: '() => void',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'positionRelativeToAnchor',
-        type: 'boolean',
-        defaultValue: true,
-        description:
-          'Depicts if the Flyout shares a relative root with the anchor element',
-        href: 'anchor',
-      },
-      {
-        name: 'color',
-        type: `"blue" | "orange" | "red" | "white" | "darkGray"`,
-        defaultValue: 'white',
-        description:
-          'The background color of the Flyout; red matches other default error messaging',
-        href: 'errorFlyout',
-      },
-      {
-        name: 'shouldFocus',
-        type: 'boolean',
-        defaultValue: true,
-        description: 'Focus on the flyout when opened',
-        href: 'errorFlyout',
-      },
-      {
-        name: 'showCaret',
-        type: 'boolean',
-        defaultValue: false,
-        description: 'Show the caret on the flyout',
-        href: 'showCaret',
-      },
-      {
-        name: 'size',
-        type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number`,
-        description: `xs: 180px, sm: 230px, md: 284px, lg: 320px, xl: 360px, flexible: no inherent sizing from flyout. Sets the maximum width of the Flyout.`,
-        defaultValue: 'sm',
-        href: 'basicExample',
-      },
-    ]}
   />
 );
 

--- a/docs/src/GroupAvatar.doc.js
+++ b/docs/src/GroupAvatar.doc.js
@@ -17,6 +17,31 @@ applied to each collaborator image to ensure the component retains a circular ap
   />
 );
 
+card(
+  <PropTable
+    props={[
+      {
+        name: 'collaborators',
+        type: 'Array<{ name: string, src?: string }>',
+        required: true,
+      },
+      {
+        name: 'outline',
+        type: 'boolean',
+        defaultValue: false,
+        description: `Adds a white border around GroupAvatar so it's visible when displayed on other images`,
+      },
+      {
+        name: 'size',
+        type: `"xs" | "sm" | "md" | "lg" | "xl" | "fit"`,
+        defaultValue: 'fit',
+        description:
+          'xs: 24px, sm: 32px, md: 48px, lg: 64px, xl: 120px. If size is `fit`, GroupAvatar will fill 100% of the parent container width',
+      },
+    ]}
+  />
+);
+
 const user1 = {
   name: 'Keerthi',
   src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
@@ -144,30 +169,4 @@ card(
   `}
   />
 );
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'collaborators',
-        type: 'Array<{ name: string, src?: string }>',
-        required: true,
-      },
-      {
-        name: 'outline',
-        type: 'boolean',
-        defaultValue: false,
-        description: `Adds a white border around GroupAvatar so it's visible when displayed on other images`,
-      },
-      {
-        name: 'size',
-        type: `"xs" | "sm" | "md" | "lg" | "xl" | "fit"`,
-        defaultValue: 'fit',
-        description:
-          'xs: 24px, sm: 32px, md: 48px, lg: 64px, xl: 120px. If size is `fit`, GroupAvatar will fill 100% of the parent container width',
-      },
-    ]}
-  />
-);
-
 export default cards;

--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -17,6 +17,58 @@ The \`Heading\` component allows you to show headings on the page & has a bigger
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibilityLevel',
+        type: '1 | 2 | 3 | 4 | 5 | 6',
+        description: 'Allows you to override the default heading level',
+        href: 'levels',
+      },
+      {
+        name: 'align',
+        type: `"left" | "right" | "center" | "justify"`,
+        defaultValue: 'left',
+        href: 'align',
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'color',
+        type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
+        defaultValue: 'darkGray',
+        href: 'colors',
+      },
+      {
+        name: 'id',
+        type: 'string',
+      },
+      {
+        name: 'overflow',
+        type: '"normal" | "breakWord"',
+        defaultValue: 'breakWord',
+        href: 'overflowTruncation',
+      },
+      {
+        name: 'size',
+        type: `"sm" | "md" | "lg"`,
+        description: `sm: 20px, md: 28px, lg: 36px`,
+        defaultValue: 'lg',
+        href: 'sizes',
+      },
+      {
+        name: 'truncate',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'overflowTruncation',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="sizes"
     name="Example: Sizes"
@@ -136,58 +188,6 @@ card(
   </Heading>
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilityLevel',
-        type: '1 | 2 | 3 | 4 | 5 | 6',
-        description: 'Allows you to override the default heading level',
-        href: 'levels',
-      },
-      {
-        name: 'align',
-        type: `"left" | "right" | "center" | "justify"`,
-        defaultValue: 'left',
-        href: 'align',
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'color',
-        type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
-        defaultValue: 'darkGray',
-        href: 'colors',
-      },
-      {
-        name: 'id',
-        type: 'string',
-      },
-      {
-        name: 'overflow',
-        type: '"normal" | "breakWord"',
-        defaultValue: 'breakWord',
-        href: 'overflowTruncation',
-      },
-      {
-        name: 'size',
-        type: `"sm" | "md" | "lg"`,
-        description: `sm: 20px, md: 28px, lg: 36px`,
-        defaultValue: 'lg',
-        href: 'sizes',
-      },
-      {
-        name: 'truncate',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'overflowTruncation',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Icon.doc.js
+++ b/docs/src/Icon.doc.js
@@ -21,45 +21,6 @@ Show icons with different colors and sizes in an accessible way.
 );
 
 card(
-  <Example
-    id="iconWithLabel"
-    description="Icon with a label"
-    name="Example"
-    defaultCode={`
-<Box alignItems="center" display="flex">
-  <Box marginRight={1} padding={1}>
-    <Icon icon="pin" accessibilityLabel="Pin" color="darkGray" />
-  </Box>
-  <Text align="center" color="darkGray" weight="bold">
-    Pinterest
-  </Text>
-</Box>
-`}
-  />
-);
-
-card(
-  <Combination id="iconCombinations" name="Icon Combinations" icon={icons}>
-    {(props) => (
-      <Icon color="darkGray" accessibilityLabel="" size={32} {...props} />
-    )}
-  </Combination>
-);
-
-card(
-  <Combination
-    id="sizeColorCombinations"
-    name="Size & Color Combinations"
-    size={[16, 24, 32]}
-    color={['gray', 'darkGray', 'red']}
-  >
-    {(props, i) => (
-      <Icon key={i} icon="heart" accessibilityLabel="" {...props} />
-    )}
-  </Combination>
-);
-
-card(
   <PropTable
     props={[
       {
@@ -101,6 +62,45 @@ card(
       },
     ]}
   />
+);
+
+card(
+  <Example
+    id="iconWithLabel"
+    description="Icon with a label"
+    name="Example"
+    defaultCode={`
+<Box alignItems="center" display="flex">
+  <Box marginRight={1} padding={1}>
+    <Icon icon="pin" accessibilityLabel="Pin" color="darkGray" />
+  </Box>
+  <Text align="center" color="darkGray" weight="bold">
+    Pinterest
+  </Text>
+</Box>
+`}
+  />
+);
+
+card(
+  <Combination id="iconCombinations" name="Icon Combinations" icon={icons}>
+    {(props) => (
+      <Icon color="darkGray" accessibilityLabel="" size={32} {...props} />
+    )}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="sizeColorCombinations"
+    name="Size & Color Combinations"
+    size={[16, 24, 32]}
+    color={['gray', 'darkGray', 'red']}
+  >
+    {(props, i) => (
+      <Icon key={i} icon="heart" accessibilityLabel="" {...props} />
+    )}
+  </Combination>
 );
 
 export default cards;

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -17,6 +17,217 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibilityLabel',
+        type: 'string',
+        required: true,
+        defaultValue: null,
+        description: [
+          'Supply a short, descriptive label for screen-readers to provide context about the icon button component behavior. IconButton does not have text for screen reader to read and provide context. Therefore, we must pass an alternative text.',
+          'Accessibility: It populates aria-label.',
+        ],
+        href: 'basic',
+      },
+      {
+        name: 'accessibilityControls',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          `Specify the 'id' of an associated element (or elements) whose contents or visibility are controlled by a button component so that screen reader users can identify the relationship between elements.`,
+          'Optional with button-role buttons.',
+          'Accessibility: It populates aria-controls.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'accessibilityExpanded',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Indicate that a button component hides or exposes collapsible components and expose whether they are currently expanded or collapsed.',
+          'Optional with button-role buttons.',
+          'Accessibility: It populates aria-expanded.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'accessibilityHaspopup',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Indicate that a button component controls the appearance of interactive popup elements, such as menu or dialog.',
+          'Optional with button-role buttons.',
+          'Accessibility: It populates aria-haspopup.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'bgColor',
+        type:
+          '"transparent" | "transparentDarkGray" | "darkGray" | "gray" | "lightGray" | "white" | "red"',
+        required: false,
+        defaultValue: 'transparent',
+        description: 'Primary colors to apply to the button background.',
+        href: 'backgroundColorCombinations',
+      },
+      {
+        name: 'dangerouslySetSvgPath',
+        type: `{ __path: string }`,
+        required: false,
+        defaultValue: null,
+        description: [
+          'Define a new icon different from the built-in Gestalt icons.',
+          `When using 'dangerouslySetSvgPath', the viewbox around the SVG path must be 24x24 px`,
+        ],
+        href: 'icon',
+      },
+      {
+        name: 'disabled',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description:
+          'Set disabled state so IconButton looks inactive, cannot be interacted with, and actions are not available.',
+        href: 'roles',
+      },
+      {
+        name: 'iconColor',
+        type: `"darkGray" | "gray" | "red" | "white"`,
+        required: false,
+        defaultValue: 'gray',
+        description: 'Primary color to apply to the Gestalt Icon.',
+        href: 'iconColor',
+      },
+      {
+        name: 'icon',
+        type: '$Keys<typeof icons>',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Add a Gestalt icon to be displayed and convey the behaviour of the button.',
+          `Accessibility: Icons are visual information and are not accessible for screen readers. 'accessibilityLabel' must be passed to provide sufficient context to the IconButton.`,
+        ],
+        href: 'icon',
+      },
+      {
+        name: 'href',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Specify a link URL.',
+          'Required with link-role buttons.',
+        ],
+        href: 'roles',
+      },
+      {
+        name: 'onClick',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a button component is clicked (pressed and released) with a mouse or keyboard.',
+          'Required with button-role buttons.',
+        ],
+        href: 'selected',
+      },
+      {
+        name: 'padding',
+        type: `1 | 2 | 3 | 4 | 5`,
+        required: false,
+        defaultValue: null,
+        description: [
+          'Sets a padding for the IconButton.',
+          `Combine the 'padding' with 'size' options for different icon/button size ratios. If omitted, padding is derived from the default padding for each 'size' prop.`,
+          'Padding options are 1-5 representing the padding in boints.',
+        ],
+        href: 'padding',
+      },
+      {
+        name: 'rel',
+        type: `'none' | 'nofollow'`,
+        required: false,
+        defaultValue: 'none',
+        description: 'Optional with link-role buttons.',
+        href: 'roles',
+      },
+      {
+        name: 'ref',
+        type: `React.Ref<'button'> | React.Ref<'a'>`,
+        description:
+          'Forward the ref to the underlying button or anchor element',
+        href: 'ref',
+      },
+      {
+        name: 'tabIndex',
+        type: `-1 | 0`,
+        required: false,
+        defaultValue: 0,
+        description: [
+          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
+          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
+          `If component is disabled, the component is also unreachable from keyboard navigation.`,
+        ],
+        href: 'roles',
+      },
+      {
+        name: 'role',
+        type: `'button' | 'link'`,
+        required: false,
+        defaultValue: 'button',
+        description: [
+          `Select a button variant:`,
+          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a '<button>'.`,
+          `- 'link': Use for buttons to act like links. The button is rendered as an '<a>'.`,
+          `Required with link-role buttons.`,
+        ],
+        href: 'roles',
+      },
+      {
+        name: 'selected',
+        type: 'boolean',
+        required: false,
+        defaultValue: false,
+        description: [
+          'Control the "selected" state of a button component to toggle binary states.',
+          'Optional with button-role + button-type buttons.',
+        ],
+        href: 'selected',
+      },
+      {
+        name: 'size',
+        type: `"xs" | "sm" | "md" | "lg" | "xl"`,
+        required: false,
+        defaultValue: 'md',
+        description:
+          'Display an IconButton in different sizes. Size changes the component padding modifying its fixed height & width: xs (24px), sm (32px), md (40px), lg (48px), xl (56px).',
+        href: 'size',
+      },
+      {
+        name: 'target',
+        type: `null | 'self' | 'blank'`,
+        required: false,
+        defaultValue: 'null',
+        description: [
+          'Define the frame or window to open the anchor defined on `href`:',
+          `- 'null' opens the anchor in the same window.`,
+          `- 'blank' opens the anchor in a new window.`,
+          `- 'self' opens an anchor in the same frame.`,
+          'Optional with link-role buttons.',
+        ],
+        href: 'roles',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Basic IconButton"
     id="basic"
@@ -298,217 +509,6 @@ function MenuIconButtonExample() {
   );
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        required: true,
-        defaultValue: null,
-        description: [
-          'Supply a short, descriptive label for screen-readers to provide context about the icon button component behavior. IconButton does not have text for screen reader to read and provide context. Therefore, we must pass an alternative text.',
-          'Accessibility: It populates aria-label.',
-        ],
-        href: 'basic',
-      },
-      {
-        name: 'accessibilityControls',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: [
-          `Specify the 'id' of an associated element (or elements) whose contents or visibility are controlled by a button component so that screen reader users can identify the relationship between elements.`,
-          'Optional with button-role buttons.',
-          'Accessibility: It populates aria-controls.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'accessibilityExpanded',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Indicate that a button component hides or exposes collapsible components and expose whether they are currently expanded or collapsed.',
-          'Optional with button-role buttons.',
-          'Accessibility: It populates aria-expanded.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'accessibilityHaspopup',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Indicate that a button component controls the appearance of interactive popup elements, such as menu or dialog.',
-          'Optional with button-role buttons.',
-          'Accessibility: It populates aria-haspopup.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'bgColor',
-        type:
-          '"transparent" | "transparentDarkGray" | "darkGray" | "gray" | "lightGray" | "white" | "red"',
-        required: false,
-        defaultValue: 'transparent',
-        description: 'Primary colors to apply to the button background.',
-        href: 'backgroundColorCombinations',
-      },
-      {
-        name: 'dangerouslySetSvgPath',
-        type: `{ __path: string }`,
-        required: false,
-        defaultValue: null,
-        description: [
-          'Define a new icon different from the built-in Gestalt icons.',
-          `When using 'dangerouslySetSvgPath', the viewbox around the SVG path must be 24x24 px`,
-        ],
-        href: 'icon',
-      },
-      {
-        name: 'disabled',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description:
-          'Set disabled state so IconButton looks inactive, cannot be interacted with, and actions are not available.',
-        href: 'roles',
-      },
-      {
-        name: 'iconColor',
-        type: `"darkGray" | "gray" | "red" | "white"`,
-        required: false,
-        defaultValue: 'gray',
-        description: 'Primary color to apply to the Gestalt Icon.',
-        href: 'iconColor',
-      },
-      {
-        name: 'icon',
-        type: '$Keys<typeof icons>',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Add a Gestalt icon to be displayed and convey the behaviour of the button.',
-          `Accessibility: Icons are visual information and are not accessible for screen readers. 'accessibilityLabel' must be passed to provide sufficient context to the IconButton.`,
-        ],
-        href: 'icon',
-      },
-      {
-        name: 'href',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Specify a link URL.',
-          'Required with link-role buttons.',
-        ],
-        href: 'roles',
-      },
-      {
-        name: 'onClick',
-        type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Callback fired when a button component is clicked (pressed and released) with a mouse or keyboard.',
-          'Required with button-role buttons.',
-        ],
-        href: 'selected',
-      },
-      {
-        name: 'padding',
-        type: `1 | 2 | 3 | 4 | 5`,
-        required: false,
-        defaultValue: null,
-        description: [
-          'Sets a padding for the IconButton.',
-          `Combine the 'padding' with 'size' options for different icon/button size ratios. If omitted, padding is derived from the default padding for each 'size' prop.`,
-          'Padding options are 1-5 representing the padding in boints.',
-        ],
-        href: 'padding',
-      },
-      {
-        name: 'rel',
-        type: `'none' | 'nofollow'`,
-        required: false,
-        defaultValue: 'none',
-        description: 'Optional with link-role buttons.',
-        href: 'roles',
-      },
-      {
-        name: 'ref',
-        type: `React.Ref<'button'> | React.Ref<'a'>`,
-        description:
-          'Forward the ref to the underlying button or anchor element',
-        href: 'ref',
-      },
-      {
-        name: 'tabIndex',
-        type: `-1 | 0`,
-        required: false,
-        defaultValue: 0,
-        description: [
-          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
-          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
-          `If component is disabled, the component is also unreachable from keyboard navigation.`,
-        ],
-        href: 'roles',
-      },
-      {
-        name: 'role',
-        type: `'button' | 'link'`,
-        required: false,
-        defaultValue: 'button',
-        description: [
-          `Select a button variant:`,
-          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a '<button>'.`,
-          `- 'link': Use for buttons to act like links. The button is rendered as an '<a>'.`,
-          `Required with link-role buttons.`,
-        ],
-        href: 'roles',
-      },
-      {
-        name: 'selected',
-        type: 'boolean',
-        required: false,
-        defaultValue: false,
-        description: [
-          'Control the "selected" state of a button component to toggle binary states.',
-          'Optional with button-role + button-type buttons.',
-        ],
-        href: 'selected',
-      },
-      {
-        name: 'size',
-        type: `"xs" | "sm" | "md" | "lg" | "xl"`,
-        required: false,
-        defaultValue: 'md',
-        description:
-          'Display an IconButton in different sizes. Size changes the component padding modifying its fixed height & width: xs (24px), sm (32px), md (40px), lg (48px), xl (56px).',
-        href: 'size',
-      },
-      {
-        name: 'target',
-        type: `null | 'self' | 'blank'`,
-        required: false,
-        defaultValue: 'null',
-        description: [
-          'Define the frame or window to open the anchor defined on `href`:',
-          `- 'null' opens the anchor in the same window.`,
-          `- 'blank' opens the anchor in a new window.`,
-          `- 'self' opens an anchor in the same frame.`,
-          'Optional with link-role buttons.',
-        ],
-        href: 'roles',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -21,6 +21,91 @@ make it even more awesome.
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'alt',
+        type: 'string',
+        required: true,
+      },
+      {
+        name: 'color',
+        type: 'string',
+        required: true,
+        href: 'placeholders',
+      },
+      {
+        name: 'fit',
+        type: `"cover" | "contain" | "none"`,
+        defaultValue: 'none',
+        description: `Doesn't work with srcSet or sizes.`,
+        href: 'fit',
+      },
+      {
+        name: 'importance',
+        type: `"high" | "low" | "auto"`,
+        defaultValue: 'auto',
+        description: `Priority Hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded (only available via Chrome Origin Trial). ‘high‘ the developer considers the resource as being high priority. ‘low‘ the developer considers the resource as being low priority. ‘auto‘ the developer does not indicate a preference. This also serves as the attribute's invalid value default and missing value default.`,
+        href: 'fit',
+      },
+      {
+        name: 'loading',
+        type: `"eager" | "lazy" | "auto"`,
+        defaultValue: 'auto',
+        description: `
+        Controls if loading the image should be deferred when it's off-screen. ‘lazy’ to defer the load until the image or iframe reaches a distance threshold from the viewport. ‘eager’ to load the resource immediately. ‘auto’ the default behavior, which is to eagerly load the resource.
+        `,
+        href: 'fit',
+      },
+      {
+        name: 'naturalHeight',
+        type: 'number',
+        required: true,
+        description: 'Exact height of source image',
+        href: 'fit',
+      },
+      {
+        name: 'naturalWidth',
+        type: 'number',
+        required: true,
+        description: 'Exact width of source image',
+        href: 'fit',
+      },
+      {
+        name: 'onError',
+        type: '() => void',
+      },
+      {
+        name: 'onLoad',
+        type: '() => void',
+      },
+      {
+        name: 'sizes',
+        type: 'string',
+        description:
+          'A list of one or more strings separated by commas indicating a set of source sizes',
+      },
+      {
+        name: 'src',
+        type: 'string',
+        required: true,
+        href: 'placeholders',
+      },
+      {
+        name: 'srcSet',
+        type: 'string',
+        description:
+          'A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use.',
+      },
+    ]}
+  />
+);
+
+card(
   <Card
     description={`
     One thing that might be unusual is that the \`width\` and the \`height\` of the
@@ -248,91 +333,6 @@ card(
   />
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'alt',
-        type: 'string',
-        required: true,
-      },
-      {
-        name: 'color',
-        type: 'string',
-        required: true,
-        href: 'placeholders',
-      },
-      {
-        name: 'fit',
-        type: `"cover" | "contain" | "none"`,
-        defaultValue: 'none',
-        description: `Doesn't work with srcSet or sizes.`,
-        href: 'fit',
-      },
-      {
-        name: 'importance',
-        type: `"high" | "low" | "auto"`,
-        defaultValue: 'auto',
-        description: `Priority Hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded (only available via Chrome Origin Trial). ‘high‘ the developer considers the resource as being high priority. ‘low‘ the developer considers the resource as being low priority. ‘auto‘ the developer does not indicate a preference. This also serves as the attribute's invalid value default and missing value default.`,
-        href: 'fit',
-      },
-      {
-        name: 'loading',
-        type: `"eager" | "lazy" | "auto"`,
-        defaultValue: 'auto',
-        description: `
-        Controls if loading the image should be deferred when it's off-screen. ‘lazy’ to defer the load until the image or iframe reaches a distance threshold from the viewport. ‘eager’ to load the resource immediately. ‘auto’ the default behavior, which is to eagerly load the resource.
-        `,
-        href: 'fit',
-      },
-      {
-        name: 'naturalHeight',
-        type: 'number',
-        required: true,
-        description: 'Exact height of source image',
-        href: 'fit',
-      },
-      {
-        name: 'naturalWidth',
-        type: 'number',
-        required: true,
-        description: 'Exact width of source image',
-        href: 'fit',
-      },
-      {
-        name: 'onError',
-        type: '() => void',
-      },
-      {
-        name: 'onLoad',
-        type: '() => void',
-      },
-      {
-        name: 'sizes',
-        type: 'string',
-        description:
-          'A list of one or more strings separated by commas indicating a set of source sizes',
-      },
-      {
-        name: 'src',
-        type: 'string',
-        required: true,
-        href: 'placeholders',
-      },
-      {
-        name: 'srcSet',
-        type: 'string',
-        description:
-          'A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use.',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Label.doc.js
+++ b/docs/src/Label.doc.js
@@ -15,6 +15,23 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'htmlFor',
+        type: 'string',
+        required: true,
+        description: 'Id of the element this label is describing',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description={`
     Whenever you are using a [SelectList](#/SelectList), [Switch](#/Switch), [TextField](#/TextField) or [TextArea](#/TextArea) component, you should use a \`Label\`.
@@ -40,23 +57,6 @@ function LabelExample() {
   );
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'htmlFor',
-        type: 'string',
-        required: true,
-        description: 'Id of the element this label is describing',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -16,6 +16,23 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+        required: true,
+      },
+      {
+        name: 'zIndex',
+        type: 'interface Indexable { index(): number; }',
+        description: `An object representing the zIndex value of the Layer.`,
+      },
+    ]}
+  />
+);
+
+card(
   <Card
     description="
     Because creating a portal in Layer depends on DOM manipulation, if document is not present,
@@ -106,23 +123,6 @@ function zIndexExample() {
   );
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-        required: true,
-      },
-      {
-        name: 'zIndex',
-        type: 'interface Indexable { index(): number; }',
-        description: `An object representing the zIndex value of the Layer.`,
-      },
-    ]}
   />
 );
 

--- a/docs/src/Letterbox.doc.js
+++ b/docs/src/Letterbox.doc.js
@@ -23,6 +23,36 @@ CSS property \`background-size: cover\`.`}
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'contentAspectRatio',
+        type: 'number',
+        required: true,
+        description:
+          'Proportional relationship between width and height of element',
+      },
+      {
+        name: 'height',
+        type: 'number',
+        required: true,
+        description: 'Desired final height of element',
+      },
+      {
+        name: 'width',
+        type: 'number',
+        required: true,
+        description: 'Desired final width of element',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Tall content (564:806)"
     defaultCode={`
@@ -99,36 +129,6 @@ card(
   />
 </Letterbox>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'contentAspectRatio',
-        type: 'number',
-        required: true,
-        description:
-          'Proportional relationship between width and height of element',
-      },
-      {
-        name: 'height',
-        type: 'number',
-        required: true,
-        description: 'Desired final height of element',
-      },
-      {
-        name: 'width',
-        type: 'number',
-        required: true,
-        description: 'Desired final width of element',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -15,6 +15,103 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibilitySelected',
+        type: 'boolean',
+        href: 'tab',
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'hoverStyle',
+        type: `'none' | 'underline'`,
+        defaultValue: 'underline',
+        href: 'Permutations',
+      },
+      {
+        name: 'href',
+        type: 'string',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        description: 'id attribute of the anchor tag',
+      },
+      {
+        name: 'inline',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'advancedExample',
+      },
+      {
+        name: 'onBlur',
+        type: '() => void',
+      },
+      {
+        name: 'accessibilityLabel',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply a short, descriptive label for screen-readers to replace link texts that do not provide sufficient context about the link component behavior. Texts like `Click Here,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text.',
+          'Accessibility: It populates aria-label. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'onClick',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+        href: 'PreventDefault',
+      },
+      {
+        name: 'onFocus',
+        type: '() => void',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'a'>",
+        description: 'Forward the ref to the underlying anchor element',
+      },
+      {
+        name: 'rel',
+        type: `"none" | "nofollow"`,
+        defaultValue: 'none',
+      },
+      {
+        name: 'role',
+        type: `"tab"`,
+        href: 'tab',
+      },
+      {
+        name: 'rounding',
+        type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
+        defaultValue: '0',
+        href: 'advancedExample',
+      },
+      {
+        name: 'tapStyle',
+        type: `"none" | "compress"`,
+        defaultValue: 'none',
+        href: 'Permutations',
+      },
+      {
+        name: 'target',
+        type: `"null" | "self" | "blank"`,
+        defaultValue: 'null',
+        href: 'PreventDefault',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description={`
     You should wrap \`Link\` components inside of a \`Text\` component to get the correct font & underline color.
@@ -200,103 +297,6 @@ function PreventDefaultExample() {
   );
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilitySelected',
-        type: 'boolean',
-        href: 'tab',
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'hoverStyle',
-        type: `'none' | 'underline'`,
-        defaultValue: 'underline',
-        href: 'Permutations',
-      },
-      {
-        name: 'href',
-        type: 'string',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        description: 'id attribute of the anchor tag',
-      },
-      {
-        name: 'inline',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'advancedExample',
-      },
-      {
-        name: 'onBlur',
-        type: '() => void',
-      },
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Supply a short, descriptive label for screen-readers to replace link texts that do not provide sufficient context about the link component behavior. Texts like `Click Here,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text.',
-          'Accessibility: It populates aria-label. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'onClick',
-        type:
-          '({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
-        href: 'PreventDefault',
-      },
-      {
-        name: 'onFocus',
-        type: '() => void',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'a'>",
-        description: 'Forward the ref to the underlying anchor element',
-      },
-      {
-        name: 'rel',
-        type: `"none" | "nofollow"`,
-        defaultValue: 'none',
-      },
-      {
-        name: 'role',
-        type: `"tab"`,
-        href: 'tab',
-      },
-      {
-        name: 'rounding',
-        type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
-        defaultValue: '0',
-        href: 'advancedExample',
-      },
-      {
-        name: 'tapStyle',
-        type: `"none" | "compress"`,
-        defaultValue: 'none',
-        href: 'Permutations',
-      },
-      {
-        name: 'target',
-        type: `"null" | "self" | "blank"`,
-        defaultValue: 'null',
-        href: 'PreventDefault',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Mask.doc.js
+++ b/docs/src/Mask.doc.js
@@ -19,6 +19,47 @@ putting a \`Mask\` on it.
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'height',
+        type: `number | string`,
+        href: 'basicExample',
+        description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
+      },
+      {
+        name: 'width',
+        type: `number | string`,
+        href: 'basicExample',
+        description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
+      },
+      {
+        name: 'rounding',
+        type: `"circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
+        defaultValue: 0,
+        href: 'roundingCombinations',
+      },
+      {
+        name: 'wash',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'wash',
+      },
+      {
+        name: 'willChangeTransform',
+        type: 'boolean',
+        defaultValue: true,
+        href: 'willChangeTransform',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="basicExample"
     name="Example"
@@ -103,47 +144,6 @@ card(
   </Mask>
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'height',
-        type: `number | string`,
-        href: 'basicExample',
-        description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
-      },
-      {
-        name: 'width',
-        type: `number | string`,
-        href: 'basicExample',
-        description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
-      },
-      {
-        name: 'rounding',
-        type: `"circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
-        defaultValue: 0,
-        href: 'roundingCombinations',
-      },
-      {
-        name: 'wash',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'wash',
-      },
-      {
-        name: 'willChangeTransform',
-        type: 'boolean',
-        defaultValue: true,
-        href: 'willChangeTransform',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Masonry.doc.js
+++ b/docs/src/Masonry.doc.js
@@ -18,6 +18,98 @@ It contains performance optimizations like virtualization and support for infini
   />
 );
 
+card(
+  <PropTable
+    props={[
+      {
+        name: 'columnWidth',
+        type: 'number',
+        defaultValue: 236,
+        description:
+          'Specifies a fixed width of elements in the grid. However, using flexible is preferred.',
+      },
+      {
+        name: 'comp',
+        type: 'React.ComponentType',
+        required: true,
+        description:
+          'A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: `data: T`, `itemIdx: number`, and `isMeasuring: boolean`.',
+      },
+      {
+        name: 'flexible',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Item width will grow to fill column space and shrink to fit if below min columns.',
+      },
+      {
+        name: 'gutterWidth',
+        type: `number`,
+        defaultValue: 'null',
+        description:
+          'The amount of vertical and horizontal space between each item, specified in pixels.',
+      },
+      {
+        name: 'items',
+        type: 'T[]',
+        required: true,
+        description:
+          'An array of items to display that contains the information that `comp` needs to render.',
+      },
+      {
+        name: 'minCols',
+        type: 'number',
+        defaultValue: 3,
+        description: 'Minimum number of columns to display.',
+      },
+      {
+        name: 'loadItems',
+        type: '() => void',
+        description:
+          'A callback when the user scrolls and you need to load more items into the grid. Note that `scrollContainer` must be specified.',
+      },
+      {
+        name: 'scrollContainer',
+        type: '() => HTMLElement',
+        description:
+          'A function that returns a DOM node that Masonry uses for on-scroll event subscription. This DOM node is intended to be the most immediate ancestor of Masonry in the DOM that will have a scroll bar; in most cases this will be the `window` itself, although sometimes Masonry is used inside containers that have `overflow: auto`. `scrollContainer` is optional, although it is required for features such as `virtualize` and `loadItems`.',
+      },
+      {
+        name: 'virtualize',
+        type: 'boolean',
+        description:
+          'Specifies whether or not Masonry dynamically adds/removes content from the grid based on the user’s viewport and scroll position. Note that `scrollContainer` must be specified when virtualizing.',
+        defaultValue: false,
+      },
+      {
+        name: 'virtualBoundsTop',
+        type: 'number',
+        description:
+          'If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsTop` allows customization of the buffer size above the viewport, specified in pixels.',
+      },
+      {
+        name: 'virtualBoundsBottom',
+        type: 'number',
+        description:
+          'If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsBottom` allows customization of the buffer size below the viewport, specified in pixels.',
+      },
+      {
+        name: 'measurementStore',
+        type: 'typeof MeasurementStore',
+        description:
+          'Masonry internally caches item sizes/positions using a measurement store. If `measurementStore` is provided, Masonry will use it as its cache and will keep it updated with future measurements. This is often used to prevent re-measurement when users navigate away and back to a grid. Create a new measurement store with `Masonry.createMeasurementStore()`.',
+      },
+      {
+        name: 'layout',
+        type: 'MasonryDefaultLayout | MasonryUniformRowLayout',
+        defaultValue: 'MasonryDefaultLayout',
+        description:
+          'MasonryUniformRowLayout will make it so that each row is as tall as the tallest item in that row.',
+      },
+    ]}
+  />
+);
+
 type Props = {|
   flexible?: boolean,
   id?: string,
@@ -239,98 +331,6 @@ card(
   >
     <ExampleMasonry layout="uniformRow" id="uniform" />
   </Card>
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'columnWidth',
-        type: 'number',
-        defaultValue: 236,
-        description:
-          'Specifies a fixed width of elements in the grid. However, using flexible is preferred.',
-      },
-      {
-        name: 'comp',
-        type: 'React.ComponentType',
-        required: true,
-        description:
-          'A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: `data: T`, `itemIdx: number`, and `isMeasuring: boolean`.',
-      },
-      {
-        name: 'flexible',
-        type: 'boolean',
-        defaultValue: false,
-        description:
-          'Item width will grow to fill column space and shrink to fit if below min columns.',
-      },
-      {
-        name: 'gutterWidth',
-        type: `number`,
-        defaultValue: 'null',
-        description:
-          'The amount of vertical and horizontal space between each item, specified in pixels.',
-      },
-      {
-        name: 'items',
-        type: 'T[]',
-        required: true,
-        description:
-          'An array of items to display that contains the information that `comp` needs to render.',
-      },
-      {
-        name: 'minCols',
-        type: 'number',
-        defaultValue: 3,
-        description: 'Minimum number of columns to display.',
-      },
-      {
-        name: 'loadItems',
-        type: '() => void',
-        description:
-          'A callback when the user scrolls and you need to load more items into the grid. Note that `scrollContainer` must be specified.',
-      },
-      {
-        name: 'scrollContainer',
-        type: '() => HTMLElement',
-        description:
-          'A function that returns a DOM node that Masonry uses for on-scroll event subscription. This DOM node is intended to be the most immediate ancestor of Masonry in the DOM that will have a scroll bar; in most cases this will be the `window` itself, although sometimes Masonry is used inside containers that have `overflow: auto`. `scrollContainer` is optional, although it is required for features such as `virtualize` and `loadItems`.',
-      },
-      {
-        name: 'virtualize',
-        type: 'boolean',
-        description:
-          'Specifies whether or not Masonry dynamically adds/removes content from the grid based on the user’s viewport and scroll position. Note that `scrollContainer` must be specified when virtualizing.',
-        defaultValue: false,
-      },
-      {
-        name: 'virtualBoundsTop',
-        type: 'number',
-        description:
-          'If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsTop` allows customization of the buffer size above the viewport, specified in pixels.',
-      },
-      {
-        name: 'virtualBoundsBottom',
-        type: 'number',
-        description:
-          'If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsBottom` allows customization of the buffer size below the viewport, specified in pixels.',
-      },
-      {
-        name: 'measurementStore',
-        type: 'typeof MeasurementStore',
-        description:
-          'Masonry internally caches item sizes/positions using a measurement store. If `measurementStore` is provided, Masonry will use it as its cache and will keep it updated with future measurements. This is often used to prevent re-measurement when users navigate away and back to a grid. Create a new measurement store with `Masonry.createMeasurementStore()`.',
-      },
-      {
-        name: 'layout',
-        type: 'MasonryDefaultLayout | MasonryUniformRowLayout',
-        defaultValue: 'MasonryDefaultLayout',
-        description:
-          'MasonryUniformRowLayout will make it so that each row is as tall as the tallest item in that row.',
-      },
-    ]}
-  />
 );
 
 export default cards;

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -16,6 +16,68 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibilityModalLabel',
+        type: 'string',
+        required: true,
+        description:
+          'String that clients such as VoiceOver will read to describe the modal. Always localize the label.',
+        href: 'accessibility',
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'closeOnOutsideClick',
+        type: 'boolean',
+        description: 'Close the modal when you click outside of it',
+        defaultValue: true,
+        href: 'closeOnOutsideClickExample',
+      },
+      {
+        name: 'footer',
+        type: 'React.Node',
+        href: 'sizesExample',
+      },
+      {
+        name: 'heading',
+        type: `string | React.Node`,
+        required: false,
+        href: 'heading',
+      },
+      {
+        name: 'onDismiss',
+        type: '() => void',
+        required: true,
+        href: 'sizesExample',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'div'>",
+        description: 'Forward the ref to the underlying div element',
+        href: 'refExample',
+      },
+      {
+        name: 'role',
+        type: `"alertdialog" | "dialog"`,
+        defaultValue: 'dialog',
+        href: 'role',
+      },
+      {
+        name: 'size',
+        type: `"sm" | "md" | "lg" | number`,
+        defaultValue: 'sm',
+        description: `sm: 540px, md: 720px, lg: 900px`,
+        href: 'sizesExample',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="sizesExample"
     name="Sizes"
@@ -651,68 +713,6 @@ card(
     ~~~
   `}
     name="Accessibility Props"
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilityModalLabel',
-        type: 'string',
-        required: true,
-        description:
-          'String that clients such as VoiceOver will read to describe the modal. Always localize the label.',
-        href: 'accessibility',
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'closeOnOutsideClick',
-        type: 'boolean',
-        description: 'Close the modal when you click outside of it',
-        defaultValue: true,
-        href: 'closeOnOutsideClickExample',
-      },
-      {
-        name: 'footer',
-        type: 'React.Node',
-        href: 'sizesExample',
-      },
-      {
-        name: 'heading',
-        type: `string | React.Node`,
-        required: false,
-        href: 'heading',
-      },
-      {
-        name: 'onDismiss',
-        type: '() => void',
-        required: true,
-        href: 'sizesExample',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'div'>",
-        description: 'Forward the ref to the underlying div element',
-        href: 'refExample',
-      },
-      {
-        name: 'role',
-        type: `"alertdialog" | "dialog"`,
-        defaultValue: 'dialog',
-        href: 'role',
-      },
-      {
-        name: 'size',
-        type: `"sm" | "md" | "lg" | number`,
-        defaultValue: 'sm',
-        description: `sm: 540px, md: 720px, lg: 900px`,
-        href: 'sizesExample',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Pog.doc.js
+++ b/docs/src/Pog.doc.js
@@ -21,78 +21,6 @@ This abstraction to allow for links that look like an IconButton.
 );
 
 card(
-  <Example
-    name="Example"
-    defaultCode={`
-<Pog
-  icon="heart"
-  iconColor="red"
-/>
-`}
-  />
-);
-
-card(
-  <Combination
-    id="stateCombinations"
-    name="Combinations: State"
-    hovered={[false, true]}
-    focused={[false, true]}
-    active={[false, true]}
-  >
-    {(props) => <Pog icon="heart" {...props} />}
-  </Combination>
-);
-
-card(
-  <Combination
-    id="sizeCombinations"
-    name="Combinations: Size with default padding"
-    size={['xs', 'sm', 'md', 'lg', 'xl']}
-  >
-    {(props) => <Pog icon="heart" {...props} />}
-  </Combination>
-);
-
-card(
-  <Combination
-    id="paddingCombinations"
-    name="Combinations: Size with custom padding"
-    size={['xs', 'sm', 'md', 'lg', 'xl']}
-    padding={[1, 2, 3, 4, 5]}
-  >
-    {(props) => <Pog icon="heart" {...props} />}
-  </Combination>
-);
-
-card(
-  <Combination
-    id="iconColorCombinations"
-    name="Combinations: Icon Color"
-    iconColor={['darkGray', 'gray', 'red', 'white']}
-  >
-    {(props) => <Pog icon="heart" {...props} />}
-  </Combination>
-);
-
-card(
-  <Combination
-    id="backgroundColorCombinations"
-    name="Combinations: Background Color"
-    bgColor={[
-      'transparent',
-      'transparentDarkGray',
-      'darkGray',
-      'white',
-      'lightGray',
-      'gray',
-    ]}
-  >
-    {(props) => <Pog icon="heart" {...props} />}
-  </Combination>
-);
-
-card(
   <PropTable
     props={[
       {
@@ -163,6 +91,78 @@ card(
       },
     ]}
   />
+);
+
+card(
+  <Example
+    name="Example"
+    defaultCode={`
+<Pog
+  icon="heart"
+  iconColor="red"
+/>
+`}
+  />
+);
+
+card(
+  <Combination
+    id="stateCombinations"
+    name="Combinations: State"
+    hovered={[false, true]}
+    focused={[false, true]}
+    active={[false, true]}
+  >
+    {(props) => <Pog icon="heart" {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="sizeCombinations"
+    name="Combinations: Size with default padding"
+    size={['xs', 'sm', 'md', 'lg', 'xl']}
+  >
+    {(props) => <Pog icon="heart" {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="paddingCombinations"
+    name="Combinations: Size with custom padding"
+    size={['xs', 'sm', 'md', 'lg', 'xl']}
+    padding={[1, 2, 3, 4, 5]}
+  >
+    {(props) => <Pog icon="heart" {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="iconColorCombinations"
+    name="Combinations: Icon Color"
+    iconColor={['darkGray', 'gray', 'red', 'white']}
+  >
+    {(props) => <Pog icon="heart" {...props} />}
+  </Combination>
+);
+
+card(
+  <Combination
+    id="backgroundColorCombinations"
+    name="Combinations: Background Color"
+    bgColor={[
+      'transparent',
+      'transparentDarkGray',
+      'darkGray',
+      'white',
+      'lightGray',
+      'gray',
+    ]}
+  >
+    {(props) => <Pog icon="heart" {...props} />}
+  </Combination>
 );
 
 export default cards;

--- a/docs/src/Provider.doc.js
+++ b/docs/src/Provider.doc.js
@@ -15,6 +15,27 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'colorScheme',
+        type: `"light" | "dark" | "userPreference"`,
+        defaultValue: 'light',
+        description:
+          'The color scheme for components inside the provider. Specify "userPreference" to use "prefers-color-scheme" media query.',
+        href: 'colorScheme',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        description:
+          'An optional id for your provider. If not passed in, settings will be applied as globally as possible (example: it sets color scheme variables at :root).',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description="Specify a light or dark color scheme for components"
     name="Color scheme"
@@ -56,27 +77,6 @@ function Example(props) {
     </Provider>
   );
 }`}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'colorScheme',
-        type: `"light" | "dark" | "userPreference"`,
-        defaultValue: 'light',
-        description:
-          'The color scheme for components inside the provider. Specify "userPreference" to use "prefers-color-scheme" media query.',
-        href: 'colorScheme',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        description:
-          'An optional id for your provider. If not passed in, settings will be applied as globally as possible (example: it sets color scheme variables at :root).',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Pulsar.doc.js
+++ b/docs/src/Pulsar.doc.js
@@ -17,6 +17,24 @@ or combination with other education components for more instructions."
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'paused',
+        type: 'boolean',
+        defaultValue: false,
+      },
+      {
+        name: 'size',
+        type: `number`,
+        description: `Use numbers for pixel sizes`,
+        defaultValue: 136,
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description={`
     Pulsars can be shown and hidden using the \`paused\` prop.
@@ -107,24 +125,6 @@ class FlyoutExample extends React.Component {
   }
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'paused',
-        type: 'boolean',
-        defaultValue: false,
-      },
-      {
-        name: 'size',
-        type: `number`,
-        description: `Use numbers for pixel sizes`,
-        defaultValue: 136,
-      },
-    ]}
   />
 );
 

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -19,6 +19,75 @@ radio buttons if the user can select more than one option from a list.
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'checked',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'radio-button-combos',
+      },
+      {
+        name: 'disabled',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'radio-button-combos',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+      },
+      {
+        name: 'image',
+        type: 'React.Node',
+        href: 'images',
+        description:
+          'An optional <Image/> component can be supplied to add an image to each radio button. Spacing is already accounted for, simply specify the width and height.',
+      },
+      {
+        name: 'label',
+        type: 'string',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        description: 'The name given for all radio buttons in a single group',
+      },
+      {
+        name: 'onChange',
+        type: '({ event: SyntheticInputEvent<>, checked: boolean }) => void',
+        required: true,
+      },
+      {
+        name: 'value',
+        type: 'string',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'input'>",
+        description: 'Forward the ref to the underlying input element',
+        href: 'ref',
+      },
+      {
+        name: 'size',
+        type: `"sm" | "md"`,
+        description: `sm: 16px, md: 24px`,
+        defaultValue: 'md',
+        href: 'ref',
+      },
+      {
+        name: 'subtext',
+        type: 'string',
+        href: 'subtext',
+        description:
+          'Optional description for the radio button, used to provide more detail about an option',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Example"
     defaultCode={`
@@ -347,75 +416,6 @@ card(
       />
     )}
   </Combination>
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'checked',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'radio-button-combos',
-      },
-      {
-        name: 'disabled',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'radio-button-combos',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-      },
-      {
-        name: 'image',
-        type: 'React.Node',
-        href: 'images',
-        description:
-          'An optional <Image/> component can be supplied to add an image to each radio button. Spacing is already accounted for, simply specify the width and height.',
-      },
-      {
-        name: 'label',
-        type: 'string',
-      },
-      {
-        name: 'name',
-        type: 'string',
-        description: 'The name given for all radio buttons in a single group',
-      },
-      {
-        name: 'onChange',
-        type: '({ event: SyntheticInputEvent<>, checked: boolean }) => void',
-        required: true,
-      },
-      {
-        name: 'value',
-        type: 'string',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'input'>",
-        description: 'Forward the ref to the underlying input element',
-        href: 'ref',
-      },
-      {
-        name: 'size',
-        type: `"sm" | "md"`,
-        description: `sm: 16px, md: 24px`,
-        defaultValue: 'md',
-        href: 'ref',
-      },
-      {
-        name: 'subtext',
-        type: 'string',
-        href: 'subtext',
-        description:
-          'Optional description for the radio button, used to provide more detail about an option',
-      },
-    ]}
-  />
 );
 
 export default cards;

--- a/docs/src/Row.doc.js
+++ b/docs/src/Row.doc.js
@@ -21,47 +21,6 @@ card(
 );
 
 card(
-  <Example
-    description={`
-    With a very limited set of props that only relate to horizontal layout, Row is useful for separating concerns to prevent overloaded Box usage.
-    Compare this example to the first example in the Box docs.
-  `}
-    name="Example: Media object"
-    defaultCode={`
-<Row gap={1}>
-  <Avatar name="chrislloyd" size="md" />
-  <Stack>
-    <Text weight="bold">Chris Lloyd</Text>
-    <Text>joined 2 years ago</Text>
-  </Stack>
-</Row>
-`}
-  />
-);
-
-card(
-  <Combination
-    description={`
-    Row is strictly for horizontal flex layouts. If you're new to flex layout, please read the excellent [CSS-Tricks guide to flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
-  `}
-    id="layout"
-    name="Layout"
-    justifyContent={['start', 'end', 'center', 'between', 'around']}
-    alignItems={['start', 'end', 'center', 'baseline', 'stretch']}
-  >
-    {({ alignItems, justifyContent, ...rest }) => (
-      <Box width={96} {...rest}>
-        <Row alignItems={alignItems} justifyContent={justifyContent}>
-          <Box margin={1} color="gray" height={8} width={8} />
-          <Box margin={1} color="gray" height={16} width={8} />
-          <Box margin={1} color="gray" height={32} width={8} />
-        </Row>
-      </Box>
-    )}
-  </Combination>
-);
-
-card(
   <PropTable
     Component={Row}
     props={[
@@ -150,6 +109,47 @@ card(
       },
     ]}
   />
+);
+
+card(
+  <Example
+    description={`
+    With a very limited set of props that only relate to horizontal layout, Row is useful for separating concerns to prevent overloaded Box usage.
+    Compare this example to the first example in the Box docs.
+  `}
+    name="Example: Media object"
+    defaultCode={`
+<Row gap={1}>
+  <Avatar name="chrislloyd" size="md" />
+  <Stack>
+    <Text weight="bold">Chris Lloyd</Text>
+    <Text>joined 2 years ago</Text>
+  </Stack>
+</Row>
+`}
+  />
+);
+
+card(
+  <Combination
+    description={`
+    Row is strictly for horizontal flex layouts. If you're new to flex layout, please read the excellent [CSS-Tricks guide to flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
+  `}
+    id="layout"
+    name="Layout"
+    justifyContent={['start', 'end', 'center', 'between', 'around']}
+    alignItems={['start', 'end', 'center', 'baseline', 'stretch']}
+  >
+    {({ alignItems, justifyContent, ...rest }) => (
+      <Box width={96} {...rest}>
+        <Row alignItems={alignItems} justifyContent={justifyContent}>
+          <Box margin={1} color="gray" height={8} width={8} />
+          <Box margin={1} color="gray" height={16} width={8} />
+          <Box margin={1} color="gray" height={32} width={8} />
+        </Row>
+      </Box>
+    )}
+  </Combination>
 );
 
 export default cards;

--- a/docs/src/SearchField.doc.js
+++ b/docs/src/SearchField.doc.js
@@ -11,57 +11,6 @@ const card = (c) => cards.push(c);
 card(<PageHeader name="SearchField" />);
 
 card(
-  <Example
-    description={`
-    We want to make sure every button on the page is unique when being read by screenreader.
-    \`accessibilityExpanded\` allows us to specify that the associated content (i.e. Flyout) is open.
-    \`accessibilityHaspopup\` allows us to specify that the button has associated content (i.e. Flyout).
-    \`accessibilityLabel\` allows us to update the spoken text.
-
-    Be sure to internationalize your \`accessibilityLabel\`.
-  `}
-    name="Example: Accessibility"
-    defaultCode={`
-  function SearchFieldExample() {
-    const [value, setValue] = React.useState('');
-
-    return (
-      <Box color="white" rounding={2} padding={3} display="flex" alignItems="center">
-        <Box padding={3}>
-          <Icon
-            icon="pinterest"
-            color="red"
-            size={20}
-            accessibilityLabel="Pinterest"
-          />
-        </Box>
-        <Box flex="grow" paddingX={2}>
-          <SearchField
-            accessibilityLabel="Demo Search Field"
-            id="searchField"
-            onChange={({value}) => setValue(value)}
-            placeholder="Search and explore"
-            value={value}
-          />
-        </Box>
-        <Box paddingX={2}>
-          <IconButton
-            accessibilityLabel="Notifications"
-            icon="speech-ellipsis"
-            size="md"
-          />
-        </Box>
-        <Box paddingX={2}>
-          <IconButton accessibilityLabel="Profile" icon="person" size="md" />
-        </Box>
-      </Box>
-    );
-  }
-`}
-  />
-);
-
-card(
   <PropTable
     props={[
       {
@@ -124,6 +73,57 @@ card(
         type: 'string',
       },
     ]}
+  />
+);
+
+card(
+  <Example
+    description={`
+    We want to make sure every button on the page is unique when being read by screenreader.
+    \`accessibilityExpanded\` allows us to specify that the associated content (i.e. Flyout) is open.
+    \`accessibilityHaspopup\` allows us to specify that the button has associated content (i.e. Flyout).
+    \`accessibilityLabel\` allows us to update the spoken text.
+
+    Be sure to internationalize your \`accessibilityLabel\`.
+  `}
+    name="Example: Accessibility"
+    defaultCode={`
+  function SearchFieldExample() {
+    const [value, setValue] = React.useState('');
+
+    return (
+      <Box color="white" rounding={2} padding={3} display="flex" alignItems="center">
+        <Box padding={3}>
+          <Icon
+            icon="pinterest"
+            color="red"
+            size={20}
+            accessibilityLabel="Pinterest"
+          />
+        </Box>
+        <Box flex="grow" paddingX={2}>
+          <SearchField
+            accessibilityLabel="Demo Search Field"
+            id="searchField"
+            onChange={({value}) => setValue(value)}
+            placeholder="Search and explore"
+            value={value}
+          />
+        </Box>
+        <Box paddingX={2}>
+          <IconButton
+            accessibilityLabel="Notifications"
+            icon="speech-ellipsis"
+            size="md"
+          />
+        </Box>
+        <Box paddingX={2}>
+          <IconButton accessibilityLabel="Profile" icon="person" size="md" />
+        </Box>
+      </Box>
+    );
+  }
+`}
   />
 );
 

--- a/docs/src/SegmentedControl.doc.js
+++ b/docs/src/SegmentedControl.doc.js
@@ -21,6 +21,43 @@ When a control is engaged, information below the control should get updated.
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'items',
+        type: 'Array<React.Node>',
+        required: true,
+      },
+      {
+        name: 'onChange',
+        type: '({ event: SyntheticMouseEvent<>, activeIndex: number }) => void',
+        required: true,
+      },
+      {
+        name: 'responsive',
+        type: 'boolean',
+        required: false,
+        description:
+          'By default, items have equal widths. If this prop is true, the width of an item is based on its content.',
+      },
+      {
+        name: 'selectedItemIndex',
+        type: 'number',
+        required: true,
+        description: 'Index of element in `items` that is selected.',
+      },
+      {
+        name: 'size',
+        type: '"md" | "lg"',
+        required: false,
+        description: 'md: 40px, lg: 48px',
+        defaultValue: 'md',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description="Segmented Controls are naive components, meaning you need to wire up the behavior when you click on an item.
 
@@ -81,43 +118,6 @@ function SegmentedControlExample() {
   );
 }
     `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'items',
-        type: 'Array<React.Node>',
-        required: true,
-      },
-      {
-        name: 'onChange',
-        type: '({ event: SyntheticMouseEvent<>, activeIndex: number }) => void',
-        required: true,
-      },
-      {
-        name: 'responsive',
-        type: 'boolean',
-        required: false,
-        description:
-          'By default, items have equal widths. If this prop is true, the width of an item is based on its content.',
-      },
-      {
-        name: 'selectedItemIndex',
-        type: 'number',
-        required: true,
-        description: 'Index of element in `items` that is selected.',
-      },
-      {
-        name: 'size',
-        type: '"md" | "lg"',
-        required: false,
-        description: 'md: 40px, lg: 48px',
-        defaultValue: 'md',
-      },
-    ]}
   />
 );
 

--- a/docs/src/SelectList.doc.js
+++ b/docs/src/SelectList.doc.js
@@ -15,6 +15,74 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'disabled',
+        type: 'boolean',
+        defaultValue: 'false',
+      },
+      {
+        name: 'errorMessage',
+        type: 'string',
+        href: 'exampleWithError',
+      },
+      {
+        name: 'helperText',
+        type: 'string',
+        description: 'More information about how to complete the form field',
+        href: 'helperText',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'label',
+        type: 'string',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        href: 'basicExample',
+      },
+      {
+        name: 'onChange',
+        type: '({ event: SyntheticInputEvent<>, value: string }) => void',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'options',
+        type: 'Array<{ label: string, value: string, disabled?: boolean }>',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'placeholder',
+        type: 'string',
+        href: 'basicExample',
+      },
+      {
+        name: 'size',
+        type: '"md" | "lg"',
+        required: false,
+        description: 'md: 40px, lg: 48px',
+        defaultValue: 'md',
+      },
+      {
+        name: 'value',
+        type: 'string',
+        description: 'Value that is selected.',
+        href: 'basicExample',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="basicExample"
     name="Example"
@@ -130,74 +198,6 @@ function Example(props) {
   );
 }
     `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'disabled',
-        type: 'boolean',
-        defaultValue: 'false',
-      },
-      {
-        name: 'errorMessage',
-        type: 'string',
-        href: 'exampleWithError',
-      },
-      {
-        name: 'helperText',
-        type: 'string',
-        description: 'More information about how to complete the form field',
-        href: 'helperText',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'label',
-        type: 'string',
-      },
-      {
-        name: 'name',
-        type: 'string',
-        href: 'basicExample',
-      },
-      {
-        name: 'onChange',
-        type: '({ event: SyntheticInputEvent<>, value: string }) => void',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'options',
-        type: 'Array<{ label: string, value: string, disabled?: boolean }>',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'placeholder',
-        type: 'string',
-        href: 'basicExample',
-      },
-      {
-        name: 'size',
-        type: '"md" | "lg"',
-        required: false,
-        description: 'md: 40px, lg: 48px',
-        defaultValue: 'md',
-      },
-      {
-        name: 'value',
-        type: 'string',
-        description: 'Value that is selected.',
-        href: 'basicExample',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -16,6 +16,129 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibilityDismissButtonLabel',
+        type: 'string',
+        required: true,
+        defaultValue: null,
+        description: [
+          'Supply a short, descriptive label for screen-readers as a text alternative to the Dismiss button.',
+          'Accessibility: It populates aria-label on the <button> element for the Dismiss button.',
+        ],
+        href: 'accessibilityExample',
+      },
+      {
+        name: 'accessibilitySheetLabel',
+        type: 'string',
+        required: true,
+        defaultValue: null,
+        description: [
+          'Supply a short, descriptive label for screen-readers to contextualize the purpose of Sheet.',
+          'Please do not repeat the same text being passed in the "heading" prop, but instead provide something that summarizes the Sheet. For instance, if the heading is "Pin Builder", the accessibilitySheetLabel can be "Create a new Pin".',
+          'Accessibility: It populates aria-label on the <div role="dialog"> element which represents the Sheet component.',
+        ],
+        href: 'accessibilityExample',
+      },
+      {
+        name: 'children',
+        type: 'React.Node | (({| onDismissStart: () => void |}) => React.Node)',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply the container element or render prop that is going to be used as the Sheet main content.',
+          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
+          'Obs: This element will be padded by 32px, differently than <Modal>.',
+        ],
+        href: 'defaultPaddingAndStylingExample',
+      },
+      {
+        name: 'closeOnOutsideClick',
+        type: 'boolean',
+        required: false,
+        defaultValue: true,
+        description: [
+          'Indicate whether clicking on the backdrop (gray area) outside of the Sheet will automatically close it.',
+          'Possible values:',
+          '- true: clicking on the backdrop will close the Sheet.',
+          '- false: clicking on the backdrop will keep the Sheet open.',
+        ],
+        href: 'closeOnOutsideClickExample',
+      },
+      {
+        name: 'footer',
+        type: 'React.Node | (({| onDismissStart: () => void |}) => React.Node)',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply the container element or render prop that is going to be used as the Sheet custom footer.',
+          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
+          'Obs: This element will be padded by 32px, similarly to <Modal>.',
+        ],
+        href: 'defaultPaddingAndStylingExample',
+      },
+      {
+        name: 'heading',
+        type: `string`,
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply the text that is going to be placed as the Sheet text heading.',
+          'Please do not repeat the same text being passed in the "accessibilitySheetLabel" prop, but instead provide something that identifies the Sheet. For instance, if the heading is "Pin Builder", the accessibilitySheetLabel can be "Create a new Pin".',
+          'Obs: This element will be padded by 32px, similarly to <Modal>.',
+        ],
+        href: 'defaultPaddingAndStylingExample',
+      },
+      {
+        name: 'onDismiss',
+        type: '() => void',
+        required: true,
+        defaultValue: null,
+        description: [
+          'Callback fired when the Sheet is dismissed from one of these ways:',
+          '- Clicking on the Dismiss button.',
+          '- Pressing the ESC key.',
+          '- Clicking on the backdrop (gray area) outside of the Sheet when the prop "closeOnOutsideClick" is true.',
+        ],
+        href: 'defaultPaddingAndStylingExample',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'div'>",
+        description:
+          'Forward the ref to the underlying <div role="dialog"> element which represents the Sheet component.',
+        href: 'refExample',
+      },
+      {
+        name: 'size',
+        type: `"sm" | "md" | "lg"`,
+        defaultValue: 'sm',
+        description: [
+          'Determine the width of the Sheet component. Possible values:',
+          '- sm: 540px',
+          '- md: 720px',
+          '- lg: 900px',
+        ],
+        href: 'sizesExample',
+      },
+      {
+        name: 'subHeading',
+        type: 'React.Node | (({| onDismissStart: () => void |}) => React.Node)',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply the container element or the render prop that is going to be used as the Sheet sub-heading docked under the heading.',
+          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
+          'It can only be provided when a heading is also provided.',
+        ],
+        href: 'subHeadingExample',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="sizesExample"
     name="Sizes"
@@ -94,12 +217,12 @@ card(
     name="Example: animations"
     description={`
     ### 1) Animation types
-    A \`<Sheet>\` can perform 2 animations: **in** (on show) and **out** (on dismiss). 
+    A \`<Sheet>\` can perform 2 animations: **in** (on show) and **out** (on dismiss).
     PS: These animations are controlled by the accessibility hook [useReducedMotion](/useReducedMotion).
 
     #### a) In (on show)
     During the initial render, it will kick in the **in** animation, which does 2 simultaneous transitions:
-    - Backdrop fade in 
+    - Backdrop fade in
     - Sheet slide in from the side
 
     Once the **in** animation is finished, the \`<Sheet>\` will have been fully rendered and ready for user interaction.
@@ -114,7 +237,7 @@ card(
 
     ### 2) Animation on children and footer
     The **in** animation is called with the initial render process from the entrypoint, with no option for customization.
-    The **out** animation, however, is called from the default exitpoints: 
+    The **out** animation, however, is called from the default exitpoints:
       - ESC key
       - Click on outside
       - X button (header)
@@ -123,7 +246,7 @@ card(
     \`\`\`
     ({ onDismissStart }) => ( ... )
     \`\`\`
-     
+
     When using this render prop, just pass the argument \`onDismissStart\` to your exitpoint action elements.
 
     In the example below, please notice all the following animations:
@@ -172,22 +295,22 @@ function AnimationExample() {
           >
             {({ onDismissStart }) => (
               <Row justifyContent="center" alignItems="center" height="100%">
-                <IconButton 
+                <IconButton
                   accessibilityLabel="Done icon left"
-                  icon="directional-arrow-right" 
+                  icon="directional-arrow-right"
                   iconColor="red"
-                  inline 
-                  onClick={onDismissStart} 
-                  size="lg"                     
+                  inline
+                  onClick={onDismissStart}
+                  size="lg"
                 />
                 <Button color="red" inline onClick={onDismissStart} size="lg" text="Done on Children" />
-                <IconButton 
+                <IconButton
                   accessibilityLabel="Done icon right"
-                  icon="directional-arrow-left" 
+                  icon="directional-arrow-left"
                   iconColor="red"
-                  inline 
-                  onClick={onDismissStart} 
-                  size="lg"                     
+                  inline
+                  onClick={onDismissStart}
+                  size="lg"
                 />
               </Row>
             )}
@@ -329,7 +452,7 @@ function DefaultPaddingExample(props) {
                   <li>Dez</li>
                 </ol>
               </Text>
-            </Box>  
+            </Box>
             <Box marginBottom={2}>
               <Text weight="bold">普通话</Text>
               <Text>
@@ -346,7 +469,7 @@ function DefaultPaddingExample(props) {
                   <li>十</li>
                 </ol>
               </Text>
-            </Box>            
+            </Box>
           </Sheet>
         </Layer>
       )}
@@ -362,7 +485,7 @@ card(
     id="subHeadingExample"
     name="Sub-heading"
     description={`
-      Specifies a sub-heading component to be docked under the heading. 
+      Specifies a sub-heading component to be docked under the heading.
       The shadow (when scrolling) between the \`subHeading\`, \`children\`, and \`footer\` are included as well. Please try scrolling up and down the children to verify the shadow.
     `}
     defaultCode={`
@@ -376,7 +499,7 @@ function SubheadingExample(props) {
     const ptRef = React.useRef();
     const chRef = React.useRef();
     const refs = [enRef, esRef, ptRef, chRef];
-  
+
     const handleChangeTab = ({ activeTabIndex, event }) => {
       event.preventDefault();
       setActiveTabIndex(activeTabIndex);
@@ -470,7 +593,7 @@ function SubheadingExample(props) {
               <li>Dez</li>
             </ol>
           </Text>
-        </Box>  
+        </Box>
         <Box marginBottom={8} ref={chRef}>
           <Text weight="bold">普通话</Text>
           <Text>
@@ -487,7 +610,7 @@ function SubheadingExample(props) {
               <li>十</li>
             </ol>
           </Text>
-        </Box>            
+        </Box>
       </Sheet>
     );
   };
@@ -557,11 +680,11 @@ function RefExample() {
                 <Box marginBottom={4}>
                   <Heading size="md">Focused content</Heading>
                 </Box>
-                <Button 
-                  inline 
+                <Button
+                  inline
                   onClick={() => alert('Geronimoooo!')}
-                  ref={buttonRef} 
-                  text="Focused button (Press Enter to be convinced)" 
+                  ref={buttonRef}
+                  text="Focused button (Press Enter to be convinced)"
                 />
               </Box>
             </Sheet>
@@ -598,129 +721,6 @@ card(
     ~~~
   `}
     name="Accessibility Props"
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilityDismissButtonLabel',
-        type: 'string',
-        required: true,
-        defaultValue: null,
-        description: [
-          'Supply a short, descriptive label for screen-readers as a text alternative to the Dismiss button.',
-          'Accessibility: It populates aria-label on the <button> element for the Dismiss button.',
-        ],
-        href: 'accessibilityExample',
-      },
-      {
-        name: 'accessibilitySheetLabel',
-        type: 'string',
-        required: true,
-        defaultValue: null,
-        description: [
-          'Supply a short, descriptive label for screen-readers to contextualize the purpose of Sheet.',
-          'Please do not repeat the same text being passed in the "heading" prop, but instead provide something that summarizes the Sheet. For instance, if the heading is "Pin Builder", the accessibilitySheetLabel can be "Create a new Pin".',
-          'Accessibility: It populates aria-label on the <div role="dialog"> element which represents the Sheet component.',
-        ],
-        href: 'accessibilityExample',
-      },
-      {
-        name: 'children',
-        type: 'React.Node | (({| onDismissStart: () => void |}) => React.Node)',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Supply the container element or render prop that is going to be used as the Sheet main content.',
-          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
-          'Obs: This element will be padded by 32px, differently than <Modal>.',
-        ],
-        href: 'defaultPaddingAndStylingExample',
-      },
-      {
-        name: 'closeOnOutsideClick',
-        type: 'boolean',
-        required: false,
-        defaultValue: true,
-        description: [
-          'Indicate whether clicking on the backdrop (gray area) outside of the Sheet will automatically close it.',
-          'Possible values:',
-          '- true: clicking on the backdrop will close the Sheet.',
-          '- false: clicking on the backdrop will keep the Sheet open.',
-        ],
-        href: 'closeOnOutsideClickExample',
-      },
-      {
-        name: 'footer',
-        type: 'React.Node | (({| onDismissStart: () => void |}) => React.Node)',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Supply the container element or render prop that is going to be used as the Sheet custom footer.',
-          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
-          'Obs: This element will be padded by 32px, similarly to <Modal>.',
-        ],
-        href: 'defaultPaddingAndStylingExample',
-      },
-      {
-        name: 'heading',
-        type: `string`,
-        required: false,
-        defaultValue: null,
-        description: [
-          'Supply the text that is going to be placed as the Sheet text heading.',
-          'Please do not repeat the same text being passed in the "accessibilitySheetLabel" prop, but instead provide something that identifies the Sheet. For instance, if the heading is "Pin Builder", the accessibilitySheetLabel can be "Create a new Pin".',
-          'Obs: This element will be padded by 32px, similarly to <Modal>.',
-        ],
-        href: 'defaultPaddingAndStylingExample',
-      },
-      {
-        name: 'onDismiss',
-        type: '() => void',
-        required: true,
-        defaultValue: null,
-        description: [
-          'Callback fired when the Sheet is dismissed from one of these ways:',
-          '- Clicking on the Dismiss button.',
-          '- Pressing the ESC key.',
-          '- Clicking on the backdrop (gray area) outside of the Sheet when the prop "closeOnOutsideClick" is true.',
-        ],
-        href: 'defaultPaddingAndStylingExample',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'div'>",
-        description:
-          'Forward the ref to the underlying <div role="dialog"> element which represents the Sheet component.',
-        href: 'refExample',
-      },
-      {
-        name: 'size',
-        type: `"sm" | "md" | "lg"`,
-        defaultValue: 'sm',
-        description: [
-          'Determine the width of the Sheet component. Possible values:',
-          '- sm: 540px',
-          '- md: 720px',
-          '- lg: 900px',
-        ],
-        href: 'sizesExample',
-      },
-      {
-        name: 'subHeading',
-        type: 'React.Node | (({| onDismissStart: () => void |}) => React.Node)',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Supply the container element or the render prop that is going to be used as the Sheet sub-heading docked under the heading.',
-          'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
-          'It can only be provided when a heading is also provided.',
-        ],
-        href: 'subHeadingExample',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Spinner.doc.js
+++ b/docs/src/Spinner.doc.js
@@ -10,36 +10,6 @@ const card = (c) => cards.push(c);
 card(<PageHeader name="Spinner" />);
 
 card(
-  <Example
-    description={`
-    Spinners indicate when a user has to wait for something else to occur. They delay showing for 300ms to improve perceived performance.
-
-    The label on a spinner is for accessibility. You should pick labels that relate to the specific part of the product it's being used in ("Loading homefeed" for instance).
-  `}
-    name="Example"
-    defaultCode={`
-function SpinnerExample() {
-  const [show, setShow] = React.useState(false);
-
-  return (
-    <Box>
-      <Box paddingY={2}>
-        <Button
-          inline
-          text={!show ? "Show spinner" : "Hide spinner"}
-          onClick={() => setShow(!show)}
-          size="md"
-        />
-      </Box>
-      <Spinner show={show} accessibilityLabel="Example spinner" />
-    </Box>
-  );
-}
-`}
-  />
-);
-
-card(
   <PropTable
     props={[
       {
@@ -70,6 +40,36 @@ card(
         defaultValue: 'md',
       },
     ]}
+  />
+);
+
+card(
+  <Example
+    description={`
+    Spinners indicate when a user has to wait for something else to occur. They delay showing for 300ms to improve perceived performance.
+
+    The label on a spinner is for accessibility. You should pick labels that relate to the specific part of the product it's being used in ("Loading homefeed" for instance).
+  `}
+    name="Example"
+    defaultCode={`
+function SpinnerExample() {
+  const [show, setShow] = React.useState(false);
+
+  return (
+    <Box>
+      <Box paddingY={2}>
+        <Button
+          inline
+          text={!show ? "Show spinner" : "Hide spinner"}
+          onClick={() => setShow(!show)}
+          size="md"
+        />
+      </Box>
+      <Spinner show={show} accessibilityLabel="Example spinner" />
+    </Box>
+  );
+}
+`}
   />
 );
 

--- a/docs/src/Stack.doc.js
+++ b/docs/src/Stack.doc.js
@@ -21,50 +21,6 @@ card(
 );
 
 card(
-  <Example
-    description={`
-    With a very limited set of props that only relate to vertical layout, Stack is useful for separating concerns to prevent overloaded Box usage.
-  `}
-    name="Example: Menu"
-    defaultCode={`
-<Box borderStyle="sm" paddingX={2} paddingY={3} rounding={3} width={130}>
-  <Stack alignItems="center" gap={2}>
-    <Text>Menu Item 1</Text>
-    <Text>Menu Item 2</Text>
-    <Text>Menu Item 3</Text>
-  </Stack>
-</Box>
-`}
-  />
-);
-
-card(
-  <Combination
-    description={`
-    Stack is strictly for vertical flex layouts. If you're new to flex layout, please read the excellent [CSS-Tricks guide to flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
-  `}
-    id="layout"
-    name="Layout"
-    justifyContent={['start', 'end', 'center', 'between', 'around']}
-    alignItems={['start', 'end', 'center', 'baseline', 'stretch']}
-  >
-    {({ alignItems, justifyContent, ...rest }) => (
-      <Box height={96} width={96} {...rest}>
-        <Stack
-          alignItems={alignItems}
-          height="100%"
-          justifyContent={justifyContent}
-        >
-          <Box margin={1} color="gray" width={8} height={8} />
-          <Box margin={1} color="gray" width={16} height={8} />
-          <Box margin={1} color="gray" width={32} height={8} />
-        </Stack>
-      </Box>
-    )}
-  </Combination>
-);
-
-card(
   <PropTable
     Component={Stack}
     props={[
@@ -153,6 +109,50 @@ card(
       },
     ]}
   />
+);
+
+card(
+  <Example
+    description={`
+    With a very limited set of props that only relate to vertical layout, Stack is useful for separating concerns to prevent overloaded Box usage.
+  `}
+    name="Example: Menu"
+    defaultCode={`
+<Box borderStyle="sm" paddingX={2} paddingY={3} rounding={3} width={130}>
+  <Stack alignItems="center" gap={2}>
+    <Text>Menu Item 1</Text>
+    <Text>Menu Item 2</Text>
+    <Text>Menu Item 3</Text>
+  </Stack>
+</Box>
+`}
+  />
+);
+
+card(
+  <Combination
+    description={`
+    Stack is strictly for vertical flex layouts. If you're new to flex layout, please read the excellent [CSS-Tricks guide to flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
+  `}
+    id="layout"
+    name="Layout"
+    justifyContent={['start', 'end', 'center', 'between', 'around']}
+    alignItems={['start', 'end', 'center', 'baseline', 'stretch']}
+  >
+    {({ alignItems, justifyContent, ...rest }) => (
+      <Box height={96} width={96} {...rest}>
+        <Stack
+          alignItems={alignItems}
+          height="100%"
+          justifyContent={justifyContent}
+        >
+          <Box margin={1} color="gray" width={8} height={8} />
+          <Box margin={1} color="gray" width={16} height={8} />
+          <Box margin={1} color="gray" width={32} height={8} />
+        </Stack>
+      </Box>
+    )}
+  </Combination>
 );
 
 export default cards;

--- a/docs/src/Sticky.doc.js
+++ b/docs/src/Sticky.doc.js
@@ -13,6 +13,48 @@ card(
     description="Sticky allows an element to become fixed when it reaches a threshold (top, left, bottom, or right)."
   />
 );
+
+card(
+  <PropTable
+    props={[
+      {
+        name: 'bottom',
+        type: 'number | string',
+        description: `Use numbers for pixels: bottom={100} and strings for percentages: width="100%"`,
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'left',
+        type: 'number | string',
+        description: `Use numbers for pixels: left={100} and strings for percentages: left="100%"`,
+      },
+      {
+        name: 'right',
+        type: 'number | string',
+        description: `Use numbers for pixels: right={100} and strings for percentages: right="100%"`,
+      },
+      {
+        name: 'top',
+        type: 'number | string',
+        description: `Use numbers for pixels: top={100} and strings for percentages: top="100%"`,
+      },
+      {
+        name: 'height',
+        type: 'number',
+        description: `Use numbers for pixels: height={100}. This is only useful when the sticky container and its content need to have different heights.`,
+      },
+      {
+        name: 'zIndex',
+        type: 'interface Indexable { index(): number; }',
+        description: `An object representing the zIndex value of the Sticky.`,
+      },
+    ]}
+  />
+);
+
 card(
   <Example
     name="Example: Sticky top"
@@ -62,47 +104,6 @@ function Example() {
   )
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'bottom',
-        type: 'number | string',
-        description: `Use numbers for pixels: bottom={100} and strings for percentages: width="100%"`,
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'left',
-        type: 'number | string',
-        description: `Use numbers for pixels: left={100} and strings for percentages: left="100%"`,
-      },
-      {
-        name: 'right',
-        type: 'number | string',
-        description: `Use numbers for pixels: right={100} and strings for percentages: right="100%"`,
-      },
-      {
-        name: 'top',
-        type: 'number | string',
-        description: `Use numbers for pixels: top={100} and strings for percentages: top="100%"`,
-      },
-      {
-        name: 'height',
-        type: 'number',
-        description: `Use numbers for pixels: height={100}. This is only useful when the sticky container and its content need to have different heights.`,
-      },
-      {
-        name: 'zIndex',
-        type: 'interface Indexable { index(): number; }',
-        description: `An object representing the zIndex value of the Sticky.`,
-      },
-    ]}
   />
 );
 

--- a/docs/src/Switch.doc.js
+++ b/docs/src/Switch.doc.js
@@ -20,6 +20,42 @@ If you have a cell with multiple options that can activated, consider using chec
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'disabled',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'switchCombinations',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        href: 'basicExample',
+      },
+      {
+        name: 'onChange',
+        type: '({ event: SyntheticInputEvent<>, value: boolean }) => void',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'switched',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'switchCombinations',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="basicExample"
     description={`
@@ -68,42 +104,6 @@ card(
       );
     }}
   </Combination>
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'disabled',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'switchCombinations',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'name',
-        type: 'string',
-        href: 'basicExample',
-      },
-      {
-        name: 'onChange',
-        type: '({ event: SyntheticInputEvent<>, value: boolean }) => void',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'switched',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'switchCombinations',
-      },
-    ]}
-  />
 );
 
 export default cards;

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -17,6 +17,30 @@ card(
 );
 
 card(
+  <PropTable
+    Component={Table}
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'borderStyle',
+        type: `"sm" | "none"`,
+        description: 'Specify a border width for table: "sm" is 1px',
+        defaultValue: 'none',
+      },
+      {
+        name: 'maxHeight',
+        type: `number | string`,
+        description: `Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%"`,
+        href: 'stickyHeader',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Example: Basic Table"
     defaultCode={`
@@ -85,12 +109,11 @@ card(
   />
 );
 
-card(<Card name="Table.Body" />);
-
 card(
   <PropTable
-    showHeading={false}
     Component={Table?.Body}
+    name="Table.Body"
+    id="Table.Body"
     props={[
       {
         name: 'children',
@@ -100,11 +123,10 @@ card(
   />
 );
 
-card(<Card name="Table.Cell" />);
-
 card(
   <PropTable
-    showHeading={false}
+    name="Table.Cell"
+    id="Table.Cell"
     Component={Table?.Cell}
     props={[
       {
@@ -125,11 +147,10 @@ card(
   />
 );
 
-card(<Card name="Table.Footer" />);
-
 card(
   <PropTable
-    showHeading={false}
+    name="Table.Footer"
+    id="Table.Footer"
     Component={Table?.Footer}
     props={[
       {
@@ -144,7 +165,8 @@ card(<Card name="Table.Header" />);
 
 card(
   <PropTable
-    showHeading={false}
+    name="Table.Header"
+    id="Table.Header"
     Component={Table?.Header}
     props={[
       {
@@ -237,11 +259,10 @@ card(
   />
 );
 
-card(<Card name="Table.HeaderCell" />);
-
 card(
   <PropTable
-    showHeading={false}
+    name="Table.HeaderCell"
+    id="Table.HeaderCell"
     Component={Table?.HeaderCell}
     props={[
       {
@@ -267,11 +288,10 @@ card(
   />
 );
 
-card(<Card name="Table.Row" />);
-
 card(
   <PropTable
-    showHeading={false}
+    name="Table.Row"
+    id="Table.Row"
     Component={Table?.Row}
     props={[
       {
@@ -291,7 +311,8 @@ card(
 
 card(
   <PropTable
-    showHeading={false}
+    name="Table.RowExpandable"
+    id="Table.RowExpandable"
     Component={Table?.Row}
     props={[
       {
@@ -559,7 +580,8 @@ card(
 
 card(
   <PropTable
-    showHeading={false}
+    name="Table.SortableHeaderCell"
+    id="Table.SortableHeaderCell"
     Component={Table?.SortableHeaderCell}
     props={[
       {
@@ -638,30 +660,6 @@ card(
       );
     }
 `}
-  />
-);
-
-card(
-  <PropTable
-    Component={Table}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'borderStyle',
-        type: `"sm" | "none"`,
-        description: 'Specify a border width for table: "sm" is 1px',
-        defaultValue: 'none',
-      },
-      {
-        name: 'maxHeight',
-        type: `number | string`,
-        description: `Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%"`,
-        href: 'stickyHeader',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -16,6 +16,43 @@ card(
 );
 
 card(
+  <PropTable
+    Component={Tabs}
+    props={[
+      {
+        name: 'activeTabIndex',
+        type: 'number',
+        required: true,
+      },
+      {
+        name: 'tabs',
+        type: `Array<{| text: React.Node, href: string, id?: string, indicator?: 'dot' |}>`,
+        required: true,
+      },
+      {
+        name: 'onChange',
+        type: `({ +event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>, +activeTabIndex: number }) => void`,
+        required: true,
+        description:
+          'If your app uses a tool such as react-router to navigate between pages, be sure to use onChange to navigate instead of getting a full page refresh with href',
+      },
+      {
+        name: 'size',
+        type: '"md" | "lg"',
+        required: false,
+        description: 'md: 40px, lg: 48px',
+        defaultValue: 'md',
+      },
+      {
+        name: 'wrap',
+        type: 'boolean',
+        description: `By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.`,
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Example"
     defaultCode={`
@@ -64,43 +101,6 @@ function TabExample() {
   );
 }
   `}
-  />
-);
-
-card(
-  <PropTable
-    Component={Tabs}
-    props={[
-      {
-        name: 'activeTabIndex',
-        type: 'number',
-        required: true,
-      },
-      {
-        name: 'tabs',
-        type: `Array<{| text: React.Node, href: string, id?: string, indicator?: 'dot' |}>`,
-        required: true,
-      },
-      {
-        name: 'onChange',
-        type: `({ +event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>, +activeTabIndex: number }) => void`,
-        required: true,
-        description:
-          'If your app uses a tool such as react-router to navigate between pages, be sure to use onChange to navigate instead of getting a full page refresh with href',
-      },
-      {
-        name: 'size',
-        type: '"md" | "lg"',
-        required: false,
-        description: 'md: 40px, lg: 48px',
-        defaultValue: 'md',
-      },
-      {
-        name: 'wrap',
-        type: 'boolean',
-        description: `By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.`,
-      },
-    ]}
   />
 );
 

--- a/docs/src/TapArea.doc.js
+++ b/docs/src/TapArea.doc.js
@@ -17,6 +17,245 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'accessibilityLabel',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Supply a short, descriptive label for screen-readers to replace TapArea texts that do not provide sufficient context about the button component behavior.',
+          'Accessibility: It populates aria-label.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'accessibilityControls',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Specify the `id` of an associated element (or elements) whose contents or visibility are controlled by a button component so that screen reader users can identify the relationship between elements.',
+          'Optional with button-role.',
+          'Accessibility: It populates aria-controls.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'accessibilityExpanded',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Indicate that a button component hides or exposes collapsible components and expose whether they are currently expanded or collapsed.',
+          'Optional with button-role.',
+          'Accessibility: It populates aria-expanded.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'accessibilityHaspopup',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Indicate that a button component controls the appearance of interactive popup elements, such as menu or dialog.',
+          'Optional with button-role.',
+          'Accessibility: It populates aria-haspopup.',
+        ],
+        href: 'accessibility',
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+        required: true,
+        defaultValue: null,
+        description:
+          'TapArea is a wrapper around non-button components (or children) that provides clicking / touching functionality as if they were a unified button area.',
+        href: 'basic-taparea',
+      },
+      {
+        name: 'disabled',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description:
+          'Set disabled state so TapArea cannot be interacted with and actions are not available.',
+        href: 'roles',
+      },
+      {
+        name: 'fullHeight',
+        type: 'boolean',
+        required: false,
+        defaultValue: null,
+        description:
+          'Set the TapArea height to expand to the full height of the parent.',
+        href: 'fullHeightWidth',
+      },
+      {
+        name: 'fullWidth',
+        type: 'boolean',
+        required: false,
+        defaultValue: true,
+        description:
+          'Set the TapArea width to expand to the full width of the parent.',
+        href: 'fullHeightWidth',
+      },
+      {
+        name: 'mouseCursor',
+        type: `"copy" | "grab" | "grabbing" | "move" | "noDrop" | "pointer" | "zoomIn" | "zoomOut"`,
+        required: false,
+        defaultValue: 'pointer',
+        description: [
+          'Select a mouse cursor type to convey the TapArea expected behavior .',
+        ],
+        href: 'mouseCursor',
+      },
+      {
+        name: 'onBlur',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: ['Callback fired when a TapArea component loses focus.'],
+        href: 'basicExample',
+      },
+      {
+        name: 'onFocus',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a TapArea component gets focus via keyboard navigation, mouse click (pressed), or focus method',
+        ],
+        href: 'basicExample',
+      },
+      {
+        name: 'onMouseEnter',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a mouse pointer moves onto a TapArea component.',
+        ],
+        href: 'basicExample',
+      },
+      {
+        name: 'onMouseLeave',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a mouse pointer moves out a TapArea component.',
+        ],
+        href: 'basicExample',
+      },
+      {
+        name: 'onTap',
+        type:
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+        required: false,
+        defaultValue: null,
+        description: [
+          'Callback fired when a TapArea component is clicked (pressed and released) with a mouse or keyboard.',
+        ],
+        href: 'basic-taparea',
+      },
+      {
+        name: 'ref',
+        type: `React.Ref<'div'> | React.Ref<'a'>`,
+        required: false,
+        defaultValue: null,
+        description: 'Forward the ref to the underlying div or anchor element.',
+        href: 'ref',
+      },
+      {
+        name: 'tabIndex',
+        type: `-1 | 0`,
+        required: false,
+        defaultValue: 0,
+        description: [
+          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
+          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
+          `If component is disabled, the component is also unreachable from keyboard navigation.`,
+        ],
+        href: 'roles',
+      },
+      {
+        name: 'rounding',
+        type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
+        required: false,
+        defaultValue: null,
+        description: [
+          'Sets a border radius for the TapArea. Select a rounding option that aligns with its children.',
+          'Options are "circle" or "pill" for fully rounded corners or 0-8 representing the radius in boints.',
+        ],
+        href: 'rounding',
+      },
+      {
+        name: 'href',
+        type: 'string',
+        required: false,
+        defaultValue: null,
+        description: ['Specify a link URL.', 'Required with role=link.'],
+        href: 'roles',
+      },
+      {
+        name: 'role',
+        type: `'button' | 'link'`,
+        required: false,
+        defaultValue: 'button',
+        description: [
+          `Select a TapArea variant:`,
+          `- 'button': Use for TapArea to act like buttons. The TapArea is rendered as a '<div>'.`,
+          `- 'link': Use for TapArea to act like links. The button is rendered as an '<a>'.`,
+          `Required with role=link.`,
+        ],
+        href: 'roles',
+      },
+      {
+        name: 'rel',
+        type: `'none' | 'nofollow'`,
+        required: false,
+        defaultValue: 'none',
+        description: 'Optional with role=link.',
+        href: 'roles',
+      },
+      {
+        name: 'target',
+        type: `null | 'self' | 'blank'`,
+        required: false,
+        defaultValue: 'null',
+        description: [
+          'Define the frame or window to open the anchor defined on `href`:',
+          `- 'null' opens the anchor in the same window.`,
+          `- 'blank' opens the anchor in a new window.`,
+          `- 'self' opens an anchor in the same frame.`,
+          'Optional with role=link.',
+        ],
+        href: 'roles',
+      },
+      {
+        name: 'tapStyle',
+        type: `none | 'compress'`,
+        required: false,
+        defaultValue: 'none',
+        description: [
+          'Set a compressing behavior when the TapArea is clicked / touched.',
+          `- 'none' does not compress TapArea.`,
+          `- 'compress' scales down TapArea.`,
+        ],
+        href: 'roles',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Basic TapArea"
     id="basic-taparea"
@@ -377,245 +616,6 @@ function MenuButtonExample() {
   );
 }
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Supply a short, descriptive label for screen-readers to replace TapArea texts that do not provide sufficient context about the button component behavior.',
-          'Accessibility: It populates aria-label.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'accessibilityControls',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Specify the `id` of an associated element (or elements) whose contents or visibility are controlled by a button component so that screen reader users can identify the relationship between elements.',
-          'Optional with button-role.',
-          'Accessibility: It populates aria-controls.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'accessibilityExpanded',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Indicate that a button component hides or exposes collapsible components and expose whether they are currently expanded or collapsed.',
-          'Optional with button-role.',
-          'Accessibility: It populates aria-expanded.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'accessibilityHaspopup',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Indicate that a button component controls the appearance of interactive popup elements, such as menu or dialog.',
-          'Optional with button-role.',
-          'Accessibility: It populates aria-haspopup.',
-        ],
-        href: 'accessibility',
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-        required: true,
-        defaultValue: null,
-        description:
-          'TapArea is a wrapper around non-button components (or children) that provides clicking / touching functionality as if they were a unified button area.',
-        href: 'basic-taparea',
-      },
-      {
-        name: 'disabled',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description:
-          'Set disabled state so TapArea cannot be interacted with and actions are not available.',
-        href: 'roles',
-      },
-      {
-        name: 'fullHeight',
-        type: 'boolean',
-        required: false,
-        defaultValue: null,
-        description:
-          'Set the TapArea height to expand to the full height of the parent.',
-        href: 'fullHeightWidth',
-      },
-      {
-        name: 'fullWidth',
-        type: 'boolean',
-        required: false,
-        defaultValue: true,
-        description:
-          'Set the TapArea width to expand to the full width of the parent.',
-        href: 'fullHeightWidth',
-      },
-      {
-        name: 'mouseCursor',
-        type: `"copy" | "grab" | "grabbing" | "move" | "noDrop" | "pointer" | "zoomIn" | "zoomOut"`,
-        required: false,
-        defaultValue: 'pointer',
-        description: [
-          'Select a mouse cursor type to convey the TapArea expected behavior .',
-        ],
-        href: 'mouseCursor',
-      },
-      {
-        name: 'onBlur',
-        type:
-          '({ event: SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement> }) => void',
-        required: false,
-        defaultValue: null,
-        description: ['Callback fired when a TapArea component loses focus.'],
-        href: 'basicExample',
-      },
-      {
-        name: 'onFocus',
-        type:
-          '({ event: SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement> }) => void',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Callback fired when a TapArea component gets focus via keyboard navigation, mouse click (pressed), or focus method',
-        ],
-        href: 'basicExample',
-      },
-      {
-        name: 'onMouseEnter',
-        type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> }) => void',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Callback fired when a mouse pointer moves onto a TapArea component.',
-        ],
-        href: 'basicExample',
-      },
-      {
-        name: 'onMouseLeave',
-        type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> }) => void',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Callback fired when a mouse pointer moves out a TapArea component.',
-        ],
-        href: 'basicExample',
-      },
-      {
-        name: 'onTap',
-        type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
-        required: false,
-        defaultValue: null,
-        description: [
-          'Callback fired when a TapArea component is clicked (pressed and released) with a mouse or keyboard.',
-        ],
-        href: 'basic-taparea',
-      },
-      {
-        name: 'ref',
-        type: `React.Ref<'div'> | React.Ref<'a'>`,
-        required: false,
-        defaultValue: null,
-        description: 'Forward the ref to the underlying div or anchor element.',
-        href: 'ref',
-      },
-      {
-        name: 'tabIndex',
-        type: `-1 | 0`,
-        required: false,
-        defaultValue: 0,
-        description: [
-          'Remove the component from sequential keyboard navigation to improve accessibility. The component is not focusable with keyboard navigation but it can be focused with Javascript or visually by clicking with the mouse.',
-          `The default behaviour for the component is to be focusable in sequential keyboard navigation in the order defined by the document's source order.`,
-          `If component is disabled, the component is also unreachable from keyboard navigation.`,
-        ],
-        href: 'roles',
-      },
-      {
-        name: 'rounding',
-        type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
-        required: false,
-        defaultValue: null,
-        description: [
-          'Sets a border radius for the TapArea. Select a rounding option that aligns with its children.',
-          'Options are "circle" or "pill" for fully rounded corners or 0-8 representing the radius in boints.',
-        ],
-        href: 'rounding',
-      },
-      {
-        name: 'href',
-        type: 'string',
-        required: false,
-        defaultValue: null,
-        description: ['Specify a link URL.', 'Required with role=link.'],
-        href: 'roles',
-      },
-      {
-        name: 'role',
-        type: `'button' | 'link'`,
-        required: false,
-        defaultValue: 'button',
-        description: [
-          `Select a TapArea variant:`,
-          `- 'button': Use for TapArea to act like buttons. The TapArea is rendered as a '<div>'.`,
-          `- 'link': Use for TapArea to act like links. The button is rendered as an '<a>'.`,
-          `Required with role=link.`,
-        ],
-        href: 'roles',
-      },
-      {
-        name: 'rel',
-        type: `'none' | 'nofollow'`,
-        required: false,
-        defaultValue: 'none',
-        description: 'Optional with role=link.',
-        href: 'roles',
-      },
-      {
-        name: 'target',
-        type: `null | 'self' | 'blank'`,
-        required: false,
-        defaultValue: 'null',
-        description: [
-          'Define the frame or window to open the anchor defined on `href`:',
-          `- 'null' opens the anchor in the same window.`,
-          `- 'blank' opens the anchor in a new window.`,
-          `- 'self' opens an anchor in the same frame.`,
-          'Optional with role=link.',
-        ],
-        href: 'roles',
-      },
-      {
-        name: 'tapStyle',
-        type: `none | 'compress'`,
-        required: false,
-        defaultValue: 'none',
-        description: [
-          'Set a compressing behavior when the TapArea is clicked / touched.',
-          `- 'none' does not compress TapArea.`,
-          `- 'compress' scales down TapArea.`,
-        ],
-        href: 'roles',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -15,6 +15,68 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'align',
+        type: `"left" | "right" | "center" | "justify"`,
+        defaultValue: 'left',
+        href: 'align',
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
+      },
+      {
+        name: 'color',
+        type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
+        defaultValue: 'darkGray',
+        href: 'color',
+      },
+      {
+        name: 'inline',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'inline',
+      },
+      {
+        name: 'italic',
+        type: 'boolean',
+        defaultValue: false,
+        href: 'styles',
+      },
+      {
+        name: 'overflow',
+        type: `"normal" | "breakWord" | "noWrap"`,
+        defaultValue: 'breakWord',
+        href: 'overflow',
+      },
+      {
+        name: 'size',
+        type: `"sm" | "md" | "lg"`,
+        description: `sm: 12px, md: 14px, lg: 16px`,
+        defaultValue: 'lg',
+        href: 'size',
+      },
+      {
+        name: 'truncate',
+        type: 'boolean',
+        description:
+          'Truncate the text to a single line. Add the title attribute if `<Text>` only contains text.',
+        href: 'overflow',
+        defaultValue: false,
+      },
+      {
+        name: 'weight',
+        type: `"bold" | "normal"`,
+        defaultValue: 'normal',
+        href: 'styles',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     description="Use this to adjust the positioning of text within wrapper elements."
     id="align"
@@ -162,68 +224,6 @@ card(
   </Box>
 </Box>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'align',
-        type: `"left" | "right" | "center" | "justify"`,
-        defaultValue: 'left',
-        href: 'align',
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'color',
-        type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
-        defaultValue: 'darkGray',
-        href: 'color',
-      },
-      {
-        name: 'inline',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'inline',
-      },
-      {
-        name: 'italic',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'styles',
-      },
-      {
-        name: 'overflow',
-        type: `"normal" | "breakWord" | "noWrap"`,
-        defaultValue: 'breakWord',
-        href: 'overflow',
-      },
-      {
-        name: 'size',
-        type: `"sm" | "md" | "lg"`,
-        description: `sm: 12px, md: 14px, lg: 16px`,
-        defaultValue: 'lg',
-        href: 'size',
-      },
-      {
-        name: 'truncate',
-        type: 'boolean',
-        description:
-          'Truncate the text to a single line. Add the title attribute if `<Text>` only contains text.',
-        href: 'overflow',
-        defaultValue: false,
-      },
-      {
-        name: 'weight',
-        type: `"bold" | "normal"`,
-        defaultValue: 'normal',
-        href: 'styles',
-      },
-    ]}
   />
 );
 

--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -16,6 +16,88 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'disabled',
+        type: 'boolean',
+        defaultValue: 'false',
+        href: 'disabledExample',
+      },
+      {
+        name: 'errorMessage',
+        type: 'string',
+        href: 'errorMessageExample',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'textarea'>",
+        description: 'Forward the ref to the underlying textarea element',
+        href: 'refExample',
+      },
+      {
+        name: 'helperText',
+        type: 'string',
+        description: 'More information about how to complete the form field',
+        href: 'helperText',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'label',
+        type: 'string',
+      },
+      {
+        name: 'name',
+        type: 'string',
+      },
+      {
+        name: 'onBlur',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLTextAreaElement>, value: string }) => void',
+      },
+      {
+        name: 'onChange',
+        type:
+          '({ event: SyntheticInputEvent<HTMLTextAreaElement>, value: string }) => void',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'onFocus',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLTextAreaElement>, value: string }) => void',
+      },
+      {
+        name: 'onKeyDown',
+        type:
+          '({ event: SyntheticKeyboardEvent<HTMLTextAreaElement>, value: string }) => void',
+      },
+      {
+        name: 'placeholder',
+        type: 'string',
+        href: 'basicExample',
+      },
+      {
+        name: 'rows',
+        type: 'number',
+        description: 'Number of rows to display',
+        defaultValue: 3,
+      },
+      {
+        name: 'value',
+        type: 'string',
+        href: 'basicExample',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="basicExample"
     name="Example"
@@ -176,88 +258,6 @@ card(
     in a \`form\` and attach an \`onSubmit\` handler to that \`form\`.
   `}
     name="onSubmit"
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'disabled',
-        type: 'boolean',
-        defaultValue: 'false',
-        href: 'disabledExample',
-      },
-      {
-        name: 'errorMessage',
-        type: 'string',
-        href: 'errorMessageExample',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'textarea'>",
-        description: 'Forward the ref to the underlying textarea element',
-        href: 'refExample',
-      },
-      {
-        name: 'helperText',
-        type: 'string',
-        description: 'More information about how to complete the form field',
-        href: 'helperText',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'label',
-        type: 'string',
-      },
-      {
-        name: 'name',
-        type: 'string',
-      },
-      {
-        name: 'onBlur',
-        type:
-          '({ event: SyntheticFocusEvent<HTMLTextAreaElement>, value: string }) => void',
-      },
-      {
-        name: 'onChange',
-        type:
-          '({ event: SyntheticInputEvent<HTMLTextAreaElement>, value: string }) => void',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'onFocus',
-        type:
-          '({ event: SyntheticFocusEvent<HTMLTextAreaElement>, value: string }) => void',
-      },
-      {
-        name: 'onKeyDown',
-        type:
-          '({ event: SyntheticKeyboardEvent<HTMLTextAreaElement>, value: string }) => void',
-      },
-      {
-        name: 'placeholder',
-        type: 'string',
-        href: 'basicExample',
-      },
-      {
-        name: 'rows',
-        type: 'number',
-        description: 'Number of rows to display',
-        defaultValue: 3,
-      },
-      {
-        name: 'value',
-        type: 'string',
-        href: 'basicExample',
-      },
-    ]}
   />
 );
 

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -13,6 +13,98 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'autoComplete',
+        type: `"current-password" | "new-password" | "on" | "off" | "username"`,
+      },
+      {
+        name: 'disabled',
+        type: 'boolean',
+        defaultValue: 'false',
+        href: 'disabledExample',
+      },
+      {
+        name: 'errorMessage',
+        type: 'string',
+        href: 'errorMessageExample',
+      },
+      {
+        name: 'helperText',
+        type: 'string',
+        description: 'More information about how to complete the form field',
+        href: 'helperText',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'label',
+        type: 'string',
+      },
+      {
+        name: 'name',
+        type: 'string',
+      },
+      {
+        name: 'onBlur',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLInputElement>, value: string }) => void',
+      },
+      {
+        name: 'onChange',
+        type:
+          '({ event: SyntheticInputEvent<HTMLInputElement>, value: string }) => void',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'onFocus',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLInputElement>, value: string }) => void',
+      },
+      {
+        name: 'onKeyDown',
+        type:
+          '({ event: SyntheticKeyboardEvent<HTMLInputElement>, value: string }) => void',
+      },
+      {
+        name: 'placeholder',
+        type: 'string',
+        href: 'basicExample',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'input'>",
+        description: 'Forward the ref to the underlying input element',
+      },
+      {
+        name: 'size',
+        type: '"md" | "lg"',
+        required: false,
+        description: 'md: 40px, lg: 48px',
+        defaultValue: 'md',
+      },
+      {
+        name: 'type',
+        type: `"date" | "email" | "number" | "password" | "text" | "url"`,
+        defaultValue: 'text',
+        href: 'basicExample',
+      },
+      {
+        name: 'value',
+        type: 'string',
+        href: 'basicExample',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="basicExample"
     name="Example"
@@ -172,98 +264,6 @@ card(
     in a \`form\` and attach an \`onSubmit\` handler to that \`form\`.
   `}
     name="onSubmit"
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'autoComplete',
-        type: `"current-password" | "new-password" | "on" | "off" | "username"`,
-      },
-      {
-        name: 'disabled',
-        type: 'boolean',
-        defaultValue: 'false',
-        href: 'disabledExample',
-      },
-      {
-        name: 'errorMessage',
-        type: 'string',
-        href: 'errorMessageExample',
-      },
-      {
-        name: 'helperText',
-        type: 'string',
-        description: 'More information about how to complete the form field',
-        href: 'helperText',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'label',
-        type: 'string',
-      },
-      {
-        name: 'name',
-        type: 'string',
-      },
-      {
-        name: 'onBlur',
-        type:
-          '({ event: SyntheticFocusEvent<HTMLInputElement>, value: string }) => void',
-      },
-      {
-        name: 'onChange',
-        type:
-          '({ event: SyntheticInputEvent<HTMLInputElement>, value: string }) => void',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'onFocus',
-        type:
-          '({ event: SyntheticFocusEvent<HTMLInputElement>, value: string }) => void',
-      },
-      {
-        name: 'onKeyDown',
-        type:
-          '({ event: SyntheticKeyboardEvent<HTMLInputElement>, value: string }) => void',
-      },
-      {
-        name: 'placeholder',
-        type: 'string',
-        href: 'basicExample',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'input'>",
-        description: 'Forward the ref to the underlying input element',
-      },
-      {
-        name: 'size',
-        type: '"md" | "lg"',
-        required: false,
-        description: 'md: 40px, lg: 48px',
-        defaultValue: 'md',
-      },
-      {
-        name: 'type',
-        type: `"date" | "email" | "number" | "password" | "text" | "url"`,
-        defaultValue: 'text',
-        href: 'basicExample',
-      },
-      {
-        name: 'value',
-        type: 'string',
-        href: 'basicExample',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -19,6 +19,41 @@ The Toast component is purely visual. In order to properly handle the showing an
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'button',
+        type: 'React.Node',
+        href: 'imageTextButtonExample',
+      },
+      {
+        name: 'color',
+        type: `'darkGray' | 'red'`,
+        href: 'redColorTextAlertExample',
+      },
+      {
+        name: 'thumbnail',
+        type: 'React.Node',
+        href: 'imageTextExample',
+      },
+      {
+        name: 'thumbnailShape',
+        type: `'circle' | 'rectangle' | 'square'`,
+        defaultValue: 'square',
+        href: 'imageTextExample',
+      },
+      {
+        name: 'text',
+        type: 'string | Array<string>',
+        description:
+          'Use string for guide toasts (one line of text) and Array<string> for confirmation toasts (two lines of text).',
+        href: 'textOnlyExample',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     id="textOnlyExample"
     name="Example: Text only"
@@ -302,41 +337,6 @@ card(
       />
     )}
   </Combination>
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'button',
-        type: 'React.Node',
-        href: 'imageTextButtonExample',
-      },
-      {
-        name: 'color',
-        type: `'darkGray' | 'red'`,
-        href: 'redColorTextAlertExample',
-      },
-      {
-        name: 'thumbnail',
-        type: 'React.Node',
-        href: 'imageTextExample',
-      },
-      {
-        name: 'thumbnailShape',
-        type: `'circle' | 'rectangle' | 'square'`,
-        defaultValue: 'square',
-        href: 'imageTextExample',
-      },
-      {
-        name: 'text',
-        type: 'string | Array<string>',
-        description:
-          'Use string for guide toasts (one line of text) and Array<string> for confirmation toasts (two lines of text).',
-        href: 'textOnlyExample',
-      },
-    ]}
-  />
 );
 
 export default cards;

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -17,6 +17,51 @@ card(
 );
 
 card(
+  <PropTable
+    props={[
+      {
+        name: 'children',
+        type: 'React.Node',
+        required: true,
+        description: 'The element to wrap with a tooltip on hover.',
+      },
+      {
+        name: 'idealDirection',
+        type: `'up' | 'right' | 'down' | 'left'`,
+        description: 'Preferred direction for the Tooltip to open',
+        defaultValue: 'down',
+      },
+      {
+        name: 'inline',
+        type: 'boolean',
+        href: 'inline',
+        description:
+          'Flag used to help render the tooltip inline to the element',
+      },
+      {
+        name: 'text',
+        type: 'string',
+        required: true,
+        description:
+          'String that is shown as addition information in a tooltip bubble to describe the child. Always localize the text.',
+      },
+      {
+        name: 'link',
+        type: 'React.Node',
+        required: false,
+        description: 'A link which will show on the bottom of a tooltip',
+      },
+      {
+        name: 'zIndex',
+        type: 'interface Indexable { index(): number; }',
+        required: false,
+        description: 'An object representing the zIndex value of the Tooltip.',
+      },
+    ]}
+  />
+);
+
+card(
   <Example
     name="Tooltips"
     description="General Tooltip usage involves wrapping your target in a Tooltip. Notice how long
@@ -115,51 +160,6 @@ card(
   />
 </Tooltip>
 `}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-        required: true,
-        description: 'The element to wrap with a tooltip on hover.',
-      },
-      {
-        name: 'idealDirection',
-        type: `'up' | 'right' | 'down' | 'left'`,
-        description: 'Preferred direction for the Tooltip to open',
-        defaultValue: 'down',
-      },
-      {
-        name: 'inline',
-        type: 'boolean',
-        href: 'inline',
-        description:
-          'Flag used to help render the tooltip inline to the element',
-      },
-      {
-        name: 'text',
-        type: 'string',
-        required: true,
-        description:
-          'String that is shown as addition information in a tooltip bubble to describe the child. Always localize the text.',
-      },
-      {
-        name: 'link',
-        type: 'React.Node',
-        required: false,
-        description: 'A link which will show on the bottom of a tooltip',
-      },
-      {
-        name: 'zIndex',
-        type: 'interface Indexable { index(): number; }',
-        required: false,
-        description: 'An object representing the zIndex value of the Tooltip.',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -13,6 +13,94 @@ card(
     description={`Use a \`Typeahead\` when you want to let the user filter a list when selecting.`}
   />
 );
+card(
+  <PropTable
+    props={[
+      {
+        name: 'options',
+        type: 'Array<{ label: string, value: string }>',
+        description:
+          'The data much be an array with objects containing only label and value properties',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'value',
+        type: 'string',
+        description: 'The default value set in the Typeahead',
+        required: false,
+        href: 'defaultItemExample',
+      },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        href: 'basicExample',
+      },
+      {
+        name: 'label',
+        type: 'string',
+      },
+      {
+        name: 'noResultText',
+        type: 'string',
+        href: 'basicExample',
+        required: true,
+        description: 'The text shown when the input value returns no matches',
+      },
+      {
+        name: 'onBlur',
+        type:
+          '({ event: SyntheticFocusEvent<HTMLInputElement> | SyntheticEvent<HTMLInputElement> , value: string }) => void',
+        required: false,
+        description: 'Callback when you focus outside the component ',
+        href: 'basicExample',
+      },
+
+      {
+        name: 'onChange',
+        type: '({ event: SyntheticInputEvent<>, value: string }) => void',
+        required: false,
+        description: 'Callback when user types into the control input field',
+        href: 'basicExample',
+      },
+
+      {
+        name: 'onFocus',
+        type: '({ event: SyntheticFocusEvent<>, value: string }) => void',
+        required: false,
+        description: 'Callback when you focus on the component',
+        href: 'basicExample',
+      },
+      {
+        name: 'onSelect',
+        type: '({ event: SyntheticInputEvent<>, value: string }) => void',
+        required: false,
+        description: 'Callback when you select an item ',
+        href: 'basicExample',
+      },
+      {
+        name: 'placeholder',
+        type: 'string',
+        href: 'basicExample',
+      },
+      {
+        name: 'size',
+        type: '"md" | "lg"',
+        required: false,
+        description: 'md: 40px, lg: 48px',
+        defaultValue: 'md',
+      },
+      {
+        name: 'ref',
+        type: "React.Ref<'input'>",
+        description:
+          'Forward the ref to the underlying component container element',
+        href: 'refExample',
+      },
+    ]}
+  />
+);
 
 card(
   <Example
@@ -133,95 +221,6 @@ function TypeaheadExample() {
     </Row>
   );
 }`}
-  />
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'options',
-        type: 'Array<{ label: string, value: string }>',
-        description:
-          'The data much be an array with objects containing only label and value properties',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'value',
-        type: 'string',
-        description: 'The default value set in the Typeahead',
-        required: false,
-        href: 'defaultItemExample',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'label',
-        type: 'string',
-      },
-      {
-        name: 'noResultText',
-        type: 'string',
-        href: 'basicExample',
-        required: true,
-        description: 'The text shown when the input value returns no matches',
-      },
-      {
-        name: 'onBlur',
-        type:
-          '({ event: SyntheticFocusEvent<HTMLInputElement> | SyntheticEvent<HTMLInputElement> , value: string }) => void',
-        required: false,
-        description: 'Callback when you focus outside the component ',
-        href: 'basicExample',
-      },
-
-      {
-        name: 'onChange',
-        type: '({ event: SyntheticInputEvent<>, value: string }) => void',
-        required: false,
-        description: 'Callback when user types into the control input field',
-        href: 'basicExample',
-      },
-
-      {
-        name: 'onFocus',
-        type: '({ event: SyntheticFocusEvent<>, value: string }) => void',
-        required: false,
-        description: 'Callback when you focus on the component',
-        href: 'basicExample',
-      },
-      {
-        name: 'onSelect',
-        type: '({ event: SyntheticInputEvent<>, value: string }) => void',
-        required: false,
-        description: 'Callback when you select an item ',
-        href: 'basicExample',
-      },
-      {
-        name: 'placeholder',
-        type: 'string',
-        href: 'basicExample',
-      },
-      {
-        name: 'size',
-        type: '"md" | "lg"',
-        required: false,
-        description: 'md: 40px, lg: 48px',
-        defaultValue: 'md',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'input'>",
-        description:
-          'Forward the ref to the underlying component container element',
-        href: 'refExample',
-      },
-    ]}
   />
 );
 

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -18,218 +18,6 @@ supercharged with lots of goodies to turn a regular video in a full blown viewin
 );
 
 card(
-  <Example
-    id="basicExample"
-    name="Video media basics"
-    description={`
-    The source url you pass into \`Video\` will be used to download and play the video file. While it is
-    downloading the metadata, you may show a thumbnail image by using the \`poster\` prop.
-  `}
-    defaultCode={`
-<Video
-  aspectRatio={853 / 480}
-  captions=""
-  poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
-  src="http://media.w3.org/2010/05/bunny/movie.mp4"
-/>
-`}
-  />
-);
-
-card(
-  <Example
-    name="Video multiple sources"
-    description={`
-    Not all browsers support the same video encoding types. If you have multiple video file sources, you can pass
-    them as a list to \`Video\` in the order you want the HTML video tag to use as fallbacks.
-  `}
-    defaultCode={`
-<Video
-  aspectRatio={426 / 240}
-  captions=""
-  playing
-  src={[
-    {
-      type: "video/mp4",
-      src: "https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
-    },
-    {
-      type: "video/ogg",
-      src: "https://archive.org/download/ElephantsDream/ed_hd.ogv"
-    },
-  ]}
-/>
-`}
-  />
-);
-
-card(
-  <Example
-    id="nativeVideoAttributesExample"
-    name="Native video attributes"
-    description={`
-    \`Video\` supports the native HTML video attributes such as \`autoPlay\`, \`loop\`, \`muted\`, and more.
-    Simply pass these through as props on the \`Video\` component.
-  `}
-    defaultCode={`
-<Video
-  aspectRatio={1920 / 1080}
-  captions=""
-  loop
-  playing
-  src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
-/>
-`}
-  />
-);
-
-card(
-  <Example
-    id="videoControlsExample"
-    name="Video controls"
-    description={`
-    \`Video\` components can show a control bar to users in order to allow them access to certain features
-    such as play/pause, timestamps, mute, and fullscreen. Pass in the \`controls\` prop to make them appear.
-  `}
-    defaultCode={`
-<Video
-  accessibilityMaximizeLabel="Maximize"
-  accessibilityMinimizeLabel="Minimize"
-  accessibilityMuteLabel="Mute"
-  accessibilityPauseLabel="Pause"
-  accessibilityPlayLabel="Play"
-  accessibilityUnmuteLabel="Unmute"
-  aspectRatio={853 / 480}
-  captions=""
-  controls
-  src="http://media.w3.org/2010/05/bunny/movie.mp4"
-/>
-`}
-  />
-);
-
-card(
-  <Example
-    name="Video with children"
-    description={`
-    \`Video\` component can show components in the \`chilren\` prop on top of the html video element, while under the controls.
-    The children of \`Video\` are not same as the children of the html \`video\` element; they're "outside" the html \`video\` element.
-  `}
-    defaultCode={`
-<Video
-  accessibilityMaximizeLabel="Maximize"
-  accessibilityMinimizeLabel="Minimize"
-  accessibilityMuteLabel="Mute"
-  accessibilityPauseLabel="Pause"
-  accessibilityPlayLabel="Play"
-  accessibilityUnmuteLabel="Unmute"
-  aspectRatio={853 / 480}
-  captions=""
-  controls
-  playing
-  src="http://media.w3.org/2010/05/bunny/movie.mp4"
->
-  <Box width="100%" height="100%"
-    display="flex"
-    justifyContent="center"
-    alignItems="center"
-    dangerouslySetInlineStyle={{__style:{backgroundColor:'rgba(0, 0, 0, 0.3)'}}}>
-      <IconButton
-        accessibilityLabel="Love"
-        bgColor="white"
-        icon="trash-can"
-        size="lg" />
-  </Box>
-</Video>
-`}
-  />
-);
-
-card(
-  <Example
-    id="videoUpdatesExample"
-    name="Video updates"
-    description={`
-    \`Video\` is robust enough to handle any updates, such as changing the source, volume, or speed.`}
-    defaultCode={`
-function Example() {
-  const [input, setInput] = React.useState("http://media.w3.org/2010/05/bunny/movie.mp4");
-  const [playbackRate, setPlaybackRate] = React.useState(1);
-  const [playing, setPlaying] = React.useState(false);
-  const [src, setSrc] = React.useState("http://media.w3.org/2010/05/bunny/movie.mp4");
-  const [volume, setVolume] = React.useState(1);
-
-  return (
-    <Box>
-      <Box paddingY={2}>
-        <Box marginBottom={2}>
-          <Label htmlFor="video-source">
-            <Text>Video source URL</Text>
-          </Label>
-        </Box>
-        <Box display="flex" marginLeft={-1} marginRight={-1}>
-          <Box flex="grow" paddingX={1}>
-            <TextField
-              id="video-source"
-              onChange={({ value }) => setInput(value)}
-              value={input}
-            />
-          </Box>
-          <Box paddingX={1}>
-            <Button
-              text="Submit"
-              color="red"
-              onClick={() => setSrc(input)}
-            />
-          </Box>
-        </Box>
-      </Box>
-      <Box paddingY={2}>
-        <Button
-          text={volume === 0 ? "Unmute" : "Mute"}
-          onClick={() => setVolume(volume === 0 ? 1 : 0)}
-        />
-      </Box>
-      <Box display="flex" paddingY={2} marginLeft={-1} marginRight={-1}>
-        <Box paddingX={1} column={6}>
-          <Button
-            text="Playback x0.5"
-            onClick={() => setPlaybackRate(playbackRate / 2)}
-          />
-        </Box>
-        <Box paddingX={1} column={6}>
-          <Button
-            text="Playback x2"
-            onClick={() => setPlaybackRate(playbackRate * 2)}
-          />
-        </Box>
-      </Box>
-      <Video
-        accessibilityMaximizeLabel="Maximize"
-        accessibilityMinimizeLabel="Minimize"
-        accessibilityMuteLabel="Mute"
-        accessibilityPauseLabel="Pause"
-        accessibilityPlayLabel="Play"
-        accessibilityUnmuteLabel="Unmute"
-        aspectRatio={853 / 480}
-        captions=""
-        controls
-        onPlay={() => setPlaying(true)}
-        onPause={() => setPlaying(false)}
-        onVolumeChange={({ volume }) => setVolume(volume)}
-        playbackRate={playbackRate}
-        playing={playing}
-        src={src}
-        volume={volume}
-      />
-    </Box>
-  );
-}
-`}
-  />
-);
-
-card(
   <PropTable
     props={[
       {
@@ -452,6 +240,218 @@ card(
         href: 'nativeVideoAttributesExample',
       },
     ]}
+  />
+);
+
+card(
+  <Example
+    id="basicExample"
+    name="Video media basics"
+    description={`
+    The source url you pass into \`Video\` will be used to download and play the video file. While it is
+    downloading the metadata, you may show a thumbnail image by using the \`poster\` prop.
+  `}
+    defaultCode={`
+<Video
+  aspectRatio={853 / 480}
+  captions=""
+  poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
+  src="http://media.w3.org/2010/05/bunny/movie.mp4"
+/>
+`}
+  />
+);
+
+card(
+  <Example
+    name="Video multiple sources"
+    description={`
+    Not all browsers support the same video encoding types. If you have multiple video file sources, you can pass
+    them as a list to \`Video\` in the order you want the HTML video tag to use as fallbacks.
+  `}
+    defaultCode={`
+<Video
+  aspectRatio={426 / 240}
+  captions=""
+  playing
+  src={[
+    {
+      type: "video/mp4",
+      src: "https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
+    },
+    {
+      type: "video/ogg",
+      src: "https://archive.org/download/ElephantsDream/ed_hd.ogv"
+    },
+  ]}
+/>
+`}
+  />
+);
+
+card(
+  <Example
+    id="nativeVideoAttributesExample"
+    name="Native video attributes"
+    description={`
+    \`Video\` supports the native HTML video attributes such as \`autoPlay\`, \`loop\`, \`muted\`, and more.
+    Simply pass these through as props on the \`Video\` component.
+  `}
+    defaultCode={`
+<Video
+  aspectRatio={1920 / 1080}
+  captions=""
+  loop
+  playing
+  src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+/>
+`}
+  />
+);
+
+card(
+  <Example
+    id="videoControlsExample"
+    name="Video controls"
+    description={`
+    \`Video\` components can show a control bar to users in order to allow them access to certain features
+    such as play/pause, timestamps, mute, and fullscreen. Pass in the \`controls\` prop to make them appear.
+  `}
+    defaultCode={`
+<Video
+  accessibilityMaximizeLabel="Maximize"
+  accessibilityMinimizeLabel="Minimize"
+  accessibilityMuteLabel="Mute"
+  accessibilityPauseLabel="Pause"
+  accessibilityPlayLabel="Play"
+  accessibilityUnmuteLabel="Unmute"
+  aspectRatio={853 / 480}
+  captions=""
+  controls
+  src="http://media.w3.org/2010/05/bunny/movie.mp4"
+/>
+`}
+  />
+);
+
+card(
+  <Example
+    name="Video with children"
+    description={`
+    \`Video\` component can show components in the \`chilren\` prop on top of the html video element, while under the controls.
+    The children of \`Video\` are not same as the children of the html \`video\` element; they're "outside" the html \`video\` element.
+  `}
+    defaultCode={`
+<Video
+  accessibilityMaximizeLabel="Maximize"
+  accessibilityMinimizeLabel="Minimize"
+  accessibilityMuteLabel="Mute"
+  accessibilityPauseLabel="Pause"
+  accessibilityPlayLabel="Play"
+  accessibilityUnmuteLabel="Unmute"
+  aspectRatio={853 / 480}
+  captions=""
+  controls
+  playing
+  src="http://media.w3.org/2010/05/bunny/movie.mp4"
+>
+  <Box width="100%" height="100%"
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    dangerouslySetInlineStyle={{__style:{backgroundColor:'rgba(0, 0, 0, 0.3)'}}}>
+      <IconButton
+        accessibilityLabel="Love"
+        bgColor="white"
+        icon="trash-can"
+        size="lg" />
+  </Box>
+</Video>
+`}
+  />
+);
+
+card(
+  <Example
+    id="videoUpdatesExample"
+    name="Video updates"
+    description={`
+    \`Video\` is robust enough to handle any updates, such as changing the source, volume, or speed.`}
+    defaultCode={`
+function Example() {
+  const [input, setInput] = React.useState("http://media.w3.org/2010/05/bunny/movie.mp4");
+  const [playbackRate, setPlaybackRate] = React.useState(1);
+  const [playing, setPlaying] = React.useState(false);
+  const [src, setSrc] = React.useState("http://media.w3.org/2010/05/bunny/movie.mp4");
+  const [volume, setVolume] = React.useState(1);
+
+  return (
+    <Box>
+      <Box paddingY={2}>
+        <Box marginBottom={2}>
+          <Label htmlFor="video-source">
+            <Text>Video source URL</Text>
+          </Label>
+        </Box>
+        <Box display="flex" marginLeft={-1} marginRight={-1}>
+          <Box flex="grow" paddingX={1}>
+            <TextField
+              id="video-source"
+              onChange={({ value }) => setInput(value)}
+              value={input}
+            />
+          </Box>
+          <Box paddingX={1}>
+            <Button
+              text="Submit"
+              color="red"
+              onClick={() => setSrc(input)}
+            />
+          </Box>
+        </Box>
+      </Box>
+      <Box paddingY={2}>
+        <Button
+          text={volume === 0 ? "Unmute" : "Mute"}
+          onClick={() => setVolume(volume === 0 ? 1 : 0)}
+        />
+      </Box>
+      <Box display="flex" paddingY={2} marginLeft={-1} marginRight={-1}>
+        <Box paddingX={1} column={6}>
+          <Button
+            text="Playback x0.5"
+            onClick={() => setPlaybackRate(playbackRate / 2)}
+          />
+        </Box>
+        <Box paddingX={1} column={6}>
+          <Button
+            text="Playback x2"
+            onClick={() => setPlaybackRate(playbackRate * 2)}
+          />
+        </Box>
+      </Box>
+      <Video
+        accessibilityMaximizeLabel="Maximize"
+        accessibilityMinimizeLabel="Minimize"
+        accessibilityMuteLabel="Mute"
+        accessibilityPauseLabel="Pause"
+        accessibilityPlayLabel="Play"
+        accessibilityUnmuteLabel="Unmute"
+        aspectRatio={853 / 480}
+        captions=""
+        controls
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onVolumeChange={({ volume }) => setVolume(volume)}
+        playbackRate={playbackRate}
+        playing={playing}
+        src={src}
+        volume={volume}
+      />
+    </Box>
+  );
+}
+`}
   />
 );
 

--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -6,6 +6,7 @@ import Navigation from './Navigation.js';
 import useTracking from './useTracking.js';
 import { SidebarContextProvider } from './sidebarContext.js';
 import useLocalStorage from './useLocalStorage.js';
+import { PropTableContextProvider } from './propTableContext.js';
 
 type Props = {|
   children?: Node,
@@ -74,7 +75,7 @@ export default function App(props: Props): Node {
                 width="100%"
                 role="main"
               >
-                {children}
+                <PropTableContextProvider>{children}</PropTableContextProvider>
               </Box>
               <Divider />
 

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Box, Heading, Icon, Link, Row } from 'gestalt';
+import { Box, Heading, IconButton, Row } from 'gestalt';
 import slugify from 'slugify';
 import Markdown from './Markdown.js';
 
@@ -10,6 +10,7 @@ type Props = {|
   headingSize?: 'sm' | 'md',
   id?: string,
   name: string,
+  toggle?: Node,
   stacked?: boolean,
   showHeading?: boolean,
 |};
@@ -20,6 +21,7 @@ export default function Card({
   headingSize = 'md',
   id,
   name,
+  toggle,
   stacked = false,
   showHeading = true,
 }: Props): Node {
@@ -39,20 +41,18 @@ export default function Card({
           >
             <Row alignItems="baseline" gap={1}>
               <Box>{name}</Box>
-              <Link
-                href={`#${slugifiedId}`}
-                inline
+
+              <IconButton
+                dangerouslySetSvgPath={{
+                  __path:
+                    'M21.001 7.241l-4.053 4.052-1.06-1.06.672-.672a1.5 1.5 0 10-2.121-2.121l-.671.672-1.061-1.06L16.759 3l4.242 4.241zm-9.708 9.708l-4.052 4.052-4.242-4.241 4.053-4.053 1.059 1.06-.671.672a1.5 1.5 0 002.121 2.121l.671-.672 1.061 1.061zM14.639.879l-4.053 4.052a3 3 0 000 4.242l1.061 1.06-1.415 1.414-1.06-1.061a3 3 0 00-4.241 0L.879 14.638a2.998 2.998 0 000 4.242l4.241 4.242a3 3 0 004.241 0l4.053-4.052a3 3 0 000-4.242l-1.06-1.061 1.414-1.413 1.06 1.06a3 3 0 004.241 0l4.052-4.052a2.998 2.998 0 000-4.242L18.88.879a2.997 2.997 0 00-4.241 0z',
+                }}
                 accessibilityLabel={`${name} - Anchor tag`}
-              >
-                <Icon
-                  dangerouslySetSvgPath={{
-                    __path:
-                      'M21.001 7.241l-4.053 4.052-1.06-1.06.672-.672a1.5 1.5 0 10-2.121-2.121l-.671.672-1.061-1.06L16.759 3l4.242 4.241zm-9.708 9.708l-4.052 4.052-4.242-4.241 4.053-4.053 1.059 1.06-.671.672a1.5 1.5 0 002.121 2.121l.671-.672 1.061 1.061zM14.639.879l-4.053 4.052a3 3 0 000 4.242l1.061 1.06-1.415 1.414-1.06-1.061a3 3 0 00-4.241 0L.879 14.638a2.998 2.998 0 000 4.242l4.241 4.242a3 3 0 004.241 0l4.053-4.052a3 3 0 000-4.242l-1.06-1.061 1.414-1.413 1.06 1.06a3 3 0 004.241 0l4.052-4.052a2.998 2.998 0 000-4.242L18.88.879a2.997 2.997 0 00-4.241 0z',
-                  }}
-                  accessibilityLabel=""
-                  size={14}
-                />
-              </Link>
+                size="sm"
+                href={`#${slugifiedId}`}
+                role="link"
+              />
+              {toggle}
             </Row>
           </Box>
         </Heading>

--- a/docs/src/components/createHydra.js
+++ b/docs/src/components/createHydra.js
@@ -1,0 +1,101 @@
+// @flow strict
+
+/* As we further embrace React contexts over alternatives like Redux or props drilling, the "hydra" pattern becomes more useful.
+Since all of our hydras tend to follow the same boilerplate setup, createHydra abstracts the setup.
+
+`createHydra` is a generic function that returns a context provider and consumers
+in the form of render props, hooks.
+
+To create a hydra, you must specify a non-optional object type that represents the context value
+and pass a prop name as a function parameter with the format `____Context` (e.g. requestContext).
+
+Example usage:
+
+export type TrackingParametersContextType = {| foo: number |};
+
+const {
+  Provider: TrackingParametersContextProvider,
+  Consumer: TrackingParametersContextConsumer,
+  useHook: useTrackingParametersContext,
+} = createHydra<TrackingParametersContextType>();
+
+export {
+  TrackingParametersContextProvider,
+  TrackingParametersContextConsumer,
+  useTrackingParametersContext,
+ };
+
+Related articles:
+
+https://americanexpress.io/hydra/
+https://kentcdodds.com/blog/how-to-use-react-context-effectively */
+
+import { createContext, useContext, type Context, type Node } from 'react';
+
+export type Hydra<ContextType> = {|
+  Provider: $PropertyType<Context<ContextType | void>, 'Provider'>,
+  Consumer: ({| children: (ContextType) => Node |}) => Node,
+  useHook: () => ContextType,
+|};
+
+function formatDisplayName(
+  displayName: string,
+  subjectDisplayName?: string
+): { [string]: string, ... } {
+  let slicedDisplayName = displayName.slice(1);
+  slicedDisplayName = slicedDisplayName.endsWith('Context')
+    ? slicedDisplayName
+    : `${slicedDisplayName}Context`;
+
+  if (subjectDisplayName) {
+    const hocDisplayName = `with${displayName[0].toUpperCase()}${slicedDisplayName}(${subjectDisplayName})`;
+    return { hocDisplayName };
+  }
+
+  const propsDisplayName = `${displayName[0].toLowerCase()}${slicedDisplayName}`;
+  const messageDisplayName = `${displayName[0].toUpperCase()}${slicedDisplayName}`;
+
+  return { propsDisplayName, messageDisplayName };
+}
+
+export default function createHydra<ContextType>(
+  displayName: string,
+  defaultValue?: ContextType
+): Hydra<ContextType> {
+  const context = createContext<ContextType | void>(defaultValue);
+  const { messageDisplayName } = formatDisplayName(displayName);
+  context.displayName = messageDisplayName;
+
+  // Provider:
+  const { Provider } = context;
+
+  // Consumer: Render Prop
+  const Consumer = ({ children }: { children: (ContextType) => Node, ... }) => {
+    const contextValue = useContext(context);
+
+    if (contextValue === undefined) {
+      throw new Error(
+        `${messageDisplayName}Consumer must be used within a ${messageDisplayName}Provider.`
+      );
+    }
+    return children(contextValue);
+  };
+
+  // Consumer: Hook
+  function useHook(): ContextType {
+    const contextValue = useContext(context);
+
+    if (contextValue === undefined) {
+      throw new Error(
+        `use${messageDisplayName} must be used within a ${messageDisplayName}Provider.`
+      );
+    }
+
+    return contextValue;
+  }
+
+  Provider.displayName = `${messageDisplayName}Provider`;
+  Consumer.displayName = `${messageDisplayName}Consumer`;
+
+  return { Provider, Consumer, useHook };
+}

--- a/docs/src/components/propTableContext.js
+++ b/docs/src/components/propTableContext.js
@@ -1,0 +1,40 @@
+// @flow strict
+import React, { type Node } from 'react';
+import createHydra, { type Hydra } from './createHydra.js';
+import useLocalStorage from './useLocalStorage.js';
+
+const propTableVariantKey = 'gestalt-propTable-variant';
+
+type PropTableVariant = 'collapsed' | 'expanded';
+export type PropTableContextType = {|
+  propTableVariant: PropTableVariant,
+  setPropTableVariant: (val: PropTableVariant) => void,
+|};
+
+const hydra: Hydra<PropTableContextType> = createHydra<PropTableContextType>(
+  'PropTable'
+);
+
+const {
+  Provider: ContextProvider,
+  Consumer: PropTableContextConsumer,
+  useHook: usePropTableContext,
+} = hydra;
+
+function PropTableContextProvider({ children }: {| children?: Node |}): Node {
+  const [propTableVariant, setPropTableVariant] = useLocalStorage<
+    'expanded' | 'collapsed'
+  >(propTableVariantKey, 'expanded');
+
+  return (
+    <ContextProvider value={{ propTableVariant, setPropTableVariant }}>
+      {children}
+    </ContextProvider>
+  );
+}
+
+export {
+  PropTableContextProvider,
+  PropTableContextConsumer,
+  usePropTableContext,
+};


### PR DESCRIPTION
1/3rd of the survey responses mentioned they wanted to see `Prop` back on the top of the docs. In order to also make this work for designers, we added a collapsible feature:

![props-demo-4](https://user-images.githubusercontent.com/127199/98152553-c5ec9800-1e86-11eb-84e6-68924596606a.gif)

The state whether to collapse props is saved in local storage so it's maintained across page navigation and refreshes.

## Test Plan

1. Go to `/Icon`
2. Click the toggle button to collapse the props
3. Props should collapse