### PR TITLE
Tabs: pass disableOnNavigation arg in onChange for link behavior management

### DIFF
--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -31,7 +31,7 @@ card(
       },
       {
         name: 'onChange',
-        type: `({ +event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>, +activeTabIndex: number }) => void`,
+        type: `({| +event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>, +activeTabIndex: number, disableOnNavigation: () => void  |}) => void`,
         required: true,
         description:
           'If your app uses a tool such as react-router to navigate between pages, be sure to use onChange to navigate instead of getting a full page refresh with href',

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -13,7 +13,7 @@ type OnChangeHandler = AbstractEventHandler<
   | SyntheticKeyboardEvent<HTMLAnchorElement>
   | SyntheticMouseEvent<HTMLDivElement>
   | SyntheticKeyboardEvent<HTMLDivElement>,
-  {| +activeTabIndex: number |},
+  {| +activeTabIndex: number, disableOnNavigation: () => void |},
 >;
 
 function Dot() {
@@ -105,7 +105,9 @@ const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef<
         href={href}
         id={id}
         onBlur={() => setFocused(false)}
-        onClick={({ event }) => onChange({ activeTabIndex: index, event })}
+        onClick={({ event, disableOnNavigation }) =>
+          onChange({ activeTabIndex: index, event, disableOnNavigation })
+        }
         onFocus={() => setFocused(true)}
         role="tab"
         rounding="pill"
@@ -181,7 +183,9 @@ const TabV2WithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef
         onMouseUp={() => setPressed(false)}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        onTap={({ event }) => onChange({ activeTabIndex: index, event })}
+        onTap={({ event, disableOnNavigation }) =>
+          onChange({ activeTabIndex: index, event, disableOnNavigation })
+        }
         role="link"
         rounding={TAB_ROUNDING}
         tapStyle="compress"


### PR DESCRIPTION
To keep logic consistent across all cmps with link behavior, we are adding `disableOnNavigation` to Tabs (accessible in `onChange`)

## Description

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- JIRA: https://jira.pinadmin.com/browse/PDS-XXX
- [TDD](paper doc link)
- [Figma](link to figma file)

### Checklist

- [ ] Added Unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified Accessibility: keyboard & screen reader interaction
- [ ] Checked Dark Mode, Responsiveness, and Right-to-Left support
- [ ] Checked Stakeholder feedback (ex. Gestalt designers)
