### PR TITLE
Docs: Fix responsiveness on PageHeader

### DIFF
--- a/docs/src/components/App.js
+++ b/docs/src/components/App.js
@@ -30,7 +30,7 @@ export default function App({ children }: Props): Node {
 
                   <Divider />
 
-                  <Box width="100%">
+                  <Box width="100%" minWidth={0}>
                     <Box padding={4} mdPadding={6} lgPadding={8} width="100%" role="main">
                       {children}
                     </Box>


### PR DESCRIPTION
## Before

![Screen Shot 2021-04-20 at 4 51 15 PM](https://user-images.githubusercontent.com/127199/115477525-f176fb00-a1f8-11eb-9697-51c37033a2e3.png)

## After

![Screen Shot 2021-04-20 at 4 51 52 PM](https://user-images.githubusercontent.com/127199/115477529-f340be80-a1f8-11eb-9163-0be1989b23a2.png)

## Test Plan

1. Go to `/PageHeader`
2. Resize the browser window
3. Ensure the contents of the docs don't overlap the navigation