### PR TITLE
Docs: component source link tweaks

### DIFF
--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Badge, Box, Text, Tooltip, Heading, Link } from 'gestalt';
+import { Badge, Box, Flex, Heading, Link, Text, Tooltip } from 'gestalt';
 import Markdown from './Markdown.js';
 
 type Props = {|
@@ -33,24 +33,26 @@ export default function ComponentHeader({
   return (
     <Box marginBottom={6}>
       <Box marginBottom={4}>
-        <Heading>
-          {name}{' '}
-          {pilot ? (
-            <Tooltip
-              inline
-              text={`This is the initial version of ${name}, and additional (non-breaking) functionality is planned for the future. Any feedback is greatly appreciated!`}
-            >
-              <Badge text="Pilot" position="top" />
-            </Tooltip>
-          ) : null}
-        </Heading>
-        {showSourceLink && (
-          <Text color="gray">
-            <Link href={githubUrl(fileName || name)} inline target="blank">
-            </Link>
-          </Text>
-        )}
+        <Flex direction="column" gap={1}>
+          <Heading>
+            {name}{' '}
+            {pilot ? (
+              <Tooltip
+                inline
+                text={`This is the initial version of ${name}, and additional (non-breaking) functionality is planned for the future. Any feedback is greatly appreciated!`}
+              >
+                <Badge text="Pilot" position="top" />
+              </Tooltip>
+            ) : null}
+          </Heading>
+          {showSourceLink && (
+            <Text color="gray">
+              <Link href={githubUrl(fileName ?? name)} inline target="blank">
                 View source on GitHub
+              </Link>
+            </Text>
+          )}
+        </Flex>
       </Box>
       {description && <Markdown text={description} />}
     </Box>

--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -12,10 +12,9 @@ type Props = {|
 |};
 
 const gestaltPath = (component) => {
-  if (component === 'DatePicker') {
-    return `packages/gestalt-datepicker/src/${component}.js`;
-  }
-  return `packages/gestalt/src/${component}.js`;
+  const packageName =
+    component === 'DatePicker' ? 'gestalt-datepicker' : 'gestalt';
+  return `packages/${packageName}/src/${component}.js`;
 };
 
 const githubUrl = (component) =>

--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -47,10 +47,10 @@ export default function ComponentHeader({
         {showSourceLink && (
           <Text color="gray">
             <Link href={githubUrl(fileName || name)} inline target="blank">
-              View source on Github
             </Link>
           </Text>
         )}
+                View source on GitHub
       </Box>
       {description && <Markdown text={description} />}
     </Box>

--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -47,8 +47,8 @@ export default function ComponentHeader({
         </Heading>
         {showSourceLink && (
           <Text color="gray">
-            <Link href={githubUrl(fileName || name)} inline>
-              Source
+            <Link href={githubUrl(fileName || name)} inline target="blank">
+              View source on Github
             </Link>
           </Text>
         )}


### PR DESCRIPTION
A couple of small tweaks to the source link on component pages:
- Update copy to "View source on Github" to make the link more prominent and clear
- Add `target="blank"` to open the target in a new tab