### PR TITLE
[WIP] DatePicker: Add timezone prop to support UTC dates

### DIFF
--- a/docs/src/DatePicker.doc.js
+++ b/docs/src/DatePicker.doc.js
@@ -180,6 +180,14 @@ card(
         href: 'rangePicker',
       },
       {
+        name: 'timezone',
+        type: `'local' | 'utc'`,
+        defaultValue: 'local',
+        description:
+          "Timezone that input dates are in. While `local` uses the local timezone provided by the user's browser, `utc` provides the equivalent Coordinated Universal Time or UTC date, the primary time standard by which the world regulates clocks and time.",
+        href: 'utcTimezone',
+      },
+      {
         name: 'value',
         type: 'Date',
         description: 'Pre-selected date value.',
@@ -423,6 +431,29 @@ function DatePickerExample() {
   )
 }
 `}
+  />,
+);
+
+card(
+  <Example
+    id="utcTimezone"
+    description="Use dates in UTC timezone"
+    name="Example: UTC Dates"
+    defaultCode={`
+    function DatePickerExample() {
+      const [date, setDate] = React.useState(new Date(Date.UTC(2021, 1, 15)));
+
+      return (
+        <DatePicker
+          id="example-utc"
+          label="Select a date"
+          value={date}
+          onChange={({value}) => setDate(value)}
+          timezone="utc"
+        />
+      )
+    }
+    `}
   />,
 );
 

--- a/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
+++ b/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
@@ -105,4 +105,29 @@ describe('DatePicker', () => {
       'react-datepicker__day react-datepicker__day--013 react-datepicker__day--selected',
     );
   });
+
+  test('accepts utc timezone dates', () => {
+    const initialUTCDate = new Date(Date.UTC(2018, 2, 24));
+    const expectedNewDate = new Date(Date.UTC(2018, 2, 14));
+
+    render(
+      <DatePicker
+        id="fake_id"
+        onChange={mockOnChange}
+        placeholder="Select date"
+        timezone="utc"
+        value={initialUTCDate}
+      />,
+    );
+
+    fireEvent.focus(screen.getByDisplayValue('03/24/2018'));
+
+    expect(screen.queryByText('March 2018')).toBeInTheDocument();
+
+    const selectedDay = screen.getByText('14');
+
+    fireEvent.click(selectedDay);
+
+    expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ value: expectedNewDate }));
+  });
 });


### PR DESCRIPTION
Currently, the DatePicker only handles dates that are in the local timezone. This PR adds a `timezone` prop with a `utc` option to handle cases where the input dates are in UTC

## Test Plan

* Added a unit test
* Tested manually
* Added an example in the documentation
