### PR TITLE
Docs: Add page about screen size support

### DIFF
--- a/cypress/integration/accessibility_Screen sizes_spec.js
+++ b/cypress/integration/accessibility_Screen sizes_spec.js
@@ -1,0 +1,10 @@
+describe('Screen sizes Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/Screen sizes');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the ScreenSizes page', () => {
+    cy.checkA11y();
+  });
+});

--- a/docs/src/Screen Sizes.doc.js
+++ b/docs/src/Screen Sizes.doc.js
@@ -1,0 +1,184 @@
+// @flow strict
+import type { Node } from 'react';
+import MainSection from './components/MainSection.js';
+import PageHeader from './components/PageHeader.js';
+
+const cards: Array<Node> = [];
+
+const card = (c) => cards.push(c);
+
+card(
+  <PageHeader
+    name="Screen sizes"
+    description="There are a multitude of screen sizes that Pinterest operates on. Our design system is built to flex to any and all screen sizes across platforms but for consistency and ease of handoff we only design for a handful of screen sizes per platform. Our screen sizes are always at 1x."
+    showSourceLink={false}
+  />,
+);
+
+card(
+  <MainSection name="Web (px)">
+    <MainSection.Card
+      cardSize="lg"
+      showCode={false}
+      defaultCode={`
+      <Box width={'100%'}>
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Text weight="bold">Device</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Size (px)</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Small phone</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>320 x 568</Text>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Phone</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>360 x 780</Text>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Tablet</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>768 x 1024</Text>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Desktop Breakpoints (min-width)</Text>
+                <Box paddingY={2} maxWidth={500}>
+                  <Text italic>Components in Gestalt adjust to browser size at these breakpoints. When designing, please make sure your designs take these breakpoints into consideration.</Text>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Flex direction="column" gap={2}>
+                  <Text>sm: 576px</Text>
+                  <Text>md: 768px</Text>
+                  <Text>lg: 1312px</Text>
+                </Flex>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Box>
+      `}
+    />
+  </MainSection>,
+);
+card(
+  <MainSection name="iOS (pt)">
+    <MainSection.Card
+      cardSize="lg"
+      showCode={false}
+      defaultCode={`
+      <Box width={'100%'}>
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Text weight="bold">Device</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Size (pt)</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Small phone</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>320 x 568</Text>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Phone</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>360 x 780</Text>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Tablet</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>768 x 1024</Text>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Box>
+      `}
+    />
+  </MainSection>,
+);
+card(
+  <MainSection name="Android (dp)">
+    <MainSection.Card
+      cardSize="lg"
+      showCode={false}
+      defaultCode={`
+      <Box width={'100%'}>
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Text weight="bold">Device</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Size (dp)</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Small phone</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>320 x 480</Text>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Phone</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>360 x 640</Text>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
+                <Text>Tablet</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>800 x 1280</Text>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Box>
+      `}
+    />
+  </MainSection>,
+);
+
+export default cards;

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -36,6 +36,11 @@ card(
         description: `Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%"`,
         href: 'stickyHeader',
       },
+      {
+        name: 'stickyColumns',
+        type: `number`,
+        description: `Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](#stickyColumn) example for details.`,
+      },
     ]}
   />,
 );

--- a/docs/src/components/sidebarIndex.js
+++ b/docs/src/components/sidebarIndex.js
@@ -22,9 +22,12 @@ const sidebarIndex: Array<sidebarIndexType> = [
       'Installation',
       'Development',
       'Eslint Plugin',
-      'Layouts',
       'Faq',
     ],
+  },
+  {
+    sectionName: 'Guidelines',
+    pages: ['Screen Sizes', 'Layouts'],
   },
   {
     sectionName: 'Foundation',


### PR DESCRIPTION
## Description

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

Move the screen sizes [doc](https://paper.dropbox.com/doc/Screen-sizes--BKKuQhad6eGbvLxpdU_urluaAg-k8c16MNf9Gly3ScR6AmZV) from Paper into Gestalt

### Links

- JIRA: https://jira.pinadmin.com/browse/PDS-2798
- [TDD](paper doc link)
- [Figma](link to figma file)

### Checklist

- [X] Added documentation + accessibility tests

