### PR TITLE
ESLint: improve performance & bug fix for box-no-disallowed-props

### DIFF
--- a/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.test.js
@@ -34,6 +34,15 @@ export default function TestElement() {
     },
     {
       code: `
+import { Box as GestaltBox } from 'gestalt';
+
+export default function TestElement() {
+  return <GestaltBox as="main">Test</GestaltBox>;
+}
+    `,
+    },
+    {
+      code: `
 import { Box } from 'gestalt';
 
 export default function TestElement() {
@@ -55,6 +64,21 @@ export default function TestElement() {
         {
           message:
             'backgroundColor is not allowed on Box. Please see https://gestalt.netlify.app/Box for all allowed props.',
+        },
+      ],
+    },
+    {
+      code: `
+import { Box as GestaltBox } from 'gestalt';
+
+export default function TestElement() {
+  return <GestaltBox backgroundColor="#fff">Test</GestaltBox>;
+}
+      `,
+      errors: [
+        {
+          message:
+            'backgroundColor is not allowed on Box (imported as GestaltBox). Please see https://gestalt.netlify.app/Box for all allowed props.',
         },
       ],
     },


### PR DESCRIPTION
## Description

* ` box-no-disallowed-improvements` takes a long time & currently errors on non-Box components since we do not have a check for the locally imported name.
* Improve error message when we use import aliases for `Box`: `import { Box as GestaltBox } from 'gestalt'`