### PR TITLE
Z-Index: Consolidate proptype to reduce needed suppressions

### DIFF
--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -24,7 +24,7 @@ import React, {
 import PropTypes from 'prop-types';
 import styles from './Box.css';
 import { buildStyles } from './boxTransforms.js';
-import { type Indexable } from './zIndex.js';
+import { type Indexable, UnsafeIndexablePropType } from './zIndex.js';
 import {
   type DangerouslySetInlineStyle,
   type AlignContent,
@@ -327,6 +327,5 @@ BoxWithForwardRef.propTypes = {
 
   role: PropTypes.string,
 
-  // eslint-disable-next-line react/forbid-prop-types
-  zIndex: PropTypes.any,
+  zIndex: UnsafeIndexablePropType,
 };

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -13,7 +13,7 @@ import Layer from './Layer.js';
 import DropdownItem from './DropdownItem.js';
 import DropdownSection from './DropdownSection.js';
 import DropdownContext from './DropdownContextProvider.js';
-import { type Indexable } from './zIndex.js';
+import { type Indexable, UnsafeIndexablePropType } from './zIndex.js';
 import handleContainerScrolling, {
   type DirectionOptionType,
 } from './utils/keyboardNavigation.js';
@@ -233,8 +233,7 @@ Dropdown.propTypes = {
   idealDirection: PropTypes.oneOf(['up', 'right', 'down', 'left']),
   onDismiss: PropTypes.func.isRequired,
   onSelect: PropTypes.func,
-  // eslint-disable-next-line react/forbid-prop-types
-  zIndex: PropTypes.any,
+  zIndex: UnsafeIndexablePropType,
 };
 
 Dropdown.Item = DropdownItem;

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -57,13 +57,9 @@ const PositionPropType: React$PropType$Primitive<PositionType> = PropTypes.oneOf
 
 Sticky.propTypes = {
   children: PropTypes.node,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   top: PositionPropType,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   left: PositionPropType,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   bottom: PositionPropType,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   right: PositionPropType,
   height: PropTypes.number,
   zIndex: UnsafeIndexablePropType,

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -1,22 +1,27 @@
 // @flow strict
-
 import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import layout from './Layout.css';
-import { type Indexable, FixedZIndex } from './zIndex.js';
+import {
+  FixedZIndex,
+  type Indexable,
+  UnsafeIndexablePropType,
+} from './zIndex.js';
+
+type PositionType = number | string;
 
 type Threshold =
-  | {| top: number | string |}
-  | {| bottom: number | string |}
-  | {| left: number | string |}
-  | {| right: number | string |}
-  | {| top: number | string, bottom: number | string |}
-  | {| left: number | string, right: number | string |}
+  | {| top: PositionType |}
+  | {| bottom: PositionType |}
+  | {| left: PositionType |}
+  | {| right: PositionType |}
+  | {| top: PositionType, bottom: PositionType |}
+  | {| left: PositionType, right: PositionType |}
   | {|
-      top: number | string,
-      left: number | string,
-      right: number | string,
-      bottom: number | string,
+      top: PositionType,
+      left: PositionType,
+      right: PositionType,
+      bottom: PositionType,
     |};
 
 type Props = {|
@@ -46,17 +51,20 @@ export default function Sticky(props: Props): Node {
   );
 }
 
+const PositionPropType: React$PropType$Primitive<PositionType> = PropTypes.oneOfType(
+  [PropTypes.number, PropTypes.string]
+);
+
 Sticky.propTypes = {
   children: PropTypes.node,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  top: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  top: PositionPropType,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  left: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  left: PositionPropType,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  bottom: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  bottom: PositionPropType,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  right: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  right: PositionPropType,
   height: PropTypes.number,
-  // eslint-disable-next-line react/forbid-prop-types
-  zIndex: PropTypes.any,
+  zIndex: UnsafeIndexablePropType,
 };

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -19,7 +19,7 @@ import Tag from './Tag.js';
 import handleContainerScrolling, {
   type DirectionOptionType,
 } from './utils/keyboardNavigation.js';
-import { type Indexable } from './zIndex.js';
+import { type Indexable, UnsafeIndexablePropType } from './zIndex.js';
 
 type Props = {|
   id: string,
@@ -330,8 +330,7 @@ TypeaheadWithForwardRef.propTypes = {
   size: PropTypes.oneOf(['md', 'lg']),
   tags: PropTypes.arrayOf(PropTypes.node),
   value: PropTypes.string,
-  // eslint-disable-next-line react/forbid-prop-types
-  zIndex: PropTypes.any,
+  zIndex: UnsafeIndexablePropType,
 };
 
 TypeaheadWithForwardRef.displayName = 'Typeahead';

--- a/packages/gestalt/src/zIndex.js
+++ b/packages/gestalt/src/zIndex.js
@@ -1,6 +1,9 @@
 // @flow strict
-
 // eslint-disable-next-line max-classes-per-file
+import PropTypes from 'prop-types';
+
+export const UnsafeIndexablePropType = PropTypes.any;
+
 export interface Indexable {
   index(): number;
 }


### PR DESCRIPTION
Also so that future updates are easier when we figure out the correct PropType to use.

And some unrelated type de-duping in Sticky, since I was in there.