### PR TITLE
Docs: Add ability for Do/Don't in bullet lists

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -303,7 +303,7 @@ If you need to use these features for animation purposes, use a \`<div>\` instea
     color="maroon"
     height={50}
   >
-    <Text color="white" weight="bold">Clicking here will do nothing</Text>
+    <Text color="white" weight="bold">Adding onClick here will do nothing</Text>
   </Box>
 </Box>
 `}
@@ -326,7 +326,7 @@ If you need to use these features for animation purposes, use a \`<div>\` instea
         marginTop={3}
       >
         <Text color="white" weight="bold">
-          These all collapsed
+          These margins all collapsed
         </Text>
       </Box>
     </Box>
@@ -796,23 +796,23 @@ card(
     description={`
       [Flex](/Flex)
 
-      - Use Flex for flexbox layouts, especially when even spacing between elements is desired, by using the \`gap\` property.
+      Use Flex for flexbox layouts, especially when even spacing between elements is desired, by using the \`gap\` property.
 
       [Container](/Container)
 
-      - Use Container to responsively layout content with a max-width on large screens.
+      Use Container to responsively layout content with a max-width on large screens.
 
       [ScrollableContainer](/ScrollableContainer)
 
-      - For proper positioning when using anchor components (Flyout, Tooltip, etc.) that can scroll within the viewport, use a ScrollableContainer.
+      For proper positioning when using anchor components (Flyout, Tooltip, etc.) that can scroll within the viewport, use a ScrollableContainer.
 
       [TapArea](/TapArea)
 
-      - If a tap target is needed in order to click on a portion of the page, use TapArea, since \`onClick\` is not supported on Box.
+      If a tap target is needed in order to click on a portion of the page, use TapArea, since \`onClick\` is not supported on Box.
 
       [Sticky](/Sticky)
 
-      - Use Sticky if a portion of the page should stick to either the top or bottom when scrolling.
+      Use Sticky if a portion of the page should stick to either the top or bottom when scrolling.
 
     `}
   />,

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -19,6 +19,10 @@ type Props = {|
   type?: 'do' | "don't" | 'info',
 |};
 
+type PreviewCardProps = {|
+  children?: Node,
+|};
+
 const CARD_SIZE_NAME_TO_PIXEL = {
   sm: 236,
   md: 362,
@@ -52,41 +56,37 @@ const MainSectionCard = ({
   const borderStyle =
     type !== 'info' ? `3px solid ${COLOR_TO_HEX[TYPE_TO_COLOR[type]]}` : undefined;
   const cardTitle = Array.isArray(title) ? title.join(', ') : title;
+  const shouldShowCode = showCode && cardSize !== 'sm' && type === 'info';
+
+  const PreviewCard = ({ children: cardChildren }: PreviewCardProps): Node => {
+    return (
+      <Box
+        alignItems="center"
+        borderStyle="sm"
+        color={shaded ? 'lightGray' : 'white'}
+        display="flex"
+        height={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
+        justifyContent="center"
+        padding={4}
+        position="relative"
+        rounding={2}
+      >
+        {cardChildren}
+      </Box>
+    );
+  };
+
   return (
     <Box width={CARD_SIZE_NAME_TO_PIXEL[cardSize]} marginTop={4} marginBottom={4}>
-      {children ? (
-        <Box
-          alignItems="center"
-          borderStyle="sm"
-          color={shaded ? 'lightGray' : 'white'}
-          display="flex"
-          height={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
-          justifyContent="center"
-          padding={4}
-          position="relative"
-          rounding={2}
-        >
-          {children}
-        </Box>
-      ) : (
-        <LiveProvider code={code} scope={scope} theme={theme}>
-          <Box
-            alignItems="center"
-            borderStyle="sm"
-            color={shaded ? 'lightGray' : 'white'}
-            display="flex"
-            height={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
-            justifyContent="center"
-            padding={4}
-            position="relative"
-            rounding={2}
-          >
-            <LivePreview style={{ display: 'contents' }} />
-          </Box>
+      {children && <PreviewCard>{children}</PreviewCard>}
 
-          {showCode && code && cardSize !== 'sm' && (
-            <ExampleCode code={code} name={cardTitle || ''} />
-          )}
+      {code && (
+        <LiveProvider code={code} scope={scope} theme={theme}>
+          <PreviewCard>
+            <LivePreview style={{ display: 'contents' }} />
+          </PreviewCard>
+
+          {shouldShowCode && <ExampleCode code={code} name={cardTitle || ''} />}
 
           <Box paddingX={2}>
             <Text color="watermelon">
@@ -95,8 +95,9 @@ const MainSectionCard = ({
           </Box>
         </LiveProvider>
       )}
+
       <Box
-        marginTop={4}
+        marginTop={borderStyle ? 4 : 3}
         dangerouslySetInlineStyle={{
           __style: { borderTop: borderStyle },
         }}

--- a/scripts/templates/ComponentName.doc.js
+++ b/scripts/templates/ComponentName.doc.js
@@ -70,6 +70,16 @@ Code for this example goes here
 Code for this example goes here
 `}
       />
+      <MainSection.Card
+        cardSize="md"
+        type="do"
+        description={`
+        Description about what you should Do. Using backticks instead of quotes allows you to use [Markdown]("https://www.markdownguide.org/")
+
+        - You do not need code for these
+        - You can instead use bulleted lists of Dos
+        `}
+      />
     </MainSection.Subsection>
   </MainSection>,
 );
@@ -158,11 +168,11 @@ card(
     description={`
       [Component Name](/component-name)
 
-      - Details about why to use this over current component.
+      Details about why to use this over current component.
 
       [Component Name](/component-name)
 
-      - Details about why to use this over current component.
+      Details about why to use this over current component.
 
       Using backticks instead of quotes allows you to use [Markdown]("https://www.markdownguide.org/")
     `}


### PR DESCRIPTION
You can now make Do/Don't bullet-lists, with no code or example

Do/Don't also no longer show code blocks

![Screen Shot 2021-02-09 at 12 49 53 PM](https://user-images.githubusercontent.com/5125094/107426635-55809300-6ad5-11eb-9f34-08e9a1fddf81.png)


## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
