### PR TITLE
Typeahead: Fix static `value` bug

### DIFF
--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -88,7 +88,12 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
 
   // Track input value
   const defaultOption: OptionObject | null = findDefaultOption(value);
-  const [search, setSearch] = useState<string>(defaultOption?.label || '');
+  const displayValue = defaultOption?.label ?? '';
+  const [search, setSearch] = useState<string>('');
+  // Make sure we respect any external changes to `value`
+  useEffect(() => {
+    setSearch(displayValue);
+  }, [displayValue]);
 
   // Track the selected item - could be used to see if someone is selecting the same thing again
   const [selected, setSelected] = useState<OptionObject | null>(defaultOption);

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -90,16 +90,16 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const defaultOption: OptionObject | null = findDefaultOption(value);
   const displayValue = defaultOption?.label ?? '';
   const [search, setSearch] = useState<string>(displayValue);
-  // Make sure we respect any external changes to `value`
-  useEffect(() => {
-    setSearch(displayValue);
-  }, [displayValue]);
-
   // Track the selected item - could be used to see if someone is selecting the same thing again
   const [selected, setSelected] = useState<OptionObject | null>(defaultOption);
 
-  const [hoveredItem, setHoveredItem] = useState<number | null>(0);
+  // Make sure we respect any external changes to `value`
+  useEffect(() => {
+    setSearch(displayValue);
+    setSelected(defaultOption);
+  }, [defaultOption, displayValue]);
 
+  const [hoveredItem, setHoveredItem] = useState<number | null>(0);
   const [availableOptions, setAvailableOptions] = useState<$ReadOnlyArray<OptionObject>>(options);
 
   // Ref to the input

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -89,7 +89,7 @@ const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   // Track input value
   const defaultOption: OptionObject | null = findDefaultOption(value);
   const displayValue = defaultOption?.label ?? '';
-  const [search, setSearch] = useState<string>('');
+  const [search, setSearch] = useState<string>(displayValue);
   // Make sure we respect any external changes to `value`
   useEffect(() => {
     setSearch(displayValue);


### PR DESCRIPTION
Typeahead initializes its displayed value with the passed-in `value` prop (if present), but ignores any changes to that prop. So if, say an action elsewhere on the page causes a new `value` to be passed in, Typeahead completely ignores it.

This PR adds a useEffect to listen for any changes to `value` and update the internal displayed value variable accordingly.

### Test Plan

I recommend copying the code from [this sandbox](https://codesandbox.io/s/default-item-example-forked-5z7sb?file=/example.js:179-183) into one of the docs examples, then play around and see if you can break it. You should be able to select a new value via the dropdown or by typing, and the programmatic selection via the buttons should work fine as well.