### PR TITLE
Image: Add option for presentation role

### DIFF
--- a/docs/src/Image.doc.js
+++ b/docs/src/Image.doc.js
@@ -89,6 +89,13 @@ card(
         type: '() => void',
       },
       {
+        name: 'role',
+        type: `"img" | "presentation"`,
+        defaultValue: 'img',
+        description: `When Image is used purely as a presentational or decorative addition, the \`role\` should be set to "presentation" for better accessibility.`,
+        href: 'Presentational-Images-with-Role',
+      },
+      {
         name: 'sizes',
         type: 'string',
         description:
@@ -312,6 +319,39 @@ card(
     naturalWidth={496}
     src="https://i.ibb.co/FY2MKr5/stock6.jpg"
   />
+</Box>
+`}
+  />,
+);
+
+card(
+  <Example
+    description={`
+      Sometimes Images are purely presentational. For example, an Image used above an article title may be used to draw people's attention visually, but doesn't add any additional information or context about the article. In this case, the \`role\` should be set to "presentation" in order to inform screen readers and other assistive technology that this image does not need alternative text or any additional label.
+    `}
+    name="Presentational Images with Role"
+    defaultCode={`
+<Box
+  display="flex"
+  alignContent="center"
+  justifyContent="between"
+  direction="column"
+  borderStyle="sm"
+  height={300}
+  width={300}
+>
+  <Box height={200} width="100%">
+    <Image
+      alt=""
+      role="presentation"
+      color="#000"
+      fit="cover"
+      naturalHeight={1}
+      naturalWidth={1}
+      src="https://i.ibb.co/FY2MKr5/stock6.jpg"
+    />
+  </Box>
+  <Heading align="center" size="lg">Article Title</Heading>
 </Box>
 `}
   />,

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -152,7 +152,7 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
-          role={role}
+          role={role === 'presentation' ? 'presentation' : undefined}
         />
         {childContent}
       </Box>

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -20,6 +20,7 @@ type Props = {|
   naturalWidth: number,
   onError?: () => void,
   onLoad?: () => void,
+  role?: 'img' | 'presentation',
   sizes?: string,
   src: string,
   srcSet?: string,
@@ -41,6 +42,7 @@ export default class Image extends PureComponent<Props> {
     naturalWidth: PropTypes.number.isRequired,
     onError: PropTypes.func,
     onLoad: PropTypes.func,
+    role: PropTypes.oneOf(['img', 'presentation']),
     sizes: PropTypes.string,
     src: PropTypes.string.isRequired,
     srcSet: PropTypes.string,
@@ -103,6 +105,7 @@ export default class Image extends PureComponent<Props> {
       loading,
       naturalHeight,
       naturalWidth,
+      role = 'img',
       sizes,
       src,
       srcSet,
@@ -118,13 +121,13 @@ export default class Image extends PureComponent<Props> {
     return isScaledImage ? (
       <Box height="100%" position="relative">
         <div
-          aria-label={alt}
+          aria-label={role === 'presentation' ? undefined : alt}
           className={fit === 'contain' || fit === 'cover' ? styles[fit] : null}
           style={{
             backgroundColor: color,
             backgroundImage: `url('${src}')`,
           }}
-          role="img"
+          role={role}
         />
         {childContent}
       </Box>
@@ -149,6 +152,7 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
+          role={role}
         />
         {childContent}
       </Box>

--- a/packages/gestalt/src/Image.test.js
+++ b/packages/gestalt/src/Image.test.js
@@ -39,3 +39,20 @@ test('Image with fit: contain matches snapshot', () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Image with fit: contain and role matches snapshot', () => {
+  const component = renderer.create(
+    <Image
+      alt="foo"
+      fit="contain"
+      role="presentation"
+      naturalHeight={50}
+      naturalWidth={50}
+      src="foo.png"
+    >
+      Foo.png
+    </Image>,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/Image.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Image.test.js.snap
@@ -17,8 +17,36 @@ exports[`Image matches snapshot 1`] = `
     loading="auto"
     onError={[Function]}
     onLoad={[Function]}
+    role="img"
     src="foo.png"
   />
+</div>
+`;
+
+exports[`Image with fit: contain and role matches snapshot 1`] = `
+<div
+  className="box relative"
+  style={
+    Object {
+      "height": "100%",
+    }
+  }
+>
+  <div
+    className="contain"
+    role="presentation"
+    style={
+      Object {
+        "backgroundColor": "transparent",
+        "backgroundImage": "url('foo.png')",
+      }
+    }
+  />
+  <div
+    className="absolute bottom0 box left0 overflowHidden right0 top0"
+  >
+    Foo.png
+  </div>
 </div>
 `;
 
@@ -95,6 +123,7 @@ exports[`Image with overlay matches snapshot 1`] = `
     loading="auto"
     onError={[Function]}
     onLoad={[Function]}
+    role="img"
     src="foo.png"
   />
   <div

--- a/packages/gestalt/src/__snapshots__/Image.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Image.test.js.snap
@@ -17,7 +17,6 @@ exports[`Image matches snapshot 1`] = `
     loading="auto"
     onError={[Function]}
     onLoad={[Function]}
-    role="img"
     src="foo.png"
   />
 </div>
@@ -123,7 +122,6 @@ exports[`Image with overlay matches snapshot 1`] = `
     loading="auto"
     onError={[Function]}
     onLoad={[Function]}
-    role="img"
     src="foo.png"
   />
   <div


### PR DESCRIPTION
### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

For cases like our Today articles, where we have Images using a fit option that don't need any alt text or aria label, we need a way to specify them as  presentational with role="presentation"


### Links

- [Slack Convo](https://pinterest.slack.com/archives/C045W45GC/p1624384582379700)

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
