### PR TITLE
Docs: Add shared documentation components for docs redesign

### DIFF
--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -245,31 +245,20 @@ card(
         type="do"
         description="Do place primary buttons to the right or bottom of other button styles."
         defaultCode={`
-      <ButtonGroup>
-        <Button text="Button" inline color="gray"/>
-        <Button text="Button" inline color="red"/>
-      </ButtonGroup>
+  <ButtonGroup>
+    <Button text="Button" inline color="gray"/>
+    <Button text="Button" inline color="red"/>
+  </ButtonGroup>
     `}
       />
       <MainSection.Card
         description="Don't place more than one primary button per surface."
         type="don't"
         defaultCode={`
-      <ButtonGroup>
-        <Button text="Button" inline color="red"/>
-        <Button text="Button" inline color="red"/>
-      </ButtonGroup>
-    `}
-      />
-      <MainSection.Card
-        description="Don't place more than one primary button per surface."
-        type="info"
-        title="Info Example"
-        defaultCode={`
-      <ButtonGroup>
-        <Button text="Button" inline color="red"/>
-        <Button text="Button" inline color="red"/>
-      </ButtonGroup>
+  <ButtonGroup>
+    <Button text="Button" inline color="red"/>
+    <Button text="Button" inline color="red"/>
+  </ButtonGroup>
     `}
       />
     </MainSection.Subsection>
@@ -308,7 +297,7 @@ function Example() {
         <Tooltip text="Submit button">
           <Button
             type="submit"
-            name="satisfaction-questionaire"
+            name="satisfaction-questionnaire"
             text="Submit your response"
             inline
             disabled={disabled}
@@ -358,17 +347,17 @@ function Example() {
   />
 );
 
-card(
-  <Example
-    name="Size"
-    id="size"
-    defaultCode={`<Flex gap={2}>
-  <Button size="sm" text="Small-sized button" inline />
-  <Button text="Medium-sized button" inline />
-  <Button size="lg" text="Large-sized button" inline />
-</Flex>`}
-  />
-);
+// card(
+//   <Example
+//     name="Size"
+//     id="size"
+//     defaultCode={`<Flex gap={2}>
+//   <Button size="sm" text="Small-sized button" inline />
+//   <Button text="Medium-sized button" inline />
+//   <Button size="lg" text="Large-sized button" inline />
+// </Flex>`}
+//   />
+// );
 
 card(
   <MainSection
@@ -377,7 +366,7 @@ card(
   >
     <MainSection.Subsection
       title="Size"
-      description="There are 3 size options: sm, md, and lg. Lg is the default for Pinner product."
+      description={`There are 3 size options: sm, md, and lg, which can be set using the \`size\` property.`}
     >
       <MainSection.Card
         cardSize="sm"
@@ -409,7 +398,7 @@ card(
     </MainSection.Subsection>
     <MainSection.Subsection title="Hierarchy">
       <MainSection.Card
-        cardSize="sm"
+        cardSize="md"
         title="Primary"
         description="High emphasis, used for primary actions."
         defaultCode={`
@@ -418,7 +407,7 @@ card(
     `}
       />
       <MainSection.Card
-        cardSize="sm"
+        cardSize="md"
         title="Secondary"
         description="Medium emphasis, used for secondary actions."
         defaultCode={`
@@ -427,7 +416,7 @@ card(
     `}
       />
       <MainSection.Card
-        cardSize="sm"
+        cardSize="md"
         title="Tertiary"
         shaded
         description="Low emphasis when placed on white backgrounds, used for tertiary actions, and medium emphasis, used for secondary actions when placed on dark backgrounds."

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -5,7 +5,8 @@ import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
-import MainSection from './components/MainSection.js';
+// To be used when converting Button docs
+// import MainSection from './components/MainSection.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -235,35 +236,36 @@ card(
   />
 );
 
-card(
-  <MainSection
-    name="Best Practices"
-    description="Buttons communicate actions that users can take and are typically placed in UIs including closeup modules, modals, flyouts, forms, cards, and bars."
-  >
-    <MainSection.Subsection>
-      <MainSection.Card
-        type="do"
-        description="Do place primary buttons to the right or bottom of other button styles."
-        defaultCode={`
-  <ButtonGroup>
-    <Button text="Button" inline color="gray"/>
-    <Button text="Button" inline color="red"/>
-  </ButtonGroup>
-    `}
-      />
-      <MainSection.Card
-        description="Don't place more than one primary button per surface."
-        type="don't"
-        defaultCode={`
-  <ButtonGroup>
-    <Button text="Button" inline color="red"/>
-    <Button text="Button" inline color="red"/>
-  </ButtonGroup>
-    `}
-      />
-    </MainSection.Subsection>
-  </MainSection>
-);
+// To be continued when converting Button docs
+// card(
+//   <MainSection
+//     name="Best Practices"
+//     description="Buttons communicate actions that users can take and are typically placed in UIs including closeup modules, modals, flyouts, forms, cards, and bars."
+//   >
+//     <MainSection.Subsection>
+//       <MainSection.Card
+//         type="do"
+//         description="Do place primary buttons to the right or bottom of other button styles."
+//         defaultCode={`
+//   <ButtonGroup>
+//     <Button text="Button" inline color="gray"/>
+//     <Button text="Button" inline color="red"/>
+//   </ButtonGroup>
+//     `}
+//       />
+//       <MainSection.Card
+//         description="Don't place more than one primary button per surface."
+//         type="don't"
+//         defaultCode={`
+//   <ButtonGroup>
+//     <Button text="Button" inline color="red"/>
+//     <Button text="Button" inline color="red"/>
+//   </ButtonGroup>
+//     `}
+//       />
+//     </MainSection.Subsection>
+//   </MainSection>
+// );
 
 card(
   <Example
@@ -347,87 +349,88 @@ function Example() {
   />
 );
 
-// card(
-//   <Example
-//     name="Size"
-//     id="size"
-//     defaultCode={`<Flex gap={2}>
-//   <Button size="sm" text="Small-sized button" inline />
-//   <Button text="Medium-sized button" inline />
-//   <Button size="lg" text="Large-sized button" inline />
-// </Flex>`}
-//   />
-// );
-
 card(
-  <MainSection
-    name="Variants"
-    description="Buttons can vary by size and/or color (hierarchy)."
-  >
-    <MainSection.Subsection
-      title="Size"
-      description={`There are 3 size options: sm, md, and lg, which can be set using the \`size\` property.`}
-    >
-      <MainSection.Card
-        cardSize="sm"
-        title="Lg"
-        description="Large is the only size available in Pinner product and is considered the default size."
-        defaultCode={`
-        <Button text="Button" inline color="red" size="lg"/>
-
-    `}
-      />
-      <MainSection.Card
-        cardSize="sm"
-        title="Md"
-        description="Medium"
-        defaultCode={`
-        <Button text="Button" inline color="red" size="md"/>
-
-    `}
-      />
-      <MainSection.Card
-        cardSize="sm"
-        title="Sm"
-        description="Small"
-        defaultCode={`
-        <Button text="Button" inline color="red" size="sm"/>
-
-    `}
-      />
-    </MainSection.Subsection>
-    <MainSection.Subsection title="Hierarchy">
-      <MainSection.Card
-        cardSize="md"
-        title="Primary"
-        description="High emphasis, used for primary actions."
-        defaultCode={`
-        <Button text="Button" inline color="red"/>
-
-    `}
-      />
-      <MainSection.Card
-        cardSize="md"
-        title="Secondary"
-        description="Medium emphasis, used for secondary actions."
-        defaultCode={`
-        <Button text="Button" inline color="gray" />
-
-    `}
-      />
-      <MainSection.Card
-        cardSize="md"
-        title="Tertiary"
-        shaded
-        description="Low emphasis when placed on white backgrounds, used for tertiary actions, and medium emphasis, used for secondary actions when placed on dark backgrounds."
-        defaultCode={`
-        <Button text="Button" inline color="white"/>
-
-    `}
-      />
-    </MainSection.Subsection>
-  </MainSection>
+  <Example
+    name="Size"
+    id="size"
+    defaultCode={`<Flex gap={2}>
+  <Button size="sm" text="Small-sized button" inline />
+  <Button text="Medium-sized button" inline />
+  <Button size="lg" text="Large-sized button" inline />
+</Flex>`}
+  />
 );
+
+// To be continued when converting Button docs
+// card(
+//   <MainSection
+//     name="Variants"
+//     description="Buttons can vary by size and/or color (hierarchy)."
+//   >
+//     <MainSection.Subsection
+//       title="Size"
+//       description={`There are 3 size options: sm, md, and lg, which can be set using the \`size\` property.`}
+//     >
+//       <MainSection.Card
+//         cardSize="sm"
+//         title="Lg"
+//         description="Large is the only size available in Pinner product and is considered the default size."
+//         defaultCode={`
+//         <Button text="Button" inline color="red" size="lg"/>
+
+//     `}
+//       />
+//       <MainSection.Card
+//         cardSize="sm"
+//         title="Md"
+//         description="Medium"
+//         defaultCode={`
+//         <Button text="Button" inline color="red" size="md"/>
+
+//     `}
+//       />
+//       <MainSection.Card
+//         cardSize="sm"
+//         title="Sm"
+//         description="Small"
+//         defaultCode={`
+//         <Button text="Button" inline color="red" size="sm"/>
+
+//     `}
+//       />
+//     </MainSection.Subsection>
+//     <MainSection.Subsection title="Hierarchy">
+//       <MainSection.Card
+//         cardSize="md"
+//         title="Primary"
+//         description="High emphasis, used for primary actions."
+//         defaultCode={`
+//         <Button text="Button" inline color="red"/>
+
+//     `}
+//       />
+//       <MainSection.Card
+//         cardSize="md"
+//         title="Secondary"
+//         description="Medium emphasis, used for secondary actions."
+//         defaultCode={`
+//         <Button text="Button" inline color="gray" />
+
+//     `}
+//       />
+//       <MainSection.Card
+//         cardSize="md"
+//         title="Tertiary"
+//         shaded
+//         description="Low emphasis when placed on white backgrounds, used for tertiary actions, and medium emphasis, used for secondary actions when placed on dark backgrounds."
+//         defaultCode={`
+//         <Button text="Button" inline color="white"/>
+
+//     `}
+//       />
+//     </MainSection.Subsection>
+//   </MainSection>
+// );
 
 card(
   <Combination

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -5,6 +5,7 @@ import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
+import MainSection from './components/MainSection.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -235,6 +236,47 @@ card(
 );
 
 card(
+  <MainSection
+    name="Best Practices"
+    description="Buttons communicate actions that users can take and are typically placed in UIs including closeup modules, modals, flyouts, forms, cards, and bars."
+  >
+    <MainSection.Subsection>
+      <MainSection.Card
+        type="do"
+        description="Do place primary buttons to the right or bottom of other button styles."
+        defaultCode={`
+      <ButtonGroup>
+        <Button text="Button" inline color="gray"/>
+        <Button text="Button" inline color="red"/>
+      </ButtonGroup>
+    `}
+      />
+      <MainSection.Card
+        description="Don't place more than one primary button per surface."
+        type="don't"
+        defaultCode={`
+      <ButtonGroup>
+        <Button text="Button" inline color="red"/>
+        <Button text="Button" inline color="red"/>
+      </ButtonGroup>
+    `}
+      />
+      <MainSection.Card
+        description="Don't place more than one primary button per surface."
+        type="info"
+        title="Info Example"
+        defaultCode={`
+      <ButtonGroup>
+        <Button text="Button" inline color="red"/>
+        <Button text="Button" inline color="red"/>
+      </ButtonGroup>
+    `}
+      />
+    </MainSection.Subsection>
+  </MainSection>
+);
+
+card(
   <Example
     name="Basic Button"
     id="basic-button"
@@ -317,31 +359,102 @@ function Example() {
 );
 
 card(
-  <>
-    <Example
-      name="Size"
-      id="size"
-      defaultCode={`<Flex gap={2}>
+  <Example
+    name="Size"
+    id="size"
+    defaultCode={`<Flex gap={2}>
   <Button size="sm" text="Small-sized button" inline />
   <Button text="Medium-sized button" inline />
   <Button size="lg" text="Large-sized button" inline />
 </Flex>`}
-    />
-    <Combination
-      id="color"
-      name="Color"
-      color={['gray', 'red', 'blue', 'white', 'transparent']}
+  />
+);
+
+card(
+  <MainSection
+    name="Variants"
+    description="Buttons can vary by size and/or color (hierarchy)."
+  >
+    <MainSection.Subsection
+      title="Size"
+      description="There are 3 size options: sm, md, and lg. Lg is the default for Pinner product."
     >
-      {(props, i) => (
-        <Button
-          id={`example-${i}`}
-          onChange={() => {}}
-          {...props}
-          text="Button"
-        />
-      )}
-    </Combination>
-  </>
+      <MainSection.Card
+        cardSize="sm"
+        title="Lg"
+        description="Large is the only size available in Pinner product and is considered the default size."
+        defaultCode={`
+        <Button text="Button" inline color="red" size="lg"/>
+
+    `}
+      />
+      <MainSection.Card
+        cardSize="sm"
+        title="Md"
+        description="Medium"
+        defaultCode={`
+        <Button text="Button" inline color="red" size="md"/>
+
+    `}
+      />
+      <MainSection.Card
+        cardSize="sm"
+        title="Sm"
+        description="Small"
+        defaultCode={`
+        <Button text="Button" inline color="red" size="sm"/>
+
+    `}
+      />
+    </MainSection.Subsection>
+    <MainSection.Subsection title="Hierarchy">
+      <MainSection.Card
+        cardSize="sm"
+        title="Primary"
+        description="High emphasis, used for primary actions."
+        defaultCode={`
+        <Button text="Button" inline color="red"/>
+
+    `}
+      />
+      <MainSection.Card
+        cardSize="sm"
+        title="Secondary"
+        description="Medium emphasis, used for secondary actions."
+        defaultCode={`
+        <Button text="Button" inline color="gray" />
+
+    `}
+      />
+      <MainSection.Card
+        cardSize="sm"
+        title="Tertiary"
+        shaded
+        description="Low emphasis when placed on white backgrounds, used for tertiary actions, and medium emphasis, used for secondary actions when placed on dark backgrounds."
+        defaultCode={`
+        <Button text="Button" inline color="white"/>
+
+    `}
+      />
+    </MainSection.Subsection>
+  </MainSection>
+);
+
+card(
+  <Combination
+    id="color"
+    name="Color"
+    color={['gray', 'red', 'blue', 'white', 'transparent']}
+  >
+    {(props, i) => (
+      <Button
+        id={`example-${i}`}
+        onChange={() => {}}
+        {...props}
+        text="Button"
+      />
+    )}
+  </Combination>
 );
 
 card(

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -40,7 +40,7 @@ export default function Card({
             data-anchor
           >
             <Flex alignItems="baseline" gap={2}>
-              <Box>{name}</Box>
+              <Heading size="md">{name}</Heading>
 
               <IconButton
                 dangerouslySetSvgPath={{

--- a/docs/src/components/Example.js
+++ b/docs/src/components/Example.js
@@ -55,7 +55,7 @@ const Example = ({
           )}
         </Box>
 
-        <Box padding={2}>
+        <Box paddingX={2}>
           <Text color="watermelon">
             <LiveError />
           </Text>

--- a/docs/src/components/ExampleCode.js
+++ b/docs/src/components/ExampleCode.js
@@ -34,7 +34,7 @@ export default function ExampleCode({
 
   return (
     <>
-      <Box display="flex" direction="row" justifyContent="center" marginTop={2}>
+      <Box display="flex" direction="row" justifyContent="start" marginTop={2}>
         <Tooltip inline text="Open in CodeSandbox" idealDirection="up">
           <IconButton
             dangerouslySetSvgPath={{
@@ -43,7 +43,7 @@ export default function ExampleCode({
             }}
             accessibilityLabel="Open in CodeSandbox"
             iconColor="darkGray"
-            size="lg"
+            size="sm"
             onClick={() => {
               handleCodeSandbox({ code, title: name });
             }}
@@ -57,7 +57,7 @@ export default function ExampleCode({
             }}
             accessibilityLabel="Copy Code"
             iconColor="darkGray"
-            size="lg"
+            size="sm"
             onClick={() => {
               copyCode({ code });
             }}
@@ -74,7 +74,7 @@ export default function ExampleCode({
             } code for ${name}`}
             iconColor="darkGray"
             icon={expanded ? 'eye-hide' : 'eye'}
-            size="lg"
+            size="sm"
             onClick={() => setExpanded(!expanded)}
           />
         </Tooltip>

--- a/docs/src/components/ExampleCode.js
+++ b/docs/src/components/ExampleCode.js
@@ -22,13 +22,15 @@ export default function ExampleCode({
   name: string,
 |}): Node {
   const [expanded, setExpanded] = useState(true);
+  const [showExpandButton, setShowExpandButton] = useState(false);
   const codeExampleRef = useRef(null);
-  const CODE_EXAMPLE_HEIGHT = 100;
+  const CODE_EXAMPLE_HEIGHT = 152;
 
   useEffect(() => {
     const height = codeExampleRef?.current?.clientHeight ?? 0;
     if (height - 80 > CODE_EXAMPLE_HEIGHT) {
       setExpanded(false);
+      setShowExpandButton(true);
     }
   }, [code]);
 
@@ -49,13 +51,13 @@ export default function ExampleCode({
             }}
           />
         </Tooltip>
-        <Tooltip inline text="Copy Code" idealDirection="up">
+        <Tooltip inline text="Copy code" idealDirection="up">
           <IconButton
             dangerouslySetSvgPath={{
               __path:
                 'M15.25 0h-6.5a1.75 1.75 0 000 3.5h6.5a5.256 5.256 0 015.25 5.25v6.5a1.75 1.75 0 103.5 0v-6.5C24 3.925 20.075 0 15.25 0zm-.75 6.5H3a3 3 0 00-3 3V21a3 3 0 003 3h11.5a3 3 0 003-3V9.5a3 3 0 00-3-3z',
             }}
-            accessibilityLabel="Copy Code"
+            accessibilityLabel="Copy code"
             iconColor="darkGray"
             size="sm"
             onClick={() => {
@@ -63,21 +65,23 @@ export default function ExampleCode({
             }}
           />
         </Tooltip>
-        <Tooltip
-          inline
-          text={`${expanded ? 'Collapse' : 'Expand'} code example`}
-          idealDirection="up"
-        >
-          <IconButton
-            accessibilityLabel={`${
-              expanded ? 'Collapse' : 'Expand'
-            } code for ${name}`}
-            iconColor="darkGray"
-            icon={expanded ? 'eye-hide' : 'eye'}
-            size="sm"
-            onClick={() => setExpanded(!expanded)}
-          />
-        </Tooltip>
+        {showExpandButton && (
+          <Tooltip
+            inline
+            text={`${expanded ? 'Collapse' : 'Expand'} code example`}
+            idealDirection="up"
+          >
+            <IconButton
+              accessibilityLabel={`${
+                expanded ? 'Collapse' : 'Expand'
+              } code for ${name}`}
+              iconColor="darkGray"
+              icon={expanded ? 'eye-hide' : 'eye'}
+              size="sm"
+              onClick={() => setExpanded(!expanded)}
+            />
+          </Tooltip>
+        )}
       </Box>
       <Box display="flex" direction="column" width="100%" marginTop={2}>
         <Box
@@ -100,7 +104,7 @@ export default function ExampleCode({
             {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
             <label>
-              <LiveEditor padding={16} />
+              <LiveEditor style={{ minHeight: '152px' }} padding={16} />
             </label>
           </Box>
         </Box>

--- a/docs/src/components/ExampleCode.js
+++ b/docs/src/components/ExampleCode.js
@@ -85,11 +85,12 @@ export default function ExampleCode({
       </Box>
       <Box display="flex" direction="column" width="100%" marginTop={2}>
         <Box
-          position="relative"
-          display="flex"
+          borderStyle="sm"
           color="darkGray"
-          ref={codeExampleRef}
+          display="flex"
           overflow="hidden"
+          position="relative"
+          ref={codeExampleRef}
           rounding={2}
           {...(expanded
             ? {}

--- a/docs/src/components/MainSection.js
+++ b/docs/src/components/MainSection.js
@@ -1,0 +1,24 @@
+// @flow strict
+import React, { type Node } from 'react';
+import MainSectionCard from './MainSectionCard.js';
+import Card from './Card.js';
+import MainSectionSubsection from './MainSectionSubsection.js';
+
+type Props = {|
+  description?: string,
+  name: string,
+  children: Node,
+|};
+
+const MainSection = ({ children, description, name }: Props): Node => {
+  return (
+    <Card name={name} description={description}>
+      {children}
+    </Card>
+  );
+};
+
+MainSection.Card = MainSectionCard;
+
+MainSection.Subsection = MainSectionSubsection;
+export default MainSection;

--- a/docs/src/components/MainSection.js
+++ b/docs/src/components/MainSection.js
@@ -5,9 +5,9 @@ import Card from './Card.js';
 import MainSectionSubsection from './MainSectionSubsection.js';
 
 type Props = {|
+  children: Node,
   description?: string,
   name: string,
-  children: Node,
 |};
 
 const MainSection = ({ children, description, name }: Props): Node => {

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -1,0 +1,88 @@
+// @flow strict
+import { Box, Text } from 'gestalt';
+import * as gestalt from 'gestalt'; // eslint-disable-line import/no-namespace
+import DatePicker from 'gestalt-datepicker';
+
+import React, { type Node } from 'react';
+import { LiveProvider, LiveError, LivePreview } from 'react-live';
+import theme from './atomDark.js';
+
+type Props = {|
+  defaultCode: string,
+  description: string,
+  type?: 'do' | "don't" | 'info',
+  shaded?: boolean,
+  cardSize?: 'sm' | 'md',
+  title?: string,
+|};
+
+const CARD_SIZE_NAME_TO_PIXEL = {
+  sm: 236,
+  md: 362,
+};
+
+const TYPE_TO_COLOR = {
+  do: 'green',
+  "don't": 'red',
+  info: 'darkGray',
+};
+
+const MainSectionCard = ({
+  defaultCode,
+  description,
+  type = 'info',
+  shaded = false,
+  cardSize = 'md',
+  title,
+}: Props): Node => {
+  const code = defaultCode.trim();
+  const scope = { ...gestalt, DatePicker };
+  const borderStyle =
+    type !== 'info' ? `3px solid ${TYPE_TO_COLOR[type]}` : undefined;
+  return (
+    <Box
+      width={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
+      marginTop={4}
+      marginBottom={2}
+    >
+      <LiveProvider code={code} scope={scope} theme={theme}>
+        <Box padding={0}>
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            color={shaded ? 'lightGray' : 'white'}
+            display="flex"
+            height={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
+            justifyContent="center"
+            padding={4}
+            position="relative"
+            rounding={2}
+          >
+            <LivePreview />
+          </Box>
+        </Box>
+        <Box padding={2}>
+          <Text color="watermelon">
+            <LiveError />
+          </Text>
+        </Box>
+      </LiveProvider>
+      <Box
+        dangerouslySetInlineStyle={{
+          __style: { borderTop: borderStyle },
+        }}
+      >
+        <Box paddingY={1}>
+          <Text weight="bold" color={TYPE_TO_COLOR[type]}>
+            {title || type.charAt(0).toUpperCase() + type.slice(1)}
+          </Text>
+        </Box>
+        <Box width="90%">
+          <Text>{description}</Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default MainSectionCard;

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -2,16 +2,17 @@
 import { Box, Text } from 'gestalt';
 import * as gestalt from 'gestalt'; // eslint-disable-line import/no-namespace
 import DatePicker from 'gestalt-datepicker';
-
 import React, { type Node } from 'react';
 import { LiveProvider, LiveError, LivePreview } from 'react-live';
+import ExampleCode from './ExampleCode.js';
 import theme from './atomDark.js';
 
 type Props = {|
   defaultCode: string,
-  description: string,
+  description?: string,
   type?: 'do' | "don't" | 'info',
   shaded?: boolean,
+  showCode?: boolean,
   cardSize?: 'sm' | 'md',
   title?: string,
 |};
@@ -32,6 +33,7 @@ const MainSectionCard = ({
   description,
   type = 'info',
   shaded = false,
+  showCode = true,
   cardSize = 'md',
   title,
 }: Props): Node => {
@@ -42,11 +44,11 @@ const MainSectionCard = ({
   return (
     <Box
       width={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
-      marginTop={4}
-      marginBottom={2}
+      marginTop={2}
+      marginBottom={12}
     >
       <LiveProvider code={code} scope={scope} theme={theme}>
-        <Box padding={0}>
+        <Box>
           <Box
             alignItems="center"
             borderStyle="sm"
@@ -61,13 +63,17 @@ const MainSectionCard = ({
             <LivePreview />
           </Box>
         </Box>
-        <Box padding={2}>
+        {showCode && cardSize !== 'sm' && (
+          <ExampleCode code={code} name={title || ''} />
+        )}
+        <Box paddingX={2}>
           <Text color="watermelon">
             <LiveError />
           </Text>
         </Box>
       </LiveProvider>
       <Box
+        marginTop={2}
         dangerouslySetInlineStyle={{
           __style: { borderTop: borderStyle },
         }}
@@ -77,9 +83,11 @@ const MainSectionCard = ({
             {title || type.charAt(0).toUpperCase() + type.slice(1)}
           </Text>
         </Box>
-        <Box width="90%">
-          <Text>{description}</Text>
-        </Box>
+        {description && (
+          <Box width="90%">
+            <Text>{description}</Text>
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -29,6 +29,7 @@ const TYPE_TO_COLOR = {
   info: 'darkGray',
 };
 
+// Colors used here map to colors.css's .red and .green styles
 const COLOR_TO_HEX = {
   green: '#0fa573',
   red: '#e60023',

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -9,13 +9,13 @@ import theme from './atomDark.js';
 import Markdown from './Markdown.js';
 
 type Props = {|
+  cardSize?: 'sm' | 'md',
   defaultCode: string,
   description?: string,
-  type?: 'do' | "don't" | 'info',
   shaded?: boolean,
   showCode?: boolean,
-  cardSize?: 'sm' | 'md',
   title?: string,
+  type?: 'do' | "don't" | 'info',
 |};
 
 const CARD_SIZE_NAME_TO_PIXEL = {
@@ -29,19 +29,26 @@ const TYPE_TO_COLOR = {
   info: 'darkGray',
 };
 
+const COLOR_TO_HEX = {
+  green: '#0fa573',
+  red: '#e60023',
+};
+
 const MainSectionCard = ({
+  cardSize = 'md',
   defaultCode,
   description,
-  type = 'info',
   shaded = false,
   showCode = true,
-  cardSize = 'md',
   title,
+  type = 'info',
 }: Props): Node => {
   const code = defaultCode.trim();
   const scope = { ...gestalt, DatePicker };
   const borderStyle =
-    type !== 'info' ? `3px solid ${TYPE_TO_COLOR[type]}` : undefined;
+    type !== 'info'
+      ? `3px solid ${COLOR_TO_HEX[TYPE_TO_COLOR[type]]}`
+      : undefined;
   return (
     <Box
       width={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
@@ -49,24 +56,24 @@ const MainSectionCard = ({
       marginBottom={8}
     >
       <LiveProvider code={code} scope={scope} theme={theme}>
-        <Box>
-          <Box
-            alignItems="center"
-            borderStyle="sm"
-            color={shaded ? 'lightGray' : 'white'}
-            display="flex"
-            height={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
-            justifyContent="center"
-            padding={4}
-            position="relative"
-            rounding={2}
-          >
-            <LivePreview />
-          </Box>
+        <Box
+          alignItems="center"
+          borderStyle="sm"
+          color={shaded ? 'lightGray' : 'white'}
+          display="flex"
+          height={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
+          justifyContent="center"
+          padding={4}
+          position="relative"
+          rounding={2}
+        >
+          <LivePreview />
         </Box>
+
         {showCode && cardSize !== 'sm' && (
           <ExampleCode code={code} name={title || ''} />
         )}
+
         <Box paddingX={2}>
           <Text color="watermelon">
             <LiveError />

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -46,7 +46,7 @@ const MainSectionCard = ({
     <Box
       width={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
       marginTop={2}
-      marginBottom={12}
+      marginBottom={8}
     >
       <LiveProvider code={code} scope={scope} theme={theme}>
         <Box>

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -6,6 +6,7 @@ import React, { type Node } from 'react';
 import { LiveProvider, LiveError, LivePreview } from 'react-live';
 import ExampleCode from './ExampleCode.js';
 import theme from './atomDark.js';
+import Markdown from './Markdown.js';
 
 type Props = {|
   defaultCode: string,
@@ -84,8 +85,8 @@ const MainSectionCard = ({
           </Text>
         </Box>
         {description && (
-          <Box width="90%">
-            <Text>{description}</Text>
+          <Box width="90%" marginTop={-3}>
+            <Markdown text={description} />
           </Box>
         )}
       </Box>

--- a/docs/src/components/MainSectionSubsection.js
+++ b/docs/src/components/MainSectionSubsection.js
@@ -1,6 +1,7 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Box, Flex, Heading, Text } from 'gestalt';
+import { Box, Flex, Heading } from 'gestalt';
+import Markdown from './Markdown.js';
 
 type Props = {|
   description?: string,
@@ -14,13 +15,17 @@ const MainSectionSubsection = ({
   title,
 }: Props): Node => {
   return (
-    <Box marginBottom={2}>
+    <Box>
       {title && (
         <Box paddingY={1}>
           <Heading size="sm">{title}</Heading>
         </Box>
       )}
-      {description && <Text>{description}</Text>}
+      {description && (
+        <Box>
+          <Markdown text={description} />
+        </Box>
+      )}
       <Flex wrap gap={4}>
         {children}
       </Flex>

--- a/docs/src/components/MainSectionSubsection.js
+++ b/docs/src/components/MainSectionSubsection.js
@@ -1,0 +1,31 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { Box, Flex, Heading, Text } from 'gestalt';
+
+type Props = {|
+  description?: string,
+  title?: string,
+  children: Node,
+|};
+
+const MainSectionSubsection = ({
+  children,
+  description,
+  title,
+}: Props): Node => {
+  return (
+    <Box marginBottom={2}>
+      {title && (
+        <Box paddingY={1}>
+          <Heading size="sm">{title}</Heading>
+        </Box>
+      )}
+      {description && <Text>{description}</Text>}
+      <Flex wrap gap={4}>
+        {children}
+      </Flex>
+    </Box>
+  );
+};
+
+export default MainSectionSubsection;

--- a/docs/src/components/MainSectionSubsection.js
+++ b/docs/src/components/MainSectionSubsection.js
@@ -22,7 +22,7 @@ const MainSectionSubsection = ({
         </Box>
       )}
       {description && (
-        <Box>
+        <Box marginTop={-3}>
           <Markdown text={description} />
         </Box>
       )}

--- a/docs/src/components/MainSectionSubsection.js
+++ b/docs/src/components/MainSectionSubsection.js
@@ -4,9 +4,9 @@ import { Box, Flex, Heading } from 'gestalt';
 import Markdown from './Markdown.js';
 
 type Props = {|
+  children: Node,
   description?: string,
   title?: string,
-  children: Node,
 |};
 
 const MainSectionSubsection = ({
@@ -15,7 +15,7 @@ const MainSectionSubsection = ({
   title,
 }: Props): Node => {
   return (
-    <Box>
+    <>
       {title && (
         <Box paddingY={1}>
           <Heading size="sm">{title}</Heading>
@@ -29,7 +29,7 @@ const MainSectionSubsection = ({
       <Flex wrap gap={4}>
         {children}
       </Flex>
-    </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
Adds MainSection, MainSection.Subsection, and MainSection.Card components for docs redesign

Supports small and medium sizes (2 vs 3 across), and Do, Don't, or Info styles

**Dos and Don'ts:**
![Screen Shot 2021-01-21 at 4 39 36 PM](https://user-images.githubusercontent.com/5125094/105429999-668d6100-5c07-11eb-8bff-03a2ec8c87e1.png)


**Variants Info:** 

![Screen Shot 2021-01-21 at 4 39 25 PM](https://user-images.githubusercontent.com/5125094/105430013-6c834200-5c07-11eb-9309-230711357fe5.png)




## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->

