### PR TITLE
Docs: unify quotes in the proptable

### DIFF
--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -19,7 +19,11 @@ type Props = {|
   id?: string,
 |};
 
-const buildDescription = (lines: Array<string>): Node => (
+const unifyQuotes = (input) => {
+  return input?.replace(/'/g, '"');
+};
+
+const Description = (lines: Array<string>): Node => (
   <Flex alignItems="start" direction="column" gap={2}>
     {lines.map((line, idx) => (
       <Text key={idx} color="gray">
@@ -207,7 +211,7 @@ export default function PropTable({
                           )}
                         </Td>
                         <Td border={!description}>
-                          <code>{type}</code>
+                          <code>{unifyQuotes(type)}</code>
                         </Td>
                         <Td
                           shrink
@@ -228,7 +232,7 @@ export default function PropTable({
                           <Td colspan={hasRequired ? 2 : 1} />
                           <Td colspan={2} color="gray">
                             {Array.isArray(description)
-                              ? buildDescription(description)
+                              ? Description(description)
                               : description}
                           </Td>
                         </tr>


### PR DESCRIPTION
We currently have a combination of single quotes and double quotes in the proptable.

### Before
![Screen Shot 2020-11-19 at 11 18 58 AM](https://user-images.githubusercontent.com/127199/99713365-10f6d580-2a59-11eb-8008-6c695f89dbd5.png)
https://gestalt.netlify.app/Toast

### After
![Screen Shot 2020-11-19 at 11 18 44 AM](https://user-images.githubusercontent.com/127199/99713368-118f6c00-2a59-11eb-883d-67d50a264126.png)
https://deploy-preview-1292--gestalt.netlify.app/Toast