### PR TITLE
SearchField: Add onKeyDown prop 

### DIFF
--- a/docs/src/SearchField.doc.js
+++ b/docs/src/SearchField.doc.js
@@ -51,6 +51,7 @@ card(
       {
         name: 'onKeyDown',
         type: '({ event: SyntheticKeyboardEvent<HTMLInputElement>, value: string }) => void',
+        description: 'Callback for key stroke events.',
       },
       {
         name: 'placeholder',

--- a/docs/src/SearchField.doc.js
+++ b/docs/src/SearchField.doc.js
@@ -49,6 +49,10 @@ card(
       }) => void`,
       },
       {
+        name: 'onKeyDown',
+        type: '({ event: SyntheticKeyboardEvent<HTMLInputElement>, value: string }) => void',
+      },
+      {
         name: 'placeholder',
         type: 'string',
       },

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -188,6 +188,7 @@ SearchFieldWithForwardRef.propTypes = {
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
   placeholder: PropTypes.string,
   size: PropTypes.oneOf(['md', 'lg']),
   value: PropTypes.string,

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -23,6 +23,10 @@ type Props = {|
     value: string,
     syntheticEvent: SyntheticEvent<HTMLInputElement>,
   |}) => void,
+  onKeyDown?: ({|
+    event: SyntheticKeyboardEvent<HTMLInputElement>,
+    value: string,
+  |}) => void,
   placeholder?: string,
   size?: 'md' | 'lg',
   value?: string,
@@ -40,6 +44,7 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
     onBlur,
     onChange,
     onFocus,
+    onKeyDown,
     placeholder,
     size = 'md',
     value,
@@ -78,6 +83,12 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
     setFocused(false);
     if (onBlur) {
       onBlur({ event });
+    }
+  };
+
+  const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
+    if (onKeyDown) {
+      onKeyDown({ event, value: event.currentTarget.value });
     }
   };
 
@@ -136,6 +147,7 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
           className={className}
           id={id}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
           placeholder={placeholder}
           role="searchbox"
           type="search"

--- a/packages/gestalt/src/SearchField.jsdom.test.js
+++ b/packages/gestalt/src/SearchField.jsdom.test.js
@@ -61,22 +61,24 @@ describe('<SearchField />', () => {
     expect(JSON.stringify(component.toJSON())).not.toContain('Error message');
   });
 
-  it('should call onKeyDown callback when keyboard input is entered', (done) => {
-    const { getByRole } = render(
-      <SearchField
-        accessibilityLabel="Demo Search Field"
-        id="searchField"
-        onChange={() => {}}
-        onKeyDown={({ event, value }) => {
-          expect(value).toEqual('Search');
-          expect(event.key).toEqual('a');
-          done();
-        }}
-        placeholder="Search and explore"
-        size="lg"
-        value="Search"
-      />,
-    );
-    fireEvent.keyDown(getByRole('searchbox'), { key: 'a' });
+  it('should call onKeyDown callback when keyboard input is entered', () => {
+    return new Promise((resolve) => {
+      const { getByRole } = render(
+        <SearchField
+          accessibilityLabel="Demo Search Field"
+          id="searchField"
+          onChange={() => {}}
+          onKeyDown={({ event, value }) => {
+            expect(value).toEqual('Search');
+            expect(event.key).toEqual('a');
+            resolve();
+          }}
+          placeholder="Search and explore"
+          size="lg"
+          value="Search"
+        />,
+      );
+      fireEvent.keyDown(getByRole('searchbox'), { key: 'a' });
+    });
   });
 });

--- a/packages/gestalt/src/SearchField.jsdom.test.js
+++ b/packages/gestalt/src/SearchField.jsdom.test.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { create } from 'react-test-renderer';
 import SearchField from './SearchField.js';
 
@@ -59,5 +59,24 @@ describe('<SearchField />', () => {
       />,
     );
     expect(JSON.stringify(component.toJSON())).not.toContain('Error message');
+  });
+
+  it('should call onKeyDown callback when keyboard input is entered', (done) => {
+    const { getByRole } = render(
+      <SearchField
+        accessibilityLabel="Demo Search Field"
+        id="searchField"
+        onChange={() => {}}
+        onKeyDown={({ event, value }) => {
+          expect(value).toEqual('Search');
+          expect(event.key).toEqual('a');
+          done();
+        }}
+        placeholder="Search and explore"
+        size="lg"
+        value="Search"
+      />,
+    );
+    fireEvent.keyDown(getByRole('searchbox'), { key: 'a' });
   });
 });


### PR DESCRIPTION
I was trying to implement search results dropdown UI for the SearchField gestalt component. But I ran into a roadblock figuring out how to implement keyboard navigation in the search results dropdown since there is no way to handle keyboard events in SearchField. I concluded that this was not possible without adding a `onKeyDown` prop to SearchField. 

Alternatively, I could have used TextField component which has `onKeyDown` prop but I would lose some of the UI benefits of using SearchField such as the icons.

I also considered using Typeahead component but I need to customize the search results UI to more than just rows of text. 

Here is a screenshot of what I'm trying to build:
![Screen Shot 2021-02-28 at 12 13 48 AM](https://user-images.githubusercontent.com/590451/109411891-ea024680-7959-11eb-99a7-a2e9d61328b3.png)

I plan to handle ArrowUp, ArrowDown, and Enter keyboard events to implement keyboard navigation on this dropdown. 

## Test Plan

- Unit tests
- Manual verification that the callback works. 
