### PR TITLE
Docs: fix right sidebar scrolling bug

### DIFF
--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -22,16 +22,21 @@ export default function App({ children }: Props): Node {
             <NavigationContextProvider>
               <Box minHeight="100vh" color="white">
                 <Header />
+
                 <Box mdDisplay="flex">
                   <Box minWidth={240}>
                     <Navigation />
                   </Box>
+
                   <Divider />
+
                   <Box width="100%">
                     <Box padding={4} mdPadding={6} lgPadding={8} width="100%" role="main">
                       {children}
                     </Box>
+
                     <Divider />
+
                     <Box padding={4} mdPadding={6} lgPadding={8} role="contentinfo">
                       <Box paddingX={2} paddingY={1}>
                         <Text align="right">

--- a/docs/src/components/CardPage.js
+++ b/docs/src/components/CardPage.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Box, FixedZIndex, Flex, Link, Sticky, Text } from 'gestalt';
+import { Box, Flex, Link, Text } from 'gestalt';
 import SearchContent from './SearchContent.js';
 import Toc from './Toc.js';
 
@@ -9,11 +9,11 @@ type Props = {|
   page: string,
 |};
 
-const CardPage = ({ cards, page }: Props): Node => {
+export default function CardPage({ cards, page }: Props): Node {
   const editPageUrl = `https://github.com/pinterest/gestalt/tree/master/docs/src/${page}.doc.js`;
 
   return (
-    <Box display="flex">
+    <Flex>
       <Box flex="grow" maxWidth={800}>
         <SearchContent>
           {cards.map((card, i) => (
@@ -40,6 +40,7 @@ const CardPage = ({ cards, page }: Props): Node => {
           </Link>
         </Box>
       </Box>
+
       <Box
         minWidth={200}
         maxWidth={240}
@@ -50,12 +51,8 @@ const CardPage = ({ cards, page }: Props): Node => {
         lgDisplay="block"
         flex="none"
       >
-        <Sticky top={90} zIndex={new FixedZIndex(0)}>
-          <Toc cards={cards} />
-        </Sticky>
+        <Toc cards={cards} />
       </Box>
-    </Box>
+    </Flex>
   );
-};
-
-export default CardPage;
+}

--- a/docs/src/components/Toc.js
+++ b/docs/src/components/Toc.js
@@ -1,6 +1,6 @@
 // @flow strict
-import React, { useEffect, useState, type Node } from 'react';
-import { Box, Text, Link } from 'gestalt';
+import React, { type Node, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Flex, Link, Text } from 'gestalt';
 
 function throttle(func, wait) {
   let context;
@@ -49,9 +49,9 @@ function throttle(func, wait) {
 }
 
 function useThrottledOnScroll(callback, delay) {
-  const throttledCallback = React.useMemo(() => throttle(callback, delay), [callback, delay]);
+  const throttledCallback = useMemo(() => throttle(callback, delay), [callback, delay]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener('scroll', throttledCallback);
     return () => {
       window.removeEventListener('scroll', throttledCallback);
@@ -59,13 +59,17 @@ function useThrottledOnScroll(callback, delay) {
   }, [throttledCallback]);
 }
 
-export default function Toc({ cards }: {| cards: Array<Node> |}): Node {
-  const [anchors, setAnchors] = useState([]);
-  const [activeState, setActiveState] = React.useState(null);
-  const clickedRef = React.useRef(false);
-  const unsetClickedRef = React.useRef(null);
+type Props = {|
+  cards: Array<Node>,
+|};
 
-  const findActiveIndex = React.useCallback(() => {
+export default function Toc({ cards }: Props): Node {
+  const [anchors, setAnchors] = useState([]);
+  const [activeState, setActiveState] = useState(null);
+  const clickedRef = useRef(false);
+  const unsetClickedRef = useRef(null);
+
+  const findActiveIndex = useCallback(() => {
     // Don't set the active index based on scroll if a link was just clicked
     if (clickedRef.current) {
       return;
@@ -130,42 +134,44 @@ export default function Toc({ cards }: {| cards: Array<Node> |}): Node {
     }
   };
 
-  React.useEffect(
+  useEffect(
     () => () => {
       clearTimeout(unsetClickedRef.current);
     },
     [],
   );
+
   return (
-    <Box>
-      {anchors.map((anchor, index) => (
-        <Box key={index} display="flex">
-          <Box color={activeState === anchor.id ? 'pine' : 'lightGray'} width={1} flex="none" />
-          <Link
-            hoverStyle={activeState === anchor.id ? 'none' : 'underline'}
-            href={`#${anchor.id}`}
-            onClick={({ event }) => handleClick(anchor.id, event)}
-          >
-            <Box padding={2}>
-              {anchor.closest('h2') ? (
-                <Text color={activeState === anchor.id ? 'pine' : 'darkGray'} weight="bold">
-                  {anchor.closest('h2')?.textContent}
-                </Text>
-              ) : (
-                <Box paddingX={3}>
-                  <Text
-                    size="md"
-                    color={activeState === anchor.id ? 'pine' : 'darkGray'}
-                    weight="bold"
-                  >
-                    {anchor.innerText}
+    <Box maxHeight="calc(100% - 60px)" minWidth={240} overflow="auto" position="fixed">
+      {anchors.map((anchor) => {
+        const isActive = activeState === anchor.id;
+        return (
+          <Flex key={anchor.id}>
+            {/* INDICATOR */}
+            <Box color={isActive ? 'pine' : 'lightGray'} width={1} flex="none" />
+
+            <Link
+              hoverStyle={isActive ? 'none' : 'underline'}
+              href={`#${anchor.id}`}
+              onClick={({ event }) => handleClick(anchor.id, event)}
+            >
+              <Box padding={2}>
+                {anchor.closest('h2') ? (
+                  <Text color={isActive ? 'pine' : 'darkGray'} weight="bold">
+                    {anchor.closest('h2')?.textContent}
                   </Text>
-                </Box>
-              )}
-            </Box>
-          </Link>
-        </Box>
-      ))}
+                ) : (
+                  <Box paddingX={3}>
+                    <Text size="md" color={isActive ? 'pine' : 'darkGray'} weight="bold">
+                      {anchor.innerText}
+                    </Text>
+                  </Box>
+                )}
+              </Box>
+            </Link>
+          </Flex>
+        );
+      })}
     </Box>
   );
 }

--- a/docs/src/components/Toc.js
+++ b/docs/src/components/Toc.js
@@ -142,7 +142,17 @@ export default function Toc({ cards }: Props): Node {
   );
 
   return (
-    <Box maxHeight="calc(100% - 60px)" minWidth={240} overflow="auto" position="fixed">
+    <Box
+      // These margins counter the padding set on the <Box role="main"> in App.js
+      marginTop={-4}
+      mdMarginTop={-6}
+      lgMarginTop={-8}
+      maxHeight="calc(100% - 60px)"
+      minWidth={240}
+      overflow="auto"
+      paddingY={8} // re-apply just the padding we need
+      position="fixed"
+    >
       {anchors.map((anchor) => {
         const isActive = activeState === anchor.id;
         return (


### PR DESCRIPTION
and other misc cleanup.

[Bug ticket](https://jira.pinadmin.com/browse/BUG-121250)

This is essentially a copy/paste of Christian's fix for the left sidebar scroll behavior, but for the right sidebar. For some components (e.g. Box) that sidebar can be pretty lengthy, and on shorter viewport heights it can be taller than the viewport. The current behavior is that the sidebar doesn't scroll up until the user reaches the end of the content, which isn't great. This PR adds the ability to scroll that sidebar independent from the content. For most users, there should be no noticeable change.

New scroll behavior on shorter screens:
https://user-images.githubusercontent.com/12059539/107691248-0fa40600-6c60-11eb-867d-1da88a1f442f.mov

No changes for normal height screens:
https://user-images.githubusercontent.com/12059539/107691309-28142080-6c60-11eb-9d38-5e2e00edd4ab.mov

