### PR TITLE
Add hoverColor prop to Link component

### DIFF
--- a/docs/src/Link.doc.js
+++ b/docs/src/Link.doc.js
@@ -29,6 +29,12 @@ card(
         type: 'React.Node',
       },
       {
+        name: 'hoverColor',
+        type: `'undefined' | 'inherit' | 'white' | 'lightGray' | 'gray' | 'red' | 'blue'`,
+        defaultValue: 'undefined',
+        href: 'Example',
+      },
+      {
         name: 'hoverStyle',
         type: `'none' | 'underline'`,
         defaultValue: 'underline',

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -246,6 +246,56 @@
   background-color: var(--g-orange);
 }
 
+/* hover colors */
+
+.hoverInherit:hover{
+  color: inherit;
+}
+
+.hoverInheritBg:hover{
+  background-color: inherit;
+}
+
+.hoverWhite:hover{
+  color: var(--g-colorGray0Hovered);
+}
+
+.hoverWhiteBg:hover{
+  background-color: var(--g-colorGray0Hovered);
+}
+
+.hoverLightGray:hover{
+  color: var(--g-colorGray100Hovered);
+}
+
+.hoverLightGrayBg:hover{
+  background-color: var(--g-colorGray100Hovered);
+}
+
+.hoverGray:hover{
+  color: var(--g-colorGray200Hovered);
+}
+
+.hoverGrayBg:hover{
+  background-color: var(--g-colorGray200Hovered);
+}
+
+.hoverRed:hover{
+  color: var(--g-colorRed100Hovered);
+}
+
+.hoverRedBg:hover{
+  background-color: var(--g-colorRed100Hovered);
+}
+
+.hoverBlue:hover{
+  color: var(--g-blueHovered);
+}
+
+.hoverBlueBg:hover{
+  background-color: var(--g-blueHovered);
+}
+
 /* transparent */
 
 .transparentBg {

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -4,6 +4,7 @@ import type { AbstractComponent, Node, Element } from 'react';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import colors from './Colors.css';
 import { useOnNavigation } from './contexts/OnNavigation.js';
 import touchableStyles from './Touchable.css';
 import styles from './Link.css';
@@ -18,6 +19,7 @@ type Props = {|
   accessibilityLabel?: string,
   accessibilitySelected?: boolean,
   children?: Node,
+  hoverColor?: 'inherit' | 'white' | 'lightGray' | 'gray' | 'red' | 'blue',
   hoverStyle?: 'none' | 'underline',
   href: string,
   id?: string,
@@ -54,6 +56,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     rel = 'none',
     role,
     rounding = 0,
+    hoverColor,
     hoverStyle = 'underline',
     tapStyle = 'none',
     target = null,
@@ -85,6 +88,12 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     styles.link,
     focusStyles.hideOutline,
     touchableStyles.tapTransition,
+    hoverColor === 'inherit' && colors.hoverInherit,
+    hoverColor === 'white' && colors.hoverWhite,
+    hoverColor === 'lightGray' && colors.hoverLightGray,
+    hoverColor === 'gray' && colors.hoverGray,
+    hoverColor === 'red' && colors.hoverRed,
+    hoverColor === 'blue' && colors.hoverBlue,
     getRoundingClassName(rounding),
     {
       [layoutStyles.inlineBlock]: inline,
@@ -167,6 +176,14 @@ LinkWithForwardRef.propTypes = {
   accessibilityLabel: PropTypes.string,
   accessibilitySelected: PropTypes.bool,
   children: PropTypes.node,
+  hoverColor: (PropTypes.oneOf([
+    'inherit',
+    'white',
+    'lightGray',
+    'gray',
+    'red',
+    'blue',
+  ]): React$PropType$Primitive<'inherit' | 'white' | 'lightGray' | 'gray' | 'red' | 'blue'>),
   hoverStyle: (PropTypes.oneOf(['none', 'underline']): React$PropType$Primitive<
     'none' | 'underline',
   >),

--- a/packages/gestalt/src/Link.test.js
+++ b/packages/gestalt/src/Link.test.js
@@ -74,11 +74,17 @@ it('with onTap', () =>
       .toJSON(),
   ).toMatchSnapshot());
 
-it('with custom rounding, hoverStyle, and tapStyle', () =>
+it('with custom rounding, hoverColor, hoverStyle, and tapStyle', () =>
   expect(
     renderer
       .create(
-        <Link href="https://example.com" rounding="pill" hoverStyle="none" tapStyle="compress">
+        <Link
+          href="https://example.com"
+          rounding="pill"
+          hoverColor="red"
+          hoverStyle="none"
+          tapStyle="compress"
+        >
           Link
         </Link>,
       )

--- a/packages/gestalt/src/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.js.snap
@@ -149,6 +149,27 @@ exports[`with accessibilitySelected and role 1`] = `
 </a>
 `;
 
+exports[`with custom rounding, hoverColor, hoverStyle, and tapStyle 1`] = `
+<a
+  className="link hideOutline tapTransition hoverRed pill block accessibilityOutline"
+  href="https://example.com"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyPress={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  rel=""
+  target={null}
+>
+  Link
+</a>
+`;
+
 exports[`with custom rounding, hoverStyle, and tapStyle 1`] = `
 <a
   className="link hideOutline tapTransition pill block accessibilityOutline"


### PR DESCRIPTION
## Description

The idea of this PR is add into the `Link` component an extra prop called `hoverColor`, this prop enables a way to change the color of the anchor element when is hovered. 

## Case

A real scenario is where the `a`  element has some rules defined globally, for example

```css
a:hover {
  color: black;
}
```

So, when we use `<Link>` component

```js
<Text color="red">
  <Link href="https://pinterest.com">
    Link with color red
  </Link>
</Text>
```

it looks like this

![image](https://user-images.githubusercontent.com/1939521/117609402-fced8000-b12d-11eb-9284-ecb8f01acb77.png)

but when it's hovered, we can see the link in black (from the global rule) instead of red (using the color of the wrapper)

![image](https://user-images.githubusercontent.com/1939521/117609431-07a81500-b12e-11eb-87a8-9bc1047436e3.png)

## Solution

These changes allow us to use `hoverColor` to override that color, using an specific hover color from the available colors ([https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Colors.css](https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Colors.css)) or use the `inherit` value to use the same color of the parent `Text`.

![image](https://user-images.githubusercontent.com/1939521/117690116-7e71fc00-b188-11eb-96bc-a444aa36dd03.png)

---

## Another possible solution

Add an extra css rule to `Link` component ([https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Link.css](https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Link.css)) to override defined `a:hover` .

```css
.link:hover{
  color: inherit;
}
``` 

## Drawbacks

I think, this alternate solution is not the best fit for this problem because, don't let us customize the color of the link, instead of that, just use the same one as the `Text` component.
