### PR TITLE
Datapoint: remove compression on click

### DIFF
--- a/cypress/integration/accessibility_Datapoint_spec.js
+++ b/cypress/integration/accessibility_Datapoint_spec.js
@@ -8,7 +8,7 @@ describe('Datapoint Accessibility check', () => {
     cy.configureAxe({
       rules: [
         {
-          id: 'button-name',
+          id: 'aria-command-name', // Tooltip provides description to the button
           enabled: false,
         },
       ],

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 import Text from './Text.js';
 import Heading from './Heading.js';
 import Flex from './Flex.js';
-import IconButton from './IconButton.js';
+import Icon from './Icon.js';
 import Tooltip from './Tooltip.js';
+import TapArea from './TapArea.js';
 import DatapointTrend from './DatapointTrend.js';
 
 type TrendObject = {|
@@ -41,13 +42,12 @@ export default function Datapoint({
         <Text size="sm">{title}</Text>
         {tooltipText && (
           <Tooltip text={tooltipText} idealDirection="up">
-            <IconButton
-              accessibilityLabel=""
-              size="sm"
-              icon="info-circle"
-              iconColor="gray"
-              padding={1}
-            />
+            {/* Interactive elements require an a11yLabel on them or their children. In this particular case,
+            screenreaders do read the Tooltip text that provides the context to the interactive children.
+            Therefore no a11yLabel is needed and integration tests can be safely disabled. */}
+            <TapArea accessibilityLabel="" rounding="circle" tapStyle="none">
+              <Icon accessibilityLabel="" size={16} icon="info-circle" color="gray" />
+            </TapArea>
           </Tooltip>
         )}
       </Flex>


### PR DESCRIPTION
## Main Change
Replace `Iconbutton` with `TapArea` + `Icon` to remove default click compression in  IconButtons (info Icon). 
Tooltips are rendered on hover and the click event has no effect on hiding/showing the tooltip.
The compression on click is confusing as the user could expect an event after clicking the button.
 
Context: An interactive element is needed inside the Tooltip as Tooltip should be anchored with interactive elements. Interactive elements provide keyboard navigation. On keyboard navigation, the tooltip is rendered automatically. TapArea with tapStyle="none" provides the same navigation without the compression.

## Manual testing

![Kapture 2021-05-13 at 19 35 15](https://user-images.githubusercontent.com/10593890/118200075-5dc4d300-b422-11eb-8913-f336b4385505.gif)

![Kapture 2021-05-13 at 19 37 43](https://user-images.githubusercontent.com/10593890/118200252-b6946b80-b422-11eb-8eda-a4c367bf8d80.gif)

### BEFORE

![Kapture 2021-05-13 at 19 51 15](https://user-images.githubusercontent.com/10593890/118201076-ab423f80-b424-11eb-85a8-e163f52f88af.gif)

### AFTER

![Kapture 2021-05-13 at 21 07 19](https://user-images.githubusercontent.com/10593890/118205847-4dffbb80-b42f-11eb-8ab2-8db620813caf.gif)


## Description

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- JIRA: https://jira.pinadmin.com/browse/PDS-XXX
- [TDD](paper doc link)
- [Figma](link to figma file)

### Checklist

- [ ] Added Unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified Accessibility: keyboard & screen reader interaction
- [ ] Checked Dark Mode, Responsiveness, and Right-to-Left support
- [ ] Checked Stakeholder feedback (ex. Gestalt designers)
