### PR TITLE
Internal: add resolution for `trim-newlines` to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "lodash": "4.17.21",
     "multicast-dns": "7.2.3",
     "serialize-javascript": "3.1.0",
+    "trim-newlines": "3.0.1",
     "ws": "7.4.6"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18934,15 +18934,10 @@ treeify@^1.1.0:
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
   integrity sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
-
-trim-newlines@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
-  integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+trim-newlines@3.0.1, trim-newlines@^1.0.0, trim-newlines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-repeated@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
[Security alert](https://github.com/pinterest/gestalt/security/dependabot/yarn.lock/trim-newlines/open)

`trim-newlines` is used by a couple of versions of `meow` (3.7.0 + 9.0.0). Both of those versions are used by our direct dependencies (`stylelint` + `css-modules-flow-types-cli`), but sadly neither of those modules have been updated.

A [previous attempt at this fix](https://github.com/pinterest/gestalt/pull/1544) (adding a resolution for `meow`) failed CI, likely due to the multiple major version jump involved.

This PR adds a resolution for the latest version of `trim-newlines`. 🤞 this doesn't break anything, since it's a multiple major version jump for both `meow` versions.