### PR TITLE
Update Flyout Docs - Remove bold text

### DIFF
--- a/docs/src/Flyout.doc.js
+++ b/docs/src/Flyout.doc.js
@@ -111,7 +111,7 @@ function FlyoutExample() {
             size="md"
           >
             <Box padding={3} display="flex" alignItems="center" direction="column" column={12}>
-              <Text align="center" weight="bold">
+              <Text align="center">
                 Need help with something? Check out our Help Center.
               </Text>
               <Box paddingX={2} marginTop={3}>
@@ -156,7 +156,7 @@ function FlyoutExample() {
             size="md"
           >
             <Box padding={3} column={12}>
-              <Text align="center" weight="bold">
+              <Text align="center">
                 Flyout with a caret, not a 🥕
               </Text>
             </Box>
@@ -196,7 +196,7 @@ function ErrorFlyoutExample() {
             size="md"
           >
             <Box padding={3}>
-              <Text color="white" weight="bold">
+              <Text color="white">
                 Oops! This item is out of stock.
               </Text>
             </Box>


### PR DESCRIPTION
Design realized there was a mistake in the docs with the text being bold by default in flyouts. It should be regular weight.

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
