### PR TITLE
Scrollcontainer (prototype version)

### DIFF
--- a/docs/src/ScrollBox.doc.js
+++ b/docs/src/ScrollBox.doc.js
@@ -1,0 +1,72 @@
+// @flow strict
+import React, { type Node } from 'react';
+import Example from './components/Example.js';
+import PageHeader from './components/PageHeader.js';
+
+const cards: Array<Node> = [];
+const card = (c) => cards.push(c);
+
+card(
+  <PageHeader
+    name="ScrollBox"
+    fileName="ScrollBox"
+    description="ScrollBox is a..."
+  />
+);
+
+card(
+  <Example
+    description={`
+The following example shows ...
+  `}
+    id="ScrollBox"
+    name="ScrollBox"
+    defaultCode={`
+function ScrollBoxExample() {
+  const [showLayer, setShowLayer] = React.useState(false);
+  const anchorRef = React.useRef();
+
+  return (
+    <Provider id="docsExample">
+      <ScrollBox height="200px">
+        <Box height="600px">
+          <Box ref={anchorRef}>
+            <Button
+              inline
+              text="Toggle Layer in ScrollBox"
+              onClick={() => setShowLayer(!showLayer)}
+            />
+          </Box>
+          {showLayer && (
+            <Layer>
+              <Flyout
+                anchor={anchorRef.current}
+                idealDirection="up"
+                onDismiss={() => setShowLayer(false)}
+                positionRelativeToAnchor={false}
+                size="md"
+              >
+                <Box
+                  padding={3}
+                  display="flex"
+                  alignItems="center"
+                  direction="column"
+                  column={12}
+                >
+                  <Text align="center" weight="bold">
+                    Portal is attached to ScrollBox
+                  </Text>
+                </Box>
+              </Flyout>
+            </Layer>
+          )}
+        </Box>
+      </ScrollBox>
+    </Provider>
+  )
+}
+`}
+  />
+);
+
+export default cards;

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -86,6 +86,7 @@ const sidebarIndex: Array<sidebarIndexType> = [
       'Module',
       'Layer',
       'Masonry',
+      'ScrollBox',
       'Sheet',
       'Sticky',
       'ZIndex Classes',

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -93,7 +93,6 @@ function getTriggerRect(
       triggerBoundingRect.left = boundingAnchorRect.left - boundingContainerRect.left;
       triggerBoundingRect.right = boundingAnchorRect.right - boundingContainerRect.right;
       triggerBoundingRect.top = boundingAnchorRect.top - boundingContainerRect.top;
-      console.log({boundingAnchorRect, boundingContainerRect, triggerBoundingRect})
     }
 
 

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -1,8 +1,10 @@
 // @flow strict
-import { useRef, useState, type Portal, type Node, useEffect } from 'react';
+import React, { useRef, useState, type Portal, type Node, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { type Indexable } from './zIndex.js';
+import { useScroll } from './contexts/Scroll.js';
 import styles from './Layer.css';
+
 
 export default function Layer({
   children,
@@ -10,25 +12,56 @@ export default function Layer({
 }: {|
   children: Node,
   zIndex?: Indexable,
-|}): Portal | null {
+|}): Portal | Node {
   const [mounted, setMounted] = useState(false);
   const element = useRef<?HTMLDivElement>(null);
   const zIndex = zIndexIndexable?.index();
+  const positionRef = useRef<?HTMLDivElement>(null);
+  const { refs } = useScroll();
 
   useEffect(() => {
     setMounted(true);
+
+    if (!positionRef.current) {
+      return;
+    }
 
     if (typeof document !== 'undefined' && document.createElement) {
       element.current = document.createElement('div');
     }
 
-    if (typeof document !== 'undefined' && document.body && element.current) {
-      document.body.appendChild(element.current);
+    let containerNode = null;
+    let curNode = positionRef.current;
+
+    while (!containerNode) {
+      const parentNode = curNode.parentNode;
+      if (parentNode) {
+        refs.forEach((ref) => {
+          if (ref && ref.isSameNode(curNode)) {
+            containerNode = ref;
+          }
+        });
+        curNode = parentNode;
+      } else {
+        break;
+      }
+    }
+
+    if (element.current) {
+      if (containerNode) {
+        containerNode.appendChild(element.current);
+      } else if (typeof document !== 'undefined' && document.body) {
+        document.body.appendChild(element.current);
+      }
     }
 
     return () => {
-      if (typeof document !== 'undefined' && document.body && element.current) {
-        document.body.removeChild(element.current);
+      if (element.current) {
+        if (containerNode) {
+          containerNode.removeChild(element.current);
+        } else if (typeof document !== 'undefined' && document.body) {
+          document.body.removeChild(element.current);
+        }
       }
     };
   }, []);
@@ -39,10 +72,10 @@ export default function Layer({
     }
     element.current.style.zIndex = zIndex === undefined ? '' : `${zIndex}`;
     element.current.className = zIndex === undefined ? '' : styles.layer;
-  }, [zIndex]);
+  }, [zIndex, refs]);
 
   if (!mounted || !element.current) {
-    return null;
+    return <div ref={positionRef} />;
   }
 
   return createPortal(children, element.current);

--- a/packages/gestalt/src/Provider.js
+++ b/packages/gestalt/src/Provider.js
@@ -6,6 +6,9 @@ import {
   type ColorScheme,
   ColorSchemePropType,
 } from './contexts/ColorScheme.js';
+import {
+  ScrollProvider,
+} from './contexts/Scroll.js';
 
 type Props = {|
   children: Node,
@@ -15,9 +18,11 @@ type Props = {|
 
 export default function Provider({ children, colorScheme, id }: Props): Node {
   return (
-    <ColorSchemeProvider colorScheme={colorScheme} id={id}>
-      {children}
-    </ColorSchemeProvider>
+    <ScrollProvider>
+      <ColorSchemeProvider colorScheme={colorScheme} id={id}>
+        {children}
+      </ColorSchemeProvider>
+    </ScrollProvider>
   );
 }
 

--- a/packages/gestalt/src/ScrollBox.js
+++ b/packages/gestalt/src/ScrollBox.js
@@ -1,0 +1,54 @@
+// @flow strict
+import React, { type Node, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import Box from './Box.js';
+import Heading from './Heading.js';
+import Icon from './Icon.js';
+import IconButton from './IconButton.js';
+import Button from './Button.js';
+import Text from './Text.js';
+import { useScroll } from './contexts/Scroll.js';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import styles from './Callout.css';
+
+
+type Props = {
+  children?: Node,
+  height?: string,
+};
+
+export default function ScrollBox({ children, height }: Props): Node {
+  const { addRef, removeRef } = useScroll();
+  const anchorRef = React.useRef<?HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (anchorRef.current) {
+      const ref = anchorRef.current;
+      addRef(ref);
+      return () => {
+        removeRef(ref);
+      };
+    }
+  }, []);
+
+  return (
+    <div
+      ref={anchorRef}
+      style={{
+        height,
+        backgroundColor: "green",
+        position: "relative",
+        overflow: "auto"
+      }}
+    >
+    {children}
+  </div>
+  );
+}
+
+ScrollBox.propTypes = {
+  children: PropTypes.node,
+  height: PropTypes.string,
+};
+

--- a/packages/gestalt/src/contexts/Scroll.js
+++ b/packages/gestalt/src/contexts/Scroll.js
@@ -1,0 +1,63 @@
+// @flow strict
+import React, {
+  useContext,
+  useState,
+  createContext,
+  type Context,
+  type Element,
+  type Node,
+} from 'react';
+import PropTypes from 'prop-types';
+
+export type ColorScheme = 'light' | 'dark' | 'userPreference';
+
+export const ColorSchemePropType: React$PropType$Primitive<ColorScheme> = PropTypes.oneOf(
+  ['light', 'dark', 'userPreference']
+);
+
+type Scroll = {|
+  refs: Array<?HTMLDivElement>,
+  addRef: (ref: HTMLDivElement) => void,
+  removeRef: (ref: HTMLDivElement) => void,
+|};
+
+type Props = {|
+  children: Node,
+|};
+
+const ScrollContext: Context<Scroll> = createContext<Scroll>({
+  refs: [],
+  addRef: (ref) => {},
+  removeRef: (ref) => {},
+});
+
+export function ScrollProvider({
+  children,
+}: Props): Element<typeof ScrollContext.Provider> {
+  const [refs, setRefs] = useState([]);
+
+  const scrollContext = {
+    refs,
+    addRef: (ref) => {
+      setRefs((oldRefs) => [...oldRefs, ref]);
+    },
+    removeRef: (ref) => {
+      setRefs((oldRefs) => [...oldRefs].filter((r) => r !== ref));
+    }
+  };
+
+  return (
+    <ScrollContext.Provider value={scrollContext}>
+      {children}
+    </ScrollContext.Provider>
+  );
+}
+
+ScrollProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export function useScroll(): Scroll {
+  const scroll = useContext(ScrollContext);
+  return scroll;
+}

--- a/packages/gestalt/src/contexts/Scroll.js
+++ b/packages/gestalt/src/contexts/Scroll.js
@@ -25,7 +25,7 @@ type Props = {|
   children: Node,
 |};
 
-const ScrollContext: Context<Scroll> = createContext<Scroll>({
+export const ScrollContext: Context<Scroll> = createContext<Scroll>({
   refs: [],
   addRef: (ref) => {},
   removeRef: (ref) => {},

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -36,6 +36,7 @@ import Pog from './Pog.js';
 import Provider from './Provider.js';
 import Pulsar from './Pulsar.js';
 import RadioButton from './RadioButton.js';
+import ScrollBox from './ScrollBox.js';
 import ScrollFetch from './ScrollFetch.js';
 import SearchField from './SearchField.js';
 import SegmentedControl from './SegmentedControl.js';
@@ -60,6 +61,7 @@ import useFocusVisible from './useFocusVisible.js';
 import useReducedMotion from './useReducedMotion.js';
 import { FixedZIndex, CompositeZIndex } from './zIndex.js';
 import { useColorScheme } from './contexts/ColorScheme.js';
+import { useScroll } from './contexts/Scroll.js';
 
 export {
   ActivationCard,
@@ -101,6 +103,7 @@ export {
   Provider,
   Pulsar,
   RadioButton,
+  ScrollBox,
   ScrollFetch,
   SearchField,
   SegmentedControl,
@@ -124,4 +127,5 @@ export {
   useColorScheme,
   useFocusVisible,
   useReducedMotion,
+  useScroll,
 };


### PR DESCRIPTION
**WIP**

ScrollBox is a new component that can be used to "capture"<Layer />'s and mount React portals in nodes other than document.body.

The main unfinished change is altering logic in Contents.js to reference the correct node instead of window.