### PR TITLE
Typeahead: add zIndex prop to support component in Modals with zIndex

### DIFF
--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -106,6 +106,13 @@ card(
           'Forward the ref to the underlying component container element',
         href: 'refExample',
       },
+      {
+        name: 'zIndex',
+        type: 'interface Indexable { index(): number; }',
+        description:
+          'An object representing the z-index value of the Typeahead list. Only use when Typeahead is used within a parent component that has a z-index set.',
+        href: 'zIndex',
+      },
     ]}
   />
 );
@@ -249,7 +256,7 @@ function Example(props) {
 card(
   <Example
     id="defaultItemExample2"
-    name="Ref Example"
+    name="With Ref"
     defaultCode={`
 function TypeaheadExample() {
   const ref = React.useRef();
@@ -281,7 +288,7 @@ function TypeaheadExample() {
 card(
   <Example
     id="tagsExample"
-    name="Example: Tags"
+    name="With Tags"
     description={`
     You can include [Tag](/Tag) elements in the input using the \`tags\` prop.
 
@@ -350,6 +357,73 @@ function Example(props) {
   );
 }
 `}
+  />
+);
+
+card(
+  <Example
+    id="zIndex"
+    name="With ZIndex"
+    description={`
+    When Typeahead is used within a parent component that has a z-index set, a z-index will also need to be set on the Typeahead. Otherwise the Typeahead will render behind the parent component in the stacking context.`}
+    defaultCode={`
+function Example(props) {
+  const [open, setOpen] = React.useState(false);
+  const [option, setOption] = React.useState();
+
+  const HEADER_ZINDEX = new FixedZIndex(10);
+  const MODAL_ZINDEX = new CompositeZIndex([HEADER_ZINDEX]);
+  const TYPEAHEAD_ZINDEX = new CompositeZIndex([MODAL_ZINDEX]);
+
+  return (
+    <>
+      <Button
+        inline
+        text="Report a stolen account"
+        onClick={() => setOpen(true)}
+      />
+      {open && (
+        <Layer zIndex={MODAL_ZINDEX}>
+          <Modal
+            accessibilityModalLabel="Select the account being reported"
+            onDismiss={() => setOpen(false)}
+            size="sm"
+            heading="Report a stolen account"
+            footer={
+              <Button
+                onClick={() => setOpen(false)}
+                text="Submit"
+                color="red"
+                size="lg"
+                type="submit"
+              />
+            }
+          >
+            <Box padding={8}>
+              <Typeahead
+                zIndex={TYPEAHEAD_ZINDEX}
+                label="Select the account being reported"
+                id="reported_account"
+                noResultText="No Results"
+                options={[
+                  {
+                    label: "basic_user@email.com",
+                    value: "basic_user@email.com"
+                  },
+                  {
+                    label: "business_user@email.com",
+                    value: "business_user@email.com"
+                  },
+                ]}
+                placeholder="Select an account"
+              />
+            </Box>
+          </Modal>
+        </Layer>
+      )}
+    </>
+  );
+}`}
   />
 );
 

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -19,6 +19,7 @@ import Tag from './Tag.js';
 import handleContainerScrolling, {
   type DirectionOptionType,
 } from './utils/keyboardNavigation.js';
+import { type Indexable } from './zIndex.js';
 
 type Props = {|
   id: string,
@@ -53,6 +54,7 @@ type Props = {|
   size?: 'md' | 'lg',
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   value?: string,
+  zIndex?: Indexable,
 |};
 
 const TypeaheadWithForwardRef: React$AbstractComponent<
@@ -73,6 +75,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<
     size,
     tags,
     value = null,
+    zIndex,
   } = props;
 
   // Store original data
@@ -252,7 +255,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<
       />
 
       {containerOpen && positioningRef.current && (
-        <Layer>
+        <Layer zIndex={zIndex}>
           <Flyout
             showCaret={false}
             anchor={positioningRef.current}
@@ -327,6 +330,8 @@ TypeaheadWithForwardRef.propTypes = {
   size: PropTypes.oneOf(['md', 'lg']),
   tags: PropTypes.arrayOf(PropTypes.node),
   value: PropTypes.string,
+  // eslint-disable-next-line react/forbid-prop-types
+  zIndex: PropTypes.any,
 };
 
 TypeaheadWithForwardRef.displayName = 'Typeahead';


### PR DESCRIPTION
Typeahead didn't include zIndex prop to support component within Modals with existing zIndex. Other components as Dropdown do include zIndex to support these cases.

This PR implements zIndex prop in Typeahead and adds an example to the Docs

![image](https://user-images.githubusercontent.com/10593890/105769302-a2883500-5f2b-11eb-87df-f3e460675609.png)

Without the zIndex, the Typeahead is overlayed by the Modal zIndex.

![image](https://user-images.githubusercontent.com/10593890/105769590-06aaf900-5f2c-11eb-8ff1-b403b357febc.png)

NOTE: This fix allows Typeahead in Modals with zIndex but scrollable Modals will present Flyout positioning issue.  To be fixed with the upcoming ScrollableBox component.
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
