### PR TITLE
Typeahead: Close container on icon button click

### DIFF
--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -238,7 +238,9 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
             showCaret={false}
             anchor={positioningRef.current}
             idealDirection="down"
-            onDismiss={() => {}}
+            onDismiss={() => {
+              setContainerOpen(false);
+            }}
             positionRelativeToAnchor={false}
             size="flexible"
             // Forces the popover to re-render and adjust its position correctly

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -1,5 +1,14 @@
 // @flow strict
-import React, { forwardRef, Fragment, type Element, type Node, type Ref, useState } from 'react';
+import React, {
+  forwardRef,
+  Fragment,
+  type Element,
+  type Node,
+  type Ref,
+  useState,
+  useRef,
+  useImperativeHandle,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import focusStyles from './Focus.css';
@@ -64,6 +73,9 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
   const [hovered, setHovered] = useState<boolean>(false);
   const [focused, setFocused] = useState(false);
 
+  const innerRef = useRef(null);
+  useImperativeHandle(ref, () => innerRef.current);
+
   const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
     onChange({
       value: event.currentTarget.value,
@@ -93,7 +105,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
   const handleClick = (event: SyntheticFocusEvent<HTMLInputElement>) => {
     handleFocus(event);
     setContainer(true);
-    ref.current?.focus();
+    innerRef.current?.focus();
   };
 
   const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
@@ -140,7 +152,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
 
   const inputElement = (
     <input
-      ref={ref}
+      ref={innerRef}
       autoComplete="off"
       aria-label={label}
       className={tags ? typeaheadStyle.unstyledInput : className}

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -93,7 +93,7 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
   const handleClick = (event: SyntheticFocusEvent<HTMLInputElement>) => {
     handleFocus(event);
     setContainer(true);
-    ref.current.focus();
+    ref.current?.focus();
   };
 
   const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -91,13 +91,9 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
   };
 
   const handleClick = (event: SyntheticFocusEvent<HTMLInputElement>) => {
-    if (focused) {
-      setFocused(false);
-    } else {
-      handleFocus(event);
-    }
-
-    setContainer((prevVal) => !prevVal);
+    handleFocus(event);
+    setContainer(true);
+    ref.current.focus();
   };
 
   const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {

--- a/packages/gestalt/src/TypeaheadInputField.js
+++ b/packages/gestalt/src/TypeaheadInputField.js
@@ -91,8 +91,13 @@ const TypeaheadInputFieldWithForwardRef: React$AbstractComponent<
   };
 
   const handleClick = (event: SyntheticFocusEvent<HTMLInputElement>) => {
-    handleFocus(event);
-    setContainer(true);
+    if (focused) {
+      setFocused(false);
+    } else {
+      handleFocus(event);
+    }
+
+    setContainer((prevVal) => !prevVal);
   };
 
   const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Allow people to close the menu by clicking outside of the typeahead, after the icon button was used to open the typeahead menu

Also focus on the input when icon button is used to open typeahead

## Test Plan
Manual testing

JIRA:[ BUG-122962](https://jira.pinadmin.com/browse/BUG-122962)