### PR TITLE
Button: fix incorrect styling for disabled buttons on Safari / iOS

### DIFF
--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -194,6 +194,12 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
   const handleLinkClick = ({ event, disableOnNavigation }) =>
     handleClick(event, disableOnNavigation);
 
+  const buttonContent = iconEnd ? (
+    <IconEnd text={buttonText} textColor={textColor} icon={iconEnd} size={size} />
+  ) : (
+    buttonText
+  );
+
   if (props.role === 'link') {
     const { href, rel = 'none', target = null } = props;
 
@@ -212,53 +218,22 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         target={target}
         wrappedComponent="button"
       >
-        {iconEnd ? (
-          <IconEnd text={buttonText} textColor={textColor} icon={iconEnd} size={size} />
-        ) : (
-          buttonText
-        )}
+        {buttonContent}
       </InternalLink>
     );
   }
 
-  if (props.type === 'submit') {
-    const { name } = props;
-
-    return (
-      <button
-        aria-label={accessibilityLabel}
-        className={buttonRoleClasses}
-        disabled={disabled}
-        name={name}
-        onBlur={handleBlur}
-        onClick={handleClick}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        onTouchCancel={handleTouchCancel}
-        onTouchEnd={handleTouchEnd}
-        onTouchMove={handleTouchMove}
-        onTouchStart={handleTouchStart}
-        ref={innerRef}
-        style={compressStyle || undefined}
-        tabIndex={disabled ? null : tabIndex}
-        type="submit"
-      >
-        {iconEnd ? (
-          <IconEnd text={buttonText} textColor={textColor} icon={iconEnd} size={size} />
-        ) : (
-          buttonText
-        )}
-      </button>
-    );
-  }
-
-  const { accessibilityControls, accessibilityExpanded, accessibilityHaspopup, name } = props;
+  const { name } = props;
 
   return (
     <button
-      aria-controls={accessibilityControls}
-      aria-expanded={accessibilityExpanded}
-      aria-haspopup={accessibilityHaspopup}
+      {...(props.type === 'submit'
+        ? {}
+        : {
+            'aria-controls': props.accessibilityControls,
+            'aria-expanded': props.accessibilityExpanded,
+            'aria-haspopup': props.accessibilityHaspopup,
+          })}
       aria-label={accessibilityLabel}
       className={buttonRoleClasses}
       disabled={disabled}
@@ -274,13 +249,9 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
       ref={innerRef}
       style={compressStyle || undefined}
       tabIndex={disabled ? null : tabIndex}
-      type="button"
+      type={props.type === 'submit' ? 'submit' : 'button'}
     >
-      {iconEnd ? (
-        <IconEnd text={buttonText} textColor={textColor} icon={iconEnd} size={size} />
-      ) : (
-        buttonText
-      )}
+      {buttonContent}
     </button>
   );
 });

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -237,6 +237,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
       aria-label={accessibilityLabel}
       className={buttonRoleClasses}
       disabled={disabled}
+      key={disabled ? 'disabled' : 'enabled'} // workaround for issue #1556
       name={name}
       onBlur={handleBlur}
       onClick={handleClick}


### PR DESCRIPTION
This fixes #1556 by changing the `key` value every time `disabled` is changed

Before:
![Screen Shot 2021-06-15 at 10 57 27 AM](https://user-images.githubusercontent.com/5341184/122105431-9ebb5900-cdcd-11eb-9d3d-1706631781de.png)

After:
![Screen Shot 2021-06-15 at 11 34 05 AM](https://user-images.githubusercontent.com/5341184/122105448-a4b13a00-cdcd-11eb-940f-e77d32706bdb.png)
