### PR TITLE
Module: Add badgeText prop

### DIFF
--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -168,7 +168,7 @@ card(
     description={`
     An Icon can be provided to be placed before the \`title\`.
 
-    It is recommended that icons be used sparingly to convey additional information, and instead should simply reenforce information in the title. If the icon does provide additional information about this module (locked, disabled, new, etc.), be sure to provide an \`iconAccessibilityLabel\`.
+    It is recommended that icons be used sparingly to convey additional information, and instead should simply reinforce information in the title. Be sure to provide an \`iconAccessibilityLabel\`.
     `}
     id="static-icon"
     defaultCode={`
@@ -193,7 +193,7 @@ function ModuleExample() {
 card(
   <Example
     name="Static - Badge"
-    description={`Badge text can be provided, which will be displayed after the \`title\`.`}
+    description={`Badge text can be provided, which will be displayed after the \`title\`. Note that if no title text is provided, the badge will not be displayed.`}
     id="static-badge"
     defaultCode={`
 function ModuleExample() {
@@ -251,7 +251,7 @@ card(
   <Example
     name="Expandable"
     id="expandable-default"
-    description={`Modules can also allow for expanding and collapsing content. The \`title\` is required and always present, the collapsed state shows optional \`summary\` content, and the expanded state shows any content desired.`}
+    description={`Modules can also allow for expanding and collapsing content. The \`title\` is required and always present. The collapsed state shows optional \`summary\` content, while the expanded state shows any content desired.`}
     defaultCode={`
 function ModuleExample1() {
   return (
@@ -313,8 +313,12 @@ function ModuleExample2() {
 
 card(
   <Example
-    name="Expandable - Icon"
-    description={`An Icon can be provided to be placed before the \`title\`. If the icon provides information about this module (locked, disabled, new, etc.), be sure to provide an \`iconAccessibilityLabel\`.`}
+    name="Expandable - Icon and Badge"
+    description={`
+    An Icon can be provided to be placed before the \`title\`.
+    It is recommended that icons be used sparingly to convey additional information, and instead should simply reinforce information in the title. Be sure to provide an \`iconAccessibilityLabel\`.
+
+    Badge text can also be provided, which will be displayed after the \`title\`.`}
     defaultCode={`
 function ModuleExample3() {
   return (
@@ -326,10 +330,16 @@ function ModuleExample3() {
         items={[
           {
             children: <Text size="md">Children1</Text>,
-            iconAccessibilityLabel: "title icon",
             icon: 'lock',
+            iconAccessibilityLabel: "title icon",
             title: 'Example with icon',
-          }]}>
+          },
+          {
+            badgeText: 'Try it out!',
+            children: <Text size="md">Children1</Text>,
+            title: 'Example with icon',
+          },
+        ]}>
       </Module.Expandable>
     </Box>
   );

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -201,7 +201,7 @@ function ModuleExample() {
     <Box column={12} maxWidth={800} padding={2}>
       <Module
         badgeText="Try it out!"
-        id="ModuleExample - icon"
+        id="ModuleExample - badge"
         title="Title"
         >
         <Text size="md">This is example content.</Text>

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -24,17 +24,17 @@ card(
     id="static-Module"
     props={[
       {
-        name: 'id',
-        href: 'static-default',
+        name: 'badgeText',
+        href: 'static-badge',
         type: 'string',
-        required: true,
-        description: 'Id to identify this Module',
+        description:
+          'Add a badge displayed after the title. Will not be displayed if `title` is not provided. Be sure to localize the text.',
       },
       {
-        name: 'title',
+        name: 'children',
         href: 'static-default',
-        type: 'string',
-        description: 'Title of this Module',
+        type: 'React.Node',
+        description: 'Content to display underneath Module title',
       },
       {
         name: 'icon',
@@ -46,7 +46,21 @@ card(
         name: 'iconAccessibilityLabel',
         href: 'static-icon',
         type: 'string',
-        description: 'Label to provide information about the icon used for screen readers',
+        description:
+          'Label to provide information about the icon used for screen readers. Be sure to localize the label.',
+      },
+      {
+        name: 'id',
+        href: 'static-default',
+        type: 'string',
+        required: true,
+        description: 'Unique id to identify this Module',
+      },
+      {
+        name: 'title',
+        href: 'static-default',
+        type: 'string',
+        description: 'Title of this Module. Be sure to localize the text.',
       },
       {
         name: 'type',
@@ -54,12 +68,6 @@ card(
         type: '"info" | "error"',
         defaultValue: 'info',
         description: 'If set to `error`, displays error icon and changes title to red text',
-      },
-      {
-        name: 'children',
-        href: 'static-default',
-        type: 'React.Node',
-        description: 'Content to display underneath Module title',
       },
     ]}
   />,
@@ -72,19 +80,12 @@ card(
     id="expandable-module"
     props={[
       {
-        name: 'id',
-        href: 'expandable-default',
-        type: 'string',
-        required: true,
-        description: 'Base Id used to give each item in the Module a unique Id',
-      },
-      {
         name: 'accessibilityExpandLabel',
         href: 'expandable-default',
         type: 'string',
         required: true,
         description:
-          'Label used to communicate to screen readers which module will be expanded when interacting with the title button. Should be something clear, like "Expand Security Policies Module"',
+          'Label used to communicate to screen readers which module will be expanded when interacting with the title button. Should be something clear, like "Expand Security Policies Module". Be sure to localize the label.',
       },
       {
         name: 'accessibilityCollapseLabel',
@@ -92,7 +93,7 @@ card(
         type: 'string',
         required: true,
         description:
-          'Label used to communicate to screen readers which module will be collapsed when interacting with the title button. Should be something clear, like "Collapse Security Policies Module"',
+          'Label used to communicate to screen readers which module will be collapsed when interacting with the title button. Should be something clear, like "Collapse Security Policies Module". Be sure to localize the label.',
       },
       {
         name: 'expandedIndex',
@@ -103,21 +104,36 @@ card(
         ],
       },
       {
-        name: 'onExpandedChange',
-        type: '(?number) => void',
-        required: false,
-        description: [
-          'This callback is executed whenever any module item is expanded or collapsed. It receives the index of the currently expanded module, or null if none are expanded.',
-        ],
+        name: 'id',
+        href: 'expandable-default',
+        type: 'string',
+        required: true,
+        description: 'Unique id to identify this Module',
       },
       {
         name: 'items',
         href: 'expandable-items',
-        type:
-          'Array<{| title: string, icon?: $Keys<typeof icons>, summary?: Array<string>, type?: "info" | "error", iconAccessibilityLabel?: string, children: ?React.Node |}>',
+        type: `
+        Array<{|
+          badgeText?: string,
+          children: ?React.Node,
+          icon?: $Keys<typeof icons>,
+          iconAccessibilityLabel?: string,
+          summary?: Array<string>,
+          title: string,
+          type?: "info" | "error" |}>
+        `,
         required: true,
         description:
-          'Array of modules to display in a stack - only one item can be expanded at a time',
+          'Array of modules displayed in a stack. Only one item can be expanded at a time.',
+      },
+      {
+        name: 'onExpandedChange',
+        type: '(?number) => void',
+        required: false,
+        description: [
+          'Callback executed whenever any module item is expanded or collapsed. It receives the index of the currently expanded module, or null if none are expanded.',
+        ],
       },
     ]}
   />,
@@ -162,6 +178,29 @@ function ModuleExample() {
       <Module
         icon="lock"
         iconAccessibilityLabel="Module Locked - check permission settings"
+        id="ModuleExample - icon"
+        title="Title"
+        >
+        <Text size="md">This is example content.</Text>
+      </Module>
+    </Box>
+  );
+}
+`}
+  />,
+);
+
+card(
+  <Example
+    name="Static - Badge"
+    description={`Badge text can be provided, which will be displayed after the \`title\`.`}
+    id="static-badge"
+    defaultCode={`
+function ModuleExample() {
+  return (
+    <Box column={12} maxWidth={800} padding={2}>
+      <Module
+        badgeText="Try it out!"
         id="ModuleExample - icon"
         title="Title"
         >

--- a/docs/src/Module.doc.js
+++ b/docs/src/Module.doc.js
@@ -336,8 +336,8 @@ function ModuleExample3() {
           },
           {
             badgeText: 'Try it out!',
-            children: <Text size="md">Children1</Text>,
-            title: 'Example with icon',
+            children: <Text size="md">Children2</Text>,
+            title: 'Example with badge',
           },
         ]}>
       </Module.Expandable>

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -1,18 +1,19 @@
 // @flow strict
-import type { Node } from 'react';
+import { type Node } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import styles from './Badge.css';
 import colors from './Colors.css';
 import { useColorScheme } from './contexts/ColorScheme.js';
 
+type Position = 'middle' | 'top';
+
 type Props = {|
-  position?: 'middle' | 'top',
+  position?: Position,
   text: string,
 |};
 
-export default function Badge(props: Props): Node {
-  const { position = 'middle', text } = props;
+export default function Badge({ position = 'middle', text }: Props): Node {
   const { name: colorSchemeName } = useColorScheme();
 
   const cs = cx(styles.Badge, styles[position], colors.blueBg, {
@@ -23,7 +24,6 @@ export default function Badge(props: Props): Node {
 }
 
 Badge.propTypes = {
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  position: PropTypes.oneOf(['middle', 'top']),
+  position: (PropTypes.oneOf(['middle', 'top']): React$PropType$Primitive<Position>),
   text: PropTypes.string.isRequired,
 };

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -4,14 +4,16 @@ import Box from './Box.js';
 import Flex from './Flex.js';
 import ModuleTitle from './ModuleTitle.js';
 import ModuleExpandable from './ModuleExpandable.js';
-import { type BaseModuleProps } from './moduleTypes.js';
+import { type BaseModuleTitleProps } from './moduleTypes.js';
 
 type Props = {|
-  ...BaseModuleProps,
+  ...BaseModuleTitleProps,
+  children?: Node,
   id: string,
 |};
 
 export default function Module({
+  badgeText,
   children,
   icon,
   iconAccessibilityLabel,
@@ -24,6 +26,7 @@ export default function Module({
       <Flex direction="column" gap={6}>
         {title && (
           <ModuleTitle
+            badgeText={badgeText}
             icon={icon}
             iconAccessibilityLabel={iconAccessibilityLabel}
             title={title}

--- a/packages/gestalt/src/Module.test.js
+++ b/packages/gestalt/src/Module.test.js
@@ -36,6 +36,17 @@ describe('Module', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('renders a badge correctly', () => {
+    const tree = renderer
+      .create(
+        <Module badgeText="Try it out!" id="module-test" title="Testing">
+          <Text>Testing</Text>
+        </Module>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('renders an error correctly', () => {
     const tree = renderer
       .create(

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { Fragment, useState, useEffect } from 'react';
+import { Fragment, type Node, useState, useEffect } from 'react';
 import Box from './Box.js';
 import Divider from './Divider.js';
 import ModuleExpandableItem from './ModuleExpandableItem.js';
@@ -36,31 +34,34 @@ export default function ModuleExpandable({
 
   return (
     <Box borderStyle="shadow" rounding={4}>
-      {items.map(({ children, icon, iconAccessibilityLabel, summary, title, type }, index) => (
-        <Fragment key={index}>
-          <ModuleExpandableItem
-            accessibilityCollapseLabel={accessibilityCollapseLabel}
-            accessibilityExpandLabel={accessibilityExpandLabel}
-            icon={icon}
-            iconAccessibilityLabel={iconAccessibilityLabel}
-            id={`${id}-${index}`}
-            isCollapsed={expandedId !== index}
-            onModuleClicked={(isExpanded) => {
-              if (onExpandedChange) {
-                onExpandedChange(isExpanded ? null : index);
-              }
-              setExpandedId(isExpanded ? null : index);
-            }}
-            summary={summary}
-            title={title}
-            type={type}
-          >
-            {children}
-          </ModuleExpandableItem>
+      {items.map(
+        ({ badgeText, children, icon, iconAccessibilityLabel, summary, title, type }, index) => (
+          <Fragment key={index}>
+            {index > 0 && <Divider />}
 
-          {index !== items.length - 1 && <Divider />}
-        </Fragment>
-      ))}
+            <ModuleExpandableItem
+              accessibilityCollapseLabel={accessibilityCollapseLabel}
+              accessibilityExpandLabel={accessibilityExpandLabel}
+              badgeText={badgeText}
+              icon={icon}
+              iconAccessibilityLabel={iconAccessibilityLabel}
+              id={`${id}-${index}`}
+              isCollapsed={expandedId !== index}
+              onModuleClicked={(isExpanded) => {
+                if (onExpandedChange) {
+                  onExpandedChange(isExpanded ? null : index);
+                }
+                setExpandedId(isExpanded ? null : index);
+              }}
+              summary={summary}
+              title={title}
+              type={type}
+            >
+              {children}
+            </ModuleExpandableItem>
+          </Fragment>
+        ),
+      )}
     </Box>
   );
 }

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -20,6 +20,7 @@ type Props = {|
 export default function ModuleExpandableItem({
   accessibilityCollapseLabel,
   accessibilityExpandLabel,
+  badgeText,
   children,
   icon,
   iconAccessibilityLabel,
@@ -45,6 +46,7 @@ export default function ModuleExpandableItem({
             <Box alignItems="baseline" display="flex" flex="grow" marginEnd={6}>
               <Box column={isCollapsed && summary ? 6 : 12}>
                 <ModuleTitle
+                  badgeText={badgeText}
                   icon={icon}
                   iconAccessibilityLabel={iconAccessibilityLabel}
                   title={title}

--- a/packages/gestalt/src/ModuleExpandableItem.test.js
+++ b/packages/gestalt/src/ModuleExpandableItem.test.js
@@ -39,6 +39,24 @@ describe('ModuleExpandableItem', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('renders correctly with badge', () => {
+    const tree = renderer
+      .create(
+        <ModuleExpandableItem
+          accessibilityExpandLabel="click to expand"
+          accessibilityCollapseLabel="click to collapse"
+          badgeText="Try it out!"
+          id="uniqueTestID"
+          isCollapsed
+          onModuleClicked={() => {}}
+          title="test title"
+          type="info"
+        />,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('renders correctly with summary', () => {
     const tree = renderer
       .create(

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -39,9 +39,11 @@ export default function ModuleTitle({
         <Icon accessibilityLabel={iconAccessibilityLabel ?? ''} color={color} icon={iconName} />
       )}
 
-      <Text color={color} truncate weight="bold">
-        {title}
-      </Text>
+      <Flex.Item minWidth={0}>
+        <Text color={color} truncate weight="bold">
+          {title}
+        </Text>
+      </Flex.Item>
 
       {badgeText && (
         <Box marginStart={2}>

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -1,25 +1,26 @@
 // @flow strict
-import type { Node } from 'react';
+import { type Node } from 'react';
+import Badge from './Badge.js';
+import Box from './Box.js';
 import Flex from './Flex.js';
 import Icon from './Icon.js';
 import Text from './Text.js';
-import icons from './icons/index.js';
-import { type TypeOptions } from './moduleTypes.js';
+import { type BaseModuleTitleProps, type TypeOptions } from './moduleTypes.js';
 
-type TitleProps = {|
-  icon?: $Keys<typeof icons>,
-  iconAccessibilityLabel?: string,
-  title: string,
-  type: TypeOptions,
+type Props = {|
+  ...BaseModuleTitleProps,
+  title: string, // overwriting to be required
+  type: TypeOptions, // overwriting to be required
 |};
 
 export default function ModuleTitle({
+  badgeText,
   icon,
   iconAccessibilityLabel,
   title,
   type = 'info',
-}: TitleProps): Node {
-  const MODULE_TYPE_ATTRIBUTES = {
+}: Props): Node {
+  const TYPE_ICON_ATTRIBUTES = {
     info: {
       icon,
       color: 'darkGray',
@@ -30,7 +31,7 @@ export default function ModuleTitle({
     },
   };
 
-  const { color, icon: iconName } = MODULE_TYPE_ATTRIBUTES[type];
+  const { color, icon: iconName } = TYPE_ICON_ATTRIBUTES[type];
 
   return (
     <Flex gap={2}>
@@ -41,6 +42,12 @@ export default function ModuleTitle({
       <Text color={color} truncate weight="bold">
         {title}
       </Text>
+
+      {badgeText && (
+        <Box marginStart={2}>
+          <Badge text={badgeText} />
+        </Box>
+      )}
     </Flex>
   );
 }

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -46,7 +46,11 @@ export default function ModuleTitle({
       </Flex.Item>
 
       {badgeText && (
-        <Box marginStart={2}>
+        <Box
+          dangerouslySetInlineStyle={{ __style: { top: '1px' } }}
+          marginStart={2}
+          position="relative"
+        >
           <Badge text={badgeText} />
         </Box>
       )}

--- a/packages/gestalt/src/__snapshots__/Module.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Module.test.js.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Module renders a badge correctly 1`] = `
+<div
+  className="box paddingX6 paddingY6 rounding4 shadow"
+  id="module-test"
+>
+  <div
+    className="Flex columnGap6 xsDirectionColumn"
+  >
+    <div
+      className="FlexItem"
+    >
+      <div
+        className="Flex rowGap2 xsDirectionRow"
+      >
+        <div
+          className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
+        >
+          <div
+            className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+            title="Testing"
+          >
+            Testing
+          </div>
+        </div>
+        <div
+          className="FlexItem"
+        >
+          <div
+            className="box marginStart2 relative"
+            style={
+              Object {
+                "top": "1px",
+              }
+            }
+          >
+            <span
+              className="Badge middle blueBg"
+            >
+              Try it out!
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="FlexItem"
+    >
+      <div
+        className="Text fontSize3 darkGray alignLeft breakWord fontWeightNormal"
+      >
+        Testing
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Module renders a title correctly 1`] = `
 <div
   className="box paddingX6 paddingY6 rounding4 shadow"
@@ -16,6 +78,11 @@ exports[`Module renders a title correctly 1`] = `
       >
         <div
           className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
         >
           <div
             className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -66,6 +133,11 @@ exports[`Module renders an error correctly 1`] = `
         </div>
         <div
           className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
         >
           <div
             className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
@@ -122,6 +194,11 @@ exports[`Module renders an icon correctly 1`] = `
         </div>
         <div
           className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
         >
           <div
             className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -48,6 +48,11 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                 >
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -147,6 +152,11 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                 >
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -263,6 +273,11 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                   </div>
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
@@ -366,6 +381,11 @@ exports[`Module Expandable renders correctly with one item 1`] = `
                 >
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -489,6 +509,11 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                 >
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -575,6 +600,11 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                 >
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -691,6 +721,11 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                   </div>
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"

--- a/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
@@ -45,12 +45,103 @@ exports[`ModuleExpandableItem renders correctly 1`] = `
               >
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <div
                     className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
                     title="test title"
                   >
                     test title
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ModuleExpandableItem renders correctly with badge 1`] = `
+<div
+  className="box paddingX6 paddingY6"
+>
+  <div
+    className="Flex columnGap6 xsDirectionColumn"
+  >
+    <div
+      className="FlexItem"
+    >
+      <div
+        aria-controls="uniqueTestID"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-label="click to expand"
+        className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <div
+          className="Flex rowGap0 xsDirectionRow"
+        >
+          <div
+            className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+          >
+            <div
+              className="box xsCol12"
+            >
+              <div
+                className="Flex rowGap2 xsDirectionRow"
+              >
+                <div
+                  className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
+                >
+                  <div
+                    className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
+                    title="test title"
+                  >
+                    test title
+                  </div>
+                </div>
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="box marginStart2 relative"
+                    style={
+                      Object {
+                        "top": "1px",
+                      }
+                    }
+                  >
+                    <span
+                      className="Badge middle blueBg"
+                    >
+                      Try it out!
+                    </span>
                   </div>
                 </div>
               </div>
@@ -108,6 +199,11 @@ exports[`ModuleExpandableItem renders correctly with children 1`] = `
               >
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <div
                     className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -188,6 +284,11 @@ exports[`ModuleExpandableItem renders correctly with error 1`] = `
                 </div>
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <div
                     className="Text fontSize3 red alignLeft breakWord fontWeightBold truncate"
@@ -268,6 +369,11 @@ exports[`ModuleExpandableItem renders correctly with icon 1`] = `
                 </div>
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <div
                     className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -331,6 +437,11 @@ exports[`ModuleExpandableItem renders correctly with summary 1`] = `
               >
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <div
                     className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"
@@ -432,6 +543,11 @@ exports[`ModuleExpandableItem renders correctly with when expanded 1`] = `
               >
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <div
                     className="Text fontSize3 darkGray alignLeft breakWord fontWeightBold truncate"

--- a/packages/gestalt/src/moduleTypes.js
+++ b/packages/gestalt/src/moduleTypes.js
@@ -4,8 +4,8 @@ import icons from './icons/index.js';
 
 export type TypeOptions = 'error' | 'info';
 
-export type BaseModuleProps = {|
-  children?: Node,
+export type BaseModuleTitleProps = {|
+  badgeText?: string,
   icon?: $Keys<typeof icons>,
   iconAccessibilityLabel?: string,
   title?: string,
@@ -13,7 +13,8 @@ export type BaseModuleProps = {|
 |};
 
 export type ModuleExpandableItemBaseProps = {|
-  ...BaseModuleProps,
+  ...BaseModuleTitleProps,
+  children?: Node,
   summary?: $ReadOnlyArray<string>,
-  title: string, // overwriting base to be required
+  title: string, // overwriting to be required
 |};


### PR DESCRIPTION
[Figma designs](https://www.figma.com/file/B5S5iyikCHqKUcmofquJOe/Web-Creation-Improvements?node-id=136%3A5387)

This PR adds an optional `badgeText` prop to Module (and related Module components) to display a badge after the title text.

<img width="236" alt="Screen Shot 2021-04-28 at 12 53 36 PM" src="https://user-images.githubusercontent.com/12059539/116465535-34048d00-a822-11eb-8492-1dcb9880c2c7.png">

<img width="283" alt="Screen Shot 2021-04-28 at 1 08 49 PM" src="https://user-images.githubusercontent.com/12059539/116466099-f18f8000-a822-11eb-8bb1-5131a5a42456.png">


## Test Plan
Check out the new "Static – Badge" and "Expandable - Icon and Badge " sections in the docs.