### PR TITLE
Text: Update `word-break` style

### DIFF
--- a/packages/gestalt/src/Typography.css
+++ b/packages/gestalt/src/Typography.css
@@ -98,5 +98,5 @@ html[dir="rtl"] .alignStart,
   display: -webkit-box; /* stylelint-disable-line value-no-vendor-prefix */
   max-width: 100%;
   overflow: hidden;
-  word-break: break-all;
+  word-break: break-word;
 }


### PR DESCRIPTION
This updates the `lineClamp` styles to break on word, not character. This will prevent this sort of undesirable UI:
<img width="752" alt="Screen Shot 2021-06-28 at 6 39 28 PM" src="https://user-images.githubusercontent.com/12059539/123881646-014a4400-d8fa-11eb-9966-b706825e5431.png">
