### PR TITLE
TextField, TextArea: Open errorMessage type to accept Node

### DIFF
--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -168,6 +168,31 @@ function Example(props) {
 
 card(
   <Example
+    id="errorMessageExample"
+    name="Example: Error message"
+    description={`
+    A TextArea can display its own error message.
+    To use our errors, simply pass in an \`errorMessage\` when there is an error present and we will     handle the rest.`}
+    defaultCode={`
+function Example(props) {
+  const [value, setValue] = React.useState('')
+  return (
+    <TextArea
+      id="witherror"
+      onChange={({value}) => setValue(value)}
+      errorMessage={!value ? "This field can't be blank!" : null}
+      placeholder="Write something about yourself..."
+      label="With an error message"
+      value={value}
+    />
+  );
+}
+`}
+  />,
+);
+
+card(
+  <Example
     id="refExample"
     name="Example: ref"
     description={`
@@ -201,31 +226,6 @@ function TextAreaPopoverExample() {
         </Popover>
       )}
     </Box>
-  );
-}
-`}
-  />,
-);
-
-card(
-  <Example
-    id="errorMessageExample"
-    name="Example: Error message"
-    description={`
-    A TextArea can display its own error message.
-    To use our errors, simply pass in an \`errorMessage\` when there is an error present and we will     handle the rest.`}
-    defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('')
-  return (
-    <TextArea
-      id="witherror"
-      onChange={({value}) => setValue(value)}
-      errorMessage={!value ? "This field can't be blank!" : null}
-      placeholder="Write something about yourself..."
-      label="With an error message"
-      value={value}
-    />
   );
 }
 `}

--- a/docs/src/TextArea.doc.js
+++ b/docs/src/TextArea.doc.js
@@ -21,8 +21,10 @@ card(
       },
       {
         name: 'errorMessage',
-        type: 'string',
+        type: 'React.Node',
         href: 'errorMessageExample',
+        description:
+          'For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in Link or TapArea.',
       },
       {
         name: 'ref',

--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -25,8 +25,10 @@ card(
       },
       {
         name: 'errorMessage',
-        type: 'string',
+        type: 'React.Node',
         href: 'errorMessageExample',
+        description:
+          'For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in Link or TapArea.',
       },
       {
         name: 'helperText',

--- a/packages/gestalt/src/FormErrorMessage.css
+++ b/packages/gestalt/src/FormErrorMessage.css
@@ -1,0 +1,5 @@
+.formErrorMessage * {
+  /* Ensure that error message will always be correct size regardless of what's passed in */
+  /* stylelint-disable-next-line declaration-no-important */
+  font-size: var(--g-text-font-size-1) !important;
+}

--- a/packages/gestalt/src/FormErrorMessage.js
+++ b/packages/gestalt/src/FormErrorMessage.js
@@ -1,15 +1,23 @@
 // @flow strict
-
-import type { Node } from 'react';
+import { type Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Text from './Text.js';
+import styles from './FormErrorMessage.css';
 
-export default function FormErrorMessage({ id, text = '' }: {| id: string, text?: string |}): Node {
+type Props = {|
+  id: string,
+  text?: Node,
+|};
+
+export default function FormErrorMessage({ id, text = '' }: Props): Node {
   return (
     <Box marginTop={2}>
       <Text color="red" size="sm">
-        <span id={`${id}-error`}>{text}</span>
+        {/* Class used to ensure all children are font size "sm" */}
+        <span className={styles.formErrorMessage} id={`${id}-error`}>
+          {text}
+        </span>
       </Text>
     </Box>
   );
@@ -17,5 +25,5 @@ export default function FormErrorMessage({ id, text = '' }: {| id: string, text?
 
 FormErrorMessage.propTypes = {
   id: PropTypes.string.isRequired,
-  text: PropTypes.string,
+  text: PropTypes.node,
 };

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -1,8 +1,5 @@
 // @flow strict
-
-import type { Element, Node } from 'react';
-
-import { forwardRef, useState } from 'react';
+import { forwardRef, type Element, type Node, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Box from './Box.js';
@@ -19,8 +16,8 @@ const ROW_HEIGHT = 24;
 const INPUT_PADDING_WITH_TAGS = 20;
 
 type Props = {|
-  errorMessage?: string,
   disabled?: boolean,
+  errorMessage?: Node,
   hasError?: boolean,
   helperText?: string,
   id: string,
@@ -44,8 +41,8 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
   HTMLTextAreaElement,
 >(function TextArea(props, ref): Node {
   const {
-    errorMessage,
     disabled = false,
+    errorMessage,
     hasError = false,
     helperText,
     id,
@@ -86,11 +83,13 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
     }
   };
 
+  const hasErrorMessage = Boolean(errorMessage);
+
   const classes = classnames(
     styles.textArea,
     formElement.base,
     disabled ? formElement.disabled : formElement.enabled,
-    (hasError || errorMessage) && !focused ? formElement.errored : formElement.normal,
+    (hasError || hasErrorMessage) && !focused ? formElement.errored : formElement.normal,
     tags
       ? {
           [focusStyles.accessibilityOutlineFocus]: focused,
@@ -101,8 +100,8 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
 
   const inputElement = (
     <textarea
-      aria-describedby={errorMessage && focused ? `${id}-error` : null}
-      aria-invalid={errorMessage || hasError ? 'true' : 'false'}
+      aria-describedby={hasErrorMessage && focused ? `${id}-error` : null}
+      aria-invalid={hasErrorMessage || hasError ? 'true' : 'false'}
       className={tags ? styles.unstyledTextArea : classes}
       disabled={disabled}
       id={id}
@@ -148,14 +147,14 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
         inputElement
       )}
       {helperText && !errorMessage ? <FormHelperText text={helperText} /> : null}
-      {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
+      {hasErrorMessage && <FormErrorMessage id={id} text={errorMessage} />}
     </span>
   );
 });
 
 TextAreaWithForwardRef.propTypes = {
   disabled: PropTypes.bool,
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.node,
   hasError: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Element, Node } from 'react';
-
-import { forwardRef, useState } from 'react';
+import { forwardRef, type Element, type Node, useState } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
@@ -17,7 +15,7 @@ import styles from './TextField.css';
 type Props = {|
   autoComplete?: 'current-password' | 'new-password' | 'on' | 'off' | 'username',
   disabled?: boolean,
-  errorMessage?: string,
+  errorMessage?: Node,
   hasError?: boolean,
   helperText?: string,
   id: string,
@@ -95,11 +93,13 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     }
   };
 
+  const hasErrorMessage = Boolean(errorMessage);
+
   const classes = classnames(
     styles.textField,
     formElement.base,
     disabled ? formElement.disabled : formElement.enabled,
-    (hasError || errorMessage) && !focused ? formElement.errored : formElement.normal,
+    (hasError || hasErrorMessage) && !focused ? formElement.errored : formElement.normal,
     size === 'md' ? layout.medium : layout.large,
     tags
       ? {
@@ -115,8 +115,8 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
 
   const inputElement = (
     <input
-      aria-describedby={errorMessage && focused ? `${id}-error` : null}
-      aria-invalid={errorMessage || hasError ? 'true' : 'false'}
+      aria-describedby={hasErrorMessage && focused ? `${id}-error` : null}
+      aria-invalid={hasErrorMessage || hasError ? 'true' : 'false'}
       autoComplete={autoComplete}
       className={tags ? styles.unstyledTextField : classes}
       disabled={disabled}
@@ -159,7 +159,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
         inputElement
       )}
       {helperText && !errorMessage ? <FormHelperText text={helperText} /> : null}
-      {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}
+      {hasErrorMessage && <FormErrorMessage id={id} text={errorMessage} />}
     </span>
   );
 });
@@ -167,7 +167,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
 TextFieldWithForwardRef.propTypes = {
   autoComplete: PropTypes.oneOf(['current-password', 'new-password', 'on', 'off', 'username']),
   disabled: PropTypes.bool,
-  errorMessage: PropTypes.string,
+  errorMessage: PropTypes.node,
   hasError: PropTypes.bool,
   helperText: PropTypes.string,
   id: PropTypes.string.isRequired,

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -479,6 +479,7 @@ exports[`Checkbox with error 1`] = `
           className="Text fontSize1 red alignLeft breakWord fontWeightNormal"
         >
           <span
+            className="formErrorMessage"
             id="id-error"
           >
             Error message

--- a/packages/gestalt/src/__snapshots__/FormErrorMessage.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/FormErrorMessage.test.js.snap
@@ -8,6 +8,7 @@ exports[`FormErrorMessage with errorMessage 1`] = `
     className="Text fontSize1 red alignLeft breakWord fontWeightNormal"
   >
     <span
+      className="formErrorMessage"
       id="test-error"
     >
       some error message
@@ -24,6 +25,7 @@ exports[`FormErrorMessage with no errorMessage 1`] = `
     className="Text fontSize1 red alignLeft breakWord fontWeightNormal"
   >
     <span
+      className="formErrorMessage"
       id="test-error"
     >
       

--- a/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
@@ -38,6 +38,7 @@ exports[`TextArea TextArea with error 1`] = `
       className="Text fontSize1 red alignLeft breakWord fontWeightNormal"
     >
       <span
+        className="formErrorMessage"
         id="test-error"
       >
         error message

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -56,6 +56,7 @@ exports[`TextField TextField with error 1`] = `
       className="Text fontSize1 red alignLeft breakWord fontWeightNormal"
     >
       <span
+        className="formErrorMessage"
         id="test-error"
       >
         error message


### PR DESCRIPTION
We have need in the product for clickable text in the error messages for TextField, specifically as part of the login flow:
<img width="293" alt="Screen Shot 2021-05-17 at 12 00 54 PM" src="https://user-images.githubusercontent.com/12059539/118551245-8eeb1f00-b712-11eb-8b0a-0e4806885ab2.png">

In order to allow this, we need to update the `errorMessage` type from `string` to `React.Node`. Unfortunately this opens the flood gates to pass anything as the error message, so we'll need to monitor usage to avoid abuse. I added a note about usage in the prop description.

### Reviewers
Paste this code into an example to test the new functionality (replace TextField with TextArea accordingly for that doc).

I specifically didn't update the docs with examples of this behavior because it's something we want to _support_ but not _encourage_.

```js
function Example(props) {
  const [value, setValue] = React.useState('')

  const errorMessage = (

    <React.Fragment>
      This field can't be
      <button
    onClick={() => {
      alert('CLICK')
    }}
    style={{ background: 'transparent', border: 'none', verticalAlign: 'inherit', padding: 0 }}
    type="button"
  >
    <Text key="err_text" color="red" inline size="lg" weight="bold">
      blank!
    </Text>
  </button>
    </React.Fragment>
  );

  return (
    <TextField
      id="aboutme"
      errorMessage={errorMessage}
      onChange={({ value }) => setValue(value)}
      label="With an error message"
      value={value}
    />
  );
}
```