### PR TITLE
ScrollBoundaryContainer: fix positioning within when no available spa…

### DIFF
--- a/packages/gestalt/src/utils/positioningUtils.js
+++ b/packages/gestalt/src/utils/positioningUtils.js
@@ -26,6 +26,11 @@ const SPACES_INDEX_MAP = {
   '3': 'left',
 };
 
+const NO_SPACE_CONDITION_INDEX_MAP = {
+  '0': 'up',
+  '1': 'down',
+};
+
 const DIR_INDEX_MAP = {
   up: 0,
   right: 1,
@@ -167,18 +172,27 @@ export function getPopoverDir({
     up = 0;
     down = 0;
   }
-  const spaces = [up, right, down, left];
 
-  // Identify best direction of available spaces
-  const max = Math.max(...spaces);
   // Chose the main direction for the popover based on available spaces & user preference
+  const spaces = [up, right, down, left];
+  const noAvailableSpaceConditionSpaces = [up, down];
+
   let popoverDir;
+
   if (idealDirection && spaces[DIR_INDEX_MAP[idealDirection]] > 0) {
     // user pref
     popoverDir = idealDirection;
   } else {
+    const noAvailableSpaceCondition = up <= 0 && right <= 0 && down <= 0 && left <= 0;
+    const AVAILABLE_SPACES_INDEX_MAP = noAvailableSpaceCondition
+      ? NO_SPACE_CONDITION_INDEX_MAP
+      : SPACES_INDEX_MAP;
+    const availableSpaces = noAvailableSpaceCondition ? noAvailableSpaceConditionSpaces : spaces;
+
+    // Identify best direction of available spaces
+    const max = Math.max(...availableSpaces);
     // If no direction pref, chose the direction in which there is the most space available
-    popoverDir = SPACES_INDEX_MAP[spaces.indexOf(max)];
+    popoverDir = AVAILABLE_SPACES_INDEX_MAP[availableSpaces.indexOf(max)];
   }
 
   return popoverDir;


### PR DESCRIPTION
…ce condition is met

Popovers within a ScrollBoundaryContainer have much less space around to position themselves. This PR fixes Popover's positioning within ScrollBoundaryContainer (Including Modals and Sheet) but limiting the positioning directions to just "Up" and "Down" if no available space is available. 

Be limiting to "Up" and "Down", the Popover won't overflow to the sides ("left", "right") which could lead to hiding the Popover's overflow "up" or "down". Therefore, the Popover will make the container overflow with a scroll bar.

To see bug in action: 
![image](https://user-images.githubusercontent.com/10593890/111012593-8ec55080-836a-11eb-82b9-1061dba09112.png)
https://www.loom.com/share/d464133f3dbd40f08921259e9af95c9e


To see fix in action: https://deploy-preview-1421--gestalt.netlify.app/Popover#With-Layer

BEFORE / AFTER video: https://www.loom.com/share/867634ec3c5547628bbd9c8926626b4d?from_recorder=1

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
