### PR TITLE
Modal, Sheet: deprecate ref (forwardRef removal) + codemod

### DIFF
--- a/docs/src/Modal.doc.js
+++ b/docs/src/Modal.doc.js
@@ -73,11 +73,6 @@ card(
           'Callback fired when Modal is dismissed by clicking on the backdrop outside of the Modal (if `closeOnOutsideClick` is true).',
       },
       {
-        name: 'ref',
-        type: "React.Ref<'div'>",
-        description: 'Ref that will be set on the underlying div element',
-      },
-      {
         name: 'role',
         type: `"alertdialog" | "dialog"`,
         defaultValue: 'dialog',

--- a/packages/gestalt-codemods/28.0.0/sheet_modal_deprecate_ref_props.js
+++ b/packages/gestalt-codemods/28.0.0/sheet_modal_deprecate_ref_props.js
@@ -1,0 +1,68 @@
+/*
+ * Converts
+ *   <Sheet ref={ref}/>
+ *   <Modal ref={ref}/>
+ * To
+ *   <Sheet />
+ *   <Modal />
+ */
+
+// Run
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/28.0.0/sheet_modal_deprecate_ref_props.js relative/path/to/your/code
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter((node) => ['Sheet', 'Modal'].includes(node.imported.name))
+      .map((node) => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  src
+    .find(j.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove Dynamic ${node.openingElement.name.name} properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+      attrs
+        .map((attr) => {
+          if (attr?.name?.name && attr.name.name === 'ref') {
+            // eslint-disable-next-line no-console
+            console.log(
+              `Manually remove ref: Location: ${file.path} @line: ${node.loc.start.line}`,
+            );
+            return attr;
+          }
+          return attr;
+        })
+        .filter(Boolean);
+
+      return null;
+    })
+    .toSource();
+
+  return null;
+}

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -1,7 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-
-import { useCallback, forwardRef, useState, useEffect, useRef } from 'react';
+import { useCallback, useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ESCAPE } from './keyCodes.js';
@@ -16,17 +15,23 @@ import { ScrollBoundaryContainerWithForwardRef as InternalScrollBoundaryContaine
 import { ScrollBoundaryContainerProvider } from './contexts/ScrollBoundaryContainer.js';
 import modalStyles from './Modal.css';
 
+type Size = 'sm' | 'md' | 'lg' | number;
+
+type Role = 'alertdialog' | 'dialog';
+
+type Align = 'start' | 'center';
+
 type Props = {|
   _dangerouslyDisableScrollBoundaryContainer?: boolean, // Temporary undocumented prop to disable ScrollBoundaryContainer.
   accessibilityModalLabel: string,
-  align?: 'start' | 'center',
+  align?: Align,
   children?: Node,
   closeOnOutsideClick?: boolean,
   footer?: Node,
   heading?: Node,
   onDismiss: () => void,
-  role?: 'alertdialog' | 'dialog',
-  size?: 'sm' | 'md' | 'lg' | number,
+  role?: Role,
+  size?: Size,
   subHeading?: string,
 |};
 
@@ -62,10 +67,7 @@ function Header({
 /**
  * https://gestalt.pinterest.systems/Modal
  */
-const ModalWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> = forwardRef<
-  Props,
-  HTMLDivElement,
->(function Modal(props, ref): Node {
+export default function Modal(props: Props): Node {
   const {
     _dangerouslyDisableScrollBoundaryContainer = false,
     accessibilityModalLabel,
@@ -137,7 +139,6 @@ const ModalWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> = forw
               className={classnames(modalStyles.wrapper, focusStyles.hideOutline)}
               tabIndex={-1}
               style={{ width }}
-              ref={ref}
             >
               <Box flex="grow" position="relative" display="flex" direction="column" width="100%">
                 {Boolean(heading) && (
@@ -181,22 +182,21 @@ const ModalWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> = forw
       </TrapFocusBehavior>
     </StopScrollBehavior>
   );
-});
+}
 
-ModalWithForwardRef.propTypes = {
+Modal.propTypes = {
   _dangerouslyDisableScrollBoundaryContainer: PropTypes.string,
   accessibilityModalLabel: PropTypes.string.isRequired,
-  align: PropTypes.oneOf(['start', 'center']),
+  align: (PropTypes.oneOf(['start', 'center']): React$PropType$Primitive<Align>),
   children: PropTypes.node,
   closeOnOutsideClick: PropTypes.bool,
   footer: PropTypes.node,
-  heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  heading: PropTypes.node,
   onDismiss: PropTypes.func,
-  role: PropTypes.oneOf(['alertdialog', 'dialog']),
-  size: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['sm', 'md', 'lg'])]),
+  role: (PropTypes.oneOf(['alertdialog', 'dialog']): React$PropType$Primitive<Role>),
+  size: (PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.oneOf(['sm', 'md', 'lg']),
+  ]): React$PropType$Primitive<Size>),
   subHeading: PropTypes.string,
 };
-
-ModalWithForwardRef.displayName = 'Modal';
-
-export default ModalWithForwardRef;

--- a/packages/gestalt/src/Modal.jsdom.test.js
+++ b/packages/gestalt/src/Modal.jsdom.test.js
@@ -1,5 +1,4 @@
 // @flow strict
-import { createRef } from 'react';
 import { render } from '@testing-library/react';
 import Modal from './Modal.js';
 
@@ -7,16 +6,14 @@ const mockOnDismiss = jest.fn();
 
 describe('Modal', () => {
   if (typeof document !== 'undefined') {
-    test('Modal renders with ref', () => {
-      const modalRef = createRef();
+    test('Modal renders', () => {
       const modal = render(
-        <Modal accessibilityModalLabel="Test modal" onDismiss={mockOnDismiss} ref={modalRef}>
+        <Modal accessibilityModalLabel="Test modal" onDismiss={mockOnDismiss}>
           Modal content
         </Modal>,
       );
 
       expect(modal).toMatchSnapshot();
-      expect(modalRef.current instanceof HTMLDivElement).toEqual(true);
     });
   }
 });

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -8,23 +8,18 @@ This guide will help you navigate and understand its design. This file is roughl
 
   1. Internal components <Header> and <DismissButton>
   2. Sheet function: the one with the actual component logic
-  3. <SheetWithForwardRef> component: wrapper for forwarding ref to <Sheet>
-  4. AnimatedSheet function: adds animation capabilities
-  5. <AnimatedSheetWithForwardRef> component: wrapper for forwarding ref to <AnimatedSheet>, the one which gets exported
+  3. AnimatedSheet function: adds animation capabilities
 
 This is how all these components are used:
 
-a. The default export is <AnimatedSheetWithForwardRef>
-b. <AnimatedSheetWithForwardRef> wraps AnimatedSheet
-c. AnimatedSheet includes <SheetWithForwardRef>
-d. <SheetWithForwardRef> wraps Sheet
-e. Sheet is the actual component logic which includes the internal components <Header> and <DismissButton>.
+a. The default export is <AnimatedSheet>
+b. AnimatedSheet includes <Sheet>
+c. Sheet is the actual component logic which includes the internal components <Header> and <DismissButton>.
 
 */
 
 import type { Node } from 'react';
-
-import { forwardRef, useCallback, useState, useEffect, useRef } from 'react';
+import { useCallback, useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ESCAPE } from './keyCodes.js';
@@ -41,6 +36,7 @@ import TrapFocusBehavior from './behaviors/TrapFocusBehavior.js';
 import { ScrollBoundaryContainerWithForwardRef as InternalScrollBoundaryContainer } from './ScrollBoundaryContainer.js';
 import { ScrollBoundaryContainerProvider } from './contexts/ScrollBoundaryContainer.js';
 
+type Size = 'sm' | 'md' | 'lg';
 type SheetMainProps = {|
   accessibilityDismissButtonLabel: string,
   accessibilitySheetLabel: string,
@@ -48,7 +44,7 @@ type SheetMainProps = {|
   closeOnOutsideClick?: boolean,
   footer?: Node,
   onDismiss: () => void,
-  size?: 'sm' | 'md' | 'lg',
+  size?: Size,
 |};
 
 type SheetProps = {|
@@ -111,13 +107,9 @@ const DismissButton = ({
 /*
 
 <Sheet> component: the one with the actual component logic
-<SheetWithForwardRef> component: wrapper for forwarding ref to <Sheet>
 
  */
-const SheetWithForwardRef: React$AbstractComponent<SheetProps, HTMLDivElement> = forwardRef<
-  SheetProps,
-  HTMLDivElement,
->(function Sheet(props, sheetRef): Node {
+function Sheet(props: SheetProps): Node {
   const {
     accessibilityDismissButtonLabel,
     accessibilitySheetLabel,
@@ -194,7 +186,6 @@ const SheetWithForwardRef: React$AbstractComponent<SheetProps, HTMLDivElement> =
                 [sheetStyles.wrapperAnimationOut]: animationState === 'out',
               })}
               onAnimationEnd={onAnimationEnd}
-              ref={sheetRef}
               role="dialog"
               style={{ width: SIZE_WIDTH_MAP[size] }}
               tabIndex={-1}
@@ -255,13 +246,9 @@ const SheetWithForwardRef: React$AbstractComponent<SheetProps, HTMLDivElement> =
       </TrapFocusBehavior>
     </StopScrollBehavior>
   );
-});
+}
 
-SheetWithForwardRef.displayName = 'Sheet';
-
-// TODO: remove $FlowFixMe once this PR is released: https://github.com/facebook/flow/pull/8476
-
-SheetWithForwardRef.propTypes = {
+Sheet.propTypes = {
   accessibilityDismissButtonLabel: PropTypes.string.isRequired,
   accessibilitySheetLabel: PropTypes.string.isRequired,
   children: PropTypes.node,
@@ -269,22 +256,18 @@ SheetWithForwardRef.propTypes = {
   footer: PropTypes.node,
   heading: PropTypes.string,
   onDismiss: PropTypes.func.isRequired,
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: (PropTypes.oneOf(['sm', 'md', 'lg']): React$PropType$Primitive<Size>),
   subHeading: PropTypes.node,
 };
 
 /**
  * <AnimatedSheet> component: adds animation capabilities
- * <AnimatedSheetWithForwardRef> component: wrapper for forwarding ref to <AnimatedSheet>, the one which gets exported
  */
 
 /**
  * https://gestalt.pinterest.systems/Sheet
  */
-const AnimatedSheetWithForwardRef: React$AbstractComponent<
-  AnimatedSheetProps,
-  HTMLDivElement,
-> = forwardRef<AnimatedSheetProps, HTMLDivElement>(function AnimatedSheet(props, sheetRef): Node {
+export default function AnimatedSheet(props: AnimatedSheetProps): Node {
   const {
     accessibilityDismissButtonLabel,
     accessibilitySheetLabel,
@@ -300,35 +283,33 @@ const AnimatedSheetWithForwardRef: React$AbstractComponent<
   return (
     <AnimationController onDismissEnd={onDismiss}>
       {({ onDismissStart }) => (
-        <SheetWithForwardRef
+        <Sheet
           accessibilityDismissButtonLabel={accessibilityDismissButtonLabel}
           accessibilitySheetLabel={accessibilitySheetLabel}
           closeOnOutsideClick={closeOnOutsideClick}
           footer={typeof footer === 'function' ? footer({ onDismissStart }) : footer}
           heading={heading}
           onDismiss={onDismissStart}
-          ref={sheetRef}
           size={size}
           subHeading={
             typeof subHeading === 'function' ? subHeading({ onDismissStart }) : subHeading
           }
         >
           {typeof children === 'function' ? children({ onDismissStart }) : children}
-        </SheetWithForwardRef>
+        </Sheet>
       )}
     </AnimationController>
   );
-});
-
-AnimatedSheetWithForwardRef.displayName = 'AnimatedSheet';
+}
 
 // TODO: remove $FlowFixMe once this PR is released: https://github.com/facebook/flow/pull/8476
 
-AnimatedSheetWithForwardRef.propTypes = {
-  ...SheetWithForwardRef.propTypes,
+AnimatedSheet.propTypes = {
+  ...Sheet.propTypes,
+  // $FlowFixMe[signature-verification-failure]
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   footer: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   subHeading: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
-
-export default AnimatedSheetWithForwardRef;

--- a/packages/gestalt/src/Sheet.jsdom.test.js
+++ b/packages/gestalt/src/Sheet.jsdom.test.js
@@ -93,23 +93,6 @@ describe('Sheet', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should attach a ref', () => {
-    const sheetRef = createRef();
-
-    render(
-      <Sheet
-        accessibilityDismissButtonLabel="Dismiss"
-        accessibilitySheetLabel="Test Sheet"
-        onDismiss={jest.fn()}
-        ref={sheetRef}
-      >
-        <section />
-      </Sheet>,
-    );
-
-    expect(sheetRef.current instanceof HTMLDivElement).toEqual(true);
-  });
-
   it('should focus the dismiss button upon render', () => {
     const { container } = render(
       <Sheet

--- a/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Modal Modal renders with ref 1`] = `
+exports[`Modal Modal renders 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body


### PR DESCRIPTION
Modal, Sheet: deprecate ref (forwardRef removal)

Deprecating refs as there are no cases for accessing the inner tags on any case and could lead to bad practices
Modal
![image](https://user-images.githubusercontent.com/10593890/124053088-99752580-d9ed-11eb-9d53-a9dd8378b15f.png) + gestaltExtension 
![image](https://user-images.githubusercontent.com/10593890/124053151-b9a4e480-d9ed-11eb-9546-408f4c3f0b07.png)
Sheet
![image](https://user-images.githubusercontent.com/10593890/124053116-a7c34180-d9ed-11eb-9737-b5b644f41f2b.png)

Codemod to console.log existing refs in Moalds and Sheets. Run
```
yarn codemod --parser=flow -t=packages/gestalt-codemods/28.0.0/sheet_modal_deprecate_ref_props.js relative/path/to/your/code

```
### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
