### PR TITLE
Docs: Fix outdated What's New Page

### DIFF
--- a/docs/src/What's New.doc.js
+++ b/docs/src/What's New.doc.js
@@ -13,7 +13,7 @@ function Changelog() {
   useEffect(() => {
     const fetchChangelog = async () => {
       const result = await fetch(
-        'https://cdn.jsdelivr.net/gh/pinterest/gestalt@master/CHANGELOG.md',
+        'https://raw.githubusercontent.com/pinterest/gestalt/master/CHANGELOG.md',
       );
       setChangelogData(
         result.ok


### PR DESCRIPTION
https://cdn.jsdelivr.net heavily caches their files so our What's New Page stays outdated for a while.

## Before

![image](https://user-images.githubusercontent.com/127199/113242302-7d82ac00-9265-11eb-97cf-58ad982d97d1.png)


## After

![image](https://user-images.githubusercontent.com/127199/113242356-a60aa600-9265-11eb-87a7-e4dbf27372c2.png)
