### PR TITLE
Callout: Include Node type for Message property

### DIFF
--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -31,7 +31,7 @@ type Props = {|
     onDismiss: () => void,
   |},
   iconAccessibilityLabel: string,
-  message: string,
+  message: string | Node,
   primaryAction?: ActionData,
   secondaryAction?: ActionData,
   type: 'error' | 'info' | 'warning',
@@ -240,7 +240,7 @@ Callout.propTypes = {
     onDismiss: PropTypes.func.isRequired,
   }),
   iconAccessibilityLabel: PropTypes.string.isRequired,
-  message: PropTypes.string.isRequired,
+  message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   primaryAction: PropTypes.shape({
     href: PropTypes.string,


### PR DESCRIPTION
Using a React Node in the message causes a type error: 

![image](https://user-images.githubusercontent.com/5871660/104059134-e1cb2d80-5198-11eb-916b-58d4df74ea52.png)


