### PR TITLE
Tabs: Increase padding, adjust active tab interaction logic

### DIFF
--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -52,6 +52,7 @@ card(
 function TabExample() {
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [wrap, setWrap] = React.useState(false);
+  const [bgColor, setBgColor] = React.useState(false);
 
   const handleChange = ({ activeTabIndex, event }) => {
     event.preventDefault();
@@ -69,18 +70,37 @@ function TabExample() {
 
   return (
     <Flex alignItems="start" direction="column" gap={4}>
-      <Flex gap={4} padding={2}>
-        <Label htmlFor="wrap">
-          <Text>Wrap</Text>
-        </Label>
-        <Switch
-          id="wrap"
-          onChange={() => setWrap(!wrap)}
-          switched={wrap}
-        />
+      <Flex gap={8}>
+        <Flex gap={4}>
+          <Label htmlFor="wrap">
+            <Text>Wrap</Text>
+          </Label>
+          <Switch
+            id="wrap"
+            onChange={() => setWrap((currVal) => !currVal)}
+            switched={wrap}
+          />
+        </Flex>
+
+        <Flex gap={4}>
+          <Label htmlFor="bgColor">
+            <Text>Background color</Text>
+          </Label>
+          <Switch
+            id="bgColor"
+            onChange={() => setBgColor((currVal) => !currVal)}
+            switched={bgColor}
+          />
+        </Flex>
       </Flex>
 
-      <Box borderStyle="sm" maxWidth={500} overflow="auto" padding={1}>
+      <Box
+        borderStyle="sm"
+        color={bgColor ? 'lightGray' : undefined}
+        maxWidth={500}
+        overflow="auto"
+        padding={1}
+      >
         <Tabs
           activeTabIndex={activeIndex}
           onChange={handleChange}

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -89,7 +89,7 @@ type TabProps = {|
 |};
 
 const TAB_ROUNDING = 2;
-const TAB_INNER_PADDING = 1;
+const TAB_INNER_PADDING = 2;
 
 export const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef<
   TabProps,
@@ -102,7 +102,7 @@ export const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwa
   let color = 'white';
   if (pressed) {
     color = 'lightWash';
-  } else if ((hovered || focused) && !isActive) {
+  } else if (hovered || focused) {
     color = 'lightGray';
   }
 
@@ -110,16 +110,19 @@ export const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwa
     <Box id={id} paddingY={3} ref={ref}>
       <TapArea
         accessibilityCurrent={isActive ? 'page' : undefined}
+        disabled={isActive}
         href={href}
         onBlur={() => setFocused(false)}
         onFocus={() => setFocused(true)}
-        onMouseDown={() => setPressed(true)}
+        onMouseDown={() => (isActive ? undefined : setPressed(true))}
         onMouseUp={() => setPressed(false)}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        onTap={({ event, disableOnNavigation }) =>
-          onChange({ activeTabIndex: index, event, disableOnNavigation })
-        }
+        onTap={({ event, disableOnNavigation }) => {
+          setHovered(false);
+          setFocused(false);
+          onChange({ activeTabIndex: index, event, disableOnNavigation });
+        }}
         role="link"
         rounding={TAB_ROUNDING}
         tapStyle="compress"


### PR DESCRIPTION
The current Tabs UI doesn't look great on a colored background:
<img width="343" alt="screen_shot_2021-06-30_at_4 40 59_pm" src="https://user-images.githubusercontent.com/12059539/124195629-ac383a80-da7f-11eb-9724-420651948e48.png">

This PR attempts to address that by increasing the padding around the tab text. This also adjusts the "selected tab" logic to disable the underlying TapArea and the hover/pressed states (disabling prevents keyboard and mouse focus, so need to address that state).