### PR TITLE
Image: add elementtiming attribute for profiling

### DIFF
--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -39,6 +39,12 @@ card(
         href: 'placeholders',
       },
       {
+        name: 'elementtiming',
+        type: 'string',
+        description:
+          'HTML attribute For performance profiling. See https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API',
+      },
+      {
         name: 'fit',
         type: `"cover" | "contain" | "none"`,
         defaultValue: 'none',

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -41,7 +41,7 @@ card(
       {
         name: 'elementTiming',
         type: 'string',
-        description: `HTML attribute For performance profiling (see https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API). Note that it only works if the ‘fit‘ prop is not set to ‘cover‘ or ‘contain‘.`,
+        description: `HTML attribute for performance profiling (see https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API). Note that it only works if the ‘fit‘ prop is not set to ‘cover‘ or ‘contain‘.`,
       },
       {
         name: 'fit',

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -41,8 +41,7 @@ card(
       {
         name: 'elementTiming',
         type: 'string',
-        description:
-          'HTML attribute For performance profiling. See https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API',
+        description: `HTML attribute For performance profiling (see https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API). Note that it only works if the ‘fit‘ prop is not set to ‘cover‘ or ‘contain‘.`,
       },
       {
         name: 'fit',

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -39,7 +39,7 @@ card(
         href: 'placeholders',
       },
       {
-        name: 'elementtiming',
+        name: 'elementTiming',
         type: 'string',
         description:
           'HTML attribute For performance profiling. See https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API',

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -10,7 +10,7 @@ type Props = {|
   alt: string,
   children?: Node,
   color: string,
-  elementtiming?: string,
+  elementTiming?: string,
   fit?: 'contain' | 'cover' | 'none',
   importance?: 'high' | 'low' | 'auto',
   loading?: 'eager' | 'lazy' | 'auto',
@@ -28,7 +28,7 @@ export default class Image extends PureComponent<Props> {
     alt: PropTypes.string.isRequired,
     children: PropTypes.node,
     color: PropTypes.string,
-    elementtiming: PropTypes.string,
+    elementTiming: PropTypes.string,
     fit: PropTypes.oneOf(['contain', 'cover', 'none']),
     importance: PropTypes.oneOf(['high', 'low', 'auto']),
     loading: PropTypes.oneOf(['eager', 'lazy', 'auto']),
@@ -92,7 +92,7 @@ export default class Image extends PureComponent<Props> {
       alt,
       color,
       children,
-      elementtiming,
+      elementTiming,
       fit,
       importance,
       loading,
@@ -135,7 +135,7 @@ export default class Image extends PureComponent<Props> {
         <img
           alt={alt}
           className={styles.img}
-          elementtiming={elementtiming}
+          elementtiming={elementTiming}
           importance={importance}
           loading={loading}
           onError={this.handleError}

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -10,6 +10,7 @@ type Props = {|
   alt: string,
   children?: Node,
   color: string,
+  elementtiming?: string,
   fit?: 'contain' | 'cover' | 'none',
   importance?: 'high' | 'low' | 'auto',
   loading?: 'eager' | 'lazy' | 'auto',
@@ -27,6 +28,7 @@ export default class Image extends PureComponent<Props> {
     alt: PropTypes.string.isRequired,
     children: PropTypes.node,
     color: PropTypes.string,
+    elementtiming: PropTypes.string,
     fit: PropTypes.oneOf(['contain', 'cover', 'none']),
     importance: PropTypes.oneOf(['high', 'low', 'auto']),
     loading: PropTypes.oneOf(['eager', 'lazy', 'auto']),
@@ -90,6 +92,7 @@ export default class Image extends PureComponent<Props> {
       alt,
       color,
       children,
+      elementtiming,
       fit,
       importance,
       loading,
@@ -132,6 +135,7 @@ export default class Image extends PureComponent<Props> {
         <img
           alt={alt}
           className={styles.img}
+          elementtiming={elementtiming}
           importance={importance}
           loading={loading}
           onError={this.handleError}


### PR DESCRIPTION
This PR adds the `elementTiming` attribute to `<img>` tag rendered by the `<Image>` component so that it is possible to use the [Element Timing API](https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API) to get the image timings such as [`loadTime`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceElementTiming/loadTime) and [`renderTime`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceElementTiming/renderTime)

Note that while the actual HTML attribute is all lowercased, the `elementTiming` prop is camelCased since it is an established Gestalt convention.

![Screen Shot 2021-03-09 at 12 11 25 PM](https://user-images.githubusercontent.com/5341184/110531586-99fd4f80-80d0-11eb-8bee-221bfaa3c119.png)
