### PR TITLE
Docs: convert ESLint docs to new format

### DIFF
--- a/docs/src/Eslint Plugin.doc.js
+++ b/docs/src/Eslint Plugin.doc.js
@@ -1,9 +1,7 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Flex, Heading, Link, Text } from 'gestalt';
-import Markdown from './components/Markdown.js';
-import Card from './components/Card.js';
 import PageHeader from './components/PageHeader.js';
+import MainSection from './components/MainSection.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -17,61 +15,48 @@ card(
 );
 
 card(
-  <Card name="Supported Rules">
-    <Flex alignItems="start" direction="column" gap={4}>
-      <Heading size="sm">gestalt/button-icon-restrictions</Heading>
-      <Text>
-        Require specific props when using an icon with Button. Gestalt is more permissive than PDS
-        recommends in adding icons to Buttons. Buttons using iconEnd must use:
-        <ul>
-          <li>icon &quot;arrow-down&quot;</li>
-          <li>color &quot;white&quot;</li>
-          <li>size &quot;lg&quot;</li>
-        </ul>
-      </Text>
-      <Heading size="sm">gestalt/no-box-marginleft-marginright</Heading>
-      <Text>
-        Disallow marginLeft/marginRight on Box. In order to have consistent usage of
-        marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd
-      </Text>
-      <Heading size="sm">gestalt/no-dangerous-style-duplicates</Heading>
-      <Text>
-        Prevent using dangerouslySetInlineStyle on Box for props that are already directly
-        implemented. Box supports some props already that are not widely known and instead are being
-        implemented with dangerouslySetInlineStyle. This linter checks for usage of already
-        available props as dangerous styles and suggests the alternative.
-      </Text>
-      <Heading size="sm">gestalt/no-medium-formfields</Heading>
-      <Text>
-        Disallow medium form fields. In order to have consistent form fields in production, we
-        update all of their sizes to large and disallow medium.
-      </Text>
-      <Heading size="sm">gestalt/no-role-link-components</Heading>
-      <Text>
-        Do not allow role=&apos;link&apos; on Button, TapArea, and IconButton in cases where an
-        alternative with additional functionality must be used instead such as for use with a
-        routing library
-      </Text>
-    </Flex>
-  </Card>,
+  <MainSection name="Supported Rules">
+    <MainSection.Subsection
+      title="gestalt/button-icon-restrictions"
+      description={`
+        Require specific props when using an icon with Button. Gestalt recommends in adding icons to Buttons. Buttons using \`iconEnd\` must use:
+        * icon &quot;arrow-down&quot;
+        * color &quot;white&quot;
+        * size &quot;lg&quot;
+      `}
+    />
+    <MainSection.Subsection
+      title="gestalt/no-box-marginleft-marginright"
+      description={`
+        Disallow marginLeft/marginRight on Box. In order to have consistent usage of marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd.
+      `}
+    />
+    <MainSection.Subsection
+      title="gestalt/no-dangerous-style-duplicates"
+      description={`
+        Prevent using dangerouslySetInlineStyle on Box for props that are already directly implemented. Box supports some props already that are not widely known and instead are being implemented with dangerouslySetInlineStyle. This linter checks for usage of already available props as dangerous styles and suggests the alternative.
+      `}
+    />
+    <MainSection.Subsection
+      title="gestalt/no-medium-formfields"
+      description={`
+        Disallow medium form fields. In order to have consistent form fields in production, we update all of their sizes to large and disallow medium.
+      `}
+    />
+    <MainSection.Subsection
+      title="gestalt/no-role-link-components"
+      description={`
+        Do not allow role=&apos;link&apos; on Button, TapArea, and IconButton in cases where an alternative with additional functionality must be used instead such as for use with a routing library
+      `}
+    />
+  </MainSection>,
 );
 
 card(
-  <Card name="Install">
-    <Flex alignItems="start" direction="column" gap={4}>
-      <Text>
-        You&apos;ll first need to install{' '}
-        <Link inline href="http://eslint.org" target="blank">
-          <Text weight="bold">ESLint</Text>
-        </Link>{' '}
-        , then install{' '}
-        <Text inline italic>
-          eslint-plugin-gestalt
-        </Text>
-        :
-      </Text>
-      <Markdown
-        text="
+  <MainSection
+    name="Install"
+    description={`
+You&apos;ll first need to install [ESLint](https://eslint.org), then install *eslint-plugin-gestalt*.
 ~~~bash
 $ npm install eslint --save-dev
 $ npm install eslint-plugin-gestalt --save-dev
@@ -80,107 +65,71 @@ or
 ~~~bash
 $ yarn add --dev eslint
 $ yarn add --dev eslint-plugin-gestalt
-~~~"
-      />
-      <Text>
-        **Note:** If you installed ESLint globally (using the{' '}
-        <Text inline italic>
-          -g
-        </Text>{' '}
-        flag) then you must also install{' '}
-        <Text inline italic>
-          eslint-plugin-gestalt
-        </Text>{' '}
-        globally.
-      </Text>
-    </Flex>
-  </Card>,
+~~~
+
+**Note:** If you installed ESLint globally (using the \`-g\` flag) then you must also install \`eslint-plugin-gestalt\` globally.
+`}
+  />,
 );
 
 card(
-  <Card name="Usage">
-    <Flex alignItems="start" direction="column" gap={4}>
-      <Text>
-        Add gestalt to the plugins section of your .eslintrc configuration file. You can omit the
-        eslint-plugin- prefix:
-      </Text>
-      <Markdown
-        text='
+  <MainSection
+    name="Usage"
+    description={`
+  Add gestalt to the plugins section of your .eslintrc configuration file. You can omit the eslint-plugin- prefix:
+
 ~~~jsx
 { "plugins": ["gestalt"] }
 ~~~
-'
-      />
-      <Text>Then configure the rules you want to use under the rules section.</Text>
-      <Markdown
-        text='
+
+Then configure the rules you want to use under the rules section.
+
 ~~~jsx
-{ "rules": {
-    "gestalt/rule-name": 2
-  } }
+{
+  "rules": {
+    "gestalt/rule-name": "error"
+  }
+}
 ~~~
-'
-      />
-    </Flex>
-  </Card>,
+`}
+  />,
 );
 
 card(
-  <Card name="Development">
-    <Flex alignItems="start" direction="column" gap={4}>
-      <Text>
-        New rules should be developed TDD-style by testing against simplified test cases first. See
-        the \*.test.js files and fixtures for examples. You can test locally by running:
-      </Text>
-      <Markdown
-        text="
+  <MainSection
+    name="Development"
+    description={`
+New rules should be developed TDD-style by testing against simplified test cases first. See the *.test.js files and fixtures for examples. You can test locally by running:
 ~~~bash
 yarn jest --watch eslint-plugin-gestalt/src/[name-of-test-file]
 ~~~
-"
-      />
-      <Text>
-        Once tests pass, you can check the rules against a project using gestalt through yarn link.
-        For example:
-      </Text>
-      <Markdown
-        text="
+
+Once tests pass, you can check the rules against a project using gestalt through yarn link. For example:
+
 ~~~bash
 cd ~/code/gestalt/packages/gestalt-eslint
 yarn link
 cd ~/code/project-using-gestalt
 yarn link eslint-plugin-gestalt
 ~~~
-"
-      />
-      <Text>
-        You can now add any new rules to the project&apos;s eslint config and run eslint against the
-        project to test your changes. Remember to unlink when you&apos;re done!
-      </Text>
-      <Markdown
-        text="
+
+You can now add any new rules to the project's eslint config and run eslint against the project to test your changes. Remember to unlink when you're done!
+
 ~~~bash
 cd ~/code/project-using-gestalt
 yarn unlink eslint-plugin-gestalt
 ~~~
-"
-      />
-    </Flex>
-  </Card>,
+  `}
+  />,
 );
 
 card(
-  <Card name="Releasing">
-    <Flex alignItems="start" direction="column" gap={4}>
-      <Text>
-        Every commit to master performs a release. See the main docs{' '}
-        <Link inline href="/Installation#Releasing">
-          <Text weight="bold">releasing information</Text>
-        </Link>{' '}
-        for more details.
-      </Text>
-    </Flex>
-  </Card>,
+  <MainSection
+    name="Releasing"
+    description={`
+    Every commit to master performs a release. See the main docs [releasing information](/Installation#Releasing) for more details.
+  `}
+  />,
 );
 
 export default cards;

--- a/docs/src/components/MainSection.js
+++ b/docs/src/components/MainSection.js
@@ -3,7 +3,6 @@ import React, { type Node } from 'react';
 import MainSectionCard from './MainSectionCard.js';
 import Card from './Card.js';
 import MainSectionSubsection from './MainSectionSubsection.js';
-import { capitalizeFirstLetter } from './utils.js';
 
 type Props = {|
   children?: Node,
@@ -14,7 +13,7 @@ type Props = {|
 
 const MainSection = ({ children, description, name, showHeading = true }: Props): Node => {
   return (
-    <Card name={capitalizeFirstLetter(name)} showHeading={showHeading} description={description}>
+    <Card name={name} showHeading={showHeading} description={description}>
       {children}
     </Card>
   );

--- a/docs/src/components/MainSectionSubsection.js
+++ b/docs/src/components/MainSectionSubsection.js
@@ -5,7 +5,6 @@ import slugify from 'slugify';
 import CopyLinkButton from './buttons/CopyLinkButton.js';
 import Markdown from './Markdown.js';
 import { copyToClipboard } from './Card.js';
-import { capitalizeFirstLetter } from './utils.js';
 
 type Props = {|
   children?: Node,
@@ -32,7 +31,7 @@ const MainSectionSubsection = ({ children, columns = 1, description, title }: Pr
             data-anchor
           >
             <Flex alignItems="center" gap={2}>
-              <Heading size="sm">{capitalizeFirstLetter(title)}</Heading>
+              <Heading size="sm">{title}</Heading>
               <CopyLinkButton
                 name={title}
                 onClick={() => {

--- a/docs/src/components/Markdown.css
+++ b/docs/src/components/Markdown.css
@@ -11,9 +11,14 @@
 .Markdown code {
   background-color: var(--g-colorGray100);
   color: var(--g-colorGray300);
+  display: inline-block;
   font-family: SFMono-Medium, "SF Mono", "Segoe UI Mono", "Roboto Mono", "Ubuntu Mono", Menlo, Consolas, Courier, monospace;
   font-size: var(--g-text-font-size-2);
   padding: 2px 4px;
+}
+
+.Markdown pre code {
+  display: block;
 }
 
 .Markdown .language-jsx, .Markdown .language-bash {


### PR DESCRIPTION
Makes it possible to link to a specific rule: `/Eslint%20Plugin#gestaltno-box-marginleft-marginright`

## Test Plan

1. Go to https://gestalt.netlify.app/Eslint%20Plugin
2. Ensure everything looks good