### PR TITLE
Tooltip: Only delay visibility on interaction if `link` present

### DIFF
--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -66,13 +66,15 @@ export default function Tooltip({
   const childRef = React.useRef<?HTMLDivElement>(null);
   const { current: anchor } = childRef;
 
+  const mouseLeaveDelay = link ? TIMEOUT : 0;
+
   const handleIconMouseEnter = () => {
     dispatch({ type: 'hoverInIcon' });
   };
 
   const handleIconMouseLeave = useDebouncedCallback(() => {
     dispatch({ type: 'hoverOutIcon' });
-  }, TIMEOUT);
+  }, mouseLeaveDelay);
 
   const handleTextMouseEnter = () => {
     dispatch({ type: 'hoverInText' });
@@ -80,7 +82,7 @@ export default function Tooltip({
 
   const handleTextMouseLeave = useDebouncedCallback(() => {
     dispatch({ type: 'hoverOutText' });
-  }, TIMEOUT);
+  }, mouseLeaveDelay);
 
   return (
     <Box display={inline ? 'inlineBlock' : 'block'}>


### PR DESCRIPTION
[bugfix](https://jira.pinadmin.com/browse/BUG-122739)

We currently delay the fade-out on mouseLeave/blur to allow the user to interact with the Tooltip content. However, this is only necessary if a `link` is present, and the delay leads to a confusing UI when multiple tooltips are used in a row. Long-term, we should create a more robust solution to allow user interaction with the tooltip content while not needing a delay. As a short-term fix, this PR only applies the delay if the `link` prop is used.