### PR TITLE
Popover: new id and role props for accessibility

### DIFF
--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -29,17 +29,21 @@ import {
   getPopoverDir,
 } from './utils/positioningUtils.js';
 
+export type Role = 'dialog' | 'listbox';
+
 type OwnProps = {|
   anchor: HTMLElement,
   bgColor: 'blue' | 'darkGray' | 'orange' | 'red' | 'white',
   border?: boolean,
   caret?: boolean,
   children?: Node,
+  id: ?string,
   idealDirection?: MainDirections,
   onKeyDown: (event: SyntheticKeyboardEvent<HTMLElement>) => void,
   onResize: () => void,
   positionRelativeToAnchor?: boolean,
   relativeOffset: Coordinates,
+  role: ?Role,
   rounding?: 2 | 4,
   shouldFocus?: boolean,
   triggerRect: ClientRect,
@@ -71,6 +75,7 @@ const ContentProptypes = {
   border: PropTypes.bool,
   caret: PropTypes.bool,
   children: PropTypes.node,
+  id: PropTypes.string,
   idealDirection: PropTypes.oneOf(['up', 'right', 'down', 'left']),
   onKeyDown: PropTypes.func.isRequired,
   onResize: PropTypes.func.isRequired,
@@ -79,6 +84,7 @@ const ContentProptypes = {
     y: PropTypes.number,
   }),
   positionRelativeToAnchor: PropTypes.bool,
+  role: (PropTypes.oneOf(['dialog', 'listbox']): React$PropType$Primitive<Role>),
   rounding: PropTypes.oneOf([2, 4]),
   shouldFocus: PropTypes.bool,
   triggerBoundingClientRect: PropTypes.shape({
@@ -238,7 +244,9 @@ class Contents extends Component<Props, State> {
       caret,
       children,
       colorGray100,
+      id,
       isDarkMode,
+      role,
       rounding,
       width,
     } = this.props;
@@ -253,6 +261,8 @@ class Contents extends Component<Props, State> {
 
     return (
       <div
+        id={id}
+        role={role}
         className={styles.container}
         // popoverOffset positions the Popover component
         style={{ stroke, visibility, ...popoverOffset }}

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -4,7 +4,7 @@ import type { Node as ReactNode } from 'react';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ESCAPE } from './keyCodes.js';
-import Contents from './Contents.js';
+import Contents, { type Role } from './Contents.js';
 import OutsideEventBehavior from './behaviors/OutsideEventBehavior.js';
 import { useScrollBoundaryContainer } from './contexts/ScrollBoundaryContainer.js';
 import type { ClientRect, Coordinates } from './utils/positioningTypes.js';
@@ -24,9 +24,11 @@ type OwnProps = {|
   caret?: boolean,
   children?: ReactNode,
   handleKeyDown?: (event: SyntheticKeyboardEvent<HTMLElement>) => void,
+  id?: ?string,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
   positionRelativeToAnchor: boolean,
+  role?: ?Role,
   rounding?: 2 | 4,
   shouldFocus?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | null,
@@ -53,10 +55,12 @@ const ControllerProptypes = {
   caret: PropTypes.bool,
   children: PropTypes.node,
   handleKeyDown: PropTypes.func,
+  id: PropTypes.string,
   idealDirection: PropTypes.oneOf(['up', 'right', 'down', 'left']),
   onDismiss: PropTypes.func.isRequired,
   positionRelativeToAnchor: PropTypes.bool,
   rounding: PropTypes.oneOf([2, 4]),
+  role: (PropTypes.oneOf(['dialog', 'listbox']): React$PropType$Primitive<Role>),
   shouldFocus: PropTypes.bool,
   size: PropTypes.oneOfType([
     PropTypes.number,
@@ -141,8 +145,10 @@ class Controller extends Component<Props, State> {
       border,
       caret,
       children,
+      id,
       idealDirection,
       positionRelativeToAnchor,
+      role,
       rounding,
       shouldFocus,
       size,
@@ -158,11 +164,13 @@ class Controller extends Component<Props, State> {
           bgColor={bgColor}
           border={border}
           caret={caret}
+          id={id}
           idealDirection={idealDirection}
           onKeyDown={this.handleKeyDown}
           onResize={this.handleResize}
           positionRelativeToAnchor={positionRelativeToAnchor}
           relativeOffset={relativeOffset}
+          role={role}
           rounding={rounding}
           shouldFocus={shouldFocus}
           triggerRect={triggerBoundingRect}

--- a/packages/gestalt/src/Controller.jsdom.test.js
+++ b/packages/gestalt/src/Controller.jsdom.test.js
@@ -6,6 +6,8 @@ test('Controller renders', () => {
   const element = document.createElement('div');
   const component = create(
     <Controller
+      id=""
+      role={undefined}
       anchor={element}
       positionRelativeToAnchor
       bgColor="darkGray"

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -2,18 +2,25 @@
 import type { Node } from 'react';
 import PropTypes from 'prop-types';
 import Controller from './Controller.js';
+import { type Role } from './Contents.js';
+
+type Color = 'blue' | 'orange' | 'red' | 'white' | 'darkGray';
+type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number;
+type IdealDirection = 'up' | 'right' | 'down' | 'left';
 
 type Props = {|
   anchor: ?HTMLElement,
   children?: Node,
-  color?: 'blue' | 'orange' | 'red' | 'white' | 'darkGray',
+  color?: Color,
   handleKeyDown?: (event: SyntheticKeyboardEvent<HTMLElement>) => void,
-  idealDirection?: 'up' | 'right' | 'down' | 'left',
+  id?: string,
+  idealDirection?: IdealDirection,
   onDismiss: () => void,
   positionRelativeToAnchor?: boolean,
+  role?: Role,
   shouldFocus?: boolean,
   showCaret?: boolean,
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number,
+  size?: Size,
 |};
 
 export default function Popover(props: Props): null | Node {
@@ -21,10 +28,12 @@ export default function Popover(props: Props): null | Node {
     anchor,
     children,
     handleKeyDown,
+    id,
     idealDirection,
     onDismiss,
     positionRelativeToAnchor = true,
     color = 'white',
+    role,
     shouldFocus = true,
     showCaret = false,
     size = 'sm',
@@ -41,9 +50,11 @@ export default function Popover(props: Props): null | Node {
       border
       caret={showCaret}
       handleKeyDown={handleKeyDown}
+      id={id}
       idealDirection={idealDirection}
       onDismiss={onDismiss}
       positionRelativeToAnchor={positionRelativeToAnchor}
+      role={role}
       rounding={4}
       shouldFocus={shouldFocus}
       size={size === 'flexible' ? null : size}
@@ -60,16 +71,26 @@ Popover.propTypes = {
     getBoundingClientRect: PropTypes.func,
   }),
   children: PropTypes.node,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  idealDirection: PropTypes.oneOf(['up', 'right', 'down', 'left']),
+  id: PropTypes.string,
+  idealDirection: (PropTypes.oneOf([
+    'up',
+    'right',
+    'down',
+    'left',
+  ]): React$PropType$Primitive<IdealDirection>),
   onDismiss: PropTypes.func.isRequired,
   positionRelativeToAnchor: PropTypes.bool,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  color: PropTypes.oneOf(['blue', 'orange', 'red', 'white', 'darkGray']),
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  size: PropTypes.oneOfType([
+  color: (PropTypes.oneOf([
+    'blue',
+    'orange',
+    'red',
+    'white',
+    'darkGray',
+  ]): React$PropType$Primitive<Color>),
+  role: (PropTypes.oneOf(['dialog', 'listbox']): React$PropType$Primitive<Role>),
+  size: (PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', 'flexible']), // default: sm
-  ]),
+  ]): React$PropType$Primitive<Size>),
   showCaret: PropTypes.bool,
 };


### PR DESCRIPTION
New Id prop to match aria-controls, and role

## Description

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- JIRA: https://jira.pinadmin.com/browse/PDS-XXX
- [TDD](paper doc link)
- [Figma](link to figma file)

### Checklist

- [ ] Added Unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified Accessibility: keyboard & screen reader interaction
- [ ] Checked Dark Mode, Responsiveness, and Right-to-Left support
- [ ] Checked Stakeholder feedback (ex. Gestalt designers)
