### PR TITLE
Internal: Fix setExtraStackFrame exception

### DIFF
--- a/packages/eslint-plugin-gestalt/package.json
+++ b/packages/eslint-plugin-gestalt/package.json
@@ -17,7 +17,7 @@
   "dependencies": {},
   "scripts": {
     "build": "rollup -c rollup.config.js",
-    "prepublish": "rollup -c rollup.config.js",
+    "prepublish": "NODE_ENV=production rollup -c rollup.config.js",
     "watch": "rollup -c rollup.config.js --watch"
   }
 }

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",
-    "prepublish": "rollup -c rollup.config.js",
+    "prepublish": "NODE_ENV=production rollup -c rollup.config.js",
     "watch": "rollup -c rollup.config.js --watch"
   },
   "browserslist": [

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -24,7 +24,7 @@
     "build": "rollup -c rollup.config.js",
     "postpack": "rm README.md",
     "prepack": "cp ../../README.md .",
-    "prepublish": "rollup -c rollup.config.js",
+    "prepublish": "NODE_ENV=production rollup -c rollup.config.js",
     "watch": "rollup -c rollup.config.js --watch"
   },
   "browserslist": [


### PR DESCRIPTION
## Description

In #1471 we introduced the new JSX transform. However, because we didn't set the `NODE_ENV` when building so it included the wrong version in our published package.

Results in the following Gestalt exception:

```
TypeError: Cannot read property 'setExtraStackFrame' of undefined
	at setExtraStackFrame (webpack:///node_modules/gestalt/dist/gestalt.es.js:1569:35)
	at setCurrentlyValidatingElement$1 (webpack:///node_modules/gestalt/dist/gestalt.es.js:1680:8)
	at validateExplicitKey (webpack:///node_modules/gestalt/dist/gestalt.es.js:1707:14)
	at validateChildKeys (webpack:///node_modules/gestalt/dist/gestalt.es.js:1864:18)
	at jsxs (webpack:///node_modules/gestalt/dist/gestalt.es.js:12998:43)
	at render (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:187:187)
	at qi (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:186:172)
	at pi (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:269:426)
	at ck (webpack:///node_modules/react-dom/cjs/react-dom.production.min.js:250:346)
```

More info at https://github.com/facebook/react/issues/20359

### Before

```js
/** @license React v17.0.1
 * react-jsx-runtime.development.js
 *
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */

var reactJsxRuntime_development = createCommonjsModule(function (module, exports) {
```

### After

```js
/** @license React v17.0.1
 * react-jsx-runtime.production.min.js
 *
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */

var reactJsxRuntime_production_min = createCommonjsModule(function (module, exports) {
```
