### PR TITLE
Internal: Add lint rules to enforce fragment style and use of keys

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -67,6 +67,8 @@
     "react-hooks/rules-of-hooks": "error",
     "react/destructuring-assignment": "off",
     "react/jsx-filename-extension": "off",
+    "react/jsx-fragments": ["error", "element"],
+    "react/jsx-key": ["error", { "checkFragmentShorthand": true }],
     "react/jsx-props-no-spreading": "off",
     "react/no-array-index-key": "off",
     "react/require-default-props": "off",

--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -288,10 +288,10 @@ card(
     id="display"
     name="Example: Visually Hidden"
     defaultCode={`
-<>
+<React.Fragment>
   <Text>Enable your screenreader to hear the following text:</Text>
   <Box display="visuallyHidden">In the darkest night, Box will rise to bring the light. The Lloyd has spoken.</Box>
-</>
+</React.Fragment>
 `}
   />,
 );
@@ -610,7 +610,7 @@ function ButtonFlyoutExample() {
   const [checked, setChecked] = React.useState(false);
   const anchorRef = React.useRef(null);
   return (
-    <>
+    <React.Fragment>
       <Flex alignItems="start" direction="column" gap={6}>
         <Button
           inline
@@ -635,7 +635,7 @@ function ButtonFlyoutExample() {
           </Box>
         </Flyout>
       )}
-    </>
+    </React.Fragment>
   );
 }`}
   />,

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -378,14 +378,14 @@ card(
     name="Width"
     id="widths"
     defaultCode={`
-<>
+<React.Fragment>
   <Box padding={2}>
     <Button text="Inline button" inline />
   </Box>
   <Box padding={2}>
     <Button text="Default full-width button" />
   </Box>
-</>`}
+</React.Fragment>`}
   />,
 );
 
@@ -430,7 +430,7 @@ function ButtonFlyoutExample() {
   const anchorRef = React.useRef(null);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         onClick={() => setSelected(!selected)}
@@ -450,7 +450,7 @@ function ButtonFlyoutExample() {
           </Box>
         </Flyout>
       )}
-    </>
+    </React.Fragment>
   );
 }`}
   />,
@@ -487,7 +487,7 @@ function MenuButtonExample() {
   const anchorRef = React.useRef();
 
   return (
-    <>
+    <React.Fragment>
       <Box display="inlineBlock" ref={anchorRef}>
         <Button
           accessibilityControls="menu"
@@ -524,7 +524,7 @@ function MenuButtonExample() {
           </Flyout>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -416,7 +416,7 @@ function IconButtonFlyoutExample() {
   const [checked, setChecked] = React.useState(false);
   const anchorRef = React.useRef(null);
   return (
-    <>
+    <React.Fragment>
       <IconButton
         accessibilityLabel="Love Reaction to a Pin"
         bgColor="white"
@@ -438,7 +438,7 @@ function IconButtonFlyoutExample() {
           </Box>
         </Flyout>
       )}
-    </>
+    </React.Fragment>
   );
 }`}
   />,
@@ -453,7 +453,7 @@ function MenuIconButtonExample() {
   const [selected, setSelected] = React.useState(false);
   const anchorRef = React.useRef();
   return (
-    <>
+    <React.Fragment>
       <IconButton
         accessibilityLabel="Open the options menu"
         accessibilityControls="menu"
@@ -493,7 +493,7 @@ function MenuIconButtonExample() {
           </Flyout>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}

--- a/docs/src/Layer.doc.js
+++ b/docs/src/Layer.doc.js
@@ -54,7 +54,7 @@ function Example() {
   const [showLayer, setShowLayer] = React.useState(false);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="Show Layer"
@@ -76,7 +76,7 @@ function Example() {
           </Box>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}
@@ -97,7 +97,7 @@ function zIndexExample() {
   const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="Show Layer"
@@ -119,7 +119,7 @@ function zIndexExample() {
           </Box>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}

--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -210,7 +210,7 @@ card(
 function Example(props) {
   const [showModal, setShowModal] = React.useState(false);
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="Open modal"
@@ -233,7 +233,7 @@ function Example(props) {
           </Modal>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -168,7 +168,7 @@ function SizesExample(props) {
   const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
   return (
-    <>
+    <React.Fragment>
       <Box padding={1}>
         <Button
           inline
@@ -204,7 +204,7 @@ function SizesExample(props) {
           </Sheet>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}
@@ -268,7 +268,7 @@ function AnimationExample() {
   const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="Open sheet"
@@ -317,7 +317,7 @@ function AnimationExample() {
           </Sheet>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }`}
   />,
@@ -339,7 +339,7 @@ function CloseOnOutsideExample(props) {
   const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="Open sheet"
@@ -359,7 +359,7 @@ function CloseOnOutsideExample(props) {
           </Sheet>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}
@@ -382,7 +382,7 @@ function DefaultPaddingExample(props) {
   const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="View default padding & styling"
@@ -473,7 +473,7 @@ function DefaultPaddingExample(props) {
           </Sheet>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}
@@ -620,7 +620,7 @@ function SubheadingExample(props) {
   const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="View subheading"
@@ -631,7 +631,7 @@ function SubheadingExample(props) {
           <SheetWithSubheading onDismiss={() => setShouldShow(false)} />}
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}
@@ -660,7 +660,7 @@ function RefExample() {
   const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="Open sheet"
@@ -668,7 +668,7 @@ function RefExample() {
       />
       {shouldShow && (
         <Layer zIndex={sheetZIndex}>
-          <>
+          <React.Fragment>
             <Sheet
               accessibilityDismissButtonLabel="Close"
               accessibilitySheetLabel="Focused sheet"
@@ -689,10 +689,10 @@ function RefExample() {
               </Box>
             </Sheet>
             <div ref={callbackRef} />
-          </>
+          </React.Fragment>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }`}
   />,

--- a/docs/src/TapArea.doc.js
+++ b/docs/src/TapArea.doc.js
@@ -540,7 +540,7 @@ function MenuButtonExample() {
   const anchorRef = React.useRef();
 
   return (
-    <>
+    <React.Fragment>
         <TapArea
           accessibilityLabel="Open the options menu"
           accessibilityControls="menu"
@@ -595,7 +595,7 @@ function MenuButtonExample() {
           </Flyout>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }
 `}

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import { Button, Link, Image, Text, Toast } from 'gestalt';
 import Combination from './components/Combination.js';
 import Example from './components/Example.js';
@@ -311,14 +311,14 @@ card(
     showValues={false}
     text={[
       'Section created!',
-      <React.Fragment>
+      <Fragment key="saved-text">
         Saved to{' '}
         <Text inline weight="bold">
           <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
             Home decor
           </Link>
         </Text>
-      </React.Fragment>,
+      </Fragment>,
     ]}
     thumbnail={[
       null,
@@ -357,7 +357,7 @@ card(
           />
         }
         text={
-          <React.Fragment>
+          <Fragment>
             Saved to{' '}
             <Text inline weight="bold">
               <Link
@@ -368,7 +368,7 @@ card(
                 Home decor
               </Link>
             </Text>
-          </React.Fragment>
+          </Fragment>
         }
         button={<Button key="button-key" inline text="Undo" size="lg" />}
       />

--- a/docs/src/Toast.doc.js
+++ b/docs/src/Toast.doc.js
@@ -124,14 +124,14 @@ function ToastExample() {
           {showToast && (
             <Toast
               text={
-                <>
+                <React.Fragment>
                   Saved to{' '}
                   <Text inline weight="bold">
                     <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
                       Home decor
                     </Link>
                   </Text>
-                </>
+                </React.Fragment>
               }
             />
           )}
@@ -174,9 +174,9 @@ function ToastExample() {
             <Toast
               color="red"
               text={
-                <>
+                <React.Fragment>
                   Oops! Something went wrong. Please try again later.
-                </>
+                </React.Fragment>
               }
             />
           )}
@@ -226,14 +226,14 @@ function ToastExample() {
                 />
               }
               text={
-                <>
+                <React.Fragment>
                   Saved to{' '}
                   <Text inline weight="bold">
                     <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
                       Home decor
                     </Link>
                   </Text>
-                </>
+                </React.Fragment>
               }
             />
           )}
@@ -283,14 +283,14 @@ function ToastExample() {
                 />
               }
               text={
-                <>
+                <React.Fragment>
                   Saved to{' '}
                   <Text inline weight="bold">
                     <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
                       Home decor
                     </Link>
                   </Text>
-                </>
+                </React.Fragment>
               }
               button={<Button key="button-key" inline text="Undo" size="lg" />}
             />
@@ -311,14 +311,14 @@ card(
     showValues={false}
     text={[
       'Section created!',
-      <>
+      <React.Fragment>
         Saved to{' '}
         <Text inline weight="bold">
           <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
             Home decor
           </Link>
         </Text>
-      </>,
+      </React.Fragment>,
     ]}
     thumbnail={[
       null,
@@ -357,7 +357,7 @@ card(
           />
         }
         text={
-          <>
+          <React.Fragment>
             Saved to{' '}
             <Text inline weight="bold">
               <Link
@@ -368,7 +368,7 @@ card(
                 Home decor
               </Link>
             </Text>
-          </>
+          </React.Fragment>
         }
         button={<Button key="button-key" inline text="Undo" size="lg" />}
       />

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -139,7 +139,7 @@ function Example(props) {
   const label = "Selected Item: " + (selected && selected.label || '');
 
   return (
-    <>
+    <React.Fragment>
       <Box marginBottom={4}>
        <Text>Selected Item: {(selected && selected.label) || ""}</Text>
       </Box>
@@ -153,7 +153,7 @@ function Example(props) {
         onChange={handleOnChange}
         onSelect={handleSelect}
       />
-    </>
+    </React.Fragment>
   );
 }`}
   />,
@@ -183,7 +183,7 @@ function Example(props) {
   };
 
   return (
-    <>
+    <React.Fragment>
       <Box marginBottom={4}>
        <Text>Selected Item: {(selected && selected.label) || ""}</Text>
       </Box>
@@ -198,7 +198,7 @@ function Example(props) {
         onChange={handleOnChange}
         onSelect={handleSelect}
       />
-    </>
+    </React.Fragment>
   );
 }`}
   />,
@@ -230,7 +230,7 @@ function Example(props) {
   const label = "Selected Item: " + (selected && selected.label || '');
 
   return (
-    <>
+    <React.Fragment>
       <Box marginBottom={4}>
        <Text>{ label }</Text>
       </Box>
@@ -244,7 +244,7 @@ function Example(props) {
         onChange={handleOnChange}
         onSelect={handleSelect}
       />
-    </>
+    </React.Fragment>
   );
 }`}
   />,
@@ -373,7 +373,7 @@ function Example(props) {
   const TYPEAHEAD_ZINDEX = new CompositeZIndex([MODAL_ZINDEX]);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="Report a stolen account"
@@ -418,7 +418,7 @@ function Example(props) {
           </Modal>
         </Layer>
       )}
-    </>
+    </React.Fragment>
   );
 }`}
   />,

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -44,7 +44,7 @@ export default function Card({
   const slugifiedId = id ?? slugify(name);
 
   return (
-    <>
+    <React.Fragment>
       {showHeading && (
         <Heading size={headingSize}>
           <Box
@@ -83,6 +83,6 @@ export default function Card({
           {children}
         </Box>
       </Box>
-    </>
+    </React.Fragment>
   );
 }

--- a/docs/src/components/ExampleCode.js
+++ b/docs/src/components/ExampleCode.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { useEffect, useRef, useState, type Node } from 'react';
+import React, { Fragment, type Node, useEffect, useRef, useState } from 'react';
 import { Box, IconButton, Tooltip } from 'gestalt';
 import { LiveEditor } from 'react-live';
 import handleCodeSandbox from './handleCodeSandbox.js';
@@ -29,7 +29,7 @@ export default function ExampleCode({ code, name }: {| code: string, name: strin
   }, [code]);
 
   return (
-    <>
+    <Fragment>
       <Box display="flex" direction="row" justifyContent="start" marginTop={2}>
         <Tooltip inline text="Open in CodeSandbox" idealDirection="up">
           <IconButton
@@ -100,6 +100,6 @@ export default function ExampleCode({ code, name }: {| code: string, name: strin
           </Box>
         </Box>
       </Box>
-    </>
+    </Fragment>
   );
 }

--- a/docs/src/components/MainSectionSubsection.js
+++ b/docs/src/components/MainSectionSubsection.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import { Box, Flex, Heading, IconButton } from 'gestalt';
 import slugify from 'slugify';
 import Markdown from './Markdown.js';
@@ -13,7 +13,7 @@ type Props = {|
 const MainSectionSubsection = ({ children, description, title }: Props): Node => {
   const slugifiedId = slugify(title || '');
   return (
-    <>
+    <Fragment>
       {title && (
         <Box
           dangerouslySetInlineStyle={{
@@ -48,7 +48,7 @@ const MainSectionSubsection = ({ children, description, title }: Props): Node =>
       <Flex wrap gap={4}>
         {children}
       </Flex>
-    </>
+    </Fragment>
   );
 };
 

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import { Box } from 'gestalt';
 import HeaderMenu from './HeaderMenu.js';
 import SidebarSection from './SidebarSection.js';
@@ -22,7 +22,7 @@ export default function Navigation(): Node {
   const { sidebarOrganisedBy, isSidebarOpen } = useNavigationContext();
 
   const navList = (
-    <>
+    <Fragment>
       {sidebarOrganisedBy === 'categorized' ? (
         sidebarIndex.map((section) => (
           <SidebarSection section={section} key={section.sectionName} />
@@ -34,18 +34,18 @@ export default function Navigation(): Node {
           ))}
         </Box>
       )}
-    </>
+    </Fragment>
   );
 
   return (
     <Box role="navigation">
       {isSidebarOpen && (
-        <>
+        <Fragment>
           <HeaderMenu />
           <Box height={350} overflow="scroll" display="block" mdDisplay="none" padding={4}>
             {navList}
           </Box>
-        </>
+        </Fragment>
       )}
 
       <Box display="none" mdDisplay="block" color="white">

--- a/docs/src/useReducedMotion.doc.js
+++ b/docs/src/useReducedMotion.doc.js
@@ -32,7 +32,7 @@ function Example() {
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <>
+    <React.Fragment>
       <style dangerouslySetInnerHTML={{__html: \`
         @keyframes vibrate {
           0% {
@@ -60,7 +60,7 @@ function Example() {
           <Text color="white">{shouldReduceMotion ? 'Reduced motion enabled' : 'Reduced motion disabled'}</Text>
         </Box>
       </div>
-    </>
+    </React.Fragment>
   );
 }`}
   />,

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-role-link-components/valid.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-role-link-components/valid.js
@@ -1,9 +1,12 @@
+import { Fragment } from 'react';
 import { Button, IconButton, TapArea } from 'gestalt';
 
 export default function TestElement() {
-  return <>
-    <TapArea role='button'/>
-    <IconButton role='button' />
-    <Button />
-  </>;
+  return (
+    <Fragment>
+      <TapArea role="button" />
+      <IconButton role="button" />
+      <Button />
+    </Fragment>
+  );
 }

--- a/packages/gestalt-codemods/1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.input.js
+++ b/packages/gestalt-codemods/1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.input.js
@@ -1,18 +1,20 @@
 // @flow strict
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Avatar } from 'gestalt';
 
 export default function Example() {
-  return <>
-    <Avatar
-      size="sm"
-      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
-      name="Keerthi"
-    />
-    <Avatar
-      size="md"
-      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
-      name="Keerthi"
-    />
-  </>;
+  return (
+    <Fragment>
+      <Avatar
+        size="sm"
+        src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+        name="Keerthi"
+      />
+      <Avatar
+        size="md"
+        src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+        name="Keerthi"
+      />
+    </Fragment>
+  );
 }

--- a/packages/gestalt-codemods/1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.output.js
+++ b/packages/gestalt-codemods/1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-avatar.output.js
@@ -1,18 +1,20 @@
 // @flow strict
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Avatar } from 'gestalt';
 
 export default function Example() {
-  return <>
-    <Avatar
-      size="xs"
-      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
-      name="Keerthi"
-    />
-    <Avatar
-      size="sm"
-      src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
-      name="Keerthi"
-    />
-  </>;
+  return (
+    <Fragment>
+      <Avatar
+        size="xs"
+        src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+        name="Keerthi"
+      />
+      <Avatar
+        size="sm"
+        src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
+        name="Keerthi"
+      />
+    </Fragment>
+  );
 }

--- a/packages/gestalt-codemods/1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.input.js
+++ b/packages/gestalt-codemods/1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.input.js
@@ -1,34 +1,36 @@
 // @flow strict
-import React from 'react';
+import React, { Fragment } from 'react';
 import { GroupAvatar } from 'gestalt';
 
 export default function Example() {
-  return <>
-    <GroupAvatar
-      collaborators={[
-        {
-          name: 'Keerthi',
-          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-        },
-        {
-          name: 'Shanice',
-          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-        },
-      ]}
-      size="sm"
-    />
-    <GroupAvatar
-      collaborators={[
-        {
-          name: 'Keerthi',
-          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-        },
-        {
-          name: 'Shanice',
-          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-        },
-      ]}
-      size="md"
-    />
-  </>;
+  return (
+    <Fragment>
+      <GroupAvatar
+        collaborators={[
+          {
+            name: 'Keerthi',
+            src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+          },
+          {
+            name: 'Shanice',
+            src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+          },
+        ]}
+        size="sm"
+      />
+      <GroupAvatar
+        collaborators={[
+          {
+            name: 'Keerthi',
+            src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+          },
+          {
+            name: 'Shanice',
+            src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+          },
+        ]}
+        size="md"
+      />
+    </Fragment>
+  );
 }

--- a/packages/gestalt-codemods/1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.output.js
+++ b/packages/gestalt-codemods/1.27.0/__testfixtures__/avatar-update-sizes-remove-icon-groupavatar.output.js
@@ -1,34 +1,36 @@
 // @flow strict
-import React from 'react';
+import React, { Fragment } from 'react';
 import { GroupAvatar } from 'gestalt';
 
 export default function Example() {
-  return <>
-    <GroupAvatar
-      collaborators={[
-        {
-          name: 'Keerthi',
-          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-        },
-        {
-          name: 'Shanice',
-          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-        },
-      ]}
-      size="xs"
-    />
-    <GroupAvatar
-      collaborators={[
-        {
-          name: 'Keerthi',
-          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-        },
-        {
-          name: 'Shanice',
-          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-        },
-      ]}
-      size="sm"
-    />
-  </>;
+  return (
+    <Fragment>
+      <GroupAvatar
+        collaborators={[
+          {
+            name: 'Keerthi',
+            src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+          },
+          {
+            name: 'Shanice',
+            src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+          },
+        ]}
+        size="xs"
+      />
+      <GroupAvatar
+        collaborators={[
+          {
+            name: 'Keerthi',
+            src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+          },
+          {
+            name: 'Shanice',
+            src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+          },
+        ]}
+        size="sm"
+      />
+    </Fragment>
+  );
 }

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -71,7 +71,7 @@ const CompletedCard = ({ dismissButton, message, status, statusMessage, title }:
   const icon = STATUS_ICONS[status];
 
   return (
-    <>
+    <Fragment>
       <Box display="flex">
         {icon && (
           <Box display="flex" alignContent="center">
@@ -110,7 +110,7 @@ const CompletedCard = ({ dismissButton, message, status, statusMessage, title }:
           />
         </div>
       )}
-    </>
+    </Fragment>
   );
 };
 
@@ -126,7 +126,7 @@ const UncompletedCard = ({
   const icon = STATUS_ICONS[status];
 
   return (
-    <>
+    <Fragment>
       <Box display="flex" alignContent="center" height={24}>
         {icon && (
           <Box marginEnd={2}>
@@ -171,7 +171,7 @@ const UncompletedCard = ({
           />
         </div>
       )}
-    </>
+    </Fragment>
   );
 };
 

--- a/packages/gestalt/src/AnimationController.js
+++ b/packages/gestalt/src/AnimationController.js
@@ -3,8 +3,8 @@
 
 # Welcome to AnimationController!
 
-An <AnimationController> is a wrapper to control animation of its wrapped components. 
-It works with a Context.Provider which holds the state for animationState. 
+An <AnimationController> is a wrapper to control animation of its wrapped components.
+It works with a Context.Provider which holds the state for animationState.
 Finally, it provides the custom hook useAnimation which provides an object { animationState, onAnimationEnd } where:
 - animationState: the current animation state. Possible values are: null, "in", "postIn", "out", "postOut".
 - onAnimationEnd: the callback function to be passed to onAnimationEnd event handlers on the element that is being animated.
@@ -18,61 +18,61 @@ function AnimationExample() {
     onDismissStart,
   }) => {
     const { animationState, onAnimationEnd } = useAnimation();
-       
+
     let className;
     if (['in', 'out'].includes(animationState)) {
         className = 'slide-' + animationState;
     }
-  
+
     return (
-      <>
+      <React.Fragment>
         <style>{\`
           @keyframes slide-in {
             from {
               margin-left: 100%;
-              width: 300%; 
+              width: 300%;
             }
-          
+
             to {
               margin-left: 0%;
               width: 100%;
             }
-          } 
+          }
 
           @keyframes slide-out {
             from {
               margin-left: 0%;
               width: 100%;
             }
-            
+
             to {
               margin-left: 100%;
-              width: 300%; 
+              width: 300%;
             }
-          } 
+          }
 
           .slide-in {
             animation: slide-in 1s ease-in-out;
           }
-                   
+
           .slide-out {
             animation: slide-out 1s ease-in-out;
-          }          
+          }
         \`}</style>
         <Box marginTop={4} marginBottom={4}>
           <Text>Animation state: <b>{animationState}</b></Text>
         </Box>
         <div onAnimationEnd={onAnimationEnd} className={className}>
-          <Button color="red" inline onClick={onDismissStart} text="Click me!" />          
+          <Button color="red" inline onClick={onDismissStart} text="Click me!" />
         </div>
-      </>
+      </React.Fragment>
     );
   };
 
   const [shouldShow, setShouldShow] = React.useState(false);
 
   return (
-    <>
+    <React.Fragment>
       <Button
         inline
         text="Show animation"
@@ -85,7 +85,7 @@ function AnimationExample() {
           )}
         </AnimationController>
       )}
-    </>
+    </React.Fragment>
   );
 }`}
 

--- a/packages/gestalt/src/Backdrop.js
+++ b/packages/gestalt/src/Backdrop.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './Backdrop.css';
@@ -24,7 +24,7 @@ function Backdrop({ animationState, children, closeOnOutsideClick, onClick }: Pr
   };
 
   return (
-    <>
+    <Fragment>
       {/* Disabling the linters below is fine, we don't want key event listeners (ESC handled elsewhere) */}
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
@@ -36,7 +36,7 @@ function Backdrop({ animationState, children, closeOnOutsideClick, onClick }: Pr
         onClick={handleClick}
       />
       {children}
-    </>
+    </Fragment>
   );
 }
 

--- a/packages/gestalt/src/ButtonGroup.js
+++ b/packages/gestalt/src/ButtonGroup.js
@@ -1,6 +1,5 @@
 // @flow strict
-
-import React, { Children, type Node } from 'react';
+import React, { Children, Fragment, type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 
@@ -11,7 +10,7 @@ function ButtonGroup({ children }: {| children?: Node |}): Node {
     return null;
   }
   if (count === 1) {
-    return <>{children}</>;
+    return <Fragment>{children}</Fragment>;
   }
 
   return (

--- a/packages/gestalt/src/MenuOption.js
+++ b/packages/gestalt/src/MenuOption.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Badge from './Badge.js';
@@ -86,7 +86,7 @@ export default function MenuOption({
       <Flex flex="grow" direction="column">
         <Flex alignItems="center">
           {children || (
-            <>
+            <Fragment>
               <Text truncate={shouldTruncate} weight={textWeight} color="darkGray" inline>
                 {option?.label}
               </Text>
@@ -97,7 +97,7 @@ export default function MenuOption({
                   <Badge text={badgeText} />
                 </Box>
               )}
-            </>
+            </Fragment>
           )}
         </Flex>
         {option.subtext && (

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import Box from './Box.js';
 import Icon from './Icon.js';
 import TapArea from './TapArea.js';
@@ -26,7 +26,7 @@ export default function ModuleExpandableItem({
   children,
 }: Props): Node {
   return (
-    <>
+    <Fragment>
       <TapArea
         onTap={() => {
           onModuleClicked(!isCollapsed);
@@ -78,6 +78,6 @@ export default function ModuleExpandableItem({
           {children}
         </Box>
       )}
-    </>
+    </Fragment>
   );
 }

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import Box from './Box.js';
 import Icon from './Icon.js';
 import Text from './Text.js';
@@ -22,7 +22,7 @@ export default function ModuleTitle({
     },
   };
   return (
-    <>
+    <Fragment>
       {MODULE_TYPE_ATTRIBUTES[type].icon && (
         <Box marginEnd={2}>
           <Icon
@@ -35,6 +35,6 @@ export default function ModuleTitle({
       <Text weight="bold" truncate color={MODULE_TYPE_ATTRIBUTES[type].color}>
         {title}
       </Text>
-    </>
+    </Fragment>
   );
 }

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -1,6 +1,5 @@
 // @flow strict
-
-import React, { forwardRef, useState, type Node } from 'react';
+import React, { forwardRef, Fragment, type Node, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import layout from './Layout.css';
@@ -100,7 +99,7 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
   const clearIconSize = size === 'lg' ? 12 : 10;
 
   return (
-    <>
+    <Fragment>
       <Box
         alignItems="center"
         display="flex"
@@ -165,7 +164,7 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
         )}
       </Box>
       {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
-    </>
+    </Fragment>
   );
 });
 

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node, useState } from 'react';
+import React, { Children, Fragment, type Node, useState } from 'react';
 import cx from 'classnames';
 import styles from './Table.css';
 import Box from './Box.js';
@@ -44,7 +44,7 @@ export default function TableRowExpandable(props: Props): Node {
   };
 
   return (
-    <>
+    <Fragment>
       <tr className={cs}>
         <TableCell>
           <IconButton
@@ -61,11 +61,11 @@ export default function TableRowExpandable(props: Props): Node {
       </tr>
       {expanded && (
         <tr id={id}>
-          <td colSpan={React.Children.count(children) + 1}>
+          <td colSpan={Children.count(children) + 1}>
             <Box padding={6}>{expandedContents}</Box>
           </td>
         </tr>
       )}
-    </>
+    </Fragment>
   );
 }

--- a/packages/gestalt/src/Toast.test.js
+++ b/packages/gestalt/src/Toast.test.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import React, { Fragment } from 'react';
 import { create } from 'react-test-renderer';
 import Button from './Button.js';
 import Link from './Link.js';
@@ -30,10 +30,10 @@ describe('<Toast />', () => {
           />
         }
         text={
-          <>
+          <Fragment>
             Saved to{' '}
             <Link href="https://www.pinterest.com/search/pins/?q=home%20decor">Home decor</Link>
-          </>
+          </Fragment>
         }
       />,
     ).toJSON();
@@ -50,10 +50,10 @@ describe('<Toast />', () => {
           />
         }
         text={
-          <>
+          <Fragment>
             Saved to{' '}
             <Link href="https://www.pinterest.com/search/pins/?q=home%20decor">Home decor</Link>
-          </>
+          </Fragment>
         }
         button={<Button size="lg" text="Undo" />}
       />,

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -1,6 +1,5 @@
 // @flow strict
-
-import React, { forwardRef, useState, type Element, type Node, type Ref } from 'react';
+import React, { forwardRef, Fragment, type Element, type Node, type Ref, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import focusStyles from './Focus.css';
@@ -184,7 +183,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
     </button>
   );
   return (
-    <>
+    <Fragment>
       {label && <FormLabel id={id} label={label} />}
       <Box
         alignItems="center"
@@ -214,13 +213,13 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
             {iconButton}
           </div>
         ) : (
-          <>
+          <Fragment>
             {inputElement}
             {iconButton}
-          </>
+          </Fragment>
         )}
       </Box>
-    </>
+    </Fragment>
   );
 });
 


### PR DESCRIPTION
To reduce context switching with Pinboard (and allow for one style even where keys are needed), this PR adds a lint rule to enforce the longhand (`<Fragment>`) syntax for React fragments. It also includes a lint rule to ensure we're using keys where needed.

For reference:
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md