### PR TITLE
Link/Button/IconButton/TapArea +composed components: refactored disab…

### DIFF
--- a/packages/gestalt/src/InternalLink.js
+++ b/packages/gestalt/src/InternalLink.js
@@ -152,11 +152,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
 
   // useOnNavigation is only accessible with Gestalt Provider
   // and when onNavigation prop is passed to it
-  let defaultOnNavigation = useOnNavigation({ href, target });
-
-  const disableOnNavigation = () => {
-    defaultOnNavigation = undefined;
-  };
+  const defaultOnNavigation = useOnNavigation({ href, target });
 
   return (
     <a
@@ -170,11 +166,18 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
         handleBlur();
       }}
       onClick={(event) => {
+        let defaultOnNavigationIsEnabled = true;
+        const disableOnNavigation = () => {
+          defaultOnNavigationIsEnabled = false;
+        };
+
         onClick?.({
           event,
           disableOnNavigation,
         });
-        defaultOnNavigation?.({ event });
+        if (defaultOnNavigation && defaultOnNavigationIsEnabled) {
+          defaultOnNavigation({ event });
+        }
       }}
       onFocus={(event) => {
         onFocus?.({ event });

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -100,11 +100,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
 
   // useOnNavigation is only accessible with Gestalt Provider
   // and when onNavigation prop is passed to it
-  let defaultOnNavigation = useOnNavigation({ href, target });
-
-  const disableOnNavigation = () => {
-    defaultOnNavigation = undefined;
-  };
+  const defaultOnNavigation = useOnNavigation({ href, target });
 
   return (
     <a
@@ -120,13 +116,18 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
         }
       }}
       onClick={(event) => {
+        let defaultOnNavigationIsEnabled = true;
+        const disableOnNavigation = () => {
+          defaultOnNavigationIsEnabled = false;
+        };
+
         if (onClick) {
           onClick({
             event,
             disableOnNavigation,
           });
         }
-        if (defaultOnNavigation) {
+        if (defaultOnNavigation && defaultOnNavigationIsEnabled) {
           defaultOnNavigation({ event });
         }
       }}


### PR DESCRIPTION
…leOnNavigation logic inside Link/InternalLink

As per @jackhsu978 request, refactored Link/InternalLinkso that we don't mutate `defaultOnNavigation` and the side effect doesn't go outside of the onClick event handler.



<!--
What is the purpose of this PR?

* What is the context surrounding this PR? Include links if possible.
* What kind of feedback do you want?
* Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

## Test Plan

<!--
How can reviewers verify this is good to merge?

* Is it tested?
* Is it accessible?
* Is it documented?
* Have you involved other stakeholders (such as a Pinterest Designer)?
-->
