### PR TITLE
[WIP] Gestalt: ScrollableContainer - new component with built-in scrollability logic to allow flyout-based components get correctly positioned inside scrolling containers

### DIFF
--- a/packages/gestalt/src/contexts/ScrollableBoxStore.js
+++ b/packages/gestalt/src/contexts/ScrollableBoxStore.js
@@ -1,0 +1,62 @@
+// @flow strict
+import React, {
+  useContext,
+  useState,
+  useCallback,
+  createContext,
+  type Context,
+  type Element,
+  type Node,
+} from 'react';
+import PropTypes from 'prop-types';
+
+type ScrollableBoxStoreContextType = {|
+  refs: $ReadOnlyArray<?HTMLDivElement>,
+  addRef: (ref: HTMLDivElement) => void,
+  removeRef: (ref: HTMLDivElement) => void,
+|};
+
+type Props = {|
+  children: Node,
+|};
+
+const ScrollableBoxStoreContext: Context<ScrollableBoxStoreContextType> = createContext<ScrollableBoxStoreContextType>(
+  {
+    refs: [],
+    addRef: () => {},
+    removeRef: () => {},
+  }
+);
+
+const { Provider } = ScrollableBoxStoreContext;
+
+function ScrollableBoxStoreProvider({
+  children,
+}: Props): Element<typeof Provider> {
+  const [refs, setRefs] = useState([]);
+
+  const scrollableBoxStoreContext = {
+    refs,
+    addRef: useCallback((ref) => {
+      setRefs((oldRefs) => {
+        return [...oldRefs, ref];
+      });
+    }, []),
+    removeRef: useCallback((ref) => {
+      setRefs((oldRefs) => oldRefs.filter((r) => r !== ref));
+    }, []),
+  };
+
+  return <Provider value={scrollableBoxStoreContext}>{children}</Provider>;
+}
+
+function useScrollableBoxStore(): ScrollableBoxStoreContextType {
+  const scrollableBoxStoreContext = useContext(ScrollableBoxStoreContext);
+  return scrollableBoxStoreContext;
+}
+
+export { ScrollableBoxStoreProvider, useScrollableBoxStore };
+
+ScrollableBoxStoreProvider.propTypes = {
+  children: PropTypes.node,
+};


### PR DESCRIPTION
# Problem

Layer uses React.Portal to place components outside the DOM hierarchy of the parent component. Layer appends a portal to document.body. 

However, components that depend on anchor components for placement such as 1. Tooltip, 2. Flyout, 3. Dropdown, and 4. Typeahead fail to get correctly positioned and follow anchor within scrolling containers. Under the hood, all of them use the same components for placement and positioning (Layer, Controller, Contents) which 1. append a portal to document.body and 2. take window as positioning reference.

Issue Example: https://codesandbox.io/s/bugissue-oo6vg?file=/example.js

## Gestalt Components involved
- Tooltip
- Flyout
- Dropdown
- Typeahead
- Layer
- Controller (internal)
- Contents (internal)

# Solution

## Solution parts
- ScrollableBoxStore Context: provide 2 callback function to ScrollableContainer and a store of Scrollable Boxes refs to be used by the smart Layer


- ScrollableContainer: a simple <div> container that registers its node ref into the ScrollableBoxStore so that
    - 1. Layer will get matched to and append a portal (containerNode instead of document.body), 
    - 2. Controller and Contents can use the container node to measure positioning (instead of window).


- Smart Layer: a Layer that places a temporary <div> and traverses all its parent nodes until matching a registered parent Scrollable Box. If no Scrollable Box is matched, Layer will remove the temp div and append a portal to document.body. If match is found, Layer will append portal to containerNode.


- Smart Controller & Contents: both components use same smart logic as in Layer to replace window with containerNode in all the positioning calculations for flyouts and carets. 


## Proposal: step by step logic


1. Flyout/Tooltip/Dropwdown/Typeahead are children of scrolling containers (regular Box,  Modal, etc,)
2. Add ScrollableContainer
    1. add optional `overflow='auto'|'scroll'|'scrollX'|'scrollY'` (default: `auto`)
    2. add optional `height='___px'/{___}/'___%'.`  (default: `100%`)
        1. Provider is automatically added to DOM wrapping <div>
        2. Layer detects `ScrollableBoxStore` context and triggers logic to match registered ScrollableContainer
        3. Layer appends portal to registered ScrollableContainer
        4. Flyout/Tooltip/Dropdown/Typeahead conditionally render through portal
        5. Controller/Content detect `ScrollableBoxStore` context and triggers logic to match registered ScrollableContainer
        6. Controller/Content use registered ScrollableContainer to calculate flyout & caret positioning


```
    <ScrollableContainer overflow='scroll' height={100}>
      <Box>
        <Button  ref={ref}/>
        <Layer>
          <Flyout anchor={ref.current} />
        </Layer>
      </Box>
    </ScrollableContainer>

```
Working Solution example: https://deploy-preview-1348--gestalt.netlify.app/ScrollableBox

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
