### PR TITLE
Docs: copyPaste functionality implemented into linking icon

### DIFF
--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -15,6 +15,22 @@ type Props = {|
   showHeading?: boolean,
 |};
 
+export const copyToClipboard = (hash: string): boolean => {
+  if (!navigator.clipboard) {
+    // Clipboard API not available
+    return false;
+  }
+  const url = window.location;
+  url.hash = hash;
+
+  try {
+    navigator.clipboard.writeText(url);
+  } catch (err) {
+    return false;
+  }
+  return true;
+};
+
 export default function Card({
   children,
   description,
@@ -26,6 +42,7 @@ export default function Card({
   showHeading = true,
 }: Props): Node {
   const slugifiedId = id ?? slugify(name);
+
   return (
     <>
       {showHeading && (
@@ -48,6 +65,9 @@ export default function Card({
                     'M21.001 7.241l-4.053 4.052-1.06-1.06.672-.672a1.5 1.5 0 10-2.121-2.121l-.671.672-1.061-1.06L16.759 3l4.242 4.241zm-9.708 9.708l-4.052 4.052-4.242-4.241 4.053-4.053 1.059 1.06-.671.672a1.5 1.5 0 002.121 2.121l.671-.672 1.061 1.061zM14.639.879l-4.053 4.052a3 3 0 000 4.242l1.061 1.06-1.415 1.414-1.06-1.061a3 3 0 00-4.241 0L.879 14.638a2.998 2.998 0 000 4.242l4.241 4.242a3 3 0 004.241 0l4.053-4.052a3 3 0 000-4.242l-1.06-1.061 1.414-1.413 1.06 1.06a3 3 0 004.241 0l4.052-4.052a2.998 2.998 0 000-4.242L18.88.879a2.997 2.997 0 00-4.241 0z',
                 }}
                 accessibilityLabel={`${name} - Anchor tag`}
+                onClick={() => {
+                  copyToClipboard(slugifiedId);
+                }}
                 size="sm"
                 href={`#${slugifiedId}`}
                 role="link"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10593890/106655865-eb616e80-6567-11eb-90a0-c488fdb870c4.png)
Linking icon scrolls to top, hashes url in browser, and (NEW!) now it also copies new hashed url for quick sharing.  


<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
