### PR TITLE
Docs: Update Prop Table to support Markdown for descriptions

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -36,6 +36,7 @@ card(
         defaultValue: 'block',
         responsive: true,
         href: 'Column-Layout',
+        description: `The display style, which can be customized at different breakpoints. See the [Accessibility guidelines](#Visually-hidden-content) to learn more about using \`visuallyHidden\`.`,
       },
       {
         name: 'direction',

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -198,8 +198,8 @@ card(
         defaultValue: 'button',
         description: [
           `Select a button variant:`,
-          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a '<button>'.`,
-          `- 'link': Use for buttons to act like links. The button is rendered as an '<a>'.`,
+          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a \`<button>\`.`,
+          `- 'link': Use for buttons to act like links. The button is rendered as an \`<a>\`.`,
           `Required with link-role buttons.`,
         ],
         href: 'type-roles',

--- a/docs/src/Checkbox.doc.js
+++ b/docs/src/Checkbox.doc.js
@@ -51,7 +51,7 @@ card(
         type: 'React.Node',
         href: 'images',
         description:
-          'An optional <Image/> component can be supplied to add an image to each checkbox. Spacing is already accounted for, simply specify the width and height.',
+          'An optional `<Image/>` component can be supplied to add an image to each checkbox. Spacing is already accounted for, simply specify the width and height.',
       },
       {
         name: 'indeterminate',

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -179,8 +179,8 @@ card(
         defaultValue: 'button',
         description: [
           `Select a button variant:`,
-          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a '<button>'.`,
-          `- 'link': Use for buttons to act like links. The button is rendered as an '<a>'.`,
+          `- 'button': Use to render 'submit' or 'button'-type buttons. The button is rendered as a \`<button>\`.`,
+          `- 'link': Use for buttons to act like links. The button is rendered as an \`<a>\`.`,
           `Required with link-role buttons.`,
         ],
         href: 'roles',

--- a/docs/src/Provider.doc.js
+++ b/docs/src/Provider.doc.js
@@ -36,7 +36,7 @@ card(
         type:
           '{| href: string, onNavigationOptions?:  ({ [string]: Node | ({| +event: SyntheticEvent<>, target?: null | "self" | "blank" |}) => void }) |}',
         description: [
-          `Components with link functionality use simple <a> tags. In order to replace the default link functionality with more complex ones (ex. withRouter or spam checking), onNavigation provides an interface to implement external logic into the 'onClick' event handler in links.`,
+          `Components with link functionality use simple \`<a>\` tags. In order to replace the default link functionality with more complex ones (ex. withRouter or spam checking), onNavigation provides an interface to implement external logic into the 'onClick' event handler in links.`,
           `onNavigation is a high-order function. If passed into the provider, consumer components (ex. Link, Button, IconButton and TapArea) call the onNavigation function with three named parameters ('href', 'onNavigationOptions' and 'target') that returns a function that gets called inside the 'onClick' event handler. `,
           `'onNavigationOptions' is an object that acts as a flexible API for your onNavigation external logic. The onNavigationOptions's type is flexible. Each key's value is a React.Node or an event handler function.`,
         ],

--- a/docs/src/RadioButton.doc.js
+++ b/docs/src/RadioButton.doc.js
@@ -43,7 +43,7 @@ card(
         type: 'React.Node',
         href: 'images',
         description:
-          'An optional <Image/> component can be supplied to add an image to each radio button. Spacing is already accounted for, simply specify the width and height.',
+          'An optional `<Image/>` component can be supplied to add an image to each radio button. Spacing is already accounted for, simply specify the width and height.',
       },
       {
         name: 'label',

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -25,7 +25,7 @@ card(
         defaultValue: null,
         description: [
           'Supply a short, descriptive label for screen-readers as a text alternative to the Dismiss button.',
-          'Accessibility: It populates aria-label on the <button> element for the Dismiss button.',
+          'Accessibility: It populates aria-label on the `<button>` element for the Dismiss button.',
         ],
         href: 'accessibilityExample',
       },
@@ -37,7 +37,7 @@ card(
         description: [
           'Supply a short, descriptive label for screen-readers to contextualize the purpose of Sheet.',
           'Please do not repeat the same text being passed in the "heading" prop, but instead provide something that summarizes the Sheet. For instance, if the heading is "Pin Builder", the accessibilitySheetLabel can be "Create a new Pin".',
-          'Accessibility: It populates aria-label on the <div role="dialog"> element which represents the Sheet component.',
+          'Accessibility: It populates aria-label on the `<div role="dialog">` element which represents the Sheet component.',
         ],
         href: 'accessibilityExample',
       },
@@ -49,7 +49,7 @@ card(
         description: [
           'Supply the container element or render prop that is going to be used as the Sheet main content.',
           'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
-          'Obs: This element will be padded by 32px, differently than <Modal>.',
+          'Obs: This element will be padded by 32px, differently than `<Modal>`.',
         ],
         href: 'defaultPaddingAndStylingExample',
       },
@@ -74,7 +74,7 @@ card(
         description: [
           'Supply the container element or render prop that is going to be used as the Sheet custom footer.',
           'When using a render prop, just pass the argument onDismissStart to your exitpoint action elements.',
-          'Obs: This element will be padded by 32px, similarly to <Modal>.',
+          'Obs: This element will be padded by 32px, similarly to `<Modal>`.',
         ],
         href: 'defaultPaddingAndStylingExample',
       },
@@ -86,7 +86,7 @@ card(
         description: [
           'Supply the text that is going to be placed as the Sheet text heading.',
           'Please do not repeat the same text being passed in the "accessibilitySheetLabel" prop, but instead provide something that identifies the Sheet. For instance, if the heading is "Pin Builder", the accessibilitySheetLabel can be "Create a new Pin".',
-          'Obs: This element will be padded by 32px, similarly to <Modal>.',
+          'Obs: This element will be padded by 32px, similarly to `<Modal>`.',
         ],
         href: 'defaultPaddingAndStylingExample',
       },
@@ -107,7 +107,7 @@ card(
         name: 'ref',
         type: "React.Ref<'div'>",
         description:
-          'Forward the ref to the underlying <div role="dialog"> element which represents the Sheet component.',
+          'Forward the ref to the underlying `<div role="dialog">` element which represents the Sheet component.',
         href: 'refExample',
       },
       {

--- a/docs/src/TapArea.doc.js
+++ b/docs/src/TapArea.doc.js
@@ -203,8 +203,8 @@ card(
         defaultValue: 'button',
         description: [
           `Select a TapArea variant:`,
-          `- 'button': Use for TapArea to act like buttons. The TapArea is rendered as a '<div>'.`,
-          `- 'link': Use for TapArea to act like links. The button is rendered as an '<a>'.`,
+          `- 'button': Use for TapArea to act like buttons. The TapArea is rendered as a \`<div>\`.`,
+          `- 'link': Use for TapArea to act like links. The button is rendered as an \`<a>\`.`,
           `Required with role=link.`,
         ],
         href: 'roles',

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -46,7 +46,7 @@ card(
         required: false,
         defaultValue: null,
         description: [
-          'Either <Image /> or <Icon /> to render on left side of banner. Width is not used with Icon. Image width defaults to 128 px. Max width of image is 128 px.',
+          'Either `<Image />` or `<Icon />` to render on left side of banner. Width is not used with Icon. Image width defaults to 128 px. Max width of image is 128 px.',
         ],
         href: 'Image',
       },

--- a/docs/src/Video.doc.js
+++ b/docs/src/Video.doc.js
@@ -104,7 +104,7 @@ card(
         name: 'objectFit',
         type: "'fill' | 'contain' | 'cover' | 'none' | 'scale-down'",
         description:
-          'Sets how the content of the replaced <video> element should be resized to fit its container',
+          'Sets how the content of the replaced `<video>` element should be resized to fit its container',
       },
       {
         name: 'onDurationChange',

--- a/docs/src/components/Markdown.js
+++ b/docs/src/components/Markdown.js
@@ -8,6 +8,7 @@ import 'highlight.js/styles/a11y-light.css';
 import sidebarIndex from './sidebarIndex.js';
 
 type Props = {|
+  color?: string,
   text: string,
   type?: string,
 |};
@@ -65,7 +66,7 @@ const formatComponentName = (listitem) => {
   return listitem;
 };
 
-export default function Markdown({ text, type }: Props): Node {
+export default function Markdown({ color, text, type }: Props): Node {
   const renderer = new Renderer();
   renderer.heading = (input, level) => {
     const escapedText = input
@@ -102,7 +103,7 @@ export default function Markdown({ text, type }: Props): Node {
   });
 
   return (
-    <Text>
+    <Text color={color}>
       <div
         className="Markdown"
         dangerouslySetInnerHTML={{ __html: html }} // eslint-disable-line react/no-danger

--- a/docs/src/components/Markdown.js
+++ b/docs/src/components/Markdown.js
@@ -8,7 +8,24 @@ import 'highlight.js/styles/a11y-light.css';
 import sidebarIndex from './sidebarIndex.js';
 
 type Props = {|
-  color?: string,
+  textColor?:
+    | 'green'
+    | 'pine'
+    | 'olive'
+    | 'blue'
+    | 'navy'
+    | 'midnight'
+    | 'purple'
+    | 'orchid'
+    | 'eggplant'
+    | 'maroon'
+    | 'watermelon'
+    | 'orange'
+    | 'darkGray'
+    | 'gray'
+    | 'lightGray'
+    | 'red'
+    | 'white',
   text: string,
   type?: string,
 |};
@@ -66,7 +83,7 @@ const formatComponentName = (listitem) => {
   return listitem;
 };
 
-export default function Markdown({ color, text, type }: Props): Node {
+export default function Markdown({ textColor, text, type }: Props): Node {
   const renderer = new Renderer();
   renderer.heading = (input, level) => {
     const escapedText = input
@@ -103,7 +120,7 @@ export default function Markdown({ color, text, type }: Props): Node {
   });
 
   return (
-    <Text color={color}>
+    <Text color={textColor}>
       <div
         className="Markdown"
         dangerouslySetInnerHTML={{ __html: html }} // eslint-disable-line react/no-danger

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -28,7 +28,7 @@ const unifyQuotes = (input) => {
 const Description = (lines: Array<string>): Node => (
   <Flex alignItems="start" direction="column" gap={2}>
     {lines.map((line, idx) => (
-      <Markdown key={idx} text={line} color="gray" />
+      <Markdown key={idx} text={line} textColor="gray" />
     ))}
   </Flex>
 );
@@ -203,7 +203,7 @@ export default function PropTable({
                             {Array.isArray(description) ? (
                               Description(description)
                             ) : (
-                              <Markdown text={description} color="gray" />
+                              <Markdown text={description} textColor="gray" />
                             )}
                           </Td>
                           <Td />

--- a/docs/src/components/PropTable.js
+++ b/docs/src/components/PropTable.js
@@ -4,6 +4,7 @@ import { Badge, Box, Flex, IconButton, Link, Text, Tooltip } from 'gestalt';
 import Card from './Card.js';
 import { useAppContext } from './appContext.js';
 import { capitalizeFirstLetter } from './utils.js';
+import Markdown from './Markdown.js';
 
 type Props = {|
   props: Array<{|
@@ -27,9 +28,7 @@ const unifyQuotes = (input) => {
 const Description = (lines: Array<string>): Node => (
   <Flex alignItems="start" direction="column" gap={2}>
     {lines.map((line, idx) => (
-      <Text key={idx} color="gray">
-        {line}
-      </Text>
+      <Markdown key={idx} text={line} color="gray" />
     ))}
   </Flex>
 );
@@ -153,7 +152,7 @@ export default function PropTable({
                 sortBy(properties, ({ required, name }) => `${required ? 'a' : 'b'}${name}`).reduce(
                   (
                     acc,
-                    { defaultValue, description, href, name, required, responsive, type },
+                    { defaultValue, description = '', href, name, required, responsive, type },
                     i,
                   ) => {
                     const propNameHasSecondRow = description || responsive;
@@ -201,7 +200,11 @@ export default function PropTable({
                             )}
                           </Td>
                           <Td colspan={1} color="gray">
-                            {Array.isArray(description) ? Description(description) : description}
+                            {Array.isArray(description) ? (
+                              Description(description)
+                            ) : (
+                              <Markdown text={description} color="gray" />
+                            )}
                           </Td>
                           <Td />
                         </tr>,


### PR DESCRIPTION
Change prop table descriptions to use Markdown (allows for links)

Before: 
<img width="807" alt="Screen Shot 2021-02-10 at 6 05 00 PM" src="https://user-images.githubusercontent.com/5125094/107595821-a2926100-6bca-11eb-94f2-7f4029d2ce68.png">

After:
![Screen Shot 2021-02-10 at 1 20 59 PM](https://user-images.githubusercontent.com/5125094/107595815-a0300700-6bca-11eb-865b-cbd324bbd540.png)
<img width="793" alt="Screen Shot 2021-02-10 at 6 04 49 PM" src="https://user-images.githubusercontent.com/5125094/107595818-a1613400-6bca-11eb-850c-997b1872074c.png">



## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
