### PR TITLE
Internal: Give Flex and FlexItem display names for debugging

### DIFF
--- a/packages/gestalt/src/Flex.js
+++ b/packages/gestalt/src/Flex.js
@@ -103,6 +103,8 @@ export default function Flex({
 
 Flex.Item = FlexItem;
 
+Flex.displayName = 'Flex';
+
 Flex.propTypes = {
   alignContent: AlignContentPropType,
   alignItems: AlignItemsPropType,

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -28,6 +28,8 @@ export default function FlexItem(props: Props): Node {
   return <div {...passthroughProps} {...propsStyles} />;
 }
 
+FlexItem.displayName = 'Flex.Item';
+
 FlexItem.propTypes = {
   alignSelf: AlignSelfPropType,
   children: PropTypes.node.isRequired,


### PR DESCRIPTION
Update to give display names to Flex and FlexItem to help debug react components 

Before:

<img width="614" alt="Screen Shot 2020-12-01 at 3 51 47 PM" src="https://user-images.githubusercontent.com/5125094/100810375-3981b680-33ed-11eb-8065-f45859fe69de.png">


After:
<img width="1194" alt="Screen Shot 2020-12-01 at 3 51 30 PM" src="https://user-images.githubusercontent.com/5125094/100810372-3686c600-33ed-11eb-86c7-a06291bc7f4c.png">
## Test Plan


