### PR TITLE
Upsell: Docs cleanup

### DIFF
--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -1,5 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
+import { type Node } from 'react';
 import { Upsell } from 'gestalt';
 import PropTable from './components/PropTable.js';
 import PageHeader from './components/PageHeader.js';
@@ -15,9 +15,6 @@ card(
     description="Upsells are banners that display short messages that focus on promoting an action or upgrading something the user already has."
     defaultCode={`
       <Upsell
-        title="Give $30, get $60 in ads credit"
-        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-        primaryAction={{ href: 'https://pinterest.com', label: 'Send invite', target: 'blank', accessibilityLabel: "Send ads invite" }}
         dismissButton={{
           accessibilityLabel: 'Dismiss banner',
           onDismiss: () => {},
@@ -25,6 +22,14 @@ card(
         imageData={{
           component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
         }}
+        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+        primaryAction={{
+          accessibilityLabel: "Send ads invite",
+          href: 'https://pinterest.com',
+          label: 'Send invite',
+          target: 'blank',
+        }}
+        title="Give $30, get $60 in ads credit"
       />;
     `}
   />,
@@ -36,13 +41,6 @@ card(
     Component={Upsell}
     props={[
       {
-        name: 'message',
-        type: 'string',
-        required: true,
-        defaultValue: null,
-        description: `Main content of Upsell, explains what is being offered or recommended. Content should be [localized](#Localization). See [Best Practices](#Best-practices) for more info.`,
-      },
-      {
         name: 'children',
         type: 'typeof UpsellForm',
         description: `To create forms within Upsell, pass an Upsell.Form as children`,
@@ -50,7 +48,6 @@ card(
       {
         name: 'dismissButton',
         type: '{| accessibilityLabel: string, onDismiss: () => void, |}',
-        required: false,
         defaultValue: null,
         description: `
         Adds a dismiss button to the Upsell. The \`accessibilityLabel\` should follow the [Accessibility guidelines](#Accessibility)
@@ -60,16 +57,21 @@ card(
         name: 'imageData',
         type:
           '{| component: typeof Image | typeof Icon, width?: number, mask: { rounding: "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8, wash: boolean} |}',
-        required: false,
         defaultValue: null,
         description:
           'Either an [Icon](/Icon) or an [Image](/Image) to render at the start of the banner. Width is not used with Icon. Image width defaults to 128px. See the [Icon](#Icon) and [Image](#Image) variants for more info.',
       },
       {
+        name: 'message',
+        type: 'string',
+        required: true,
+        defaultValue: null,
+        description: `Main content of Upsell, explains what is being offered or recommended. Content should be [localized](#Localization). See [Best Practices](#Best-practices) for more info.`,
+      },
+      {
         name: 'primaryAction',
         type:
           '{| accessibilityLabel: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
-        required: false,
         defaultValue: null,
         description: `
           Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [custom navigation](#Custom-navigation) variant for examples.
@@ -81,7 +83,6 @@ card(
         name: 'secondaryAction',
         type:
           '{| accessibilityLabel: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
-        required: false,
         defaultValue: null,
         description: `
           Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [custom navigation](#Custom-navigation) variant for examples.
@@ -92,7 +93,6 @@ card(
       {
         name: 'title',
         type: 'string',
-        required: false,
         defaultValue: null,
         description: `Brief title summarizing the Upsell. Content should be [localized](#Localization).`,
       },
@@ -149,21 +149,21 @@ card(
         description="Use Upsells for marketing new products or encouraging upgrades."
         defaultCode={`
 <Upsell
-  title="Give $30, get $60 in ads credit"
-  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-  primaryAction={{
-    href: 'https://pinterest.com',
-    label: 'Send invite',
-    target: 'blank',
-    accessibilityLabel: "Send ads invite"
-  }}
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',
     onDismiss: () => {},
   }}
   imageData={{
-    component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
+    component: <Icon accessibilityLabel="" color="darkGray" icon="pinterest" size={32} />,
   }}
+  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+  primaryAction={{
+    accessibilityLabel: "Send ads invite",
+    href: 'https://pinterest.com',
+    label: 'Send invite',
+    target: 'blank',
+  }}
+  title="Give $30, get $60 in ads credit"
 />;
         `}
       />
@@ -175,8 +175,8 @@ card(
         `}
         defaultCode={`
 <Box>
-  <Box marginBottom={4} display="flex" alignItems="center">
-    <Icon accessibilityLabel="" icon="pinterest" color="red" size={32} />
+  <Box alignItems="center" display="flex" marginBottom={4}>
+    <Icon accessibilityLabel="" color="red" icon="pinterest" size={32} />
     <ButtonGroup>
       <Button color="transparent" iconEnd="arrow-down" text="Business" />
       <Button color="transparent" iconEnd="arrow-down" text="Create" />
@@ -184,17 +184,11 @@ card(
       <Button color="transparent" iconEnd="arrow-down" text="Ads" />
     </ButtonGroup>
   </Box>
+
   <Divider />
+
   <Box marginTop={8}>
     <Upsell
-      title="Give $30, get $60 in ads credit"
-      message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-      primaryAction={{
-        href: 'https://pinterest.com',
-        label: 'Send invite',
-        target: 'blank',
-        accessibilityLabel: "Send ads invite"
-      }}
       dismissButton={{
         accessibilityLabel: 'Dismiss banner',
         onDismiss: () => {},
@@ -202,11 +196,20 @@ card(
       imageData={{
         component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
       }}
+      message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+      primaryAction={{
+        accessibilityLabel: "Send ads invite",
+        href: 'https://pinterest.com',
+        label: 'Send invite',
+        target: 'blank',
+      }}
+      title="Give $30, get $60 in ads credit"
     />
   </Box>
 </Box>;
         `}
       />
+
       <MainSection.Card
         cardSize="lg"
         type="do"
@@ -217,9 +220,6 @@ card(
 <Flex gap={4} direction="column">
   <Text>First Upsell:</Text>
   <Upsell
-    title="Measure ad performance"
-    message="Install the Pinterest tag to track your website traffic, conversions and more."
-    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag now' }}
     dismissButton={{
       accessibilityLabel: 'Dismiss banner',
       onDismiss: () => {},
@@ -227,19 +227,24 @@ card(
     imageData={{
       component: <Icon icon="ads-stats" accessibilityLabel="" color="darkGray" size={32} />,
     }}
+    message="Install the Pinterest tag to track your website traffic, conversions and more."
+    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag now' }}
+    title="Measure ad performance"
   />
+
   <Text>Follow-up Upsell:</Text>
   <Upsell
     imageData={{
       component: <Icon icon="send" accessibilityLabel="" color="darkGray" size={32} />,
     }}
-    title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
     message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
     primaryAction={{ label: 'Claim now', accessibilityLabel: "Claim ads credit" }}
+    title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
   />
 </Flex>;
         `}
       />
+
       <MainSection.Card
         cardSize="lg"
         type="don't"
@@ -248,9 +253,6 @@ card(
         `}
         defaultCode={`
 <Upsell
-  title="Could not link account"
-  message="There was a problem connecting your account."
-  primaryAction={{ label: 'Try again', accessibilityLabel: 'Try linking account again' }}
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',
     onDismiss: () => {},
@@ -258,9 +260,13 @@ card(
   imageData={{
     component: <Icon icon="workflow-status-warning" accessibilityLabel="Warning" color="darkGray" size={32} />,
   }}
+  message="There was a problem connecting your account."
+  primaryAction={{ label: 'Try again', accessibilityLabel: 'Try linking account again' }}
+  title="Could not link account"
 />;
         `}
       />
+
       <MainSection.Card
         cardSize="lg"
         type="don't"
@@ -269,8 +275,8 @@ card(
         `}
         defaultCode={`
 <Box>
-  <Box marginBottom={4} display="flex" alignItems="center">
-    <Icon accessibilityLabel="" icon="pinterest" color="red" size={32} />
+  <Box alignItems="center" display="flex" marginBottom={4}>
+    <Icon accessibilityLabel="" color="red" icon="pinterest" size={32} />
     <ButtonGroup>
       <Button color="transparent" iconEnd="arrow-down" text="Business" />
       <Button color="transparent" iconEnd="arrow-down" text="Create" />
@@ -278,26 +284,20 @@ card(
       <Button color="transparent" iconEnd="arrow-down" text="Ads" />
     </ButtonGroup>
   </Box>
+
   <Divider />
+
   <Box marginTop={8}>
-    <Flex gap={2} direction="column">
+    <Flex direction="column" gap={2}>
       <Upsell
         imageData={{
           component: <Icon icon="send" accessibilityLabel="" color="darkGray" size={32} />,
         }}
-        title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
         message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
         primaryAction={{ label: 'Claim now', accessibilityLabel: 'Claim ads credit now' }}
+        title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
       />
       <Upsell
-        title="Give $30, get $60 in ads credit"
-        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-        primaryAction={{
-          href: 'https://pinterest.com',
-          label: 'Send invite',
-          target: 'blank',
-          accessibilityLabel: 'Send ads invite'
-        }}
         dismissButton={{
           accessibilityLabel: 'Dismiss banner',
           onDismiss: () => {},
@@ -305,12 +305,21 @@ card(
         imageData={{
           component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
         }}
+        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+        primaryAction={{
+          accessibilityLabel: 'Send ads invite',
+          href: 'https://pinterest.com',
+          label: 'Send invite',
+          target: 'blank',
+        }}
+        title="Give $30, get $60 in ads credit"
       />
     </Flex>
   </Box>
 </Box>;
         `}
       />
+
       <MainSection.Card
         cardSize="lg"
         type="don't"
@@ -318,11 +327,8 @@ card(
         Keep showing the same Upsell once it has been dismissed. Upsells should only appear a maximum of 2 times to the same user, as they have diminishing returns.
         `}
         defaultCode={`
-<Flex gap={4} direction="column">
+<Flex direction="column" gap={4}>
   <Upsell
-    title="Measure ad performance"
-    message="Install the Pinterest tag to track your website traffic, conversions and more."
-    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
     dismissButton={{
       accessibilityLabel: 'Dismiss banner',
       onDismiss: () => {},
@@ -330,11 +336,11 @@ card(
     imageData={{
       component: <Icon icon="ads-stats" accessibilityLabel="" color="darkGray" size={32} />,
     }}
+    message="Install the Pinterest tag to track your website traffic, conversions and more."
+    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
+    title="Measure ad performance"
   />
   <Upsell
-    title="Measure ad performance"
-    message="Install the Pinterest tag to track your website traffic, conversions and more."
-    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
     dismissButton={{
       accessibilityLabel: 'Dismiss banner',
       onDismiss: () => {},
@@ -342,6 +348,9 @@ card(
     imageData={{
       component: <Icon icon="ads-stats" accessibilityLabel="" color="darkGray" size={32} />,
     }}
+    message="Install the Pinterest tag to track your website traffic, conversions and more."
+    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
+    title="Measure ad performance"
   />
 </Flex>;
         `}
@@ -368,14 +377,6 @@ card(
         cardSize="lg"
         defaultCode={`
 <Upsell
-  title="Give $30, get $60 in ads credit"
-  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-  primaryAction={{
-    href: 'https://pinterest.com',
-    label: 'Send invite',
-    accessibilityLabel: 'Invite friend to use ads',
-    target: 'blank',
-  }}
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',
     onDismiss: () => {},
@@ -383,6 +384,14 @@ card(
   imageData={{
     component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
   }}
+  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+  primaryAction={{
+    href: 'https://pinterest.com',
+    label: 'Send invite',
+    accessibilityLabel: 'Invite friend to use ads',
+    target: 'blank',
+  }}
+  title="Give $30, get $60 in ads credit"
 />;
         `}
       />
@@ -403,13 +412,13 @@ card(
   imageData={{
     component: <Icon icon="send" accessibilityLabel="" color="darkGray" size={32} />,
   }}
-  title="Fast fertig! Beenden Sie die Installation Ihres Pinterest-Tags und erhalten Sie ein Guthaben von 10 Euro"
   message="Verfolgen Sie die Anzeigenkonvertierung - Umsatz, Traffic und mehr - mit dem Pinterest Tag"
   primaryAction={{
     label: 'Beanspruche jetzt',
     accessibilityLabel: 'Beanspruche Guthaben jetzt',
     target: 'blank',
   }}
+  title="Fast fertig! Beenden Sie die Installation Ihres Pinterest-Tags und erhalten Sie ein Guthaben von 10 Euro"
 />;
         `}
       />
@@ -427,15 +436,16 @@ card(
         cardSize="lg"
         defaultCode={`
 <Upsell
-  message="Single line Upsell with no title or call to action."
   dismissButton={{
     accessibilityLabel: 'Dismiss this banner',
     onDismiss: () => {},
   }}
+  message="Single line Upsell with no title or call to action."
 />;
 `}
       />
     </MainSection.Subsection>
+
     <MainSection.Subsection
       title="Icon"
       description="The Icon is used to add additional meaning to the Upsell. The icon can reference a Pinterest product, feature or an action from our [Icon library](/Icon)."
@@ -444,14 +454,6 @@ card(
         cardSize="lg"
         defaultCode={`
 <Upsell
-  title="Give $30, get $60 in ads credit"
-  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-  primaryAction={{
-    href: 'https://pinterest.com',
-    label: 'Send invite',
-    accessibilityLabel: 'Invite friend to use ads',
-    target: 'blank',
-  }}
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',
     onDismiss: () => {},
@@ -459,10 +461,19 @@ card(
   imageData={{
     component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
   }}
+  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+  primaryAction={{
+    href: 'https://pinterest.com',
+    label: 'Send invite',
+    accessibilityLabel: 'Invite friend to use ads',
+    target: 'blank',
+  }}
+  title="Give $30, get $60 in ads credit"
 />;
         `}
       />
     </MainSection.Subsection>
+
     <MainSection.Subsection
       title="Image"
       description="The [Image](/Image) in Upsell is used to add visual interest and draw the user’s attention. Images should relate to the message of the Upsell. Upsell images should use approved photography or be illustrations using our brand colors. Images will always be 128px wide."
@@ -471,14 +482,6 @@ card(
         cardSize="lg"
         defaultCode={`
 <Upsell
-  title="Stay healthy and safe"
-  message="Check out our resources for adapting to these times."
-  primaryAction={{
-    href: 'https://pinterest.com',
-    label: 'Visit',
-    accessibilityLabel: 'Visit our Stay Safe resources',
-    target: 'blank',
-  }}
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',
     onDismiss: () => {},
@@ -496,10 +499,19 @@ card(
     mask: { rounding: 4 },
     width: 128,
   }}
+  message="Check out our resources for adapting to these times."
+  primaryAction={{
+    href: 'https://pinterest.com',
+    label: 'Visit',
+    accessibilityLabel: 'Visit our Stay Safe resources',
+    target: 'blank',
+  }}
+  title="Stay healthy and safe"
 />;
         `}
       />
     </MainSection.Subsection>
+
     <MainSection.Subsection
       title="Actions"
       description={`
@@ -516,54 +528,55 @@ function Example(props) {
   return (
     <Box marginStart={-1} marginEnd={-1}>
       <Upsell
-        title="Give $30, get $60 in ads credit"
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
         message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
         primaryAction={{
-          label: 'Send invite',
           accessibilityLabel: 'Send ads invite',
+          label: 'Send invite',
           onClick: () => {
             setShowModal(!showModal);
           },
         }}
         secondaryAction={{
+          accessibilityLabel: 'Learn more: Verified Merchant Program',
           href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
           label: 'Learn more',
           target: 'blank',
-          accessibilityLabel: 'Learn more: Verified Merchant Program',
         }}
-        dismissButton={{
-          accessibilityLabel: 'Dismiss banner',
-          onDismiss: () => {},
-        }}
+        title="Give $30, get $60 in ads credit"
       />
+
       {showModal && (
         <Layer>
           <Modal
             accessibilityModalLabel="Invite a friend to the Verified Merchant Program"
-            heading="Verified Merchant Program Invitation"
-            subHeading="When your friend spends their first $30 on ads, you’ll earn $60 of ads credit, and they’ll get $30 of ads credit, too."
-            onDismiss={() => {
-              setShowModal(!showModal);
-            }}
             footer={
               <Flex flex="grow" justifyContent="end">
                 <ButtonGroup>
                   <Button
-                    text="Cancel"
                     onClick={() => {
                       setShowModal(!showModal);
                     }}
                     size="lg"
+                    text="Cancel"
                   />
-                  <Button color="red" text="Send invite" size="lg" />
+                  <Button color="red" size="lg" text="Send invite" />
                 </ButtonGroup>
               </Flex>
             }
+            heading="Verified Merchant Program Invitation"
+            onDismiss={() => {
+              setShowModal(!showModal);
+            }}
             size="md"
+            subHeading="When your friend spends their first $30 on ads, you’ll earn $60 of ads credit, and they’ll get $30 of ads credit, too."
           >
-            <Box display="flex" direction="row" position="relative">
+            <Flex direction="row">
               <Column span={12}>
-                <Box paddingY={2} paddingX={8} display="flex">
+                <Box display="flex" paddingY={2} paddingX={8}>
                   <Column span={4}>
                     <Label htmlFor="name">
                       <Text align="left" weight="bold">
@@ -571,11 +584,13 @@ function Example(props) {
                       </Text>
                     </Label>
                   </Column>
+
                   <Column span={8}>
                     <TextField id="name" onChange={() => undefined} />
                   </Column>
                 </Box>
-                <Box paddingY={2} paddingX={8} display="flex">
+
+                <Box display="flex" paddingY={2} paddingX={8}>
                   <Column span={4}>
                     <Label htmlFor="email">
                       <Text align="left" weight="bold">
@@ -583,11 +598,13 @@ function Example(props) {
                       </Text>
                     </Label>
                   </Column>
+
                   <Column span={8}>
                     <TextField id="email" onChange={() => undefined} />
                   </Column>
                 </Box>
-                <Box paddingY={2} paddingX={8} display="flex">
+
+                <Box display="flex" paddingY={2} paddingX={8}>
                   <Column span={4}>
                     <Label htmlFor="desc">
                       <Text align="left" weight="bold">
@@ -595,12 +612,13 @@ function Example(props) {
                       </Text>
                     </Label>
                   </Column>
+
                   <Column span={8}>
                     <TextArea id="desc" onChange={() => undefined} />
                   </Column>
                 </Box>
               </Column>
-            </Box>
+            </Flex>
           </Modal>
         </Layer>
       )}
@@ -610,6 +628,7 @@ function Example(props) {
         `}
       />
     </MainSection.Subsection>
+
     <MainSection.Subsection
       title="Forms"
       description={`Inputs can be added to Upsells to collect information from users (ex: name or email) through the use of \`Upsell.Form\`. Most Upsells should have no more than 2 inputs. If more inputs are needed, direct users to a full page using the \`primaryAction\`.`}
@@ -620,10 +639,9 @@ function Example(props) {
         defaultCode={`
 function FormExample(props) {
   const [value, setValue] = React.useState('');
+
   return (
     <Upsell
-      title="Give $30, get $60 in ads credit"
-      message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
       dismissButton={{
         accessibilityLabel: 'Dismiss banner',
         onDismiss: ()=>{},
@@ -631,11 +649,13 @@ function FormExample(props) {
       imageData={{
         component: <Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32}/>
       }}
+      message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+      title="Give $30, get $60 in ads credit"
     >
       <Upsell.Form
-        onSubmit={(event) => {event.preventDefault();}}
-        submitButtonText="Submit"
+        onSubmit={({ event }) => { event.preventDefault(); }}
         submitButtonAccessibilityLabel="Submit name for ads credit"
+        submitButtonText="Submit"
       >
         <TextField
           id="nameField"
@@ -649,6 +669,7 @@ function FormExample(props) {
 }
       `}
       />
+
       <MainSection.Card
         cardSize="lg"
         title="Multiple TextFields"
@@ -656,10 +677,9 @@ function FormExample(props) {
 function Example(props) {
   const [nameValue, setNameValue] = React.useState('');
   const [emailValue, setEmailValue] = React.useState('');
+
   return (
     <Upsell
-      title="Interested in a free ads consultation?"
-      message="Learn how to grow your business with a Pinterest ads expert today!"
       dismissButton={{
         accessibilityLabel: 'Dismiss banner',
         onDismiss: ()=>{},
@@ -676,11 +696,13 @@ function Example(props) {
           mask: {rounding: 4},
         width: 128,
       }}
+      message="Learn how to grow your business with a Pinterest ads expert today!"
+      title="Interested in a free ads consultation?"
     >
       <Upsell.Form
-        onSubmit={(event) => {event.preventDefault();}}
-        submitButtonText="Contact me"
+        onSubmit={({ event }) => { event.preventDefault(); }}
         submitButtonAccessibilityLabel="Submit info for contact"
+        submitButtonText="Contact me"
       >
         <Box display="block" smDisplay="flex">
           <Box
@@ -697,6 +719,7 @@ function Example(props) {
               value={nameValue}
             />
           </Box>
+
           <Box flex="grow" smMarginStart={1} marginStart={0}>
             <TextField
               id="email"
@@ -727,7 +750,6 @@ function OnNavigation() {
   const onNavigation = ({ href,target }) => {
     const onNavigationClick = ({ event }) => {
       event.preventDefault();
-      // eslint-disable-next-line no-alert
       alert('CUSTOM NAVIGATION set on <OnLinkNavigationProvider onNavigation/>. Disabled link: '+href+'. Opening business.pinterest.com instead.');
       window.open('https://business.pinterest.com', target === 'blank' ? '_blank' : '_self');
     }
@@ -735,7 +757,6 @@ function OnNavigation() {
   }
 
   const customOnNavigation = () => {
-    // eslint-disable-next-line no-alert
     alert('CUSTOM NAVIGATION set on <Upsell primaryAction secondaryAction/>. Disabled link: https://pinterest.com. Opening help.pinterest.com instead.');
     window.open('https://help.pinterest.com', '_blank');
   }
@@ -751,8 +772,8 @@ function OnNavigation() {
   }
 
   const linkProps = {
-    href:"https://pinterest.com",
     accessibilityLabel: 'Send ads credit',
+    href: "https://pinterest.com",
     onClick: onClickHandler,
     target:"blank",
   }
@@ -788,13 +809,8 @@ function OnNavigation() {
             />
           <Divider/>
         </Flex>
+
         <Upsell
-          title="Give $30, get $60 in ads credit"
-          message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-          primaryAction={
-            { ...linkProps,
-              label: 'Send invite'
-            }}
           dismissButton={{
             accessibilityLabel: 'Dismiss banner',
             onDismiss: () => {},
@@ -802,6 +818,12 @@ function OnNavigation() {
           imageData={{
             component: <Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32}/>
           }}
+          message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+          title="Give $30, get $60 in ads credit"
+          primaryAction={
+            { ...linkProps,
+              label: 'Send invite'
+            }}
         />
       </Flex>
     </OnLinkNavigationProvider>


### PR DESCRIPTION
Our Upsell.Form examples were wrong (weren't destructuring `event` from the `onSubmit` args), so this PR fixes them and has a bunch of general cleanup for the markup of that page (alphabetizing props, breaking up blocks with semantic whitespace, etc).