### PR TITLE
Docs: Add search autodiscovery (OpenSearch)

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -9,6 +9,12 @@
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/pinterest_favicon.png" />
+    <link
+      rel="search"
+      type="application/opensearchdescription+xml"
+      href="/opensearch.xml"
+      title="Gestalt"
+    />
     <script type="text/javascript">
       // Load polyfills for IE 11
       if (/MSIE \d|Trident.*rv:/.test(navigator.userAgent))
@@ -36,9 +42,7 @@
     <title>Gestalt</title>
   </head>
   <body>
-    <noscript>
-      You need to enable JavaScript to run this app.
-    </noscript>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script>
       (() => {

--- a/docs/public/opensearch.xml
+++ b/docs/public/opensearch.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+  xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Gestalt</ShortName>
+  <Description>Gestalt Search</Description>
+  <Url type="text/html" method="get" template="https://gestalt.netlify.app/{searchTerms}"/>
+  <Image width="32" height="32">https://gestalt.netlify.app/pinterest_favicon.png</Image>
+  <InputEncoding>UTF-8</InputEncoding>
+  <moz:SearchForm>https://gestalt.netlify.app</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Adds OpenSearch support to the Gestalt docs so users don't have to manually set up their browsers. Thanks to @ayeshakmaz for pointing us in this direction

https://developer.mozilla.org/en-US/docs/Web/OpenSearch
https://www.chromium.org/tab-to-search

## Test Plan

1) Go to https://gestalt.netlify.app/ once
2) Type `Gest` in the URL bar
3) You should see an autocomplete for Gestalt

![image](https://user-images.githubusercontent.com/127199/100893900-b86c0300-3470-11eb-951d-9a9049190a7e.png)

4) Hit the `TAB` key
5) Type `Box`
6) It takes you to the `Box` docs page

Note: we'll only be able to test this once `opensearch.xml` is on the prod docs