### PR TITLE
Textfield: update tags props docs

### DIFF
--- a/docs/src/Tag.doc.js
+++ b/docs/src/Tag.doc.js
@@ -10,7 +10,7 @@ const card = (c) => cards.push(c);
 card(
   <PageHeader
     name="Tag"
-    description="Tag is a object that holds text. It also has an x icon to remove it. The tag can appear within a form field or outside of it."
+    description="Tag is a object that holds text. It also has an x icon to remove it. Tags can appear within a [form field](/TextField#tagsExample) or as standalone components."
   />
 );
 

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -210,7 +210,8 @@ card(
     id="tagsExample"
     name="Example: Tags"
     description={`
-    You can include \`Tag\` elements in the input using the \`tags\` prop.
+    You can include [Tag](/Tag) elements in the input using the \`tags\` prop.
+
     Note that the \`TextField\` component does not internally manage tags. That should be handled in the application state through the component's event callbacks. This example creates new tags by splitting the input on spaces, commas, and semicolons, and removes them on backspaces.`}
     defaultCode={`
 function Example(props) {
@@ -224,15 +225,21 @@ function Example(props) {
         id="tags"
         label="Emails"
         onChange={({ value }) => {
-          const tagInput = value.split(/[ ,;]+/);
+          const tagInput = value.split(/[\\s,;]+/);
           if (tagInput.length > 1) {
-            setTags([...tags, ...tagInput.splice(0, tagInput.length - 1)]);
+            setTags([
+              ...tags,
+              ...tagInput.splice(0, tagInput.length - 1).filter(val => val !== ''),
+            ]);
           }
           setValue(tagInput[tagInput.length - 1]);
         }}
         onKeyDown={({ event: { keyCode, target: { selectionEnd } } }) => {
           if (keyCode === 8 /* Backspace */ && selectionEnd === 0) {
             setTags([...tags.slice(0, -1)]);
+          } else if (keyCode === 13 /* Enter */ && value.trim() !== '') {
+            setTags([...tags, value.trim()]);
+            setValue('');
           }
         }}
         tags={tags.map((tag, idx) => (

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -212,11 +212,51 @@ card(
     description={`
     You can include [Tag](/Tag) elements in the input using the \`tags\` prop.
 
-    Note that the \`TextField\` component does not internally manage tags. That should be handled in the application state through the component's event callbacks. This example creates new tags by splitting the input on spaces, commas, and semicolons, and removes them on backspaces.`}
+    Note that the \`TextField\` component does not internally manage tags. That should be handled in the application state through the component's event callbacks. We recommend creating new tags on enter key presses, and removing them on backspaces when the cursor is in the beginning of the field. We also recommend filtering out empty tags.
+
+    This example showcases the recommended behavior. In addition, it creates new tags by splitting the input on spaces, commas, semicolons.`}
     defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('');
   const [tags, setTags] = React.useState(['a@pinterest.com', 'b@pinterest.com']);
+
+  const onChangeTagManagement = ({ value }) => {
+    // Create new tags around spaces, commas, and semicolons.
+    const tagInput = value.split(/[\\s,;]+/);
+    if (tagInput.length > 1) {
+      setTags([
+        ...tags,
+        // Avoid creating a tag on content after the separators, and filter out
+        // empty tags
+        ...tagInput.splice(0, tagInput.length - 1).filter(val => val !== ''),
+      ]);
+    }
+    setValue(tagInput[tagInput.length - 1]);
+  }
+
+  const onKeyDownTagManagement = ({ event: { keyCode, target: { selectionEnd } } }) => {
+    if (keyCode === 8 /* Backspace */ && selectionEnd === 0) {
+      // Remove tag on backspace if the cursor is at the beginning of the field
+      setTags([...tags.slice(0, -1)]);
+    } else if (keyCode === 13 /* Enter */ && value.trim() !== '') {
+      // Create a new tag on enter
+      setTags([...tags, value.trim()]);
+      setValue('');
+    }
+  }
+
+  const renderedTags = tags.map((tag, idx) => (
+    <Tag
+      key={tag}
+      onRemove={() => {
+        const newTags = [...tags];
+        newTags.splice(idx, 1);
+        setTags([...newTags]);
+      }}
+      removeIconAccessibilityLabel={\`Remove \${tag} tag\`}
+      text={tag}
+    />
+  ));
 
   return (
     <Box padding={2} color="white">
@@ -224,36 +264,9 @@ function Example(props) {
         autoComplete="off"
         id="tags"
         label="Emails"
-        onChange={({ value }) => {
-          const tagInput = value.split(/[\\s,;]+/);
-          if (tagInput.length > 1) {
-            setTags([
-              ...tags,
-              ...tagInput.splice(0, tagInput.length - 1).filter(val => val !== ''),
-            ]);
-          }
-          setValue(tagInput[tagInput.length - 1]);
-        }}
-        onKeyDown={({ event: { keyCode, target: { selectionEnd } } }) => {
-          if (keyCode === 8 /* Backspace */ && selectionEnd === 0) {
-            setTags([...tags.slice(0, -1)]);
-          } else if (keyCode === 13 /* Enter */ && value.trim() !== '') {
-            setTags([...tags, value.trim()]);
-            setValue('');
-          }
-        }}
-        tags={tags.map((tag, idx) => (
-          <Tag
-            key={tag}
-            onRemove={() => {
-              const newTags = [...tags];
-              newTags.splice(idx, 1);
-              setTags([...newTags]);
-            }}
-            removeIconAccessibilityLabel={\`Remove \${tag} tag\`}
-            text={tag}
-          />
-        ))}
+        onChange={onChangeTagManagement}
+        onKeyDown={onKeyDownTagManagement}
+        tags={renderedTags}
         value={value}
       />
     </Box>


### PR DESCRIPTION
Updating the docs for the tags example
- Link to Tag component
- Enter/return and whitespace characters now create a new tag in the example
- We now filter out empty tags

## Test Plan
Played around with the example, made sure the above works
<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
