### PR TITLE
Typeahead: Add `disabled` prop and highlight selected value on activation

### DIFF
--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -450,4 +450,61 @@ function Example(props) {
   />,
 );
 
+card(
+  <Example
+    id="programaticallySetExample"
+    name="Set Programatically"
+    defaultCode={`
+function Example(props) {
+  const [item, setItem] = React.useState('');
+  const [selected, setSelected] = React.useState(null);
+
+  const options = Array.from(Array(20).keys()).map((item) => ({
+    value: 'Value-' + (item + 1),
+    label: 'Label-' + (item + 1),
+  }));
+
+  const handleOnChange = ({ value }) => {
+    setItem(value);
+  };
+
+  const handleSelect = ({ item }) => {
+    setSelected(item);
+  };
+
+  if (selected !== null) console.log(selected.value);
+
+  const label = 'Selected Item: ' + ((selected && selected.label) || '');
+
+  return (
+    <React.Fragment>
+      <Box marginBottom={4}>
+        <Text>Selected Item: {(selected && selected.label) || ''}</Text>
+      </Box>
+
+      <Typeahead
+        label="Typeahead Example 1"
+        id="Typeahead-example"
+        noResultText="No Results"
+        options={options}
+        placeholder="Select a Label"
+        onChange={handleOnChange}
+        onSelect={handleSelect}
+      />
+      <Typeahead
+        label="Typeahead Example 2"
+        id="Typeahead-example"
+        noResultText="No Results"
+        options={options}
+        value={(selected && selected.value) || 'Value-5'}
+        placeholder="Select a Label"
+        onChange={handleOnChange}
+        onSelect={handleSelect}
+      />
+    </React.Fragment>
+  );
+}`}
+  />,
+);
+
 export default cards;

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -294,15 +294,23 @@ card(
     name="Disabled"
     defaultCode={`
 function TypeaheadExample() {
+  const [disabled, setDisabled] = React.useState(true)
+  const label = "Typeahead is " + (disabled ? "disabled" : "enabled");
+
   return (
+    <Box>
+      <Box marginBottom={6} >
+        <Button text={(!disabled ? "Disable" : "Enable") + " typeahead"} onClick={()=>{setDisabled(prev => !prev)}} />
+      </Box>
       <Typeahead
-        disabled
-        label="This typeahead is disabled"
-        id="favorite-shape"
+        disabled={disabled}
+        label={label}
+        id="disabled-example"
         noResultText="No Results"
         options={[{label:'square', value:'square'}, {label:'circle', value:'circle'}]}
-        placeholder="This Typeahead is disabled"
+        placeholder={label}
       />
+    </Box>
   );
 }`}
   />,

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -454,14 +454,16 @@ card(
   <Example
     id="programaticallySetExample"
     name="Set Programatically"
+    description={`
+    When Typeahead needs to be set based on another value or programically you can use the \`key={}\` to trigger a component refresh which will rerender the component with the new value.`}
     defaultCode={`
 function Example(props) {
-  const [item, setItem] = React.useState('');
+  const [item, setItem] = React.useState("");
   const [selected, setSelected] = React.useState(null);
 
   const options = Array.from(Array(20).keys()).map((item) => ({
-    value: 'Value-' + (item + 1),
-    label: 'Label-' + (item + 1),
+    value: "Value-" + (item + 1),
+    label: "Label-" + (item + 1),
   }));
 
   const handleOnChange = ({ value }) => {
@@ -472,31 +474,29 @@ function Example(props) {
     setSelected(item);
   };
 
-  if (selected !== null) console.log(selected.value);
-
-  const label = 'Selected Item: ' + ((selected && selected.label) || '');
+  const label = "Selected Item: " + ((selected && selected.label) || "");
 
   return (
     <React.Fragment>
       <Box marginBottom={4}>
-        <Text>Selected Item: {(selected && selected.label) || ''}</Text>
+        <Button
+          text="Set Value 6"
+          onClick={() => {
+            setSelected({
+              value: "Value-6",
+              label: "Label-6",
+            });
+          }}
+        />
       </Box>
 
       <Typeahead
-        label="Typeahead Example 1"
+        key={label}
+        label="Typeahead Example"
         id="Typeahead-example"
         noResultText="No Results"
         options={options}
-        placeholder="Select a Label"
-        onChange={handleOnChange}
-        onSelect={handleSelect}
-      />
-      <Typeahead
-        label="Typeahead Example 2"
-        id="Typeahead-example"
-        noResultText="No Results"
-        options={options}
-        value={(selected && selected.value) || 'Value-5'}
+        value={(selected && selected.value) || "Value-5"}
         placeholder="Select a Label"
         onChange={handleOnChange}
         onSelect={handleSelect}

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -294,8 +294,6 @@ card(
     name="Disabled"
     defaultCode={`
 function TypeaheadExample() {
-  const ref = React.useRef();
-  const [option, setOption] = React.useState();
   return (
       <Typeahead
         disabled
@@ -303,8 +301,7 @@ function TypeaheadExample() {
         id="favorite-shape"
         noResultText="No Results"
         options={[{label:'square', value:'square'}, {label:'circle', value:'circle'}]}
-        onSelect={p => ref.current.focus()}
-        placeholder="Select a shape"
+        placeholder="This Typeahead is disabled"
       />
   );
 }`}

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -59,6 +59,7 @@ card(
         type: 'boolean',
         required: false,
         description: 'Set disabled state so typeahead looks inactive and cannot be interacted with',
+        href: 'disabledExample',
       },
       {
         name: 'onChange',
@@ -282,6 +283,29 @@ function TypeaheadExample() {
         ref={ref}
       />
     </Flex>
+  );
+}`}
+  />,
+);
+
+card(
+  <Example
+    id="disabledExample"
+    name="Disabled"
+    defaultCode={`
+function TypeaheadExample() {
+  const ref = React.useRef();
+  const [option, setOption] = React.useState();
+  return (
+      <Typeahead
+        disabled
+        label="This typeahead is disabled"
+        id="favorite-shape"
+        noResultText="No Results"
+        options={[{label:'square', value:'square'}, {label:'circle', value:'circle'}]}
+        onSelect={p => ref.current.focus()}
+        placeholder="Select a shape"
+      />
   );
 }`}
   />,

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -51,10 +51,15 @@ card(
         name: 'onBlur',
         type:
           '({ event: SyntheticFocusEvent<HTMLInputElement> | SyntheticEvent<HTMLInputElement> , value: string }) => void',
-        description: 'Callback when you focus outside the component ',
+        description: 'Callback when you focus outside the component',
         href: 'basicExample',
       },
-
+      {
+        name: 'disabled',
+        type: 'boolean',
+        required: false,
+        description: 'Set disabled state so typeahead looks inactive and cannot be interacted with',
+      },
       {
         name: 'onChange',
         type: '({ event: SyntheticInputEvent<>, value: string }) => void',

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -55,8 +55,8 @@ type Props = {|
 const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
->(function Typeahead(
-  {
+>(function Typeahead(props, ref): Node {
+  const {
     disabled = false,
     id,
     label,
@@ -72,9 +72,8 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     tags,
     value = null,
     zIndex,
-  },
-  ref,
-): Node {
+  } = props;
+
   // Parent ref for positioning
   const wrapperRef = useRef(null);
 

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -91,13 +91,10 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   // Track input value
   const defaultOption: OptionObject | null = findDefaultOption(value);
   const [search, setSearch] = useState<string>(defaultOption?.label || '');
-  console.log('defaultOption:', defaultOption?.label, value, search);
 
   // Track the selected item - could be used to see if someone is selecting the same thing again
   const [selected, setSelected] = useState<OptionObject | null>(defaultOption);
-
   const [hoveredItem, setHoveredItem] = useState<number | null>(0);
-
   const [availableOptions, setAvailableOptions] = useState<$ReadOnlyArray<OptionObject>>(options);
 
   // Ref to the input

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -20,7 +20,7 @@ import handleContainerScrolling, { type DirectionOptionType } from './utils/keyb
 import { type Indexable, UnsafeIndexablePropType } from './zIndex.js';
 
 type Props = {|
-  disabled: boolean,
+  disabled?: boolean,
   id: string,
   label?: string,
   noResultText: string,
@@ -159,6 +159,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
 
     setSearch(item.label);
     setContainerOpen(false);
+
     if (inputRef.current) inputRef.current.focus();
     if (onSelect) onSelect({ event, item });
   };

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -20,6 +20,7 @@ import handleContainerScrolling, { type DirectionOptionType } from './utils/keyb
 import { type Indexable, UnsafeIndexablePropType } from './zIndex.js';
 
 type Props = {|
+  disabled: boolean,
   id: string,
   label?: string,
   noResultText: string,
@@ -54,8 +55,9 @@ type Props = {|
 const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
->(function Typeahead(props, ref): Node {
-  const {
+>(function Typeahead(
+  {
+    disabled = false,
     id,
     label,
     noResultText,
@@ -70,8 +72,9 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     tags,
     value = null,
     zIndex,
-  } = props;
-
+  },
+  ref,
+): Node {
   // Parent ref for positioning
   const wrapperRef = useRef(null);
 
@@ -216,6 +219,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   return (
     <Box position="relative" ref={wrapperRef}>
       <TypeaheadInputField
+        disabled={disabled}
         label={label}
         id={id}
         value={search}
@@ -288,6 +292,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
 
 // $FlowFixMe[prop-missing] flow 0.135.0 upgrade
 TypeaheadWithForwardRef.propTypes = {
+  disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
   label: PropTypes.string,
   noResultText: PropTypes.string.isRequired,

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -91,6 +91,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   // Track input value
   const defaultOption: OptionObject | null = findDefaultOption(value);
   const [search, setSearch] = useState<string>(defaultOption?.label || '');
+  console.log('defaultOption:', defaultOption?.label, value, search);
 
   // Track the selected item - could be used to see if someone is selecting the same thing again
   const [selected, setSelected] = useState<OptionObject | null>(defaultOption);

--- a/packages/gestalt/src/Typeahead.jsdom.test.js
+++ b/packages/gestalt/src/Typeahead.jsdom.test.js
@@ -44,6 +44,24 @@ describe('Typeahead', () => {
     expect(resultsContainer.length).toBe(TOTAL_OPTIONS);
   });
 
+  it('is disabled', () => {
+    const { container } = render(
+      <Typeahead
+        disabled
+        id="Typeahead"
+        noResultText="No Result"
+        options={FAKE_OPTIONS}
+        placeholder="Select a Label"
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        onSelect={onSelectMock}
+        label="Typeahead Example"
+      />,
+    );
+    expect(container.querySelector('input[disabled]')).toBeVisible();
+    expect(container.querySelector('button[disabled]')).toBeVisible();
+  });
+
   it('clears menu on blur', () => {
     render(Component);
     const textField = screen.getByRole('textbox', { id: 'Typeahead' });

--- a/packages/gestalt/src/Typeahead.jsdom.test.js
+++ b/packages/gestalt/src/Typeahead.jsdom.test.js
@@ -62,6 +62,32 @@ describe('Typeahead', () => {
     expect(container.querySelector('button[disabled]')).toBeVisible();
   });
 
+  it('value highlighted on activation', () => {
+    const { container } = render(
+      <Typeahead
+        disabled
+        id="Typeahead"
+        noResultText="No Result"
+        options={FAKE_OPTIONS}
+        placeholder="Select a Label"
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        onSelect={onSelectMock}
+        value="Value-5"
+        label="Typeahead Example"
+      />,
+    );
+    expect(container.querySelector('input')).toBeVisible();
+    expect(container.querySelector('input').value).toBe('label-5');
+
+    const textField = screen.getByRole('textbox', { id: 'Typeahead' });
+    textField.click();
+
+    const selectedValue = textField.value.substr(0, textField.selectionEnd);
+
+    expect(selectedValue.toLowerCase()).toBe('label-5');
+  });
+
   it('clears menu on blur', () => {
     render(Component);
     const textField = screen.getByRole('textbox', { id: 'Typeahead' });

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -15,6 +15,7 @@ import { ENTER, UP_ARROW, DOWN_ARROW } from './keyCodes.js';
 
 type Props = {|
   forwardedRef?: Ref<'input'>,
+  disabled: boolean,
   id: string,
   label?: string,
   onBlur: ({|
@@ -47,6 +48,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
 > = forwardRef<Props, HTMLInputElement>(function InputField(props, ref): Node {
   const {
     id,
+    disabled = false,
     label,
     onBlur,
     onChange,
@@ -140,6 +142,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
   const inputElement = (
     <input
       ref={ref}
+      disabled={disabled}
       autoComplete="off"
       aria-label={label}
       className={tags ? typeaheadStyle.unstyledInput : className}
@@ -225,6 +228,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
 
 // $FlowFixMe[prop-missing] flow 0.135.0 upgrade
 TypeaheadInputFieldWithForwardRef.propTypes = {
+  disabled: PropTypes.bool,
   label: PropTypes.string,
   id: PropTypes.string.isRequired,
   onBlur: PropTypes.func,

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -64,6 +64,8 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
     value,
   } = props;
 
+  console.log('VALUE', value);
+
   const [hovered, setHovered] = useState<boolean>(false);
   const [focused, setFocused] = useState(false);
 

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -16,7 +16,7 @@ import { ENTER, UP_ARROW, DOWN_ARROW } from './keyCodes.js';
 
 type Props = {|
   forwardedRef?: Ref<'input'>,
-  disabled: boolean,
+  disabled?: boolean,
   id: string,
   label?: string,
   onBlur: ({|
@@ -160,8 +160,9 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
     />
   );
 
-  const iconButton = !disabled && (
+  const iconButton = (
     <button
+      disabled={disabled}
       className={hasValue ? styles.clear : typeaheadStyle.icon}
       onClick={!hasValue ? handleClick : handleClear}
       tabIndex={-1}

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -1,5 +1,13 @@
 // @flow strict
-import React, { forwardRef, Fragment, type Element, type Node, type Ref, useState } from 'react';
+import React, {
+  useImperativeHandle,
+  forwardRef,
+  Fragment,
+  type Element,
+  type Node,
+  useState,
+  useRef,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import focusStyles from './Focus.css';
@@ -15,7 +23,6 @@ import { type DirectionOptionType } from './utils/keyboardNavigation.js';
 import { ENTER, UP_ARROW, DOWN_ARROW } from './keyCodes.js';
 
 type Props = {|
-  forwardedRef?: Ref<'input'>,
   disabled?: boolean,
   id: string,
   label?: string,
@@ -63,6 +70,12 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
     tags,
     value,
   } = props;
+
+  const innerRef = useRef(null);
+
+  // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
+  // that renders <Typeahead ref={inputRef} /> to call inputRef.current.focus()
+  useImperativeHandle(ref, () => innerRef.current);
 
   const [hovered, setHovered] = useState<boolean>(false);
   const [focused, setFocused] = useState(false);
@@ -140,10 +153,8 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
 
   const highlightSelectedInput = () => {
     // Highlight selected text on click
-    if (ref.current) {
-      // $FlowFixMe[unclear-type]
-      const inputField: HTMLInputElement = (ref.current: any);
-      inputField.select();
+    if (innerRef && innerRef.current) {
+      innerRef.current.select();
     }
   };
 
@@ -152,7 +163,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
 
   const inputElement = (
     <input
-      ref={ref}
+      ref={innerRef}
       disabled={disabled}
       autoComplete="off"
       aria-label={label}

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -49,7 +49,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
 > = forwardRef<Props, HTMLInputElement>(function InputField(props, ref): Node {
   const {
     id,
-    disabled = false,
+    disabled,
     label,
     onBlur,
     onChange,

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -64,8 +64,6 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
     value,
   } = props;
 
-  console.log('VALUE', value);
-
   const [hovered, setHovered] = useState<boolean>(false);
   const [focused, setFocused] = useState(false);
 
@@ -140,6 +138,15 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
       : {},
   );
 
+  const highlightSelectedInput = () => {
+    // Highlight selected text on click
+    if (ref.current) {
+      // $FlowFixMe[unclear-type]
+      const inputField: HTMLInputElement = (ref.current: any);
+      inputField.select();
+    }
+  };
+
   const clearButtonSize = size === 'lg' ? 24 : 20;
   const clearIconSize = size === 'lg' ? 12 : 10;
 
@@ -153,7 +160,11 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
       id={id}
       onFocus={handleFocus}
       onBlur={handleBlur}
-      onClick={() => setContainer(true)}
+      onClick={() => {
+        setContainer(true);
+
+        highlightSelectedInput();
+      }}
       onChange={handleChange}
       placeholder={placeholder}
       type="text"

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import focusStyles from './Focus.css';
 import layout from './Layout.css';
 import styles from './SearchField.css';
+import formElement from './FormElement.css';
 import typeaheadStyle from './TypeaheadInputField.css';
 import Box from './Box.js';
 import Icon from './Icon.js';
@@ -122,6 +123,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
   const className = classnames(
     styles.input,
     styles.inputActive,
+    disabled ? formElement.disabled : formElement.enabled,
     typeaheadStyle.inputRadius,
     {
       [layout.medium]: size === 'md',
@@ -158,7 +160,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
     />
   );
 
-  const iconButton = (
+  const iconButton = !disabled && (
     <button
       className={hasValue ? styles.clear : typeaheadStyle.icon}
       onClick={!hasValue ? handleClick : handleClear}

--- a/packages/gestalt/src/__snapshots__/Typeahead.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Typeahead.jsdom.test.js.snap
@@ -26,7 +26,8 @@ exports[`Typeahead renders Typeahead normal 1`] = `
     <input
       aria-label="Typeahead Example"
       autoComplete="off"
-      className="input inputActive inputRadius medium"
+      className="input inputActive enabled inputRadius medium"
+      disabled={false}
       id="Typeahead"
       onBlur={[Function]}
       onChange={[Function]}
@@ -39,6 +40,7 @@ exports[`Typeahead renders Typeahead normal 1`] = `
     />
     <button
       className="icon"
+      disabled={false}
       onClick={[Function]}
       tabIndex={-1}
       type="button"
@@ -95,7 +97,7 @@ exports[`Typeahead renders tags when supplied 1`] = `
     onMouseLeave={[Function]}
   >
     <div
-      className="input inputActive inputRadius medium inputWrapper"
+      className="input inputActive enabled inputRadius medium inputWrapper"
     >
       <div
         className="box marginBottom1 marginEnd1"
@@ -295,6 +297,7 @@ exports[`Typeahead renders tags when supplied 1`] = `
           aria-label="Tag Example"
           autoComplete="off"
           className="unstyledInput"
+          disabled={false}
           id="test"
           onBlur={[Function]}
           onChange={[Function]}
@@ -307,6 +310,7 @@ exports[`Typeahead renders tags when supplied 1`] = `
       </div>
       <button
         className="clear"
+        disabled={false}
         onClick={[Function]}
         tabIndex={-1}
         type="button"


### PR DESCRIPTION
Add the ability to disable the typeahead component 

![image](https://user-images.githubusercontent.com/5871660/110073627-c6594a80-7d23-11eb-810d-36afaef81884.png)

When user clicks a typeahead with a value, highlight the value so you can start typing right away 
![image](https://user-images.githubusercontent.com/5871660/110353107-c6cf3b00-7fda-11eb-924a-8aeb27a7f2a4.png)
