### PR TITLE
FeedbackCallout: Simplify API

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -10,9 +10,7 @@ import FeedbackCallout from './components/FeedbackCallout.js';
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
 
-card(
-  <FeedbackCallout link="https://docs.google.com/forms/d/e/1FAIpQLSe7h8kVcD7QqvPvjkE8s8WvnuFfhYvAEQ6L7tZwPgHjJPAbSw/viewform?usp=pp_url&entry.847151274=Box" />,
-);
+card(<FeedbackCallout componentName="Box" />);
 
 card(
   <PageHeader

--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -8,9 +8,7 @@ import FeedbackCallout from './components/FeedbackCallout.js';
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
 
-card(
-  <FeedbackCallout link="https://docs.google.com/forms/d/e/1FAIpQLSe7h8kVcD7QqvPvjkE8s8WvnuFfhYvAEQ6L7tZwPgHjJPAbSw/viewform?usp=pp_url&entry.847151274=Callout" />,
-);
+card(<FeedbackCallout componentName="Callout" />);
 
 card(
   <PageHeader

--- a/docs/src/Tooltip.doc.js
+++ b/docs/src/Tooltip.doc.js
@@ -8,9 +8,7 @@ import FeedbackCallout from './components/FeedbackCallout.js';
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
 
-card(
-  <FeedbackCallout link="https://docs.google.com/forms/d/e/1FAIpQLSe7h8kVcD7QqvPvjkE8s8WvnuFfhYvAEQ6L7tZwPgHjJPAbSw/viewform?usp=pp_url&entry.847151274=Tooltip" />,
-);
+card(<FeedbackCallout componentName="Tooltip" />);
 
 card(
   <PageHeader

--- a/docs/src/components/FeedbackCallout.js
+++ b/docs/src/components/FeedbackCallout.js
@@ -1,13 +1,17 @@
 // @flow strict
+import React, { type Node, useState } from 'react';
 import { Box, Callout } from 'gestalt';
-import React, { type Node } from 'react';
+
+const BASE_LINK =
+  'https://docs.google.com/forms/d/e/1FAIpQLSe7h8kVcD7QqvPvjkE8s8WvnuFfhYvAEQ6L7tZwPgHjJPAbSw/viewform?usp=pp_url&entry.847151274=';
 
 type Props = {|
-  link: string,
+  componentName: string,
 |};
 
-export default function FeedbackCallout({ link }: Props): Node {
-  const [showCallout, setShowCallout] = React.useState(true);
+export default function FeedbackCallout({ componentName }: Props): Node {
+  const [showCallout, setShowCallout] = useState(true);
+  const link = `${BASE_LINK}${componentName}`;
 
   return (
     <Box marginLeft={-1} marginRight={-1}>


### PR DESCRIPTION
These are all using the same URL, with the only change being the component name query param. This PR makes FeedbackCallout simpler to use and eliminates possible copy/paste errors with the link.