### PR TITLE
Tabs: Add ref to tab items

### DIFF
--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -26,7 +26,7 @@ card(
       },
       {
         name: 'tabs',
-        type: `Array<{| text: React.Node, href: string, id?: string, indicator?: 'dot' | number |}>`,
+        type: `Array<{| href: string, text: React.Node, id?: string, indicator?: 'dot' | number, ref?: {| current: ?HTMLElement |} |}>`,
         required: true,
       },
       {

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { useState } from 'react';
+import { type Node, useState } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Flex from './Flex.js';
@@ -81,6 +79,7 @@ type TabType = {|
   href: string,
   id?: string,
   indicator?: 'dot' | number,
+  ref?: {| current: ?HTMLElement |},
   text: Node,
 |};
 
@@ -91,6 +90,7 @@ function Tab({
   indicator,
   isActive,
   onChange,
+  ref,
   size,
   text,
 }: {|
@@ -104,7 +104,7 @@ function Tab({
   const [focused, setFocused] = useState(false);
 
   return (
-    <Box position={focused ? 'relative' : undefined}>
+    <Box position={focused ? 'relative' : undefined} ref={ref}>
       <Link
         accessibilitySelected={isActive}
         hoverStyle="none"
@@ -153,6 +153,7 @@ function TabV2({
   index,
   isActive,
   onChange,
+  ref,
   // No longer supported, will be removed when this variant ships
   // eslint-disable-next-line no-unused-vars
   size,
@@ -176,7 +177,7 @@ function TabV2({
   }
 
   return (
-    <Box id={id} paddingY={3}>
+    <Box id={id} paddingY={3} ref={ref}>
       <TapArea
         href={href}
         onBlur={() => setFocused(false)}
@@ -277,6 +278,11 @@ Tabs.propTypes = {
       href: PropTypes.string.isRequired,
       id: PropTypes.string,
       indicator: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      // type from this SO answer: https://stackoverflow.com/a/51127130/5253702
+      ref: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.shape({ current: PropTypes.instanceOf(HTMLElement) }),
+      ]),
       text: PropTypes.node.isRequired,
     }),
   ).isRequired,

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -279,10 +279,8 @@ Tabs.propTypes = {
       id: PropTypes.string,
       indicator: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       // type from this SO answer: https://stackoverflow.com/a/51127130/5253702
-      ref: PropTypes.oneOfType([
-        PropTypes.func,
-        PropTypes.shape({ current: PropTypes.instanceOf(HTMLElement) }),
-      ]),
+      // eslint-disable-next-line react/forbid-prop-types
+      ref: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
       text: PropTypes.node.isRequired,
     }),
   ).isRequired,

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useState } from 'react';
+import { forwardRef, type AbstractComponent, type Node, useState } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 import Flex from './Flex.js';
@@ -79,27 +79,21 @@ type TabType = {|
   href: string,
   id?: string,
   indicator?: 'dot' | number,
-  ref?: {| current: ?HTMLElement |},
   text: Node,
 |};
 
-function Tab({
-  href,
-  id,
-  index,
-  indicator,
-  isActive,
-  onChange,
-  ref,
-  size,
-  text,
-}: {|
+type TabProps = {|
   ...TabType,
   index: number,
   isActive: boolean,
   onChange: OnChangeHandler,
   size: 'md' | 'lg',
-|}) {
+|};
+
+const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef<
+  TabProps,
+  HTMLElement,
+>(function Tab({ href, id, index, indicator, isActive, onChange, size, text }, ref) {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
 
@@ -141,30 +135,31 @@ function Tab({
       </Link>
     </Box>
   );
-}
+});
+
+TabWithForwardRef.displayName = 'Tab';
 
 const TAB_ROUNDING = 2;
 const TAB_INNER_PADDING = 1;
 
-function TabV2({
-  href,
-  indicator,
-  id,
-  index,
-  isActive,
-  onChange,
+const TabV2WithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef<
+  TabProps,
+  HTMLElement,
+>(function TabV2(
+  {
+    href,
+    indicator,
+    id,
+    index,
+    isActive,
+    onChange,
+    // No longer supported, will be removed when this variant ships
+    // eslint-disable-next-line no-unused-vars
+    size,
+    text,
+  },
   ref,
-  // No longer supported, will be removed when this variant ships
-  // eslint-disable-next-line no-unused-vars
-  size,
-  text,
-}: {|
-  ...TabType,
-  index: number,
-  isActive: boolean,
-  onChange: OnChangeHandler,
-  size: 'md' | 'lg',
-|}) {
+) {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
   const [pressed, setPressed] = useState(false);
@@ -226,13 +221,15 @@ function TabV2({
       </TapArea>
     </Box>
   );
-}
+});
+
+TabV2WithForwardRef.displayName = 'TabV2';
 
 type Props = {|
   activeTabIndex: number,
   onChange: OnChangeHandler,
   size?: 'md' | 'lg',
-  tabs: $ReadOnlyArray<TabType>,
+  tabs: $ReadOnlyArray<{| ...TabType, ref?: {| current: ?HTMLElement |} |}>,
   wrap?: boolean,
   // Temporary prop for the Tabs Redesign project experiments
   _dangerouslyUseV2?: boolean,
@@ -246,11 +243,11 @@ export default function Tabs({
   wrap,
   _dangerouslyUseV2,
 }: Props): Node {
-  const TabComponent = _dangerouslyUseV2 ? TabV2 : Tab;
+  const TabComponent = _dangerouslyUseV2 ? TabV2WithForwardRef : TabWithForwardRef;
 
   return (
     <Flex alignItems="center" gap={_dangerouslyUseV2 ? 4 : 0} justifyContent="start" wrap={wrap}>
-      {tabs.map(({ id, href, text, indicator }, index) => (
+      {tabs.map(({ href, id, indicator, ref, text }, index) => (
         <TabComponent
           key={id || `${href}_${index}`}
           href={href}
@@ -259,6 +256,7 @@ export default function Tabs({
           isActive={activeTabIndex === index}
           indicator={indicator}
           onChange={onChange}
+          ref={ref}
           size={size}
           text={text}
         />
@@ -266,6 +264,24 @@ export default function Tabs({
     </Flex>
   );
 }
+
+const TabItemPropType = {
+  href: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  indicator: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  text: PropTypes.node.isRequired,
+};
+
+const TabPropType = {
+  ...TabItemPropType,
+  index: PropTypes.number.isRequired,
+  isActive: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+  size: PropTypes.oneOf(['md', 'lg']),
+};
+
+TabWithForwardRef.propTypes = TabPropType;
+TabV2WithForwardRef.propTypes = TabPropType;
 
 Tabs.propTypes = {
   activeTabIndex: PropTypes.number.isRequired,
@@ -275,13 +291,10 @@ Tabs.propTypes = {
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   tabs: PropTypes.arrayOf(
     PropTypes.shape({
-      href: PropTypes.string.isRequired,
-      id: PropTypes.string,
-      indicator: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      ...TabItemPropType,
       // type from this SO answer: https://stackoverflow.com/a/51127130/5253702
       // eslint-disable-next-line react/forbid-prop-types
       ref: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
-      text: PropTypes.node.isRequired,
     }),
   ).isRequired,
   wrap: PropTypes.bool,


### PR DESCRIPTION
In at least one place in Pinboard, we're passing text wrapped in a Box setting a ref and a height to attach an Experience popover to a tab. That height breaks the Tabs V2 UI, but is necessary to properly space the popover from the entire tab element (since the ref is on the text, not the element as a whole). By allowing the user to set a ref on a tab element, it will no longer be necessary to use the wrapping Box with a height set, this unbreaking the Tabs V2 UI.