### PR TITLE
Docs: Add event tracking for buttons

### DIFF
--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -1,8 +1,9 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Box, Flex, Heading, IconButton, Tooltip } from 'gestalt';
+import { Box, Flex, Heading } from 'gestalt';
 import slugify from 'slugify';
 import Markdown from './Markdown.js';
+import CopyLinkButton from './buttons/CopyLinkButton.js';
 
 type Props = {|
   children?: Node,
@@ -58,22 +59,18 @@ export default function Card({
         >
           <Flex alignItems="center" gap={2}>
             <Heading size={headingSize}>{name}</Heading>
-            <Tooltip inline text="Copy link">
-              <IconButton
-                accessibilityLabel={`Copy link to ${name}`}
-                icon="link"
-                onClick={() => {
-                  copyToClipboard(slugifiedId);
-                }}
-                size="xs"
-                iconColor="darkGray"
-              />
-            </Tooltip>
+            <CopyLinkButton
+              name={name}
+              onClick={() => {
+                copyToClipboard(slugifiedId);
+              }}
+            />
 
             {toggle}
           </Flex>
         </Box>
       )}
+
       <Box marginStart={-2} marginEnd={-2} display="flex" direction={stacked ? 'column' : 'row'}>
         <Box paddingX={2} column={12} color="white">
           {description && (

--- a/docs/src/components/ExampleCode.js
+++ b/docs/src/components/ExampleCode.js
@@ -1,9 +1,12 @@
 // @flow strict
-import React, { Fragment, type Node, useEffect, useRef, useState } from 'react';
-import { Box, IconButton, Tooltip } from 'gestalt';
+import React, { type Node, useEffect, useRef, useState } from 'react';
+import { Box, Flex } from 'gestalt';
 import { LiveEditor } from 'react-live';
-import handleCodeSandbox from './handleCodeSandbox.js';
 import clipboardCopy from './clipboardCopy.js';
+import handleCodeSandbox from './handleCodeSandbox.js';
+import CollapseExpandCodeButton from './buttons/CollapseExpandCodeButton.js';
+import CopyCodeButton from './buttons/CopyCodeButton.js';
+import OpenSandboxButton from './buttons/OpenSandboxButton.js';
 
 async function copyCode({ code }: {| code: string |}) {
   try {
@@ -29,79 +32,59 @@ export default function ExampleCode({ code, name }: {| code: string, name: strin
   }, [code]);
 
   return (
-    <Fragment>
-      <Box display="flex" direction="row" justifyContent="start" marginTop={2}>
-        <Tooltip inline text="Open in CodeSandbox" idealDirection="up">
-          <IconButton
-            dangerouslySetSvgPath={{
-              __path:
-                'M9.365 21.17v-8.645L1.93 8.248v4.928l3.405 1.974v3.705l4.029 2.314zm1.93.05l4.104-2.363v-3.794l3.427-1.986V8.211l-7.53 4.348v8.661zm6.54-14.666L13.878 4.26l-3.475 2.017L6.9 4.257 2.907 6.583l7.452 4.288 7.477-4.316zM0 18.017V6.04L10.377 0l10.38 6.015v11.983l-10.38 5.98L0 18.018z',
-            }}
-            accessibilityLabel="Open in CodeSandbox"
-            iconColor="darkGray"
-            size="xs"
+    <Box marginTop={2}>
+      <Flex direction="column" gap={2}>
+        <Flex justifyContent="start">
+          <OpenSandboxButton
             onClick={() => {
               handleCodeSandbox({ code, title: name });
             }}
           />
-        </Tooltip>
-        <Tooltip inline text="Copy code" idealDirection="up">
-          <IconButton
-            icon="drag-drop"
-            accessibilityLabel="Copy code"
-            iconColor="darkGray"
-            size="xs"
+          <CopyCodeButton
             onClick={() => {
               copyCode({ code });
             }}
           />
-        </Tooltip>
-        {showExpandButton && (
-          <Tooltip
-            inline
-            text={`${expanded ? 'Collapse' : 'Expand'} code example`}
-            idealDirection="up"
-          >
-            <IconButton
-              accessibilityLabel={`${expanded ? 'Collapse' : 'Expand'} code for ${name}`}
-              iconColor="darkGray"
-              icon={expanded ? 'minimize' : 'maximize'}
-              size="xs"
+          {showExpandButton && (
+            <CollapseExpandCodeButton
+              expanded={expanded}
+              name={name}
               onClick={() => setExpanded(!expanded)}
             />
-          </Tooltip>
-        )}
-      </Box>
-      <Box display="flex" direction="column" width="100%" marginTop={2}>
-        <Box
-          borderStyle="sm"
-          display="flex"
-          overflow="hidden"
-          position="relative"
-          ref={codeExampleRef}
-          rounding={2}
-          {...(expanded ? {} : { maxHeight: CODE_EXAMPLE_HEIGHT, overflow: 'hidden' })}
-        >
+          )}
+        </Flex>
+
+        <Flex direction="column" width="100%">
           <Box
-            flex="grow"
-            onFocus={() => {
-              setExpanded(true);
-            }}
+            borderStyle="sm"
+            display="flex"
+            overflow="hidden"
+            position="relative"
+            ref={codeExampleRef}
+            rounding={2}
+            {...(expanded ? {} : { maxHeight: CODE_EXAMPLE_HEIGHT, overflow: 'hidden' })}
           >
-            {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
-            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label>
-              <LiveEditor
-                className="live-editor-pane"
-                style={{
-                  minHeight: '152px',
-                }}
-                padding={16}
-              />
-            </label>
+            <Box
+              flex="grow"
+              onFocus={() => {
+                setExpanded(true);
+              }}
+            >
+              {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label>
+                <LiveEditor
+                  className="live-editor-pane"
+                  style={{
+                    minHeight: '152px',
+                  }}
+                  padding={16}
+                />
+              </label>
+            </Box>
           </Box>
-        </Box>
-      </Box>
-    </Fragment>
+        </Flex>
+      </Flex>
+    </Box>
   );
 }

--- a/docs/src/components/Header.js
+++ b/docs/src/components/Header.js
@@ -4,6 +4,7 @@ import { Box, FixedZIndex, Text, Icon, IconButton, Sticky } from 'gestalt';
 import DocSearch from './DocSearch.js';
 import HeaderMenu from './HeaderMenu.js';
 import Link from './Link.js';
+import trackButtonClick from './buttons/trackButtonClick.js';
 import { useNavigationContext } from './navigationContext.js';
 
 function Header() {
@@ -22,7 +23,7 @@ function Header() {
     >
       <Box marginStart={-2} marginEnd={-2}>
         <Text color="white" weight="bold">
-          <Link to="/">
+          <Link to="/" onClick={() => trackButtonClick('Pinterest logo')}>
             <Box padding={2}>
               <Box
                 display="flex"

--- a/docs/src/components/HeaderMenu.js
+++ b/docs/src/components/HeaderMenu.js
@@ -1,18 +1,16 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Box, Text, IconButton, Tooltip, Link as GestaltLink } from 'gestalt';
+import { Box, Link as GestaltLink, Text, Tooltip } from 'gestalt';
 import { useAppContext } from './appContext.js';
 import { useNavigationContext } from './navigationContext.js';
+import DarkModeButton from './buttons/DarkModeButton.js';
+import LTRButton from './buttons/LTRButton.js';
+import SidebarCategorizationButton from './buttons/SidebarCategorizationButton.js';
+import trackButtonClick from './buttons/trackButtonClick.js';
 
 export default function HeaderMenu({ isHeader }: {| isHeader?: boolean |}): Node {
   const { colorScheme, setColorScheme, textDirection, setTextDirection } = useAppContext();
   const { sidebarOrganisedBy, setSidebarOrganizedBy } = useNavigationContext();
-  const togglePageDirSvgPath = {
-    __path:
-      textDirection === 'rtl'
-        ? 'M9 10v5h2V4h2v11h2V4h2V2H9C6.79 2 5 3.79 5 6s1.79 4 4 4zm12 8l-4-4v3H5v2h12v3l4-4z'
-        : 'M10 10v5h2V4h2v11h2V4h2V2h-8C7.79 2 6 3.79 6 6s1.79 4 4 4zm-2 7v-3l-4 4 4 4v-3h12v-2H8z',
-  };
 
   const onChangeColorScheme = () => setColorScheme(colorScheme === 'light' ? 'dark' : 'light');
 
@@ -20,57 +18,41 @@ export default function HeaderMenu({ isHeader }: {| isHeader?: boolean |}): Node
 
   return (
     <Box
+      alignItems="center"
+      color="pine"
       display={isHeader ? 'none' : 'flex'}
       mdDisplay={isHeader ? 'flex' : 'none'}
-      alignItems="center"
       justifyContent={isHeader ? undefined : 'center'}
-      color="pine"
     >
-      <Tooltip inline text={textDirection === 'rtl' ? 'Left-To-Right View' : 'Right-To-Left View'}>
-        <IconButton
-          size="md"
-          accessibilityLabel="toggle page direction: Left-To-Right / Right-To-Left View"
-          iconColor="white"
-          dangerouslySetSvgPath={togglePageDirSvgPath}
-          onClick={() => onTextDirectionChange()}
-        />
-      </Tooltip>
-      <Tooltip inline text={colorScheme === 'light' ? 'Dark-Mode View' : 'Light-Mode View'}>
-        <IconButton
-          size="md"
-          accessibilityLabel="toggle color scheme: light / dark mode views"
-          iconColor="white"
-          icon="workflow-status-in-progress"
-          onClick={() => onChangeColorScheme()}
-        />
-      </Tooltip>
-      <Tooltip
-        inline
-        text={`Sidebar: ${sidebarOrganisedBy === 'categorized' ? 'Alphabetical' : 'Categorize'}`}
-      >
-        <Box display="flex" alignItems="center">
-          <IconButton
-            size="md"
-            accessibilityLabel="Toggle sidebar categorization"
-            iconColor="white"
-            icon={sidebarOrganisedBy === 'categorized' ? 'arrow-circle-down' : 'folder'}
-            onClick={() =>
-              setSidebarOrganizedBy(
-                sidebarOrganisedBy === 'categorized' ? 'alphabetical' : 'categorized',
-              )
-            }
-          />
-        </Box>
-      </Tooltip>
-      <Tooltip inline text="Opens Codesandbox ready to start coding with Gestalt">
+      <LTRButton onClick={() => onTextDirectionChange()} textDirection={textDirection} />
+      <DarkModeButton colorScheme={colorScheme} onClick={() => onChangeColorScheme()} />
+      <SidebarCategorizationButton
+        onClick={() =>
+          setSidebarOrganizedBy(
+            sidebarOrganisedBy === 'categorized' ? 'alphabetical' : 'categorized',
+          )
+        }
+        sidebarOrganisedBy={sidebarOrganisedBy}
+      />
+
+      <Tooltip inline text="Opens CodeSandbox ready to start coding with Gestalt">
         <Text color="white">
-          <GestaltLink href="https://codesandbox.io/s/k5plvp9v8v" target="blank">
+          <GestaltLink
+            href="https://codesandbox.io/s/k5plvp9v8v"
+            onClick={() => trackButtonClick('Playground')}
+            target="blank"
+          >
             <Box padding={2}>Playground</Box>
           </GestaltLink>
         </Text>
       </Tooltip>
+
       <Text color="white">
-        <GestaltLink href="https://github.com/pinterest/gestalt" target="blank">
+        <GestaltLink
+          href="https://github.com/pinterest/gestalt"
+          onClick={() => trackButtonClick('GitHub')}
+          target="blank"
+        >
           <Box padding={2}>GitHub</Box>
         </GestaltLink>
       </Text>

--- a/docs/src/components/MainSectionSubsection.js
+++ b/docs/src/components/MainSectionSubsection.js
@@ -1,7 +1,8 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Box, Flex, Heading, IconButton, Tooltip } from 'gestalt';
+import { Box, Flex, Heading } from 'gestalt';
 import slugify from 'slugify';
+import CopyLinkButton from './buttons/CopyLinkButton.js';
 import Markdown from './Markdown.js';
 import { copyToClipboard } from './Card.js';
 import { convertToSentenceCase } from './utils.js';
@@ -14,6 +15,7 @@ type Props = {|
 
 const MainSectionSubsection = ({ children, description, title }: Props): Node => {
   const slugifiedId = slugify(title || '');
+
   return (
     <Box marginTop={4}>
       <Box marginBottom={title || description ? 8 : 0}>
@@ -29,26 +31,23 @@ const MainSectionSubsection = ({ children, description, title }: Props): Node =>
           >
             <Flex alignItems="center" gap={2}>
               <Heading size="sm">{convertToSentenceCase(title)}</Heading>
-              <Tooltip inline text="Copy link">
-                <IconButton
-                  accessibilityLabel={`Copy link to ${title}`}
-                  icon="link"
-                  size="xs"
-                  onClick={() => {
-                    copyToClipboard(slugifiedId);
-                  }}
-                  iconColor="darkGray"
-                />
-              </Tooltip>
+              <CopyLinkButton
+                name={title}
+                onClick={() => {
+                  copyToClipboard(slugifiedId);
+                }}
+              />
             </Flex>
           </Box>
         )}
+
         {description && (
           <Box maxWidth={572} marginTop={title ? 2 : 0} color="white">
             <Markdown text={description} />
           </Box>
         )}
       </Box>
+
       {children && (
         <Flex wrap gap={4}>
           {children}

--- a/docs/src/components/PageHeader.js
+++ b/docs/src/components/PageHeader.js
@@ -3,6 +3,7 @@ import React, { type Node } from 'react';
 import { Badge, Box, Flex, Heading, Text, Tooltip } from 'gestalt';
 import Markdown from './Markdown.js';
 import MainSection from './MainSection.js';
+import trackButtonClick from './buttons/trackButtonClick.js';
 
 type Props = {|
   name: string,
@@ -52,7 +53,11 @@ export default function ComponentHeader({
             ) : null}
           </Heading>
           {showSourceLink && (
-            <a href={githubUrl(fileName ?? name)} target="blank">
+            <a
+              href={githubUrl(fileName ?? name)}
+              onClick={() => trackButtonClick('View source on GitHub', fileName ?? name)}
+              target="blank"
+            >
               <Text underline>View source on GitHub</Text>
             </a>
           )}

--- a/docs/src/components/appContext.js
+++ b/docs/src/components/appContext.js
@@ -8,7 +8,7 @@ const localStorageColorSchemeKey = 'gestalt-color-scheme';
 const localStorageTextDirectionKey = 'gestalt-text-direction';
 
 type PropTableVariant = 'collapsed' | 'expanded';
-type ColorScheme = 'light' | 'dark' | 'userPreference';
+export type ColorScheme = 'light' | 'dark' | 'userPreference';
 type DirectionScheme = 'ltr' | 'rtl';
 
 export type AppContextType = {|

--- a/docs/src/components/buttons/CollapseExpandCodeButton.js
+++ b/docs/src/components/buttons/CollapseExpandCodeButton.js
@@ -1,0 +1,29 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { IconButton, Tooltip } from 'gestalt';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  expanded: boolean,
+  name: string,
+  onClick: () => void,
+|};
+
+export default function CollapseExpandCodeButton({ expanded, name, onClick }: Props): Node {
+  const label = `${expanded ? 'Collapse' : 'Expand'} code example`;
+
+  return (
+    <Tooltip inline text={label} idealDirection="up">
+      <IconButton
+        accessibilityLabel={`${label} for ${name}`}
+        iconColor="darkGray"
+        icon={expanded ? 'minimize' : 'maximize'}
+        onClick={() => {
+          trackButtonClick(label, name);
+          onClick();
+        }}
+        size="xs"
+      />
+    </Tooltip>
+  );
+}

--- a/docs/src/components/buttons/CopyCodeButton.js
+++ b/docs/src/components/buttons/CopyCodeButton.js
@@ -1,0 +1,27 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { IconButton, Tooltip } from 'gestalt';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  onClick: () => void,
+|};
+
+export default function CopyCodeButton({ onClick }: Props): Node {
+  const label = 'Copy code';
+
+  return (
+    <Tooltip inline text={label} idealDirection="up">
+      <IconButton
+        accessibilityLabel={label}
+        icon="drag-drop"
+        iconColor="darkGray"
+        onClick={() => {
+          trackButtonClick(label);
+          onClick();
+        }}
+        size="xs"
+      />
+    </Tooltip>
+  );
+}

--- a/docs/src/components/buttons/CopyLinkButton.js
+++ b/docs/src/components/buttons/CopyLinkButton.js
@@ -1,0 +1,28 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { IconButton, Tooltip } from 'gestalt';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  name: string,
+  onClick: () => void,
+|};
+
+export default function CopyLinkButton({ name, onClick }: Props): Node {
+  const label = 'Copy link';
+
+  return (
+    <Tooltip inline text={label}>
+      <IconButton
+        accessibilityLabel={`${label} to ${name}`}
+        icon="link"
+        onClick={() => {
+          trackButtonClick(label, name);
+          onClick();
+        }}
+        size="xs"
+        iconColor="darkGray"
+      />
+    </Tooltip>
+  );
+}

--- a/docs/src/components/buttons/DarkModeButton.js
+++ b/docs/src/components/buttons/DarkModeButton.js
@@ -1,0 +1,30 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { IconButton, Tooltip } from 'gestalt';
+// eslint-disable-next-line import/no-relative-parent-imports
+import { type ColorScheme } from '../appContext.js';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  colorScheme: ColorScheme,
+  onClick: () => void,
+|};
+
+export default function DarkModeButton({ colorScheme, onClick }: Props): Node {
+  const colorSchemeCopy = colorScheme === 'light' ? 'Dark-Mode View' : 'Light-Mode View';
+
+  return (
+    <Tooltip inline text={colorSchemeCopy}>
+      <IconButton
+        accessibilityLabel="Toggle color scheme: light / dark mode views"
+        icon="workflow-status-in-progress"
+        iconColor="white"
+        onClick={() => {
+          trackButtonClick('Toggle color scheme', colorSchemeCopy);
+          onClick();
+        }}
+        size="md"
+      />
+    </Tooltip>
+  );
+}

--- a/docs/src/components/buttons/LTRButton.js
+++ b/docs/src/components/buttons/LTRButton.js
@@ -1,0 +1,35 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { IconButton, Tooltip } from 'gestalt';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  onClick: () => void,
+  textDirection: 'rtl' | 'ltr',
+|};
+
+export default function LTRButton({ onClick, textDirection }: Props): Node {
+  const togglePageDirSvgPath = {
+    __path:
+      textDirection === 'rtl'
+        ? 'M9 10v5h2V4h2v11h2V4h2V2H9C6.79 2 5 3.79 5 6s1.79 4 4 4zm12 8l-4-4v3H5v2h12v3l4-4z'
+        : 'M10 10v5h2V4h2v11h2V4h2V2h-8C7.79 2 6 3.79 6 6s1.79 4 4 4zm-2 7v-3l-4 4 4 4v-3h12v-2H8z',
+  };
+
+  const directionCopy = textDirection === 'rtl' ? 'Left-To-Right View' : 'Right-To-Left View';
+
+  return (
+    <Tooltip inline text={directionCopy}>
+      <IconButton
+        accessibilityLabel="Toggle page direction: Left-To-Right / Right-To-Left View"
+        dangerouslySetSvgPath={togglePageDirSvgPath}
+        iconColor="white"
+        onClick={() => {
+          trackButtonClick('Toggle page direction', directionCopy);
+          onClick();
+        }}
+        size="md"
+      />
+    </Tooltip>
+  );
+}

--- a/docs/src/components/buttons/OpenSandboxButton.js
+++ b/docs/src/components/buttons/OpenSandboxButton.js
@@ -1,0 +1,30 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { IconButton, Tooltip } from 'gestalt';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  onClick: () => void,
+|};
+
+export default function OpenSandboxButton({ onClick }: Props): Node {
+  const label = 'Open in CodeSandbox';
+
+  return (
+    <Tooltip inline text={label} idealDirection="up">
+      <IconButton
+        accessibilityLabel={label}
+        dangerouslySetSvgPath={{
+          __path:
+            'M9.365 21.17v-8.645L1.93 8.248v4.928l3.405 1.974v3.705l4.029 2.314zm1.93.05l4.104-2.363v-3.794l3.427-1.986V8.211l-7.53 4.348v8.661zm6.54-14.666L13.878 4.26l-3.475 2.017L6.9 4.257 2.907 6.583l7.452 4.288 7.477-4.316zM0 18.017V6.04L10.377 0l10.38 6.015v11.983l-10.38 5.98L0 18.018z',
+        }}
+        iconColor="darkGray"
+        onClick={() => {
+          trackButtonClick(label);
+          onClick();
+        }}
+        size="xs"
+      />
+    </Tooltip>
+  );
+}

--- a/docs/src/components/buttons/SidebarCategorizationButton.js
+++ b/docs/src/components/buttons/SidebarCategorizationButton.js
@@ -1,0 +1,33 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { Flex, IconButton, Tooltip } from 'gestalt';
+// eslint-disable-next-line import/no-relative-parent-imports
+import { type SidebarOrganisedBy } from '../navigationContext.js';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  onClick: () => void,
+  sidebarOrganisedBy: SidebarOrganisedBy,
+|};
+
+export default function SidebarCategorizationButton({ onClick, sidebarOrganisedBy }: Props): Node {
+  const sidebarOrganisedByCopy =
+    sidebarOrganisedBy === 'categorized' ? 'Alphabetical' : 'Categorize';
+
+  return (
+    <Tooltip inline text={`Sidebar: ${sidebarOrganisedByCopy}`}>
+      <Flex alignItems="center">
+        <IconButton
+          accessibilityLabel="Toggle sidebar categorization"
+          icon={sidebarOrganisedBy === 'categorized' ? 'arrow-circle-down' : 'folder'}
+          iconColor="white"
+          onClick={() => {
+            trackButtonClick('Sidebar Categorization', sidebarOrganisedByCopy);
+            onClick();
+          }}
+          size="md"
+        />
+      </Flex>
+    </Tooltip>
+  );
+}

--- a/docs/src/components/buttons/trackButtonClick.js
+++ b/docs/src/components/buttons/trackButtonClick.js
@@ -1,6 +1,7 @@
 // @flow strict
 
-// Since some buttons have text and some only have icons, we'll use the a11yLabel for consistency
+// `buttonLabel` should be relatively generic.
+// pass `value` to provide more context, such as the current component
 export default function trackButtonClick(buttonLabel: string, value?: string) {
   if (!window.gtag) {
     return;

--- a/docs/src/components/buttons/trackButtonClick.js
+++ b/docs/src/components/buttons/trackButtonClick.js
@@ -1,0 +1,14 @@
+// @flow strict
+
+// Since some buttons have text and some only have icons, we'll use the a11yLabel for consistency
+export default function trackButtonClick(buttonLabel: string, value?: string) {
+  if (!window.gtag) {
+    return;
+  }
+
+  window.gtag('event', 'click', {
+    'event_category': 'button',
+    'event_label': buttonLabel,
+    value,
+  });
+}

--- a/docs/src/components/navigationContext.js
+++ b/docs/src/components/navigationContext.js
@@ -5,7 +5,7 @@ import useLocalStorage from './useLocalStorage.js';
 
 const localStorageOrganizedByKey = 'gestalt-sidebar-organized-by';
 
-type SidebarOrganisedBy = 'categorized' | 'alphabetical';
+export type SidebarOrganisedBy = 'categorized' | 'alphabetical';
 
 export type NavigationContextType = {|
   isSidebarOpen: boolean,


### PR DESCRIPTION
This PR adds Google Analytics event tracking to all our buttons across the docs. If there's a button I missed, please let me know!

We're logging the button clicked, and sometimes additional metadata where useful. You can check this by viewing the [real-time events](https://analytics.google.com/analytics/web/#/realtime/rt-event/a12967896w242172598p225758288/metric.type=5&filter.list=40==button;) and clicking around on the preview site.

![image](https://user-images.githubusercontent.com/10593890/111206410-b13faf80-859e-11eb-8dbf-c35dac19c081.png)
