### PR TITLE
TextField: Add email option for autocomplete

### DIFF
--- a/docs/src/TextField.doc.js
+++ b/docs/src/TextField.doc.js
@@ -15,7 +15,7 @@ card(
     props={[
       {
         name: 'autoComplete',
-        type: `"current-password" | "new-password" | "on" | "off" | "username"`,
+        type: `"current-password" | "new-password" | "on" | "off" | "username" | "email"`,
       },
       {
         name: 'disabled',
@@ -124,6 +124,7 @@ function Example(props) {
       label="Email"
       value={value}
       type="email"
+      autoComplete="email"
     />
   );
 }

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -13,7 +13,7 @@ import layout from './Layout.css';
 import styles from './TextField.css';
 
 type Props = {|
-  autoComplete?: 'current-password' | 'new-password' | 'on' | 'off' | 'username',
+  autoComplete?: 'current-password' | 'new-password' | 'on' | 'off' | 'username' | 'email',
   disabled?: boolean,
   errorMessage?: Node,
   hasError?: boolean,
@@ -165,7 +165,14 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
 });
 
 TextFieldWithForwardRef.propTypes = {
-  autoComplete: PropTypes.oneOf(['current-password', 'new-password', 'on', 'off', 'username']),
+  autoComplete: PropTypes.oneOf([
+    'current-password',
+    'new-password',
+    'on',
+    'off',
+    'username',
+    'email',
+  ]),
   disabled: PropTypes.bool,
   errorMessage: PropTypes.node,
   hasError: PropTypes.bool,


### PR DESCRIPTION
## Description
Add email as an option (request from slack for a11y tests)
<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- JIRA: https://jira.pinadmin.com/browse/PDS-XXX
- [TDD](paper doc link)
- [Figma](link to figma file)

### Checklist

- [ ] Added Unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified Accessibility: keyboard & screen reader interaction
- [ ] Checked Dark Mode, Responsiveness, and Right-to-Left support
- [ ] Checked Stakeholder feedback (ex. Gestalt designers)
