### PR TITLE
Modal: Update backdrop wash to 80% opacity

### DIFF
--- a/packages/gestalt/src/Backdrop.css
+++ b/packages/gestalt/src/Backdrop.css
@@ -2,7 +2,7 @@
   0% {
     opacity: 0;
   }
-  
+
   100% {
     opacity: 0.9;
   }
@@ -11,8 +11,8 @@
 @keyframes fade-out {
   0% {
     opacity: 0.9;
-  }  
-  
+  }
+
   100% {
     opacity: 0;
   }
@@ -20,7 +20,7 @@
 
 .backdrop {
   composes: absolute left0 top0 right0 bottom0 overflowScrollY from "./Layout.css";
-  background: var(--g-colorTransparentGray400);
+  background: var(--g-colorTransparentGray800);
   height: 100%;
   opacity: 0.9;
 }

--- a/packages/gestalt/src/Backdrop.css
+++ b/packages/gestalt/src/Backdrop.css
@@ -22,7 +22,6 @@
   composes: absolute left0 top0 right0 bottom0 overflowScrollY from "./Layout.css";
   background: var(--g-colorTransparentGray800);
   height: 100%;
-  opacity: 0.9;
 }
 
 .backdropAnimationIn {

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -44,7 +44,6 @@
   --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
   --g-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
-  --g-colorTransparentGray400: rgba(0, 0, 0, 0.4);
   --g-colorTransparentGray800: rgba(0, 0, 0, 0.8);
 }
 

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -45,6 +45,7 @@
   --g-colorTransparentGray60: rgba(0, 0, 0, 0.06);
   --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
   --g-colorTransparentGray400: rgba(0, 0, 0, 0.4);
+  --g-colorTransparentGray800: rgba(0, 0, 0, 0.8);
 }
 
 /** PRIMARY COLORS **/

--- a/packages/gestalt/src/Mask.css
+++ b/packages/gestalt/src/Mask.css
@@ -14,6 +14,6 @@
   composes: left0 from "./Layout.css";
   composes: right0 from "./Layout.css";
   composes: top0 from "./Layout.css";
-  background: rgba(0, 0, 0, 0.03);
+  background: rgba(0, 0, 0, 0.04);
   pointer-events: none;
 }


### PR DESCRIPTION
Update Modal's Backdrop wash to 80% opacity black

- added new var   --g-colorTransparentGray800: rgba(0, 0, 0, 0.8);
- Also changed the Mask wash to be 4% opacity to be consistent with mobile

Before:
<img width="799" alt="Screen Shot 2020-12-09 at 2 24 25 PM" src="https://user-images.githubusercontent.com/5125094/101696382-e4682500-3a2a-11eb-9e51-2adbe59c282a.png">

After:

<img width="807" alt="Screen Shot 2020-12-09 at 2 24 34 PM" src="https://user-images.githubusercontent.com/5125094/101696391-e7fbac00-3a2a-11eb-9e4a-b5e681c0ffb3.png">

## Test Plan
Manually verified visually
