### PR TITLE
ESLint: add rule to disallow non-standard Box props

### DIFF
--- a/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js
@@ -1,0 +1,140 @@
+/**
+ * Error on disallowed props on `Box`
+ */
+
+// @flow strict
+const allowedBaseProps = [
+  'dangerouslySetInlineStyle',
+  'display',
+  'column',
+  'direction',
+  'smDisplay',
+  'smColumn',
+  'smDirection',
+  'mdDisplay',
+  'mdColumn',
+  'mdDirection',
+  'lgDisplay',
+  'lgColumn',
+  'lgDirection',
+  'alignContent',
+  'alignItems',
+  'alignSelf',
+  'as',
+  'bottom',
+  'borderStyle',
+  'color',
+  'fit',
+  'flex',
+  'height',
+  'justifyContent',
+  'left',
+  'margin',
+  'marginTop',
+  'marginBottom',
+  'marginStart',
+  'marginEnd',
+  'smMargin',
+  'smMarginTop',
+  'smMarginBottom',
+  'smMarginStart',
+  'smMarginEnd',
+  'mdMargin',
+  'mdMarginTop',
+  'mdMarginBottom',
+  'mdMarginStart',
+  'mdMarginEnd',
+  'lgMargin',
+  'lgMarginTop',
+  'lgMarginBottom',
+  'lgMarginStart',
+  'lgMarginEnd',
+  'maxHeight',
+  'maxWidth',
+  'minHeight',
+  'minWidth',
+  'opacity',
+  'overflow',
+  'padding',
+  'smPadding',
+  'mdPadding',
+  'lgPadding',
+  'paddingX',
+  'smPaddingX',
+  'mdPaddingX',
+  'lgPaddingX',
+  'paddingY',
+  'smPaddingY',
+  'mdPaddingY',
+  'lgPaddingY',
+  'position',
+  'right',
+  'rounding',
+  'top',
+  'width',
+  'wrap',
+  'userSelect',
+  'role',
+  'zIndex',
+];
+
+const allowedPrefixProps = ['data-', 'aria-'];
+
+const errorMessage = (props: $ReadOnlyArray<string>): string =>
+  `${
+    props.length === 1 ? `${props[0]} is` : `${props.join(', ')} are`
+  } not allowed on Box. Please see https://gestalt.netlify.app/Box for all allowed props.`;
+
+const rule = {
+  meta: {
+    docs: {
+      description: 'Do no allow certain props on Box',
+      recommended: false,
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  // $FlowFixMe[unclear-type]
+  create(context: Object): Object {
+    let importedComponent = false;
+
+    return {
+      ImportDeclaration(decl) {
+        if (decl.source.value !== 'gestalt') {
+          return;
+        }
+        importedComponent = decl.specifiers.some((node) => {
+          return node.imported.name === 'Box';
+        });
+      },
+      JSXOpeningElement(node) {
+        if (!importedComponent) {
+          return;
+        }
+
+        const disallowedProps = Object.keys(node.attributes)
+          .map((key: string) => node.attributes[key]?.name?.name)
+          .filter(
+            (propName: string) =>
+              propName &&
+              !allowedBaseProps.includes(propName) &&
+              !allowedPrefixProps.some((allowedPrefixProp) =>
+                propName.startsWith(allowedPrefixProp),
+              ),
+          );
+
+        if (disallowedProps.length) {
+          const message = errorMessage(disallowedProps);
+          context.report(node, message);
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.test.js
@@ -1,0 +1,77 @@
+// @flow strict
+import { RuleTester } from 'eslint';
+import rule from './no-box-disallowed-props.js';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('no-box-disallowedProps', rule, {
+  valid: [
+    {
+      code: `
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return <Box as="main">Test</Box>;
+}
+    `,
+    },
+    {
+      code: `
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return <Box data-pinId="12345">Test</Box>;
+}
+    `,
+    },
+    {
+      code: `
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return <Box aria-label="Accessibility Label">Test</Box>;
+}
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return <Box backgroundColor="#fff">Test</Box>;
+}
+      `,
+      errors: [
+        {
+          message:
+            'backgroundColor is not allowed on Box. Please see https://gestalt.netlify.app/Box for all allowed props.',
+        },
+      ],
+    },
+    {
+      code: `
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return <Box backgroundColor="#fff" invalidProp="Invalid">Test</Box>;
+}
+      `,
+      errors: [
+        {
+          message:
+            'backgroundColor, invalidProp are not allowed on Box. Please see https://gestalt.netlify.app/Box for all allowed props.',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -80,6 +80,7 @@ extra runtime typechecks in the transformers for performance.
 
 */
 
+// Please update `eslint-plugin-gestalt/no-box-disallowed-props` if you make changes to these props
 type Props = {
   children?: Node,
   dangerouslySetInlineStyle?: DangerouslySetInlineStyle,


### PR DESCRIPTION
## Description

Lint against non-standard `Box` props since they result in warnings.

Example

```js
<Box backgroundColor="#fff" />
```

Results in

> Warning: React does not recognize the `backgroundColor` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `backgroundcolor` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

### Solution

Add an ESLint rule to disallow non-standard Box props. That way we can detect these issues as we code and will no longer have these warnings show up.

### What do you dislike about this solution?

That we duplicate the list of `Box` props in the ESLint rule. However, that seems better than trying to import `Box` in the ESLint plug-in, running an AST to get the list of available props. That would make the rule slower and harder to maintain.

### Checklist

- [x] Added Unit and Flow Tests
