### PR TITLE
Tabs, TapArea, InternalLink: Add support for aria-current

### DIFF
--- a/packages/gestalt/src/InternalLink.js
+++ b/packages/gestalt/src/InternalLink.js
@@ -1,7 +1,12 @@
 // @flow strict
-import type { AbstractComponent, Node, Element } from 'react';
-
-import { forwardRef, useImperativeHandle, useRef } from 'react';
+import {
+  forwardRef,
+  type AbstractComponent,
+  type Element,
+  type Node,
+  useImperativeHandle,
+  useRef,
+} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import buttonStyles from './Button.css';
@@ -17,6 +22,7 @@ import getRoundingClassName, { RoundingPropType, type Rounding } from './getRoun
 import { useOnLinkNavigation } from './contexts/OnLinkNavigation.js';
 
 type Props = {|
+  accessibilityCurrent?: boolean,
   accessibilityLabel?: string,
   children?: Node,
   colorClass?: string,
@@ -51,6 +57,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
   HTMLAnchorElement,
 >(function Link(props, ref): Element<'a'> {
   const {
+    accessibilityCurrent,
     accessibilityLabel,
     children,
     colorClass,
@@ -164,6 +171,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
 
   return (
     <a
+      aria-current={accessibilityCurrent ? 'page' : undefined}
       aria-label={accessibilityLabel}
       className={className}
       href={disabled ? undefined : href}
@@ -223,6 +231,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
 });
 
 InternalLinkWithForwardRef.propTypes = {
+  accessibilityCurrent: PropTypes.bool,
   accessibilityLabel: PropTypes.string,
   children: PropTypes.node,
   colorClass: PropTypes.string,

--- a/packages/gestalt/src/InternalLink.js
+++ b/packages/gestalt/src/InternalLink.js
@@ -18,11 +18,12 @@ import touchableStyles from './Touchable.css';
 import useFocusVisible from './useFocusVisible.js';
 import useTapFeedback, { keyPressShouldTriggerTap } from './useTapFeedback.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import { AriaCurrentPropType, type AriaCurrent } from './ariaTypes.js';
 import getRoundingClassName, { RoundingPropType, type Rounding } from './getRoundingClassName.js';
 import { useOnLinkNavigation } from './contexts/OnLinkNavigation.js';
 
 type Props = {|
-  accessibilityCurrent?: boolean,
+  accessibilityCurrent?: AriaCurrent,
   accessibilityLabel?: string,
   children?: Node,
   colorClass?: string,
@@ -171,7 +172,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
 
   return (
     <a
-      aria-current={accessibilityCurrent ? 'page' : undefined}
+      aria-current={accessibilityCurrent}
       aria-label={accessibilityLabel}
       className={className}
       href={disabled ? undefined : href}
@@ -231,7 +232,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
 });
 
 InternalLinkWithForwardRef.propTypes = {
-  accessibilityCurrent: PropTypes.bool,
+  accessibilityCurrent: AriaCurrentPropType,
   accessibilityLabel: PropTypes.string,
   children: PropTypes.node,
   colorClass: PropTypes.string,

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -109,7 +109,7 @@ export const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwa
   return (
     <Box id={id} paddingY={3} ref={ref}>
       <TapArea
-        accessibilityCurrent={isActive}
+        accessibilityCurrent={isActive ? 'page' : undefined}
         href={href}
         onBlur={() => setFocused(false)}
         onFocus={() => setFocused(true)}

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -109,6 +109,7 @@ export const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwa
   return (
     <Box id={id} paddingY={3} ref={ref}>
       <TapArea
+        accessibilityCurrent={isActive}
         href={href}
         onBlur={() => setFocused(false)}
         onFocus={() => setFocused(true)}

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -7,6 +7,7 @@ import InternalLink from './InternalLink.js';
 import useTapFeedback, { keyPressShouldTriggerTap } from './useTapFeedback.js';
 import getRoundingClassName, { RoundingPropType, type Rounding } from './getRoundingClassName.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import { AriaCurrentPropType, type AriaCurrent } from './ariaTypes.js';
 import focusStyles from './Focus.css';
 import useFocusVisible from './useFocusVisible.js';
 
@@ -54,7 +55,7 @@ type TapAreaType = {|
 
 type LinkTapAreaType = {|
   ...BaseTapArea,
-  accessibilityCurrent?: boolean,
+  accessibilityCurrent?: AriaCurrent,
   href: string,
   rel?: 'none' | 'nofollow',
   role: 'link',
@@ -250,7 +251,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
 
 TapAreaWithForwardRef.propTypes = {
   accessibilityControls: PropTypes.string,
-  accessibilityCurrent: PropTypes.bool,
+  accessibilityCurrent: AriaCurrentPropType,
   accessibilityExpanded: PropTypes.bool,
   accessibilityHaspopup: PropTypes.bool,
   accessibilityLabel: PropTypes.string,

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { forwardRef, type Node, useImperativeHandle, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './Touchable.css';
@@ -56,6 +54,7 @@ type TapAreaType = {|
 
 type LinkTapAreaType = {|
   ...BaseTapArea,
+  accessibilityCurrent?: boolean,
   href: string,
   rel?: 'none' | 'nofollow',
   role: 'link',
@@ -176,10 +175,11 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
   const handleLinkOnMouseLeave = ({ event }) => handleOnMouseLeave(event);
 
   if (props.role === 'link') {
-    const { href, rel = 'none', target = null } = props;
+    const { accessibilityCurrent, href, rel = 'none', target = null } = props;
 
     return (
       <InternalLink
+        accessibilityCurrent={accessibilityCurrent}
         accessibilityLabel={accessibilityLabel}
         disabled={disabled}
         href={href}
@@ -250,6 +250,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
 
 TapAreaWithForwardRef.propTypes = {
   accessibilityControls: PropTypes.string,
+  accessibilityCurrent: PropTypes.bool,
   accessibilityExpanded: PropTypes.bool,
   accessibilityHaspopup: PropTypes.bool,
   accessibilityLabel: PropTypes.string,

--- a/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tabs.test.js.snap
@@ -11,6 +11,7 @@ exports[`<Tabs /> matches snapshot with default props 1`] = `
       className="box paddingY3"
     >
       <a
+        aria-current="page"
         className="link hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
         href="#"
         onBlur={[Function]}
@@ -136,6 +137,7 @@ exports[`<Tabs /> matches snapshot with dot indicators 1`] = `
       className="box paddingY3"
     >
       <a
+        aria-current="page"
         className="link hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
         href="#"
         onBlur={[Function]}
@@ -289,6 +291,7 @@ exports[`<Tabs /> matches snapshot with wrap 1`] = `
       className="box paddingY3"
     >
       <a
+        aria-current="page"
         className="link hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
         href="#"
         onBlur={[Function]}

--- a/packages/gestalt/src/ariaTypes.js
+++ b/packages/gestalt/src/ariaTypes.js
@@ -1,0 +1,13 @@
+// @flow strict
+import PropTypes from 'prop-types';
+
+export type AriaCurrent = 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false';
+export const AriaCurrentPropType = (PropTypes.oneOf([
+  'page',
+  'step',
+  'location',
+  'date',
+  'time',
+  'true',
+  'false',
+]): React$PropType$Primitive<AriaCurrent>);


### PR DESCRIPTION
### Summary

The previous version of Tabs supported `aria-selected` to indicate the selected tab. However, [that is only correct if used with `role="tab"`](https://www.stefanjudis.com/blog/aria-selected-and-when-to-use-it/), which we removed because that does not refer to a collection of links (we really need to rename Tabs and SegmentedControl). [The proper way to indicate the current location in a collection of links is `aria-current="page"`](https://www.w3.org/WAI/tutorials/menus/structure/), so this PR adds support for that.

Note: this is a purposefully simplified implementation of `aria-current`. `aria-current` is actually an enum, not a boolean. However, for our _current_ (:pun_dog:) needs, this will suffice. If we decide to implement support for other enum values in the future, that can be a purely internal refactor with no changes needed to the external API. (This prop is purposefully undocumented on TapArea for that reason — once we figure out the proper API we can document it.)

### Checklist

- [x] Verified accessibility: keyboard & screen reader interaction
