### PR TITLE
Layer: fix a bug where Layer ummounts children on rerender when zIndex changes

### DIFF
--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -45,62 +45,6 @@ card(
 card(
   <Example
     description="
-    Since Layer is rendered within a portal element being manually added to the DOM, it is supposed to be rendered and dismissed only once. 
-    Any re-renders triggered by the parent will effectively remove the portal element from the DOM, hence it won't be recreated and internal elements like Sheet may not reappear.
-    The example below demonstrates a technique to avoid the re-rendering of Layer by making sure parent re-renders don't force children re-renders. This is accomplished by memoizing locally-defined functions with React.useCallback() if they're passed down as props, and memoizing the entire component with React.memo().
-  "
-    name="Avoid Re-rendering"
-    defaultCode={`
-function Example() {
-  // We're using React.memo() here to prevent re-renders. This is similar to
-  // shouldComponentUpdate(), but for functional components.
-  const ResilientLayer = React.memo((props) => {
-    const { onDismiss, shouldShow } = props;
-
-    if (!shouldShow) {
-      return null;
-    }
-    return (
-      <Layer>
-        <Sheet 
-          accessibilityDismissButtonLabel="Close"
-          accessibilitySheetLabel="Resilient layer"
-          onDismiss={onDismiss}
-        >
-          <Text>Resilient Layer Content</Text>
-        </Sheet>
-      </Layer>
-    );
-  });
-
-  const [showLayer, setShowLayer] = React.useState(false);
-
-  // We're using React.useCallback() here to memoize this function since it 
-  // gets passed down as a prop to <ResilientLayer>.
-  // It's very important to pass down any function prop using useCallback,
-  // otherwise, each parent re-render would recreate these functions, 
-  // which would force a children re-render as it receives different props.
-  // In our case, our children Layer would re-render and destroy its contents.
-  const onDismiss = React.useCallback(() => setShowLayer(false), []);
-
-  return (
-    <>
-      <Button
-        inline
-        text="Show Resilient Layer"
-        onClick={() => setShowLayer(true)}
-      />
-      <ResilientLayer onDismiss={onDismiss} shouldShow={showLayer} />
-    </>
-  );
-}
-`}
-  />
-);
-
-card(
-  <Example
-    description="
     Child content will be rendered outside the DOM hierarchy for easy overlaying. Click to see an example.
   "
     name="Overlaying Content"

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -6,21 +6,20 @@ import styles from './Layer.css';
 
 export default function Layer({
   children,
-  zIndex,
+  zIndex: zIndexIndexable,
 }: {|
   children: Node,
   zIndex?: Indexable,
 |}): Portal | null {
   const [mounted, setMounted] = useState(false);
   const element = useRef<?HTMLDivElement>(null);
+  const zIndex: number | null = zIndexIndexable?.index() ?? null;
 
   useEffect(() => {
     setMounted(true);
 
     if (typeof document !== 'undefined' && document.createElement) {
       element.current = document.createElement('div');
-      element.current.style.zIndex = zIndex ? `${zIndex.index()}` : '';
-      element.current.className = zIndex ? styles.layer : '';
     }
 
     if (typeof document !== 'undefined' && document.body && element.current) {
@@ -32,6 +31,13 @@ export default function Layer({
         document.body.removeChild(element.current);
       }
     };
+  }, []);
+
+  useEffect(() => {
+    if (element.current) {
+      element.current.style.zIndex = zIndex === null ? '' : `${zIndex}`;
+      element.current.className = zIndex === null ? '' : styles.layer;
+    }
   }, [zIndex]);
 
   if (!mounted || !element.current) {

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -13,7 +13,7 @@ export default function Layer({
 |}): Portal | null {
   const [mounted, setMounted] = useState(false);
   const element = useRef<?HTMLDivElement>(null);
-  const zIndex: number | null = zIndexIndexable?.index() ?? null;
+  const zIndex = zIndexIndexable?.index();
 
   useEffect(() => {
     setMounted(true);
@@ -34,10 +34,11 @@ export default function Layer({
   }, []);
 
   useEffect(() => {
-    if (element.current) {
-      element.current.style.zIndex = zIndex === null ? '' : `${zIndex}`;
-      element.current.className = zIndex === null ? '' : styles.layer;
+    if (!element.current) {
+      return;
     }
+    element.current.style.zIndex = zIndex === undefined ? '' : `${zIndex}`;
+    element.current.className = zIndex === undefined ? '' : styles.layer;
   }, [zIndex]);
 
   if (!mounted || !element.current) {


### PR DESCRIPTION
This fixes #1326.

When we pass `zIndex` indexable object and the reference is changed, the cleanup routine of `useEffect` hook, which depends on `zIndex` would be fired and would replace the entire children tree with a new one. I believe this is an oversight when we added `zIndex` support in #1223. I am fixing this bug by:

1. make sure the `useEffect` hook which appends/removes a div element only runs on mount/unmount.
2. the zIndex is handled by a separate `useEffect` after the `useEffect` hook above so that it (1) initiailizes the zIndex after the div has been created on mount, and (2) updates zIndex-related attributes of the div element whenever the value of the zIndex prop changes.

I also removed the documentation where we encourage people to avoid rerendering. Avoid rerendering should only be a perf optimization and should not be used as a semantic guarentee.