### PR TITLE
Modal: Add subHeading and align props

### DIFF
--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -27,6 +27,14 @@ card(
         href: 'accessibility',
       },
       {
+        name: 'align',
+        type: `"center" | "left"`,
+        defaultValue: 'center',
+        description:
+          'Use to specify the alignment of heading when supplied heading is a string',
+        href: 'headingOptions',
+      },
+      {
         name: 'children',
         type: 'React.Node',
       },
@@ -72,6 +80,12 @@ card(
         defaultValue: 'sm',
         description: `sm: 540px, md: 720px, lg: 900px`,
         href: 'sizesExample',
+      },
+      {
+        name: 'subHeading',
+        type: `string`,
+        required: false,
+        href: 'headingOptions',
       },
     ]}
   />
@@ -259,6 +273,89 @@ function Example(props) {
               size="md"
             >
               <Box>
+                <Heading size="md">Children</Heading>
+              </Box>
+            </Modal>
+          </Layer>
+        )}
+      </Box>
+    </Box>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    id="headingOptions"
+    name="Heading options"
+    description={`
+      When the supplied heading is a string, you have the option of adding a subtitle and aligning text left or center.
+    `}
+    defaultCode={`
+function Example(props) {
+  function reducer(state, action) {
+    switch (action.type) {
+      case 'left':
+        return {modal: 'left'};
+      case 'center':
+        return {modal: 'center'};
+      case 'none':
+        return {modal: 'none'};
+      default:
+        throw new Error();
+    }
+  }
+
+  const initialState = {modal: 'none'};
+  const [state, dispatch] = React.useReducer(reducer, initialState);
+  const HEADER_ZINDEX = new FixedZIndex(10);
+  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+
+  return (
+    <Box marginLeft={-1} marginRight={-1}>
+      <Box padding={1}>
+        <Button
+          inline
+          text="Left aligned heading"
+          onClick={() => { dispatch({type: 'left'}) }}
+        />
+        {state.modal === 'left' && (
+          <Layer zIndex={zIndex}>
+            <Modal
+              accessibilityModalLabel="View default padding and styling"
+              align="left"
+              heading="Heading"
+              onDismiss={() => { dispatch({type: 'none'}) }}
+              footer={<Heading size="md">Footer</Heading>}
+              size="md"
+              subHeading="This is the \`subHeading\`. It has the same specificed alignment as the \`heading\`."
+            >
+              <Box padding={8}>
+                <Heading size="md">Children</Heading>
+              </Box>
+            </Modal>
+          </Layer>
+        )}
+      </Box>
+      <Box padding={1}>
+        <Button
+          inline
+          text="Center aligned heading"
+          onClick={() => { dispatch({type: 'center'}) }}
+        />
+        {state.modal === 'center' && (
+          <Layer zIndex={zIndex}>
+            <Modal
+              accessibilityModalLabel="View default padding and styling"
+              heading="Heading"
+              onDismiss={() => { dispatch({type: 'none'}) }}
+              footer={<Heading size="md">Footer</Heading>}
+              size="md"
+              subHeading="This is the \`subHeading\`. It has the same specificed alignment as the \`heading\`."
+            >
+              <Box padding={8}>
                 <Heading size="md">Children</Heading>
               </Box>
             </Modal>

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -31,7 +31,7 @@ card(
         type: `"center" | "left"`,
         defaultValue: 'center',
         description:
-          'Use to specify the alignment of heading when supplied heading is a string',
+          'Use to specify the alignment of `heading` & `subHeading` strings',
         href: 'headingOptions',
       },
       {
@@ -85,6 +85,7 @@ card(
         name: 'subHeading',
         type: `string`,
         required: false,
+        description: `Only renders with \`heading\` strings`,
         href: 'headingOptions',
       },
     ]}

--- a/packages/gestalt/src/Modal.flowtest.js
+++ b/packages/gestalt/src/Modal.flowtest.js
@@ -1,7 +1,7 @@
 // @flow strict
 import React from 'react';
 import Modal from './Modal.js';
-import Test from './Test.js';
+import Text from './Text.js';
 
 const Valid = <Modal accessibilityModalLabel="Modal" onDismiss={() => {}} />;
 

--- a/packages/gestalt/src/Modal.flowtest.js
+++ b/packages/gestalt/src/Modal.flowtest.js
@@ -5,17 +5,17 @@ import Text from './Text.js';
 
 const Valid = <Modal accessibilityModalLabel="Modal" onDismiss={() => {}} />;
 
-// $FlowExpectedError[prop-missing]
+// $FlowExpectedError[incompatible-type]
 const MissingProp = <Modal />;
 
-// $FlowExpectedError[prop-missing]
+// $FlowExpectedError[incompatible-type]
 const NonExistingProp = <Modal nonexisting={33} />;
 
 const InvalidProp = (
-  // $FlowExpectedError[incompatible-type]
   <Modal
     accessibilityModalLabel="Modal"
     onDismiss={() => {}}
+    // $FlowExpectedError[incompatible-type]
     heading={<Text>Test</Text>}
     subHeading="clever subheading"
   />

--- a/packages/gestalt/src/Modal.flowtest.js
+++ b/packages/gestalt/src/Modal.flowtest.js
@@ -1,6 +1,7 @@
 // @flow strict
 import React from 'react';
 import Modal from './Modal.js';
+import Test from './Test.js';
 
 const Valid = <Modal accessibilityModalLabel="Modal" onDismiss={() => {}} />;
 
@@ -9,3 +10,13 @@ const MissingProp = <Modal />;
 
 // $FlowExpectedError[prop-missing]
 const NonExistingProp = <Modal nonexisting={33} />;
+
+const InvalidProp = (
+  // $FlowExpectedError[incompatible-type]
+  <Modal
+    accessibilityModalLabel="Modal"
+    onDismiss={() => {}}
+    heading={<Text>Test</Text>}
+    subHeading="clever subheading"
+  />
+);

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -20,15 +20,21 @@ import modalStyles from './Modal.css';
 
 type Props = {|
   accessibilityModalLabel: string,
-  align?: 'left' | 'center',
   children?: Node,
   closeOnOutsideClick?: boolean,
   footer?: Node,
-  heading?: string | Node,
   onDismiss: () => void,
   role?: 'alertdialog' | 'dialog',
   size?: 'sm' | 'md' | 'lg' | number,
-  subHeading?: string,
+  ...
+    | {|
+        heading?: Node,
+      |}
+    | {|
+        heading?: string,
+        subHeading?: string,
+        align?: 'left' | 'center',
+      |},
 |};
 
 const SIZE_WIDTH_MAP = {
@@ -43,13 +49,9 @@ function Header({
   subHeading,
 }: {|
   align: 'left' | 'center',
-  heading: string | Node,
+  heading: string,
   subHeading?: string,
 |}) {
-  if (typeof heading !== 'string') {
-    return heading;
-  }
-
   return (
     <Box justifyContent={align === 'left' ? 'start' : 'center'} padding={8}>
       <Heading size="md" accessibilityLevel={1} align={align}>
@@ -78,7 +80,7 @@ const ModalWithForwardRef: React$AbstractComponent<
     heading,
     role = 'dialog',
     size = 'sm',
-    subHeading,
+    subHeading = undefined,
   } = props;
 
   const [showTopShadow, setShowTopShadow] = useState(false);
@@ -164,11 +166,15 @@ const ModalWithForwardRef: React$AbstractComponent<
                       [modalStyles.shadow]: showTopShadow,
                     })}
                   >
-                    <Header
-                      align={align}
-                      heading={heading}
-                      subHeading={subHeading}
-                    />
+                    {typeof heading === 'string' ? (
+                      <Header
+                        align={align}
+                        heading={heading}
+                        subHeading={subHeading}
+                      />
+                    ) : (
+                      heading
+                    )}
                   </div>
                 )}
                 <Box

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -14,11 +14,13 @@ import Backdrop from './Backdrop.js';
 import focusStyles from './Focus.css';
 import Heading from './Heading.js';
 import StopScrollBehavior from './behaviors/StopScrollBehavior.js';
+import Text from './Text.js';
 import TrapFocusBehavior from './behaviors/TrapFocusBehavior.js';
 import modalStyles from './Modal.css';
 
 type Props = {|
   accessibilityModalLabel: string,
+  align?: 'left' | 'center',
   children?: Node,
   closeOnOutsideClick?: boolean,
   footer?: Node,
@@ -26,6 +28,7 @@ type Props = {|
   onDismiss: () => void,
   role?: 'alertdialog' | 'dialog',
   size?: 'sm' | 'md' | 'lg' | number,
+  subHeading?: string,
 |};
 
 const SIZE_WIDTH_MAP = {
@@ -34,16 +37,29 @@ const SIZE_WIDTH_MAP = {
   lg: 900,
 };
 
-function Header({ heading }: {| heading: string | Node |}) {
+function Header({
+  align,
+  heading,
+  subHeading,
+}: {|
+  align: 'left' | 'center',
+  heading: string | Node,
+  subHeading?: string,
+|}) {
   if (typeof heading !== 'string') {
     return heading;
   }
 
   return (
-    <Box display="flex" justifyContent="center" padding={8}>
-      <Heading size="md" accessibilityLevel={1}>
+    <Box justifyContent={align === 'left' ? 'start' : 'center'} padding={8}>
+      <Heading size="md" accessibilityLevel={1} align={align}>
         {heading}
       </Heading>
+      {subHeading && (
+        <Box marginTop={1}>
+          <Text align={align}>{subHeading}</Text>
+        </Box>
+      )}
     </Box>
   );
 }
@@ -54,6 +70,7 @@ const ModalWithForwardRef: React$AbstractComponent<
 > = forwardRef<Props, HTMLDivElement>(function Modal(props, ref): Node {
   const {
     accessibilityModalLabel,
+    align = 'center',
     children,
     closeOnOutsideClick = true,
     onDismiss,
@@ -61,6 +78,7 @@ const ModalWithForwardRef: React$AbstractComponent<
     heading,
     role = 'dialog',
     size = 'sm',
+    subHeading,
   } = props;
 
   const [showTopShadow, setShowTopShadow] = useState(false);
@@ -146,7 +164,11 @@ const ModalWithForwardRef: React$AbstractComponent<
                       [modalStyles.shadow]: showTopShadow,
                     })}
                   >
-                    <Header heading={heading} />
+                    <Header
+                      align={align}
+                      heading={heading}
+                      subHeading={subHeading}
+                    />
                   </div>
                 )}
                 <Box
@@ -178,6 +200,7 @@ const ModalWithForwardRef: React$AbstractComponent<
 // $FlowFixMe[prop-missing] flow 0.135.0 upgrade
 ModalWithForwardRef.propTypes = {
   accessibilityModalLabel: PropTypes.string.isRequired,
+  align: PropTypes.oneOf(['left', 'center']),
   children: PropTypes.node,
   closeOnOutsideClick: PropTypes.bool,
   footer: PropTypes.node,
@@ -188,6 +211,7 @@ ModalWithForwardRef.propTypes = {
     PropTypes.number,
     PropTypes.oneOf(['sm', 'md', 'lg']),
   ]),
+  subHeading: PropTypes.string,
 };
 
 ModalWithForwardRef.displayName = 'Modal';


### PR DESCRIPTION
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible. This is a request from design. We added the option to had a subtitle and to align heading text to the left as needed for Pinterest business users https://www.figma.com/file/UXjPl8EYCs3C2EE9y6ASPV/Modal?node-id=56%3A247
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->
This PR updates modal so that it can take a subHeading prop to add a subtitle under the heading and an align prop to justify the heading text left or center.

<img width="952" alt="Screen Shot 2020-12-17 at 1 38 28 PM" src="https://user-images.githubusercontent.com/46180742/102546958-477e3b00-406d-11eb-85de-146fc1bdbf1f.png">
<img width="890" alt="Screen Shot 2020-12-17 at 1 38 21 PM" src="https://user-images.githubusercontent.com/46180742/102546962-49e09500-406d-11eb-9f51-fcebd9275420.png">


## Test Plan
All tests are passing and I manually checked the doc examples to make sure that no unintended changes occurred.

<!--
How can reviewers verify this is good to merge?

* Is it tested? yes 
* Is it accessible? yes
* Is it documented? yes
* Have you involved other stakeholders (such as a Pinterest Designer)? yes!
-->
