### PR TITLE
Internal: fix stripping URLs from code

### DIFF
--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -135,7 +135,7 @@ function cleanSource() {
 
     // Remove URLs in source files so links don't show up twice
     shell.exec(
-      `find ${src} -type f -name "*.js" -exec sed -i -e 's!http(s){0,1}://[^[:space:]]*!!g' {} \\;`,
+      `find ${src} -type f -name "*.js" -exec sed -i -e 's! \\* http\\(s\\)\\{0,1\\}://[^[:space:]]*!!g' {} \\;`,
     );
 
     // Convert .js to .js.flow so to disallow imports under `src/*`


### PR DESCRIPTION
## Description

Follow up from #1558 where we introduced links to our documentation from code.
Looking at https://unpkg.com/gestalt@24.2.0/src/Box.js.flow I noticed that the URLs weren't stripped so we do see double URLs in the editor (one clickable and the other one not).

Root cause is that I didn't escape characters in the regex.