### PR TITLE
Internal: Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ docs/build/
 *.log
 stats.html
 screenshots
+.DS_Store
 
 packages/gestalt/dist/*
 packages/gestalt-datepicker/dist/*


### PR DESCRIPTION

What is the purpose of this PR?
* Added .DS_Store to our .gitignore to avoid those pesky files showing up in commits.

