### PR TITLE
Link/Button/IconButton/TapArea +composed components: always pass disableOnNavigation to onClick

### DIFF
--- a/docs/src/ActivationCard.doc.js
+++ b/docs/src/ActivationCard.doc.js
@@ -44,7 +44,7 @@ card(
       {
         name: 'link',
         type:
-          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }, {| disableOnNavigation?: () => void |}) => void |}',
+          '{| accessibilityLabel?: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }, {| disableOnNavigation: () => void |}) => void |}',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/src/Button.doc.js
+++ b/docs/src/Button.doc.js
@@ -113,7 +113,7 @@ card(
       {
         name: 'onClick',
         type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -64,7 +64,7 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation?: () => void |}',
+          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         required: false,
         defaultValue: null,
         description: `
@@ -76,7 +76,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation?: () => void |}',
+          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         required: false,
         defaultValue: null,
         description: `

--- a/docs/src/Dropdown.doc.js
+++ b/docs/src/Dropdown.doc.js
@@ -196,7 +196,7 @@ card(
       {
         name: 'onClick',
         type:
-          'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation?: () => void |}',
+          'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         description: [
           'Callback fired when a component is activated with a mouse or keyboard. ',
           'See the [Custom navigation context](#Custom-navigation-context) variant and [Provider](/Provider) for more info.',

--- a/docs/src/IconButton.doc.js
+++ b/docs/src/IconButton.doc.js
@@ -127,7 +127,7 @@ card(
       {
         name: 'onClick',
         type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -69,7 +69,7 @@ card(
       {
         name: 'onClick',
         type:
-          'AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}>',
+          'AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}>',
         description:
           'Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [custom navigation](#Custom-navigation) variant for examples.',
         href: 'Custom-navigation',

--- a/docs/src/TapArea.doc.js
+++ b/docs/src/TapArea.doc.js
@@ -133,7 +133,7 @@ card(
       {
         name: 'onMouseDown',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: ['Callback fired when a click event begins.'],
@@ -149,7 +149,7 @@ card(
       {
         name: 'onMouseEnter',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: ['Callback fired when a mouse pointer moves onto a TapArea component.'],
@@ -165,7 +165,7 @@ card(
       {
         name: 'onTap',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation?: () => void |}> }) }) => void',
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) }) => void',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -71,7 +71,7 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation?: () => void |}',
+          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         required: false,
         defaultValue: null,
         description: `
@@ -83,7 +83,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation?: () => void |}',
+          '{| accessibilityLabel?: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         required: false,
         defaultValue: null,
         description: `

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -20,7 +20,7 @@ type LinkData = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   rel?: 'none' | 'nofollow',
   target?: null | 'self' | 'blank',

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -42,7 +42,7 @@ type BaseButton = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   tabIndex?: -1 | 0,
   size?: 'sm' | 'md' | 'lg',
@@ -177,7 +177,9 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
   );
 
   const handleClick = (event, disableOnNavigation) =>
-    onClick ? onClick(disableOnNavigation ? { event, disableOnNavigation } : { event }) : undefined;
+    onClick
+      ? onClick({ event, disableOnNavigation: disableOnNavigation ?? (() => {}) })
+      : undefined;
 
   const handleLinkClick = ({ event, disableOnNavigation }) =>
     handleClick(event, disableOnNavigation);

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -15,7 +15,7 @@ type PublicProps = {|
   isExternal?: boolean,
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   option: OptionObject,
   selected?: OptionObject | $ReadOnlyArray<OptionObject> | null,

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -29,7 +29,7 @@ type BaseIconButton = {|
     | SyntheticKeyboardEvent<HTMLButtonElement>
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   padding?: 1 | 2 | 3 | 4 | 5,
@@ -125,7 +125,9 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
   };
 
   const handleClick = (event, disableOnNavigation) =>
-    onClick ? onClick(disableOnNavigation ? { event, disableOnNavigation } : { event }) : undefined;
+    onClick
+      ? onClick({ event, disableOnNavigation: disableOnNavigation ?? (() => {}) })
+      : undefined;
 
   const handleLinkClick = ({ event, disableOnNavigation }) =>
     handleClick(event, disableOnNavigation);

--- a/packages/gestalt/src/InternalLink.js
+++ b/packages/gestalt/src/InternalLink.js
@@ -33,7 +33,7 @@ type Props = {|
   mouseCursor?: 'copy' | 'grab' | 'grabbing' | 'move' | 'noDrop' | 'pointer' | 'zoomIn' | 'zoomOut',
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   onBlur?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
   onFocus?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
@@ -158,6 +158,15 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
     defaultOnNavigation = undefined;
   };
 
+  const handleKeyPress = (event) => {
+    // Check to see if space or enter were pressed
+    if (onClick && keyPressShouldTriggerTap(event)) {
+      // Prevent the default action to stop scrolling when space is pressed
+      event.preventDefault();
+      onClick({ event, disableOnNavigation: () => {} });
+    }
+  };
+
   return (
     <a
       aria-label={accessibilityLabel}
@@ -193,14 +202,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
         onMouseUp?.({ event });
         handleMouseUp();
       }}
-      onKeyPress={(event) => {
-        // Check to see if space or enter were pressed
-        if (onClick && keyPressShouldTriggerTap(event)) {
-          // Prevent the default action to stop scrolling when space is pressed
-          event.preventDefault();
-          onClick({ event });
-        }
-      }}
+      onKeyPress={handleKeyPress}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchCancel={handleTouchCancel}

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -29,7 +29,7 @@ type Props = {|
   onBlur?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   onFocus?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
   rel?: 'none' | 'nofollow',
@@ -106,6 +106,15 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     defaultOnNavigation = undefined;
   };
 
+  const handleKeyPress = (event) => {
+    // Check to see if space or enter were pressed
+    if (onClick && keyPressShouldTriggerTap(event)) {
+      // Prevent the default action to stop scrolling when space is pressed
+      event.preventDefault();
+      onClick({ event, disableOnNavigation: () => {} });
+    }
+  };
+
   return (
     <a
       aria-label={accessibilityLabel}
@@ -137,14 +146,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
       }}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
-      onKeyPress={(event) => {
-        // Check to see if space or enter were pressed
-        if (onClick && keyPressShouldTriggerTap(event)) {
-          // Prevent the default action to stop scrolling when space is pressed
-          event.preventDefault();
-          onClick({ event });
-        }
-      }}
+      onKeyPress={handleKeyPress}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchCancel={handleTouchCancel}

--- a/packages/gestalt/src/MenuOption.js
+++ b/packages/gestalt/src/MenuOption.js
@@ -26,7 +26,7 @@ type Props = {|
   index: number,
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   option: OptionObject,
   selected?: OptionObject | $ReadOnlyArray<OptionObject> | null,

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -14,7 +14,7 @@ type Props = {|
     | SyntheticKeyboardEvent<HTMLDivElement>
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   rowSpan?: number,
   scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -36,7 +36,7 @@ type BaseTapArea = {|
     | SyntheticKeyboardEvent<HTMLDivElement>
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   tabIndex?: -1 | 0,
   rounding?: Rounding,
@@ -119,9 +119,18 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
     },
   );
 
+  const handleKeyPress = (event) => {
+    // Check to see if space or enter were pressed
+    if (!disabled && onTap && keyPressShouldTriggerTap(event)) {
+      // Prevent the default action to stop scrolling when space is pressed
+      event.preventDefault();
+      onTap({ event, disableOnNavigation: () => {} });
+    }
+  };
+
   const handleClick = (event, disableOnNavigation) =>
     !disabled && onTap
-      ? onTap(disableOnNavigation ? { event, disableOnNavigation } : { event })
+      ? onTap({ event, disableOnNavigation: disableOnNavigation ?? (() => {}) })
       : undefined;
 
   const handleLinkClick = ({ event, disableOnNavigation }) =>
@@ -218,14 +227,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
       }}
       onMouseEnter={handleOnMouseEnter}
       onMouseLeave={handleOnMouseLeave}
-      onKeyPress={(event) => {
-        // Check to see if space or enter were pressed
-        if (!disabled && onTap && keyPressShouldTriggerTap(event)) {
-          // Prevent the default action to stop scrolling when space is pressed
-          event.preventDefault();
-          onTap({ event });
-        }
-      }}
+      onKeyPress={handleKeyPress}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchCancel={handleTouchCancel}

--- a/packages/gestalt/src/commonTypes.js
+++ b/packages/gestalt/src/commonTypes.js
@@ -11,7 +11,7 @@ export type ActionDataType = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
-    {| disableOnNavigation?: () => void |},
+    {| disableOnNavigation: () => void |},
   >,
   rel?: 'none' | 'nofollow',
   target?: null | 'self' | 'blank',


### PR DESCRIPTION
`disableOnNavigation`  is not always passed to onClick. Within Link or Internal Link, it does disable the logic from Provider. 

Outside of it, it's just a noop function.

This change changes the flow type so `disableOnNavigation` isn't optional. This prevents having to call `disableOnNavigation` with optional chaining `disableOnNavigation?.()` in the best of the cases or conditional statements within `onClick`:

`disableOnNavigation && disableOnNavigation()
`
`if (disableOnNavigation)  disableOnNavigation()
`

This change won't break code but might require cleaning optional chaining to prevent eslint complains.
<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
