### PR TITLE
Module: Fix border-radius + misc cleanup

### DIFF
--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -132,15 +132,11 @@ card(
 function ModuleExample() {
   return (
     <Flex direction="column" gap={2} maxWidth={800}>
-      <Module
-        id="ModuleExample - default - 1"
-        >
+      <Module id="ModuleExample - default - 1">
         <Text size="md">This is example content.</Text>
       </Module>
-      <Module
-        id="ModuleExample - default - 2"
-        title="Title"
-        >
+
+      <Module id="ModuleExample - default - 2" title="Title">
         <Text size="md">This is example content.</Text>
       </Module>
     </Flex>
@@ -162,12 +158,12 @@ card(
     defaultCode={`
 function ModuleExample() {
   return (
-    <Box maxWidth={800} padding={2} column={12}>
+    <Box column={12} maxWidth={800} padding={2}>
       <Module
-        id="ModuleExample - icon"
-        title="Title"
         icon="lock"
         iconAccessibilityLabel="Module Locked - check permission settings"
+        id="ModuleExample - icon"
+        title="Title"
         >
         <Text size="md">This is example content.</Text>
       </Module>
@@ -185,23 +181,25 @@ card(
     defaultCode={`
 function ModuleExample() {
   const [value, setValue] = React.useState('');
+
   return (
-    <Box maxWidth={800} padding={2} column={12}>
+    <Box column={12} maxWidth={800} padding={2}>
       <Module
         id="ModuleExample - error"
         title="Personal Info"
         type={!value ? "error" : "info"}
-        >
-        <Box marginBottom={4}>
+      >
+        <Flex direction="column" gap={4}>
           <Text size="md">This is example content.</Text>
-        </Box>
-        <TextField
-          id="first-name"
-          errorMessage={!value ? "This field can't be blank!" : null}
-          onChange={({ value }) => setValue(value)}
-          label="Enter Your Name"
-          value={value}
-        />
+
+          <TextField
+            errorMessage={!value ? "This field can't be blank!" : null}
+            id="first-name"
+            label="Enter Your Name"
+            onChange={({ value }) => setValue(value)}
+            value={value}
+          />
+        </Flex>
       </Module>
     </Box>
   );
@@ -218,16 +216,16 @@ card(
     defaultCode={`
 function ModuleExample1() {
   return (
-    <Box maxWidth={800} padding={2} column={12} >
+    <Box column={12} maxWidth={800} padding={2}>
       <Module.Expandable
-        id="ModuleExample - default"
         accessibilityExpandLabel="Expand the module"
         accessibilityCollapseLabel="Collapse the module"
+        id="ModuleExample - default"
         items={[
           {
-            title: 'Title',
-            summary: ['summary1', 'summary2', 'summary3'],
             children: <Text size="md">Children1</Text>,
+            summary: ['summary1', 'summary2', 'summary3'],
+            title: 'Title',
           }]}>
       </Module.Expandable>
     </Box>
@@ -245,26 +243,26 @@ card(
     defaultCode={`
 function ModuleExample2() {
   return (
-    <Box maxWidth={800} padding={2} column={12} >
+    <Box column={12} maxWidth={800} padding={2}>
       <Module.Expandable
         id="ModuleExample2"
         accessibilityExpandLabel="Expand the module"
         accessibilityCollapseLabel="Collapse the module"
         items={[
           {
-            title: 'Title1',
-            summary: ['summary1'],
             children: <Text size="md">Children1</Text>,
+            summary: ['summary1'],
+            title: 'Title1',
           },
           {
-            title: 'Title2',
-            summary: ['summary2'],
             children: <Text size="md">Children2</Text>,
+            summary: ['summary2'],
+            title: 'Title2',
           },
           {
-            title: 'Title3',
-            summary: ['summary3'],
             children: <Text size="md">Children3</Text>,
+            summary: ['summary3'],
+            title: 'Title3',
           }]}>
       </Module.Expandable>
     </Box>
@@ -281,17 +279,17 @@ card(
     defaultCode={`
 function ModuleExample3() {
   return (
-    <Box maxWidth={800} padding={2} column={12} >
+    <Box column={12} maxWidth={800} padding={2}>
       <Module.Expandable
-        id="ModuleExample3"
         accessibilityExpandLabel="Expand the module"
         accessibilityCollapseLabel="Collapse the module"
+        id="ModuleExample3"
         items={[
           {
-            title: 'Example with icon',
             children: <Text size="md">Children1</Text>,
             iconAccessibilityLabel: "title icon",
             icon: 'lock',
+            title: 'Example with icon',
           }]}>
       </Module.Expandable>
     </Box>
@@ -309,26 +307,27 @@ function ModuleExample4() {
   const [value, setValue] = React.useState('');
   const moduleType = !value ? 'error' : 'info';
   const summaryInfo = !value ? 'Name is missing' : 'Name: ' + value;
+
   return (
-    <Box maxWidth={800} padding={2} column={12}>
+    <Box column={12} maxWidth={800} padding={2}>
       <Module.Expandable
-        id="ModuleExample4"
         accessibilityExpandLabel="Expand the module"
         accessibilityCollapseLabel="Collapse the module"
+        id="ModuleExample4"
         items={[
           {
-            title: 'Personal Info',
-            summary: [summaryInfo],
             children: <Text size="md">
               <TextField
-                id="aboutme"
                 errorMessage={!value ? "This field can't be blank!" : null}
-                onChange={({ value }) => setValue(value)}
+                id="aboutme"
                 label="Enter Your Name"
+                onChange={({ value }) => setValue(value)}
                 value={value}
               />
             </Text>,
             iconAccessibilityLabel: "error icon",
+            summary: [summaryInfo],
+            title: 'Personal Info',
             type: moduleType
           }]}>
       </Module.Expandable>
@@ -352,16 +351,18 @@ function ModuleExample5() {
       'second-1': 1,
   }
   return (
-    <Box maxWidth={800} padding={2} column={12}>
-      <Flex direction='column' gap={3}>
-        <Box padding={1} borderStyle='sm'>
-          <Text>Step 1</Text>
+    <Box column={12} maxWidth={800} padding={2}>
+      <Flex direction="column" gap={4}>
+        <Flex direction="column" gap={2}>
+          <Box marginStart={2}>
+            <Text>Step 1</Text>
+          </Box>
+
           <Module.Expandable
-            id="ModuleExampleStep1"
             accessibilityExpandLabel="Expand the module"
             accessibilityCollapseLabel="Collapse the module"
             expandedIndex={extExpandedId && extExpandedId.startsWith('first') && mapIds[extExpandedId]}
-            onExpandedChange={(index) => setExtExpandedId(Number.isFinite(index) ? \`first-$\{index}\`: index)}
+            id="ModuleExampleStep1"
             items={[
               {
                 title: 'Title1',
@@ -374,10 +375,15 @@ function ModuleExample5() {
                 children: <Text size="md">Children2</Text>,
               },
             ]}
+            onExpandedChange={(index) => setExtExpandedId(Number.isFinite(index) ? \`first-$\{index}\`: index)}
           />
-        </Box>
-        <Box padding={1} borderStyle='sm'>
-          <Text>Step 2</Text>
+        </Flex>
+
+        <Flex direction="column" gap={2}>
+          <Box marginStart={2}>
+            <Text>Step 2</Text>
+          </Box>
+
           <Module.Expandable
             id="ModuleExampleStep2"
             accessibilityExpandLabel="Expand the module"
@@ -397,7 +403,7 @@ function ModuleExample5() {
               },
             ]}
           />
-        </Box>
+        </Flex>
       </Flex>
     </Box>
   );

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -1,33 +1,39 @@
 // @flow strict
 import React, { type Node } from 'react';
 import Box from './Box.js';
-import { type BaseProps } from './moduleTypes.js';
+import Flex from './Flex.js';
 import ModuleTitle from './ModuleTitle.js';
 import ModuleExpandable from './ModuleExpandable.js';
+import { type BaseModuleProps } from './moduleTypes.js';
+
+type Props = {|
+  ...BaseModuleProps,
+  id: string,
+|};
 
 export default function Module({
   children,
-  id,
   icon,
   iconAccessibilityLabel,
+  id,
   title,
   type = 'info',
-}: BaseProps): Node {
+}: Props): Node {
   return (
-    <Box id={id} rounding={2} borderStyle="shadow" direction="column">
-      {title && (
-        <Box padding={6} display="flex">
+    <Box borderStyle="shadow" id={id} padding={6} rounding={4}>
+      <Flex direction="column" gap={6}>
+        {title && (
           <ModuleTitle
-            type={type}
-            title={title}
             icon={icon}
             iconAccessibilityLabel={iconAccessibilityLabel}
+            title={title}
+            type={type}
           />
-        </Box>
-      )}
-      <Box marginTop={title ? -6 : 0} padding={6}>
-        {children}
-      </Box>
+        )}
+
+        {/* Flex.Item necessary to prevent gap from being applied to each child */}
+        <Flex.Item>{children}</Flex.Item>
+      </Flex>
     </Box>
   );
 }

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -1,53 +1,63 @@
 // @flow strict
-import React, { useState, useEffect, type Node } from 'react';
+import React, { Fragment, type Node, useState, useEffect } from 'react';
 import Box from './Box.js';
 import Divider from './Divider.js';
 import ModuleExpandableItem from './ModuleExpandableItem.js';
-import { type ExpandableBaseProps } from './moduleTypes.js';
+import { type ModuleExpandableItemBaseProps } from './moduleTypes.js';
+
+function getExpandedId(expandedIndex: ?number): ?number {
+  return Number.isFinite(expandedIndex) ? expandedIndex : null;
+}
+
+type Props = {|
+  accessibilityExpandLabel: string,
+  accessibilityCollapseLabel: string,
+  expandedIndex?: ?number,
+  id: string,
+  items: $ReadOnlyArray<ModuleExpandableItemBaseProps>,
+  onExpandedChange?: (?number) => void,
+|};
 
 export default function ModuleExpandable({
-  id,
   accessibilityExpandLabel,
   accessibilityCollapseLabel,
   expandedIndex,
-  onExpandedChange,
+  id,
   items,
-}: ExpandableBaseProps): Node {
-  const [expandedId, setExpandedId] = useState<?number>(
-    Number.isFinite(expandedIndex) ? expandedIndex : null,
-  );
+  onExpandedChange,
+}: Props): Node {
+  const [expandedId, setExpandedId] = useState<?number>(getExpandedId(expandedIndex));
 
   useEffect(() => {
-    setExpandedId(Number.isFinite(expandedIndex) ? expandedIndex : null);
+    setExpandedId(getExpandedId(expandedIndex));
   }, [expandedIndex, setExpandedId]);
 
   return (
-    <Box rounding={2} borderStyle="shadow">
-      {items.map(({ icon, iconAccessibilityLabel, title, type, summary, children }, index) => (
-        <React.Fragment key={index}>
-          <Box>
-            <ModuleExpandableItem
-              id={`${id}-${index}`}
-              title={title}
-              icon={icon}
-              iconAccessibilityLabel={iconAccessibilityLabel}
-              summary={summary}
-              isCollapsed={expandedId !== index}
-              type={type}
-              accessibilityExpandLabel={accessibilityExpandLabel}
-              accessibilityCollapseLabel={accessibilityCollapseLabel}
-              onModuleClicked={(isExpanded) => {
-                if (onExpandedChange) {
-                  onExpandedChange(isExpanded ? null : index);
-                }
-                setExpandedId(isExpanded ? null : index);
-              }}
-            >
-              {children}
-            </ModuleExpandableItem>
-          </Box>
+    <Box borderStyle="shadow" rounding={4}>
+      {items.map(({ children, icon, iconAccessibilityLabel, summary, title, type }, index) => (
+        <Fragment key={index}>
+          <ModuleExpandableItem
+            accessibilityCollapseLabel={accessibilityCollapseLabel}
+            accessibilityExpandLabel={accessibilityExpandLabel}
+            icon={icon}
+            iconAccessibilityLabel={iconAccessibilityLabel}
+            id={`${id}-${index}`}
+            isCollapsed={expandedId !== index}
+            onModuleClicked={(isExpanded) => {
+              if (onExpandedChange) {
+                onExpandedChange(isExpanded ? null : index);
+              }
+              setExpandedId(isExpanded ? null : index);
+            }}
+            summary={summary}
+            title={title}
+            type={type}
+          >
+            {children}
+          </ModuleExpandableItem>
+
           {index !== items.length - 1 && <Divider />}
-        </React.Fragment>
+        </Fragment>
       ))}
     </Box>
   );

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -1,83 +1,88 @@
 // @flow strict
-import React, { Fragment, type Node } from 'react';
+import React, { type Node } from 'react';
 import Box from './Box.js';
+import Flex from './Flex.js';
 import Icon from './Icon.js';
+import ModuleTitle from './ModuleTitle.js';
 import TapArea from './TapArea.js';
 import Text from './Text.js';
-import { type BaseProps, type ExpandableItemProps } from './moduleTypes.js';
-import ModuleTitle from './ModuleTitle.js';
+import { type ModuleExpandableItemBaseProps } from './moduleTypes.js';
 
 type Props = {|
-  ...BaseProps,
-  ...ExpandableItemProps,
+  ...ModuleExpandableItemBaseProps,
+  accessibilityExpandLabel: string,
+  accessibilityCollapseLabel: string,
+  id: string,
+  isCollapsed: boolean,
+  onModuleClicked: (boolean) => void,
 |};
 
 export default function ModuleExpandableItem({
-  id,
-  title,
+  accessibilityCollapseLabel,
+  accessibilityExpandLabel,
+  children,
   icon,
   iconAccessibilityLabel,
-  accessibilityExpandLabel,
-  accessibilityCollapseLabel,
-  summary,
+  id,
   isCollapsed,
   onModuleClicked,
+  summary,
+  title,
   type = 'info',
-  children,
 }: Props): Node {
   return (
-    <Fragment>
-      <TapArea
-        onTap={() => {
-          onModuleClicked(!isCollapsed);
-        }}
-        accessibilityLabel={isCollapsed ? accessibilityExpandLabel : accessibilityCollapseLabel}
-        accessibilityControls={id}
-        accessibilityExpanded={!isCollapsed}
-      >
-        <Box padding={6} display="flex">
-          <Box display="flex" flex="grow" marginEnd={6} alignItems="baseline">
-            <Box column={isCollapsed && summary ? 6 : 12} display="flex">
-              <ModuleTitle
-                type={type}
-                title={title}
-                icon={icon}
-                iconAccessibilityLabel={iconAccessibilityLabel}
-              />
-            </Box>
-            {summary && isCollapsed && (
-              <Box column={6} marginStart={6}>
-                {summary.map((item, i) => (
-                  <Box key={i} marginBottom={i === summary.length - 1 ? 0 : 2}>
-                    <Text size="md" truncate>
-                      {item}
-                    </Text>
-                  </Box>
-                ))}
+    <Box padding={6}>
+      <Flex direction="column" gap={6}>
+        <TapArea
+          accessibilityControls={id}
+          accessibilityExpanded={!isCollapsed}
+          accessibilityLabel={isCollapsed ? accessibilityExpandLabel : accessibilityCollapseLabel}
+          onTap={() => {
+            onModuleClicked(!isCollapsed);
+          }}
+        >
+          <Flex>
+            <Box alignItems="baseline" display="flex" flex="grow" marginEnd={6}>
+              <Box column={isCollapsed && summary ? 6 : 12}>
+                <ModuleTitle
+                  icon={icon}
+                  iconAccessibilityLabel={iconAccessibilityLabel}
+                  title={title}
+                  type={type}
+                />
               </Box>
-            )}
-          </Box>
-          <Box id={id}>
+
+              {summary && isCollapsed && (
+                <Box column={6} marginStart={6}>
+                  <Flex direction="column" gap={2}>
+                    {summary.map((item, i) => (
+                      <Text key={i} size="md" truncate>
+                        {item}
+                      </Text>
+                    ))}
+                  </Flex>
+                </Box>
+              )}
+            </Box>
+
             {children && (
-              <Box padding={1}>
+              <Box id={id} padding={1}>
                 <Icon
-                  icon={isCollapsed ? 'arrow-down' : 'arrow-up'}
-                  color="darkGray"
-                  size="12"
                   accessibilityLabel={
                     isCollapsed ? accessibilityExpandLabel : accessibilityCollapseLabel
                   }
+                  color="darkGray"
+                  icon={isCollapsed ? 'arrow-down' : 'arrow-up'}
+                  size="12"
                 />
               </Box>
             )}
-          </Box>
-        </Box>
-      </TapArea>
-      {!isCollapsed && (
-        <Box marginTop={-6} padding={6}>
-          {children}
-        </Box>
-      )}
-    </Fragment>
+          </Flex>
+        </TapArea>
+
+        {/* Flex.Item necessary to prevent gap from being applied to each child */}
+        {!isCollapsed && <Flex.Item>{children}</Flex.Item>}
+      </Flex>
+    </Box>
   );
 }

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -1,14 +1,22 @@
 // @flow strict
-import React, { Fragment, type Node } from 'react';
-import Box from './Box.js';
+import React, { type Node } from 'react';
+import Flex from './Flex.js';
 import Icon from './Icon.js';
 import Text from './Text.js';
-import { type TitleProps } from './moduleTypes.js';
+import icons from './icons/index.js';
+import { type TypeOptions } from './moduleTypes.js';
+
+type TitleProps = {|
+  icon?: $Keys<typeof icons>,
+  iconAccessibilityLabel?: string,
+  title: string,
+  type: TypeOptions,
+|};
 
 export default function ModuleTitle({
-  title,
   icon,
   iconAccessibilityLabel,
+  title,
   type = 'info',
 }: TitleProps): Node {
   const MODULE_TYPE_ATTRIBUTES = {
@@ -21,20 +29,18 @@ export default function ModuleTitle({
       color: 'red',
     },
   };
+
+  const { color, icon: iconName } = MODULE_TYPE_ATTRIBUTES[type];
+
   return (
-    <Fragment>
-      {MODULE_TYPE_ATTRIBUTES[type].icon && (
-        <Box marginEnd={2}>
-          <Icon
-            icon={MODULE_TYPE_ATTRIBUTES[type].icon}
-            accessibilityLabel={iconAccessibilityLabel || ''}
-            color={MODULE_TYPE_ATTRIBUTES[type].color}
-          />
-        </Box>
+    <Flex gap={2}>
+      {iconName && (
+        <Icon accessibilityLabel={iconAccessibilityLabel ?? ''} color={color} icon={iconName} />
       )}
-      <Text weight="bold" truncate color={MODULE_TYPE_ATTRIBUTES[type].color}>
+
+      <Text color={color} truncate weight="bold">
         {title}
       </Text>
-    </Fragment>
+    </Flex>
   );
 }

--- a/packages/gestalt/src/__snapshots__/Module.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Module.test.js.snap
@@ -2,64 +2,88 @@
 
 exports[`Module renders a title correctly 1`] = `
 <div
-  className="box rounding2 shadow xsDirectionColumn"
+  className="box paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
-    className="box paddingX6 paddingY6 xsDisplayFlex"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-      title="Module Test"
+      className="FlexItem"
     >
-      Module Test
+      <div
+        className="Flex rowGap2 xsDirectionRow"
+      >
+        <div
+          className="FlexItem"
+        >
+          <div
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+            title="Module Test"
+          >
+            Module Test
+          </div>
+        </div>
+      </div>
     </div>
+    <div
+      className="FlexItem"
+    />
   </div>
-  <div
-    className="box marginTopN6 paddingX6 paddingY6"
-  />
 </div>
 `;
 
 exports[`Module renders an error correctly 1`] = `
 <div
-  className="box rounding2 shadow xsDirectionColumn"
+  className="box paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
-    className="box paddingX6 paddingY6 xsDisplayFlex"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="box marginEnd2"
+      className="FlexItem"
     >
-      <svg
-        aria-hidden={null}
-        aria-label="locked"
-        className="icon red iconBlock"
-        height={16}
-        role="img"
-        viewBox="0 0 24 24"
-        width={16}
+      <div
+        className="Flex rowGap2 xsDirectionRow"
       >
-        <path
-          d="test-file-stub"
-        />
-      </svg>
+        <div
+          className="FlexItem"
+        >
+          <svg
+            aria-hidden={null}
+            aria-label="locked"
+            className="icon red iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
+        <div
+          className="FlexItem"
+        >
+          <div
+            className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
+            title="Testing"
+          >
+            Testing
+          </div>
+        </div>
+      </div>
     </div>
     <div
-      className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
-      title="Testing"
+      className="FlexItem"
     >
-      Testing
-    </div>
-  </div>
-  <div
-    className="box marginTopN6 paddingX6 paddingY6"
-  >
-    <div
-      className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-    >
-      Testing
+      <div
+        className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+      >
+        Testing
+      </div>
     </div>
   </div>
 </div>
@@ -67,43 +91,55 @@ exports[`Module renders an error correctly 1`] = `
 
 exports[`Module renders an icon correctly 1`] = `
 <div
-  className="box rounding2 shadow xsDirectionColumn"
+  className="box paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
-    className="box paddingX6 paddingY6 xsDisplayFlex"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="box marginEnd2"
+      className="FlexItem"
     >
-      <svg
-        aria-hidden={null}
-        aria-label="locked"
-        className="icon darkGray iconBlock"
-        height={16}
-        role="img"
-        viewBox="0 0 24 24"
-        width={16}
+      <div
+        className="Flex rowGap2 xsDirectionRow"
       >
-        <path
-          d="test-file-stub"
-        />
-      </svg>
+        <div
+          className="FlexItem"
+        >
+          <svg
+            aria-hidden={null}
+            aria-label="locked"
+            className="icon darkGray iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
+        <div
+          className="FlexItem"
+        >
+          <div
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+            title="Testing"
+          >
+            Testing
+          </div>
+        </div>
+      </div>
     </div>
     <div
-      className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-      title="Testing"
+      className="FlexItem"
     >
-      Testing
-    </div>
-  </div>
-  <div
-    className="box marginTopN6 paddingX6 paddingY6"
-  >
-    <div
-      className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
-    >
-      Testing
+      <div
+        className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+      >
+        Testing
+      </div>
     </div>
   </div>
 </div>
@@ -111,16 +147,20 @@ exports[`Module renders an icon correctly 1`] = `
 
 exports[`Module renders content correctly 1`] = `
 <div
-  className="box rounding2 shadow xsDirectionColumn"
+  className="box paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
-    className="box marginTop0 paddingX6 paddingY6"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+      className="FlexItem"
     >
-      Testing
+      <div
+        className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+      >
+        Testing
+      </div>
     </div>
   </div>
 </div>
@@ -128,11 +168,15 @@ exports[`Module renders content correctly 1`] = `
 
 exports[`Module renders the base correctly 1`] = `
 <div
-  className="box rounding2 shadow xsDirectionColumn"
+  className="box paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
-    className="box marginTop0 paddingX6 paddingY6"
-  />
+    className="Flex columnGap6 xsDirectionColumn"
+  >
+    <div
+      className="FlexItem"
+    />
+  </div>
 </div>
 `;

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -2,269 +2,317 @@
 
 exports[`Module Expandable renders correctly with multiple items 1`] = `
 <div
-  className="box rounding2 shadow"
+  className="box rounding4 shadow"
 >
   <div
-    className="box"
+    className="box paddingX6 paddingY6"
   >
     <div
-      aria-controls="uniqueTestID-0"
-      aria-disabled={false}
-      aria-expanded={false}
-      aria-label="click to expand"
-      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="button"
-      tabIndex={0}
+      className="Flex columnGap6 xsDirectionColumn"
     >
       <div
-        className="box paddingX6 paddingY6 xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+          aria-controls="uniqueTestID-0"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-label="click to expand"
+          className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={0}
         >
           <div
-            className="box xsCol6 xsDisplayFlex"
+            className="Flex rowGap0 xsDirectionRow"
           >
             <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-              title="Title1"
-            >
-              Title1
-            </div>
-          </div>
-          <div
-            className="box marginStart6 xsCol6"
-          >
-            <div
-              className="box marginBottom0"
+              className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
             >
               <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary1"
+                className="box xsCol6"
               >
-                summary1
+                <div
+                  className="Flex rowGap2 xsDirectionRow"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                      title="Title1"
+                    >
+                      Title1
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="box"
-          id="uniqueTestID-0"
-        >
-          <div
-            className="box paddingX1 paddingY1"
-          >
-            <svg
-              aria-hidden={null}
-              aria-label="click to expand"
-              className="icon darkGray iconBlock"
-              height="12"
-              role="img"
-              viewBox="0 0 24 24"
-              width="12"
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <hr
-    className="divider"
-  />
-  <div
-    className="box"
-  >
-    <div
-      aria-controls="uniqueTestID-1"
-      aria-disabled={false}
-      aria-expanded={false}
-      aria-label="click to expand"
-      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="button"
-      tabIndex={0}
-    >
-      <div
-        className="box paddingX6 paddingY6 xsDisplayFlex"
-      >
-        <div
-          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
-        >
-          <div
-            className="box xsCol6 xsDisplayFlex"
-          >
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-              title="Title2"
-            >
-              Title2
-            </div>
-          </div>
-          <div
-            className="box marginStart6 xsCol6"
-          >
-            <div
-              className="box marginBottom0"
-            >
               <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary2"
+                className="box marginStart6 xsCol6"
               >
-                summary2
+                <div
+                  className="Flex columnGap2 xsDirectionColumn"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                      title="summary1"
+                    >
+                      summary1
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-        <div
-          className="box"
-          id="uniqueTestID-1"
-        >
-          <div
-            className="box paddingX1 paddingY1"
-          >
-            <svg
-              aria-hidden={null}
-              aria-label="click to expand"
-              className="icon darkGray iconBlock"
-              height="12"
-              role="img"
-              viewBox="0 0 24 24"
-              width="12"
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <hr
-    className="divider"
-  />
-  <div
-    className="box"
-  >
-    <div
-      aria-controls="uniqueTestID-2"
-      aria-disabled={false}
-      aria-expanded={false}
-      aria-label="click to expand"
-      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="button"
-      tabIndex={0}
-    >
-      <div
-        className="box paddingX6 paddingY6 xsDisplayFlex"
-      >
-        <div
-          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
-        >
-          <div
-            className="box xsCol6 xsDisplayFlex"
-          >
             <div
-              className="box marginEnd2"
+              className="box paddingX1 paddingY1"
+              id="uniqueTestID-0"
             >
               <svg
-                aria-hidden={true}
-                aria-label=""
-                className="icon red iconBlock"
-                height={16}
+                aria-hidden={null}
+                aria-label="click to expand"
+                className="icon darkGray iconBlock"
+                height="12"
                 role="img"
                 viewBox="0 0 24 24"
-                width={16}
+                width="12"
               >
                 <path
                   d="test-file-stub"
                 />
               </svg>
             </div>
-            <div
-              className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
-              title="Title3"
-            >
-              Title3
-            </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="divider"
+  />
+  <div
+    className="box paddingX6 paddingY6"
+  >
+    <div
+      className="Flex columnGap6 xsDirectionColumn"
+    >
+      <div
+        className="FlexItem"
+      >
+        <div
+          aria-controls="uniqueTestID-1"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-label="click to expand"
+          className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={0}
+        >
           <div
-            className="box marginStart6 xsCol6"
+            className="Flex rowGap0 xsDirectionRow"
           >
             <div
-              className="box marginBottom0"
+              className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
             >
               <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary3"
+                className="box xsCol6"
               >
-                summary3
+                <div
+                  className="Flex rowGap2 xsDirectionRow"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                      title="Title2"
+                    >
+                      Title2
+                    </div>
+                  </div>
+                </div>
               </div>
+              <div
+                className="box marginStart6 xsCol6"
+              >
+                <div
+                  className="Flex columnGap2 xsDirectionColumn"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                      title="summary2"
+                    >
+                      summary2
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="box paddingX1 paddingY1"
+              id="uniqueTestID-1"
+            >
+              <svg
+                aria-hidden={null}
+                aria-label="click to expand"
+                className="icon darkGray iconBlock"
+                height="12"
+                role="img"
+                viewBox="0 0 24 24"
+                width="12"
+              >
+                <path
+                  d="test-file-stub"
+                />
+              </svg>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="divider"
+  />
+  <div
+    className="box paddingX6 paddingY6"
+  >
+    <div
+      className="Flex columnGap6 xsDirectionColumn"
+    >
+      <div
+        className="FlexItem"
+      >
         <div
-          className="box"
-          id="uniqueTestID-2"
+          aria-controls="uniqueTestID-2"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-label="click to expand"
+          className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={0}
         >
           <div
-            className="box paddingX1 paddingY1"
+            className="Flex rowGap0 xsDirectionRow"
           >
-            <svg
-              aria-hidden={null}
-              aria-label="click to expand"
-              className="icon darkGray iconBlock"
-              height="12"
-              role="img"
-              viewBox="0 0 24 24"
-              width="12"
+            <div
+              className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
             >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
+              <div
+                className="box xsCol6"
+              >
+                <div
+                  className="Flex rowGap2 xsDirectionRow"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-label=""
+                      className="icon red iconBlock"
+                      height={16}
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width={16}
+                    >
+                      <path
+                        d="test-file-stub"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
+                      title="Title3"
+                    >
+                      Title3
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="box marginStart6 xsCol6"
+              >
+                <div
+                  className="Flex columnGap2 xsDirectionColumn"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                      title="summary3"
+                    >
+                      summary3
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="box paddingX1 paddingY1"
+              id="uniqueTestID-2"
+            >
+              <svg
+                aria-hidden={null}
+                aria-label="click to expand"
+                className="icon darkGray iconBlock"
+                height="12"
+                role="img"
+                viewBox="0 0 24 24"
+                width="12"
+              >
+                <path
+                  d="test-file-stub"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -275,104 +323,120 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
 
 exports[`Module Expandable renders correctly with one item 1`] = `
 <div
-  className="box rounding2 shadow"
+  className="box rounding4 shadow"
 >
   <div
-    className="box"
+    className="box paddingX6 paddingY6"
   >
     <div
-      aria-controls="uniqueTestID-0"
-      aria-disabled={false}
-      aria-expanded={false}
-      aria-label="click to expand"
-      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="button"
-      tabIndex={0}
+      className="Flex columnGap6 xsDirectionColumn"
     >
       <div
-        className="box paddingX6 paddingY6 xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+          aria-controls="uniqueTestID-0"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-label="click to expand"
+          className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={0}
         >
           <div
-            className="box xsCol6 xsDisplayFlex"
+            className="Flex rowGap0 xsDirectionRow"
           >
             <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-              title="Title"
-            >
-              Title
-            </div>
-          </div>
-          <div
-            className="box marginStart6 xsCol6"
-          >
-            <div
-              className="box marginBottom2"
+              className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
             >
               <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary1"
+                className="box xsCol6"
               >
-                summary1
+                <div
+                  className="Flex rowGap2 xsDirectionRow"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                      title="Title"
+                    >
+                      Title
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="box marginStart6 xsCol6"
+              >
+                <div
+                  className="Flex columnGap2 xsDirectionColumn"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                      title="summary1"
+                    >
+                      summary1
+                    </div>
+                  </div>
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                      title="summary2"
+                    >
+                      summary2
+                    </div>
+                  </div>
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                      title="summary3"
+                    >
+                      summary3
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
             <div
-              className="box marginBottom2"
+              className="box paddingX1 paddingY1"
+              id="uniqueTestID-0"
             >
-              <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary2"
+              <svg
+                aria-hidden={null}
+                aria-label="click to expand"
+                className="icon darkGray iconBlock"
+                height="12"
+                role="img"
+                viewBox="0 0 24 24"
+                width="12"
               >
-                summary2
-              </div>
+                <path
+                  d="test-file-stub"
+                />
+              </svg>
             </div>
-            <div
-              className="box marginBottom0"
-            >
-              <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary3"
-              >
-                summary3
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="box"
-          id="uniqueTestID-0"
-        >
-          <div
-            className="box paddingX1 paddingY1"
-          >
-            <svg
-              aria-hidden={null}
-              aria-label="click to expand"
-              className="icon darkGray iconBlock"
-              height="12"
-              role="img"
-              viewBox="0 0 24 24"
-              width="12"
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
           </div>
         </div>
       </div>
@@ -383,260 +447,304 @@ exports[`Module Expandable renders correctly with one item 1`] = `
 
 exports[`renders correctly with multiple items with expandedId 1`] = `
 <div
-  className="box rounding2 shadow"
+  className="box rounding4 shadow"
 >
   <div
-    className="box"
+    className="box paddingX6 paddingY6"
   >
     <div
-      aria-controls="uniqueTestID-0"
-      aria-disabled={false}
-      aria-expanded={true}
-      aria-label="click to collapse"
-      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="button"
-      tabIndex={0}
+      className="Flex columnGap6 xsDirectionColumn"
     >
       <div
-        className="box paddingX6 paddingY6 xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+          aria-controls="uniqueTestID-0"
+          aria-disabled={false}
+          aria-expanded={true}
+          aria-label="click to collapse"
+          className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={0}
         >
           <div
-            className="box xsCol12 xsDisplayFlex"
+            className="Flex rowGap0 xsDirectionRow"
           >
             <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-              title="Title1"
-            >
-              Title1
-            </div>
-          </div>
-        </div>
-        <div
-          className="box"
-          id="uniqueTestID-0"
-        >
-          <div
-            className="box paddingX1 paddingY1"
-          >
-            <svg
-              aria-hidden={null}
-              aria-label="click to collapse"
-              className="icon darkGray iconBlock"
-              height="12"
-              role="img"
-              viewBox="0 0 24 24"
-              width="12"
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="box marginTopN6 paddingX6 paddingY6"
-    >
-      Children1
-    </div>
-  </div>
-  <hr
-    className="divider"
-  />
-  <div
-    className="box"
-  >
-    <div
-      aria-controls="uniqueTestID-1"
-      aria-disabled={false}
-      aria-expanded={false}
-      aria-label="click to expand"
-      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="button"
-      tabIndex={0}
-    >
-      <div
-        className="box paddingX6 paddingY6 xsDisplayFlex"
-      >
-        <div
-          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
-        >
-          <div
-            className="box xsCol6 xsDisplayFlex"
-          >
-            <div
-              className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-              title="Title2"
-            >
-              Title2
-            </div>
-          </div>
-          <div
-            className="box marginStart6 xsCol6"
-          >
-            <div
-              className="box marginBottom0"
+              className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
             >
               <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary2"
+                className="box xsCol12"
               >
-                summary2
+                <div
+                  className="Flex rowGap2 xsDirectionRow"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                      title="Title1"
+                    >
+                      Title1
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-        <div
-          className="box"
-          id="uniqueTestID-1"
-        >
-          <div
-            className="box paddingX1 paddingY1"
-          >
-            <svg
-              aria-hidden={null}
-              aria-label="click to expand"
-              className="icon darkGray iconBlock"
-              height="12"
-              role="img"
-              viewBox="0 0 24 24"
-              width="12"
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <hr
-    className="divider"
-  />
-  <div
-    className="box"
-  >
-    <div
-      aria-controls="uniqueTestID-2"
-      aria-disabled={false}
-      aria-expanded={false}
-      aria-label="click to expand"
-      className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="button"
-      tabIndex={0}
-    >
-      <div
-        className="box paddingX6 paddingY6 xsDisplayFlex"
-      >
-        <div
-          className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
-        >
-          <div
-            className="box xsCol6 xsDisplayFlex"
-          >
             <div
-              className="box marginEnd2"
+              className="box paddingX1 paddingY1"
+              id="uniqueTestID-0"
             >
               <svg
-                aria-hidden={true}
-                aria-label=""
-                className="icon red iconBlock"
-                height={16}
+                aria-hidden={null}
+                aria-label="click to collapse"
+                className="icon darkGray iconBlock"
+                height="12"
                 role="img"
                 viewBox="0 0 24 24"
-                width={16}
+                width="12"
               >
                 <path
                   d="test-file-stub"
                 />
               </svg>
             </div>
-            <div
-              className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
-              title="Title3"
-            >
-              Title3
-            </div>
           </div>
+        </div>
+      </div>
+      <div
+        className="FlexItem"
+      >
+        Children1
+      </div>
+    </div>
+  </div>
+  <hr
+    className="divider"
+  />
+  <div
+    className="box paddingX6 paddingY6"
+  >
+    <div
+      className="Flex columnGap6 xsDirectionColumn"
+    >
+      <div
+        className="FlexItem"
+      >
+        <div
+          aria-controls="uniqueTestID-1"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-label="click to expand"
+          className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={0}
+        >
           <div
-            className="box marginStart6 xsCol6"
+            className="Flex rowGap0 xsDirectionRow"
           >
             <div
-              className="box marginBottom0"
+              className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
             >
               <div
-                className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-                title="summary3"
+                className="box xsCol6"
               >
-                summary3
+                <div
+                  className="Flex rowGap2 xsDirectionRow"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                      title="Title2"
+                    >
+                      Title2
+                    </div>
+                  </div>
+                </div>
               </div>
+              <div
+                className="box marginStart6 xsCol6"
+              >
+                <div
+                  className="Flex columnGap2 xsDirectionColumn"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                      title="summary2"
+                    >
+                      summary2
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="box paddingX1 paddingY1"
+              id="uniqueTestID-1"
+            >
+              <svg
+                aria-hidden={null}
+                aria-label="click to expand"
+                className="icon darkGray iconBlock"
+                height="12"
+                role="img"
+                viewBox="0 0 24 24"
+                width="12"
+              >
+                <path
+                  d="test-file-stub"
+                />
+              </svg>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+  <hr
+    className="divider"
+  />
+  <div
+    className="box paddingX6 paddingY6"
+  >
+    <div
+      className="Flex columnGap6 xsDirectionColumn"
+    >
+      <div
+        className="FlexItem"
+      >
         <div
-          className="box"
-          id="uniqueTestID-2"
+          aria-controls="uniqueTestID-2"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-label="click to expand"
+          className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={0}
         >
           <div
-            className="box paddingX1 paddingY1"
+            className="Flex rowGap0 xsDirectionRow"
           >
-            <svg
-              aria-hidden={null}
-              aria-label="click to expand"
-              className="icon darkGray iconBlock"
-              height="12"
-              role="img"
-              viewBox="0 0 24 24"
-              width="12"
+            <div
+              className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
             >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
+              <div
+                className="box xsCol6"
+              >
+                <div
+                  className="Flex rowGap2 xsDirectionRow"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-label=""
+                      className="icon red iconBlock"
+                      height={16}
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width={16}
+                    >
+                      <path
+                        d="test-file-stub"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
+                      title="Title3"
+                    >
+                      Title3
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="box marginStart6 xsCol6"
+              >
+                <div
+                  className="Flex columnGap2 xsDirectionColumn"
+                >
+                  <div
+                    className="FlexItem"
+                  >
+                    <div
+                      className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                      title="summary3"
+                    >
+                      summary3
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="box paddingX1 paddingY1"
+              id="uniqueTestID-2"
+            >
+              <svg
+                aria-hidden={null}
+                aria-label="click to expand"
+                className="icon darkGray iconBlock"
+                height="12"
+                role="img"
+                viewBox="0 0 24 24"
+                width="12"
+              >
+                <path
+                  d="test-file-stub"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
@@ -2,383 +2,481 @@
 
 exports[`ModuleExpandableItem renders correctly 1`] = `
 <div
-  aria-controls="uniqueTestID"
-  aria-disabled={false}
-  aria-expanded={false}
-  aria-label="click to expand"
-  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onFocus={[Function]}
-  onKeyPress={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  role="button"
-  tabIndex={0}
+  className="box paddingX6 paddingY6"
 >
   <div
-    className="box paddingX6 paddingY6 xsDisplayFlex"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+      className="FlexItem"
     >
       <div
-        className="box xsCol12 xsDisplayFlex"
+        aria-controls="uniqueTestID"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-label="click to expand"
+        className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
       >
         <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-          title="test title"
+          className="Flex rowGap0 xsDirectionRow"
         >
-          test title
+          <div
+            className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+          >
+            <div
+              className="box xsCol12"
+            >
+              <div
+                className="Flex rowGap2 xsDirectionRow"
+              >
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                    title="test title"
+                  >
+                    test title
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div
-      className="box"
-      id="uniqueTestID"
-    />
   </div>
 </div>
 `;
 
 exports[`ModuleExpandableItem renders correctly with children 1`] = `
 <div
-  aria-controls="uniqueTestID"
-  aria-disabled={false}
-  aria-expanded={false}
-  aria-label="click to expand"
-  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onFocus={[Function]}
-  onKeyPress={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  role="button"
-  tabIndex={0}
+  className="box paddingX6 paddingY6"
 >
   <div
-    className="box paddingX6 paddingY6 xsDisplayFlex"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+      className="FlexItem"
     >
       <div
-        className="box xsCol12 xsDisplayFlex"
+        aria-controls="uniqueTestID"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-label="click to expand"
+        className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
       >
         <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-          title="test title"
+          className="Flex rowGap0 xsDirectionRow"
         >
-          test title
+          <div
+            className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+          >
+            <div
+              className="box xsCol12"
+            >
+              <div
+                className="Flex rowGap2 xsDirectionRow"
+              >
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                    title="test title"
+                  >
+                    test title
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div
-      className="box"
-      id="uniqueTestID"
-    />
   </div>
 </div>
 `;
 
 exports[`ModuleExpandableItem renders correctly with error 1`] = `
 <div
-  aria-controls="uniqueTestID"
-  aria-disabled={false}
-  aria-expanded={false}
-  aria-label="click to expand"
-  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onFocus={[Function]}
-  onKeyPress={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  role="button"
-  tabIndex={0}
+  className="box paddingX6 paddingY6"
 >
   <div
-    className="box paddingX6 paddingY6 xsDisplayFlex"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+      className="FlexItem"
     >
       <div
-        className="box xsCol12 xsDisplayFlex"
+        aria-controls="uniqueTestID"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-label="click to expand"
+        className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
       >
         <div
-          className="box marginEnd2"
+          className="Flex rowGap0 xsDirectionRow"
         >
-          <svg
-            aria-hidden={true}
-            aria-label=""
-            className="icon red iconBlock"
-            height={16}
-            role="img"
-            viewBox="0 0 24 24"
-            width={16}
+          <div
+            className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
           >
-            <path
-              d="test-file-stub"
-            />
-          </svg>
-        </div>
-        <div
-          className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
-          title="test title"
-        >
-          test title
+            <div
+              className="box xsCol12"
+            >
+              <div
+                className="Flex rowGap2 xsDirectionRow"
+              >
+                <div
+                  className="FlexItem"
+                >
+                  <svg
+                    aria-hidden={true}
+                    aria-label=""
+                    className="icon red iconBlock"
+                    height={16}
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="test-file-stub"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
+                    title="test title"
+                  >
+                    test title
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div
-      className="box"
-      id="uniqueTestID"
-    />
   </div>
 </div>
 `;
 
 exports[`ModuleExpandableItem renders correctly with icon 1`] = `
 <div
-  aria-controls="uniqueTestID"
-  aria-disabled={false}
-  aria-expanded={false}
-  aria-label="click to expand"
-  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onFocus={[Function]}
-  onKeyPress={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  role="button"
-  tabIndex={0}
+  className="box paddingX6 paddingY6"
 >
   <div
-    className="box paddingX6 paddingY6 xsDisplayFlex"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+      className="FlexItem"
     >
       <div
-        className="box xsCol12 xsDisplayFlex"
+        aria-controls="uniqueTestID"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-label="click to expand"
+        className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
       >
         <div
-          className="box marginEnd2"
+          className="Flex rowGap0 xsDirectionRow"
         >
-          <svg
-            aria-hidden={null}
-            aria-label="lock icon label"
-            className="icon darkGray iconBlock"
-            height={16}
-            role="img"
-            viewBox="0 0 24 24"
-            width={16}
+          <div
+            className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
           >
-            <path
-              d="test-file-stub"
-            />
-          </svg>
-        </div>
-        <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-          title="test title"
-        >
-          test title
+            <div
+              className="box xsCol12"
+            >
+              <div
+                className="Flex rowGap2 xsDirectionRow"
+              >
+                <div
+                  className="FlexItem"
+                >
+                  <svg
+                    aria-hidden={null}
+                    aria-label="lock icon label"
+                    className="icon darkGray iconBlock"
+                    height={16}
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="test-file-stub"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                    title="test title"
+                  >
+                    test title
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div
-      className="box"
-      id="uniqueTestID"
-    />
   </div>
 </div>
 `;
 
 exports[`ModuleExpandableItem renders correctly with summary 1`] = `
 <div
-  aria-controls="uniqueTestID"
-  aria-disabled={false}
-  aria-expanded={false}
-  aria-label="click to expand"
-  className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onContextMenu={[Function]}
-  onFocus={[Function]}
-  onKeyPress={[Function]}
-  onMouseDown={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  role="button"
-  tabIndex={0}
+  className="box paddingX6 paddingY6"
 >
   <div
-    className="box paddingX6 paddingY6 xsDisplayFlex"
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+      className="FlexItem"
     >
       <div
-        className="box xsCol6 xsDisplayFlex"
+        aria-controls="uniqueTestID"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-label="click to expand"
+        className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
       >
         <div
-          className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-          title="test title"
-        >
-          test title
-        </div>
-      </div>
-      <div
-        className="box marginStart6 xsCol6"
-      >
-        <div
-          className="box marginBottom2"
+          className="Flex rowGap0 xsDirectionRow"
         >
           <div
-            className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-            title="summary1"
+            className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
           >
-            summary1
-          </div>
-        </div>
-        <div
-          className="box marginBottom2"
-        >
-          <div
-            className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-            title="summary2"
-          >
-            summary2
-          </div>
-        </div>
-        <div
-          className="box marginBottom0"
-        >
-          <div
-            className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
-            title="summary3"
-          >
-            summary3
+            <div
+              className="box xsCol6"
+            >
+              <div
+                className="Flex rowGap2 xsDirectionRow"
+              >
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                    title="test title"
+                  >
+                    test title
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="box marginStart6 xsCol6"
+            >
+              <div
+                className="Flex columnGap2 xsDirectionColumn"
+              >
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                    title="summary1"
+                  >
+                    summary1
+                  </div>
+                </div>
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                    title="summary2"
+                  >
+                    summary2
+                  </div>
+                </div>
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize2 darkGray alignLeft breakWord fontWeightNormal truncate"
+                    title="summary3"
+                  >
+                    summary3
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
-    <div
-      className="box"
-      id="uniqueTestID"
-    />
   </div>
 </div>
 `;
 
 exports[`ModuleExpandableItem renders correctly with when expanded 1`] = `
-Array [
+<div
+  className="box paddingX6 paddingY6"
+>
   <div
-    aria-controls="uniqueTestID"
-    aria-disabled={false}
-    aria-expanded={true}
-    aria-label="click to collapse"
-    className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onContextMenu={[Function]}
-    onFocus={[Function]}
-    onKeyPress={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    tabIndex={0}
+    className="Flex columnGap6 xsDirectionColumn"
   >
     <div
-      className="box paddingX6 paddingY6 xsDisplayFlex"
+      className="FlexItem"
     >
       <div
-        className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+        aria-controls="uniqueTestID"
+        aria-disabled={false}
+        aria-expanded={true}
+        aria-label="click to collapse"
+        className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
       >
         <div
-          className="box xsCol12 xsDisplayFlex"
+          className="Flex rowGap0 xsDirectionRow"
         >
           <div
-            className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
-            title="test title"
+            className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
           >
-            test title
+            <div
+              className="box xsCol12"
+            >
+              <div
+                className="Flex rowGap2 xsDirectionRow"
+              >
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                    title="test title"
+                  >
+                    test title
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="box paddingX1 paddingY1"
+            id="uniqueTestID"
+          >
+            <svg
+              aria-hidden={null}
+              aria-label="click to collapse"
+              className="icon darkGray iconBlock"
+              height="12"
+              role="img"
+              viewBox="0 0 24 24"
+              width="12"
+            >
+              <path
+                d="test-file-stub"
+              />
+            </svg>
           </div>
         </div>
       </div>
-      <div
-        className="box"
-        id="uniqueTestID"
-      >
-        <div
-          className="box paddingX1 paddingY1"
-        >
-          <svg
-            aria-hidden={null}
-            aria-label="click to collapse"
-            className="icon darkGray iconBlock"
-            height="12"
-            role="img"
-            viewBox="0 0 24 24"
-            width="12"
-          >
-            <path
-              d="test-file-stub"
-            />
-          </svg>
-        </div>
+    </div>
+    <div
+      className="FlexItem"
+    >
+      <div>
+        test children
       </div>
     </div>
-  </div>,
-  <div
-    className="box marginTopN6 paddingX6 paddingY6"
-  >
-    <div>
-      test children
-    </div>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/packages/gestalt/src/moduleTypes.js
+++ b/packages/gestalt/src/moduleTypes.js
@@ -2,44 +2,18 @@
 import { type Node } from 'react';
 import icons from './icons/index.js';
 
-type TypeOptions = 'error' | 'info';
+export type TypeOptions = 'error' | 'info';
 
-export type BaseProps = {|
-  id: string,
-  title?: string,
-  icon?: $Keys<typeof icons>,
-  iconAccessibilityLabel?: string,
-  type?: TypeOptions,
+export type BaseModuleProps = {|
   children?: Node,
-|};
-
-export type ExpandableBaseProps = {|
-  id: string,
-  accessibilityExpandLabel: string,
-  accessibilityCollapseLabel: string,
-  expandedIndex?: ?number,
-  items: $ReadOnlyArray<{|
-    title: string,
-    icon?: $Keys<typeof icons>,
-    iconAccessibilityLabel?: string,
-    summary?: $ReadOnlyArray<string>,
-    type?: TypeOptions,
-    children?: Node,
-  |}>,
-  onExpandedChange?: (?number) => void,
-|};
-
-export type ExpandableItemProps = {|
-  accessibilityExpandLabel: string,
-  accessibilityCollapseLabel: string,
-  summary?: $ReadOnlyArray<string>,
-  isCollapsed: boolean,
-  onModuleClicked: (boolean) => void,
-|};
-
-export type TitleProps = {|
-  title?: string,
   icon?: $Keys<typeof icons>,
   iconAccessibilityLabel?: string,
+  title?: string,
   type?: TypeOptions,
+|};
+
+export type ModuleExpandableItemBaseProps = {|
+  ...BaseModuleProps,
+  summary?: $ReadOnlyArray<string>,
+  title: string, // overwriting base to be required
 |};


### PR DESCRIPTION
Per https://jira.pinadmin.com/browse/PDS-2601, Module was using the wrong border-radius. This PR updates that value. It also includes misc cleanup to simplify markup, lint/prettify the docs examples code, etc.

## PR Changes

- Border radius to 16px

DESIGN | BEFORE | AFTER
------------- | ------------ | -------------
![image](https://user-images.githubusercontent.com/10593890/110160577-31edf700-7dba-11eb-87cb-f4b0a627d177.png) | ![image](https://user-images.githubusercontent.com/10593890/110160420-0408b280-7dba-11eb-9c1f-cc61bafd2903.png) | ![image](https://user-images.githubusercontent.com/10593890/110160474-1125a180-7dba-11eb-98df-4f1649990091.png)
![image](https://user-images.githubusercontent.com/10593890/110160236-bf7d1700-7db9-11eb-8b1e-9a04e0d968f8.png) | ![image](https://user-images.githubusercontent.com/10593890/110160274-c99f1580-7db9-11eb-970a-22e46d9fa7b3.png) | ![image](https://user-images.githubusercontent.com/10593890/110160312-d7549b00-7db9-11eb-813e-a3dc6caca213.png)

- Refactor Module and subModules props so shared ones are in separate files but non-shared ones stay in the same file. Alphabetize.
- Refactor Module and subModules to replace Flex with Box when possible
- Refactor Module.Expandable/ExpandableItem to replace misused Fragments with Box
- Docs: cleanup for better reading and prop alphabetization.