### PR TITLE
Modal: add padding to container and margin top to children container

### DIFF
--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -40,7 +40,7 @@ function Header({ heading }: {| heading: string | Node |}) {
   }
 
   return (
-    <Heading size="md" accessibilityLevel={1}>
+    <Heading size="sm" accessibilityLevel={1}>
       {heading}
     </Heading>
   );
@@ -136,14 +136,20 @@ const ModalWithForwardRef: React$AbstractComponent<
                 position="relative"
                 display="flex"
                 direction="column"
-                width="100%"              >
+                width="100%"
+              >
                 {heading && (
                   <div
                     className={classnames(modalStyles.shadowContainer, {
                       [modalStyles.shadow]: showTopShadow,
                     })}
                   >
-                    <Box display="flex" justifyContent="center" paddingX={4} paddingY={6}>
+                    <Box
+                      display="flex"
+                      justifyContent="center"
+                      paddingX={4}
+                      paddingY={6}
+                    >
                       <Header heading={heading} />
                     </Box>
                   </div>

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -136,16 +136,14 @@ const ModalWithForwardRef: React$AbstractComponent<
                 position="relative"
                 display="flex"
                 direction="column"
-                width="100%"
-                paddingX={4}
-              >
+                width="100%"              >
                 {heading && (
                   <div
                     className={classnames(modalStyles.shadowContainer, {
                       [modalStyles.shadow]: showTopShadow,
                     })}
                   >
-                    <Box display="flex" justifyContent="center" paddingY={6}>
+                    <Box display="flex" justifyContent="center" paddingX={4} paddingY={6}>
                       <Header heading={heading} />
                     </Box>
                   </div>
@@ -156,6 +154,7 @@ const ModalWithForwardRef: React$AbstractComponent<
                   onScroll={updateShadows}
                   ref={content}
                   marginTop={4}
+                  paddingX={4}
                 >
                   {children}
                 </Box>
@@ -165,7 +164,7 @@ const ModalWithForwardRef: React$AbstractComponent<
                       [modalStyles.shadow]: showBottomShadow,
                     })}
                   >
-                    <Box paddingY={4}>{footer}</Box>
+                    <Box padding={4}>{footer}</Box>
                   </div>
                 )}
               </Box>

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -40,7 +40,7 @@ function Header({ heading }: {| heading: string | Node |}) {
   }
 
   return (
-    <Heading size="sm" accessibilityLevel={1}>
+    <Heading size="md" accessibilityLevel={1}>
       {heading}
     </Heading>
   );

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -40,11 +40,9 @@ function Header({ heading }: {| heading: string | Node |}) {
   }
 
   return (
-    <Box display="flex" justifyContent="center" padding={8}>
-      <Heading size="md" accessibilityLevel={1}>
-        {heading}
-      </Heading>
-    </Box>
+    <Heading size="md" accessibilityLevel={1}>
+      {heading}
+    </Heading>
   );
 }
 
@@ -139,6 +137,7 @@ const ModalWithForwardRef: React$AbstractComponent<
                 display="flex"
                 direction="column"
                 width="100%"
+                paddingX={4}
               >
                 {heading && (
                   <div
@@ -146,7 +145,9 @@ const ModalWithForwardRef: React$AbstractComponent<
                       [modalStyles.shadow]: showTopShadow,
                     })}
                   >
-                    <Header heading={heading} />
+                    <Box display="flex" justifyContent="center" paddingY={6}>
+                      <Header heading={heading} />
+                    </Box>
                   </div>
                 )}
                 <Box
@@ -154,6 +155,7 @@ const ModalWithForwardRef: React$AbstractComponent<
                   overflow="auto"
                   onScroll={updateShadows}
                   ref={content}
+                  marginTop={4}
                 >
                   {children}
                 </Box>
@@ -163,7 +165,7 @@ const ModalWithForwardRef: React$AbstractComponent<
                       [modalStyles.shadow]: showBottomShadow,
                     })}
                   >
-                    <Box padding={8}>{footer}</Box>
+                    <Box paddingY={4}>{footer}</Box>
                   </div>
                 )}
               </Box>

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -159,8 +159,8 @@ const ModalWithForwardRef: React$AbstractComponent<
                   overflow="auto"
                   onScroll={updateShadows}
                   ref={content}
-                  marginTop={4}
-                  paddingX={4}
+                  paddingX={8}
+                  paddingY={4}
                 >
                   {children}
                 </Box>

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -91,7 +91,7 @@ Internal components <Header> and <DismissButton>
 */
 const Header = ({ heading }: {| heading: string |}) => (
   <Box display="flex" justifyContent="start">
-    <Heading size="sm" accessibilityLevel={1}>
+    <Heading size="md" accessibilityLevel={1}>
       {heading}
     </Heading>
   </Box>

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -273,8 +273,8 @@ const SheetWithForwardRef: React$AbstractComponent<
                   flex="grow"
                   overflow="auto"
                   onScroll={updateShadows}
-                  paddingX={4}
-                  marginTop={4}
+                  paddingX={8}
+                  paddingY={4}
                   ref={contentRef}
                 >
                   {children}

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -90,8 +90,8 @@ Internal components <Header> and <DismissButton>
 
 */
 const Header = ({ heading }: {| heading: string |}) => (
-  <Box display="flex" justifyContent="start" padding={8}>
-    <Heading size="md" accessibilityLevel={1}>
+  <Box display="flex" justifyContent="start">
+    <Heading size="sm" accessibilityLevel={1}>
       {heading}
     </Heading>
   </Box>
@@ -230,10 +230,10 @@ const SheetWithForwardRef: React$AbstractComponent<
                       flex="grow"
                       justifyContent="between"
                     >
-                      <Box flex="grow">
+                      <Box flex="grow" paddingX={4} paddingY={6}>
                         <Header heading={heading} />
                       </Box>
-                      <Box flex="none" paddingX={6} paddingY={7}>
+                      <Box flex="none" paddingX={4} paddingY={6}>
                         <DismissButton
                           accessibilityDismissButtonLabel={
                             accessibilityDismissButtonLabel
@@ -242,7 +242,9 @@ const SheetWithForwardRef: React$AbstractComponent<
                         />
                       </Box>
                     </Flex>
-                    {subHeading}
+                    <Box flex="grow" paddingX={4} marginBottom={4}>
+                      {subHeading}
+                    </Box>
                   </div>
                 )}
                 {!heading && (
@@ -271,7 +273,8 @@ const SheetWithForwardRef: React$AbstractComponent<
                   flex="grow"
                   overflow="auto"
                   onScroll={updateShadows}
-                  padding={8}
+                  paddingX={4}
+                  marginTop={4}
                   ref={contentRef}
                 >
                   {children}
@@ -282,7 +285,7 @@ const SheetWithForwardRef: React$AbstractComponent<
                       [sheetStyles.shadow]: showBottomShadow,
                     })}
                   >
-                    <Box padding={8}>{footer}</Box>
+                    <Box padding={4}>{footer}</Box>
                   </div>
                 )}
               </Box>

--- a/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
@@ -22,11 +22,11 @@ Object {
             tabindex="-1"
           >
             <div
-              class="box flexGrow relative xsDirectionColumn xsDisplayFlex"
+              class="box flexGrow paddingX4 relative xsDirectionColumn xsDisplayFlex"
               style="width: 100%;"
             >
               <div
-                class="box flexGrow overflowAuto"
+                class="box flexGrow marginTop4 overflowAuto"
               >
                 Modal content
               </div>
@@ -52,11 +52,11 @@ Object {
           tabindex="-1"
         >
           <div
-            class="box flexGrow relative xsDirectionColumn xsDisplayFlex"
+            class="box flexGrow paddingX4 relative xsDirectionColumn xsDisplayFlex"
             style="width: 100%;"
           >
             <div
-              class="box flexGrow overflowAuto"
+              class="box flexGrow marginTop4 overflowAuto"
             >
               Modal content
             </div>

--- a/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
@@ -22,11 +22,11 @@ Object {
             tabindex="-1"
           >
             <div
-              class="box flexGrow paddingX4 relative xsDirectionColumn xsDisplayFlex"
+              class="box flexGrow relative xsDirectionColumn xsDisplayFlex"
               style="width: 100%;"
             >
               <div
-                class="box flexGrow marginTop4 overflowAuto"
+                class="box flexGrow marginTop4 overflowAuto paddingX4"
               >
                 Modal content
               </div>
@@ -52,11 +52,11 @@ Object {
           tabindex="-1"
         >
           <div
-            class="box flexGrow paddingX4 relative xsDirectionColumn xsDisplayFlex"
+            class="box flexGrow relative xsDirectionColumn xsDisplayFlex"
             style="width: 100%;"
           >
             <div
-              class="box flexGrow marginTop4 overflowAuto"
+              class="box flexGrow marginTop4 overflowAuto paddingX4"
             >
               Modal content
             </div>

--- a/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
@@ -26,7 +26,7 @@ Object {
               style="width: 100%;"
             >
               <div
-                class="box flexGrow marginTop4 overflowAuto paddingX4"
+                class="box flexGrow overflowAuto paddingX8 paddingY4"
               >
                 Modal content
               </div>
@@ -56,7 +56,7 @@ Object {
             style="width: 100%;"
           >
             <div
-              class="box flexGrow marginTop4 overflowAuto paddingX4"
+              class="box flexGrow overflowAuto paddingX8 paddingY4"
             >
               Modal content
             </div>

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -33,7 +33,7 @@ exports[`Sheet should render all props with nodes 1`] = `
                   class="box xsDisplayFlex"
                 >
                   <h1
-                    class="Heading fontSize1 darkGray alignLeft breakWord"
+                    class="Heading fontSize2 darkGray alignLeft breakWord"
                   >
                     Sheet title
                   </h1>
@@ -129,7 +129,7 @@ exports[`Sheet should render all props with render props 1`] = `
                   class="box xsDisplayFlex"
                 >
                   <h1
-                    class="Heading fontSize1 darkGray alignLeft breakWord"
+                    class="Heading fontSize2 darkGray alignLeft breakWord"
                   >
                     Sheet title
                   </h1>

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -76,7 +76,7 @@ exports[`Sheet should render all props with nodes 1`] = `
             </div>
           </div>
           <div
-            class="box flexGrow marginTop4 overflowAuto paddingX4"
+            class="box flexGrow overflowAuto paddingX8 paddingY4"
           >
             <section />
           </div>
@@ -174,7 +174,7 @@ exports[`Sheet should render all props with render props 1`] = `
             </div>
           </div>
           <div
-            class="box flexGrow marginTop4 overflowAuto paddingX4"
+            class="box flexGrow overflowAuto paddingX8 paddingY4"
           >
             <button
               type="submit"
@@ -252,7 +252,7 @@ exports[`Sheet should render animation in 1`] = `
             </div>
           </div>
           <div
-            class="box flexGrow marginTop4 overflowAuto paddingX4"
+            class="box flexGrow overflowAuto paddingX8 paddingY4"
           >
             <section />
           </div>
@@ -317,7 +317,7 @@ exports[`Sheet should render animation out 1`] = `
             </div>
           </div>
           <div
-            class="box flexGrow marginTop4 overflowAuto paddingX4"
+            class="box flexGrow overflowAuto paddingX8 paddingY4"
           >
             <section />
           </div>

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -27,20 +27,20 @@ exports[`Sheet should render all props with nodes 1`] = `
               class="Flex rowGap0 flexGrow itemsCenter justifyBetween xsDirectionRow"
             >
               <div
-                class="box flexGrow"
+                class="box flexGrow paddingX4 paddingY6"
               >
                 <div
-                  class="box paddingX8 paddingY8 xsDisplayFlex"
+                  class="box xsDisplayFlex"
                 >
                   <h1
-                    class="Heading fontSize2 darkGray alignLeft breakWord"
+                    class="Heading fontSize1 darkGray alignLeft breakWord"
                   >
                     Sheet title
                   </h1>
                 </div>
               </div>
               <div
-                class="box flexNone paddingX6 paddingY7"
+                class="box flexNone paddingX4 paddingY6"
               >
                 <button
                   aria-label="Dismiss"
@@ -69,10 +69,14 @@ exports[`Sheet should render all props with nodes 1`] = `
                 </button>
               </div>
             </div>
-            <nav />
+            <div
+              class="box flexGrow marginBottom4 paddingX4"
+            >
+              <nav />
+            </div>
           </div>
           <div
-            class="box flexGrow overflowAuto paddingX8 paddingY8"
+            class="box flexGrow marginTop4 overflowAuto paddingX4"
           >
             <section />
           </div>
@@ -80,7 +84,7 @@ exports[`Sheet should render all props with nodes 1`] = `
             class="shadowContainer"
           >
             <div
-              class="box paddingX8 paddingY8"
+              class="box paddingX4 paddingY4"
             >
               <footer />
             </div>
@@ -119,20 +123,20 @@ exports[`Sheet should render all props with render props 1`] = `
               class="Flex rowGap0 flexGrow itemsCenter justifyBetween xsDirectionRow"
             >
               <div
-                class="box flexGrow"
+                class="box flexGrow paddingX4 paddingY6"
               >
                 <div
-                  class="box paddingX8 paddingY8 xsDisplayFlex"
+                  class="box xsDisplayFlex"
                 >
                   <h1
-                    class="Heading fontSize2 darkGray alignLeft breakWord"
+                    class="Heading fontSize1 darkGray alignLeft breakWord"
                   >
                     Sheet title
                   </h1>
                 </div>
               </div>
               <div
-                class="box flexNone paddingX6 paddingY7"
+                class="box flexNone paddingX4 paddingY6"
               >
                 <button
                   aria-label="Dismiss"
@@ -161,12 +165,16 @@ exports[`Sheet should render all props with render props 1`] = `
                 </button>
               </div>
             </div>
-            <button
-              type="submit"
-            />
+            <div
+              class="box flexGrow marginBottom4 paddingX4"
+            >
+              <button
+                type="submit"
+              />
+            </div>
           </div>
           <div
-            class="box flexGrow overflowAuto paddingX8 paddingY8"
+            class="box flexGrow marginTop4 overflowAuto paddingX4"
           >
             <button
               type="submit"
@@ -176,7 +184,7 @@ exports[`Sheet should render all props with render props 1`] = `
             class="shadowContainer"
           >
             <div
-              class="box paddingX8 paddingY8"
+              class="box paddingX4 paddingY4"
             >
               <button
                 type="submit"
@@ -244,7 +252,7 @@ exports[`Sheet should render animation in 1`] = `
             </div>
           </div>
           <div
-            class="box flexGrow overflowAuto paddingX8 paddingY8"
+            class="box flexGrow marginTop4 overflowAuto paddingX4"
           >
             <section />
           </div>
@@ -309,7 +317,7 @@ exports[`Sheet should render animation out 1`] = `
             </div>
           </div>
           <div
-            class="box flexGrow overflowAuto paddingX8 paddingY8"
+            class="box flexGrow marginTop4 overflowAuto paddingX4"
           >
             <section />
           </div>


### PR DESCRIPTION
# Modal spacing update

- Add 16px padding to container (x axis)
- Add 24px padding to Header container (y axis)
- Add 16px margin top to children container 
- Add 16px padding to footer container (y axis)

Proposed:
![image](https://user-images.githubusercontent.com/10033075/98745653-b8597580-2392-11eb-8d22-8e963cc78256.png)

Implemented:
![image](https://user-images.githubusercontent.com/10033075/98856875-fdd27d00-243c-11eb-9347-b366a12b4aba.png)
![image](https://user-images.githubusercontent.com/10033075/98856890-0460f480-243d-11eb-9787-169068ba6a7c.png)



On smaller windows: 
![image](https://user-images.githubusercontent.com/10033075/98856910-0a56d580-243d-11eb-9e7e-d0f96cac89ef.png)

Sheet: 
![image](https://user-images.githubusercontent.com/10033075/98856927-12167a00-243d-11eb-8b95-a929ae832437.png)




## Test Plan

Manual run
