### PR TITLE
Tabs: Add `bgColor` prop, tweak padding/states

### DIFF
--- a/docs/src/Tabs.doc.js
+++ b/docs/src/Tabs.doc.js
@@ -12,6 +12,18 @@ card(
   <PageHeader
     name="Tabs"
     description={`Tabs may be used navigate between multiple URLs. Tabs are intended as page-level navigation - if you're looking at just switching panels please use [SegmentedControl](/SegmentedControl).`}
+    defaultCode={`
+      <Tabs
+        activeTabIndex={0}
+        onChange={() => {}}
+        tabs={[
+          { href: "#", text: "Explore", indicator: "dot" },
+          { href: "#", text: "Shop" },
+          { href: "#", text: "Profiles" },
+        ]}
+        wrap
+      />
+    `}
   />,
 );
 
@@ -25,9 +37,10 @@ card(
         required: true,
       },
       {
-        name: 'tabs',
-        type: `Array<{| href: string, text: React.Node, id?: string, indicator?: 'dot' | number, ref?: {| current: ?HTMLElement |} |}>`,
-        required: true,
+        name: 'bgColor',
+        type: `"default" | "transparent"`,
+        defaultValue: 'default',
+        description: `If Tabs is displayed in a container with a colored background, use this prop to remove the white tab background. See the [background color](#Background-color) example to learn more.`,
       },
       {
         name: 'onChange',
@@ -35,6 +48,11 @@ card(
         required: true,
         description:
           'If your app uses a tool such as react-router to navigate between pages, be sure to use onChange to navigate instead of getting a full page refresh with href',
+      },
+      {
+        name: 'tabs',
+        type: `Array<{| href: string, text: React.Node, id?: string, indicator?: 'dot' | number, ref?: {| current: ?HTMLElement |} |}>`,
+        required: true,
       },
       {
         name: 'wrap',
@@ -83,6 +101,57 @@ function TabExample() {
       <Box borderStyle="sm" maxWidth={500} overflow="auto" padding={1}>
         <Tabs
           activeTabIndex={activeIndex}
+          onChange={handleChange}
+          tabs={tabs}
+          wrap={wrap}
+        />
+      </Box>
+    </Flex>
+  );
+}
+  `}
+  />,
+);
+
+card(
+  <Example
+    name="Background color"
+    defaultCode={`
+function TabExample() {
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const [wrap, setWrap] = React.useState(false);
+
+  const handleChange = ({ activeTabIndex, event }) => {
+    event.preventDefault();
+    setActiveIndex(activeTabIndex)
+  };
+
+  const tabs = [
+    { href: "https://pinterest.com", text: "Boards for You", indicator: "dot" },
+    { href: "https://pinterest.com", text: "Pins for You" },
+    { href: "https://pinterest.com", text: "1" },
+    { href: "https://pinterest.com", text: "❤" },
+    { href: "https://pinterest.com", text: "Following" },
+    { href: "https://pinterest.com", text: "People to Follow" },
+  ];
+
+  return (
+    <Flex alignItems="start" direction="column" gap={4}>
+      <Flex gap={4} padding={2}>
+        <Label htmlFor="wrap">
+          <Text>Wrap</Text>
+        </Label>
+        <Switch
+          id="wrap"
+          onChange={() => setWrap(!wrap)}
+          switched={wrap}
+        />
+      </Flex>
+
+      <Box borderStyle="sm" color="lightGray" maxWidth={500} overflow="auto" padding={1}>
+        <Tabs
+          activeTabIndex={activeIndex}
+          bgColor="transparent"
           onChange={handleChange}
           tabs={tabs}
           wrap={wrap}

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -80,53 +80,77 @@ type TabType = {|
   indicator?: 'dot' | number,
   text: Node,
 |};
+type BgColor = 'default' | 'transparent';
 
 type TabProps = {|
   ...TabType,
+  bgColor: BgColor,
   index: number,
   isActive: boolean,
   onChange: OnChangeHandler,
 |};
 
 const TAB_ROUNDING = 2;
-const TAB_INNER_PADDING = 1;
+const TAB_INNER_PADDING = 2;
+const colors = {
+  default: {
+    base: 'white',
+    pressed: 'lightWash',
+    hover: 'lightGray',
+  },
+  transparent: {
+    base: 'transparent',
+    // From Colors.css, matches <Button color="transparent" />
+    pressed: 'rgba(0, 0, 0, 0.1)',
+    hover: 'rgba(0, 0, 0, 0.06)',
+  },
+};
 
 export const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef<
   TabProps,
   HTMLElement,
->(function Tab({ href, indicator, id, index, isActive, onChange, text }, ref) {
+>(function Tab({ bgColor, href, indicator, id, index, isActive, onChange, text }, ref) {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
   const [pressed, setPressed] = useState(false);
 
-  let color = 'white';
+  const bgColorSet = colors[bgColor];
+
+  let color = bgColorSet.base;
   if (pressed) {
-    color = 'lightWash';
-  } else if ((hovered || focused) && !isActive) {
-    color = 'lightGray';
+    color = bgColorSet.pressed;
+  } else if (hovered || focused) {
+    color = bgColorSet.hover;
   }
 
   return (
     <Box id={id} paddingY={3} ref={ref}>
       <TapArea
         accessibilityCurrent={isActive ? 'page' : undefined}
+        disabled={isActive}
         href={href}
         onBlur={() => setFocused(false)}
         onFocus={() => setFocused(true)}
-        onMouseDown={() => setPressed(true)}
+        onMouseDown={() => (isActive ? undefined : setPressed(true))}
         onMouseUp={() => setPressed(false)}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        onTap={({ event, disableOnNavigation }) =>
-          onChange({ activeTabIndex: index, event, disableOnNavigation })
-        }
+        onTap={({ event, disableOnNavigation }) => {
+          setHovered(false);
+          setFocused(false);
+          onChange({ activeTabIndex: index, event, disableOnNavigation });
+        }}
         role="link"
         rounding={TAB_ROUNDING}
         tapStyle="compress"
       >
         <Flex alignItems="center" direction="column">
           <Box
-            color={color}
+            // $FlowExpectedError[incompatible-type] Flow doesn't understand the non-RGBA colors are valid for Box
+            color={color.startsWith('rgba') ? undefined : color}
+            dangerouslySetInlineStyle={{
+              __style: { backgroundColor: color.startsWith('rgba') ? color : undefined },
+            }}
             padding={TAB_INNER_PADDING}
             position="relative"
             rounding={TAB_ROUNDING}
@@ -165,6 +189,7 @@ TabWithForwardRef.displayName = 'Tab';
 
 type Props = {|
   activeTabIndex: number,
+  bgColor?: BgColor,
   onChange: OnChangeHandler,
   tabs: $ReadOnlyArray<{| ...TabType, ref?: {| current: ?HTMLElement |} |}>,
   wrap?: boolean,
@@ -173,17 +198,24 @@ type Props = {|
 /**
  * https://gestalt.pinterest.systems/Tabs
  */
-export default function Tabs({ activeTabIndex, onChange, tabs, wrap }: Props): Node {
+export default function Tabs({
+  activeTabIndex,
+  bgColor = 'default',
+  onChange,
+  tabs,
+  wrap,
+}: Props): Node {
   return (
     <Flex alignItems="center" gap={4} justifyContent="start" wrap={wrap}>
       {tabs.map(({ href, id, indicator, ref, text }, index) => (
         <TabWithForwardRef
-          key={id || `${href}_${index}`}
+          bgColor={bgColor}
           href={href}
           id={id}
           index={index}
           isActive={activeTabIndex === index}
           indicator={indicator}
+          key={id || `${href}_${index}`}
           onChange={onChange}
           ref={ref}
           text={text}
@@ -199,9 +231,14 @@ const TabItemPropType = {
   indicator: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   text: PropTypes.node.isRequired,
 };
+const BgColorPropType = (PropTypes.oneOf([
+  'default',
+  'transparent',
+]): React$PropType$Primitive<BgColor>);
 
 TabWithForwardRef.propTypes = {
   ...TabItemPropType,
+  bgColor: BgColorPropType,
   index: PropTypes.number.isRequired,
   isActive: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
@@ -209,6 +246,7 @@ TabWithForwardRef.propTypes = {
 
 Tabs.propTypes = {
   activeTabIndex: PropTypes.number.isRequired,
+  bgColor: BgColorPropType,
   onChange: PropTypes.func.isRequired,
   // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
   tabs: PropTypes.arrayOf(


### PR DESCRIPTION
### Summary

The current Tabs UI doesn't look great on a colored background:
<img width="343" alt="124195629-ac383a80-da7f-11eb-9724-420651948e48" src="https://user-images.githubusercontent.com/12059539/125003178-81b02980-e00b-11eb-9969-1a5f19eed413.png">

This PR attempts to address that by making a few changes:
- Adds a new optional `bgColor` prop of `'default' | 'transparent'`. The `'transparent'` variant removes the background and uses RGBA-based colors for the hover/pressed/focused states, so the effect is additive on top of the surrounding background color
- Increases padding around the tab text
- Adjusts the "selected tab" logic to disable the underlying TapArea and the hover/pressed states (disabling prevents keyboard and mouse focus, so no need to address that state)

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-2922)

### Checklist

- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction