### PR TITLE
ScrollBoundaryContainer: fix positioning within when no available spa…

### DIFF
--- a/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
@@ -8,7 +8,7 @@ exports[`Controller renders 1`] = `
       Object {
         "left": -10,
         "stroke": null,
-        "top": -4,
+        "top": 4,
         "visibility": "visible",
       }
     }
@@ -21,10 +21,10 @@ exports[`Controller renders 1`] = `
         className="darkGray caret"
         style={
           Object {
-            "bottom": -4,
+            "bottom": null,
             "left": 10,
             "right": null,
-            "top": null,
+            "top": -4,
           }
         }
       >
@@ -33,7 +33,7 @@ exports[`Controller renders 1`] = `
           width={12}
         >
           <path
-            d="M12 0c-.694 0-1.36.278-1.847.773L7.625 3.34c-.807.819-2.188.885-3.084.148a2.098 2.098 0 01-.163-.148L1.853.775A2.6 2.6 0 000 0"
+            d="M0 4c.694 0 1.36-.278 1.846-.773L4.376.66c.806-.819 2.187-.885 3.083-.148.057.047.111.096.163.148l2.526 2.565A2.6 2.6 0 0012 4"
             stroke="rgba(0, 0, 0, 0.02)"
           />
         </svg>

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -9,7 +9,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
     <div>
       <div
         class="container"
-        style="stroke: #efefef; visibility: visible; top: -8px; left: -10px;"
+        style="stroke: #efefef; visibility: visible; top: 8px; left: -10px;"
       >
         <div
           class="rounding4 contents maxDimensions minDimensions"

--- a/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
@@ -10,7 +10,7 @@ exports[`Popover renders 1`] = `
       Object {
         "left": -10,
         "stroke": "#efefef",
-        "top": NaN,
+        "top": 8,
         "visibility": "visible",
       }
     }
@@ -40,7 +40,7 @@ exports[`Popover renders as blue 1`] = `
       Object {
         "left": -10,
         "stroke": null,
-        "top": NaN,
+        "top": 8,
         "visibility": "visible",
       }
     }
@@ -70,7 +70,7 @@ exports[`Popover renders as error 1`] = `
       Object {
         "left": -10,
         "stroke": null,
-        "top": NaN,
+        "top": 8,
         "visibility": "visible",
       }
     }

--- a/packages/gestalt/src/utils/positioningUtils.js
+++ b/packages/gestalt/src/utils/positioningUtils.js
@@ -26,11 +26,6 @@ const SPACES_INDEX_MAP = {
   '3': 'left',
 };
 
-const NO_SPACE_CONDITION_INDEX_MAP = {
-  '0': 'up',
-  '1': 'down',
-};
-
 const DIR_INDEX_MAP = {
   up: 0,
   right: 1,
@@ -175,7 +170,6 @@ export function getPopoverDir({
 
   // Choose the main direction for the popover based on available spaces & user preference
   const spaces = [up, right, down, left];
-  const noAvailableSpaceConditionSpaces = [up, down];
 
   let popoverDir;
 
@@ -184,15 +178,11 @@ export function getPopoverDir({
     popoverDir = idealDirection;
   } else {
     const noAvailableSpaceCondition = up <= 0 && right <= 0 && down <= 0 && left <= 0;
-    const AVAILABLE_SPACES_INDEX_MAP = noAvailableSpaceCondition
-      ? NO_SPACE_CONDITION_INDEX_MAP
-      : SPACES_INDEX_MAP;
-    const availableSpaces = noAvailableSpaceCondition ? noAvailableSpaceConditionSpaces : spaces;
 
     // Identify best direction of available spaces
-    const max = Math.max(...availableSpaces);
+    const max = Math.max(...spaces);
     // If no direction pref, chose the direction in which there is the most space available
-    popoverDir = AVAILABLE_SPACES_INDEX_MAP[availableSpaces.indexOf(max)];
+    popoverDir = noAvailableSpaceCondition ? 'down' : SPACES_INDEX_MAP[spaces.indexOf(max)];
   }
 
   return popoverDir;


### PR DESCRIPTION
…ce condition is met

In the previous [PR](https://github.com/pinterest/gestalt/pull/1428) to fix this condition, we assumed going up would trigger scroll, but up & left don't expand/scroll in those directions. For cases where there's no available space for placing a Popover (up/right/down/left spaces in the container are negative or 0), place Popover 'down' to force the container to expand and add scroll enabling access to full Popover.

![image](https://user-images.githubusercontent.com/10593890/112042191-9e3c5a80-8b1d-11eb-8e8f-5093b6a7b07a.png)
![image](https://user-images.githubusercontent.com/10593890/112042317-c461fa80-8b1d-11eb-8ce9-27959267914d.png)

<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
