### PR TITLE
Typeahead: Add hasError & errorMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ packages/eslint-plugin-gestalt/dist/*
 # https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Configuring-Folder-Structure
 cypress/videos/
 cypress/screenshots/
+
+.idea/

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -111,6 +111,11 @@ card(
         href: 'zIndex',
       },
       {
+        name: 'hasError',
+        type: 'boolean',
+        href: 'errorExample',
+      },
+      {
         name: 'errorMessage',
         type: 'string',
         href: 'errorExample',
@@ -468,6 +473,7 @@ function Example(props) {
         onChange={handleOnChange}
         onSelect={handleSelect}
         errorMessage="Oops! An Error Occurred."
+        hasError
       />
     </React.Fragment>
   );

--- a/docs/src/Typeahead.doc.js
+++ b/docs/src/Typeahead.doc.js
@@ -110,6 +110,11 @@ card(
           'An object representing the z-index value of the Typeahead list. Only use when Typeahead is used within a parent component that has a z-index set.',
         href: 'zIndex',
       },
+      {
+        name: 'errorMessage',
+        type: 'string',
+        href: 'errorExample',
+      },
     ]}
   />,
 );
@@ -418,6 +423,52 @@ function Example(props) {
           </Modal>
         </Layer>
       )}
+    </React.Fragment>
+  );
+}`}
+  />,
+);
+
+card(
+  <Example
+    id="errorExample"
+    name="Error Message Example"
+    defaultCode={`
+function Example(props) {
+  const [item, setItem] = React.useState("");
+  const [selected, setSelected] = React.useState(null);
+
+  const options = Array.from(Array(20).keys()).map((item) => ({
+    value: "Value-" + (item + 1),
+    label: "Label-" + (item + 1),
+  }));
+
+  const handleOnChange = ({ value }) => {
+    setItem(value);
+  };
+
+  const handleSelect = ({item}) => {
+    setSelected(item);
+  };
+
+  const label = "Selected Item: " + (selected && selected.label || '');
+
+  return (
+    <React.Fragment>
+      <Box marginBottom={4}>
+       <Text>Selected Item: {(selected && selected.label) || ""}</Text>
+      </Box>
+
+      <Typeahead
+        label="Typeahead Example With Error"
+        id="Typeahead-example-with-error"
+        noResultText="No Results"
+        options={options}
+        placeholder="Select a Label"
+        onChange={handleOnChange}
+        onSelect={handleSelect}
+        errorMessage="Oops! An Error Occurred."
+      />
     </React.Fragment>
   );
 }`}

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -71,7 +71,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     tags,
     value = null,
     zIndex,
-    errorMessage = null,
+    errorMessage,
   } = props;
 
   // Parent ref for positioning

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -49,6 +49,7 @@ type Props = {|
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   value?: string,
   zIndex?: Indexable,
+  errorMessage?: string,
 |};
 
 const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
@@ -70,6 +71,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     tags,
     value = null,
     zIndex,
+    errorMessage = null,
   } = props;
 
   // Parent ref for positioning
@@ -230,6 +232,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
         setContainer={setContainerOpen}
         tags={tags}
         ref={inputRef}
+        errorMessage={errorMessage}
       />
 
       {containerOpen && positioningRef.current && (
@@ -309,6 +312,7 @@ TypeaheadWithForwardRef.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.node),
   value: PropTypes.string,
   zIndex: UnsafeIndexablePropType,
+  errorMessage: PropTypes.string,
 };
 
 TypeaheadWithForwardRef.displayName = 'Typeahead';

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -49,6 +49,7 @@ type Props = {|
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   value?: string,
   zIndex?: Indexable,
+  hasError?: boolean,
   errorMessage?: string,
 |};
 
@@ -71,6 +72,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     tags,
     value = null,
     zIndex,
+    hasError = false,
     errorMessage,
   } = props;
 
@@ -232,6 +234,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
         setContainer={setContainerOpen}
         tags={tags}
         ref={inputRef}
+        hasError={hasError}
         errorMessage={errorMessage}
       />
 
@@ -312,6 +315,7 @@ TypeaheadWithForwardRef.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.node),
   value: PropTypes.string,
   zIndex: UnsafeIndexablePropType,
+  hasError: PropTypes.bool,
   errorMessage: PropTypes.string,
 };
 

--- a/packages/gestalt/src/Typeahead.jsdom.test.js
+++ b/packages/gestalt/src/Typeahead.jsdom.test.js
@@ -153,6 +153,7 @@ describe('Typeahead', () => {
         id="test"
         options={[{ value: 'test', label: 'test' }]}
         errorMessage="Error message"
+        hasError
       />,
     );
     expect(JSON.stringify(component.toJSON())).toContain('Error message');

--- a/packages/gestalt/src/Typeahead.jsdom.test.js
+++ b/packages/gestalt/src/Typeahead.jsdom.test.js
@@ -143,4 +143,31 @@ describe('Typeahead', () => {
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('Renders a FormErrorMessage if an error message is passed in', () => {
+    const component = create(
+      <Typeahead
+        noResultText="No Result"
+        label="Ref Example"
+        value="test"
+        id="test"
+        options={[{ value: 'test', label: 'test' }]}
+        errorMessage="Error message"
+      />,
+    );
+    expect(JSON.stringify(component.toJSON())).toContain('Error message');
+  });
+
+  it('Does not render a FormErrorMessage when errorMessage is null', () => {
+    const component = create(
+      <Typeahead
+        noResultText="No Result"
+        label="Ref Example"
+        value="test"
+        id="test"
+        options={[{ value: 'test', label: 'test' }]}
+      />,
+    );
+    expect(JSON.stringify(component.toJSON())).not.toContain('Error message');
+  });
 });

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -41,6 +41,7 @@ type Props = {|
   size?: 'md' | 'lg',
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   value?: string,
+  hasError?: boolean,
   errorMessage?: string,
 |};
 
@@ -62,6 +63,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
     size = 'md',
     tags,
     value,
+    hasError = false,
     errorMessage,
   } = props;
 
@@ -136,7 +138,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
           [typeaheadStyle.inputWrapper]: true,
         }
       : {},
-    errorMessage ? formElement.errored : formElement.normal,
+    (hasError || errorMessage) && !focused ? formElement.errored : formElement.normal,
   );
 
   const clearButtonSize = size === 'lg' ? 24 : 20;
@@ -145,7 +147,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
   const inputElement = (
     <input
       aria-describedby={errorMessage && focused ? `${id}-error` : null}
-      aria-invalid={errorMessage ? 'true' : 'false'}
+      aria-invalid={errorMessage || hasError ? 'true' : 'false'}
       ref={ref}
       autoComplete="off"
       aria-label={label}
@@ -246,6 +248,7 @@ TypeaheadInputFieldWithForwardRef.propTypes = {
   setContainer: PropTypes.func,
   tags: PropTypes.arrayOf(PropTypes.node),
   value: PropTypes.string,
+  hasError: PropTypes.bool,
   errorMessage: PropTypes.string,
 };
 

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -6,12 +6,14 @@ import focusStyles from './Focus.css';
 import layout from './Layout.css';
 import styles from './SearchField.css';
 import typeaheadStyle from './TypeaheadInputField.css';
+import formElement from './FormElement.css';
 import Box from './Box.js';
 import Icon from './Icon.js';
 import FormLabel from './FormLabel.js';
 import Tag from './Tag.js';
 import { type DirectionOptionType } from './utils/keyboardNavigation.js';
 import { ENTER, UP_ARROW, DOWN_ARROW } from './keyCodes.js';
+import FormErrorMessage from './FormErrorMessage.js';
 
 type Props = {|
   forwardedRef?: Ref<'input'>,
@@ -39,6 +41,7 @@ type Props = {|
   size?: 'md' | 'lg',
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   value?: string,
+  errorMessage?: string,
 |};
 
 const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
@@ -59,6 +62,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
     size = 'md',
     tags,
     value,
+    errorMessage,
   } = props;
 
   const [hovered, setHovered] = useState<boolean>(false);
@@ -132,6 +136,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
           [typeaheadStyle.inputWrapper]: true,
         }
       : {},
+    errorMessage ? formElement.errored : formElement.normal,
   );
 
   const clearButtonSize = size === 'lg' ? 24 : 20;
@@ -139,6 +144,8 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
 
   const inputElement = (
     <input
+      aria-describedby={errorMessage && focused ? `${id}-error` : null}
+      aria-invalid={errorMessage ? 'true' : 'false'}
       ref={ref}
       autoComplete="off"
       aria-label={label}
@@ -219,6 +226,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
           </Fragment>
         )}
       </Box>
+      {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
     </Fragment>
   );
 });
@@ -238,6 +246,7 @@ TypeaheadInputFieldWithForwardRef.propTypes = {
   setContainer: PropTypes.func,
   tags: PropTypes.arrayOf(PropTypes.node),
   value: PropTypes.string,
+  errorMessage: PropTypes.string,
 };
 
 TypeaheadInputFieldWithForwardRef.displayName = 'TypeaheadInputField';

--- a/packages/gestalt/src/TypeaheadInputField.jsdom.test.js
+++ b/packages/gestalt/src/TypeaheadInputField.jsdom.test.js
@@ -1,6 +1,7 @@
 // @flow strict
 import React from 'react';
 import { render } from '@testing-library/react';
+import { create } from 'react-test-renderer';
 import TypeaheadInputField from './TypeaheadInputField.js';
 
 describe('<TypeaheadInputField />', () => {
@@ -45,5 +46,40 @@ describe('<TypeaheadInputField />', () => {
       />,
     );
     expect(container.querySelector('.large')).toBeVisible();
+  });
+
+  it('Renders a FormErrorMessage if an error message is passed in', () => {
+    const component = create(
+      <TypeaheadInputField
+        label="Demo Typeahead Field"
+        errorMessage="Error message"
+        id="InputField"
+        onChange={onChangeMock}
+        onClear={onClearMock}
+        onBlur={onBlurMock}
+        setContainer={setContainerMock}
+        onFocus={onFocusMock}
+        onKeyNavigation={onKeyNavigationMock}
+        value="Start Typing..."
+      />,
+    );
+    expect(JSON.stringify(component.toJSON())).toContain('Error message');
+  });
+
+  it('Does not render a FormErrorMessage when errorMessage is null', () => {
+    const component = create(
+      <TypeaheadInputField
+        label="Demo Typeahead Field"
+        id="InputField"
+        onChange={onChangeMock}
+        onClear={onClearMock}
+        onBlur={onBlurMock}
+        setContainer={setContainerMock}
+        onFocus={onFocusMock}
+        onKeyNavigation={onKeyNavigationMock}
+        value="Start Typing..."
+      />,
+    );
+    expect(JSON.stringify(component.toJSON())).not.toContain('Error message');
   });
 });

--- a/packages/gestalt/src/TypeaheadInputField.jsdom.test.js
+++ b/packages/gestalt/src/TypeaheadInputField.jsdom.test.js
@@ -48,7 +48,7 @@ describe('<TypeaheadInputField />', () => {
     expect(container.querySelector('.large')).toBeVisible();
   });
 
-  it('Renders a FormErrorMessage if an error message is passed in', () => {
+  it('Renders a FormErrorMessage if error message is passed in', () => {
     const component = create(
       <TypeaheadInputField
         label="Demo Typeahead Field"
@@ -61,6 +61,7 @@ describe('<TypeaheadInputField />', () => {
         onFocus={onFocusMock}
         onKeyNavigation={onKeyNavigationMock}
         value="Start Typing..."
+        hasError
       />,
     );
     expect(JSON.stringify(component.toJSON())).toContain('Error message');

--- a/packages/gestalt/src/__snapshots__/Typeahead.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Typeahead.jsdom.test.js.snap
@@ -24,9 +24,11 @@ exports[`Typeahead renders Typeahead normal 1`] = `
     onMouseLeave={[Function]}
   >
     <input
+      aria-describedby={null}
+      aria-invalid="false"
       aria-label="Typeahead Example"
       autoComplete="off"
-      className="input inputActive inputRadius medium"
+      className="input inputActive inputRadius medium normal"
       id="Typeahead"
       onBlur={[Function]}
       onChange={[Function]}
@@ -95,7 +97,7 @@ exports[`Typeahead renders tags when supplied 1`] = `
     onMouseLeave={[Function]}
   >
     <div
-      className="input inputActive inputRadius medium inputWrapper"
+      className="input inputActive inputRadius medium inputWrapper normal"
     >
       <div
         className="box marginBottom1 marginEnd1"
@@ -292,6 +294,8 @@ exports[`Typeahead renders tags when supplied 1`] = `
           test
         </div>
         <input
+          aria-describedby={null}
+          aria-invalid="false"
           aria-label="Tag Example"
           autoComplete="off"
           className="unstyledInput"


### PR DESCRIPTION
<!--
What is the purpose of this PR?
To add 2 new optional props hasError and errorMessage to Typeahead Component and using them to populate aria-invalid and aria-describedby

* What is the context surrounding this PR? #1156 
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description` Yes
-->
What is the purpose of this PR?
To add 2 new optional props `hasError` and `errorMessage` to Typeahead Component and using them to populate `aria-invalid` and `aria-describedby`

* What is the context surrounding this PR? #1156 
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description` Yes

## Test Plan
How can reviewers verify this is good to merge?

* Is it tested? Yes
* Is it accessible? Yes
* Is it documented? Yes
* Have you involved other stakeholders (such as a Pinterest Designer)? No
<!--
How can reviewers verify this is good to merge?

* Is it tested? Yes
* Is it accessible? Yes
* Is it documented? Yes
* Have you involved other stakeholders (such as a Pinterest Designer)? No
-->
