### PR TITLE
Tabs: Add experimental redesign

### DIFF
--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -4,48 +4,103 @@ import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Flex from './Flex.js';
 import Link from './Link.js';
+import TapArea from './TapArea.js';
 import Text from './Text.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type OnChangeHandler = AbstractEventHandler<
-  SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+  | SyntheticMouseEvent<HTMLAnchorElement>
+  | SyntheticKeyboardEvent<HTMLAnchorElement>
+  | SyntheticMouseEvent<HTMLDivElement>
+  | SyntheticKeyboardEvent<HTMLDivElement>,
   {| +activeTabIndex: number |},
 >;
 
-function Circle() {
+function Dot() {
   return (
     <Box
       color="red"
       dangerouslySetInlineStyle={{ __style: { marginTop: '1px' } }}
       height={6}
-      marginStart={2}
       rounding="circle"
       width={6}
     />
   );
 }
 
+const UNDERLINE_HEIGHT = 3;
+
+function Underline() {
+  return (
+    <Box
+      color="darkGray"
+      dangerouslySetInlineStyle={{
+        __style: {
+          borderRadius: 1.5,
+        },
+      }}
+      height={UNDERLINE_HEIGHT}
+      width="100%"
+    />
+  );
+}
+
+const COUNT_HEIGHT_PX = 16;
+
+function Count({ count }: {| count: number |}) {
+  const displayCount = count < 100 ? `${count}` : '99+';
+
+  return (
+    <Box
+      color="red"
+      dangerouslySetInlineStyle={{
+        __style: {
+          padding: `0 ${displayCount.length > 1 ? 3 : 0}px`,
+        },
+      }}
+      height={COUNT_HEIGHT_PX}
+      minWidth={COUNT_HEIGHT_PX}
+      rounding="pill"
+    >
+      <Box
+        dangerouslySetInlineStyle={{
+          __style: { padding: '0 0 1px 1px' },
+        }}
+      >
+        <Text align="center" color="white" size="sm" weight="bold">
+          {displayCount}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+type TabType = {|
+  href: string,
+  id?: string,
+  indicator?: 'dot' | number,
+  text: Node,
+|};
+
 function Tab({
-  children,
-  size,
   href,
-  indicator,
   id,
   index,
+  indicator,
   isActive,
   onChange,
+  size,
+  text,
 }: {|
-  children: Node,
-  size: 'md' | 'lg',
-  isActive: boolean,
-  href: string,
-  indicator?: 'dot',
+  ...TabType,
   index: number,
-  id?: string,
+  isActive: boolean,
   onChange: OnChangeHandler,
+  size: 'md' | 'lg',
 |}) {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
+
   return (
     <Box position={focused ? 'relative' : undefined}>
       <Link
@@ -73,12 +128,99 @@ function Tab({
           rounding="pill"
           userSelect="none"
         >
-          <Text color={isActive ? 'white' : 'darkGray'} weight="bold" overflow="noWrap">
-            {children}
-          </Text>
-          {indicator === 'dot' && <Circle />}
+          <Flex alignItems="center" gap={2} justifyContent="center">
+            <Text color={isActive ? 'white' : 'darkGray'} weight="bold" overflow="noWrap">
+              {text}
+            </Text>
+
+            {indicator === 'dot' && <Dot />}
+          </Flex>
         </Box>
       </Link>
+    </Box>
+  );
+}
+
+const TAB_ROUNDING = 2;
+const TAB_INNER_PADDING = 1;
+
+function TabV2({
+  href,
+  indicator,
+  id,
+  index,
+  isActive,
+  onChange,
+  // No longer supported, will be removed when this variant ships
+  // eslint-disable-next-line no-unused-vars
+  size,
+  text,
+}: {|
+  ...TabType,
+  index: number,
+  isActive: boolean,
+  onChange: OnChangeHandler,
+  size: 'md' | 'lg',
+|}) {
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [pressed, setPressed] = useState(false);
+
+  let color = 'white';
+  if (pressed) {
+    color = 'lightWash';
+  } else if ((hovered || focused) && !isActive) {
+    color = 'lightGray';
+  }
+
+  return (
+    <Box id={id} padding={3}>
+      <TapArea
+        href={href}
+        onBlur={() => setFocused(false)}
+        onFocus={() => setFocused(true)}
+        onMouseDown={() => setPressed(true)}
+        onMouseUp={() => setPressed(false)}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onTap={({ event }) => onChange({ activeTabIndex: index, event })}
+        role="link"
+        rounding={TAB_ROUNDING}
+        tapStyle="compress"
+      >
+        <Flex alignItems="center" direction="column">
+          <Box
+            color={color}
+            padding={TAB_INNER_PADDING}
+            position="relative"
+            rounding={TAB_ROUNDING}
+            userSelect="none"
+          >
+            <Flex alignItems="center" gap={2} justifyContent="center">
+              <Text color="darkGray" overflow="noWrap" weight="bold">
+                {text}
+              </Text>
+
+              {indicator === 'dot' && <Dot />}
+              {/* Flow is dumb and doesn't realize Number.isFinite will return false for a string or undefined */}
+              {typeof indicator === 'number' && Number.isFinite(indicator) && (
+                <Count count={indicator} />
+              )}
+            </Flex>
+
+            {isActive && (
+              <Box
+                dangerouslySetInlineStyle={{ __style: { bottom: -UNDERLINE_HEIGHT } }}
+                position="absolute"
+                // 4px/boint, padding on left and right
+                width={`calc(100% - ${TAB_INNER_PADDING * 4 * 2}px)`}
+              >
+                <Underline />
+              </Box>
+            )}
+          </Box>
+        </Flex>
+      </TapArea>
     </Box>
   );
 }
@@ -87,31 +229,37 @@ type Props = {|
   activeTabIndex: number,
   onChange: OnChangeHandler,
   size?: 'md' | 'lg',
-  tabs: $ReadOnlyArray<{|
-    href: string,
-    id?: string,
-    indicator?: 'dot',
-    text: Node,
-  |}>,
+  tabs: $ReadOnlyArray<TabType>,
   wrap?: boolean,
+  // Temporary prop for the Tabs Redesign project experiments
+  _dangerouslyUseV2?: boolean,
 |};
 
-export default function Tabs({ activeTabIndex, onChange, size = 'md', tabs, wrap }: Props): Node {
+export default function Tabs({
+  activeTabIndex,
+  onChange,
+  size = 'md',
+  tabs,
+  wrap,
+  // TODO: remove this default
+  _dangerouslyUseV2 = true,
+}: Props): Node {
+  const TabComponent = _dangerouslyUseV2 ? TabV2 : Tab;
+
   return (
-    <Flex alignItems="center" justifyContent="start" wrap={wrap}>
+    <Flex alignItems="center" gap={4} justifyContent="start" wrap={wrap}>
       {tabs.map(({ id, href, text, indicator }, index) => (
-        <Tab
+        <TabComponent
           key={id || `${href}_${index}`}
-          size={size}
-          onChange={onChange}
           href={href}
           id={id}
           index={index}
           isActive={activeTabIndex === index}
           indicator={indicator}
-        >
-          {text}
-        </Tab>
+          onChange={onChange}
+          size={size}
+          text={text}
+        />
       ))}
     </Flex>
   );
@@ -127,7 +275,7 @@ Tabs.propTypes = {
     PropTypes.shape({
       href: PropTypes.string.isRequired,
       id: PropTypes.string,
-      indicator: PropTypes.string,
+      indicator: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       text: PropTypes.node.isRequired,
     }),
   ).isRequired,

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -246,7 +246,7 @@ export default function Tabs({
   const TabComponent = _dangerouslyUseV2 ? TabV2 : Tab;
 
   return (
-    <Flex alignItems="center" gap={4} justifyContent="start" wrap={wrap}>
+    <Flex alignItems="center" gap={_dangerouslyUseV2 ? 4 : 0} justifyContent="start" wrap={wrap}>
       {tabs.map(({ id, href, text, indicator }, index) => (
         <TabComponent
           key={id || `${href}_${index}`}

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -174,7 +174,7 @@ function TabV2({
   }
 
   return (
-    <Box id={id} padding={3}>
+    <Box id={id} paddingY={3}>
       <TapArea
         href={href}
         onBlur={() => setFocused(false)}
@@ -247,7 +247,7 @@ export default function Tabs({
   const TabComponent = _dangerouslyUseV2 ? TabV2 : Tab;
 
   return (
-    <Flex alignItems="center" gap={_dangerouslyUseV2 ? 2 : 0} justifyContent="start" wrap={wrap}>
+    <Flex alignItems="center" gap={_dangerouslyUseV2 ? 4 : 0} justifyContent="start" wrap={wrap}>
       {tabs.map(({ id, href, text, indicator }, index) => (
         <TabComponent
           key={id || `${href}_${index}`}

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -241,8 +241,7 @@ export default function Tabs({
   size = 'md',
   tabs,
   wrap,
-  // TODO: remove this default before merging this PR
-  _dangerouslyUseV2 = true,
+  _dangerouslyUseV2,
 }: Props): Node {
   const TabComponent = _dangerouslyUseV2 ? TabV2 : Tab;
 

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -241,7 +241,8 @@ export default function Tabs({
   size = 'md',
   tabs,
   wrap,
-  _dangerouslyUseV2,
+  // TODO: remove this default before merging this PR
+  _dangerouslyUseV2 = true,
 }: Props): Node {
   const TabComponent = _dangerouslyUseV2 ? TabV2 : Tab;
 

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -246,7 +246,7 @@ export default function Tabs({
   const TabComponent = _dangerouslyUseV2 ? TabV2 : Tab;
 
   return (
-    <Flex alignItems="center" gap={_dangerouslyUseV2 ? 4 : 0} justifyContent="start" wrap={wrap}>
+    <Flex alignItems="center" gap={_dangerouslyUseV2 ? 2 : 0} justifyContent="start" wrap={wrap}>
       {tabs.map(({ id, href, text, indicator }, index) => (
         <TabComponent
           key={id || `${href}_${index}`}

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -241,8 +241,7 @@ export default function Tabs({
   size = 'md',
   tabs,
   wrap,
-  // TODO: remove this default
-  _dangerouslyUseV2 = true,
+  _dangerouslyUseV2,
 }: Props): Node {
   const TabComponent = _dangerouslyUseV2 ? TabV2 : Tab;
 

--- a/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
@@ -37,9 +37,17 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
         }
       >
         <div
-          className="Text fontSize3 white alignLeft noWrap fontWeightBold"
+          className="Flex rowGap2 itemsCenter justifyCenter xsDirectionRow"
         >
-          News
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize3 white alignLeft noWrap fontWeightBold"
+            >
+              News
+            </div>
+          </div>
         </div>
       </div>
     </a>
@@ -77,9 +85,17 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
         }
       >
         <div
-          className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
+          className="Flex rowGap2 itemsCenter justifyCenter xsDirectionRow"
         >
-          You
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
+            >
+              You
+            </div>
+          </div>
         </div>
       </div>
     </a>
@@ -124,20 +140,32 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
         }
       >
         <div
-          className="Text fontSize3 white alignLeft noWrap fontWeightBold"
+          className="Flex rowGap2 itemsCenter justifyCenter xsDirectionRow"
         >
-          News
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize3 white alignLeft noWrap fontWeightBold"
+            >
+              News
+            </div>
+          </div>
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="box circle redBg"
+              style={
+                Object {
+                  "height": 6,
+                  "marginTop": "1px",
+                  "width": 6,
+                }
+              }
+            />
+          </div>
         </div>
-        <div
-          className="box circle marginStart2 redBg"
-          style={
-            Object {
-              "height": 6,
-              "marginTop": "1px",
-              "width": 6,
-            }
-          }
-        />
       </div>
     </a>
   </div>
@@ -174,20 +202,32 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
         }
       >
         <div
-          className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
+          className="Flex rowGap2 itemsCenter justifyCenter xsDirectionRow"
         >
-          You
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
+            >
+              You
+            </div>
+          </div>
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="box circle redBg"
+              style={
+                Object {
+                  "height": 6,
+                  "marginTop": "1px",
+                  "width": 6,
+                }
+              }
+            />
+          </div>
         </div>
-        <div
-          className="box circle marginStart2 redBg"
-          style={
-            Object {
-              "height": 6,
-              "marginTop": "1px",
-              "width": 6,
-            }
-          }
-        />
       </div>
     </a>
   </div>
@@ -231,9 +271,17 @@ exports[`<Tabs /> matches snapshot with lg size and wrap 1`] = `
         }
       >
         <div
-          className="Text fontSize3 white alignLeft noWrap fontWeightBold"
+          className="Flex rowGap2 itemsCenter justifyCenter xsDirectionRow"
         >
-          News
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize3 white alignLeft noWrap fontWeightBold"
+            >
+              News
+            </div>
+          </div>
         </div>
       </div>
     </a>
@@ -271,9 +319,17 @@ exports[`<Tabs /> matches snapshot with lg size and wrap 1`] = `
         }
       >
         <div
-          className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
+          className="Flex rowGap2 itemsCenter justifyCenter xsDirectionRow"
         >
-          You
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize3 darkGray alignLeft noWrap fontWeightBold"
+            >
+              You
+            </div>
+          </div>
         </div>
       </div>
     </a>


### PR DESCRIPTION
[Design doc](https://www.figma.com/file/vlihOKdfamsqUQhd9ybkQv/Tab-component-redesign?node-id=30%3A2387)

This PR adds a new tab variant for the Tabs component, accessible by passing a new undocumented prop, `_dangerouslyUseV2`. The rest of the component API remains the same, with one exception: the `indicator` field of each tab object can now also accept a number. Though not used initially, this will be used in future experiments as a replacement for the notification dot. (For now we need to support both; we _may_ be able to deprecate the dot variant in the future.)

### Test Plan

Add `_dangerouslyUseV2={true}` to the docs example to see the new UI. Note that we're dropping support for the `'md'` size, so both examples will be identical. Try passing a number instead of `'dot'` as the `indicator` for a tab. Also be sure to open DevTools and view as mobile to observe the different touch interactions.