### PR TITLE
Docs: Add versioning info to development page

### DIFF
--- a/docs/src/DatePicker.doc.js
+++ b/docs/src/DatePicker.doc.js
@@ -197,7 +197,7 @@ card(
     description="
     Use DatePicker to select date inputs.
   "
-    name="Example: Basic Date Picker."
+    name="Example: Basic Date Picker"
     defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;
@@ -288,7 +288,7 @@ function DatePickerRangeExample() {
 card(
   <Example
     id="disabled"
-    name="Example: Disabled."
+    name="Example: Disabled"
     defaultCode={`
 function DatePickerExample() {
   const [date, setDate] = React.useState(new Date());
@@ -313,7 +313,7 @@ card(
     description="
     Disable dates outside of a min and max date range.
   "
-    name="Example: Delimited selection period."
+    name="Example: Delimited selection period"
     defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;
@@ -338,7 +338,7 @@ card(
     description="
     Enable an array of dates.
   "
-    name="Example: Enabled dates."
+    name="Example: Enabled dates"
     defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;
@@ -362,7 +362,7 @@ card(
     description="
     Disable an array of dates.
   "
-    name="Example: Disabled dates."
+    name="Example: Disabled dates"
     defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;

--- a/docs/src/Development.doc.js
+++ b/docs/src/Development.doc.js
@@ -281,7 +281,26 @@ git push -f origin HEAD
           <Text>
             Ensure checks pass on your Pull Request - having the &quot;Require
             Semver&nbsp;/ Test (pull_request)&quot; check fail is expected, a
-            Gestalt maintainer needs to add a correct semver label.
+            Gestalt maintainer needs to add a correct semver label. Our
+            versioning guidelines are:
+            <ul>
+              <li>
+                <em>Patch</em>: internal fixes, documentation changes, or
+                package upgrades
+              </li>
+              <li>
+                <em>Minor</em>: new features or properties for a component, or
+                new components
+              </li>
+              <li>
+                <em>Major</em>: any breaking change, whether it be in a specific
+                component or the library itself (will most likely include a{' '}
+                <Link href="#codemods" inline>
+                  <Text weight="bold">codemod</Text>
+                </Link>
+                )
+              </li>
+            </ul>
           </Text>
         </li>
         <li>

--- a/docs/src/Development.doc.js
+++ b/docs/src/Development.doc.js
@@ -280,27 +280,13 @@ git push -f origin HEAD
         <li>
           <Text>
             Ensure checks pass on your Pull Request - having the &quot;Require
-            Semver&nbsp;/ Test (pull_request)&quot; check fail is expected, a
-            Gestalt maintainer needs to add a correct semver label. Our
-            versioning guidelines are:
-            <ul>
-              <li>
-                <em>Patch</em>: internal fixes, documentation changes, or
-                package upgrades
-              </li>
-              <li>
-                <em>Minor</em>: new features or properties for a component, or
-                new components
-              </li>
-              <li>
-                <em>Major</em>: any breaking change, whether it be in a specific
-                component or the library itself (will most likely include a{' '}
-                <Link href="#codemods" inline>
-                  <Text weight="bold">codemod</Text>
-                </Link>
-                )
-              </li>
-            </ul>
+            Semver&nbsp;/ Test (pull_request)&quot; check fail is expected,
+            because a Gestalt maintainer needs to add a correct semver label.
+            Check out our{' '}
+            <Link href="#versioning" inline>
+              <Text weight="bold">versioning guidelines</Text>
+            </Link>{' '}
+            for more info.
           </Text>
         </li>
         <li>
@@ -325,7 +311,35 @@ card(
         a component, keep the scope of changes to that specific task and get the
         title exactly reflect those changes.
       </Text>
-
+      <Heading id="versioning" size="sm">
+        Versioning
+      </Heading>
+      <Text>
+        Our versioning guidelines follow those outlined at{' '}
+        <Link href="https://semver.org/" inline>
+          <Text weight="bold">semver.org</Text>
+        </Link>
+        :
+        <ul>
+          <li>
+            <em>Patch</em>: internal fixes, documentation changes, or package
+            upgrades (anything that consumers of Gestalt don&apos;t need to
+            worry about)
+          </li>
+          <li>
+            <em>Minor</em>: any new functionality or properties for a component,
+            or net-new components
+          </li>
+          <li>
+            <em>Major</em>: any breaking change, whether it be in a specific
+            component or the library itself (will most likely include a{' '}
+            <Link href="#codemods" inline>
+              <Text weight="bold">codemod</Text>
+            </Link>
+            )
+          </li>
+        </ul>
+      </Text>
       <Heading id="codemods" size="sm">
         Codemods
       </Heading>


### PR DESCRIPTION
Add info about versioning to the Development docs page

<img width="840" alt="Screen Shot 2021-01-12 at 7 10 41 PM" src="https://user-images.githubusercontent.com/5125094/104389676-04977200-550a-11eb-8a95-055b6f9f4e91.png">



## Test Plan

n/a
