### PR TITLE
Revert "Internal: src/ directories: remove test files &  only publish.js.flow (#1525)

### DIFF
--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -11,9 +11,6 @@ const { getOctokit, context } = require('@actions/github');
 function packageJSONPath(item) {
   return path.join(__dirname, '..', 'packages', item, 'package.json');
 }
-function srcDirectory(item) {
-  return path.join(__dirname, '..', 'packages', item, 'src');
-}
 
 const packages = ['gestalt', 'gestalt-datepicker', 'eslint-plugin-gestalt'];
 const packageJSON = packageJSONPath('gestalt');
@@ -91,14 +88,11 @@ ${previousChangelog}`,
   );
 }
 
-function commitChanges({ message }) {
+async function commitChanges({ newVersion }) {
   shell.exec('git add .');
   shell.exec('git config --global user.email "pinterest.gestalt@gmail.com"');
   shell.exec('git config --global user.name "Gestalt Bot"');
-  shell.exec(`git commit -am "${message}"`);
-}
-
-function pushChanges() {
+  shell.exec(`git commit -am "Version bump: v${newVersion}"`);
   shell.exec('git push --set-upstream origin master');
 }
 
@@ -119,20 +113,6 @@ async function createGitHubRelease({ newVersion, releaseNotes }) {
   } = createReleaseResponse;
 
   return { releaseId, htmlUrl, uploadUrl };
-}
-
-function cleanSource() {
-  packages.forEach((packageName) => {
-    const src = srcDirectory(packageName);
-    shell.exec(`find ${src} -type f -name "*.flowtest.js" -delete`);
-    shell.exec(`find ${src} -type f -name "*.test.js" -delete`);
-    shell.exec(`find ${src} -type d -name "__fixtures__" -exec rm -rf {} +`);
-    shell.exec(`find ${src} -type d -name "__snapshots__" -exec rm -rf {} +`);
-
-    shell.exec(
-      `find ${src} -type f -name "*.js" -exec sh -c 'mv "$1" "\${1%.js}.js.flow"' _ {} \\;`,
-    );
-  });
 }
 
 (async () => {
@@ -161,12 +141,7 @@ function cleanSource() {
   await updateChangelog({ releaseNotes });
 
   console.log('\nCommit Changes');
-  commitChanges({ message: `Version bump: v${newVersion}` });
-  pushChanges();
-
-  console.log('\nClean src/ directories & Convert .js to .js.flow');
-  cleanSource();
-  commitChanges({ message: `v${newVersion}: Clean source` });
+  await commitChanges({ newVersion });
 
   console.log('\nCreate GitHub Release');
   const { releaseId, htmlUrl, uploadUrl } = await createGitHubRelease({


### PR DESCRIPTION
This reverts commit 67f32d5e9d6ad48ddbe10027864731c1ce0a5b76.

Revert because the `yarn publish` didn't go through: https://github.com/pinterest/gestalt/runs/2680315007

```
2021-05-27T00:01:39.1026540Z [2/4] Logging in...
2021-05-27T00:01:39.1034991Z [3/4] Publishing...
2021-05-27T00:01:39.1051762Z $ NODE_ENV=production rollup -c rollup.config.js
2021-05-27T00:01:40.6646277Z 
2021-05-27T00:01:40.6649522Z src/index.js → dist/gestalt.js, dist/gestalt.es.js...
2021-05-27T00:01:40.7061802Z [!] Error: Could not resolve entry module (src/index.js).
2021-05-27T00:01:40.7120830Z Error: Could not resolve entry module (src/index.js).
2021-05-27T00:01:40.7121873Z     at error (/home/runner/work/gestalt/gestalt/node_modules/rollup/dist/shared/rollup.js:5305:30)
2021-05-27T00:01:40.7123175Z     at ModuleLoader.loadEntryModule (/home/runner/work/gestalt/gestalt/node_modules/rollup/dist/shared/rollup.js:18552:20)
2021-05-27T00:01:40.7124164Z     at async Promise.all (index 0)
2021-05-27T00:01:40.7124623Z 
2021-05-27T00:01:40.7290101Z error Command failed with exit code 1.
2021-05-27T00:01:40.7291407Z info Visit https://yarnpkg.com/en/docs/cli/publish for documentation about this command.
2021-05-27T00:01:40.7394462Z ##[error]Process completed with exit code 1.
```