### PR TITLE
Upsell: Add image prop

### DIFF
--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -133,7 +133,7 @@ card(
     defaultCode={`
 <Upsell
   title="Give $30, get $60 in ads credit"
-  message="When your friend spends their first $30 on ads, you’ll earn $60 of ads credit, and they’ll get $30 of ads credit, too"
+  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
   primaryLink={{href: "https://pinterest.com", label:"Send invite"}}
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',
@@ -153,7 +153,7 @@ card(
     defaultCode={`
 <Upsell
   title="Stay healthy and safe"
-  message="Please practice social distancing, and check out our resources for adapting to these times."
+  message="Check out our resources for adapting to these times."
   primaryLink={{href: "https://pinterest.com", label:"Visit"}}
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',
@@ -162,7 +162,7 @@ card(
   imageData={{
       component: 
         <Image
-          alt="Please practice social distancing, and check out our resources for adapting to these times."
+          alt="Check out our resources for adapting to these times."
           color="rgb(231, 186, 176)"
           naturalHeight={751}
           naturalWidth={564}

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -40,14 +40,14 @@ card(
         href: '',
       },
       {
-        name: 'image',
-        type: 'React.Node',
+        name: 'imageData',
+        type: '{| component: typeof Image | typeof Icon, width?: number, |}',
         required: false,
         defaultValue: null,
         description: [
-          'React node to render on left side of banner. Max width is 128 px.',
+          'Either <Image /> or <Icon /> to render on left side of banner. Width is not used with Icon. Image width defaults to 128 px. Max width of image is 128 px.',
         ],
-        href: '',
+        href: 'Image',
       },
       {
         name: 'primaryLink',
@@ -138,7 +138,9 @@ card(
     accessibilityLabel: 'Dismiss banner',
     onDismiss: ()=>{},
   }}
-  image={<Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32}/>}
+  imageData={{
+    component: <Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32}/>
+  }}
 />
 `}
   />
@@ -156,15 +158,17 @@ card(
     accessibilityLabel: 'Dismiss banner',
     onDismiss: ()=>{},
   }}
-  image={
-      <Image
-        alt="Please practice social distancing, and check out our resources for adapting to these times."
-        color="rgb(231, 186, 176)"
-        naturalHeight={751}
-        naturalWidth={564}
-        src="https://i.ibb.co/7bQQYkX/stock2.jpg"
-      />
-    }
+  imageData={{
+      component: 
+        <Image
+          alt="Please practice social distancing, and check out our resources for adapting to these times."
+          color="rgb(231, 186, 176)"
+          naturalHeight={751}
+          naturalWidth={564}
+          src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+        />,
+      width: 128,
+    }}
 />
 `}
   />

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -41,7 +41,8 @@ card(
       },
       {
         name: 'imageData',
-        type: '{| component: typeof Image | typeof Icon, width?: number, |}',
+        type:
+          '{| component: typeof Image | typeof Icon, width?: number, mask: { rounding: "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8, wash: boolean} |}',
         required: false,
         defaultValue: null,
         description: [
@@ -167,6 +168,7 @@ card(
           naturalWidth={564}
           src="https://i.ibb.co/7bQQYkX/stock2.jpg"
         />,
+        mask: {rounding: 4},
       width: 128,
     }}
 />

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -40,6 +40,16 @@ card(
         href: '',
       },
       {
+        name: 'image',
+        type: 'React.Node',
+        required: false,
+        defaultValue: null,
+        description: [
+          'React node to render on left side of banner. Max width is 128 px.',
+        ],
+        href: '',
+      },
+      {
         name: 'primaryLink',
         type:
           '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
@@ -113,6 +123,55 @@ card(
   }}
 />
   `}
+  />
+);
+
+card(
+  <Example
+    name="Icon"
+    defaultCode={`
+<Upsell
+  title="Give $30, get $60 in ads credit"
+  message="When your friend spends their first $30 on ads, you’ll earn $60 of ads credit, and they’ll get $30 of ads credit, too"
+  primaryLink={{href: "https://pinterest.com", label:"Send invite"}}
+  dismissButton={{
+    accessibilityLabel: 'Dismiss banner',
+    onDismiss: ()=>{},
+  }}
+  image={<Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32}/>}
+/>
+`}
+  />
+);
+
+card(
+  <Example
+    name="Image"
+    defaultCode={`
+<Upsell
+  title="Stay healthy and safe"
+  message="Please practice social distancing, and check out our resources for adapting to these times."
+  primaryLink={{href: "https://pinterest.com", label:"Visit"}}
+  dismissButton={{
+    accessibilityLabel: 'Dismiss banner',
+    onDismiss: ()=>{},
+  }}
+  image={
+    <Box
+      width={128}
+      height={128}
+    >
+      <Image
+        alt="Please practice social distancing, and check out our resources for adapting to these times."
+        color="rgb(231, 186, 176)"
+        naturalHeight={751}
+        naturalWidth={564}
+        src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+      />
+    </Box>
+  }
+/>
+`}
   />
 );
 

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -157,10 +157,6 @@ card(
     onDismiss: ()=>{},
   }}
   image={
-    <Box
-      width={128}
-      height={128}
-    >
       <Image
         alt="Please practice social distancing, and check out our resources for adapting to these times."
         color="rgb(231, 186, 176)"
@@ -168,8 +164,7 @@ card(
         naturalWidth={564}
         src="https://i.ibb.co/7bQQYkX/stock2.jpg"
       />
-    </Box>
-  }
+    }
 />
 `}
   />

--- a/packages/gestalt/src/Upsell.flowtest.js
+++ b/packages/gestalt/src/Upsell.flowtest.js
@@ -1,11 +1,23 @@
 // @flow strict
 import React from 'react';
 import Upsell from './Upsell.js';
+import Icon from './Icon.js';
+import Box from './Box.js';
 
-const Valid = <Upsell message="Upsell message" />;
+const Valid = (
+  <Upsell
+    message="Upsell message"
+    imageData={{ component: <Icon accessibilityLabel="test" /> }}
+  />
+);
 
 // $FlowExpectedError[prop-missing]
 const NonExistingProp = <Upsell nonexisting={33} />;
 
 // $FlowExpectedError[prop-missing]
 const MissingProp = <Upsell />;
+
+const InvalidImage = (
+  // $FlowExpectedError[incompatible-type]
+  <Upsell message="Upsell message" imageData={{ component: <Box /> }} />
+);

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
 import Heading from './Heading.js';
+import Icon from './Icon.js';
 import IconButton from './IconButton.js';
+import Image from './Image.js';
 import Button from './Button.js';
 import Text from './Text.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
@@ -27,7 +29,10 @@ type Props = {|
     accessibilityLabel: string,
     onDismiss: () => void,
   |},
-  image?: Node,
+  imageData?: {|
+    component: typeof Image | typeof Icon,
+    width?: number,
+  |},
   message: string,
   primaryLink?: LinkData,
   secondaryLink?: LinkData,
@@ -72,12 +77,14 @@ const UpsellLink = ({
 
 export default function Upsell({
   dismissButton,
-  image,
+  imageData,
   message,
   primaryLink,
   secondaryLink,
   title,
 }: Props): Node {
+  const isImage = imageData && imageData.component.type === Image;
+
   return (
     <Box
       display="flex"
@@ -106,12 +113,16 @@ export default function Upsell({
           smMarginBottom={primaryLink || secondaryLink ? 0 : undefined}
           smPaddingY={3}
         >
-          {image && (
-            <Box maxWidth={128} column={3}>
-              {image}
+          {imageData && (
+            <Box
+              marginBottom={4}
+              smMarginBottom={0}
+              width={isImage ? Math.min(imageData.width, 128) : undefined}
+            >
+              {imageData.component}
             </Box>
           )}
-          <Box maxWidth={648} column={image ? 9 : 12}>
+          <Box maxWidth={648}>
             <Box
               display="flex"
               smDisplay="block"
@@ -119,15 +130,32 @@ export default function Upsell({
               alignItems="center"
               marginBottom="auto"
               marginTop="auto"
-              marginEnd={6}
-              marginStart={image ? 6 : 0}
+              marginEnd={0}
+              marginStart={0}
+              smMarginEnd={6}
+              smMarginStart={imageData ? 6 : 0}
             >
-              {title && (
-                <Box marginBottom={2}>
-                  <Heading size="sm">{title}</Heading>
-                </Box>
-              )}
-              <Text>{message}</Text>
+              {/* We repeat this code block to ensure that text is 
+              centered for our smaller displays and left aligned 
+              for larger displays */}
+              <Box smDisplay="none">
+                {title && (
+                  <Box marginBottom={2}>
+                    <Heading align="center" size="sm">
+                      {title}
+                    </Heading>
+                  </Box>
+                )}
+                <Text align="center">{message}</Text>
+              </Box>
+              <Box smDisplay="block" display="none">
+                {title && (
+                  <Box marginBottom={2}>
+                    <Heading size="sm">{title}</Heading>
+                  </Box>
+                )}
+                <Text>{message}</Text>
+              </Box>
             </Box>
           </Box>
         </Box>
@@ -166,7 +194,10 @@ Upsell.propTypes = {
     accessibilityLabel: PropTypes.string.isRequired,
     onDismiss: PropTypes.func.isRequired,
   }),
-  image: PropTypes.node,
+  imageData: PropTypes.exact({
+    component: PropTypes.node.isRequired,
+    width: PropTypes.number,
+  }),
   message: PropTypes.string.isRequired,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   primaryLink: PropTypes.shape({

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { type Element, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -30,7 +30,7 @@ type Props = {|
     onDismiss: () => void,
   |},
   imageData?: {|
-    component: typeof Image | typeof Icon,
+    component: Element<typeof Image | typeof Icon>,
     width?: number,
   |},
   message: string,
@@ -83,7 +83,7 @@ export default function Upsell({
   secondaryLink,
   title,
 }: Props): Node {
-  const isImage = imageData && imageData.component.type === Image;
+  const isImage = imageData?.component && imageData.component.type === Image;
 
   return (
     <Box
@@ -117,7 +117,10 @@ export default function Upsell({
             <Box
               marginBottom={4}
               smMarginBottom={0}
-              width={isImage ? Math.min(imageData.width, 128) : undefined}
+              width={
+                isImage ? Math.min(imageData.width || 128, 128) : undefined
+              }
+              flex="none"
             >
               {imageData.component}
             </Box>
@@ -190,11 +193,12 @@ export default function Upsell({
 
 Upsell.propTypes = {
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  dismissButton: PropTypes.exact({
+  dismissButton: PropTypes.shape({
     accessibilityLabel: PropTypes.string.isRequired,
     onDismiss: PropTypes.func.isRequired,
   }),
-  imageData: PropTypes.exact({
+  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
+  imageData: PropTypes.shape({
     component: PropTypes.node.isRequired,
     width: PropTypes.number,
   }),

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -27,6 +27,7 @@ type Props = {|
     accessibilityLabel: string,
     onDismiss: () => void,
   |},
+  image?: Node,
   message: string,
   primaryLink?: LinkData,
   secondaryLink?: LinkData,
@@ -70,6 +71,7 @@ const UpsellLink = ({
 
 export default function Upsell({
   dismissButton,
+  image,
   message,
   primaryLink,
   secondaryLink,
@@ -99,11 +101,23 @@ export default function Upsell({
           mdMarginBottom={primaryLink || secondaryLink ? 0 : undefined}
           mdPaddingY={3}
         >
+          {image && (
+            <Box
+              marginBottom={0}
+              marginTop={0}
+              mdMarginBottom="auto"
+              mdMarginTop="auto"
+              maxWidth={128}
+            >
+              {image}
+            </Box>
+          )}
           <Box
             marginBottom="auto"
             marginTop="auto"
             maxWidth={648}
             marginEnd={6}
+            marginStart={image ? 6 : 0}
           >
             {title && (
               <Box marginBottom={2}>
@@ -149,6 +163,7 @@ Upsell.propTypes = {
     accessibilityLabel: PropTypes.string.isRequired,
     onDismiss: PropTypes.func.isRequired,
   }),
+  image: PropTypes.node,
   message: PropTypes.string.isRequired,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   primaryLink: PropTypes.shape({

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -3,11 +3,12 @@ import React, { type Element, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
+import Button from './Button.js';
 import Heading from './Heading.js';
 import Icon from './Icon.js';
 import IconButton from './IconButton.js';
 import Image from './Image.js';
-import Button from './Button.js';
+import Mask from './Mask.js';
 import Text from './Text.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './Upsell.css';
@@ -31,6 +32,10 @@ type Props = {|
   |},
   imageData?: {|
     component: Element<typeof Image | typeof Icon>,
+    mask?: {|
+      rounding?: 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8,
+      wash?: boolean,
+    |},
     width?: number,
   |},
   message: string,
@@ -122,7 +127,12 @@ export default function Upsell({
               }
               flex="none"
             >
-              {imageData.component}
+              <Mask
+                rounding={imageData.mask?.rounding || 0}
+                wash={imageData.mask?.wash || false}
+              >
+                {imageData.component}
+              </Mask>
             </Box>
           )}
           <Box maxWidth={648}>
@@ -200,6 +210,10 @@ Upsell.propTypes = {
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   imageData: PropTypes.shape({
     component: PropTypes.node.isRequired,
+    mask: PropTypes.shape({
+      rounding: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 'circle']),
+      wash: PropTypes.bool,
+    }),
     width: PropTypes.number,
   }),
   message: PropTypes.string.isRequired,

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -48,13 +48,14 @@ const UpsellLink = ({
 
   return (
     <Box
-      display="flex"
+      display="block"
+      smDisplay="flex"
       alignItems="center"
       justifyContent="center"
       paddingX={1}
       marginTop={type === 'primary' && stacked ? 2 : undefined}
-      mdMarginTop="auto"
-      mdMarginBottom="auto"
+      smMarginTop="auto"
+      smMarginBottom="auto"
     >
       <Button
         accessibilityLabel={accessibilityLabel}
@@ -81,53 +82,56 @@ export default function Upsell({
     <Box
       display="flex"
       direction="column"
-      mdDirection="row"
+      smDirection="row"
       padding={6}
-      mdPadding={8}
+      smPadding={8}
       position="relative"
       rounding={4}
       borderStyle="shadow"
     >
       <Box
-        mdDisplay="flex"
+        smDisplay="flex"
         wrap
         width="100%"
-        mdMarginTop={-3}
-        mdMarginBottom={-3}
+        smMarginTop={-3}
+        smMarginBottom={-3}
       >
         <Box
           display="flex"
+          direction="column"
+          smDirection="row"
+          justifyContent="center"
+          alignItems="center"
           marginBottom={primaryLink || secondaryLink ? 4 : undefined}
-          mdMarginBottom={primaryLink || secondaryLink ? 0 : undefined}
-          mdPaddingY={3}
+          smMarginBottom={primaryLink || secondaryLink ? 0 : undefined}
+          smPaddingY={3}
         >
           {image && (
-            <Box
-              marginBottom={0}
-              marginTop={0}
-              mdMarginBottom="auto"
-              mdMarginTop="auto"
-              maxWidth={128}
-            >
+            <Box maxWidth={128} column={3}>
               {image}
             </Box>
           )}
-          <Box
-            marginBottom="auto"
-            marginTop="auto"
-            maxWidth={648}
-            marginEnd={6}
-            marginStart={image ? 6 : 0}
-          >
-            {title && (
-              <Box marginBottom={2}>
-                <Heading size="sm">{title}</Heading>
-              </Box>
-            )}
-            <Text>{message}</Text>
+          <Box maxWidth={648} column={image ? 9 : 12}>
+            <Box
+              display="flex"
+              smDisplay="block"
+              direction="column"
+              alignItems="center"
+              marginBottom="auto"
+              marginTop="auto"
+              marginEnd={6}
+              marginStart={image ? 6 : 0}
+            >
+              {title && (
+                <Box marginBottom={2}>
+                  <Heading size="sm">{title}</Heading>
+                </Box>
+              )}
+              <Text>{message}</Text>
+            </Box>
           </Box>
         </Box>
-        <Box mdDisplay="flex" marginStart="auto" mdMarginEnd={4} mdPaddingY={3}>
+        <Box smDisplay="flex" marginStart="auto" smMarginEnd={4} smPaddingY={3}>
           {secondaryLink && (
             <UpsellLink type="secondary" data={secondaryLink} />
           )}
@@ -140,7 +144,6 @@ export default function Upsell({
           )}
         </Box>
       </Box>
-
       {dismissButton && (
         <div className={classnames(styles.rtlPos)}>
           <IconButton

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -63,7 +63,7 @@ const UpsellLink = ({
       alignItems="center"
       justifyContent="center"
       paddingX={1}
-      marginTop={type === 'primary' && stacked ? 2 : undefined}
+      marginTop={type === 'secondary' && stacked ? 2 : undefined}
       smMarginTop="auto"
       smMarginBottom="auto"
     >
@@ -174,14 +174,19 @@ export default function Upsell({
         </Box>
         <Box smDisplay="flex" marginStart="auto" smMarginEnd={4} smPaddingY={3}>
           {secondaryLink && (
-            <UpsellLink type="secondary" data={secondaryLink} />
+            <Box smDisplay="block" display="none">
+              <UpsellLink type="secondary" data={secondaryLink} />
+            </Box>
           )}
-          {primaryLink && (
-            <UpsellLink
-              stacked={!!secondaryLink}
-              type="primary"
-              data={primaryLink}
-            />
+          {primaryLink && <UpsellLink type="primary" data={primaryLink} />}
+          {secondaryLink && (
+            <Box smDisplay="none">
+              <UpsellLink
+                type="secondary"
+                data={secondaryLink}
+                stacked={!!secondaryLink}
+              />
+            </Box>
           )}
         </Box>
       </Box>

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -208,12 +208,12 @@ export default function Upsell({
 
 Upsell.propTypes = {
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  dismissButton: PropTypes.shape({
+  dismissButton: PropTypes.exact({
     accessibilityLabel: PropTypes.string.isRequired,
     onDismiss: PropTypes.func.isRequired,
   }),
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  imageData: PropTypes.shape({
+  imageData: PropTypes.exact({
     component: PropTypes.node.isRequired,
     mask: PropTypes.shape({
       rounding: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 'circle']),

--- a/packages/gestalt/src/Upsell.test.js
+++ b/packages/gestalt/src/Upsell.test.js
@@ -67,14 +67,16 @@ describe('<Upsell />', () => {
           onDismiss: () => {},
         }}
         title="A Title"
-        image={
-          <Icon
-            icon="pinterest"
-            accessibilityLabel="Pin"
-            color="darkGray"
-            size={32}
-          />
-        }
+        imageData={{
+          component: (
+            <Icon
+              icon="pinterest"
+              accessibilityLabel="Pin"
+              color="darkGray"
+              size={32}
+            />
+          ),
+        }}
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/Upsell.test.js
+++ b/packages/gestalt/src/Upsell.test.js
@@ -1,6 +1,7 @@
 // @flow strict
 import React from 'react';
 import { create } from 'react-test-renderer';
+import Icon from './Icon.js';
 import Upsell from './Upsell.js';
 
 describe('<Upsell />', () => {
@@ -51,6 +52,29 @@ describe('<Upsell />', () => {
           onDismiss: () => {},
         }}
         title="A Title"
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('message + title + primaryLink + dismissButton + image', () => {
+    const tree = create(
+      <Upsell
+        message="Insert a clever upsell message here"
+        primaryLink={{ href: 'pinterest.com', label: 'Visit Pinterest' }}
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        title="A Title"
+        image={
+          <Icon
+            icon="pinterest"
+            accessibilityLabel="Pin"
+            color="darkGray"
+            size={32}
+          />
+        }
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -16,7 +16,7 @@ exports[`<Upsell /> Basic Upsell 1`] = `
       className="box mdPaddingY3 xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginTopAuto"
+        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
         style={
           Object {
             "maxWidth": 648,
@@ -37,6 +37,150 @@ exports[`<Upsell /> Basic Upsell 1`] = `
 </div>
 `;
 
+exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = `
+<div
+  className="box mdDirectionRow mdPaddingX8 mdPaddingY8 paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+>
+  <div
+    className="box flexWrap mdDisplayFlex mdMarginBottomN3 mdMarginTopN3"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="box marginBottom4 mdMarginBottom0 mdPaddingY3 xsDisplayFlex"
+    >
+      <div
+        className="box marginBottom0 marginTop0 mdMarginBottomAuto mdMarginTopAuto"
+        style={
+          Object {
+            "maxWidth": 128,
+          }
+        }
+      >
+        <svg
+          aria-hidden={null}
+          aria-label="Pin"
+          className="icon darkGray iconBlock"
+          height={32}
+          role="img"
+          viewBox="0 0 24 24"
+          width={32}
+        >
+          <path
+            d="test-file-stub"
+          />
+        </svg>
+      </div>
+      <div
+        className="box marginBottomAuto marginEnd6 marginStart6 marginTopAuto"
+        style={
+          Object {
+            "maxWidth": 648,
+          }
+        }
+      >
+        <div
+          className="box marginBottom2"
+        >
+          <h3
+            className="Heading fontSize1 darkGray alignLeft breakWord"
+          >
+            A Title
+          </h3>
+        </div>
+        <div
+          className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+        >
+          Insert a clever upsell message here
+        </div>
+      </div>
+    </div>
+    <div
+      className="box marginStartAuto mdDisplayFlex mdMarginEnd4 mdPaddingY3"
+    >
+      <div
+        className="box itemsCenter justifyCenter mdMarginBottomAuto mdMarginTopAuto paddingX1 xsDisplayFlex"
+      >
+        <a
+          className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg red"
+          href="pinterest.com"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={null}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          rel=""
+          tabIndex={0}
+          target={null}
+        >
+          <div
+            className="Text fontSize3 white alignCenter fontWeightBold"
+          >
+            Visit Pinterest
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div
+    className="rtlPos"
+  >
+    <button
+      aria-label="Dismiss banner"
+      className="button tapTransition enabled"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="pog transparent"
+        style={
+          Object {
+            "height": 48,
+            "width": 48,
+          }
+        }
+      >
+        <svg
+          aria-hidden={true}
+          aria-label=""
+          className="icon darkGray iconBlock"
+          height={16}
+          role="img"
+          viewBox="0 0 24 24"
+          width={16}
+        >
+          <path
+            d="test-file-stub"
+          />
+        </svg>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<Upsell /> message + title + primaryLink + dismissButton 1`] = `
 <div
   className="box mdDirectionRow mdPaddingX8 mdPaddingY8 paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
@@ -53,7 +197,7 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton 1`] = `
       className="box marginBottom4 mdMarginBottom0 mdPaddingY3 xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginTopAuto"
+        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
         style={
           Object {
             "maxWidth": 648,
@@ -175,7 +319,7 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
       className="box marginBottom4 mdMarginBottom0 mdPaddingY3 xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginTopAuto"
+        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
         style={
           Object {
             "maxWidth": 648,
@@ -282,7 +426,7 @@ exports[`<Upsell /> message + title + primaryLink 1`] = `
       className="box marginBottom4 mdMarginBottom0 mdPaddingY3 xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginTopAuto"
+        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
         style={
           Object {
             "maxWidth": 648,
@@ -359,7 +503,7 @@ exports[`<Upsell /> message + title 1`] = `
       className="box mdPaddingY3 xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginTopAuto"
+        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
         style={
           Object {
             "maxWidth": 648,

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -70,6 +70,28 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = 
       className="box itemsCenter justifyCenter marginBottom4 smDirectionRow smMarginBottom0 smPaddingY3 xsDirectionColumn xsDisplayFlex"
     >
       <div
+        className="box marginBottom4 smMarginBottom0"
+        style={
+          Object {
+            "width": undefined,
+          }
+        }
+      >
+        <svg
+          aria-hidden={null}
+          aria-label="Pin"
+          className="icon darkGray iconBlock"
+          height={32}
+          role="img"
+          viewBox="0 0 24 24"
+          width={32}
+        >
+          <path
+            d="test-file-stub"
+          />
+        </svg>
+      </div>
+      <div
         className="box"
         style={
           Object {
@@ -78,7 +100,7 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = 
         }
       >
         <div
-          className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
+          className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart6 xsDirectionColumn xsDisplayFlex"
         >
           <div
             className="box smDisplayNone"

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`<Upsell /> Basic Upsell 1`] = `
 <div
-  className="box mdDirectionRow mdPaddingX8 mdPaddingY8 paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box paddingX6 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
-    className="box flexWrap mdDisplayFlex mdMarginBottomN3 mdMarginTopN3"
+    className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
     style={
       Object {
         "width": "100%",
@@ -13,10 +13,10 @@ exports[`<Upsell /> Basic Upsell 1`] = `
     }
   >
     <div
-      className="box mdPaddingY3 xsDisplayFlex"
+      className="box itemsCenter justifyCenter smDirectionRow smPaddingY3 xsDirectionColumn xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
+        className="box"
         style={
           Object {
             "maxWidth": 648,
@@ -24,14 +24,31 @@ exports[`<Upsell /> Basic Upsell 1`] = `
         }
       >
         <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+          className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
-          Insert a clever upsell message here
+          <div
+            className="box smDisplayNone"
+          >
+            <div
+              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
+          <div
+            className="box smDisplayBlock xsDisplayNone"
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="box marginStartAuto mdDisplayFlex mdMarginEnd4 mdPaddingY3"
+      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     />
   </div>
 </div>
@@ -39,10 +56,10 @@ exports[`<Upsell /> Basic Upsell 1`] = `
 
 exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = `
 <div
-  className="box mdDirectionRow mdPaddingX8 mdPaddingY8 paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box paddingX6 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
-    className="box flexWrap mdDisplayFlex mdMarginBottomN3 mdMarginTopN3"
+    className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
     style={
       Object {
         "width": "100%",
@@ -50,32 +67,10 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = 
     }
   >
     <div
-      className="box marginBottom4 mdMarginBottom0 mdPaddingY3 xsDisplayFlex"
+      className="box itemsCenter justifyCenter marginBottom4 smDirectionRow smMarginBottom0 smPaddingY3 xsDirectionColumn xsDisplayFlex"
     >
       <div
-        className="box marginBottom0 marginTop0 mdMarginBottomAuto mdMarginTopAuto"
-        style={
-          Object {
-            "maxWidth": 128,
-          }
-        }
-      >
-        <svg
-          aria-hidden={null}
-          aria-label="Pin"
-          className="icon darkGray iconBlock"
-          height={32}
-          role="img"
-          viewBox="0 0 24 24"
-          width={32}
-        >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
-      </div>
-      <div
-        className="box marginBottomAuto marginEnd6 marginStart6 marginTopAuto"
+        className="box"
         style={
           Object {
             "maxWidth": 648,
@@ -83,26 +78,52 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = 
         }
       >
         <div
-          className="box marginBottom2"
+          className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
-          <h3
-            className="Heading fontSize1 darkGray alignLeft breakWord"
+          <div
+            className="box smDisplayNone"
           >
-            A Title
-          </h3>
-        </div>
-        <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-        >
-          Insert a clever upsell message here
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignCenter breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
+          <div
+            className="box smDisplayBlock xsDisplayNone"
+          >
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignLeft breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="box marginStartAuto mdDisplayFlex mdMarginEnd4 mdPaddingY3"
+      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     >
       <div
-        className="box itemsCenter justifyCenter mdMarginBottomAuto mdMarginTopAuto paddingX1 xsDisplayFlex"
+        className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
       >
         <a
           className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg red"
@@ -183,10 +204,10 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = 
 
 exports[`<Upsell /> message + title + primaryLink + dismissButton 1`] = `
 <div
-  className="box mdDirectionRow mdPaddingX8 mdPaddingY8 paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box paddingX6 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
-    className="box flexWrap mdDisplayFlex mdMarginBottomN3 mdMarginTopN3"
+    className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
     style={
       Object {
         "width": "100%",
@@ -194,10 +215,10 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton 1`] = `
     }
   >
     <div
-      className="box marginBottom4 mdMarginBottom0 mdPaddingY3 xsDisplayFlex"
+      className="box itemsCenter justifyCenter marginBottom4 smDirectionRow smMarginBottom0 smPaddingY3 xsDirectionColumn xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
+        className="box"
         style={
           Object {
             "maxWidth": 648,
@@ -205,26 +226,52 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton 1`] = `
         }
       >
         <div
-          className="box marginBottom2"
+          className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
-          <h3
-            className="Heading fontSize1 darkGray alignLeft breakWord"
+          <div
+            className="box smDisplayNone"
           >
-            A Title
-          </h3>
-        </div>
-        <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-        >
-          Insert a clever upsell message here
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignCenter breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
+          <div
+            className="box smDisplayBlock xsDisplayNone"
+          >
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignLeft breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="box marginStartAuto mdDisplayFlex mdMarginEnd4 mdPaddingY3"
+      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     >
       <div
-        className="box itemsCenter justifyCenter mdMarginBottomAuto mdMarginTopAuto paddingX1 xsDisplayFlex"
+        className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
       >
         <a
           className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg red"
@@ -305,10 +352,10 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton 1`] = `
 
 exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
 <div
-  className="box mdDirectionRow mdPaddingX8 mdPaddingY8 paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box paddingX6 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
-    className="box flexWrap mdDisplayFlex mdMarginBottomN3 mdMarginTopN3"
+    className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
     style={
       Object {
         "width": "100%",
@@ -316,10 +363,10 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
     }
   >
     <div
-      className="box marginBottom4 mdMarginBottom0 mdPaddingY3 xsDisplayFlex"
+      className="box itemsCenter justifyCenter marginBottom4 smDirectionRow smMarginBottom0 smPaddingY3 xsDirectionColumn xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
+        className="box"
         style={
           Object {
             "maxWidth": 648,
@@ -327,26 +374,52 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
         }
       >
         <div
-          className="box marginBottom2"
+          className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
-          <h3
-            className="Heading fontSize1 darkGray alignLeft breakWord"
+          <div
+            className="box smDisplayNone"
           >
-            A Title
-          </h3>
-        </div>
-        <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-        >
-          Insert a clever upsell message here
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignCenter breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
+          <div
+            className="box smDisplayBlock xsDisplayNone"
+          >
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignLeft breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="box marginStartAuto mdDisplayFlex mdMarginEnd4 mdPaddingY3"
+      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     >
       <div
-        className="box itemsCenter justifyCenter mdMarginBottomAuto mdMarginTopAuto paddingX1 xsDisplayFlex"
+        className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
       >
         <a
           className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg gray"
@@ -376,7 +449,7 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
         </a>
       </div>
       <div
-        className="box itemsCenter justifyCenter marginTop2 mdMarginBottomAuto mdMarginTopAuto paddingX1 xsDisplayFlex"
+        className="box itemsCenter justifyCenter marginTop2 paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
       >
         <a
           className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg red"
@@ -412,10 +485,10 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
 
 exports[`<Upsell /> message + title + primaryLink 1`] = `
 <div
-  className="box mdDirectionRow mdPaddingX8 mdPaddingY8 paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box paddingX6 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
-    className="box flexWrap mdDisplayFlex mdMarginBottomN3 mdMarginTopN3"
+    className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
     style={
       Object {
         "width": "100%",
@@ -423,10 +496,10 @@ exports[`<Upsell /> message + title + primaryLink 1`] = `
     }
   >
     <div
-      className="box marginBottom4 mdMarginBottom0 mdPaddingY3 xsDisplayFlex"
+      className="box itemsCenter justifyCenter marginBottom4 smDirectionRow smMarginBottom0 smPaddingY3 xsDirectionColumn xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
+        className="box"
         style={
           Object {
             "maxWidth": 648,
@@ -434,26 +507,52 @@ exports[`<Upsell /> message + title + primaryLink 1`] = `
         }
       >
         <div
-          className="box marginBottom2"
+          className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
-          <h3
-            className="Heading fontSize1 darkGray alignLeft breakWord"
+          <div
+            className="box smDisplayNone"
           >
-            A Title
-          </h3>
-        </div>
-        <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-        >
-          Insert a clever upsell message here
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignCenter breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
+          <div
+            className="box smDisplayBlock xsDisplayNone"
+          >
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignLeft breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="box marginStartAuto mdDisplayFlex mdMarginEnd4 mdPaddingY3"
+      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     >
       <div
-        className="box itemsCenter justifyCenter mdMarginBottomAuto mdMarginTopAuto paddingX1 xsDisplayFlex"
+        className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
       >
         <a
           className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg red"
@@ -489,10 +588,10 @@ exports[`<Upsell /> message + title + primaryLink 1`] = `
 
 exports[`<Upsell /> message + title 1`] = `
 <div
-  className="box mdDirectionRow mdPaddingX8 mdPaddingY8 paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box paddingX6 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
-    className="box flexWrap mdDisplayFlex mdMarginBottomN3 mdMarginTopN3"
+    className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
     style={
       Object {
         "width": "100%",
@@ -500,10 +599,10 @@ exports[`<Upsell /> message + title 1`] = `
     }
   >
     <div
-      className="box mdPaddingY3 xsDisplayFlex"
+      className="box itemsCenter justifyCenter smDirectionRow smPaddingY3 xsDirectionColumn xsDisplayFlex"
     >
       <div
-        className="box marginBottomAuto marginEnd6 marginStart0 marginTopAuto"
+        className="box"
         style={
           Object {
             "maxWidth": 648,
@@ -511,23 +610,49 @@ exports[`<Upsell /> message + title 1`] = `
         }
       >
         <div
-          className="box marginBottom2"
+          className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
-          <h3
-            className="Heading fontSize1 darkGray alignLeft breakWord"
+          <div
+            className="box smDisplayNone"
           >
-            A Title
-          </h3>
-        </div>
-        <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-        >
-          Insert a clever upsell message here
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignCenter breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
+          <div
+            className="box smDisplayBlock xsDisplayNone"
+          >
+            <div
+              className="box marginBottom2"
+            >
+              <h3
+                className="Heading fontSize1 darkGray alignLeft breakWord"
+              >
+                A Title
+              </h3>
+            </div>
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+            >
+              Insert a clever upsell message here
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="box marginStartAuto mdDisplayFlex mdMarginEnd4 mdPaddingY3"
+      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     />
   </div>
 </div>

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -70,7 +70,7 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = 
       className="box itemsCenter justifyCenter marginBottom4 smDirectionRow smMarginBottom0 smPaddingY3 xsDirectionColumn xsDisplayFlex"
     >
       <div
-        className="box marginBottom4 smMarginBottom0"
+        className="box flexNone marginBottom4 smMarginBottom0"
         style={
           Object {
             "width": undefined,

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -77,19 +77,29 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = 
           }
         }
       >
-        <svg
-          aria-hidden={null}
-          aria-label="Pin"
-          className="icon darkGray iconBlock"
-          height={32}
-          role="img"
-          viewBox="0 0 24 24"
-          width={32}
+        <div
+          className="Mask rounding0 willChangeTransform"
+          style={
+            Object {
+              "height": undefined,
+              "width": undefined,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={null}
+            aria-label="Pin"
+            className="icon darkGray iconBlock"
+            height={32}
+            role="img"
+            viewBox="0 0 24 24"
+            width={32}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
       <div
         className="box"

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -451,37 +451,41 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
       className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     >
       <div
-        className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
+        className="box smDisplayBlock xsDisplayNone"
       >
-        <a
-          className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg gray"
-          href="pinterest.com/help"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onContextMenu={null}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchCancel={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          rel=""
-          tabIndex={0}
-          target={null}
+        <div
+          className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
         >
-          <div
-            className="Text fontSize3 darkGray alignCenter fontWeightBold"
+          <a
+            className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg gray"
+            href="pinterest.com/help"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onContextMenu={null}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            rel=""
+            tabIndex={0}
+            target={null}
           >
-            Learn more
-          </div>
-        </a>
+            <div
+              className="Text fontSize3 darkGray alignCenter fontWeightBold"
+            >
+              Learn more
+            </div>
+          </a>
+        </div>
       </div>
       <div
-        className="box itemsCenter justifyCenter marginTop2 paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
+        className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
       >
         <a
           className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg red"
@@ -509,6 +513,40 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
             Visit Pinterest
           </div>
         </a>
+      </div>
+      <div
+        className="box smDisplayNone"
+      >
+        <div
+          className="box itemsCenter justifyCenter marginTop2 paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
+        >
+          <a
+            className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg gray"
+            href="pinterest.com/help"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onContextMenu={null}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            rel=""
+            tabIndex={0}
+            target={null}
+          >
+            <div
+              className="Text fontSize3 darkGray alignCenter fontWeightBold"
+            >
+              Learn more
+            </div>
+          </a>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible. 
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

This PR adds an optional image prop that can be used to add in an image or icon to the left side of the banner.

Icon and Image examples 
<img width="791" alt="Screen Shot 2020-12-03 at 3 32 36 PM" src="https://user-images.githubusercontent.com/46180742/101101232-fbb39800-357c-11eb-9473-b6ec8ae98f0e.png">
<img width="793" alt="Screen Shot 2020-12-03 at 3 32 55 PM" src="https://user-images.githubusercontent.com/46180742/101101236-feae8880-357c-11eb-907f-9f6a413b1675.png">

On smaller screens
<img width="482" alt="Screen Shot 2020-12-03 at 3 33 25 PM" src="https://user-images.githubusercontent.com/46180742/101101248-066e2d00-357d-11eb-97a1-b5b7bd4bcf5d.png">
<img width="482" alt="Screen Shot 2020-12-03 at 3 33 32 PM" src="https://user-images.githubusercontent.com/46180742/101101256-09691d80-357d-11eb-9e89-a77bc87187ca.png">


## Test Plan
Added additional tests and manually verified that components respond to different screen sizes as expected.

<!--
How can reviewers verify this is good to merge?

* Is it tested? Yes
* Is it accessible? Yes
* Is it documented? Yes
* Have you involved other stakeholders (such as a Pinterest Designer)? Yes
-->
