### PR TITLE
Sheet: Add shouldCloseOnKeyEvent prop

### DIFF
--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -115,7 +115,7 @@ card(
         type: `boolean`,
         defaultValue: 'true',
         description: ['Determine if component should close on key event'],
-        href: 'refExample',
+        href: 'shouldCloseOnKeyEventExample',
       },
       {
         name: 'size',
@@ -696,6 +696,60 @@ function RefExample() {
               </Box>
             </Sheet>
             <div ref={callbackRef} />
+          </>
+        </Layer>
+      )}
+    </>
+  );
+}`}
+  />
+);
+
+card(
+  <Example
+    id="shouldCloseOnKeyEventExample"
+    name="Example: shouldCloseOnKeyEvent"
+    description={`
+    A \`Sheet\` with shouldCloseOnKeyEvent
+  `}
+    defaultCode={`
+function ShouldCloseOnKeyEventExample() {
+  const [shouldShow, setShouldShow] = React.useState(false);
+  const [shouldCloseOnKeyEvent, setShouldCloseOnKeyEvent] = React.useState(false);
+  const HEADER_ZINDEX = new FixedZIndex(10);
+  const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
+  return (
+    <>
+      <Button
+        inline
+        text="Open sheet"
+        onClick={() => setShouldShow(true)}
+      />
+      <Button
+        inline
+        text={\`shouldCloseOnKeyEvent: \${shouldCloseOnKeyEvent ? 'Enabled' : 'Disabled'}\`}
+        onClick={() => setShouldCloseOnKeyEvent(!shouldCloseOnKeyEvent)}
+      />
+      {shouldShow && (
+        <Layer zIndex={sheetZIndex}>
+          <>
+            <Sheet
+              accessibilityDismissButtonLabel="Close"
+              accessibilitySheetLabel="Focused sheet"
+              onDismiss={() => setShouldShow(false)}
+              shouldCloseOnKeyEvent={shouldCloseOnKeyEvent}
+              size="md"
+            >
+              <Box color="white" minHeight={400} padding={8}>
+                <Box marginBottom={4}>
+                  <Heading size="md">Sheet</Heading>
+                </Box>
+                <Text>
+                  This sheet {shouldCloseOnKeyEvent ? "CAN" : "CAN'T"} be closed with ESC key.
+                </Text>
+              </Box>
+            </Sheet>
+            <div />
           </>
         </Layer>
       )}

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -709,27 +709,35 @@ card(
   <Example
     id="shouldCloseOnKeyEventExample"
     name="Example: shouldCloseOnKeyEvent"
-    description={`
-    A \`Sheet\` with shouldCloseOnKeyEvent
-  `}
+    description={`\`shouldCloseOnKeyEvent\` may need to be \`false\` if the Sheet contains components that rely on the ESC key.
+                  When this prop is \`false\`, using the ESC key to close a component will not inadvertently close the Sheet.
+                  This prop should be restored to \`true\` to allow for the ESC key to close the Sheet.`}
     defaultCode={`
 function ShouldCloseOnKeyEventExample() {
   const [shouldShow, setShouldShow] = React.useState(false);
   const [shouldCloseOnKeyEvent, setShouldCloseOnKeyEvent] = React.useState(false);
   const HEADER_ZINDEX = new FixedZIndex(10);
   const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
+
   return (
     <>
-      <Button
-        inline
-        text="Open sheet"
-        onClick={() => setShouldShow(true)}
-      />
-      <Button
-        inline
-        text={\`shouldCloseOnKeyEvent: \${shouldCloseOnKeyEvent ? 'Enabled' : 'Disabled'}\`}
-        onClick={() => setShouldCloseOnKeyEvent(!shouldCloseOnKeyEvent)}
-      />
+      <Box
+        display="inlineBlock">
+        <Button
+          inline
+          text="Open sheet"
+          onClick={() => setShouldShow(true)}
+        />
+      </Box>
+      <Box
+        paddingX={3}
+        display="inlineBlock">
+        <Button
+          inline
+          text={\`shouldCloseOnKeyEvent: \${shouldCloseOnKeyEvent ? 'Enabled' : 'Disabled'}\`}
+          onClick={() => setShouldCloseOnKeyEvent(!shouldCloseOnKeyEvent)}
+        />
+      </Box>
       {shouldShow && (
         <Layer zIndex={sheetZIndex}>
           <>
@@ -747,6 +755,11 @@ function ShouldCloseOnKeyEventExample() {
                 <Text>
                   This sheet {shouldCloseOnKeyEvent ? "CAN" : "CAN'T"} be closed with ESC key.
                 </Text>
+                <DatePicker
+                  id="dp-test"
+                  label="Close DatePicker with ESC key"
+                  onChange={() => {}}
+                />
               </Box>
             </Sheet>
             <div />

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -114,9 +114,7 @@ card(
         name: 'shouldCloseOnKeyEvent',
         type: `() => boolean`,
         defaultValue: 'null',
-        description: [
-          'Determine if component should close on key event',
-        ],
+        description: ['Determine if component should close on key event'],
         href: 'refExample',
       },
       {

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -111,6 +111,15 @@ card(
         href: 'refExample',
       },
       {
+        name: 'shouldCloseOnKeyEvent',
+        type: `() => boolean`,
+        defaultValue: 'null',
+        description: [
+          'Determine if component should close on key event',
+        ],
+        href: 'refExample',
+      },
+      {
         name: 'size',
         type: `"sm" | "md" | "lg"`,
         defaultValue: 'sm',

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -112,8 +112,8 @@ card(
       },
       {
         name: 'shouldCloseOnKeyEvent',
-        type: `() => boolean`,
-        defaultValue: 'null',
+        type: `boolean`,
+        defaultValue: 'true',
         description: ['Determine if component should close on key event'],
         href: 'refExample',
       },

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -51,7 +51,7 @@ type SheetMainProps = {|
   closeOnOutsideClick?: boolean,
   footer?: Node,
   onDismiss: () => void,
-  shouldCloseOnKeyEvent?: () => boolean,
+  shouldCloseOnKeyEvent?: boolean,
   size?: 'sm' | 'md' | 'lg',
 |};
 
@@ -135,7 +135,7 @@ const SheetWithForwardRef: React$AbstractComponent<
     footer,
     heading,
     onDismiss,
-    shouldCloseOnKeyEvent,
+    shouldCloseOnKeyEvent = true,
     size = 'sm',
     subHeading,
   } = props;
@@ -149,12 +149,7 @@ const SheetWithForwardRef: React$AbstractComponent<
   // Handle onDismiss triggering from ESC keyup event
   useEffect(() => {
     function handleKeyUp(event: {| keyCode: number |}) {
-      if (
-        (shouldCloseOnKeyEvent &&
-          shouldCloseOnKeyEvent() &&
-          event.keyCode === ESCAPE) ||
-        (!shouldCloseOnKeyEvent && event.keyCode === ESCAPE)
-      ) {
+      if (shouldCloseOnKeyEvent && event.keyCode === ESCAPE) {
         onDismiss();
       }
     }

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -51,6 +51,7 @@ type SheetMainProps = {|
   closeOnOutsideClick?: boolean,
   footer?: Node,
   onDismiss: () => void,
+  shouldCloseOnKeyEvent?: () => boolean,
   size?: 'sm' | 'md' | 'lg',
 |};
 
@@ -134,6 +135,7 @@ const SheetWithForwardRef: React$AbstractComponent<
     footer,
     heading,
     onDismiss,
+    shouldCloseOnKeyEvent,
     size = 'sm',
     subHeading,
   } = props;
@@ -147,7 +149,12 @@ const SheetWithForwardRef: React$AbstractComponent<
   // Handle onDismiss triggering from ESC keyup event
   useEffect(() => {
     function handleKeyUp(event: {| keyCode: number |}) {
-      if (event.keyCode === ESCAPE) {
+      if (
+        (shouldCloseOnKeyEvent &&
+          shouldCloseOnKeyEvent() &&
+          event.keyCode === ESCAPE) ||
+        (!shouldCloseOnKeyEvent && event.keyCode === ESCAPE)
+      ) {
         onDismiss();
       }
     }
@@ -156,7 +163,7 @@ const SheetWithForwardRef: React$AbstractComponent<
     return function cleanup() {
       window.removeEventListener('keyup', handleKeyUp);
     };
-  }, [onDismiss]);
+  }, [onDismiss, shouldCloseOnKeyEvent]);
 
   // Handle onDismiss triggering from outside click
   const handleOutsideClick = useCallback(() => {
@@ -334,6 +341,7 @@ const AnimatedSheetWithForwardRef: React$AbstractComponent<
     heading = undefined,
     size,
     subHeading = undefined,
+    shouldCloseOnKeyEvent,
   } = props;
 
   return (
@@ -349,6 +357,7 @@ const AnimatedSheetWithForwardRef: React$AbstractComponent<
           heading={heading}
           onDismiss={onDismissStart}
           ref={sheetRef}
+          shouldCloseOnKeyEvent={shouldCloseOnKeyEvent}
           size={size}
           subHeading={
             typeof subHeading === 'function'

--- a/packages/gestalt/src/Sheet.jsdom.test.js
+++ b/packages/gestalt/src/Sheet.jsdom.test.js
@@ -199,9 +199,7 @@ describe('Sheet', () => {
         accessibilityDismissButtonLabel="Dismiss"
         accessibilitySheetLabel="Test Sheet"
         onDismiss={mockOnDismiss}
-        shouldCloseOnKeyEvent={() => {
-          return true;
-        }}
+        shouldCloseOnKeyEvent={true}
       >
         <section />
       </Sheet>
@@ -222,9 +220,7 @@ describe('Sheet', () => {
         accessibilityDismissButtonLabel="Dismiss"
         accessibilitySheetLabel="Test Sheet"
         onDismiss={mockOnDismiss}
-        shouldCloseOnKeyEvent={() => {
-          return false;
-        }}
+        shouldCloseOnKeyEvent={false}
       >
         <section />
       </Sheet>
@@ -235,6 +231,43 @@ describe('Sheet', () => {
     fireEvent.animationEnd(container.querySelector('div[role="dialog"]'));
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(0);
+  });
+
+  it('should dismiss from ESC key if shouldCloseOnKeyEvent is changed from false to true', () => {
+    const mockOnDismiss = jest.fn();
+
+    const { rerender, container } = render(
+      <Sheet
+        accessibilityDismissButtonLabel="Dismiss"
+        accessibilitySheetLabel="Test Sheet"
+        onDismiss={mockOnDismiss}
+        shouldCloseOnKeyEvent={false}
+      >
+        <section />
+      </Sheet>
+    );
+    fireEvent.keyUp(window.document, {
+      keyCode: 27,
+    });
+    fireEvent.animationEnd(container.querySelector('div[role="dialog"]'));
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(0);
+
+    rerender(<Sheet
+      accessibilityDismissButtonLabel="Dismiss"
+      accessibilitySheetLabel="Test Sheet"
+      onDismiss={mockOnDismiss}
+      shouldCloseOnKeyEvent={true}
+    >
+      <section />
+    </Sheet>);
+
+    fireEvent.keyUp(window.document, {
+      keyCode: 27,
+    });
+    fireEvent.animationEnd(container.querySelector('div[role="dialog"]'));
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
   });
 
   it('should dismiss from clicking outside when closeOnOutsideClick is true', () => {

--- a/packages/gestalt/src/Sheet.jsdom.test.js
+++ b/packages/gestalt/src/Sheet.jsdom.test.js
@@ -191,6 +191,52 @@ describe('Sheet', () => {
     expect(mockOnDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it('should dismiss from the ESC key if shouldCloseOnKeyEvent returns true', () => {
+    const mockOnDismiss = jest.fn();
+
+    const { container } = render(
+      <Sheet
+        accessibilityDismissButtonLabel="Dismiss"
+        accessibilitySheetLabel="Test Sheet"
+        onDismiss={mockOnDismiss}
+        shouldCloseOnKeyEvent={() => {
+          return true;
+        }}
+      >
+        <section />
+      </Sheet>
+    );
+    fireEvent.keyUp(window.document, {
+      keyCode: 27,
+    });
+    fireEvent.animationEnd(container.querySelector('div[role="dialog"]'));
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not dismiss from the ESC key if shouldCloseOnKeyEvent returns false', () => {
+    const mockOnDismiss = jest.fn();
+
+    const { container } = render(
+      <Sheet
+        accessibilityDismissButtonLabel="Dismiss"
+        accessibilitySheetLabel="Test Sheet"
+        onDismiss={mockOnDismiss}
+        shouldCloseOnKeyEvent={() => {
+          return false;
+        }}
+      >
+        <section />
+      </Sheet>
+    );
+    fireEvent.keyUp(window.document, {
+      keyCode: 27,
+    });
+    fireEvent.animationEnd(container.querySelector('div[role="dialog"]'));
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(0);
+  });
+
   it('should dismiss from clicking outside when closeOnOutsideClick is true', () => {
     const mockOnDismiss = jest.fn();
 

--- a/packages/gestalt/src/Sheet.jsdom.test.js
+++ b/packages/gestalt/src/Sheet.jsdom.test.js
@@ -199,7 +199,6 @@ describe('Sheet', () => {
         accessibilityDismissButtonLabel="Dismiss"
         accessibilitySheetLabel="Test Sheet"
         onDismiss={mockOnDismiss}
-        shouldCloseOnKeyEvent={true}
       >
         <section />
       </Sheet>
@@ -253,14 +252,15 @@ describe('Sheet', () => {
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(0);
 
-    rerender(<Sheet
-      accessibilityDismissButtonLabel="Dismiss"
-      accessibilitySheetLabel="Test Sheet"
-      onDismiss={mockOnDismiss}
-      shouldCloseOnKeyEvent={true}
-    >
-      <section />
-    </Sheet>);
+    rerender(
+      <Sheet
+        accessibilityDismissButtonLabel="Dismiss"
+        accessibilitySheetLabel="Test Sheet"
+        onDismiss={mockOnDismiss}
+      >
+        <section />
+      </Sheet>
+    );
 
     fireEvent.keyUp(window.document, {
       keyCode: 27,


### PR DESCRIPTION
What is the purpose of this PR?

Currently there is no way to disable the close key event for Sheet component. This PR allows the sheet component to have such behavior.

## Test Plan

* Is it tested? Yes
* Is it accessible? Yes
* Is it documented? Yes