### PR TITLE
Internal: Add links to docs from code

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -35,6 +35,9 @@ type Props = {|
   value?: Date,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/DatePicker
+ */
 const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> = forwardRef<
   Props,
   HTMLDivElement,

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -181,6 +181,9 @@ const UncompletedCard = ({
   );
 };
 
+/**
+ * https://gestalt.pinterest.systems/ActivationCard
+ */
 export default function ActivationCard({
   dismissButton,
   message,

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -29,6 +29,9 @@ const sizes = {
   xl: 120,
 };
 
+/**
+ * https://gestalt.pinterest.systems/Avatar
+ */
 export default function Avatar(props: Props): Node {
   const [isImageLoaded, setIsImageLoaded] = useState(true);
   const { colorGray0, colorGray100 } = useColorScheme();

--- a/packages/gestalt/src/AvatarGroup.js
+++ b/packages/gestalt/src/AvatarGroup.js
@@ -29,6 +29,9 @@ type Props = {|
 
 type UnionRefs = HTMLDivElement | HTMLAnchorElement;
 
+/**
+ * https://gestalt.pinterest.systems/AvatarGroup
+ */
 const AvatarGroupWithForwardRef: React$AbstractComponent<Props, UnionRefs> = forwardRef<
   Props,
   UnionRefs,

--- a/packages/gestalt/src/AvatarPair.js
+++ b/packages/gestalt/src/AvatarPair.js
@@ -14,6 +14,9 @@ const sizes = {
   lg: 64,
 };
 
+/**
+ * https://gestalt.pinterest.systems/AvatarPair
+ */
 export default function AvatarPair({ collaborators, size = 'fit' }: Props): Node {
   const width = size === 'fit' ? '100%' : sizes[size];
   return (

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -13,6 +13,9 @@ type Props = {|
   text: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Badge
+ */
 export default function Badge({ position = 'middle', text }: Props): Node {
   const { name: colorSchemeName } = useColorScheme();
 

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -205,6 +205,9 @@ const disallowedProps = [
 
 type OutputType = Element<As>;
 
+/**
+ * https://gestalt.pinterest.systems/Box
+ */
 const BoxWithForwardRef: AbstractComponent<Props, HTMLElement> = forwardRef<Props, HTMLElement>(
   function Box({ as, ...props }, ref): OutputType {
     const { passthroughProps, propsStyles } = buildStyles<$Diff<Props, {| as?: As |}>>({

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -104,6 +104,9 @@ const IconEnd = ({
   </Flex>
 );
 
+/**
+ * https://gestalt.pinterest.systems/Button
+ */
 const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,
   unionRefs,

--- a/packages/gestalt/src/ButtonGroup.js
+++ b/packages/gestalt/src/ButtonGroup.js
@@ -5,6 +5,9 @@ import { Children, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
 
+/**
+ * https://gestalt.pinterest.systems/ButtonGroup
+ */
 function ButtonGroup({ children }: {| children?: Node |}): Node {
   const count = Children.count(children);
 

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -96,6 +96,9 @@ const CalloutAction = ({
   );
 };
 
+/**
+ * https://gestalt.pinterest.systems/Callout
+ */
 export default function Callout({
   dismissButton,
   iconAccessibilityLabel,

--- a/packages/gestalt/src/Card.js
+++ b/packages/gestalt/src/Card.js
@@ -16,6 +16,9 @@ type Props = {|
   onMouseLeave?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Card
+ */
 export default function Card(props: Props): Node {
   const [hovered, setHovered] = useState(false);
   const { active, children, image, onMouseEnter, onMouseLeave } = props;

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -32,6 +32,9 @@ type Props = {|
   subtext?: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Checkbox
+ */
 const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -153,6 +153,9 @@ type Props = {|
   width: number,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Collage
+ */
 export default function Collage(props: Props): Node {
   const { columns, cover, gutter, height, layoutKey, renderImage, width } = props;
   const positions = getCollageLayout({

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -59,6 +59,9 @@ type Props = {|
   viewportHeight?: number,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Collection
+ */
 export default class Collection extends PureComponent<Props, void> {
   static propTypes = {
     // eslint-disable-next-line react/forbid-prop-types

--- a/packages/gestalt/src/Column.js
+++ b/packages/gestalt/src/Column.js
@@ -14,6 +14,9 @@ type ColumnProps = {|
   lgSpan?: Columns,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Column
+ */
 export default function Column(props: ColumnProps): Node {
   const { children } = props;
   const cs = classnames(

--- a/packages/gestalt/src/Container.js
+++ b/packages/gestalt/src/Container.js
@@ -7,6 +7,9 @@ type Props = {|
   children?: Node,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Container
+ */
 export default function Container(props: Props): Node {
   const { children } = props;
   return (

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -25,6 +25,9 @@ type Props = {|
   value: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Datapoint
+ */
 export default function Datapoint({
   tooltipText,
   size = 'md',

--- a/packages/gestalt/src/Divider.js
+++ b/packages/gestalt/src/Divider.js
@@ -2,6 +2,9 @@
 import type { Node } from 'react';
 import styles from './Divider.css';
 
+/**
+ * https://gestalt.pinterest.systems/Divider
+ */
 export default function Divider(): Node {
   return <hr className={styles.divider} />;
 }

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -36,6 +36,9 @@ const KEYS = {
   ENTER: 0,
 };
 
+/**
+ * https://gestalt.pinterest.systems/Dropdown
+ */
 export default function Dropdown({
   anchor,
   children,

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -31,6 +31,9 @@ type Props = {|
   ...PrivateProps,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Dropdown
+ */
 export default function DropdownItem({
   badgeText,
   children,

--- a/packages/gestalt/src/DropdownSection.js
+++ b/packages/gestalt/src/DropdownSection.js
@@ -10,6 +10,9 @@ type Props = {|
   label: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Dropdown
+ */
 export default function DropdownSection({ label, children }: Props): Node {
   return (
     <div className={styles.DropdownSection} aria-label={label}>

--- a/packages/gestalt/src/Fieldset.js
+++ b/packages/gestalt/src/Fieldset.js
@@ -15,6 +15,9 @@ type Props = {|
   legendDisplay?: 'visible' | 'hidden',
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Fieldset
+ */
 export default function Fieldset({ legend, legendDisplay = 'visible', children }: Props): Node {
   return (
     <fieldset className={classnames(formStyles.unstyled, whitespaceStyles.p0, whitespaceStyles.m0)}>

--- a/packages/gestalt/src/Flex.js
+++ b/packages/gestalt/src/Flex.js
@@ -63,6 +63,9 @@ const allowedProps = [
   'wrap',
 ];
 
+/**
+ * https://gestalt.pinterest.systems/Flex
+ */
 export default function Flex({
   alignItems,
   children: childrenProp,

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -21,6 +21,9 @@ export type Props = {|
 
 const allowedProps = ['alignSelf', 'children', 'flex', 'minWidth'];
 
+/**
+ * https://gestalt.pinterest.systems/Flex
+ */
 export default function FlexItem(props: Props): Node {
   const { passthroughProps, propsStyles } = buildStyles<Props>({
     baseStyles: styles.FlexItem,

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -46,6 +46,9 @@ const SIZE_SCALE = {
   lg: 3,
 };
 
+/**
+ * https://gestalt.pinterest.systems/Heading
+ */
 export default function Heading(props: Props): Node {
   const {
     accessibilityLevel,

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -61,6 +61,9 @@ const flipOnRtlIconNames = [
   'text-size',
 ];
 
+/**
+ * https://gestalt.pinterest.systems/Icon
+ */
 export default function Icon(props: Props): Node {
   const {
     accessibilityLabel,

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -60,6 +60,9 @@ type unionProps = IconButtonType | LinkIconButtonType;
 
 type unionRefs = HTMLButtonElement | HTMLAnchorElement;
 
+/**
+ * https://gestalt.pinterest.systems/IconButton
+ */
 const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,
   unionRefs,

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -25,6 +25,9 @@ type Props = {|
   srcSet?: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Image
+ */
 export default class Image extends PureComponent<Props> {
   static propTypes = {
     alt: PropTypes.string.isRequired,

--- a/packages/gestalt/src/Label.js
+++ b/packages/gestalt/src/Label.js
@@ -8,6 +8,9 @@ type Props = {|
   htmlFor: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Label
+ */
 export default function Label(props: Props): Node {
   const { children, htmlFor } = props;
 

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -8,6 +8,9 @@ import styles from './Layer.css';
 import { useScrollBoundaryContainer } from './contexts/ScrollBoundaryContainer.js';
 import { getContainerNode } from './utils/positioningUtils.js';
 
+/**
+ * https://gestalt.pinterest.systems/Layer
+ */
 export default function Layer({
   children,
   zIndex: zIndexIndexable,

--- a/packages/gestalt/src/Letterbox.js
+++ b/packages/gestalt/src/Letterbox.js
@@ -21,6 +21,9 @@ type Props = {|
   width: number,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Letterbox
+ */
 export default function Letterbox({ children, contentAspectRatio, height, width }: Props): Node {
   const viewportAspectRatio = aspectRatio(width, height);
 

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -37,6 +37,9 @@ type Props = {|
   disabled?: boolean,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Link
+ */
 const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardRef<
   Props,
   HTMLAnchorElement,

--- a/packages/gestalt/src/Mask.js
+++ b/packages/gestalt/src/Mask.js
@@ -16,6 +16,9 @@ type Props = {|
   wash?: boolean,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Mask
+ */
 export default function Mask(props: Props): Node {
   const { children, rounding = 0, width, height, willChangeTransform = true, wash = false } = props;
   return (

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -72,6 +72,9 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 
 const layoutNumberToCssDimension = (n) => (n !== Infinity ? n : undefined);
 
+/**
+ * https://gestalt.pinterest.systems/Masonry
+ */
 export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<T>> {
   static createMeasurementStore<T1: { ... }, T2>(): MeasurementStore<T1, T2> {
     return new MeasurementStore();

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -59,6 +59,9 @@ function Header({
   );
 }
 
+/**
+ * https://gestalt.pinterest.systems/Modal
+ */
 const ModalWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> = forwardRef<
   Props,
   HTMLDivElement,

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -12,6 +12,9 @@ type Props = {|
   id: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Module
+ */
 export default function Module({
   badgeText,
   children,

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -18,6 +18,9 @@ type Props = {|
   onExpandedChange?: (?number) => void,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Module
+ */
 export default function ModuleExpandable({
   accessibilityExpandLabel,
   accessibilityCollapseLabel,

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -17,6 +17,9 @@ type Props = {|
   onModuleClicked: (boolean) => void,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Module
+ */
 export default function ModuleExpandableItem({
   accessibilityCollapseLabel,
   accessibilityExpandLabel,

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -13,6 +13,9 @@ type Props = {|
   type: TypeOptions, // overwriting to be required
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Module
+ */
 export default function ModuleTitle({
   badgeText,
   icon,

--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -18,6 +18,9 @@ type Props = {|
   subtext?: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/PageHeader
+ */
 export default function PageHeader({
   maxWidth = '100%',
   primaryAction,

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -56,6 +56,9 @@ const defaultIconButtonIconColors = {
   white: 'gray',
 };
 
+/**
+ * https://gestalt.pinterest.systems/Pog
+ */
 export default function Pog(props: Props): Node {
   const {
     accessibilityLabel = '',

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -23,6 +23,9 @@ type Props = {|
   size?: Size,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Popover
+ */
 export default function Popover(props: Props): null | Node {
   const {
     anchor,

--- a/packages/gestalt/src/Pulsar.js
+++ b/packages/gestalt/src/Pulsar.js
@@ -9,6 +9,9 @@ type Props = {|
   size?: number,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Pulsar
+ */
 export default function Pulsar({ paused, size = 136 }: Props): Node {
   return (
     <Box

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -26,6 +26,9 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
+/**
+ * https://gestalt.pinterest.systems/RadioButton
+ */
 const RadioButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,

--- a/packages/gestalt/src/ScrollBoundaryContainer.js
+++ b/packages/gestalt/src/ScrollBoundaryContainer.js
@@ -75,7 +75,10 @@ const ScrollBoundaryContainerWithForwardRef: AbstractComponent<
   );
 });
 
-// ScrollBoundaryContainerWithProvider is the ScrollBoundaryContainer to exposed to the Gestalt library, with a limited API.
+/**
+ * ScrollBoundaryContainerWithProvider is the ScrollBoundaryContainer to exposed to the Gestalt library, with a limited API.
+ * https://gestalt.pinterest.systems/ScrollBoundaryContainer
+ */
 const ScrollBoundaryContainerWithProvider = (passthroughProps: Props): Node => (
   <ScrollBoundaryContainerProvider>
     <ScrollBoundaryContainerWithForwardRef {...passthroughProps} />

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -38,6 +38,9 @@ type Props = {|
   errorMessage?: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/SearchField
+ */
 const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -66,6 +66,9 @@ function SegmentedControlItem({
   );
 }
 
+/**
+ * https://gestalt.pinterest.systems/SegmentedControl
+ */
 export default function SegmentedControl({
   items,
   onChange,

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -34,6 +34,9 @@ type Props = {|
   value?: ?string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/SelectList
+ */
 export default function SelectList({
   disabled = false,
   errorMessage,

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -273,11 +273,13 @@ SheetWithForwardRef.propTypes = {
   subHeading: PropTypes.node,
 };
 
-/*
+/**
+ * <AnimatedSheet> component: adds animation capabilities
+ * <AnimatedSheetWithForwardRef> component: wrapper for forwarding ref to <AnimatedSheet>, the one which gets exported
+ */
 
-<AnimatedSheet> component: adds animation capabilities
-<AnimatedSheetWithForwardRef> component: wrapper for forwarding ref to <AnimatedSheet>, the one which gets exported
-
+/**
+ * https://gestalt.pinterest.systems/Sheet
  */
 const AnimatedSheetWithForwardRef: React$AbstractComponent<
   AnimatedSheetProps,

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -18,6 +18,9 @@ type Props = {|
   size?: 'sm' | 'md',
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Spinner
+ */
 export default function Spinner({
   accessibilityLabel,
   delay = true,

--- a/packages/gestalt/src/Status.js
+++ b/packages/gestalt/src/Status.js
@@ -43,6 +43,9 @@ type Props = {|
   subtext?: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Status
+ */
 export default function Status({ type, title, subtext }: Props): Node {
   const { icon, color } = ICON_COLOR_MAP[type];
 

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -16,6 +16,9 @@ type Props = {|
   switched?: boolean,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Switch
+ */
 export default function Switch({
   disabled = false,
   id,

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -22,6 +22,9 @@ type Props = {|
   stickyColumns?: ?number,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function Table(props: Props): Node {
   const { borderStyle, children, maxHeight, stickyColumns } = props;
   const [showShadowScroll, setShowShadowScroll] = useState<'left' | 'right' | null>(null);

--- a/packages/gestalt/src/TableBody.js
+++ b/packages/gestalt/src/TableBody.js
@@ -6,6 +6,9 @@ type Props = {|
   children: Node,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function TableBody(props: Props): Node {
   return <tbody className={styles.tbody}>{props.children}</tbody>;
 }

--- a/packages/gestalt/src/TableCell.js
+++ b/packages/gestalt/src/TableCell.js
@@ -12,6 +12,9 @@ type Props = {|
   previousTotalWidth?: number,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function TableCell(props: Props): Node {
   const {
     children,

--- a/packages/gestalt/src/TableFooter.js
+++ b/packages/gestalt/src/TableFooter.js
@@ -5,6 +5,9 @@ type Props = {|
   children: Node,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function TableFooter(props: Props): Node {
   return <tfoot>{props.children}</tfoot>;
 }

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -8,6 +8,9 @@ type Props = {|
   sticky?: boolean,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function TableHeader(props: Props): Node {
   const cs = cx(styles.thead, props.sticky && styles.sticky);
   return <thead className={cs}>{props.children}</thead>;

--- a/packages/gestalt/src/TableHeaderCell.js
+++ b/packages/gestalt/src/TableHeaderCell.js
@@ -13,6 +13,9 @@ type Props = {|
   previousTotalWidth?: number,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function TableHeaderCell(props: Props): Node {
   const {
     children,

--- a/packages/gestalt/src/TableRow.js
+++ b/packages/gestalt/src/TableRow.js
@@ -8,6 +8,9 @@ type Props = {|
   children: Node,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function TableRow(props: Props): Node {
   const { stickyColumns } = useTableContext();
   const rowRef = useRef();

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -26,6 +26,9 @@ type Props = {|
   id: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function TableRowExpandable(props: Props): Node {
   const {
     accessibilityCollapseLabel,

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -24,6 +24,9 @@ type Props = {|
   status: 'active' | 'inactive',
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Table
+ */
 export default function TableSortableHeaderCell(props: Props): Node {
   const { children, colSpan, scope, rowSpan, status, sortOrder, onSortChange } = props;
 

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -239,6 +239,9 @@ type Props = {|
   _dangerouslyUseV2?: boolean,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Tabs
+ */
 export default function Tabs({
   activeTabIndex,
   onChange,

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -33,6 +33,9 @@ type Props = {|
       |},
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Tag
+ */
 export default function Tag(props: Props): Node {
   const {
     disabled = false,

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -65,6 +65,9 @@ type LinkTapAreaType = {|
 type unionProps = TapAreaType | LinkTapAreaType;
 type unionRefs = HTMLDivElement | HTMLAnchorElement;
 
+/**
+ * https://gestalt.pinterest.systems/TapArea
+ */
 const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,
   unionRefs,

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -45,6 +45,9 @@ type Props = {|
   weight?: FontWeight,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Text
+ */
 export default function Text({
   align = 'start',
   children,

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -36,6 +36,9 @@ type Props = {|
   value?: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/TextArea
+ */
 const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement> = forwardRef<
   Props,
   HTMLTextAreaElement,

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -44,6 +44,9 @@ type Props = {|
   value?: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/TextField
+ */
 const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -13,6 +13,9 @@ type Props = {|
   thumbnailShape?: 'circle' | 'rectangle' | 'square',
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Toast
+ */
 export default function Toast({
   button,
   color = 'white',

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -54,6 +54,9 @@ const reducer = (state, action) => {
   }
 };
 
+/**
+ * https://gestalt.pinterest.systems/Tooltip
+ */
 export default function Tooltip({
   children,
   link,

--- a/packages/gestalt/src/Typeahead.js
+++ b/packages/gestalt/src/Typeahead.js
@@ -45,6 +45,9 @@ type Props = {|
   zIndex?: Indexable,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Typeahead
+ */
 const TypeaheadWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -87,6 +87,9 @@ const UpsellAction = ({
   );
 };
 
+/**
+ * https://gestalt.pinterest.systems/Upsell
+ */
 export default function Upsell({
   children,
   dismissButton,

--- a/packages/gestalt/src/UpsellForm.js
+++ b/packages/gestalt/src/UpsellForm.js
@@ -19,6 +19,9 @@ type Props = {|
   submitButtonDisabled?: boolean,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/Upsell
+ */
 export default function UpsellForm({
   children,
   onSubmit,

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -167,6 +167,9 @@ const isNewSource = (oldSource: Source, newSource: Source): boolean => {
   return newSource !== oldSource;
 };
 
+/**
+ * https://gestalt.pinterest.systems/Video
+ */
 export default class Video extends PureComponent<Props, State> {
   video: ?HTMLVideoElement;
 

--- a/packages/gestalt/src/contexts/ColorScheme.js
+++ b/packages/gestalt/src/contexts/ColorScheme.js
@@ -126,6 +126,9 @@ const getTheme = (colorScheme: ?ColorScheme) =>
     ? darkModeTheme
     : lightModeTheme;
 
+/**
+ * https://gestalt.pinterest.systems/ColorSchemeProvider
+ */
 export default function ColorSchemeProvider({
   children,
   colorScheme,

--- a/packages/gestalt/src/contexts/OnLinkNavigation.js
+++ b/packages/gestalt/src/contexts/OnLinkNavigation.js
@@ -26,6 +26,9 @@ const OnLinkNavigationContext: Context<OnLinkNavigationContextType | void> = cre
 
 const { Provider } = OnLinkNavigationContext;
 
+/**
+ * https://gestalt.pinterest.systems/OnLinkNavigationProvider
+ */
 export default function OnLinkNavigationProvider({
   onNavigation,
   children,

--- a/packages/gestalt/src/useFocusVisible.js
+++ b/packages/gestalt/src/useFocusVisible.js
@@ -111,6 +111,9 @@ function setupGlobalFocusEvents() {
   hasSetupGlobalListeners = true;
 }
 
+/**
+ * https://gestalt.pinterest.systems/useFocusVisible
+ */
 export default function useFocusVisible(): {|
   isFocusVisible: boolean,
 |} {

--- a/packages/gestalt/src/useReducedMotion.js
+++ b/packages/gestalt/src/useReducedMotion.js
@@ -2,6 +2,9 @@
 import { useState, useEffect } from 'react';
 import { addListener, removeListener } from './utils/matchMedia.js';
 
+/**
+ * https://gestalt.pinterest.systems/useReducedMotion
+ */
 export default function useReducedMotion(): boolean {
   const supportsMatchMedia = typeof window !== 'undefined' && window.matchMedia;
 

--- a/packages/gestalt/src/zIndex.js
+++ b/packages/gestalt/src/zIndex.js
@@ -8,6 +8,9 @@ export interface Indexable {
   index(): number;
 }
 
+/**
+ * https://gestalt.pinterest.systems/ZIndex%20Classes
+ */
 export class FixedZIndex implements Indexable {
   +z: number;
 
@@ -20,6 +23,9 @@ export class FixedZIndex implements Indexable {
   }
 }
 
+/**
+ * https://gestalt.pinterest.systems/ZIndex%20Classes
+ */
 export class CompositeZIndex implements Indexable {
   +deps: $ReadOnlyArray<FixedZIndex | CompositeZIndex>;
 

--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -133,6 +133,12 @@ function cleanSource() {
     shell.exec(`find ${src} -type d -name "__fixtures__" -exec rm -rf {} +`);
     shell.exec(`find ${src} -type d -name "__snapshots__" -exec rm -rf {} +`);
 
+    // Remove URLs in source files so links don't show up twice
+    shell.exec(
+      `find ${src} -type f -name "*.js" -exec sed -i -e 's!http(s){0,1}://[^[:space:]]*!!g' {} \\;`,
+    );
+
+    // Convert .js to .js.flow so to disallow imports under `src/*`
     shell.exec(
       `find ${src} -type f -name "*.js" -exec sh -c 'mv "$1" "\${1%.js}.js.flow"' _ {} \\;`,
     );

--- a/scripts/templates/ComponentName.js
+++ b/scripts/templates/ComponentName.js
@@ -8,6 +8,9 @@ type Props = {|
   accessibilityLabel?: string,
 |};
 
+/**
+ * https://gestalt.pinterest.systems/ComponentName
+ */
 export default function ComponentName({ accessibilityLabel }: Props): Node {
   return (
     <Box aria-label={accessibilityLabel}>


### PR DESCRIPTION
## Description

Add links from our code to our documentation. In VSCode, it means that we now have clickable links to our documentation when we hover on a component.

![Screen Shot 2021-06-16 at 10 52 23 AM](https://user-images.githubusercontent.com/127199/122272355-4fd8f680-ce95-11eb-9cd3-cc113e8bb2e4.png)

### Notes

* We need to strip the URLs from the original source files, otherwise we would see the URLs twice:
![Screen Shot 2021-06-16 at 11 33 53 AM](https://user-images.githubusercontent.com/127199/122287887-4c9a3680-cea6-11eb-881c-146fc9879ef5.png)

