### PR TITLE
Layer: Update documentation examples around avoiding unwanted re-rendering

### DIFF
--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -79,8 +79,8 @@ function Example() {
   // gets passed down as a prop to <ResilientLayer>.
   // It's very important to pass down any function prop using useCallback,
   // otherwise, each parent re-render would recreate these functions, 
-  // which would force a children re-render as is receives different props.
-  // In our case, our children Layer would re-render and destroy its content.
+  // which would force a children re-render as it receives different props.
+  // In our case, our children Layer would re-render and destroy its contents.
   const onDismiss = React.useCallback(() => setShowLayer(false), []);
 
   return (

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -45,6 +45,62 @@ card(
 card(
   <Example
     description="
+    Since Layer is rendered within a portal element being manually added to the DOM, it is supposed to be rendered and dismissed only once. 
+    Any re-renders triggered by the parent will effectively remove the portal element from the DOM, hence it won't be recreated and internal elements like Sheet may not reappear.
+    The example below demonstrates a technique to avoid the re-rendering of Layer by making sure parent re-renders don't force children re-renders. This is accomplished by memoizing locally-defined functions with React.useCallback() if they're passed down as props, and memoizing the entire component with React.memo().
+  "
+    name="Avoid Re-rendering"
+    defaultCode={`
+function Example() {
+  // We're using React.memo() here to prevent re-renders. This is similar to
+  // shouldComponentUpdate(), but for functional components.
+  const ResilientLayer = React.memo((props) => {
+    const { onDismiss, shouldShow } = props;
+
+    if (!shouldShow) {
+      return null;
+    }
+    return (
+      <Layer>
+        <Sheet 
+          accessibilityDismissButtonLabel="Close"
+          accessibilitySheetLabel="Resilient layer"
+          onDismiss={onDismiss}
+        >
+          <Text>Resilient Layer Content</Text>
+        </Sheet>
+      </Layer>
+    );
+  });
+
+  const [showLayer, setShowLayer] = React.useState(false);
+
+  // We're using React.useCallback() here to memoize this function since it 
+  // gets passed down as a prop to <ResilientLayer>.
+  // It's very important to pass down any function prop using useCallback,
+  // otherwise, each parent re-render would recreate these functions, 
+  // which would force a children re-render as is receives different props.
+  // In our case, our children Layer would re-render and destroy its content.
+  const onDismiss = React.useCallback(() => setShowLayer(false), []);
+
+  return (
+    <>
+      <Button
+        inline
+        text="Show Resilient Layer"
+        onClick={() => setShowLayer(true)}
+      />
+      <ResilientLayer onDismiss={onDismiss} shouldShow={showLayer} />
+    </>
+  );
+}
+`}
+  />
+);
+
+card(
+  <Example
+    description="
     Child content will be rendered outside the DOM hierarchy for easy overlaying. Click to see an example.
   "
     name="Overlaying Content"


### PR DESCRIPTION
This diff is just improving documentation for Layer to explain and illustrate with an example the importance of avoiding re-renderings to prevent the content from being destroyed with an accidental parent re-render.