### PR TITLE
Internal: bump resolved version of immer due to security concern

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,9 @@
     "xml2js": "^0.4.23"
   },
   "resolutions": {
+    "bl": "4.0.3",
     "serialize-javascript": "3.1.0",
-    "bl": "4.0.3"
+    "immer": "8.0.1"
   },
   "scripts": {
     "a11y:generate": "./scripts/generateAccessibilitySpecs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10281,10 +10281,10 @@ ignore@^5.1.1, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@7.0.9:
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
-  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+immer@7.0.9, immer@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
`immer` is a dependency of `react-dev-utils`, which is a dependency (and sub-package) of `react-scripts`, part of Create React App. (We use CRA for the docs site.) There is a security concern with the current version (7.0.9), which has been fixed in 8.0.1. Neither `react-scripts` nor `react-dev-utils` have updated, so this PR adds a resolution (hopefully temporarily) to use the newer version of that package.