### PR TITLE
Internal: Mark package as not having side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,5 +146,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/pinterest/gestalt"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
This adds the `sideEffects: false` setting to package.json. It's used by bundlers like webpack to [determine if it's safe to tree shake](https://webpack.js.org/guides/tree-shaking/) out unused code such as re-exports. No modules in gestalt have side effects as defined in the webpack docs, so this should be safe to add. This appears to have no effect on the build generated by rollup, but rather will be used by projects importing gestalt.

## Test Plan
Code builds as normal
