### PR TITLE
Video: Use objectFit instead of object-fit

### DIFF
--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -594,7 +594,7 @@ export default class Video extends PureComponent<Props, State> {
             onTimeUpdate={this.handleTimeUpdate}
             onProgress={this.handleProgress}
             onWaiting={this.handleWaiting}
-            {...(objectFit ? { style: { 'object-fit': objectFit } } : null)}
+            {...(objectFit ? { style: { objectFit } } : null)}
             {...((crossOrigin ? { crossOrigin } : { ...null }): {|
               crossOrigin?: CrossOrigin,
             |})}

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -646,7 +646,7 @@ exports[`Video with objectFit 1`] = `
       src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
       style={
         Object {
-          "object-fit": "contain",
+          "objectFit": "contain",
         }
       }
     >


### PR DESCRIPTION
## Description

This fixes a typo in which `<video />` contains a style prop with `{ 'object-fit': objectFit }`  when properties on the style prop should be camelCase.

### Links

- JIRA: https://jira.pinadmin.com/browse/PDS-2861

### Checklist

- [ ] Added Unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified Accessibility: keyboard & screen reader interaction
- [ ] Checked Dark Mode, Responsiveness, and Right-to-Left support
- [ ] Checked Stakeholder feedback (ex. Gestalt designers)
