### PR TITLE
Provider/Link/Button/IconButton/TapArea/+composed components: refactor link logic to support custom navigation within onClick prop in consumers + Codemode

### DIFF
--- a/docs/src/ActivationCard.doc.js
+++ b/docs/src/ActivationCard.doc.js
@@ -3,6 +3,8 @@ import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
+import MainSection from './components/MainSection.js';
+import { customNavigationDescription } from './components/docsUtils.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -42,18 +44,15 @@ card(
       {
         name: 'link',
         type:
-          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void, rel: "none" | "nofollow", target: "null" | "self" | "blank" |}',
+          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }, {| disableOnNavigation?: () => void |}) => void |}',
         required: false,
         defaultValue: null,
         description: [
           'Link-role button to render inside the activation card as a call-to-action to the user.',
           '- label: Text to render inside the button to convey the function and purpose of the button. The button text has a fixed size.',
           '- accessibilityLabel: Supply a short, descriptive label for screen-readers to replace button texts that do not provide sufficient context about the button component behavior. Texts like `Click Here,` `Follow,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the button text.',
-          '- onClick: Callback fired when the button component is clicked (pressed and released) with a mouse or keyboard.',
-          `- onNavigationOptions: onNavigationOptions works in conjunction with a Provider. Pass custom props to onNavigation. See Provider for examples. onNavigation's type is flexible. Each key's value is a React.Node or an event handler function.`,
-          'Accessibility: `accessibilityLabel` populates aria-label. Screen readers read the `accessibilityLabel` prop, if present, instead of the button `text`.',
+          '- onClick: Callback fired when the button component is clicked (pressed and released) with a mouse or keyboard. See [custom navigation](#Custom-navigation) variant for examples.',
         ],
-        href: '',
       },
       {
         name: 'status',
@@ -156,6 +155,117 @@ card(
 </Box>
   `}
   />,
+);
+
+card(
+  <MainSection name="Variants">
+    <MainSection.Subsection
+      title="Custom navigation"
+      description={customNavigationDescription('ActivationCard')}
+    >
+      <MainSection.Card
+        cardSize="lg"
+        defaultCode={`
+function OnNavigation() {
+  const [onNavigationMode, setOnNavigationMode] = React.useState('provider_disabled');
+
+  const onNavigation = ({ href,target }) => {
+    const onNavigationClick = ({ event }) => {
+      event.preventDefault();
+      // eslint-disable-next-line no-alert
+      alert('CUSTOM NAVIGATION set on <Provider onNavigation/>. Disabled link: '+href+'. Opening business.pinterest.com instead.');
+      window.open('https://business.pinterest.com', target === 'blank' ? '_blank' : '_self');
+    }
+    return onNavigationClick;
+  }
+
+  const customOnNavigation = () => {
+    // eslint-disable-next-line no-alert
+    alert('CUSTOM NAVIGATION set on <ActivationCard link/>. Disabled link: https://pinterest.com. Opening help.pinterest.com instead.');
+    window.open('https://help.pinterest.com', '_blank');
+  }
+
+  const onClickHandler = ({ event, disableOnNavigation }) => {
+    if (onNavigationMode === 'provider_disabled') {
+      disableOnNavigation()
+    } else if (onNavigationMode === 'link_custom') {
+      event.preventDefault();
+      disableOnNavigation();
+      customOnNavigation();
+    }
+  }
+
+  const linkProps = {
+    href:"https://pinterest.com",
+    onClick: onClickHandler,
+    target:"blank",
+  }
+
+  return (
+    <Provider onNavigation={onNavigation}>
+      <Flex direction="column" gap={2}>
+        <Flex direction="column" gap={2}>
+          <Text>Navigation controller:</Text>
+            <RadioButton
+              checked={onNavigationMode === 'provider_disabled'}
+              id="provider_disabled"
+              label="Default navigation (disabled custom navigation set on Provider)"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_disabled')}
+              value="provider_disabled"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'provider_custom'}
+              id="provider_custom"
+              label="Custom navigation set on Provider"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_custom')}
+              value="provider_custom"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'link_custom'}
+              id="link_custom"
+              label="Custom navigation set on Link"
+              name="navigation"
+              onChange={() => setOnNavigationMode('link_custom')}
+              value="link_custom"
+            />
+          <Divider/>
+        </Flex>
+        <ActivationCard
+            status="notStarted"
+            statusMessage="Not started"
+            title="Claim your website"
+            message="Grow distribution and track Pins linked to your website"
+            link={{
+              ...linkProps,
+              label: 'Claim your website now'
+            }}
+            dismissButton={{
+              accessibilityLabel: 'Dismiss card',
+              onDismiss: ()=>{},
+            }}
+          />
+      </Flex>
+    </Provider>
+  );
+}
+`}
+      />
+    </MainSection.Subsection>
+  </MainSection>,
+);
+
+card(
+  <MainSection name="Related">
+    <MainSection.Subsection
+      description={`
+**[Provider](/Provider)**
+Provider allows external link navigation control across all children components with link behavior.
+See [custom navigation](#Custom-navigation) variant for examples.
+      `}
+    />
+  </MainSection>,
 );
 
 export default cards;

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -5,6 +5,8 @@ import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
+import MainSection from './components/MainSection.js';
+import { customNavigationDescription } from './components/docsUtils.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -111,12 +113,12 @@ card(
       {
         name: 'onClick',
         type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: [
-          'Callback fired when a button component is clicked (pressed and released) with a mouse or keyboard.',
-          'Required with button-role + button-type buttons.',
+          'Callback fired when a button component is clicked (pressed and released) with a mouse or keyboard. ',
+          'See [custom navigation](#Custom-navigation) variant for examples.',
         ],
         href: 'selected',
       },
@@ -225,16 +227,6 @@ card(
           'Optional with link-role buttons.',
         ],
         href: 'type-roles',
-      },
-      {
-        name: 'onNavigationOptions',
-        type: '({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
-        description: [
-          'onNavigationOptions works in conjunction with a Provider. Pass custom props to onNavigation. See Provider for examples.',
-          `onNavigation's type is flexible. Each key's value is a React.Node or an event handler function.`,
-          'Optional with role=link.',
-        ],
-        href: 'OnNavigationContext',
       },
     ]}
   />,
@@ -539,6 +531,104 @@ function MenuButtonExample() {
 }
 `}
   />,
+);
+
+card(
+  <MainSection name="Variants">
+    <MainSection.Subsection
+      title="Custom navigation"
+      description={customNavigationDescription('Button')}
+    >
+      <MainSection.Card
+        cardSize="lg"
+        defaultCode={`
+function OnNavigation() {
+  const [onNavigationMode, setOnNavigationMode] = React.useState('provider_disabled');
+
+  const onNavigation = ({ href,target }) => {
+    const onNavigationClick = ({ event }) => {
+      event.preventDefault();
+      // eslint-disable-next-line no-alert
+      alert('CUSTOM NAVIGATION set on <Provider onNavigation/>. Disabled link: '+href+'. Opening business.pinterest.com instead.');
+      window.open('https://business.pinterest.com', target === 'blank' ? '_blank' : '_self');
+    }
+    return onNavigationClick;
+  }
+
+  const customOnNavigation = () => {
+    // eslint-disable-next-line no-alert
+    alert('CUSTOM NAVIGATION set on <Button onClick/>. Disabled link: https://pinterest.com. Opening help.pinterest.com instead.');
+    window.open('https://help.pinterest.com', '_blank');
+  }
+
+  const onClickHandler = ({ event, disableOnNavigation }) => {
+    if (onNavigationMode === 'provider_disabled') {
+      disableOnNavigation()
+    } else if (onNavigationMode === 'link_custom') {
+      event.preventDefault();
+      disableOnNavigation();
+      customOnNavigation();
+    }
+  }
+
+  const linkProps = {
+    href:"https://pinterest.com",
+    onClick: onClickHandler,
+    target:"blank",
+  }
+
+  return (
+    <Provider onNavigation={onNavigation}>
+      <Flex direction="column" gap={2}>
+        <Flex direction="column" gap={2}>
+          <Text>Navigation controller:</Text>
+            <RadioButton
+              checked={onNavigationMode === 'provider_disabled'}
+              id="provider_disabled"
+              label="Default navigation (disabled custom navigation set on Provider)"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_disabled')}
+              value="provider_disabled"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'provider_custom'}
+              id="provider_custom"
+              label="Custom navigation set on Provider"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_custom')}
+              value="provider_custom"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'link_custom'}
+              id="link_custom"
+              label="Custom navigation set on Button"
+              name="navigation"
+              onChange={() => setOnNavigationMode('link_custom')}
+              value="link_custom"
+            />
+          <Divider/>
+        </Flex>
+        <Button {...linkProps} role="link" text="Visit pinterest.com"/>
+      </Flex>
+    </Provider>
+  );
+}
+`}
+      />
+    </MainSection.Subsection>
+  </MainSection>,
+);
+
+card(
+  <MainSection name="Related">
+    <MainSection.Subsection
+      description={`
+**[Provider](/Provider)**
+Provider allows external link navigation control across all children components with link behavior.
+See [custom navigation](#Custom-navigation) variant for examples.
+      `}
+    />
+  </MainSection>,
 );
 
 export default cards;

--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -4,6 +4,7 @@ import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
 import MainSection from './components/MainSection.js';
 import FeedbackCallout from './components/FeedbackCallout.js';
+import { customNavigationDescription } from './components/docsUtils.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -63,24 +64,26 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void, rel: "none" | "nofollow", target: "null" | "self" | "blank" |}',
+          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation?: () => void |}',
+        required: false,
         defaultValue: null,
         description: `
-          Main action for people to take on Callout. If \`href\` is supplied, the action will serve as a link. If no \`href\` is supplied, the action will be a button.
+          Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [custom navigation](#Custom-navigation) variant for examples.
+          If no \`href\` is supplied, the action will be a button.
           The \`accessibilityLabel\` should follow the [Accessibility guidelines](#Accessibility).
         `,
-        href: '',
       },
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel?: string , href?: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }) => void |}, onNavigationOptions: ({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void, rel: "none" | "nofollow", target: "null" | "self" | "blank" |}',
+          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation?: () => void |}',
+        required: false,
         defaultValue: null,
         description: `
-          Secondary action for people to take on Callout. If \`href\` is supplied, the action will serve as a link. If no \`href\` is supplied, the action will be a button.
+          Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [custom navigation](#Custom-navigation) variant for examples.
+          If no \`href\` is supplied, the action will be a button.
           The \`accessibilityLabel\` should follow the [Accessibility guidelines](#Accessibility).
         `,
-        href: '',
       },
       {
         name: 'type',
@@ -463,6 +466,104 @@ function Example(props) {
       `}
       />
     </MainSection.Subsection>
+    <MainSection.Subsection
+      title="Custom navigation"
+      description={customNavigationDescription('Callout')}
+    >
+      <MainSection.Card
+        cardSize="lg"
+        defaultCode={`
+function OnNavigation() {
+  const [onNavigationMode, setOnNavigationMode] = React.useState('provider_disabled');
+
+  const onNavigation = ({ href,target }) => {
+    const onNavigationClick = ({ event }) => {
+      event.preventDefault();
+      // eslint-disable-next-line no-alert
+      alert('CUSTOM NAVIGATION set on <Provider onNavigation/>. Disabled link: '+href+'. Opening business.pinterest.com instead.');
+      window.open('https://business.pinterest.com', target === 'blank' ? '_blank' : '_self');
+    }
+    return onNavigationClick;
+  }
+
+  const customOnNavigation = () => {
+    // eslint-disable-next-line no-alert
+    alert('CUSTOM NAVIGATION set on <Callout primaryAction secondaryAction/>. Disabled link: https://pinterest.com. Opening help.pinterest.com instead.');
+    window.open('https://help.pinterest.com', '_blank');
+  }
+
+  const onClickHandler = ({ event, disableOnNavigation }) => {
+    if (onNavigationMode === 'provider_disabled') {
+      disableOnNavigation()
+    } else if (onNavigationMode === 'link_custom') {
+      event.preventDefault();
+      disableOnNavigation();
+      customOnNavigation();
+    }
+  }
+
+  const linkProps = {
+    href:"https://pinterest.com",
+    onClick: onClickHandler,
+    target:"blank",
+  }
+
+  return (
+    <Provider onNavigation={onNavigation}>
+      <Flex direction="column" gap={2}>
+        <Flex direction="column" gap={2}>
+          <Text>Navigation controller:</Text>
+            <RadioButton
+              checked={onNavigationMode === 'provider_disabled'}
+              id="provider_disabled"
+              label="Default navigation (disabled custom navigation set on Provider)"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_disabled')}
+              value="provider_disabled"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'provider_custom'}
+              id="provider_custom"
+              label="Custom navigation set on Provider"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_custom')}
+              value="provider_custom"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'link_custom'}
+              id="link_custom"
+              label="Custom navigation set on Link"
+              name="navigation"
+              onChange={() => setOnNavigationMode('link_custom')}
+              value="link_custom"
+            />
+          <Divider/>
+        </Flex>
+        <Callout
+          type="info"
+          iconAccessibilityLabel="Info icon"
+          title="Your business account was created!"
+          message="Apply to the Verified Merchant Program!"
+          primaryAction={
+            { ...linkProps,
+              label:'Get started',
+            }}
+          secondaryAction={
+            { ...linkProps,
+              label: 'Learn more',
+            }}
+          dismissButton={{
+            accessibilityLabel: 'Dismiss banner',
+            onDismiss: () => {},
+          }}
+        />
+      </Flex>
+    </Provider>
+  );
+}
+`}
+      />
+    </MainSection.Subsection>
   </MainSection>,
 );
 
@@ -478,6 +579,10 @@ card(
 
       **[ActivationCard](/ActivationCard)**
       ActivationCards are used in groups to communicate a user’s stage in a series of steps toward an overall action.
+
+      **[Provider](/Provider)**
+      Provider allows external link navigation control across all children components with link behavior.
+      See [custom navigation](#Custom-navigation) variant for examples.
 
     `}
     />

--- a/docs/src/Dropdown.doc.js
+++ b/docs/src/Dropdown.doc.js
@@ -5,6 +5,8 @@ import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
 import Card from './components/Card.js';
+import MainSection from './components/MainSection.js';
+import { customNavigationDescription } from './components/docsUtils.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -208,12 +210,12 @@ card(
         href: 'default',
       },
       {
-        name: 'onNavigationOptions',
-        type: '({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
+        name: 'onClick',
+        type:
+          'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation?: () => void |}',
         description: [
-          'onNavigationOptions works in conjunction with a Provider. Pass custom props to onNavigation. See Provider for examples.',
-          `onNavigation's type is flexible. Each key's value is a React.Node or an event handler function.`,
-          'Optional with href.',
+          'Callback fired when a button component is clicked (pressed and released) with a mouse or keyboard. ',
+          'See [custom navigation](#Custom-navigation) variant for examples.',
         ],
       },
     ]}
@@ -668,18 +670,134 @@ function CustomIconButtonPopoverExample() {
 );
 
 card(
-  <Card
-    description={`
-    Dropdowns should be used when offering users complex options to choose from.
-    If an item acts as navigation, it automatically requires the use of the Dropdown component.
-    Items can also be actions (like Logout or Add Account) or selections (like different display modes).
+  <MainSection name="Variants">
+    <MainSection.Subsection
+      title="Custom navigation"
+      description={customNavigationDescription('Dropdown')}
+    >
+      <MainSection.Card
+        cardSize="lg"
+        defaultCode={`
+function OnNavigation() {
+  const [onNavigationMode, setOnNavigationMode] = React.useState('provider_disabled');
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef(null);
 
-    If users need to select from a simple list of highly related options (without needing sections or subtext details), use a [SelectList](/SelectList).
+  const onNavigation = ({ href,target }) => {
+    const onNavigationClick = ({ event }) => {
+      event.preventDefault();
+      // eslint-disable-next-line no-alert
+      alert('CUSTOM NAVIGATION set on <Provider onNavigation/>. Disabled link: '+href+'. Opening business.pinterest.com instead.');
+      window.open('https://business.pinterest.com', target === 'blank' ? '_blank' : '_self');
+    }
+    return onNavigationClick;
+  }
 
-    If users need the ability to choose an option by typing in an input and filtering a long list of options, use a [Typeahead](/Typeahead).
-  `}
-    name="Related"
-  />,
+  const customOnNavigation = () => {
+    // eslint-disable-next-line no-alert
+    alert('CUSTOM NAVIGATION set on <Dropdown.Item onClick/>. Disabled link: https://pinterest.com. Opening help.pinterest.com instead.');
+    window.open('https://help.pinterest.com', '_blank');
+  }
+
+  const onClickHandler = ({ event, disableOnNavigation }) => {
+    if (onNavigationMode === 'provider_disabled') {
+      disableOnNavigation()
+    } else if (onNavigationMode === 'link_custom') {
+      event.preventDefault();
+      disableOnNavigation();
+      customOnNavigation();
+    }
+  }
+
+  const linkProps = {
+    href:"https://pinterest.com",
+    onClick: onClickHandler,
+    target:"blank",
+  }
+
+  return (
+    <Provider onNavigation={onNavigation}>
+      <Flex direction="column" gap={2}>
+        <Flex direction="column" gap={2}>
+          <Text>Navigation controller:</Text>
+            <RadioButton
+              checked={onNavigationMode === 'provider_disabled'}
+              id="provider_disabled"
+              label="Default navigation (disabled custom navigation set on Provider)"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_disabled')}
+              value="provider_disabled"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'provider_custom'}
+              id="provider_custom"
+              label="Custom navigation set on Provider"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_custom')}
+              value="provider_custom"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'link_custom'}
+              id="link_custom"
+              label="Custom navigation set on Link"
+              name="navigation"
+              onChange={() => setOnNavigationMode('link_custom')}
+              value="link_custom"
+            />
+          <Divider/>
+        </Flex>
+        <Box display="flex" justifyContent="center">
+        <Button
+          accessibilityControls="basic-dropdown-example"
+          accessibilityHaspopup
+          accessibilityExpanded={open}
+          iconEnd="arrow-down"
+          text="Menu"
+          inline
+          ref={anchorRef}
+          selected={open}
+          onClick={ () => setOpen((prevVal) => !prevVal) }
+        />
+        {open && (
+          <Dropdown id="basic-dropdown-example" anchor={anchorRef.current} onDismiss={() => {setOpen(false)}}>
+            <Dropdown.Item
+              { ...linkProps }
+              isExternal
+              option={{ value: 'item 3', label: 'Visit Settings page' }}
+            />
+          </Dropdown>
+        )}
+      </Box>
+      </Flex>
+    </Provider>
+  );
+}
+`}
+      />
+    </MainSection.Subsection>
+  </MainSection>,
+);
+
+card(
+  <MainSection name="Related">
+    <MainSection.Subsection
+      description={`
+Dropdowns should be used when offering users complex options to choose from.
+If an item acts as navigation, it automatically requires the use of the Dropdown component.
+Items can also be actions (like Logout or Add Account) or selections (like different display modes).
+
+**[Provider](/Provider)**
+Provider allows external link navigation control across all children components with link behavior.
+See [custom navigation](#Custom-navigation) variant for examples.
+
+**[SelectList](/SelectList)**
+If users need to select from a simple list of highly related options (without needing sections or subtext details), use a [SelectList](/SelectList).
+
+**[Typeahead](/Typeahead)**
+If users need the ability to choose an option by typing in an input and filtering a long list of options, use a [Typeahead](/Typeahead).
+      `}
+    />
+  </MainSection>,
 );
 
 export default cards;

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -582,7 +582,9 @@ function OnNavigation() {
           {...linkProps}
           accessibilityLabel="Link IconButton"
           icon="visit"
+          iconColor="darkGray"
           role="link"
+          size="lg"
         />
       </Flex>
     </Provider>

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -5,6 +5,8 @@ import Example from './components/Example.js';
 import PropTable from './components/PropTable.js';
 import Combination from './components/Combination.js';
 import PageHeader from './components/PageHeader.js';
+import MainSection from './components/MainSection.js';
+import { customNavigationDescription } from './components/docsUtils.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -125,12 +127,13 @@ card(
       {
         name: 'onClick',
         type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: [
           'Callback fired when a button component is clicked (pressed and released) with a mouse or keyboard.',
           'Required with button-role buttons.',
+          'See [custom navigation](#Custom-navigation) variant for examples.',
         ],
         href: 'selected',
       },
@@ -218,16 +221,6 @@ card(
           'Optional with link-role buttons.',
         ],
         href: 'roles',
-      },
-      {
-        name: 'onNavigationOptions',
-        type: '({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
-        description: [
-          'onNavigationOptions works in conjunction with a Provider. Pass custom props to onNavigation. See Provider for examples.',
-          `onNavigation's type is flexible. Each key's value is a React.Node or an event handler function.`,
-          'Optional with role=link.',
-        ],
-        href: 'OnNavigationContext',
       },
     ]}
   />,
@@ -508,6 +501,109 @@ function MenuIconButtonExample() {
 }
 `}
   />,
+);
+
+card(
+  <MainSection name="Variants">
+    <MainSection.Subsection
+      title="Custom navigation"
+      description={customNavigationDescription('IconButton')}
+    >
+      <MainSection.Card
+        cardSize="lg"
+        defaultCode={`
+function OnNavigation() {
+  const [onNavigationMode, setOnNavigationMode] = React.useState('provider_disabled');
+
+  const onNavigation = ({ href,target }) => {
+    const onNavigationClick = ({ event }) => {
+      event.preventDefault();
+      // eslint-disable-next-line no-alert
+      alert('CUSTOM NAVIGATION set on <Provider onNavigation/>. Disabled link: '+href+'. Opening business.pinterest.com instead.');
+      window.open('https://business.pinterest.com', target === 'blank' ? '_blank' : '_self');
+    }
+    return onNavigationClick;
+  }
+
+  const customOnNavigation = () => {
+    // eslint-disable-next-line no-alert
+    alert('CUSTOM NAVIGATION set on <IconButton onClick/>. Disabled link: https://pinterest.com. Opening help.pinterest.com instead.');
+    window.open('https://help.pinterest.com', '_blank');
+  }
+
+  const onClickHandler = ({ event, disableOnNavigation }) => {
+    if (onNavigationMode === 'provider_disabled') {
+      disableOnNavigation()
+    } else if (onNavigationMode === 'link_custom') {
+      event.preventDefault();
+      disableOnNavigation();
+      customOnNavigation();
+    }
+  }
+
+  const linkProps = {
+    href:"https://pinterest.com",
+    onClick: onClickHandler,
+    target:"blank",
+  }
+
+  return (
+    <Provider onNavigation={onNavigation}>
+      <Flex direction="column" gap={2}>
+        <Flex direction="column" gap={2}>
+          <Text>Navigation controller:</Text>
+            <RadioButton
+              checked={onNavigationMode === 'provider_disabled'}
+              id="provider_disabled"
+              label="Default navigation (disabled custom navigation set on Provider)"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_disabled')}
+              value="provider_disabled"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'provider_custom'}
+              id="provider_custom"
+              label="Custom navigation set on Provider"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_custom')}
+              value="provider_custom"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'link_custom'}
+              id="link_custom"
+              label="Custom navigation set on IconButton"
+              name="navigation"
+              onChange={() => setOnNavigationMode('link_custom')}
+              value="link_custom"
+            />
+          <Divider/>
+        </Flex>
+        <IconButton
+          {...linkProps}
+          accessibilityLabel="Link IconButton"
+          icon="visit"
+          role="link"
+        />
+      </Flex>
+    </Provider>
+  );
+}
+`}
+      />
+    </MainSection.Subsection>
+  </MainSection>,
+);
+
+card(
+  <MainSection name="Related">
+    <MainSection.Subsection
+      description={`
+**[Provider](/Provider)**
+Provider allows external link navigation control across all children components with link behavior.
+See [custom navigation](#Custom-navigation) variant for examples.
+      `}
+    />
+  </MainSection>,
 );
 
 export default cards;

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -3,6 +3,8 @@ import React, { type Node } from 'react';
 import PropTable from './components/PropTable.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
+import MainSection from './components/MainSection.js';
+import { customNavigationDescription } from './components/docsUtils.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -67,21 +69,14 @@ card(
       {
         name: 'onClick',
         type:
-          '({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
-        href: 'PreventDefault',
+          'AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}>',
+        description:
+          'Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [custom navigation](#Custom-navigation) variant for examples.',
+        href: 'Custom-navigation',
       },
       {
         name: 'onFocus',
         type: '() => void',
-      },
-      {
-        name: 'onNavigationOptions',
-        type: '({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
-        description: [
-          'onNavigationOptions works in conjunction with a Provider. Pass custom props to onNavigation. See Provider for examples.',
-          `onNavigation's type is flexible. Each key's value is a React.Node or an event handler function.`,
-        ],
-        href: 'OnNavigationContext',
       },
       {
         name: 'ref',
@@ -270,45 +265,105 @@ function PermutationsExample() {
 );
 
 card(
-  <Example
-    id="PreventDefault"
-    name="Prevent default"
-    defaultCode={`
-function PreventDefaultExample() {
-  const [preventDefault, setPreventDefault] = React.useState(true);
-  const onClick = ({ event }) => {
-    if (preventDefault) {
+  <MainSection name="Variants">
+    <MainSection.Subsection
+      title="Custom navigation"
+      description={customNavigationDescription('Link')}
+    >
+      <MainSection.Card
+        cardSize="lg"
+        defaultCode={`
+function OnNavigation() {
+  const [onNavigationMode, setOnNavigationMode] = React.useState('provider_disabled');
+
+  const onNavigation = ({ href,target }) => {
+    const onNavigationClick = ({ event }) => {
       event.preventDefault();
+      // eslint-disable-next-line no-alert
+      alert('CUSTOM NAVIGATION set on <Provider onNavigation/>. Disabled link: '+href+'. Opening business.pinterest.com instead.');
+      window.open('https://business.pinterest.com', target === 'blank' ? '_blank' : '_self');
     }
-  };
+    return onNavigationClick;
+  }
+
+  const customOnNavigation = () => {
+    // eslint-disable-next-line no-alert
+    alert('CUSTOM NAVIGATION set on <Link onClick/>. Disabled link: https://pinterest.com. Opening help.pinterest.com instead.');
+    window.open('https://help.pinterest.com', '_blank');
+  }
+
+  const onClickHandler = ({ event, disableOnNavigation }) => {
+    if (onNavigationMode === 'provider_disabled') {
+      disableOnNavigation()
+    } else if (onNavigationMode === 'link_custom') {
+      event.preventDefault();
+      disableOnNavigation();
+      customOnNavigation();
+    }
+  }
+
+  const linkProps = {
+    href:"https://pinterest.com",
+    onClick: onClickHandler,
+    target:"blank",
+  }
 
   return (
-    <Box>
-      <Box padding={2}>
-        <Flex alignItems="center" gap={4}>
-          <Label htmlFor="preventDefault">
-            <Text>Prevent default on tap</Text>
-          </Label>
-          <Switch
-            id="preventDefault"
-            onChange={() => setPreventDefault(!preventDefault)}
-            switched={preventDefault}
-          />
+    <Provider onNavigation={onNavigation}>
+      <Flex direction="column" gap={2}>
+        <Flex direction="column" gap={2}>
+          <Text>Navigation controller:</Text>
+            <RadioButton
+              checked={onNavigationMode === 'provider_disabled'}
+              id="provider_disabled"
+              label="Default navigation (disabled custom navigation set on Provider)"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_disabled')}
+              value="provider_disabled"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'provider_custom'}
+              id="provider_custom"
+              label="Custom navigation set on Provider"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_custom')}
+              value="provider_custom"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'link_custom'}
+              id="link_custom"
+              label="Custom navigation set on Link"
+              name="navigation"
+              onChange={() => setOnNavigationMode('link_custom')}
+              value="link_custom"
+            />
+          <Divider/>
         </Flex>
-      </Box>
-      <Divider />
-      <Box padding={2}>
-        <Text>
-          <Link href="https://pinterest.com" onClick={onClick} target='blank'>
-            https://pinterest.com
-          </Link>
-        </Text>
-      </Box>
-    </Box>
+          <Text>
+            <Link {...linkProps}>
+              Visit pinterest.com
+            </Link>
+          </Text>
+      </Flex>
+    </Provider>
   );
 }
 `}
-  />,
+      />
+    </MainSection.Subsection>
+  </MainSection>,
+);
+
+card(
+  <MainSection name="Related">
+    <MainSection.Subsection
+      description={`
+**[Provider](/Provider)**
+Provider allows external link navigation control across all children components with link behavior.
+See [custom navigation](#Custom-navigation) variant for examples.
+      `}
+    />
+  </MainSection>,
 );
 
 export default cards;

--- a/docs/src/Provider.doc.js
+++ b/docs/src/Provider.doc.js
@@ -168,7 +168,9 @@ function OnNavigation() {
             {...linkProps}
             accessibilityLabel="Link IconButton"
             icon="visit"
+            iconColor="darkGray"
             role="link"
+            size="lg"
           />
           <Box width={100}>
             <TapArea

--- a/docs/src/TapArea.doc.js
+++ b/docs/src/TapArea.doc.js
@@ -5,6 +5,8 @@ import PropTable from './components/PropTable.js';
 import Combination from './components/Combination.js';
 import Example from './components/Example.js';
 import PageHeader from './components/PageHeader.js';
+import MainSection from './components/MainSection.js';
+import { customNavigationDescription } from './components/docsUtils.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -131,7 +133,7 @@ card(
       {
         name: 'onMouseEnter',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: ['Callback fired when a mouse pointer moves onto a TapArea component.'],
@@ -149,11 +151,13 @@ card(
       {
         name: 'onTap',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) }) => void',
         required: false,
         defaultValue: null,
         description: [
           'Callback fired when a TapArea component is clicked (pressed and released) with a mouse or keyboard.',
+          'Required with button-role + button-type buttons.',
+          'See [custom navigation](#Custom-navigation) variant for examples.',
         ],
         href: 'basic-taparea',
       },
@@ -242,16 +246,6 @@ card(
           `- 'compress' scales down TapArea.`,
         ],
         href: 'roles',
-      },
-      {
-        name: 'onNavigationOptions',
-        type: '({ [string]: Node | ({| +event: SyntheticEvent<> |}) => void }) => void',
-        description: [
-          'onNavigationOptions works in conjunction with a Provider. Pass custom props to onNavigation. See Provider for examples.',
-          `onNavigation's type is flexible. Each key's value is a React.Node or an event handler function.`,
-          'Optional with role=link.',
-        ],
-        href: 'OnNavigationContext',
       },
     ]}
   />,
@@ -610,6 +604,121 @@ function MenuButtonExample() {
 }
 `}
   />,
+);
+
+card(
+  <MainSection name="Variants">
+    <MainSection.Subsection
+      title="Custom navigation"
+      description={customNavigationDescription('TapArea')}
+    >
+      <MainSection.Card
+        cardSize="lg"
+        defaultCode={`
+function OnNavigation() {
+  const [onNavigationMode, setOnNavigationMode] = React.useState('provider_disabled');
+
+  const onNavigation = ({ href,target }) => {
+    const onNavigationClick = ({ event }) => {
+      event.preventDefault();
+      // eslint-disable-next-line no-alert
+      alert('CUSTOM NAVIGATION set on <Provider onNavigation/>. Disabled link: '+href+'. Opening business.pinterest.com instead.');
+      window.open('https://business.pinterest.com', target === 'blank' ? '_blank' : '_self');
+    }
+    return onNavigationClick;
+  }
+
+  const customOnNavigation = () => {
+    // eslint-disable-next-line no-alert
+    alert('CUSTOM NAVIGATION set on <TapArea onTap/>. Disabled link: https://pinterest.com. Opening help.pinterest.com instead.');
+    window.open('https://help.pinterest.com', '_blank');
+  }
+
+  const onTapHandler = ({ event, disableOnNavigation }) => {
+    if (onNavigationMode === 'provider_disabled') {
+      disableOnNavigation()
+    } else if (onNavigationMode === 'link_custom') {
+      event.preventDefault();
+      disableOnNavigation();
+      customOnNavigation();
+    }
+  }
+
+  const linkProps = {
+    href:"https://pinterest.com",
+    onTap: onTapHandler,
+    target:"blank",
+  }
+
+  return (
+    <Provider onNavigation={onNavigation}>
+      <Flex direction="column" gap={2}>
+        <Flex direction="column" gap={2}>
+          <Text>Navigation controller:</Text>
+            <RadioButton
+              checked={onNavigationMode === 'provider_disabled'}
+              id="provider_disabled"
+              label="Default navigation (disabled custom navigation set on Provider)"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_disabled')}
+              value="provider_disabled"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'provider_custom'}
+              id="provider_custom"
+              label="Custom navigation set on Provider"
+              name="navigation"
+              onChange={() => setOnNavigationMode('provider_custom')}
+              value="provider_custom"
+            />
+            <RadioButton
+              checked={onNavigationMode === 'link_custom'}
+              id="link_custom"
+              label="Custom navigation set on TapArea"
+              name="navigation"
+              onChange={() => setOnNavigationMode('link_custom')}
+              value="link_custom"
+            />
+          <Divider/>
+        </Flex>
+        <Box width={100}>
+          <TapArea
+            {...linkProps}
+            role="link"
+            rounding={2}
+          >
+            <Box color="darkGray" rounding={4} borderStyle="sm">
+              <Mask rounding={2}>
+                <Image
+                  alt="Antelope Canyon"
+                  naturalHeight={1}
+                  naturalWidth={1}
+                  src="https://i.ibb.co/DwYrGy6/stock14.jpg"
+                />
+              </Mask>
+            </Box>
+          </TapArea>
+        </Box>
+      </Flex>
+    </Provider>
+  );
+}
+`}
+      />
+    </MainSection.Subsection>
+  </MainSection>,
+);
+
+card(
+  <MainSection name="Related">
+    <MainSection.Subsection
+      description={`
+**[Provider](/Provider)**
+Provider allows external link navigation control across all children components with link behavior.
+See [custom navigation](#Custom-navigation) variant for examples.
+      `}
+    />
+  </MainSection>,
 );
 
 export default cards;

--- a/docs/src/components/docsUtils.js
+++ b/docs/src/components/docsUtils.js
@@ -1,0 +1,23 @@
+// @flow strict
+export const customNavigationDescription = (cmp: string): string => `
+This example illustrates two custom navigation implementations to externally control the link navigation behavior of ${cmp}: setting a default logic with [Provider](/Provider) and a custom component logic with the \`onClick\` prop.
+
+If \`onNavigation\` prop is passed to Provider, it's passed down to all children Links and sets a custom default link navigation behavior. \`onNavigation\` is a higher-order function: it takes named arguments (\`href\` and \`target\`) and returns a function that gets called last on the \`onClick\` event handler.
+
+${cmp}'s \`onClick\` prop is an event handler function. This callback takes 2 named parameters: 'event', the 'onClick' event, and \`disableOnNavigation\`, a callback function that disables any default custom navigation logic set by [Provider](/Provider). \`disableOnNavigation\` is only accessible in Provider's link-role children components.
+
+In this example, ${cmp} has a parent Provider setting a default custom navigation logic. We can compare three navigation behaviors: (a) the default ${cmp} behavior (by disabling the Provider's inherited logic), (b) the default custom behavior set by Provider and (c) a custom behavior set on ${cmp}.
+
+\`onClick\` is used to disable the default custom logic set in Provider and implement custom behavior at the component level. \`disableOnNavigation\` and \`customOnNavigation\` are both called first during the 'onClick' event.
+
+If \`onNavigation\` is a [custom hook function](https://reactjs.org/docs/hooks-custom.html), it can contain complex logic, including [React hooks](https://reactjs.org/docs/hooks-reference.html), to perform side effects.
+
+In this example, both \`onNavigation\` and \`customOnNavigation\` functions execute the following actions:
+- Disable the default link behavior
+- Show an alert message
+- Open a different URL in a new window
+
+Both \`onNavigationClick\`, inside \`onNavigation\`, and \`onClick\` have event access to [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault). It could also be used to [stopPropagation()](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation).
+      `;
+
+export default undefined;

--- a/packages/gestalt-codemods/21.0.0/detect-onNavigateOptions-to-manually-update.js
+++ b/packages/gestalt-codemods/21.0.0/detect-onNavigateOptions-to-manually-update.js
@@ -1,0 +1,88 @@
+/*
+ * Detects
+ *  <Link onNavigateOptions/>
+ *  <Button onNavigateOptions/>
+ *  <IconButton onNavigateOptions/>
+ *  <TapArea onNavigateOptions/>
+ *  <Dropdown onNavigateOptions/>
+ *  <Callout primaryAction secondaryAction/>
+ *  <Upsell primaryAction secondaryAction/>
+ *  <ActivationCard link/>
+ *
+ *  Console logs each component for a manual update.
+ */
+
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/20.0.0/detect-onNavigateOptions-to-manually-update.js relative/path/to/your/code
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter((node) =>
+        [
+          'Link',
+          'Button',
+          'IconButton',
+          'TapArea',
+          'Dropdown',
+          'Callout',
+          'Upsell',
+          'ActivationCard',
+        ].includes(node.imported.name),
+      )
+      .map((node) => node.local.name);
+
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  src.find(j.JSXElement).forEach((jsxElement) => {
+    const { node } = jsxElement;
+
+    if (!localIdentifierName.includes(node.openingElement.name.name)) {
+      return null;
+    }
+
+    const attrs = node.openingElement.attributes;
+
+    if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+      throw new Error(
+        `Remove Dynamic Text properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+      );
+    }
+
+    attrs
+      .map((attr) => {
+        // Module: Console logs cmp if contains props for a manual review.
+        if (
+          ['onNavigateOptions', 'primaryAction', 'secondaryAction', 'link'].includes(
+            attr?.name?.name,
+          )
+        ) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `${node.openingElement.name.name} components with ${attr?.name?.name} prop must be reviewed manually. If 'onNavigationOptions' is used, it must be manually removed. Location: ${file.path} @line: ${node.loc.start.line}`,
+          );
+
+          return attr;
+        }
+        return attr;
+      })
+      .filter(Boolean);
+
+    return null;
+  });
+
+  return null;
+}

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -10,10 +10,6 @@ import Button from './Button.js';
 import Text from './Text.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './ActivationCard.css';
-import {
-  type OnNavigationOptionsType,
-  OnNavigationOptionsPropType,
-} from './contexts/OnNavigation.js';
 
 type LinkData = {|
   accessibilityLabel?: string,
@@ -24,8 +20,8 @@ type LinkData = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
+    {| disableOnNavigation?: () => void |},
   >,
-  onNavigationOptions?: OnNavigationOptionsType,
   rel?: 'none' | 'nofollow',
   target?: null | 'self' | 'blank',
 |};
@@ -50,7 +46,7 @@ const STATUS_ICONS = {
 };
 
 const ActivationCardLink = ({ data }: {| data: LinkData |}): Node => {
-  const { accessibilityLabel, href, label, onClick, onNavigationOptions, rel, target } = data;
+  const { accessibilityLabel, href, label, onClick, rel, target } = data;
 
   return (
     <Box
@@ -70,7 +66,6 @@ const ActivationCardLink = ({ data }: {| data: LinkData |}): Node => {
         role="link"
         size="lg"
         text={label}
-        onNavigationOptions={onNavigationOptions}
         target={target}
       />
     </Box>
@@ -243,8 +238,8 @@ ActivationCard.propTypes = {
     href: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
     onClick: PropTypes.func,
+
     accessibilityLabel: PropTypes.string,
-    onNavigationOptions: OnNavigationOptionsPropType,
     rel: PropTypes.oneOf(['none', 'nofollow']),
     target: PropTypes.oneOf([null, 'self', 'blank']),
   }),

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -15,10 +15,6 @@ import InternalLink from './InternalLink.js';
 import Icon, { type IconColor } from './Icon.js';
 import { useColorScheme } from './contexts/ColorScheme.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
-import {
-  type OnNavigationOptionsType,
-  OnNavigationOptionsPropType,
-} from './contexts/OnNavigation.js';
 
 const DEFAULT_TEXT_COLORS = {
   blue: 'white',
@@ -47,6 +43,7 @@ type BaseButton = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
+    {| disableOnNavigation?: () => void |},
   >,
   tabIndex?: -1 | 0,
   size?: 'sm' | 'md' | 'lg',
@@ -72,7 +69,6 @@ type SubmitButtonType = {|
 type LinkButtonType = {|
   ...BaseButton,
   href: string,
-  onNavigationOptions?: OnNavigationOptionsType,
   rel?: 'none' | 'nofollow',
   role: 'link',
   target?: null | 'self' | 'blank',
@@ -183,16 +179,14 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
     </Text>
   );
 
-  const handleClick = (event) => {
-    if (onClick) {
-      onClick({ event });
-    }
-  };
+  const handleClick = (event, disableOnNavigation) =>
+    onClick ? onClick(disableOnNavigation ? { event, disableOnNavigation } : { event }) : undefined;
 
-  const handleLinkClick = ({ event }) => handleClick(event);
+  const handleLinkClick = ({ event, disableOnNavigation }) =>
+    handleClick(event, disableOnNavigation);
 
   if (props.role === 'link') {
-    const { href, onNavigationOptions, rel = 'none', target = null } = props;
+    const { href, rel = 'none', target = null } = props;
 
     return (
       <InternalLink
@@ -202,7 +196,6 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         inline={inline}
         href={href}
         onClick={handleLinkClick}
-        onNavigationOptions={onNavigationOptions}
         ref={innerRef}
         rel={rel}
         tabIndex={tabIndex}
@@ -296,7 +289,6 @@ ButtonWithForwardRef.propTypes = {
   inline: PropTypes.bool,
   name: PropTypes.string,
   onClick: PropTypes.func,
-  onNavigationOptions: OnNavigationOptionsPropType,
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<'none' | 'nofollow'>),
   tabIndex: PropTypes.oneOf([-1, 0]),
   role: PropTypes.oneOf(['button', 'link']),

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -56,7 +56,7 @@ const CalloutAction = ({
   if (isDarkMode && type === 'secondary') {
     color = 'transparentWhiteText';
   }
-  const { accessibilityLabel, label, onClick, onNavigationOptions, href, rel, target } = data;
+  const { accessibilityLabel, label, onClick, href, rel, target } = data;
 
   return (
     <Box
@@ -75,7 +75,6 @@ const CalloutAction = ({
           color={color}
           href={href}
           onClick={onClick}
-          onNavigationOptions={onNavigationOptions}
           rel={rel}
           role="link"
           size="lg"

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -3,10 +3,7 @@ import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import MenuOption, { type OptionObject } from './MenuOption.js';
 import DropdownContext from './DropdownContextProvider.js';
-import {
-  type OnNavigationOptionsType,
-  OnNavigationOptionsPropType,
-} from './contexts/OnNavigation.js';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type PublicProps = {|
   badgeText?: string,
@@ -16,10 +13,13 @@ type PublicProps = {|
     item: OptionObject,
   |}) => void,
   isExternal?: boolean,
+  onClick?: AbstractEventHandler<
+    SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    {| disableOnNavigation?: () => void |},
+  >,
   option: OptionObject,
   selected?: OptionObject | $ReadOnlyArray<OptionObject> | null,
   href?: string,
-  onNavigationOptions?: OnNavigationOptionsType,
 |};
 
 type PrivateProps = {|
@@ -37,10 +37,10 @@ export default function DropdownItem({
   handleSelect,
   index = 0,
   isExternal,
+  onClick,
   option,
   selected,
   href,
-  onNavigationOptions,
 }: Props): Node {
   return (
     <DropdownContext.Consumer>
@@ -53,6 +53,7 @@ export default function DropdownItem({
           id={id}
           index={index}
           isExternal={isExternal}
+          onClick={onClick}
           option={option}
           role="menuitem"
           selected={selected}
@@ -61,7 +62,6 @@ export default function DropdownItem({
           shouldTruncate
           textWeight="bold"
           href={href}
-          onNavigationOptions={onNavigationOptions ?? {}}
         >
           {children}
         </MenuOption>
@@ -75,6 +75,7 @@ DropdownItem.displayName = 'DropdownItem';
 DropdownItem.propTypes = {
   badgeText: PropTypes.string,
   isExternal: PropTypes.bool,
+  onClick: PropTypes.func,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   option: PropTypes.shape({
     label: PropTypes.string.isRequired,
@@ -98,5 +99,4 @@ DropdownItem.propTypes = {
   ]),
   handleSelect: PropTypes.func,
   href: PropTypes.string,
-  onNavigationOptions: OnNavigationOptionsPropType,
 };

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -10,10 +10,6 @@ import styles from './IconButton.css';
 import touchableStyles from './Touchable.css';
 import useTapFeedback from './useTapFeedback.js';
 import useFocusVisible from './useFocusVisible.js';
-import {
-  type OnNavigationOptionsType,
-  OnNavigationOptionsPropType,
-} from './contexts/OnNavigation.js';
 
 type BaseIconButton = {|
   accessibilityLabel: string,
@@ -33,6 +29,7 @@ type BaseIconButton = {|
     | SyntheticKeyboardEvent<HTMLButtonElement>
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    {| disableOnNavigation?: () => void |},
   >,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   padding?: 1 | 2 | 3 | 4 | 5,
@@ -52,7 +49,6 @@ type IconButtonType = {|
 type LinkIconButtonType = {|
   ...BaseIconButton,
   href: string,
-  onNavigationOptions?: OnNavigationOptionsType,
   rel?: 'none' | 'nofollow',
   role: 'link',
   target?: null | 'self' | 'blank',
@@ -128,15 +124,11 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     );
   };
 
-  function handleClick(event) {
-    if (onClick) {
-      onClick({ event });
-    }
-  }
+  const handleClick = (event, disableOnNavigation) =>
+    onClick ? onClick(disableOnNavigation ? { event, disableOnNavigation } : { event }) : undefined;
 
-  function handleLinkClick({ event }) {
-    handleClick(event);
-  }
+  const handleLinkClick = ({ event, disableOnNavigation }) =>
+    handleClick(event, disableOnNavigation);
 
   const handleOnBlur = () => {
     setFocused(false);
@@ -164,7 +156,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
   };
 
   if (props.role === 'link') {
-    const { href, onNavigationOptions, rel, target } = props;
+    const { href, rel, target } = props;
 
     return (
       <InternalLink
@@ -178,7 +170,6 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
         onMouseUp={handleOnMouseUp}
         onMouseEnter={handleOnMouseEnter}
         onMouseLeave={handleOnMouseLeave}
-        onNavigationOptions={onNavigationOptions}
         ref={innerRef}
         rel={rel}
         tabIndex={tabIndex}
@@ -253,7 +244,6 @@ IconButtonWithForwardRef.propTypes = {
   icon: PropTypes.oneOf(Object.keys(icons)),
   iconColor: PropTypes.oneOf(['gray', 'darkGray', 'red', 'white']),
   onClick: PropTypes.func,
-  onNavigationOptions: OnNavigationOptionsPropType,
   padding: PropTypes.oneOf([1, 2, 3, 4, 5]),
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<'none' | 'nofollow'>),
   tabIndex: PropTypes.oneOf([-1, 0]),

--- a/packages/gestalt/src/MenuOption.js
+++ b/packages/gestalt/src/MenuOption.js
@@ -12,10 +12,7 @@ import getRoundingClassName from './getRoundingClassName.js';
 import Icon from './Icon.js';
 import focusStyles from './Focus.css';
 import useFocusVisible from './useFocusVisible.js';
-import {
-  type OnNavigationOptionsType,
-  OnNavigationOptionsPropType,
-} from './contexts/OnNavigation.js';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 export type OptionObject = {|
   label: string,
@@ -27,6 +24,10 @@ type Props = {|
   badgeText?: string,
   children?: Node,
   index: number,
+  onClick?: AbstractEventHandler<
+    SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    {| disableOnNavigation?: () => void |},
+  >,
   option: OptionObject,
   selected?: OptionObject | $ReadOnlyArray<OptionObject> | null,
   handleSelect?: ({|
@@ -42,7 +43,6 @@ type Props = {|
   shouldTruncate?: boolean,
   textWeight?: FontWeight,
   href?: string,
-  onNavigationOptions?: OnNavigationOptionsType,
 |};
 
 export default function MenuOption({
@@ -53,6 +53,7 @@ export default function MenuOption({
   id,
   index,
   isExternal,
+  onClick,
   option,
   role,
   selected,
@@ -61,7 +62,6 @@ export default function MenuOption({
   shouldTruncate = false,
   textWeight = 'normal',
   href,
-  onNavigationOptions,
 }: Props): Node {
   const matches = (Array.isArray(selected) ? selected : []).filter(
     ({ value }) => value === option.value,
@@ -164,12 +164,7 @@ export default function MenuOption({
     >
       <Box padding={2} color={optionStateColor} rounding={2} display="flex" direction="column">
         {href ? (
-          <Link
-            hoverStyle="none"
-            href={href}
-            onNavigationOptions={onNavigationOptions ?? {}}
-            target="blank"
-          >
+          <Link hoverStyle="none" href={href} onClick={onClick} target="blank">
             {menuOptionContents}
           </Link>
         ) : (
@@ -185,6 +180,7 @@ MenuOption.displayName = 'MenuOption';
 MenuOption.propTypes = {
   id: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
+  onClick: PropTypes.func,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   option: PropTypes.exact({
     label: PropTypes.string.isRequired,
@@ -211,5 +207,4 @@ MenuOption.propTypes = {
   setHoveredItem: PropTypes.func,
   setOptionRef: PropTypes.func,
   href: PropTypes.string,
-  onNavigationOptions: OnNavigationOptionsPropType,
 };

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -4,17 +4,18 @@ import Box from './Box.js';
 import Icon from './Icon.js';
 import TableHeaderCell from './TableHeaderCell.js';
 import TapArea from './TapArea.js';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type Props = {|
   children: Node,
   colSpan?: number,
-  onSortChange: ({|
-    event:
-      | SyntheticMouseEvent<HTMLDivElement>
-      | SyntheticKeyboardEvent<HTMLDivElement>
-      | SyntheticMouseEvent<HTMLAnchorElement>
-      | SyntheticKeyboardEvent<HTMLAnchorElement>,
-  |}) => void,
+  onSortChange: AbstractEventHandler<
+    | SyntheticMouseEvent<HTMLDivElement>
+    | SyntheticKeyboardEvent<HTMLDivElement>
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    {| disableOnNavigation?: () => void |},
+  >,
   rowSpan?: number,
   scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',
   sortOrder: 'asc' | 'desc',

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -9,10 +9,6 @@ import getRoundingClassName, { RoundingPropType, type Rounding } from './getRoun
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import focusStyles from './Focus.css';
 import useFocusVisible from './useFocusVisible.js';
-import {
-  type OnNavigationOptionsType,
-  OnNavigationOptionsPropType,
-} from './contexts/OnNavigation.js';
 
 type FocusEventHandler = AbstractEventHandler<
   SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement>,
@@ -38,6 +34,7 @@ type BaseTapArea = {|
     | SyntheticKeyboardEvent<HTMLDivElement>
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    {| disableOnNavigation?: () => void |},
   >,
   tabIndex?: -1 | 0,
   rounding?: Rounding,
@@ -54,7 +51,6 @@ type TapAreaType = {|
 type LinkTapAreaType = {|
   ...BaseTapArea,
   href: string,
-  onNavigationOptions?: OnNavigationOptionsType,
   rel?: 'none' | 'nofollow',
   role: 'link',
   target?: null | 'self' | 'blank',
@@ -119,13 +115,13 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
     },
   );
 
-  const handleClick = (event) => {
-    if (!disabled && onTap) {
-      onTap({ event });
-    }
-  };
+  const handleClick = (event, disableOnNavigation) =>
+    !disabled && onTap
+      ? onTap(disableOnNavigation ? { event, disableOnNavigation } : { event })
+      : undefined;
 
-  const handleLinkClick = ({ event }) => handleClick(event);
+  const handleLinkClick = ({ event, disableOnNavigation }) =>
+    handleClick(event, disableOnNavigation);
 
   const handleOnBlur = (event) => {
     if (!disabled && onBlur) {
@@ -160,7 +156,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
   const handleLinkOnMouseLeave = ({ event }) => handleOnMouseLeave(event);
 
   if (props.role === 'link') {
-    const { href, onNavigationOptions, rel = 'none', target = null } = props;
+    const { href, rel = 'none', target = null } = props;
 
     return (
       <InternalLink
@@ -171,7 +167,6 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
         fullWidth={fullWidth}
         mouseCursor={mouseCursor}
         onClick={handleLinkClick}
-        onNavigationOptions={onNavigationOptions}
         onBlur={handleLinkOnBlur}
         onFocus={handleLinkOnFocus}
         onMouseEnter={handleLinkOnMouseEnter}
@@ -259,7 +254,6 @@ TapAreaWithForwardRef.propTypes = {
   onTap: PropTypes.func,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
-  onNavigationOptions: OnNavigationOptionsPropType,
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<'none' | 'nofollow'>),
   tabIndex: PropTypes.oneOf([-1, 0]),
   role: PropTypes.oneOf(['tapArea', 'link']),

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -47,7 +47,7 @@ const UpsellAction = ({
   type: string,
 |}): Node => {
   const color = type === 'primary' ? 'red' : 'gray';
-  const { accessibilityLabel, href, label, onClick, onNavigationOptions, rel, target } = data;
+  const { accessibilityLabel, href, label, onClick, rel, target } = data;
 
   return (
     <Box
@@ -66,7 +66,6 @@ const UpsellAction = ({
           color={color}
           href={href}
           onClick={onClick}
-          onNavigationOptions={onNavigationOptions}
           rel={rel}
           role="link"
           size="lg"

--- a/packages/gestalt/src/commonTypes.js
+++ b/packages/gestalt/src/commonTypes.js
@@ -1,10 +1,6 @@
 // @flow strict
 import PropTypes from 'prop-types';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
-import {
-  type OnNavigationOptionsType,
-  OnNavigationOptionsPropType,
-} from './contexts/OnNavigation.js';
 
 export type ActionDataType = {|
   accessibilityLabel?: string,
@@ -15,8 +11,8 @@ export type ActionDataType = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
+    {| disableOnNavigation?: () => void |},
   >,
-  onNavigationOptions?: OnNavigationOptionsType,
   rel?: 'none' | 'nofollow',
   target?: null | 'self' | 'blank',
 |};
@@ -28,12 +24,11 @@ export type DismissButtonType = {|
 
 // $FlowFixMe[incompatible-exact]
 export const ActionDataPropType: React$PropType$Primitive<ActionDataType> = PropTypes.exact({
+  accessibilityLabel: PropTypes.string,
   href: PropTypes.string,
   label: PropTypes.string.isRequired,
   // $FlowFixMe[incompatible-type]
   onClick: PropTypes.func,
-  accessibilityLabel: PropTypes.string,
-  onNavigationOptions: OnNavigationOptionsPropType,
   rel: PropTypes.oneOf(['none', 'nofollow']),
   target: PropTypes.oneOf([null, 'self', 'blank']),
 });

--- a/packages/gestalt/src/contexts/OnNavigation.js
+++ b/packages/gestalt/src/contexts/OnNavigation.js
@@ -6,17 +6,8 @@ type EventHandlerType = ({|
   +event: SyntheticEvent<>,
 |}) => void;
 
-export type OnNavigationOptionsType = {|
-  +[string]: Node | EventHandlerType,
-|};
-
-export const OnNavigationOptionsPropType: React$PropType$Primitive<OnNavigationOptionsType> =
-  // $FlowFixMe[incompatible-type]
-  PropTypes.object;
-
 type OnNavigationArgs = {|
   href: string,
-  onNavigationOptions?: OnNavigationOptionsType,
   target?: null | 'self' | 'blank',
 |};
 
@@ -37,16 +28,10 @@ function OnNavigationProvider({ onNavigation, children }: Props): Element<typeof
   return <Provider value={onNavigation ? { onNavigation } : undefined}>{children}</Provider>;
 }
 
-const noop = () => {};
-
-function useOnNavigation({
-  href,
-  onNavigationOptions,
-  target,
-}: OnNavigationArgs): EventHandlerType {
-  const { onNavigation } = useContext(OnNavigationContext) ?? {};
-
-  return onNavigation?.({ href, onNavigationOptions, target }) ?? noop;
+function useOnNavigation({ href, target }: OnNavigationArgs): ?EventHandlerType {
+  const onNavigationContext = useContext(OnNavigationContext);
+  const onNavigationHandler = onNavigationContext?.onNavigation({ href, target });
+  return onNavigationHandler;
 }
 
 export { OnNavigationProvider, useOnNavigation };


### PR DESCRIPTION
FOLLOW UP ON Provider/Link/Button/IconButton/TapArea: implement OnNavigation context for advanced link navigation (#1364)

NOTE: Not using `noop = () => ({})` purposely as these can't take events.

# Problem
Gestalt components do not support link navigation different than a regular `<a>`. Therefore, custom components were needed to wrap Gestalt components and modify their default behavior through the `onClick` event handler. The amount of Gestalt components using Links is increasing from more foundational (Link, Button, IconButton, TapArea) to more composed ones (Callout, Upsell, Dropdown, ActivationCard)

A new solution was needed to prevent the need to wrap components to add external logic, and instead, just internally configure the components so that engineers don't need to worry about custom solutions.

# FOLLOW UP. Solution: A context provider for external link logic passed to consumer components and consumer components with optional custom navigation.

Components with link functionality use simple `<a>` tags. In order to replace the default link functionality with more complex ones (ex. withRouter or spam checking), `onNavigation` provides an interface to implement external logic into the `onClick` event handler in links.

`onNavigation` is a high-order function. It takes named arguments: `href`, `onClick` and `target`.  If passed to Provider, it gets passed down to consumer components where it's executed. Then, `onNavigation` returns a function that gets called during the `onClick` event handler

The `onNavigation` function can contain complex logic, including [React hooks](https://reactjs.org/docs/hooks-reference.html), to perform side effects. It must be a hook function, `useOnNavigation()` to allow React hooks.

The returned event handler function from  `onNavigation` uses the event access to [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault). It could also be used to [stopPropagation()](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation).

Each consumer component has an `onClick ` prop.  Provider can be disabled calling `disableOnNavigation()` inside `onClick`, a callback passed along with the `onClick` event.  After disabling Provider,  we can insert custom navigation behavior in a component level.

# PROS
- We can inject custom link logic to consumer without Provider
- Provider’s onNavigation logic can be disabled / overridden
- API is flexible AND more concise than previous `onNavigationOptions`
- We only need to document the `useOnNavigation()` hook in the codebase (the custom Pinteres-specific logic layer)
- `useOnNavigation()` or `useCustomOnNavigation()` can be reusable hooks across codebase

## Codemod

Detects
```
   <Link onNavigateOptions/>
   <Button onNavigateOptions/>
   <IconButton onNavigateOptions/>
   <TapArea onNavigateOptions/>
   <Dropdown onNavigateOptions/>
   <Callout primaryAction secondaryAction/>
   <Upsell primaryAction secondaryAction/>
   <ActivationCard link/>

``` 
Console logs each component for a manual update.
![image](https://user-images.githubusercontent.com/10593890/109892061-3c907b00-7c58-11eb-9a9a-f75d456856b5.png)

Run
`yarn codemod --parser=flow -t=packages/gestalt-codemods/20.0.0/detect-onNavigateOptions-to-manually-update.js relative/path/to/your/code
`
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
