### PR TITLE
Internal: src/ directories: remove test files & only publish .js.flow (second try)

### DIFF
--- a/packages/eslint-plugin-gestalt/package.json
+++ b/packages/eslint-plugin-gestalt/package.json
@@ -17,7 +17,7 @@
   "dependencies": {},
   "scripts": {
     "build": "rollup -c rollup.config.js",
-    "prepublish": "NODE_ENV=production rollup -c rollup.config.js",
+    "build:prod": "NODE_ENV=production rollup -c rollup.config.js",
     "watch": "rollup -c rollup.config.js --watch"
   }
 }

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",
-    "prepublish": "NODE_ENV=production rollup -c rollup.config.js",
+    "build:prod": "NODE_ENV=production rollup -c rollup.config.js",
     "watch": "rollup -c rollup.config.js --watch"
   },
   "browserslist": [

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -22,9 +22,9 @@
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",
+    "build:prod": "NODE_ENV=production rollup -c rollup.config.js",
     "postpack": "rm README.md",
     "prepack": "cp ../../README.md .",
-    "prepublish": "NODE_ENV=production rollup -c rollup.config.js",
     "watch": "rollup -c rollup.config.js --watch"
   },
   "browserslist": [

--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -8,8 +8,15 @@ const fsPromises = require('fs').promises;
 const core = require('@actions/core');
 const { getOctokit, context } = require('@actions/github');
 
+function packageDirectory(item) {
+  return path.join(__dirname, '..', 'packages', item);
+}
+
 function packageJSONPath(item) {
   return path.join(__dirname, '..', 'packages', item, 'package.json');
+}
+function srcDirectory(item) {
+  return path.join(__dirname, '..', 'packages', item, 'src');
 }
 
 const packages = ['gestalt', 'gestalt-datepicker', 'eslint-plugin-gestalt'];
@@ -88,11 +95,14 @@ ${previousChangelog}`,
   );
 }
 
-async function commitChanges({ newVersion }) {
+function commitChanges({ message }) {
   shell.exec('git add .');
   shell.exec('git config --global user.email "pinterest.gestalt@gmail.com"');
   shell.exec('git config --global user.name "Gestalt Bot"');
-  shell.exec(`git commit -am "Version bump: v${newVersion}"`);
+  shell.exec(`git commit -am "${message}"`);
+}
+
+function pushChanges() {
   shell.exec('git push --set-upstream origin master');
 }
 
@@ -113,6 +123,27 @@ async function createGitHubRelease({ newVersion, releaseNotes }) {
   } = createReleaseResponse;
 
   return { releaseId, htmlUrl, uploadUrl };
+}
+
+function cleanSource() {
+  packages.forEach((packageName) => {
+    const src = srcDirectory(packageName);
+    shell.exec(`find ${src} -type f -name "*.flowtest.js" -delete`);
+    shell.exec(`find ${src} -type f -name "*.test.js" -delete`);
+    shell.exec(`find ${src} -type d -name "__fixtures__" -exec rm -rf {} +`);
+    shell.exec(`find ${src} -type d -name "__snapshots__" -exec rm -rf {} +`);
+
+    shell.exec(
+      `find ${src} -type f -name "*.js" -exec sh -c 'mv "$1" "\${1%.js}.js.flow"' _ {} \\;`,
+    );
+  });
+}
+
+function buildPackages() {
+  packages.forEach((packageName) => {
+    const src = packageDirectory(packageName);
+    shell.exec(`cd ${src}; yarn build:prod`);
+  });
 }
 
 (async () => {
@@ -141,7 +172,15 @@ async function createGitHubRelease({ newVersion, releaseNotes }) {
   await updateChangelog({ releaseNotes });
 
   console.log('\nCommit Changes');
-  await commitChanges({ newVersion });
+  commitChanges({ message: `Version bump: v${newVersion}` });
+  pushChanges();
+
+  console.log(`\nBuild packages`);
+  buildPackages();
+
+  console.log('\nClean src/ directories & Convert .js to .js.flow');
+  cleanSource();
+  commitChanges({ message: `v${newVersion}: Clean source` });
 
   console.log('\nCreate GitHub Release');
   const { releaseId, htmlUrl, uploadUrl } = await createGitHubRelease({


### PR DESCRIPTION
## Problem(s)

* Folks are importing files within `src/` directories which results in us not being able to change internal file names
* We publish unnecessary files (e.g. test files) which makes the npm/yarn package bigger than it needs to be


## Links

Approach was inspired by https://github.com/facebook/relay/blob/625552c31ca4f5f35df1698c39f7f1eac176d1e7/gulpfile.js#L278

## Why the revert / revert?

The initial try #1525 failed because during the release/publish, we were seeing the following exception:

https://github.com/pinterest/gestalt/runs/2680315007

```
2021-05-27T00:01:39.1026540Z [2/4] Logging in...
2021-05-27T00:01:39.1034991Z [3/4] Publishing...
2021-05-27T00:01:39.1051762Z $ NODE_ENV=production rollup -c rollup.config.js
2021-05-27T00:01:40.6646277Z 
2021-05-27T00:01:40.6649522Z src/index.js → dist/gestalt.js, dist/gestalt.es.js...
2021-05-27T00:01:40.7061802Z [!] Error: Could not resolve entry module (src/index.js).
2021-05-27T00:01:40.7120830Z Error: Could not resolve entry module (src/index.js).
2021-05-27T00:01:40.7121873Z     at error (/home/runner/work/gestalt/gestalt/node_modules/rollup/dist/shared/rollup.js:5305:30)
2021-05-27T00:01:40.7123175Z     at ModuleLoader.loadEntryModule (/home/runner/work/gestalt/gestalt/node_modules/rollup/dist/shared/rollup.js:18552:20)
2021-05-27T00:01:40.7124164Z     at async Promise.all (index 0)
2021-05-27T00:01:40.7124623Z 
2021-05-27T00:01:40.7290101Z error Command failed with exit code 1.
2021-05-27T00:01:40.7291407Z info Visit https://yarnpkg.com/en/docs/cli/publish for documentation about this command.
2021-05-27T00:01:40.7394462Z ##[error]Process completed with exit code 1.
```

## How did you fix the issue?

We now perform the `build` step before cleaning up `/src`