### PR TITLE
ModuleExpandable: added external collapsing control (expandedIndex and onExpandedChange)

### DIFF
--- a/cypress/integration/accessibility_Module_spec.js
+++ b/cypress/integration/accessibility_Module_spec.js
@@ -5,14 +5,6 @@ describe('Module Accessibility check', () => {
   });
 
   it('Tests accessibility on the Module page', () => {
-    cy.configureAxe({
-      rules: [
-        {
-          id: 'color-contrast',
-          enabled: false,
-        },
-      ],
-    });
     cy.checkA11y();
   });
 });

--- a/cypress/integration/accessibility_Module_spec.js
+++ b/cypress/integration/accessibility_Module_spec.js
@@ -5,6 +5,14 @@ describe('Module Accessibility check', () => {
   });
 
   it('Tests accessibility on the Module page', () => {
+    cy.configureAxe({
+      rules: [
+        {
+          id: 'color-contrast',
+          enabled: false,
+        },
+      ],
+    });
     cy.checkA11y();
   });
 });

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -100,11 +100,19 @@ card(
         name: 'extExpandedId',
         type: '?string',
         required: false,
+        description: [
+          'The id of the item that the expand/collapse state can be controlled programally from an external component',
+        ],
+        href: 'externalControlExample',
       },
       {
         name: 'setExtExpandedId',
         type: '(?string) => void',
         required: false,
+        description: [
+          'The callback function that controls the expand/collapse state of an item',
+        ],
+        href: 'externalControlExample',
       },
       {
         name: 'items',
@@ -337,6 +345,7 @@ function ModuleExample4() {
 
 card(
   <Example
+    id="externalControlExample"
     name="Multiple items with external control"
     defaultCode={`
 function ModuleExample5() {

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -101,7 +101,7 @@ card(
         type: '?number',
         required: false,
         description: [
-          'The 0-based index of the item that the expand/collapse state can be controlled programatically from an external component',
+          'The 0-based index indicating the item that should currently be expanded. This must be updated via onExpandedChange to ensure the correct item is expanded.',
         ],
       },
       {
@@ -109,8 +109,7 @@ card(
         type: '(?number) => void',
         required: false,
         description: [
-          'The callback function that controls the expand/collapse state of an item if controlled programatically from an external component',
-          'The callback receives the index of the module component when expanded, and null when collapsed.',
+          'This callback is executed whenever any module item is expanded or collapsed. It receives the index of the currently expanded module, or null if none are expanded.',
         ],
       },
       {
@@ -364,7 +363,7 @@ function ModuleExample5() {
             accessibilityExpandLabel="Expand the module"
             accessibilityCollapseLabel="Collapse the module"
             expandedIndex={extExpandedId && extExpandedId.startsWith('first') && mapIds[extExpandedId]}
-            onExpandedChange={(index) => setExtExpandedId('first-'+index)}
+            onExpandedChange={(index) => setExtExpandedId(Number.isFinite(index) ? \`first-$\{index}\`: index)}
             items={[
               {
                 title: 'Title1',
@@ -386,7 +385,7 @@ function ModuleExample5() {
             accessibilityExpandLabel="Expand the module"
             accessibilityCollapseLabel="Collapse the module"
             expandedIndex={extExpandedId && extExpandedId.startsWith('second') && mapIds[extExpandedId]}
-            onExpandedChange={(index) => setExtExpandedId('second-'+index)}
+            onExpandedChange={(index) => setExtExpandedId(Number.isFinite(index) ? \`second-$\{index}\`: index)}
             items={[
               {
                 title: 'Title1',

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -97,17 +97,16 @@ card(
           'Label used to communicate to screen readers which module will be collapsed when interacting with the title button. Should be something clear, like "Collapse Security Policies Module"',
       },
       {
-        name: 'expandedId',
-        type: '?string',
+        name: 'expandedIndex',
+        type: '?number',
         required: false,
         description: [
-          'The ID of the item that the expand/collapse state can be controlled programatically from an external component',
-          'expandedId is constructed in the format of {id}-{index of the item}',
+          'The index of the item that the expand/collapse state can be controlled programatically from an external component',
         ],
       },
       {
-        name: 'setExpandedId',
-        type: '(?string) => void',
+        name: 'onExpandedChange',
+        type: '(?number) => void',
         required: false,
         description: [
           'The callback function that controls the expand/collapse state of an item if controlled programatically from an external component',
@@ -221,7 +220,7 @@ card(
     defaultCode={`
 function ModuleExample1() {
   return (
-    <Box maxWidth={800} padding={2} column={12}>
+    <Box maxWidth={800} padding={2} column={12} >
       <Module.Expandable
         id="ModuleExample - default"
         accessibilityExpandLabel="Expand the module"
@@ -248,7 +247,7 @@ card(
     defaultCode={`
 function ModuleExample2() {
   return (
-    <Box maxWidth={800} padding={2} column={12}>
+    <Box maxWidth={800} padding={2} column={12} >
       <Module.Expandable
         id="ModuleExample2"
         accessibilityExpandLabel="Expand the module"
@@ -284,7 +283,7 @@ card(
     defaultCode={`
 function ModuleExample3() {
   return (
-    <Box maxWidth={800} padding={2} column={12}>
+    <Box maxWidth={800} padding={2} column={12} >
       <Module.Expandable
         id="ModuleExample3"
         accessibilityExpandLabel="Expand the module"
@@ -335,6 +334,73 @@ function ModuleExample4() {
             type: moduleType
           }]}>
       </Module.Expandable>
+    </Box>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    name="Example with external control"
+    defaultCode={`
+function ModuleExample5() {
+  const [extExpandedId, setExtExpandedId] = React.useState(null);
+  const mapIds = {
+      'first-0': 0,
+      'first-1': 1,
+      'second-0': 0,
+      'second-1': 1,
+  }
+  return (
+    <Box maxWidth={800} padding={2} column={12}>
+      <Flex direction='column' gap={3}>
+        <Box padding={1} borderStyle='sm'>
+          <Text>Step 1</Text>
+          <Module.Expandable
+            id="ModuleExample5"
+            accessibilityExpandLabel="Expand the module"
+            accessibilityCollapseLabel="Collapse the module"
+            expandedIndex={extExpandedId && extExpandedId.startsWith('first') && mapIds[extExpandedId]}
+            onExpandedChange={(index) => setExtExpandedId('first-'+index)}
+            items={[
+              {
+                title: 'Title1',
+                summary: ['summary1'],
+                children: <Text size="md">Children1</Text>,
+              },
+              {
+                title: 'Title2',
+                summary: ['summary2'],
+                children: <Text size="md">Children2</Text>,
+              },
+            ]}
+          />
+        </Box>
+        <Box padding={1} borderStyle='sm'>
+          <Text>Step 2</Text>
+          <Module.Expandable
+            id="ModuleExample5"
+            accessibilityExpandLabel="Expand the module"
+            accessibilityCollapseLabel="Collapse the module"
+            expandedIndex={extExpandedId && extExpandedId.startsWith('second') && mapIds[extExpandedId]}
+            onExpandedChange={(index) => setExtExpandedId('second-'+index)}
+            items={[
+              {
+                title: 'Title1',
+                summary: ['summary1'],
+                children: <Text size="md">Children1</Text>,
+              },
+              {
+                title: 'Title2',
+                summary: ['summary2'],
+                children: <Text size="md">Children2</Text>,
+              },
+            ]}
+          />
+        </Box>
+      </Flex>
     </Box>
   );
 }

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -101,7 +101,7 @@ card(
         type: '?number',
         required: false,
         description: [
-          'The index of the item that the expand/collapse state can be controlled programatically from an external component',
+          'The 0-based index of the item that the expand/collapse state can be controlled programatically from an external component',
         ],
       },
       {
@@ -110,6 +110,7 @@ card(
         required: false,
         description: [
           'The callback function that controls the expand/collapse state of an item if controlled programatically from an external component',
+          'The callback receives the index of the module component when expanded, and null when collapsed.',
         ],
       },
       {

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -97,6 +97,16 @@ card(
           'Label used to communicate to screen readers which module will be collapsed when interacting with the title button. Should be something clear, like "Collapse Security Policies Module"',
       },
       {
+        name: 'extExpandedId',
+        type: '?string',
+        required: false,
+      },
+      {
+        name: 'setExtExpandedId',
+        type: '(?string) => void',
+        required: false,
+      },
+      {
         name: 'items',
         href: 'expandable-items',
         type:
@@ -316,6 +326,67 @@ function ModuleExample4() {
             </Text>,
             iconAccessibilityLabel: "error icon",
             type: moduleType
+          }]}>
+      </Module.Expandable>
+    </Box>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    name="Multiple items with external control"
+    defaultCode={`
+function ModuleExample5() {
+  const [extExpandedId, setExtExpandedId] = React.useState(null);
+  return (
+    <Box maxWidth={800} padding={2} column={12}>
+      <Box display="flex" paddingY={2}>
+        <Box paddingX={2}>
+          <Button
+            size="sm"
+            text={extExpandedId === "ModuleExample5-0"? "collapse 1": "expand 1"}
+            onClick={() => extExpandedId === "ModuleExample5-0"? setExtExpandedId("-1"): setExtExpandedId("ModuleExample5-0")}
+          />
+        </Box>
+        <Box paddingX={2}>
+          <Button
+            size="sm"
+            text={extExpandedId === "ModuleExample5-1"? "collapse 2": "expand 2"}
+            onClick={() => extExpandedId === "ModuleExample5-1"? setExtExpandedId("-1"): setExtExpandedId("ModuleExample5-1")}
+          />
+        </Box>
+        <Box paddingX={2}>
+          <Button
+            size="sm"
+            text={extExpandedId === "ModuleExample5-2"? "collapse 3": "expand 3"}
+            onClick={() => extExpandedId === "ModuleExample5-2"? setExtExpandedId("-1"): setExtExpandedId("ModuleExample5-2")}
+          />
+        </Box>
+      </Box>
+      <Module.Expandable
+        id="ModuleExample5"
+        accessibilityExpandLabel="Expand the module"
+        accessibilityCollapseLabel="Collapse the module"
+        extExpandedId={extExpandedId}
+        setExtExpandedId={setExtExpandedId}
+        items={[
+          {
+            title: 'Title1',
+            summary: ['summary1'],
+            children: <Text size="md">Children1</Text>,
+          },
+          {
+            title: 'Title2',
+            summary: ['summary2'],
+            children: <Text size="md">Children2</Text>,
+          },
+          {
+            title: 'Title3',
+            summary: ['summary3'],
+            children: <Text size="md">Children3</Text>,
           }]}>
       </Module.Expandable>
     </Box>

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -101,7 +101,8 @@ card(
         type: '?string',
         required: false,
         description: [
-          'The id of the item that the expand/collapse state can be controlled programatically from an external component',
+          'The ID of the item that the expand/collapse state can be controlled programatically from an external component',
+          'expandedId is constructed in the format of {id}-{index of the item}',
         ],
       },
       {

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -103,7 +103,6 @@ card(
         description: [
           'The id of the item that the expand/collapse state can be controlled programally from an external component',
         ],
-        href: 'externalControlExample',
       },
       {
         name: 'setExtExpandedId',
@@ -112,7 +111,6 @@ card(
         description: [
           'The callback function that controls the expand/collapse state of an item',
         ],
-        href: 'externalControlExample',
       },
       {
         name: 'items',
@@ -334,68 +332,6 @@ function ModuleExample4() {
             </Text>,
             iconAccessibilityLabel: "error icon",
             type: moduleType
-          }]}>
-      </Module.Expandable>
-    </Box>
-  );
-}
-`}
-  />
-);
-
-card(
-  <Example
-    id="externalControlExample"
-    name="Multiple items with external control"
-    defaultCode={`
-function ModuleExample5() {
-  const [extExpandedId, setExtExpandedId] = React.useState(null);
-  return (
-    <Box maxWidth={800} padding={2} column={12}>
-      <Box display="flex" paddingY={2}>
-        <Box paddingX={2}>
-          <Button
-            size="sm"
-            text={extExpandedId === "ModuleExample5-0"? "collapse 1": "expand 1"}
-            onClick={() => extExpandedId === "ModuleExample5-0"? setExtExpandedId("-1"): setExtExpandedId("ModuleExample5-0")}
-          />
-        </Box>
-        <Box paddingX={2}>
-          <Button
-            size="sm"
-            text={extExpandedId === "ModuleExample5-1"? "collapse 2": "expand 2"}
-            onClick={() => extExpandedId === "ModuleExample5-1"? setExtExpandedId("-1"): setExtExpandedId("ModuleExample5-1")}
-          />
-        </Box>
-        <Box paddingX={2}>
-          <Button
-            size="sm"
-            text={extExpandedId === "ModuleExample5-2"? "collapse 3": "expand 3"}
-            onClick={() => extExpandedId === "ModuleExample5-2"? setExtExpandedId("-1"): setExtExpandedId("ModuleExample5-2")}
-          />
-        </Box>
-      </Box>
-      <Module.Expandable
-        id="ModuleExample5"
-        accessibilityExpandLabel="Expand the module"
-        accessibilityCollapseLabel="Collapse the module"
-        extExpandedId={extExpandedId}
-        setExtExpandedId={setExtExpandedId}
-        items={[
-          {
-            title: 'Title1',
-            summary: ['summary1'],
-            children: <Text size="md">Children1</Text>,
-          },
-          {
-            title: 'Title2',
-            summary: ['summary2'],
-            children: <Text size="md">Children2</Text>,
-          },
-          {
-            title: 'Title3',
-            summary: ['summary3'],
-            children: <Text size="md">Children3</Text>,
           }]}>
       </Module.Expandable>
     </Box>

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -97,19 +97,19 @@ card(
           'Label used to communicate to screen readers which module will be collapsed when interacting with the title button. Should be something clear, like "Collapse Security Policies Module"',
       },
       {
-        name: 'extExpandedId',
+        name: 'expandedId',
         type: '?string',
         required: false,
         description: [
-          'The id of the item that the expand/collapse state can be controlled programally from an external component',
+          'The id of the item that the expand/collapse state can be controlled programatically from an external component',
         ],
       },
       {
-        name: 'setExtExpandedId',
+        name: 'setExpandedId',
         type: '(?string) => void',
         required: false,
         description: [
-          'The callback function that controls the expand/collapse state of an item',
+          'The callback function that controls the expand/collapse state of an item if controlled programatically from an external component',
         ],
       },
       {

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -360,7 +360,7 @@ function ModuleExample5() {
         <Box padding={1} borderStyle='sm'>
           <Text>Step 1</Text>
           <Module.Expandable
-            id="ModuleExample5"
+            id="ModuleExampleStep1"
             accessibilityExpandLabel="Expand the module"
             accessibilityCollapseLabel="Collapse the module"
             expandedIndex={extExpandedId && extExpandedId.startsWith('first') && mapIds[extExpandedId]}
@@ -382,7 +382,7 @@ function ModuleExample5() {
         <Box padding={1} borderStyle='sm'>
           <Text>Step 2</Text>
           <Module.Expandable
-            id="ModuleExample5"
+            id="ModuleExampleStep2"
             accessibilityExpandLabel="Expand the module"
             accessibilityCollapseLabel="Collapse the module"
             expandedIndex={extExpandedId && extExpandedId.startsWith('second') && mapIds[extExpandedId]}

--- a/packages/gestalt/src/ModuleExpandable.flowtest.js
+++ b/packages/gestalt/src/ModuleExpandable.flowtest.js
@@ -7,8 +7,8 @@ const Valid = (
     id="uniqueTestID"
     accessibilityExpandLabel="click to expand"
     accessibilityCollapseLabel="click to collapse"
-    extExpandedId="uniqueTestID-0"
-    setExtExpandedId={() => {}}
+    expandedId="uniqueTestID-0"
+    setExpandedId={() => {}}
     items={[
       {
         title: 'Title',

--- a/packages/gestalt/src/ModuleExpandable.flowtest.js
+++ b/packages/gestalt/src/ModuleExpandable.flowtest.js
@@ -7,8 +7,8 @@ const Valid = (
     id="uniqueTestID"
     accessibilityExpandLabel="click to expand"
     accessibilityCollapseLabel="click to collapse"
-    expandedId="uniqueTestID-0"
-    setExpandedId={() => {}}
+    expandedIndex={0}
+    onExpandedChange={() => {}}
     items={[
       {
         title: 'Title',

--- a/packages/gestalt/src/ModuleExpandable.flowtest.js
+++ b/packages/gestalt/src/ModuleExpandable.flowtest.js
@@ -7,6 +7,8 @@ const Valid = (
     id="uniqueTestID"
     accessibilityExpandLabel="click to expand"
     accessibilityCollapseLabel="click to collapse"
+    extExpandedId="uniqueTestID-0"
+    setExtExpandedId={() => {}}
     items={[
       {
         title: 'Title',

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { useState, type Node } from 'react';
+import React, { useState, useEffect, type Node } from 'react';
 import Box from './Box.js';
 import Divider from './Divider.js';
 import ModuleExpandableItem from './ModuleExpandableItem.js';
@@ -9,13 +9,15 @@ export default function ModuleExpandable({
   id,
   accessibilityExpandLabel,
   accessibilityCollapseLabel,
-  expandedId,
-  setExpandedId,
+  expandedIndex,
+  onExpandedChange,
   items,
 }: Props): Node {
-  const [localExpandedId, setLocalExpandedId] = useState(null);
-  const expId = expandedId || localExpandedId;
-  const setExpId = setExpandedId || setLocalExpandedId;
+  const [expandedId, setExpandedId] = useState(expandedIndex || null);
+
+  useEffect(() => {
+    setExpandedId(expandedIndex || expandedIndex === 0 ? expandedIndex : null);
+  }, [expandedIndex, setExpandedId]);
 
   return (
     <Box rounding={2} borderStyle="shadow">
@@ -32,12 +34,15 @@ export default function ModuleExpandable({
                 icon={icon}
                 iconAccessibilityLabel={iconAccessibilityLabel}
                 summary={summary}
-                isCollapsed={expId !== `${id}-${index}`}
+                isCollapsed={expandedId !== index}
                 type={type}
                 accessibilityExpandLabel={accessibilityExpandLabel}
                 accessibilityCollapseLabel={accessibilityCollapseLabel}
                 onModuleClicked={(isExpanded) => {
-                  setExpId(isExpanded ? null : `${id}-${index}`);
+                  if (onExpandedChange) {
+                    onExpandedChange(isExpanded ? null : index);
+                  }
+                  setExpandedId(isExpanded ? null : index);
                 }}
               >
                 {children}

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -9,13 +9,13 @@ export default function ModuleExpandable({
   id,
   accessibilityExpandLabel,
   accessibilityCollapseLabel,
-  extExpandedId,
-  setExtExpandedId,
+  expandedId,
+  setExpandedId,
   items,
 }: Props): Node {
   const [localExpandedId, setLocalExpandedId] = useState(null);
-  const expandedId = extExpandedId || localExpandedId;
-  const setExpandedId = setExtExpandedId || setLocalExpandedId;
+  const expId = expandedId || localExpandedId;
+  const setExpId = setExpandedId || setLocalExpandedId;
 
   return (
     <Box rounding={2} borderStyle="shadow">
@@ -32,12 +32,12 @@ export default function ModuleExpandable({
                 icon={icon}
                 iconAccessibilityLabel={iconAccessibilityLabel}
                 summary={summary}
-                isCollapsed={expandedId !== `${id}-${index}`}
+                isCollapsed={expId !== `${id}-${index}`}
                 type={type}
                 accessibilityExpandLabel={accessibilityExpandLabel}
                 accessibilityCollapseLabel={accessibilityCollapseLabel}
                 onModuleClicked={(isExpanded) => {
-                  setExpandedId(isExpanded ? null : `${id}-${index}`);
+                  setExpId(isExpanded ? null : `${id}-${index}`);
                 }}
               >
                 {children}

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -13,10 +13,12 @@ export default function ModuleExpandable({
   onExpandedChange,
   items,
 }: Props): Node {
-  const [expandedId, setExpandedId] = useState(expandedIndex || null);
+  const [expandedId, setExpandedId] = useState<?number>(
+    Number.isFinite(expandedIndex) ? expandedIndex : null
+  );
 
   useEffect(() => {
-    setExpandedId(expandedIndex || expandedIndex === 0 ? expandedIndex : null);
+    setExpandedId(Number.isFinite(expandedIndex) ? expandedIndex : null);
   }, [expandedIndex, setExpandedId]);
 
   return (

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -9,9 +9,13 @@ export default function ModuleExpandable({
   id,
   accessibilityExpandLabel,
   accessibilityCollapseLabel,
+  extExpandedId,
+  setExtExpandedId,
   items,
-}: ExpandableBaseProps): Node {
-  const [expandedId, setExpandedId] = useState(-1);
+}: Props): Node {
+  const [localExpandedId, setLocalExpandedId] = useState(null);
+  const expandedId = extExpandedId || localExpandedId;
+  const setExpandedId = setExtExpandedId || setLocalExpandedId;
 
   return (
     <Box rounding={2} borderStyle="shadow">
@@ -28,13 +32,13 @@ export default function ModuleExpandable({
                 icon={icon}
                 iconAccessibilityLabel={iconAccessibilityLabel}
                 summary={summary}
-                isCollapsed={expandedId !== index}
+                isCollapsed={expandedId !== `${id}-${index}`}
                 type={type}
                 accessibilityExpandLabel={accessibilityExpandLabel}
                 accessibilityCollapseLabel={accessibilityCollapseLabel}
-                onModuleClicked={(isExpanded) =>
-                  setExpandedId(isExpanded ? -1 : index)
-                }
+                onModuleClicked={(isExpanded) => {
+                  setExpandedId(isExpanded ? null : `${id}-${index}`);
+                }}
               >
                 {children}
               </ModuleExpandableItem>

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -12,7 +12,7 @@ export default function ModuleExpandable({
   expandedIndex,
   onExpandedChange,
   items,
-}: Props): Node {
+}: ExpandableBaseProps): Node {
   const [expandedId, setExpandedId] = useState<?number>(
     Number.isFinite(expandedIndex) ? expandedIndex : null
   );

--- a/packages/gestalt/src/ModuleExpandable.jsdom.test.js
+++ b/packages/gestalt/src/ModuleExpandable.jsdom.test.js
@@ -75,11 +75,11 @@ describe('ModuleExpandable', () => {
     expect(screen.getByText(/Children3/i)).toBeInTheDocument();
   });
 
-  it('should expand the module correctly with extExpandedId', () => {
+  it('should expand the module correctly with expandedId', () => {
     const newProps = {
       ...props,
-      extExpandedId: 'uniqueTestID-0',
-      setExtExpandedId: jest.fn(),
+      expandedId: 'uniqueTestID-0',
+      setExpandedId: jest.fn(),
     };
     render(<ModuleExpandable {...newProps} />);
 
@@ -93,7 +93,7 @@ describe('ModuleExpandable', () => {
       name: /click to collapse/i,
     });
     fireEvent.click(button1);
-    expect(newProps.setExtExpandedId).toHaveBeenCalledWith(null);
+    expect(newProps.setExpandedId).toHaveBeenCalledWith(null);
 
     // Click on Item 2 to expand it
     const expandButtons = screen.getAllByRole('button', {
@@ -101,6 +101,6 @@ describe('ModuleExpandable', () => {
     });
     expect(expandButtons).toHaveLength(2);
     fireEvent.click(expandButtons[0]);
-    expect(newProps.setExtExpandedId).toHaveBeenCalledWith('uniqueTestID-1');
+    expect(newProps.setExpandedId).toHaveBeenCalledWith('uniqueTestID-1');
   });
 });

--- a/packages/gestalt/src/ModuleExpandable.jsdom.test.js
+++ b/packages/gestalt/src/ModuleExpandable.jsdom.test.js
@@ -74,4 +74,33 @@ describe('ModuleExpandable', () => {
     expect(screen.queryByText(/Children2/i)).toBeNull();
     expect(screen.getByText(/Children3/i)).toBeInTheDocument();
   });
+
+  it('should expand the module correctly with extExpandedId', () => {
+    const newProps = {
+      ...props,
+      extExpandedId: 'uniqueTestID-0',
+      setExtExpandedId: jest.fn(),
+    };
+    render(<ModuleExpandable {...newProps} />);
+
+    // Item 1 is default to be expanded
+    expect(screen.getByText(/Children1/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Children2/i)).toBeNull();
+    expect(screen.queryByText(/Children3/i)).toBeNull();
+
+    // Click on Item 1 to collapse the item
+    const button1 = screen.getByRole('button', {
+      name: /click to collapse/i,
+    });
+    fireEvent.click(button1);
+    expect(newProps.setExtExpandedId).toHaveBeenCalledWith(null);
+
+    // Click on Item 2 to expand it
+    const expandButtons = screen.getAllByRole('button', {
+      name: /click to expand/i,
+    });
+    expect(expandButtons).toHaveLength(2);
+    fireEvent.click(expandButtons[0]);
+    expect(newProps.setExtExpandedId).toHaveBeenCalledWith('uniqueTestID-1');
+  });
 });

--- a/packages/gestalt/src/ModuleExpandable.jsdom.test.js
+++ b/packages/gestalt/src/ModuleExpandable.jsdom.test.js
@@ -78,29 +78,29 @@ describe('ModuleExpandable', () => {
   it('should expand the module correctly with expandedId', () => {
     const newProps = {
       ...props,
-      expandedId: 'uniqueTestID-0',
-      setExpandedId: jest.fn(),
+      expandedIndex: 0,
+      onExpandedChange: jest.fn(),
     };
     render(<ModuleExpandable {...newProps} />);
 
-    // Item 1 is default to be expanded
+    // Item with index 0 is default to be expanded
     expect(screen.getByText(/Children1/i)).toBeInTheDocument();
     expect(screen.queryByText(/Children2/i)).toBeNull();
     expect(screen.queryByText(/Children3/i)).toBeNull();
 
-    // Click on Item 1 to collapse the item
+    // Click on Item with index 0 to collapse the item
     const button1 = screen.getByRole('button', {
       name: /click to collapse/i,
     });
     fireEvent.click(button1);
-    expect(newProps.setExpandedId).toHaveBeenCalledWith(null);
+    expect(newProps.onExpandedChange).toHaveBeenCalledWith(null);
 
-    // Click on Item 2 to expand it
+    // Click on with index 1 to expand it
     const expandButtons = screen.getAllByRole('button', {
       name: /click to expand/i,
     });
-    expect(expandButtons).toHaveLength(2);
-    fireEvent.click(expandButtons[0]);
-    expect(newProps.setExpandedId).toHaveBeenCalledWith('uniqueTestID-1');
+    expect(expandButtons).toHaveLength(3);
+    fireEvent.click(expandButtons[1]);
+    expect(newProps.onExpandedChange).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/gestalt/src/ModuleExpandable.test.js
+++ b/packages/gestalt/src/ModuleExpandable.test.js
@@ -55,3 +55,36 @@ describe('Module Expandable', () => {
     expect(tree).toMatchSnapshot();
   });
 });
+
+test('renders correctly with multiple items with extExpandedId', () => {
+  const tree = renderer
+    .create(
+      <ModuleExpandable
+        id="uniqueTestID"
+        accessibilityExpandLabel="click to expand"
+        accessibilityCollapseLabel="click to collapse"
+        extExpandedId="uniqueTestID-0"
+        setExtExpandedId={() => {}}
+        items={[
+          {
+            title: 'Title1',
+            summary: ['summary1'],
+            children: 'Children1',
+          },
+          {
+            title: 'Title2',
+            summary: ['summary2'],
+            children: 'Children2',
+          },
+          {
+            title: 'Title3',
+            summary: ['summary3'],
+            children: 'Children3',
+            type: 'error',
+          },
+        ]}
+      />
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/ModuleExpandable.test.js
+++ b/packages/gestalt/src/ModuleExpandable.test.js
@@ -63,8 +63,8 @@ test('renders correctly with multiple items with expandedId', () => {
         id="uniqueTestID"
         accessibilityExpandLabel="click to expand"
         accessibilityCollapseLabel="click to collapse"
-        expandedId="uniqueTestID-0"
-        setExpandedId={() => {}}
+        expandedIndex={0}
+        onExpandedChange={() => {}}
         items={[
           {
             title: 'Title1',

--- a/packages/gestalt/src/ModuleExpandable.test.js
+++ b/packages/gestalt/src/ModuleExpandable.test.js
@@ -56,15 +56,15 @@ describe('Module Expandable', () => {
   });
 });
 
-test('renders correctly with multiple items with extExpandedId', () => {
+test('renders correctly with multiple items with expandedId', () => {
   const tree = renderer
     .create(
       <ModuleExpandable
         id="uniqueTestID"
         accessibilityExpandLabel="click to expand"
         accessibilityCollapseLabel="click to collapse"
-        extExpandedId="uniqueTestID-0"
-        setExtExpandedId={() => {}}
+        expandedId="uniqueTestID-0"
+        setExpandedId={() => {}}
         items={[
           {
             title: 'Title1',

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -283,8 +283,8 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
     <div
       aria-controls="uniqueTestID-0"
       aria-disabled={false}
-      aria-expanded={false}
-      aria-label="click to expand"
+      aria-expanded={true}
+      aria-label="click to collapse"
       className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
       onBlur={[Function]}
       onClick={[Function]}
@@ -309,27 +309,13 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
           className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
         >
           <div
-            className="box xsCol6 xsDisplayFlex"
+            className="box xsCol12 xsDisplayFlex"
           >
             <div
               className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
               title="Title1"
             >
               Title1
-            </div>
-          </div>
-          <div
-            className="box marginStart6 xsCol6"
-          >
-            <div
-              className="box marginBottom0"
-            >
-              <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary1"
-              >
-                summary1
-              </div>
             </div>
           </div>
         </div>
@@ -342,7 +328,7 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
           >
             <svg
               aria-hidden={null}
-              aria-label="click to expand"
+              aria-label="click to collapse"
               className="icon darkGray iconBlock"
               height="12"
               role="img"
@@ -356,6 +342,11 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="box marginTopN6 paddingX6 paddingY6"
+    >
+      Children1
     </div>
   </div>
   <hr

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -273,6 +273,114 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
 </div>
 `;
 
+exports[`Module Expandable renders correctly with one item 1`] = `
+<div
+  className="box rounding2 shadow"
+>
+  <div
+    className="box"
+  >
+    <div
+      aria-controls="uniqueTestID-0"
+      aria-disabled={false}
+      aria-expanded={false}
+      aria-label="click to expand"
+      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyPress={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        className="box paddingX6 paddingY6 xsDisplayFlex"
+      >
+        <div
+          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+        >
+          <div
+            className="box xsCol6 xsDisplayFlex"
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+              title="Title"
+            >
+              Title
+            </div>
+          </div>
+          <div
+            className="box marginStart6 xsCol6"
+          >
+            <div
+              className="box marginBottom2"
+            >
+              <div
+                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                title="summary1"
+              >
+                summary1
+              </div>
+            </div>
+            <div
+              className="box marginBottom2"
+            >
+              <div
+                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                title="summary2"
+              >
+                summary2
+              </div>
+            </div>
+            <div
+              className="box marginBottom0"
+            >
+              <div
+                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                title="summary3"
+              >
+                summary3
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="box"
+          id="uniqueTestID-0"
+        >
+          <div
+            className="box paddingX1 paddingY1"
+          >
+            <svg
+              aria-hidden={null}
+              aria-label="click to expand"
+              className="icon darkGray iconBlock"
+              height="12"
+              role="img"
+              viewBox="0 0 24 24"
+              width="12"
+            >
+              <path
+                d="test-file-stub"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders correctly with multiple items with expandedId 1`] = `
 <div
   className="box rounding2 shadow"
@@ -512,114 +620,6 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
         <div
           className="box"
           id="uniqueTestID-2"
-        >
-          <div
-            className="box paddingX1 paddingY1"
-          >
-            <svg
-              aria-hidden={null}
-              aria-label="click to expand"
-              className="icon darkGray iconBlock"
-              height="12"
-              role="img"
-              viewBox="0 0 24 24"
-              width="12"
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`renders correctly with one item 1`] = `
-<div
-  className="box rounding2 shadow"
->
-  <div
-    className="box"
-  >
-    <div
-      aria-controls="uniqueTestID-0"
-      aria-disabled={false}
-      aria-expanded={false}
-      aria-label="click to expand"
-      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="button"
-      tabIndex={0}
-    >
-      <div
-        className="box paddingX6 paddingY6 xsDisplayFlex"
-      >
-        <div
-          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
-        >
-          <div
-            className="box xsCol6 xsDisplayFlex"
-          >
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-              title="Title"
-            >
-              Title
-            </div>
-          </div>
-          <div
-            className="box marginStart6 xsCol6"
-          >
-            <div
-              className="box marginBottom2"
-            >
-              <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary1"
-              >
-                summary1
-              </div>
-            </div>
-            <div
-              className="box marginBottom2"
-            >
-              <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary2"
-              >
-                summary2
-              </div>
-            </div>
-            <div
-              className="box marginBottom0"
-            >
-              <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary3"
-              >
-                summary3
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="box"
-          id="uniqueTestID-0"
         >
           <div
             className="box paddingX1 paddingY1"

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -273,7 +273,280 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
 </div>
 `;
 
-exports[`Module Expandable renders correctly with one item 1`] = `
+exports[`renders correctly with multiple items with expandedId 1`] = `
+<div
+  className="box rounding2 shadow"
+>
+  <div
+    className="box"
+  >
+    <div
+      aria-controls="uniqueTestID-0"
+      aria-disabled={false}
+      aria-expanded={false}
+      aria-label="click to expand"
+      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyPress={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        className="box paddingX6 paddingY6 xsDisplayFlex"
+      >
+        <div
+          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+        >
+          <div
+            className="box xsCol6 xsDisplayFlex"
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+              title="Title1"
+            >
+              Title1
+            </div>
+          </div>
+          <div
+            className="box marginStart6 xsCol6"
+          >
+            <div
+              className="box marginBottom0"
+            >
+              <div
+                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                title="summary1"
+              >
+                summary1
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="box"
+          id="uniqueTestID-0"
+        >
+          <div
+            className="box paddingX1 paddingY1"
+          >
+            <svg
+              aria-hidden={null}
+              aria-label="click to expand"
+              className="icon darkGray iconBlock"
+              height="12"
+              role="img"
+              viewBox="0 0 24 24"
+              width="12"
+            >
+              <path
+                d="test-file-stub"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="divider"
+  />
+  <div
+    className="box"
+  >
+    <div
+      aria-controls="uniqueTestID-1"
+      aria-disabled={false}
+      aria-expanded={false}
+      aria-label="click to expand"
+      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyPress={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        className="box paddingX6 paddingY6 xsDisplayFlex"
+      >
+        <div
+          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+        >
+          <div
+            className="box xsCol6 xsDisplayFlex"
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+              title="Title2"
+            >
+              Title2
+            </div>
+          </div>
+          <div
+            className="box marginStart6 xsCol6"
+          >
+            <div
+              className="box marginBottom0"
+            >
+              <div
+                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                title="summary2"
+              >
+                summary2
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="box"
+          id="uniqueTestID-1"
+        >
+          <div
+            className="box paddingX1 paddingY1"
+          >
+            <svg
+              aria-hidden={null}
+              aria-label="click to expand"
+              className="icon darkGray iconBlock"
+              height="12"
+              role="img"
+              viewBox="0 0 24 24"
+              width="12"
+            >
+              <path
+                d="test-file-stub"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="divider"
+  />
+  <div
+    className="box"
+  >
+    <div
+      aria-controls="uniqueTestID-2"
+      aria-disabled={false}
+      aria-expanded={false}
+      aria-label="click to expand"
+      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyPress={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        className="box paddingX6 paddingY6 xsDisplayFlex"
+      >
+        <div
+          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+        >
+          <div
+            className="box xsCol6 xsDisplayFlex"
+          >
+            <div
+              className="box marginEnd2"
+            >
+              <svg
+                aria-hidden={true}
+                aria-label=""
+                className="icon red iconBlock"
+                height={16}
+                role="img"
+                viewBox="0 0 24 24"
+                width={16}
+              >
+                <path
+                  d="test-file-stub"
+                />
+              </svg>
+            </div>
+            <div
+              className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
+              title="Title3"
+            >
+              Title3
+            </div>
+          </div>
+          <div
+            className="box marginStart6 xsCol6"
+          >
+            <div
+              className="box marginBottom0"
+            >
+              <div
+                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                title="summary3"
+              >
+                summary3
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="box"
+          id="uniqueTestID-2"
+        >
+          <div
+            className="box paddingX1 paddingY1"
+          >
+            <svg
+              aria-hidden={null}
+              aria-label="click to expand"
+              className="icon darkGray iconBlock"
+              height="12"
+              role="img"
+              viewBox="0 0 24 24"
+              width="12"
+            >
+              <path
+                d="test-file-stub"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders correctly with one item 1`] = `
 <div
   className="box rounding2 shadow"
 >

--- a/packages/gestalt/src/moduleTypes.js
+++ b/packages/gestalt/src/moduleTypes.js
@@ -17,6 +17,7 @@ export type ExpandableBaseProps = {|
   id: string,
   accessibilityExpandLabel: string,
   accessibilityCollapseLabel: string,
+  expandedIndex?: ?number,
   items: $ReadOnlyArray<{|
     title: string,
     icon?: $Keys<typeof icons>,
@@ -25,6 +26,7 @@ export type ExpandableBaseProps = {|
     type?: TypeOptions,
     children?: Node,
   |}>,
+  onExpandedChange?: (?number) => void,
 |};
 
 export type ExpandableItemProps = {|


### PR DESCRIPTION
ModuleExpandable: added external collapsing control (expandedIndex and onExpandedChange)
with Tests and Docs examples

![Kapture 2021-01-15 at 16 11 23](https://user-images.githubusercontent.com/10593890/104779055-6810e200-574c-11eb-9cbe-27e7e9cb28bd.gif)

<!--
What is the purpose of this PR?
added external control extExpandedId and setExtExpandedId for ModuleExpandable component
added tests
updated docs

* What is the context surrounding this PR? Include links if possible.
We need external control to expand/collapse ModuleExpandable programmatically.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->
<!--
How can reviewers verify this is good to merge?

* Is it tested? Y
* Is it accessible? Y
* Is it documented? Y
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->


