### PR TITLE
Box: add `as` prop to use semantic tags

### DIFF
--- a/docs/src/Box.doc.js
+++ b/docs/src/Box.doc.js
@@ -34,6 +34,12 @@ card(
         href: 'Best-Practices',
       },
       {
+        name: 'as',
+        type: `"article" | "aside" | "details" | "div" | "figcaption" | "figure" | "footer" | "header" | "main" | "nav" | "section" | "summary"`,
+        defaultValue: 'div',
+        description: `Changes the underlying DOM element when needed for accessibility or SEO reasons. Note that currently only block-level elements are available.`,
+      },
+      {
         name: 'display',
         type: `"none" | "flex" | "block" | "inlineBlock" | "visuallyHidden"`,
         defaultValue: 'block',

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -203,10 +203,10 @@ const disallowedProps = [
 ];
 
 type OutputType =
-  | Element<'div'>
   | Element<'article'>
   | Element<'aside'>
   | Element<'details'>
+  | Element<'div'>
   | Element<'figcaption'>
   | Element<'figure'>
   | Element<'footer'>

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -25,6 +25,7 @@ import {
   type AlignContent,
   type AlignItems,
   type AlignSelf,
+  type As,
   type BorderStyle,
   type Bottom,
   type Column,
@@ -50,6 +51,7 @@ import {
   AlignContentPropType,
   AlignItemsPropType,
   AlignSelfPropType,
+  AsPropType,
   BorderStylePropType,
   ColorPropType,
   ColumnPropType,
@@ -98,6 +100,7 @@ type Props = {
   alignContent?: AlignContent,
   alignItems?: AlignItems,
   alignSelf?: AlignSelf,
+  as?: As,
   bottom?: Bottom,
   borderStyle?: BorderStyle,
   color?: Color,
@@ -199,19 +202,36 @@ const disallowedProps = [
   'lgMarginRight',
 ];
 
-const BoxWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwardRef<
-  Props,
-  HTMLDivElement,
->(function Box(props, ref): Element<'div'> {
-  const { passthroughProps, propsStyles } = buildStyles<Props>({
-    baseStyles: styles.box,
-    props,
-    blocklistProps: disallowedProps,
-  });
+type OutputType =
+  | Element<'div'>
+  | Element<'article'>
+  | Element<'aside'>
+  | Element<'details'>
+  | Element<'figcaption'>
+  | Element<'figure'>
+  | Element<'footer'>
+  | Element<'header'>
+  | Element<'main'>
+  | Element<'mark'>
+  | Element<'nav'>
+  | Element<'section'>
+  | Element<'summary'>
+  | Element<'time'>;
 
-  // And... magic!
-  return <div {...passthroughProps} {...propsStyles} ref={ref} />;
-});
+const BoxWithForwardRef: AbstractComponent<Props, HTMLElement> = forwardRef<Props, HTMLElement>(
+  function Box({ as, ...props }, ref): OutputType {
+    const { passthroughProps, propsStyles } = buildStyles<$Diff<Props, {| as?: As |}>>({
+      baseStyles: styles.box,
+      props,
+      blocklistProps: disallowedProps,
+    });
+
+    const BoxElement = as ?? 'div';
+
+    // And... magic!
+    return <BoxElement {...passthroughProps} {...propsStyles} ref={ref} />;
+  },
+);
 
 BoxWithForwardRef.displayName = 'Box';
 
@@ -251,6 +271,7 @@ BoxWithForwardRef.propTypes = {
   alignContent: AlignContentPropType,
   alignItems: AlignItemsPropType,
   alignSelf: AlignSelfPropType,
+  as: AsPropType,
   bottom: PropTypes.bool,
   borderStyle: BorderStylePropType,
   color: ColorPropType,

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -212,11 +212,9 @@ type OutputType =
   | Element<'footer'>
   | Element<'header'>
   | Element<'main'>
-  | Element<'mark'>
   | Element<'nav'>
   | Element<'section'>
-  | Element<'summary'>
-  | Element<'time'>;
+  | Element<'summary'>;
 
 const BoxWithForwardRef: AbstractComponent<Props, HTMLElement> = forwardRef<Props, HTMLElement>(
   function Box({ as, ...props }, ref): OutputType {

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -45,7 +45,7 @@ type OwnProps = {|
 |};
 
 type HookProps = {|
-  scrollBoundaryContainerRef: ?HTMLDivElement,
+  scrollBoundaryContainerRef: ?HTMLElement,
 |};
 type ColorSchemeProps = {|
   colorGray100: string,

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -31,7 +31,7 @@ type OwnProps = {|
 |};
 
 type HookProps = {|
-  scrollBoundaryContainerRef: ?HTMLDivElement,
+  scrollBoundaryContainerRef: ?HTMLElement,
 |};
 
 type Props = {| ...OwnProps, ...HookProps |};

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -77,7 +77,7 @@ const ModalWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> = forw
 
   const [showTopShadow, setShowTopShadow] = useState(false);
   const [showBottomShadow, setShowBottomShadow] = useState(false);
-  const contentRef = useRef<?HTMLDivElement>(null);
+  const contentRef = useRef<?HTMLElement>(null);
 
   useEffect(() => {
     function handleKeyUp(event: {| keyCode: number |}) {

--- a/packages/gestalt/src/ScrollBoundaryContainer.js
+++ b/packages/gestalt/src/ScrollBoundaryContainer.js
@@ -49,13 +49,13 @@ type InternalProps = {|
 // It has an extended API with private props (onScroll, padding, and ref) to maintain border shadows in the component main content container.
 const ScrollBoundaryContainerWithForwardRef: AbstractComponent<
   InternalProps,
-  HTMLDivElement,
-> = forwardRef<InternalProps, HTMLDivElement>(function ScrollBoundaryContainer(
+  HTMLElement,
+> = forwardRef<InternalProps, HTMLElement>(function ScrollBoundaryContainer(
   { children, onScroll, padding = 0, height = '100%', overflow = 'auto' },
   ref,
 ): Node {
   const { addRef } = useScrollBoundaryContainer();
-  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const anchorRef = useRef<HTMLElement | null>(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Button ref={inputRef} /> to call inputRef.current.focus()
   useImperativeHandle(ref, () => anchorRef.current);

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -134,7 +134,7 @@ const SheetWithForwardRef: React$AbstractComponent<SheetProps, HTMLDivElement> =
   const [showBottomShadow, setShowBottomShadow] = useState<boolean>(false);
   const { animationState, onAnimationEnd } = useAnimation();
   const containerRef = useRef<?HTMLDivElement>(null);
-  const contentRef = useRef<?HTMLDivElement>(null);
+  const contentRef = useRef<?HTMLElement>(null);
 
   // Handle onDismiss triggering from ESC keyup event
   useEffect(() => {

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -63,7 +63,7 @@ export default function Tooltip({
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const { isOpen } = state;
 
-  const childRef = React.useRef<?HTMLDivElement>(null);
+  const childRef = React.useRef<?HTMLElement>(null);
   const { current: anchor } = childRef;
 
   const mouseLeaveDelay = link ? TIMEOUT : 0;

--- a/packages/gestalt/src/boxTypes.js
+++ b/packages/gestalt/src/boxTypes.js
@@ -14,6 +14,20 @@ export type DangerouslySetInlineStyle = {|
 export type AlignContent = 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch';
 export type AlignItems = 'start' | 'end' | 'center' | 'baseline' | 'stretch';
 export type AlignSelf = 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch';
+export type As =
+  | 'article'
+  | 'aside'
+  | 'details'
+  | 'figcaption'
+  | 'figure'
+  | 'footer'
+  | 'header'
+  | 'main'
+  | 'mark'
+  | 'nav'
+  | 'section'
+  | 'summary'
+  | 'time';
 export type Bottom = boolean;
 export type BorderStyle = 'sm' | 'lg' | 'shadow' | 'none';
 export type Color =
@@ -115,6 +129,21 @@ export const AlignSelfPropType: React$PropType$Primitive<AlignSelf> = PropTypes.
   'center',
   'baseline',
   'stretch',
+]);
+export const AsPropType: React$PropType$Primitive<As> = PropTypes.oneOf([
+  'article',
+  'aside',
+  'details',
+  'figcaption',
+  'figure',
+  'footer',
+  'header',
+  'main',
+  'mark',
+  'nav',
+  'section',
+  'summary',
+  'time',
 ]);
 export const BorderStylePropType: React$PropType$Primitive<BorderStyle> = PropTypes.oneOf([
   'sm',

--- a/packages/gestalt/src/boxTypes.js
+++ b/packages/gestalt/src/boxTypes.js
@@ -18,6 +18,7 @@ export type As =
   | 'article'
   | 'aside'
   | 'details'
+  | 'div'
   | 'figcaption'
   | 'figure'
   | 'footer'
@@ -132,6 +133,7 @@ export const AsPropType: React$PropType$Primitive<As> = PropTypes.oneOf([
   'article',
   'aside',
   'details',
+  'div',
   'figcaption',
   'figure',
   'footer',

--- a/packages/gestalt/src/boxTypes.js
+++ b/packages/gestalt/src/boxTypes.js
@@ -23,11 +23,9 @@ export type As =
   | 'footer'
   | 'header'
   | 'main'
-  | 'mark'
   | 'nav'
   | 'section'
-  | 'summary'
-  | 'time';
+  | 'summary';
 export type Bottom = boolean;
 export type BorderStyle = 'sm' | 'lg' | 'shadow' | 'none';
 export type Color =
@@ -139,11 +137,9 @@ export const AsPropType: React$PropType$Primitive<As> = PropTypes.oneOf([
   'footer',
   'header',
   'main',
-  'mark',
   'nav',
   'section',
   'summary',
-  'time',
 ]);
 export const BorderStylePropType: React$PropType$Primitive<BorderStyle> = PropTypes.oneOf([
   'sm',

--- a/packages/gestalt/src/contexts/ScrollBoundaryContainer.js
+++ b/packages/gestalt/src/contexts/ScrollBoundaryContainer.js
@@ -11,7 +11,7 @@ import React, {
 import PropTypes from 'prop-types';
 
 type ScrollBoundaryContainerContextType = {|
-  scrollBoundaryContainerRef: ?HTMLDivElement,
+  scrollBoundaryContainerRef: ?HTMLElement,
   addRef: (ref: HTMLElement) => void,
 |};
 
@@ -34,8 +34,6 @@ function ScrollBoundaryContainerProvider({ children }: Props): Element<typeof Pr
   const scrollBoundaryContainerContext = {
     scrollBoundaryContainerRef,
     addRef: useCallback((ref) => {
-      // Cannot call `setScrollBoundaryContainerRef` with `ref` bound to the first parameter because a call signature declaring the expected parameter / return type is missing in  `HTMLElement` [1] but exists in  function type [2].
-      // $FlowFixMe[incompatible-call]
       setScrollBoundaryContainerRef(ref);
     }, []),
   };

--- a/packages/gestalt/src/contexts/ScrollBoundaryContainer.js
+++ b/packages/gestalt/src/contexts/ScrollBoundaryContainer.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 
 type ScrollBoundaryContainerContextType = {|
   scrollBoundaryContainerRef: ?HTMLDivElement,
-  addRef: (ref: HTMLDivElement) => void,
+  addRef: (ref: HTMLElement) => void,
 |};
 
 type Props = {|
@@ -34,6 +34,8 @@ function ScrollBoundaryContainerProvider({ children }: Props): Element<typeof Pr
   const scrollBoundaryContainerContext = {
     scrollBoundaryContainerRef,
     addRef: useCallback((ref) => {
+      // Cannot call `setScrollBoundaryContainerRef` with `ref` bound to the first parameter because a call signature declaring the expected parameter / return type is missing in  `HTMLElement` [1] but exists in  function type [2].
+      // $FlowFixMe[incompatible-call]
       setScrollBoundaryContainerRef(ref);
     }, []),
   };

--- a/packages/gestalt/src/utils/positioningUtils.js
+++ b/packages/gestalt/src/utils/positioningUtils.js
@@ -37,9 +37,9 @@ export const getContainerNode = ({
   scrollBoundaryContainerRef,
   initialPositionRef,
 }: {|
-  scrollBoundaryContainerRef: ?HTMLDivElement,
+  scrollBoundaryContainerRef: ?HTMLElement,
   initialPositionRef: ?HTMLElement,
-|}): ?HTMLDivElement => {
+|}): ?HTMLElement => {
   // containerNode references the ScrollBoundaryContainer node to which
   // append the portal
   let containerNode = null;
@@ -75,7 +75,7 @@ export const getTriggerRect = ({
 }: {|
   anchor: HTMLElement,
   positionRelativeToAnchor: boolean,
-  scrollBoundaryContainerRef: ?HTMLDivElement,
+  scrollBoundaryContainerRef: ?HTMLElement,
 |}): * => {
   let triggerBoundingRect;
   let relativeOffset;


### PR DESCRIPTION
For SEO and a11y purposes, we need to improve our support for semantic HTML elements. A simple way to accomplish this is to add a new prop to Box that will allow that component to output more than just `div` elements. This PR adds the prop `as`, which is an enum of block-level elements. This enum should cover our current use cases, and is easily added to in the future.

### Test Plan

The easiest way to verify this is working is to navigate to the Box docs on the preview link, then add something like `as="article"` to a Box example. Inspect the element and note that it now uses the `<article>` tag instead of `<div>`.