### PR TITLE
Docs: Update Upsell.doc.js with better examples

### DIFF
--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -88,9 +88,9 @@ card(
     name="Call to Actions and Title"
     defaultCode={`
 <Upsell
-  title="Download the Pinterest marketing app on Shopify"
-  message="Seamlessly add your products to Pinterest, promote them and track the results"
-  primaryLink={{href: "https://pinterest.com", label:"Install now"}}
+  title="Join the Verified Merchant Program"
+  message="Apply to the Verified Merchant Program—it’s free"
+  primaryLink={{href: "https://pinterest.com", label:"Apply now"}}
   secondaryLink={{href: "https://pinterest.com", label:"Learn more"}}
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',


### PR DESCRIPTION
Updating the example for the title and message upsell so we don't hit the first breakpoint in the docs. Design will be confused at the buttons being on the 2nd line.
