### PR TITLE
Typeahead: Bugfix to ensure the current value of `options` is used, not just the initial

### DIFF
--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -365,60 +365,47 @@ card(
     When Typeahead is used within a parent component that has a z-index set, a z-index will also need to be set on the Typeahead. Otherwise the Typeahead will render behind the parent component in the stacking context.`}
     defaultCode={`
 function Example(props) {
-  const [open, setOpen] = React.useState(false);
-  const [option, setOption] = React.useState();
+  const optionsA = Array.from(Array(20).keys()).map((item) => ({
+    value: "Value-" + (item + 1),
+    label: "Label-" + (item + 1)
+  }));
+  const optionsB = [{ label: "apple", value: "apple" }, { label: 'banana', value: 'banana' }];
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const MODAL_ZINDEX = new CompositeZIndex([HEADER_ZINDEX]);
-  const TYPEAHEAD_ZINDEX = new CompositeZIndex([MODAL_ZINDEX]);
+  const [options, setOptions] = React.useState(optionsA);
+  const defaultOption = options[0];
+  const [item, setItem] = React.useState(defaultOption.label);
+  const [selected, setSelected] = React.useState(defaultOption);
+
+  const handleOnChange = ({ value }) => {
+    setItem(value);
+  };
+
+  const handleSelect = ({ item }) => {
+    setSelected(item);
+  };
 
   return (
-    <React.Fragment>
-      <Button
-        inline
-        text="Report a stolen account"
-        onClick={() => setOpen(true)}
+    <>
+      <Box marginBottom={4}>
+        <Flex>
+          <Button text="A" onClick={() => setOptions(optionsA)} />
+          <Button text="B" onClick={() => setOptions(optionsB)} />
+        </Flex>
+
+        <Text>Selected Item: {(selected && selected.label) || ""}</Text>
+      </Box>
+
+      <Typeahead
+        label="Typeahead Example 2"
+        id="Typeahead-example-defaultItem"
+        noResultText="No Results"
+        options={options}
+        value={defaultOption.value}
+        placeholder="Select a Label"
+        onChange={handleOnChange}
+        onSelect={handleSelect}
       />
-      {open && (
-        <Layer zIndex={MODAL_ZINDEX}>
-          <Modal
-            accessibilityModalLabel="Select the account being reported"
-            onDismiss={() => setOpen(false)}
-            size="sm"
-            heading="Report a stolen account"
-            footer={
-              <Button
-                onClick={() => setOpen(false)}
-                text="Submit"
-                color="red"
-                size="lg"
-                type="submit"
-              />
-            }
-          >
-            <Box padding={8}>
-              <Typeahead
-                zIndex={TYPEAHEAD_ZINDEX}
-                label="Select the account being reported"
-                id="reported_account"
-                noResultText="No Results"
-                options={[
-                  {
-                    label: "basic_user@email.com",
-                    value: "basic_user@email.com"
-                  },
-                  {
-                    label: "business_user@email.com",
-                    value: "business_user@email.com"
-                  },
-                ]}
-                placeholder="Select an account"
-              />
-            </Box>
-          </Modal>
-        </Layer>
-      )}
-    </React.Fragment>
+    </>
   );
 }`}
   />,

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -365,47 +365,60 @@ card(
     When Typeahead is used within a parent component that has a z-index set, a z-index will also need to be set on the Typeahead. Otherwise the Typeahead will render behind the parent component in the stacking context.`}
     defaultCode={`
 function Example(props) {
-  const optionsA = Array.from(Array(20).keys()).map((item) => ({
-    value: "Value-" + (item + 1),
-    label: "Label-" + (item + 1)
-  }));
-  const optionsB = [{ label: "apple", value: "apple" }, { label: 'banana', value: 'banana' }];
+  const [open, setOpen] = React.useState(false);
+  const [option, setOption] = React.useState();
 
-  const [options, setOptions] = React.useState(optionsA);
-  const defaultOption = options[0];
-  const [item, setItem] = React.useState(defaultOption.label);
-  const [selected, setSelected] = React.useState(defaultOption);
-
-  const handleOnChange = ({ value }) => {
-    setItem(value);
-  };
-
-  const handleSelect = ({ item }) => {
-    setSelected(item);
-  };
+  const HEADER_ZINDEX = new FixedZIndex(10);
+  const MODAL_ZINDEX = new CompositeZIndex([HEADER_ZINDEX]);
+  const TYPEAHEAD_ZINDEX = new CompositeZIndex([MODAL_ZINDEX]);
 
   return (
-    <>
-      <Box marginBottom={4}>
-        <Flex>
-          <Button text="A" onClick={() => setOptions(optionsA)} />
-          <Button text="B" onClick={() => setOptions(optionsB)} />
-        </Flex>
-
-        <Text>Selected Item: {(selected && selected.label) || ""}</Text>
-      </Box>
-
-      <Typeahead
-        label="Typeahead Example 2"
-        id="Typeahead-example-defaultItem"
-        noResultText="No Results"
-        options={options}
-        value={defaultOption.value}
-        placeholder="Select a Label"
-        onChange={handleOnChange}
-        onSelect={handleSelect}
+    <React.Fragment>
+      <Button
+        inline
+        text="Report a stolen account"
+        onClick={() => setOpen(true)}
       />
-    </>
+      {open && (
+        <Layer zIndex={MODAL_ZINDEX}>
+          <Modal
+            accessibilityModalLabel="Select the account being reported"
+            onDismiss={() => setOpen(false)}
+            size="sm"
+            heading="Report a stolen account"
+            footer={
+              <Button
+                onClick={() => setOpen(false)}
+                text="Submit"
+                color="red"
+                size="lg"
+                type="submit"
+              />
+            }
+          >
+            <Box padding={8}>
+              <Typeahead
+                zIndex={TYPEAHEAD_ZINDEX}
+                label="Select the account being reported"
+                id="reported_account"
+                noResultText="No Results"
+                options={[
+                  {
+                    label: "basic_user@email.com",
+                    value: "basic_user@email.com"
+                  },
+                  {
+                    label: "business_user@email.com",
+                    value: "business_user@email.com"
+                  },
+                ]}
+                placeholder="Select an account"
+              />
+            </Box>
+          </Modal>
+        </Layer>
+      )}
+    </React.Fragment>
   );
 }`}
   />,

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -72,9 +72,6 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     zIndex,
   } = props;
 
-  // Store original data
-  // const dataRef = useRef(options);
-
   // Parent ref for positioning
   const wrapperRef = useRef(null);
 

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -73,23 +73,20 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   } = props;
 
   // Store original data
-  const dataRef = useRef(options);
+  // const dataRef = useRef(options);
 
   // Parent ref for positioning
   const wrapperRef = useRef(null);
 
   // Utility function for filtering data by value
   const filterOriginalData = (filterValue: string): $ReadOnlyArray<OptionObject> =>
-    dataRef.current.filter((item) => item.label.toLowerCase().includes(filterValue.toLowerCase()));
+    options.filter((item) => item.label.toLowerCase().includes(filterValue.toLowerCase()));
 
   // Utility function to find default value
   const findDefaultOption = (defaultValue: string | null): OptionObject | null => {
     if (defaultValue === null) return defaultValue;
 
-    return (
-      dataRef.current.find((item) => item.value.toLowerCase() === defaultValue.toLowerCase()) ||
-      null
-    );
+    return options.find((item) => item.value.toLowerCase() === defaultValue.toLowerCase()) || null;
   };
 
   // Track input value
@@ -101,9 +98,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
 
   const [hoveredItem, setHoveredItem] = useState<number | null>(0);
 
-  const [availableOptions, setAvailableOptions] = useState<$ReadOnlyArray<OptionObject>>(
-    dataRef.current,
-  );
+  const [availableOptions, setAvailableOptions] = useState<$ReadOnlyArray<OptionObject>>(options);
 
   // Ref to the input
   const inputRef = useRef(null);
@@ -113,8 +108,8 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
 
   // Reset search options when the container is closed
   useEffect(() => {
-    if (containerOpen === false) setAvailableOptions(dataRef.current);
-  }, [containerOpen]);
+    if (containerOpen === false) setAvailableOptions(options);
+  }, [containerOpen, options]);
 
   const handleFocus = ({ event }) => {
     // Run focus callback
@@ -125,7 +120,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     // Clear input and reset options when no results
     if (availableOptions.length === 0) {
       setSearch('');
-      setAvailableOptions(dataRef.current);
+      setAvailableOptions(options);
     }
 
     setContainerOpen(false);
@@ -135,21 +130,20 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   };
 
   // Handler for when text is typed
-  // eslint-disable-next-line no-shadow
-  const handleChange = ({ event, value }) => {
+  const handleChange = ({ event, value: newValue }) => {
     if (containerOpen === false) setContainerOpen(true);
 
     // Filter the available options using original data
-    const updatedOptions = filterOriginalData(value);
+    const updatedOptions = filterOriginalData(newValue);
 
     // Update the available options
     setAvailableOptions(updatedOptions);
 
     // Update the search value
-    setSearch(value);
+    setSearch(newValue);
 
     // Run onChange callback
-    if (onChange) onChange({ event, value });
+    if (onChange) onChange({ event, value: newValue });
   };
 
   const handleClear = () => {


### PR DESCRIPTION
As described in [this bug](https://jira.pinadmin.com/browse/BUG-122028), Typeahead doesn't update when `options` changes. Because it was storing the initial value of `options` in a ref (which is persisted over renders), the component doesn't respond to any changes to that prop.

This PR removes that ref and uses the `options` value directly instead.