### PR TITLE
Docs: Make sure right sidebar doesn't extend over footer

### DIFF
--- a/docs/src/components/Toc.js
+++ b/docs/src/components/Toc.js
@@ -143,11 +143,13 @@ export default function Toc({ cards }: Props): Node {
 
   return (
     <Box
+      // Accounting for the footer height as set in App.js
+      dangerouslySetInlineStyle={{ __style: { marginBottom: '90px' } }}
       // These margins counter the padding set on the <Box role="main"> in App.js
       marginTop={-4}
       mdMarginTop={-6}
       lgMarginTop={-8}
-      maxHeight="calc(100% - 60px)"
+      maxHeight="calc(100% - 60px - 90px)"
       minWidth={240}
       overflow="auto"
       paddingY={8} // re-apply just the padding we need


### PR DESCRIPTION
The recent right sidebar scrolling bugfix has a bug, where the sidebar is overlaid on the footer. This PR adds a bottom margin to the right sidebar to account for the footer height.


https://user-images.githubusercontent.com/12059539/108290663-bb0ff780-7145-11eb-951e-7d12d16bef00.mov

