### PR TITLE
Callout/Upsell: Implemented new useResponsiveMinWidth hook and utils

### DIFF
--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -11,6 +11,7 @@ import Text from './Text.js';
 import { useColorScheme } from './contexts/ColorScheme.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './Callout.css';
+import useResponsiveMinWidth from './useResponsiveMinWidth.js';
 
 type LinkData = {|
   accessibilityLabel?: string,
@@ -109,6 +110,7 @@ export default function Callout({
   // that all text is readable.
   const { name } = useColorScheme();
   const isDarkMode = name === 'darkMode';
+  const responsiveMinWidth = useResponsiveMinWidth();
 
   return (
     <Box
@@ -164,45 +166,33 @@ export default function Callout({
               marginBottom="auto"
               marginTop="auto"
             >
-              {/* We repeat this code block to ensure that text is 
-              centered for our smaller displays and left aligned 
-              for larger displays */}
-              <Box smDisplay="none">
-                {title && (
-                  <Box marginBottom={2}>
-                    <Heading align="center" size="sm">
-                      {title}
-                    </Heading>
-                  </Box>
-                )}
-                <Text align="center">{message}</Text>
-              </Box>
-              <Box smDisplay="block" display="none">
-                {title && (
-                  <Box marginBottom={2}>
-                    <Heading size="sm">{title}</Heading>
-                  </Box>
-                )}
-                <Text>{message}</Text>
-              </Box>
+              {title && (
+                <Box marginBottom={2}>
+                  <Heading
+                    align={responsiveMinWidth === 'xs' ? 'center' : undefined}
+                    size="sm"
+                  >
+                    {title}
+                  </Heading>
+                </Box>
+              )}
+              <Text align={responsiveMinWidth === 'xs' ? 'center' : undefined}>
+                {message}
+              </Text>
             </Box>
           </Box>
         </Box>
         <Box smDisplay="flex" marginStart="auto" smMarginEnd={4} smPaddingY={3}>
-          {secondaryLink && (
-            <Box smDisplay="block" display="none">
-              <CalloutLink type="secondary" data={secondaryLink} />
-            </Box>
+          {secondaryLink && responsiveMinWidth !== 'xs' && (
+            <CalloutLink type="secondary" data={secondaryLink} />
           )}
           {primaryLink && <CalloutLink type="primary" data={primaryLink} />}
-          {secondaryLink && (
-            <Box smDisplay="none">
-              <CalloutLink
-                type="secondary"
-                data={secondaryLink}
-                stacked={!!secondaryLink}
-              />
-            </Box>
+          {secondaryLink && responsiveMinWidth === 'xs' && (
+            <CalloutLink
+              type="secondary"
+              data={secondaryLink}
+              stacked={!!secondaryLink}
+            />
           )}
         </Box>
       </Box>

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -12,6 +12,7 @@ import Mask from './Mask.js';
 import Text from './Text.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './Upsell.css';
+import useResponsiveMinWidth from './useResponsiveMinWidth.js';
 
 type LinkData = {|
   accessibilityLabel?: string,
@@ -89,6 +90,7 @@ export default function Upsell({
   title,
 }: Props): Node {
   const isImage = imageData?.component && imageData.component.type === Image;
+  const responsiveMinWidth = useResponsiveMinWidth();
 
   return (
     <Box
@@ -148,45 +150,33 @@ export default function Upsell({
               smMarginEnd={6}
               smMarginStart={imageData ? 6 : 0}
             >
-              {/* We repeat this code block to ensure that text is 
-              centered for our smaller displays and left aligned 
-              for larger displays */}
-              <Box smDisplay="none">
-                {title && (
-                  <Box marginBottom={2}>
-                    <Heading align="center" size="sm">
-                      {title}
-                    </Heading>
-                  </Box>
-                )}
-                <Text align="center">{message}</Text>
-              </Box>
-              <Box smDisplay="block" display="none">
-                {title && (
-                  <Box marginBottom={2}>
-                    <Heading size="sm">{title}</Heading>
-                  </Box>
-                )}
-                <Text>{message}</Text>
-              </Box>
+              {title && (
+                <Box marginBottom={2}>
+                  <Heading
+                    align={responsiveMinWidth === 'xs' ? 'center' : undefined}
+                    size="sm"
+                  >
+                    {title}
+                  </Heading>
+                </Box>
+              )}
+              <Text align={responsiveMinWidth === 'xs' ? 'center' : undefined}>
+                {message}
+              </Text>
             </Box>
           </Box>
         </Box>
         <Box smDisplay="flex" marginStart="auto" smMarginEnd={4} smPaddingY={3}>
-          {secondaryLink && (
-            <Box smDisplay="block" display="none">
-              <UpsellLink type="secondary" data={secondaryLink} />
-            </Box>
+          {secondaryLink && responsiveMinWidth !== 'xs' && (
+            <UpsellLink type="secondary" data={secondaryLink} />
           )}
           {primaryLink && <UpsellLink type="primary" data={primaryLink} />}
-          {secondaryLink && (
-            <Box smDisplay="none">
-              <UpsellLink
-                type="secondary"
-                data={secondaryLink}
-                stacked={!!secondaryLink}
-              />
-            </Box>
+          {secondaryLink && responsiveMinWidth === 'xs' && (
+            <UpsellLink
+              type="secondary"
+              data={secondaryLink}
+              stacked={!!secondaryLink}
+            />
           )}
         </Box>
       </Box>

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -49,22 +49,9 @@ exports[`<Callout /> Error Callout 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever error callout message here
-            </div>
-          </div>
-          <div
-            className="box smDisplayBlock xsDisplayNone"
-          >
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever error callout message here
-            </div>
+            Insert a clever error callout message here
           </div>
         </div>
       </div>
@@ -125,22 +112,9 @@ exports[`<Callout /> Info Callout 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
-          </div>
-          <div
-            className="box smDisplayBlock xsDisplayNone"
-          >
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+            Insert a clever info callout message here
           </div>
         </div>
       </div>
@@ -201,22 +175,9 @@ exports[`<Callout /> Warning Callout 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever warning callout message here
-            </div>
-          </div>
-          <div
-            className="box smDisplayBlock xsDisplayNone"
-          >
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever warning callout message here
-            </div>
+            Insert a clever warning callout message here
           </div>
         </div>
       </div>
@@ -277,40 +238,18 @@ exports[`<Callout /> message + title + primaryLink + dismissButton 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+            Insert a clever info callout message here
           </div>
         </div>
       </div>
@@ -447,40 +386,18 @@ exports[`<Callout /> message + title + primaryLink + secondaryLink 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+            Insert a clever info callout message here
           </div>
         </div>
       </div>
@@ -489,38 +406,34 @@ exports[`<Callout /> message + title + primaryLink + secondaryLink 1`] = `
       className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     >
       <div
-        className="box smDisplayBlock xsDisplayNone"
+        className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
       >
-        <div
-          className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
+        <a
+          className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg transparent"
+          href="pinterest.com/help"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={null}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          rel=""
+          tabIndex={0}
+          target={null}
         >
-          <a
-            className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg transparent"
-            href="pinterest.com/help"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onContextMenu={null}
-            onFocus={[Function]}
-            onKeyPress={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            rel=""
-            tabIndex={0}
-            target={null}
+          <div
+            className="Text fontSize3 darkGray alignCenter fontWeightBold"
           >
-            <div
-              className="Text fontSize3 darkGray alignCenter fontWeightBold"
-            >
-              Learn more
-            </div>
-          </a>
-        </div>
+            Learn more
+          </div>
+        </a>
       </div>
       <div
         className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
@@ -551,40 +464,6 @@ exports[`<Callout /> message + title + primaryLink + secondaryLink 1`] = `
             Visit Pinterest
           </div>
         </a>
-      </div>
-      <div
-        className="box smDisplayNone"
-      >
-        <div
-          className="box itemsCenter justifyCenter marginTop2 paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
-        >
-          <a
-            className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg transparent"
-            href="pinterest.com/help"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onContextMenu={null}
-            onFocus={[Function]}
-            onKeyPress={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            rel=""
-            tabIndex={0}
-            target={null}
-          >
-            <div
-              className="Text fontSize3 darkGray alignCenter fontWeightBold"
-            >
-              Learn more
-            </div>
-          </a>
-        </div>
       </div>
     </div>
   </div>
@@ -640,40 +519,18 @@ exports[`<Callout /> message + title + primaryLink 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+            Insert a clever info callout message here
           </div>
         </div>
       </div>
@@ -765,40 +622,18 @@ exports[`<Callout /> message + title 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever info callout message here
-            </div>
+            Insert a clever info callout message here
           </div>
         </div>
       </div>

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -27,22 +27,9 @@ exports[`<Upsell /> Basic Upsell 1`] = `
           className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
-          </div>
-          <div
-            className="box smDisplayBlock xsDisplayNone"
-          >
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+            Insert a clever upsell message here
           </div>
         </div>
       </div>
@@ -113,40 +100,18 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton + image 1`] = 
           className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart6 xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+            Insert a clever upsell message here
           </div>
         </div>
       </div>
@@ -261,40 +226,18 @@ exports[`<Upsell /> message + title + primaryLink + dismissButton 1`] = `
           className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+            Insert a clever upsell message here
           </div>
         </div>
       </div>
@@ -409,40 +352,18 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
           className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+            Insert a clever upsell message here
           </div>
         </div>
       </div>
@@ -451,38 +372,34 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
       className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
     >
       <div
-        className="box smDisplayBlock xsDisplayNone"
+        className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
       >
-        <div
-          className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
+        <a
+          className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg gray"
+          href="pinterest.com/help"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={null}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          rel=""
+          tabIndex={0}
+          target={null}
         >
-          <a
-            className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg gray"
-            href="pinterest.com/help"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onContextMenu={null}
-            onFocus={[Function]}
-            onKeyPress={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            rel=""
-            tabIndex={0}
-            target={null}
+          <div
+            className="Text fontSize3 darkGray alignCenter fontWeightBold"
           >
-            <div
-              className="Text fontSize3 darkGray alignCenter fontWeightBold"
-            >
-              Learn more
-            </div>
-          </a>
-        </div>
+            Learn more
+          </div>
+        </a>
       </div>
       <div
         className="box itemsCenter justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
@@ -513,40 +430,6 @@ exports[`<Upsell /> message + title + primaryLink + secondaryLink 1`] = `
             Visit Pinterest
           </div>
         </a>
-      </div>
-      <div
-        className="box smDisplayNone"
-      >
-        <div
-          className="box itemsCenter justifyCenter marginTop2 paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock"
-        >
-          <a
-            className="link hideOutline tapTransition block pill accessibilityOutline buttonLink button lg gray"
-            href="pinterest.com/help"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onContextMenu={null}
-            onFocus={[Function]}
-            onKeyPress={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            rel=""
-            tabIndex={0}
-            target={null}
-          >
-            <div
-              className="Text fontSize3 darkGray alignCenter fontWeightBold"
-            >
-              Learn more
-            </div>
-          </a>
-        </div>
       </div>
     </div>
   </div>
@@ -580,40 +463,18 @@ exports[`<Upsell /> message + title + primaryLink 1`] = `
           className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+            Insert a clever upsell message here
           </div>
         </div>
       </div>
@@ -683,40 +544,18 @@ exports[`<Upsell /> message + title 1`] = `
           className="box itemsCenter marginBottomAuto marginEnd0 marginStart0 marginTopAuto smDisplayBlock smMarginEnd6 smMarginStart0 xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="box smDisplayNone"
+            className="box marginBottom2"
           >
-            <div
-              className="box marginBottom2"
+            <h3
+              className="Heading fontSize1 darkGray alignLeft breakWord"
             >
-              <h3
-                className="Heading fontSize1 darkGray alignCenter breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+              A Title
+            </h3>
           </div>
           <div
-            className="box smDisplayBlock xsDisplayNone"
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
           >
-            <div
-              className="box marginBottom2"
-            >
-              <h3
-                className="Heading fontSize1 darkGray alignLeft breakWord"
-              >
-                A Title
-              </h3>
-            </div>
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-            >
-              Insert a clever upsell message here
-            </div>
+            Insert a clever upsell message here
           </div>
         </div>
       </div>

--- a/packages/gestalt/src/useReducedMotion.js
+++ b/packages/gestalt/src/useReducedMotion.js
@@ -1,21 +1,6 @@
 // @flow strict
 import { useState, useEffect } from 'react';
-
-function addListener(mediaQuery, callback) {
-  // addEventListener on mediaQuery is not supported in all browsers (Edge / Safari)
-  if (mediaQuery.addEventListener) {
-    mediaQuery.addEventListener('change', callback);
-  } else if (mediaQuery.addListener) {
-    mediaQuery.addListener(callback);
-  }
-}
-function removeListener(mediaQuery, callback) {
-  if (mediaQuery.removeEventListener) {
-    mediaQuery.removeEventListener('change', callback);
-  } else if (mediaQuery.removeListener) {
-    mediaQuery.removeListener(callback);
-  }
-}
+import { addListener, removeListener } from './utils/matchMedia.js';
 
 export default function useReducedMotion(): boolean {
   const supportsMatchMedia = typeof window !== 'undefined' && window.matchMedia;

--- a/packages/gestalt/src/useResponsiveMinWidth.js
+++ b/packages/gestalt/src/useResponsiveMinWidth.js
@@ -1,0 +1,69 @@
+// @flow strict
+import { useMemo, useCallback, useState, useEffect } from 'react';
+import { addListener, removeListener } from './utils/matchMedia.js';
+
+type MinWidthType = 'lg' | 'md' | 'sm' | 'xs';
+
+const breakpoints = {
+  sm: '(min-width: 576px)',
+  md: '(min-width: 768px)',
+  lg: '(min-width: 1312px)',
+};
+
+export default function useResponsiveMinWidth(): ?MinWidthType {
+  const supportsMatchMedia = typeof window !== 'undefined' && window.matchMedia;
+
+  const mediaQuery = useMemo(
+    () =>
+      supportsMatchMedia
+        ? {
+            lg: window.matchMedia(breakpoints.lg),
+            md: window.matchMedia(breakpoints.md),
+            sm: window.matchMedia(breakpoints.sm),
+          }
+        : undefined,
+    [supportsMatchMedia]
+  );
+
+  const getMinWidth = useCallback(
+    () =>
+      supportsMatchMedia && mediaQuery
+        ? (mediaQuery.lg.matches && 'lg') ||
+          (mediaQuery.md.matches && 'md') ||
+          (mediaQuery.sm.matches && 'sm') ||
+          'xs'
+        : undefined,
+    [mediaQuery, supportsMatchMedia]
+  );
+
+  const [minWidth, setMinWidth] = useState(
+    supportsMatchMedia ? getMinWidth() : undefined
+  );
+
+  useEffect(() => {
+    if (!supportsMatchMedia) {
+      return () => {};
+    }
+
+    const handleChange = () => {
+      setMinWidth(getMinWidth());
+    };
+
+    handleChange();
+    if (mediaQuery) {
+      addListener(mediaQuery.lg, handleChange);
+      addListener(mediaQuery.md, handleChange);
+      addListener(mediaQuery.sm, handleChange);
+    }
+
+    return () => {
+      if (mediaQuery) {
+        removeListener(mediaQuery.lg, handleChange);
+        removeListener(mediaQuery.md, handleChange);
+        removeListener(mediaQuery.sm, handleChange);
+      }
+    };
+  }, [getMinWidth, mediaQuery, supportsMatchMedia]);
+
+  return minWidth;
+}

--- a/packages/gestalt/src/useResponsiveMinWidth.jsdom.test.js
+++ b/packages/gestalt/src/useResponsiveMinWidth.jsdom.test.js
@@ -1,0 +1,89 @@
+// @flow strict
+import { renderHook, act } from '@testing-library/react-hooks';
+import useResponsiveMinWidth from './useResponsiveMinWidth.js';
+
+const mediaqueryDefaults = {
+  matches: false,
+  onchange: null,
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+};
+
+describe('useResponsiveMinWidth', () => {
+  test('returns `xs` for extra small screens', () => {
+    window.matchMedia = jest.fn().mockImplementation((query) => {
+      return {
+        ...mediaqueryDefaults,
+        matches: query === '(min-width: 240px)',
+        media: query,
+      };
+    });
+
+    const { result } = renderHook(useResponsiveMinWidth);
+    expect(result.current).toBe('xs');
+  });
+
+  test('returns `sm` for small screens', () => {
+    window.matchMedia = jest.fn().mockImplementation((query) => {
+      return {
+        ...mediaqueryDefaults,
+        matches: query === '(min-width: 576px)',
+        media: query,
+      };
+    });
+
+    const { result } = renderHook(useResponsiveMinWidth);
+    expect(result.current).toBe('sm');
+  });
+
+  test('returns `md` for medium screens', () => {
+    window.matchMedia = jest.fn().mockImplementation((query) => {
+      return {
+        ...mediaqueryDefaults,
+        matches: query === '(min-width: 768px)',
+        media: query,
+      };
+    });
+
+    const { result } = renderHook(useResponsiveMinWidth);
+    expect(result.current).toBe('md');
+  });
+
+  test('returns `lg` for large screens', () => {
+    window.matchMedia = jest.fn().mockImplementation((query) => {
+      return {
+        ...mediaqueryDefaults,
+        matches: query === '(min-width: 1312px)',
+        media: query,
+      };
+    });
+
+    const { result } = renderHook(useResponsiveMinWidth);
+    expect(result.current).toBe('lg');
+  });
+
+  test('handles the resize of screen', () => {
+    let change;
+    window.matchMedia = jest.fn().mockImplementation((query) => {
+      return {
+        ...mediaqueryDefaults,
+        matches: false,
+        addEventListener(event, listener) {
+          this.matches = query === '(min-width: 768px)';
+          change = listener;
+        },
+        media: query,
+      };
+    });
+
+    const { result } = renderHook(useResponsiveMinWidth);
+
+    expect(result.current).toBe('xs');
+
+    act(() => {
+      change();
+    });
+
+    expect(result.current).toBe('md');
+  });
+});

--- a/packages/gestalt/src/useResponsiveMinWidth.test.js
+++ b/packages/gestalt/src/useResponsiveMinWidth.test.js
@@ -1,0 +1,10 @@
+// @flow strict
+import { renderHook } from '@testing-library/react-hooks';
+import useResponsiveMinWidth from './useResponsiveMinWidth.js';
+
+describe('useResponsiveMinWidth', () => {
+  test('Returns false during SSR (Server Side Render)', () => {
+    const { result } = renderHook(useResponsiveMinWidth);
+    expect(result.current).toBe(undefined);
+  });
+});

--- a/packages/gestalt/src/utils/matchMedia.js
+++ b/packages/gestalt/src/utils/matchMedia.js
@@ -1,0 +1,27 @@
+// @flow strict
+
+export function addListener(
+  mediaQuery: MediaQueryList,
+  callback: MediaQueryListListener
+): void {
+  // addEventListener on mediaQuery is not supported in all browsers (Edge / Safari)
+  // https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener
+  if (mediaQuery.addEventListener) {
+    // $FlowFixMe[incompatible-call]
+    mediaQuery.addEventListener('change', callback);
+  } else if (mediaQuery.addListener) {
+    mediaQuery.addListener(callback);
+  }
+}
+
+export function removeListener(
+  mediaQuery: MediaQueryList,
+  callback: MediaQueryListListener
+): void {
+  if (mediaQuery.removeEventListener) {
+    // $FlowFixMe[incompatible-call]
+    mediaQuery.removeEventListener('change', callback);
+  } else if (mediaQuery.removeListener) {
+    mediaQuery.removeListener(callback);
+  }
+}


### PR DESCRIPTION
Implemented `useResponsiveMinWidth` which uses `window.matchMedia` to return the size of the screen for each breakpoint size. This new hook implementation allows implementing responsiveness to any component props.

Having duplicated components in the `render()`  on tests is confusing for developers. Test could require changes as a result of having to duplicate one same component using `display='none'` & `smDisplay='none'` to  be able to achieve some responsiveness behaviors.

For example, we had this in `Callout` and `Upsell`

```
{/* We repeat this code block to ensure that text is 
              centered for our smaller displays and left aligned 
              for larger displays */}
              <Box smDisplay="none">
                {title && (
                  <Box marginBottom={2}>
                    <Heading align="center" size="sm">
                      {title}
                    </Heading>
                  </Box>
                )}
                <Text align="center">{message}</Text>
              </Box>
              <Box smDisplay="block" display="none">
                {title && (
                  <Box marginBottom={2}>
                    <Heading size="sm">{title}</Heading>
                  </Box>
                )}
                <Text>{message}</Text>
              </Box>
            </Box>

```
Tests using `render()` could show the duplication and that solution would force engineers to know the under the hood behavior of these two components.  

With `useResponsiveMinWidth`, we use the `matchMedia` approach which was already being used for `useColorScheme` and `useReducedMotion`

Built-in  `Box` responsive props such as display, margin, etc are still valid in most cases, but to facilitate making components more responsive in the future those won’t be sufficient for many cases as we see with `Callout` / `Upsell`.

The original  `Box` responsive props aren’t super intuitive at the beginning. The way this hook is implemented is slightly more intuitive. In this case, the hook is returning the actual screen breakpoint range. Therefore, to check for size matches we have to use logic like:
`responsiveMinWidth === 'xs'` ,
`responsiveMinWidth !== 'xs'`  or
`['md', 'lg].includes(responsiveMinWidth)`

This allows responsiveness to any other component props.

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
