### PR TITLE
[Eslint] Add border to prefer-box eslint rule

### DIFF
--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box/invalid/invalid-border.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box/invalid/invalid-border.js
@@ -1,0 +1,3 @@
+export default function TestElement() {
+  return <div style={{ border: 'solid 2px #EFEFEF' }} />;
+}

--- a/packages/eslint-plugin-gestalt/src/no-dangerous-style-duplicates.js
+++ b/packages/eslint-plugin-gestalt/src/no-dangerous-style-duplicates.js
@@ -8,7 +8,12 @@
  */
 
 // @flow strict
-import { genBointLookup, validateBackgroundColor, validateBorderRadius } from './validators.js';
+import {
+  genBointLookup,
+  validateBackgroundColor,
+  validateBorder,
+  validateBorderRadius,
+} from './validators.js';
 
 function getInlineDefinedStyles(attr) {
   return attr.value.expression &&
@@ -112,25 +117,9 @@ const rule = {
           break;
         case 'border':
           if (includeKey('border')) {
-            // If the value is a string:
-            // 1) convert everything to lowerCase (css is case-insensitive)
-            // 2) sort the values since some found uses have the wrong order
-            const value =
-              key.value && key.value.toLowerCase
-                ? key.value.toLowerCase().split(' ').sort().join(' ')
-                : key.value;
-            if (
-              value === '#efefef 1px solid' ||
-              value === '#eee 1px solid' ||
-              value === '1px lightgray solid'
-            ) {
-              matchedErrors.push('  Use prop `borderSize="sm"` instead');
-            } else if (
-              value === '#efefef 2px solid' ||
-              value === '#eee 2px solid' ||
-              value === '2px lightgray solid'
-            ) {
-              matchedErrors.push('  Use prop `borderSize="lg"` instead');
+            const message = validateBorder(key.value);
+            if (message) {
+              matchedErrors.push(message);
             }
           }
           break;

--- a/packages/eslint-plugin-gestalt/src/prefer-box.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box.js
@@ -8,7 +8,7 @@
  */
 
 // @flow strict
-import { validateBackgroundColor, validateBorderRadius } from './validators.js';
+import { validateBackgroundColor, validateBorder, validateBorderRadius } from './validators.js';
 
 function getInlineDefinedStyles(attr) {
   return attr.value.expression.properties ? attr.value.expression.properties : null;
@@ -52,6 +52,12 @@ const rule = {
           break;
         case 'borderRadius':
           message = validateBorderRadius(key.value);
+          if (message) {
+            matchedErrors.push(message);
+          }
+          break;
+        case 'border':
+          message = validateBorder(key.value);
           if (message) {
             matchedErrors.push(message);
           }

--- a/packages/eslint-plugin-gestalt/src/prefer-box.test.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box.test.js
@@ -26,6 +26,10 @@ const invalidBorderRadius = readFileSync(
   path.resolve(__dirname, './__fixtures__/prefer-box/invalid/invalid-borderRadius.js'),
   'utf-8',
 );
+const invalidBorder = readFileSync(
+  path.resolve(__dirname, './__fixtures__/prefer-box/invalid/invalid-border.js'),
+  'utf-8',
+);
 
 ruleTester.run('prefer-box', rule, {
   valid: [
@@ -54,6 +58,17 @@ ruleTester.run('prefer-box', rule, {
           message:
             'Replace this div with a gestalt Box. https://gestalt.netlify.app/Box\n' +
             '  Use prop `rounding="circle"` instead',
+        },
+      ],
+    },
+    {
+      code: invalidBorder,
+      parserOptions,
+      errors: [
+        {
+          message:
+            'Replace this div with a gestalt Box. https://gestalt.netlify.app/Box\n' +
+            '  Use prop `borderSize="lg"` instead',
         },
       ],
     },

--- a/packages/eslint-plugin-gestalt/src/validators.js
+++ b/packages/eslint-plugin-gestalt/src/validators.js
@@ -97,3 +97,26 @@ export const validateBorderRadius = (value: string): number | string => {
   }
   return roundingLookup[value];
 };
+
+export const validateBorder = (value: string): ?string => {
+  // If the value is a string:
+  // 1) convert everything to lowerCase (css is case-insensitive)
+  // 2) sort the values since some found uses have the wrong order
+  const cleanValue =
+    value && value.toLowerCase ? value.toLowerCase().split(' ').sort().join(' ') : value;
+  if (
+    cleanValue === '#efefef 1px solid' ||
+    cleanValue === '#eee 1px solid' ||
+    cleanValue === '1px lightgray solid'
+  ) {
+    return '  Use prop `borderSize="sm"` instead';
+  }
+  if (
+    cleanValue === '#efefef 2px solid' ||
+    cleanValue === '#eee 2px solid' ||
+    cleanValue === '2px lightgray solid'
+  ) {
+    return '  Use prop `borderSize="lg"` instead';
+  }
+  return undefined;
+};


### PR DESCRIPTION
Shares logic with the existing `no-dangerous-style-duplicates` to check for divs that could be a `Box`.

## Test Plan

New unit test added to check rule works as expected
