### PR TITLE
Callout: Fix vertical padding in md viewport when no actions present

### DIFF
--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -193,21 +193,28 @@ export default function Callout({
             </Box>
           </Box>
         </Box>
-        <Box smDisplay="flex" marginStart="auto" smMarginEnd={4} smPaddingY={3}>
-          {secondaryAction && responsiveMinWidth !== 'xs' && (
-            <CalloutAction type="secondary" data={secondaryAction} />
-          )}
-          {primaryAction && (
-            <CalloutAction type="primary" data={primaryAction} />
-          )}
-          {secondaryAction && responsiveMinWidth === 'xs' && (
-            <CalloutAction
-              type="secondary"
-              data={secondaryAction}
-              stacked={!!secondaryAction}
-            />
-          )}
-        </Box>
+        {(primaryAction || secondaryAction) && (
+          <Box
+            smDisplay="flex"
+            marginStart="auto"
+            smMarginEnd={4}
+            smPaddingY={3}
+          >
+            {secondaryAction && responsiveMinWidth !== 'xs' && (
+              <CalloutAction type="secondary" data={secondaryAction} />
+            )}
+            {primaryAction && (
+              <CalloutAction type="primary" data={primaryAction} />
+            )}
+            {secondaryAction && responsiveMinWidth === 'xs' && (
+              <CalloutAction
+                type="secondary"
+                data={secondaryAction}
+                stacked={!!secondaryAction}
+              />
+            )}
+          </Box>
+        )}
       </Box>
 
       {dismissButton && (

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -56,9 +56,6 @@ exports[`<Callout /> Error Callout 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
-    />
   </div>
 </div>
 `;
@@ -119,9 +116,6 @@ exports[`<Callout /> Info Callout 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
-    />
   </div>
 </div>
 `;
@@ -182,9 +176,6 @@ exports[`<Callout /> Warning Callout 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
-    />
   </div>
 </div>
 `;
@@ -735,9 +726,6 @@ exports[`<Callout /> message + title 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
-    />
   </div>
 </div>
 `;


### PR DESCRIPTION
This PR intends to fix a bogus vertical padding behavior of Callout component when there isn't action buttons and the message is long and its width transitions from something around 750px to 700px. Current behavior presents a bottom padding that is taller than the upper padding. That behavior can be confirmed by adjusting the window width in the sandbox link and the screenshot below.
https://codesandbox.io/s/error-example-forked-mg0ji?file=/example.js

<img width="761" alt="Screen Shot 2021-01-07 at 7 57 58 PM" src="https://user-images.githubusercontent.com/3874746/103954326-bc9bd800-5122-11eb-99e7-ea5ef65112a6.png">

## Changes
The only change was to avoid rendering a Box without action buttons in the Callout component


## Test Plan
Manually tested the change by loading the Callout Gestalt Docs page and set a long message in a sample that has no action buttons, then narrowing window width and checking that the isn't a vertical padding issue anymore. See attached screen recording.
https://user-images.githubusercontent.com/3874746/103953970-f1f3f600-5121-11eb-99a4-b77955297389.mov

