### PR TITLE
Lint Rules: Remove Tabs from `no-medium-formfields` rule

### DIFF
--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/invalid/invalid-tabs-default.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/invalid/invalid-tabs-default.js
@@ -1,5 +1,0 @@
-import { Tabs } from 'gestalt';
-
-export default function TestElement() {
-  return <Tabs />;
-}

--- a/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
+++ b/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
@@ -24,7 +24,7 @@ const rule = {
   create(context: Object): Object {
     let importedComponent = false;
     let localIdentifierName;
-    const componentNames = ['SearchField', 'SelectList', 'Tabs', 'TextField'];
+    const componentNames = ['SearchField', 'SelectList', 'TextField'];
 
     return {
       ImportDeclaration(decl) {

--- a/packages/eslint-plugin-gestalt/src/no-medium-formfields.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-medium-formfields.test.js
@@ -46,10 +46,6 @@ const invalidSearchFieldDefault = readFileSync(
   ),
   'utf-8',
 );
-const invalidTabsDefault = readFileSync(
-  path.resolve(__dirname, './__fixtures__/no-medium-formfields/invalid/invalid-tabs-default.js'),
-  'utf-8',
-);
 const invalidSelectListDefault = readFileSync(
   path.resolve(
     __dirname,
@@ -70,7 +66,6 @@ ruleTester.run('no-medium-formfields', rule, {
     invalidTextfieldMedium,
     invalidTextfieldRenamed,
     invalidSearchFieldDefault,
-    invalidTabsDefault,
     invalidSelectListDefault,
   ].map((code) => ({
     code,


### PR DESCRIPTION
Whoops — [we recently removed](https://github.com/pinterest/gestalt/pull/1566) the `size` prop from Tabs, but I didn't realize that was part of a lint rule as well. This PR removes Tabs from that lint rule.