### PR TITLE
Callout, Upsell: Fix action href type in docs, dedupe type definitions

### DIFF
--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -54,7 +54,7 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
+          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
         required: false,
         defaultValue: null,
         description: [
@@ -70,7 +70,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
+          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -53,7 +53,7 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
+          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
         required: false,
         defaultValue: null,
         description: [
@@ -69,7 +69,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
+          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}',
         required: false,
         defaultValue: null,
         description: [
@@ -144,7 +144,7 @@ card(
     onDismiss: ()=>{},
   }}
   imageData={{
-      component: 
+      component:
         <Image
           alt="Check out our resources for adapting to these times."
           color="rgb(231, 186, 176)"

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -9,31 +9,16 @@ import IconButton from './IconButton.js';
 import Button from './Button.js';
 import Text from './Text.js';
 import { useColorScheme } from './contexts/ColorScheme.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './Callout.css';
 import useResponsiveMinWidth from './useResponsiveMinWidth.js';
-
-type ActionData = {|
-  accessibilityLabel?: string,
-  href?: string,
-  label: string,
-  onClick?: AbstractEventHandler<
-    | SyntheticMouseEvent<HTMLButtonElement>
-    | SyntheticMouseEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent<HTMLButtonElement>
-  >,
-|};
+import { type ActionDataType, type DismissButtonType } from './commonTypes.js';
 
 type Props = {|
-  dismissButton?: {|
-    accessibilityLabel: string,
-    onDismiss: () => void,
-  |},
+  dismissButton?: DismissButtonType,
   iconAccessibilityLabel: string,
   message: string,
-  primaryAction?: ActionData,
-  secondaryAction?: ActionData,
+  primaryAction?: ActionDataType,
+  secondaryAction?: ActionDataType,
   type: 'error' | 'info' | 'warning',
   title?: string,
 |};
@@ -61,7 +46,7 @@ const CalloutAction = ({
   stacked,
   type,
 }: {|
-  data: ActionData,
+  data: ActionDataType,
   stacked?: boolean,
   type: string,
 |}): Node => {

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -10,27 +10,17 @@ import IconButton from './IconButton.js';
 import Image from './Image.js';
 import Mask from './Mask.js';
 import Text from './Text.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './Upsell.css';
 import useResponsiveMinWidth from './useResponsiveMinWidth.js';
-
-type ActionData = {|
-  accessibilityLabel?: string,
-  href?: string,
-  label: string,
-  onClick?: AbstractEventHandler<
-    | SyntheticMouseEvent<HTMLButtonElement>
-    | SyntheticMouseEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent<HTMLButtonElement>
-  >,
-|};
+import {
+  ActionDataPropType,
+  DismissButtonPropType,
+  type ActionDataType,
+  type DismissButtonType,
+} from './commonTypes.js';
 
 type Props = {|
-  dismissButton?: {|
-    accessibilityLabel: string,
-    onDismiss: () => void,
-  |},
+  dismissButton?: DismissButtonType,
   imageData?: {|
     component: Element<typeof Image | typeof Icon>,
     mask?: {|
@@ -40,8 +30,8 @@ type Props = {|
     width?: number,
   |},
   message: string,
-  primaryAction?: ActionData,
-  secondaryAction?: ActionData,
+  primaryAction?: ActionDataType,
+  secondaryAction?: ActionDataType,
   title?: string,
 |};
 
@@ -50,7 +40,7 @@ const UpsellAction = ({
   stacked,
   type,
 }: {|
-  data: ActionData,
+  data: ActionDataType,
   stacked?: boolean,
   type: string,
 |}): Node => {
@@ -210,11 +200,7 @@ export default function Upsell({
 }
 
 Upsell.propTypes = {
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  dismissButton: PropTypes.exact({
-    accessibilityLabel: PropTypes.string.isRequired,
-    onDismiss: PropTypes.func.isRequired,
-  }),
+  dismissButton: DismissButtonPropType,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   imageData: PropTypes.exact({
     component: PropTypes.node.isRequired,
@@ -225,19 +211,7 @@ Upsell.propTypes = {
     width: PropTypes.number,
   }),
   message: PropTypes.string.isRequired,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  primaryAction: PropTypes.shape({
-    href: PropTypes.string,
-    label: PropTypes.string.isRequired,
-    onClick: PropTypes.func,
-    accessibilityLabel: PropTypes.string,
-  }),
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  secondaryAction: PropTypes.shape({
-    href: PropTypes.string,
-    label: PropTypes.string.isRequired,
-    onClick: PropTypes.func,
-    accessibilityLabel: PropTypes.string,
-  }),
+  primaryAction: ActionDataPropType,
+  secondaryAction: ActionDataPropType,
   title: PropTypes.string,
 };

--- a/packages/gestalt/src/commonTypes.js
+++ b/packages/gestalt/src/commonTypes.js
@@ -1,0 +1,39 @@
+// @flow strict
+import PropTypes from 'prop-types';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
+
+export type ActionDataType = {|
+  accessibilityLabel?: string,
+  href?: string,
+  label: string,
+  onClick?: AbstractEventHandler<
+    | SyntheticMouseEvent<HTMLButtonElement>
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLButtonElement>
+  >,
+|};
+
+export type DismissButtonType = {|
+  accessibilityLabel: string,
+  onDismiss: () => void,
+|};
+
+// $FlowFixMe[incompatible-exact]
+export const ActionDataPropType: React$PropType$Primitive<ActionDataType> = PropTypes.exact(
+  {
+    href: PropTypes.string,
+    label: PropTypes.string.isRequired,
+    // $FlowFixMe[incompatible-type]
+    onClick: PropTypes.func,
+    accessibilityLabel: PropTypes.string,
+  }
+);
+// $FlowFixMe[incompatible-exact]
+// $FlowFixMe[incompatible-type]
+export const DismissButtonPropType: React$PropType$Primitive<DismissButtonType> = PropTypes.exact(
+  {
+    accessibilityLabel: PropTypes.string.isRequired,
+    onDismiss: PropTypes.func.isRequired,
+  }
+);


### PR DESCRIPTION
We were showing this type as required when it's actually optional. This PR updates the docs for both Callout and Upsell to reflect the correct type.

I also deduped the common types between the two components, putting them in a `commonTypes.js` file. That file has a lot of potential to become a "kitchen sink" type dumping ground, so we'll need to revisit the name in the future. That more correct name wasn't obvious to me now, so I went with the (temporary) generic name.