### PR TITLE
Docs: Adjust spacing for large examples with titles

### DIFF
--- a/docs/src/Provider.doc.js
+++ b/docs/src/Provider.doc.js
@@ -311,6 +311,7 @@ function OnNavigation() {
       />
       <MainSection.Card
         title="Example above: Dropdown"
+        description="kdshf iodfusf sjfh dsenbfr dkfuys adfejfha fdjkhfusiadf sjdhfasd "
         cardSize="lg"
         defaultCode={`
 function OnNavigation() {

--- a/docs/src/Provider.doc.js
+++ b/docs/src/Provider.doc.js
@@ -111,7 +111,7 @@ function Example(props) {
       `}
     >
       <MainSection.Card
-        title="Examples above from left to right: (1) Link, (2) Button, (3) IconButton, (4) TapArea"
+        title="Examples from start to end: Link, Button, IconButton, TapArea"
         cardSize="lg"
         defaultCode={`
 function OnNavigation() {
@@ -204,7 +204,7 @@ function OnNavigation() {
 `}
       />
       <MainSection.Card
-        title="Examples above from top to bottom: (1) Callout, (2) Upsell, (3) ActivationCard"
+        title="Examples from top to bottom: Callout, Upsell, ActivationCard"
         cardSize="lg"
         defaultCode={`
 function OnNavigation() {
@@ -310,8 +310,7 @@ function OnNavigation() {
 `}
       />
       <MainSection.Card
-        title="Example above: Dropdown"
-        description="kdshf iodfusf sjfh dsenbfr dkfuys adfejfha fdjkhfusiadf sjdhfasd "
+        title="With a Dropdown"
         cardSize="lg"
         defaultCode={`
 function OnNavigation() {

--- a/docs/src/components/MainSection.js
+++ b/docs/src/components/MainSection.js
@@ -2,7 +2,8 @@
 import React, { type Node } from 'react';
 import MainSectionCard from './MainSectionCard.js';
 import Card from './Card.js';
-import MainSectionSubsection, { convertToSentenceCase } from './MainSectionSubsection.js';
+import MainSectionSubsection from './MainSectionSubsection.js';
+import { convertToSentenceCase } from './utils.js';
 
 type Props = {|
   children?: Node,

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -79,6 +79,7 @@ const MainSectionCard = ({
   const TitleAndDescription = (
     <Box
       marginTop={borderStyle ? 4 : 3}
+      marginBottom={cardSize === 'lg' ? 4 : 0}
       dangerouslySetInlineStyle={{
         __style: { borderTop: borderStyle },
       }}
@@ -91,7 +92,7 @@ const MainSectionCard = ({
         </Box>
       )}
       {description && (
-        <Box width="90%" marginTop={-3}>
+        <Box width="90%" marginTop={2} color="white">
           <Markdown text={description} />
         </Box>
       )}

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -76,8 +76,32 @@ const MainSectionCard = ({
     );
   };
 
+  const TitleAndDescription = (
+    <Box
+      marginTop={borderStyle ? 4 : 3}
+      dangerouslySetInlineStyle={{
+        __style: { borderTop: borderStyle },
+      }}
+    >
+      {(title || type !== 'info') && (
+        <Box paddingY={1}>
+          <Text weight="bold" color={TYPE_TO_COLOR[type]}>
+            {cardTitle || type.charAt(0).toUpperCase() + type.slice(1)}
+          </Text>
+        </Box>
+      )}
+      {description && (
+        <Box width="90%" marginTop={-3}>
+          <Markdown text={description} />
+        </Box>
+      )}
+    </Box>
+  );
+
   return (
     <Box width={CARD_SIZE_NAME_TO_PIXEL[cardSize]} marginTop={4} marginBottom={4}>
+      {cardSize === 'lg' && TitleAndDescription}
+
       {children && <PreviewCard>{children}</PreviewCard>}
 
       {code && (
@@ -95,27 +119,7 @@ const MainSectionCard = ({
           </Box>
         </LiveProvider>
       )}
-
-      <Box
-        color="white"
-        marginTop={borderStyle ? 4 : 3}
-        dangerouslySetInlineStyle={{
-          __style: { borderTop: borderStyle },
-        }}
-      >
-        {(title || type !== 'info') && (
-          <Box paddingY={1}>
-            <Text weight="bold" color={TYPE_TO_COLOR[type]}>
-              {cardTitle || type.charAt(0).toUpperCase() + type.slice(1)}
-            </Text>
-          </Box>
-        )}
-        {description && (
-          <Box width="90%" marginTop={2} color="white">
-            <Markdown text={description} />
-          </Box>
-        )}
-      </Box>
+      {cardSize !== 'lg' && TitleAndDescription}
     </Box>
   );
 };

--- a/docs/src/components/MainSectionCard.js
+++ b/docs/src/components/MainSectionCard.js
@@ -7,6 +7,7 @@ import { LiveProvider, LiveError, LivePreview } from 'react-live';
 import ExampleCode from './ExampleCode.js';
 import theme from './atomDark.js';
 import Markdown from './Markdown.js';
+import { capitalizeFirstLetter } from './utils.js';
 
 type Props = {|
   cardSize?: 'sm' | 'md' | 'lg',
@@ -87,7 +88,7 @@ const MainSectionCard = ({
       {(title || type !== 'info') && (
         <Box paddingY={1}>
           <Text weight="bold" color={TYPE_TO_COLOR[type]}>
-            {cardTitle || type.charAt(0).toUpperCase() + type.slice(1)}
+            {cardTitle || capitalizeFirstLetter(type)}
           </Text>
         </Box>
       )}

--- a/docs/src/components/MainSectionSubsection.js
+++ b/docs/src/components/MainSectionSubsection.js
@@ -4,16 +4,13 @@ import { Box, Flex, Heading, IconButton } from 'gestalt';
 import slugify from 'slugify';
 import Markdown from './Markdown.js';
 import { copyToClipboard } from './Card.js';
+import { convertToSentenceCase } from './utils.js';
 
 type Props = {|
   children: Node,
   description?: string,
   title?: string,
 |};
-
-export const convertToSentenceCase = (title: string): string => {
-  return title.charAt(0).toUpperCase() + title.slice(1).toLowerCase();
-};
 
 const MainSectionSubsection = ({ children, description, title }: Props): Node => {
   const slugifiedId = slugify(title || '');

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -3,6 +3,7 @@ import React, { type Node, type ComponentType } from 'react';
 import { Badge, Box, Flex, IconButton, Link, Text, Tooltip } from 'gestalt';
 import Card from './Card.js';
 import { useAppContext } from './appContext.js';
+import { capitalizeFirstLetter } from './utils.js';
 
 type Props = {|
   props: Array<{|
@@ -73,7 +74,6 @@ const Td = ({
   </td>
 );
 
-const upcase = (string) => string.charAt(0).toUpperCase() + string.slice(1);
 const sortBy = (list, fn) => list.sort((a, b) => fn(a).localeCompare(fn(b)));
 
 export default function PropTable({
@@ -193,8 +193,8 @@ export default function PropTable({
                               <Box>
                                 <Text>
                                   <code>
-                                    sm{upcase(name)}, md{upcase(name)}, lg
-                                    {upcase(name)}
+                                    sm{capitalizeFirstLetter(name)}, md{capitalizeFirstLetter(name)}
+                                    , lg{capitalizeFirstLetter(name)}
                                   </code>
                                 </Text>
                               </Box>

--- a/docs/src/components/atomDark.js
+++ b/docs/src/components/atomDark.js
@@ -13,56 +13,48 @@ const atomDark = {
       types: ['cdata', 'comment', 'doctype', 'prolog'],
       style: {
         color: 'hsl(30, 20%, 50%)',
-        backgroundColor: '#2a2734',
       },
     },
     {
       types: ['punctuation'],
       style: {
         color: 'rgba(197, 200, 198, 0.7)',
-        backgroundColor: '#2a2734',
       },
     },
     {
       types: ['boolean', 'constant', 'keyword', 'number', 'property', 'symbol', 'tag'],
       style: {
         color: 'hsl(350, 40%, 70%)',
-        backgroundColor: '#2a2734',
       },
     },
     {
       types: ['selector', 'attr-name', 'string', 'char', 'builtin', 'inserted'],
       style: {
         color: 'hsl(75, 70%, 60%)',
-        backgroundColor: '#2a2734',
       },
     },
     {
       types: ['operator', 'entity', 'url', 'string', 'variable'],
       style: {
         color: 'hsl(40, 90%, 60%)',
-        backgroundColor: '#2a2734',
       },
     },
     {
       types: ['atrule', 'attr-value', 'keyword'],
       style: {
         color: 'hsl(350, 40%, 70%)',
-        backgroundColor: '#2a2734',
       },
     },
     {
       types: ['function'],
       style: {
         color: '#dad085',
-        backgroundColor: '#2a2734',
       },
     },
     {
       types: ['regex', 'important'],
       style: {
         color: '#e90',
-        backgroundColor: '#2a2734',
       },
     },
     {

--- a/docs/src/components/utils.js
+++ b/docs/src/components/utils.js
@@ -1,0 +1,7 @@
+// @flow strict
+export const convertToSentenceCase = (name: string): string => {
+  return name.charAt(0).toUpperCase() + name.slice(1).toLowerCase();
+};
+export const capitalizeFirstLetter = (name: string): string => {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+};


### PR DESCRIPTION
Move title and description above large Cards

(also fixes a code editor bug where the cursor wasn't visible)

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
