### PR TITLE
Table: Add sticky column support to sortable header

### DIFF
--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -1269,4 +1269,79 @@ card(
   />,
 );
 
+card(
+  <Example
+    id="sortableExample"
+    name="Example: Sortable header cells with sticky column"
+    defaultCode={`
+    function SortableHeaderExample() {
+      const [sortOrder, setSortOrder] = React.useState('desc');
+      const [sortCol, setSortCol] = React.useState('name');
+
+      const onSortChange = (col) => {
+        if (sortCol !== col) {
+          setSortCol(col);
+          setSortOrder('desc');
+        } else {
+          setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+        }
+      }
+
+      return (
+        <Box width="60%" overflow="auto">
+          <Table stickyColumns={1}>
+            <Table.Header>
+              <Table.Row>
+                <Table.SortableHeaderCell onSortChange={() => onSortChange('name')} sortOrder={sortOrder} status={sortCol === 'name' ? 'active' : 'inactive'}>
+                  <Text weight="bold">Name</Text>
+                </Table.SortableHeaderCell>
+                <Table.SortableHeaderCell onSortChange={() => onSortChange('id')} sortOrder={sortOrder} status={sortCol === 'id' ? 'active' : 'inactive'}>
+                  <Text weight="bold">Nickname</Text>
+                </Table.SortableHeaderCell>
+                <Table.SortableHeaderCell onSortChange={() => onSortChange('food')} sortOrder={sortOrder} status={sortCol === 'food' ? 'active' : 'inactive'}>
+                  <Text weight="bold">Favorite Food</Text>
+                </Table.SortableHeaderCell>
+                <Table.SortableHeaderCell onSortChange={() => onSortChange('friend')} sortOrder={sortOrder} status={sortCol === 'friend' ? 'active' : 'inactive'}>
+                  <Text weight="bold">Best Friend</Text>
+                </Table.SortableHeaderCell>
+                <Table.SortableHeaderCell onSortChange={() => onSortChange('birth')} sortOrder={sortOrder} status={sortCol === 'birth' ? 'active' : 'inactive'}>
+                  <Text weight="bold">Birthdate</Text>
+                </Table.SortableHeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              <Table.Row>
+                <Table.Cell><Text>Tony Stark</Text></Table.Cell>
+                <Table.Cell><Text>Iron Man</Text></Table.Cell>
+                <Table.Cell><Text>Shawarma</Text></Table.Cell>
+                <Table.Cell><Text>Spiderman</Text></Table.Cell>
+                <Table.Cell>
+                  <Box width={200}><Text>May 29, 1970</Text></Box>
+                </Table.Cell>
+              </Table.Row>
+
+              <Table.Row>
+                <Table.Cell><Text>Peter Parker</Text></Table.Cell>
+                <Table.Cell><Text>Spiderman</Text></Table.Cell>
+                <Table.Cell><Text>Sandwiches</Text></Table.Cell>
+                <Table.Cell><Text>Iron Man</Text></Table.Cell>
+                <Table.Cell><Text>December 28, 1995</Text></Table.Cell>
+              </Table.Row>
+
+              <Table.Row>
+                <Table.Cell><Text>T'Challa</Text></Table.Cell>
+                <Table.Cell><Text>Black Panther</Text></Table.Cell>
+                <Table.Cell><Text>Beef suya</Text></Table.Cell>
+                <Table.Cell><Text>Shuri</Text></Table.Cell>
+                <Table.Cell><Text>November 28, 1977</Text></Table.Cell>
+              </Table.Row>
+            </Table.Body>
+          </Table>
+        </Box>
+      );
+    }
+`}
+  />,
+);
+
 export default cards;

--- a/docs/src/Table.doc.js
+++ b/docs/src/Table.doc.js
@@ -1271,8 +1271,8 @@ card(
 
 card(
   <Example
-    id="sortableExample"
-    name="Example: Sortable header cells with sticky column"
+    id="sortableExampleSticky"
+    name="Example: Sortable header cells with sticky columns"
     defaultCode={`
     function SortableHeaderExample() {
       const [sortOrder, setSortOrder] = React.useState('desc');
@@ -1288,8 +1288,8 @@ card(
       }
 
       return (
-        <Box width="60%" overflow="auto">
-          <Table stickyColumns={1}>
+        <Box width="70%" overflow="auto">
+          <Table stickyColumns={2}>
             <Table.Header>
               <Table.Row>
                 <Table.SortableHeaderCell onSortChange={() => onSortChange('name')} sortOrder={sortOrder} status={sortCol === 'name' ? 'active' : 'inactive'}>
@@ -1307,35 +1307,15 @@ card(
                 <Table.SortableHeaderCell onSortChange={() => onSortChange('birth')} sortOrder={sortOrder} status={sortCol === 'birth' ? 'active' : 'inactive'}>
                   <Text weight="bold">Birthdate</Text>
                 </Table.SortableHeaderCell>
+                <Table.SortableHeaderCell onSortChange={() => onSortChange('desc')} sortOrder={sortOrder} status={sortCol === 'desc' ? 'active' : 'inactive'}>
+                  <Text weight="bold">Description</Text>
+                </Table.SortableHeaderCell>
+                <Table.SortableHeaderCell onSortChange={() => onSortChange('color')} sortOrder={sortOrder} status={sortCol === 'color' ? 'active' : 'inactive'}>
+                  <Text weight="bold">Favorite Color</Text>
+                </Table.SortableHeaderCell>
               </Table.Row>
             </Table.Header>
-            <Table.Body>
-              <Table.Row>
-                <Table.Cell><Text>Tony Stark</Text></Table.Cell>
-                <Table.Cell><Text>Iron Man</Text></Table.Cell>
-                <Table.Cell><Text>Shawarma</Text></Table.Cell>
-                <Table.Cell><Text>Spiderman</Text></Table.Cell>
-                <Table.Cell>
-                  <Box width={200}><Text>May 29, 1970</Text></Box>
-                </Table.Cell>
-              </Table.Row>
 
-              <Table.Row>
-                <Table.Cell><Text>Peter Parker</Text></Table.Cell>
-                <Table.Cell><Text>Spiderman</Text></Table.Cell>
-                <Table.Cell><Text>Sandwiches</Text></Table.Cell>
-                <Table.Cell><Text>Iron Man</Text></Table.Cell>
-                <Table.Cell><Text>December 28, 1995</Text></Table.Cell>
-              </Table.Row>
-
-              <Table.Row>
-                <Table.Cell><Text>T'Challa</Text></Table.Cell>
-                <Table.Cell><Text>Black Panther</Text></Table.Cell>
-                <Table.Cell><Text>Beef suya</Text></Table.Cell>
-                <Table.Cell><Text>Shuri</Text></Table.Cell>
-                <Table.Cell><Text>November 28, 1977</Text></Table.Cell>
-              </Table.Row>
-            </Table.Body>
           </Table>
         </Box>
       );

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -18,8 +18,11 @@ type Props = {|
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
     {| disableOnNavigation: () => void |},
   >,
+  previousTotalWidth?: number,
   rowSpan?: number,
   scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',
+  shouldBeSticky?: boolean,
+  shouldHaveShadow?: boolean,
   sortOrder: 'asc' | 'desc',
   status: 'active' | 'inactive',
 |};
@@ -28,7 +31,18 @@ type Props = {|
  * https://gestalt.pinterest.systems/Table
  */
 export default function TableSortableHeaderCell(props: Props): Node {
-  const { children, colSpan, scope, rowSpan, status, sortOrder, onSortChange } = props;
+  const {
+    children,
+    colSpan,
+    scope,
+    rowSpan,
+    status,
+    sortOrder,
+    onSortChange,
+    shouldBeSticky,
+    previousTotalWidth,
+    shouldHaveShadow,
+  } = props;
 
   const [isFocused, setFocused] = useState(false);
   const [isHovered, setHovered] = useState(false);
@@ -37,7 +51,14 @@ export default function TableSortableHeaderCell(props: Props): Node {
   const visibility = shouldShowIcon ? 'visible' : 'hidden';
 
   return (
-    <TableHeaderCell colSpan={colSpan} rowSpan={rowSpan} scope={scope}>
+    <TableHeaderCell
+      colSpan={colSpan}
+      rowSpan={rowSpan}
+      scope={scope}
+      shouldBeSticky={shouldBeSticky}
+      shouldHaveShadow={shouldHaveShadow}
+      previousTotalWidth={previousTotalWidth}
+    >
       <Box display="inlineBlock">
         <TapArea
           fullWidth={false}


### PR DESCRIPTION
### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

Add support for sticky columns on sortable header cells

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-2857)
- GitHub Issue: https://github.com/pinterest/gestalt/issues/1541

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
