### PR TITLE
Flex: add `minWidth` prop to Flex.Item

### DIFF
--- a/docs/src/Flex.doc.js
+++ b/docs/src/Flex.doc.js
@@ -200,7 +200,7 @@ card(
     defaultCode={`
 <Box borderStyle="sm" padding={3} rounding={3}>
   <Flex alignItems="center" gap={3}>
-    <Icon icon="lock" />
+    <Icon accessibilityLabel="Private" icon="lock" />
 
     <Flex.Item minWidth={0}>
       <Text truncate>Some really long title text that just keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going</Text>

--- a/docs/src/Flex.doc.js
+++ b/docs/src/Flex.doc.js
@@ -178,7 +178,38 @@ card(
         defaultValue: 'shrink',
         description: `Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size the Flex relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows the Flex to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves the Flex's size based on child content regardless of its container's size.`,
       },
+      {
+        name: 'minWidth',
+        type: `number | string`,
+        description: `Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%". Can be used to fix overflowing children; see [the example](#FlexItem-minWidth) to learn more.`,
+      },
     ]}
+  />,
+);
+
+card(
+  <Example
+    name="Example: Overflowing children and minWidth"
+    id="FlexItem-minWidth"
+    description={`
+    Extra-wide children can sometimes overflow the Flex parent container, breaking the layout (and skipping truncation, if applicable).
+    To fix this, simply wrap the wide child in Flex.Item with \`minWidth={0}\`. Voila!
+
+    For more info, check out [this very helpful blog post](https://css-tricks.com/flexbox-truncated-text/#the-solution-is-min-width-0-on-the-flex-child).
+  `}
+    defaultCode={`
+<Box borderStyle="sm" padding={3} rounding={3}>
+  <Flex alignItems="center" gap={3}>
+    <Icon icon="lock" />
+
+    <Flex.Item minWidth={0}>
+      <Text truncate>Some really long title text that just keeps going and going and going and going and going and going and going and going and going and going and going and going and going and going and going and going</Text>
+    </Flex.Item>
+
+    <Badge text="Try it out!" />
+  </Flex>
+</Box>
+`}
   />,
 );
 

--- a/packages/gestalt/src/Flex.js
+++ b/packages/gestalt/src/Flex.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { Children } from 'react';
+import { Children, type Node } from 'react';
 import PropTypes from 'prop-types';
 import FlexItem from './FlexItem.js';
 import styles from './Flex.css';

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -3,15 +3,23 @@ import type { Node } from 'react';
 import PropTypes from 'prop-types';
 import { buildStyles } from './boxTransforms.js';
 import styles from './Flex.css';
-import { AlignSelfPropType, FlexPropType, type AlignSelf, type Flex } from './boxTypes.js';
+import {
+  AlignSelfPropType,
+  DimensionPropType,
+  FlexPropType,
+  type AlignSelf,
+  type Dimension,
+  type Flex,
+} from './boxTypes.js';
 
 export type Props = {|
   alignSelf?: AlignSelf,
   children?: Node,
   flex?: Flex,
+  minWidth?: Dimension,
 |};
 
-const allowedProps = ['alignSelf', 'children', 'flex'];
+const allowedProps = ['alignSelf', 'children', 'flex', 'minWidth'];
 
 export default function FlexItem(props: Props): Node {
   const { passthroughProps, propsStyles } = buildStyles<Props>({
@@ -29,4 +37,5 @@ FlexItem.propTypes = {
   alignSelf: AlignSelfPropType,
   children: PropTypes.node.isRequired,
   flex: FlexPropType,
+  minWidth: DimensionPropType,
 };


### PR DESCRIPTION
Extra-wide children can overflow their parent Flex container, breaking the layout. Adding a `minWidth` prop to Flex.Item fixes this by allowing us to wrap the wide child in `<Flex.Item minWidth={0}>`. See [this blog post](https://css-tricks.com/flexbox-truncated-text/#the-solution-is-min-width-0-on-the-flex-child) for more details.

<img width="966" alt="Screen Shot 2021-04-28 at 1 59 07 PM" src="https://user-images.githubusercontent.com/12059539/116472174-6619ed00-a82a-11eb-8347-4c6bdf7dc81b.png">


## Test Plan
Check out the new "FlexItem-minWidth" example on the Flex docs.