### PR TITLE
Heading: add accessibilityLevel="none" option

### DIFF
--- a/docs/src/Heading.doc.js
+++ b/docs/src/Heading.doc.js
@@ -21,7 +21,7 @@ card(
     props={[
       {
         name: 'accessibilityLevel',
-        type: '1 | 2 | 3 | 4 | 5 | 6',
+        type: '1 | 2 | 3 | 4 | 5 | 6 | "none"',
         description: 'Allows you to override the default heading level',
         href: 'levels',
       },
@@ -175,7 +175,7 @@ card(
     description="
     For accessibility purposes, we allow you to override the heading level.
 
-    We should have one level 1 per page & levels should be appropriately nested. E.g. level 1 followed by level 2 & level 2 followed by level 2 or level 3.
+    We should have one level 1 per page &amp; levels should be appropriately nested. E.g. level 1 followed by level 2 &amp; level 2 followed by level 2 or level 3. We also allow headings without an accessibility level.
   "
     name="Example: Levels"
     defaultCode={`
@@ -185,6 +185,9 @@ card(
   </Heading>
   <Heading size="sm" accessibilityLevel={3}>
     Small heading level 3
+  </Heading>
+  <Heading size="sm" accessibilityLevel="none">
+    Small heading without a level
   </Heading>
 </Box>
 `}

--- a/packages/gestalt/src/Heading.css
+++ b/packages/gestalt/src/Heading.css
@@ -5,7 +5,7 @@
 }
 
 .Heading {
-  composes: antialiased sansSerif from "./Typography.css";
+  composes: antialiased sansSerif fontWeightBold from "./Typography.css";
   margin-bottom: 0;
   margin-top: 0;
 }

--- a/packages/gestalt/src/Heading.flowtest.js
+++ b/packages/gestalt/src/Heading.flowtest.js
@@ -3,5 +3,17 @@ import Heading from './Heading.js';
 
 const Valid = <Heading size="sm">Heading</Heading>;
 
+const ValidccessibilityLevel1 = (
+  <Heading size="sm" accessibilityLevel={1}>
+    Heading
+  </Heading>
+);
+
+const ValidAccessibilityLevelNone = (
+  <Heading size="sm" accessibilityLevel="none">
+    Heading
+  </Heading>
+);
+
 // $FlowExpectedError[prop-missing]
 const NonExistingProp = <Heading nonexisting={33} />;

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -8,7 +8,7 @@ import typography from './Typography.css';
 
 type Props = {|
   align?: 'left' | 'right' | 'center' | 'justify',
-  accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6,
+  accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6 | 'none',
   children?: Node,
   color?:
     | 'blue'
@@ -78,12 +78,12 @@ export default function Heading(props: Props): Node {
   if (truncate && typeof children === 'string') {
     newProps = { ...newProps, title: children };
   }
-  return createElement(`h${headingLevel}`, newProps, children);
+  return createElement(headingLevel === 'none' ? 'div' : `h${headingLevel}`, newProps, children);
 }
 
 Heading.propTypes = {
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  accessibilityLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+  accessibilityLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 'none']),
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   align: PropTypes.oneOf(['left', 'right', 'center', 'justify']),
   children: PropTypes.node,

--- a/packages/gestalt/src/Heading.test.js
+++ b/packages/gestalt/src/Heading.test.js
@@ -10,6 +10,13 @@ test('Heading large', () => {
 test('Heading small with level 3', () => {
   const tree = create(<Heading size="sm" accessibilityLevel={3} />).toJSON();
   expect(tree).toMatchSnapshot();
+  expect(tree?.type).toEqual('h3');
+});
+
+test('Heading small with level none', () => {
+  const tree = create(<Heading size="sm" accessibilityLevel="none" />).toJSON();
+  expect(tree).toMatchSnapshot();
+  expect(tree?.type).toEqual('div');
 });
 
 test('Heading small with id', () => {

--- a/packages/gestalt/src/__snapshots__/Heading.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Heading.test.js.snap
@@ -31,6 +31,12 @@ exports[`Heading small with level 3 1`] = `
 />
 `;
 
+exports[`Heading small with level none 1`] = `
+<div
+  className="Heading fontSize1 darkGray alignLeft breakWord"
+/>
+`;
+
 exports[`Heading truncate adds a title when the children are text only 1`] = `
 <h1
   className="Heading fontSize3 darkGray alignLeft breakWord truncate"


### PR DESCRIPTION
Adds `accessibilityLevel="none"` option to `Heading`

## Use Cases

* #1462 where we wanted a `Heading` without any accessibility level. In that case we added a new class `.TextLikeHeadingSm` but that approach is limited to just 1 font size & isn't exposed externally. /cc @ayeshakmaz 
* Pinterest's codebase has a few places where folks create their own components to get around this limitation.

## Test Plan

See flow tests and unit tests.

![Screen Shot 2021-04-22 at 7 33 45 AM](https://user-images.githubusercontent.com/127199/115735060-065da680-a33f-11eb-82a8-5e1aff0f5e13.png)

