### PR TITLE
Image: fit children

### DIFF
--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -156,7 +156,7 @@ card(
   "
     name="Overlay"
     defaultCode={`
-<Box column={6} paddingX={2}>
+<Box height={500} paddingX={2} width={250}>
   <Image
     alt="Tropic greens: The taste of Petrol and Porcelain | Interior design, Vintage Sets and Unique Pieces agave"
     color="rgb(231, 186, 176)"
@@ -164,10 +164,14 @@ card(
     naturalWidth={564}
     src="https://i.ibb.co/7bQQYkX/stock2.jpg"
   >
-    <Box padding={3}>
-      <Text color="white">
-        Tropic greens: The taste of Petrol and Porcelain
-      </Text>
+    <Box height="100%" padding={3}>
+      <Flex direction="column" height="100%" justifyContent="between">
+        <Text color="white" weight="bold">
+          Tropic greens: The taste of Petrol and Porcelain
+        </Text>
+
+        <Button color="red" onClick={() => alert('Click!')} text="Save this Pin" />
+      </Flex>
     </Box>
   </Image>
 </Box>

--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -13,8 +13,8 @@ card(
     name="Image"
     description={`
 This component is the workhorse of Pinterest. If you define Pinterest to be all
-about collecting ideas, then images is how we choose to represent those ideas.
-In response, we've added a few extra superpowers to the regular <code>img</code> tag to
+about collecting ideas, then images are how we choose to represent those ideas.
+In response, we've added a few extra superpowers to the regular \`<img>\` tag to
 make it even more awesome.
 `}
   />,
@@ -24,13 +24,13 @@ card(
   <PropTable
     props={[
       {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
         name: 'alt',
         type: 'string',
         required: true,
+      },
+      {
+        name: 'children',
+        type: 'React.Node',
       },
       {
         name: 'color',
@@ -41,7 +41,7 @@ card(
       {
         name: 'elementTiming',
         type: 'string',
-        description: `HTML attribute for performance profiling (see https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API). Note that it only works if the ‘fit‘ prop is not set to ‘cover‘ or ‘contain‘.`,
+        description: `HTML attribute for performance profiling (see https://developer.mozilla.org/en-US/docs/Web/API/Element_timing_API). Note that it only works if the \`fit\` prop is not set to \`"cover"\` or \`"contain"\`.`,
       },
       {
         name: 'fit',
@@ -54,7 +54,7 @@ card(
         name: 'importance',
         type: `"high" | "low" | "auto"`,
         defaultValue: 'auto',
-        description: `Priority Hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded (only available via Chrome Origin Trial). ‘high‘ the developer considers the resource as being high priority. ‘low‘ the developer considers the resource as being low priority. ‘auto‘ the developer does not indicate a preference. This also serves as the attribute's invalid value default and missing value default.`,
+        description: `Priority hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded (only available via Chrome Origin Trial). \`"high"\`: the developer considers the resource to be high priority. \`"low"\`: the developer considers the resource to be low priority. \`auto\` the developer does not indicate a preference.`,
         href: 'fit',
       },
       {
@@ -62,7 +62,7 @@ card(
         type: `"eager" | "lazy" | "auto"`,
         defaultValue: 'auto',
         description: `
-        Controls if loading the image should be deferred when it's off-screen. ‘lazy’ to defer the load until the image or iframe reaches a distance threshold from the viewport. ‘eager’ to load the resource immediately. ‘auto’ the default behavior, which is to eagerly load the resource.
+        Controls if loading the image should be deferred when it's off-screen. \`"lazy"\` defers the load until the image or iframe reaches a distance threshold from the viewport. \`"eager"\` loads the resource immediately. \`"auto"\` uses the default behavior, which is to eagerly load the resource.
         `,
         href: 'fit',
       },
@@ -180,16 +180,16 @@ card(
     id="fit"
     description={`
     In some cases, you may want to scale an image to fit into its container.
-    To achieve that, you can set \`fit\` to either \`cover\` or \`contain\`, depending on the effect you wish to achieve.
+    To achieve that, you can set \`fit\` to either \`"cover"\` or \`"contain"\`, depending on the effect you wish to achieve.
 
-    Contain: This makes it so that the image is "contained" within its container. This means that the image is resized appropriately
+    \`"contain"\`: This makes it so that the image is "contained" within its container. This means that the image is resized appropriately
     such that the entire image can fit in the container, while maintaining its aspect ratio (think letterbox);
 
     ~~~jsx
     <Image alt="..." color="#000" fit="contain" src="..." />
     ~~~
 
-    Cover: This does the opposite of contain and tries to scale the image as large as possible so that the entire container is occupied,
+    \`"cover"\`: This does the opposite of \`"contain"\` and tries to scale the image as large as possible so that the entire container is occupied,
     while maintaining the aspect ratio of the image.
 
     ~~~jsx
@@ -198,124 +198,96 @@ card(
 
     Notes:
 
-    * When using cover/contain, \`naturalHeight\` and \`naturalWidth\` are ignored since the aspect ratio is handled by the browser.
-    * In order for cover/contain to work properly, the container must have some sort of implicit height.
+    * When using \`"cover"\`/\`"contain"\`, \`naturalHeight\` and \`naturalWidth\` are ignored since the aspect ratio is handled by the browser.
+    * In order for \`"cover"\`/\`"contain"\` to work properly, the container must have some sort of implicit height.
   `}
     name="Fit"
     defaultCode={`
-<Box display="flex" direction="row" wrap>
-  <Box>
+<Flex alignItems="start" direction="column" gap={2} wrap>
+  <Flex direction="column">
     <h3>Square content: contain vs cover</h3>
-    <Box display="flex" direction="row" justifyContent="around">
-      <Box
-        color="darkGray"
-        height={200}
-        width={200}
-        marginStart={4}
-        marginEnd={4}
-      >
-        <Image
-          alt="square"
-          color="#000"
-          fit="contain"
-          naturalHeight={1}
-          naturalWidth={1}
-          src="https://i.ibb.co/d0pQsJz/stock3.jpg"
-        />
-      </Box>
-      <Box
-        color="darkGray"
-        height={200}
-        width={200}
-        marginStart={4}
-        marginEnd={4}
-      >
-        <Image
-          alt="square"
-          color="#000"
-          fit="cover"
-          naturalHeight={1}
-          naturalWidth={1}
-          src="https://i.ibb.co/d0pQsJz/stock3.jpg"
-        />
-      </Box>
+    <Box marginStart={4} marginEnd={4}>
+      <Flex gap={8} justifyContent="around">
+        <Box color="darkGray" height={200} width={200}>
+          <Image
+            alt="square"
+            color="#000"
+            fit="contain"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/d0pQsJz/stock3.jpg"
+          />
+        </Box>
+        <Box color="darkGray" height={200} width={200}>
+          <Image
+            alt="square"
+            color="#000"
+            fit="cover"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/d0pQsJz/stock3.jpg"
+          />
+        </Box>
+      </Flex>
     </Box>
-  </Box>
-  <Box>
+  </Flex>
+
+  <Flex direction="column">
     <h3>Wide content: contain vs cover</h3>
-    <Box display="flex" direction="row" justifyContent="around">
-      <Box
-        color="darkGray"
-        height={200}
-        width={200}
-        marginStart={4}
-        marginEnd={4}
-      >
-        <Image
-          alt="wide"
-          color="#000"
-          fit="contain"
-          naturalHeight={1}
-          naturalWidth={1}
-          src="https://i.ibb.co/SB0pXgS/stock4.jpg"
-        />
-      </Box>
-      <Box
-        color="darkGray"
-        height={200}
-        width={200}
-        marginStart={4}
-        marginEnd={4}
-      >
-        <Image
-          alt="wide"
-          color="#000"
-          fit="cover"
-          naturalHeight={1}
-          naturalWidth={1}
-          src="https://i.ibb.co/SB0pXgS/stock4.jpg"
-        />
-      </Box>
+    <Box marginStart={4} marginEnd={4}>
+      <Flex gap={8} justifyContent="around">
+        <Box color="darkGray" height={200} width={200}>
+          <Image
+            alt="wide"
+            color="#000"
+            fit="contain"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/SB0pXgS/stock4.jpg"
+          />
+        </Box>
+        <Box color="darkGray" height={200} width={200}>
+          <Image
+            alt="wide"
+            color="#000"
+            fit="cover"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/SB0pXgS/stock4.jpg"
+          />
+        </Box>
+      </Flex>
     </Box>
-  </Box>
-  <Box>
+  </Flex>
+
+  <Flex direction="column">
     <h3>Tall content: contain vs cover</h3>
-    <Box display="flex" direction="row" justifyContent="around">
-      <Box
-        color="darkGray"
-        height={200}
-        width={200}
-        marginStart={4}
-        marginEnd={4}
-      >
-        <Image
-          alt="tall"
-          color="#000"
-          fit="contain"
-          naturalHeight={1}
-          naturalWidth={1}
-          src="https://i.ibb.co/jVR29XV/stock5.jpg"
-        />
-      </Box>
-      <Box
-        color="darkGray"
-        height={200}
-        width={200}
-        marginStart={4}
-        marginEnd={4}
-      >
-        <Image
-          alt="tall"
-          color="#000"
-          fit="cover"
-          naturalHeight={1}
-          naturalWidth={1}
-          src="https://i.ibb.co/jVR29XV/stock5.jpg"
-        />
-      </Box>
+    <Box marginStart={4} marginEnd={4}>
+      <Flex gap={8} justifyContent="around">
+        <Box color="darkGray" height={200} width={200}>
+          <Image
+            alt="tall"
+            color="#000"
+            fit="contain"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/jVR29XV/stock5.jpg"
+          />
+        </Box>
+        <Box color="darkGray" height={200} width={200}>
+          <Image
+            alt="tall"
+            color="#000"
+            fit="cover"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/jVR29XV/stock5.jpg"
+          />
+        </Box>
+      </Flex>
     </Box>
-  </Box>
-</Box>
+  </Flex>
+</Flex>
 `}
   />,
 );
@@ -331,10 +303,10 @@ card(
   <Image
     alt="Tropic greens: The taste of Petrol and Porcelain | Interior design, Vintage Sets and Unique Pieces agave"
     color="rgb(231, 186, 176)"
+    loading="lazy"
     naturalHeight={496}
     naturalWidth={496}
     src="https://i.ibb.co/FY2MKr5/stock6.jpg"
-    loading="lazy"
   />
 </Box>
 `}

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -113,7 +113,7 @@ export default class Image extends PureComponent<Props> {
     ) : null;
 
     return isScaledImage ? (
-      <Box position="relative">
+      <Box height="100%" position="relative">
         <div
           aria-label={alt}
           className={fit === 'contain' || fit === 'cover' ? styles[fit] : null}

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -113,17 +113,18 @@ export default class Image extends PureComponent<Props> {
     ) : null;
 
     return isScaledImage ? (
-      <div
-        aria-label={alt}
-        className={fit === 'contain' || fit === 'cover' ? styles[fit] : null}
-        style={{
-          backgroundColor: color,
-          backgroundImage: `url('${src}')`,
-        }}
-        role="img"
-      >
+      <Box position="relative">
+        <div
+          aria-label={alt}
+          className={fit === 'contain' || fit === 'cover' ? styles[fit] : null}
+          style={{
+            backgroundColor: color,
+            backgroundImage: `url('${src}')`,
+          }}
+          role="img"
+        />
         {childContent}
-      </div>
+      </Box>
     ) : (
       <Box
         position="relative"

--- a/packages/gestalt/src/__snapshots__/Image.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Image.test.js.snap
@@ -24,16 +24,24 @@ exports[`Image matches snapshot 1`] = `
 
 exports[`Image with fit: contain matches snapshot 1`] = `
 <div
-  aria-label="foo"
-  className="contain"
-  role="img"
+  className="box relative"
   style={
     Object {
-      "backgroundColor": "transparent",
-      "backgroundImage": "url('foo.png')",
+      "height": "100%",
     }
   }
 >
+  <div
+    aria-label="foo"
+    className="contain"
+    role="img"
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundImage": "url('foo.png')",
+      }
+    }
+  />
   <div
     className="absolute bottom0 box left0 overflowHidden right0 top0"
   >
@@ -44,16 +52,24 @@ exports[`Image with fit: contain matches snapshot 1`] = `
 
 exports[`Image with fit: cover matches snapshot 1`] = `
 <div
-  aria-label="foo"
-  className="cover"
-  role="img"
+  className="box relative"
   style={
     Object {
-      "backgroundColor": "transparent",
-      "backgroundImage": "url('foo.png')",
+      "height": "100%",
     }
   }
 >
+  <div
+    aria-label="foo"
+    className="cover"
+    role="img"
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundImage": "url('foo.png')",
+      }
+    }
+  />
   <div
     className="absolute bottom0 box left0 overflowHidden right0 top0"
   >


### PR DESCRIPTION
## Description

When we scale an image (`fit` of "cover" or "contain") , we use `<div role="img">` instead of `<img>`. This causes screen readers to ignore reading any child elements — not great for accessibility.

This PR moves the child content to be a sibling of the `<div role="img">` rather than a child, un-hiding the child content from screen readers.

<img width="760" alt="Screen Shot 2021-06-16 at 2 17 17 PM" src="https://user-images.githubusercontent.com/12059539/122296138-e960d200-ceae-11eb-8d67-4487e567d0ba.png">

<img width="814" alt="Screen Shot 2021-06-16 at 2 18 51 PM" src="https://user-images.githubusercontent.com/12059539/122296114-e534b480-ceae-11eb-93f5-185e31450570.png">

TO TEST: Navigate to https://gestalt.pinterest.systems/Image#fit. Add a Button as a child to the examples. Turn your screen reader on, then tab to the button. Note that while you can tab to the button and interact with it, the screen reader doesn't read the button text. Now repeat these steps on the preview docs for this PR. Note that now the screen reader reads the button text.

### Links

- JIRA: https://jira.pinadmin.com/browse/BUG-126875

### Checklist

- [x] Verified Accessibility: keyboard & screen reader interaction
