### PR TITLE
Docs: fix Box z-index bug

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -881,7 +881,13 @@ function Example() {
   const HEADER_ZINDEX = new FixedZIndex(100);
   const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
   return (
-    <Box height={150} column={12} overflow="scroll" tabIndex={0}>
+    <Box
+      column={12}
+      dangerouslySetInlineStyle={{ __style: { isolation: 'isolate' } }}
+      height={150}
+      overflow="scroll"
+      tabIndex={0}
+    >
       <Sticky top={0} zIndex={HEADER_ZINDEX}>
         <Box color="maroon" width="80%" height={60} padding={2}>
           <Text color="white">This is sticky and won't move when scrolling</Text>


### PR DESCRIPTION
We have a subtle bug on the new Box docs page, where the code example covers the header:

https://user-images.githubusercontent.com/12059539/109564651-381c6480-7a96-11eb-93bc-262c8e1e5e57.mov

Obviously not a show-stopper, but a little annoying, right?

While reading a blog post, [this section](https://www.joshwcomeau.com/css/stacking-contexts/#airtight-abstractions-with-isolation) jumped out at me. A possible solution for this bug? As it turns out: yes!


https://user-images.githubusercontent.com/12059539/109564848-79ad0f80-7a96-11eb-90d4-24556dae01f1.mov

