### PR TITLE
Callout, Upsell, ActivationCard: implemented missing target, ref props for link functionality

### DIFF
--- a/docs/src/ActivationCard.doc.js
+++ b/docs/src/ActivationCard.doc.js
@@ -42,7 +42,7 @@ card(
       {
         name: 'link',
         type:
-          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
+          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void, rel: "none" | "nofollow", target: "null" | "self" | "blank" |}',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -54,7 +54,7 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
+          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void, rel: "none" | "nofollow", target: "null" | "self" | "blank" |}',
         required: false,
         defaultValue: null,
         description: [
@@ -71,7 +71,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
+          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void, rel: "none" | "nofollow", target: "null" | "self" | "blank" |}',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -70,7 +70,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
+          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void, rel: "none" | "nofollow", target: "null" | "self" | "blank" |}',
         required: false,
         defaultValue: null,
         description: [

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -26,6 +26,8 @@ type LinkData = {|
     | SyntheticKeyboardEvent<HTMLButtonElement>,
   >,
   onNavigationOptions?: OnNavigationOptionsType,
+  rel?: 'none' | 'nofollow',
+  target?: null | 'self' | 'blank',
 |};
 
 type Props = {|
@@ -48,7 +50,7 @@ const STATUS_ICONS = {
 };
 
 const ActivationCardLink = ({ data }: {| data: LinkData |}): Node => {
-  const { accessibilityLabel, href, label, onClick, onNavigationOptions } = data;
+  const { accessibilityLabel, href, label, onClick, onNavigationOptions, rel, target } = data;
 
   return (
     <Box
@@ -64,10 +66,12 @@ const ActivationCardLink = ({ data }: {| data: LinkData |}): Node => {
         color="gray"
         href={href}
         onClick={onClick}
+        rel={rel}
         role="link"
         size="lg"
         text={label}
         onNavigationOptions={onNavigationOptions}
+        target={target}
       />
     </Box>
   );
@@ -241,6 +245,8 @@ ActivationCard.propTypes = {
     onClick: PropTypes.func,
     accessibilityLabel: PropTypes.string,
     onNavigationOptions: OnNavigationOptionsPropType,
+    rel: PropTypes.oneOf(['none', 'nofollow']),
+    target: PropTypes.oneOf([null, 'self', 'blank']),
   }),
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   status: PropTypes.oneOf(['notStarted', 'pending', 'needsAttention', 'complete']).isRequired,

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -56,7 +56,7 @@ const CalloutAction = ({
   if (isDarkMode && type === 'secondary') {
     color = 'transparentWhiteText';
   }
-  const { accessibilityLabel, label, onClick, onNavigationOptions, href } = data;
+  const { accessibilityLabel, label, onClick, onNavigationOptions, href, rel, target } = data;
 
   return (
     <Box
@@ -76,8 +76,10 @@ const CalloutAction = ({
           href={href}
           onClick={onClick}
           onNavigationOptions={onNavigationOptions}
+          rel={rel}
           role="link"
           size="lg"
+          target={target}
           text={label}
         />
       ) : (

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -45,7 +45,7 @@ const UpsellAction = ({
   type: string,
 |}): Node => {
   const color = type === 'primary' ? 'red' : 'gray';
-  const { accessibilityLabel, href, label, onClick, onNavigationOptions } = data;
+  const { accessibilityLabel, href, label, onClick, onNavigationOptions, rel, target } = data;
 
   return (
     <Box
@@ -65,8 +65,10 @@ const UpsellAction = ({
           href={href}
           onClick={onClick}
           onNavigationOptions={onNavigationOptions}
+          rel={rel}
           role="link"
           size="lg"
+          target={target}
           text={label}
         />
       ) : (

--- a/packages/gestalt/src/commonTypes.js
+++ b/packages/gestalt/src/commonTypes.js
@@ -17,6 +17,8 @@ export type ActionDataType = {|
     | SyntheticKeyboardEvent<HTMLButtonElement>,
   >,
   onNavigationOptions?: OnNavigationOptionsType,
+  rel?: 'none' | 'nofollow',
+  target?: null | 'self' | 'blank',
 |};
 
 export type DismissButtonType = {|
@@ -32,6 +34,8 @@ export const ActionDataPropType: React$PropType$Primitive<ActionDataType> = Prop
   onClick: PropTypes.func,
   accessibilityLabel: PropTypes.string,
   onNavigationOptions: OnNavigationOptionsPropType,
+  rel: PropTypes.oneOf(['none', 'nofollow']),
+  target: PropTypes.oneOf([null, 'self', 'blank']),
 });
 // $FlowFixMe[incompatible-exact]
 // $FlowFixMe[incompatible-type]


### PR DESCRIPTION
## Problem
- Link, Button, IconButton, and TapArea all had the same link API: `href`, `target`, `rel`, `onNavigationProps`
- Callout, Upsell, ActivationCard only had `href` and `onNavigationProps`

## PR
- This PR standardizes the link API by adding `target`, `rel` to Callout, Upsell, ActivationCard
- Updates Docs

- This change would also help the implementation of `OnNavigation` context as `target` is one of the parameters passed to the OnNavigation prop.
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
