### PR TITLE
Button: Add key to fix Safari bug

### DIFF
--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -124,6 +124,10 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
     text,
   } = props;
 
+  // Key necessary for text color to update on Safari when disabled changes
+  // See https://github.com/pinterest/gestalt/issues/1556 for more context
+  const key = String(disabled);
+
   const innerRef = useRef(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Button ref={inputRef} /> to call inputRef.current.focus()
@@ -207,6 +211,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         disabled={disabled}
         fullWidth={fullWidth}
         href={href}
+        key={key}
         onClick={handleLinkClick}
         ref={innerRef}
         rel={rel}
@@ -232,6 +237,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         aria-label={accessibilityLabel}
         className={buttonRoleClasses}
         disabled={disabled}
+        key={key}
         name={name}
         onBlur={handleBlur}
         onClick={handleClick}
@@ -265,6 +271,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
       aria-label={accessibilityLabel}
       className={buttonRoleClasses}
       disabled={disabled}
+      key={key}
       name={name}
       onBlur={handleBlur}
       onClick={handleClick}


### PR DESCRIPTION
### Summary

As noted in #1556, there's weird behavior on Safari browsers (mobile and desktop) relating to text color and changing disabled state. This seems to be an issue specific to Safari itself and how it handles `pointer-events: none` vis-a-vis repaints.

This PR implements the simplest fix for this issue: adding a key to the underlying DOM element based on the `disabled` prop, forcing a re-render whenever that prop changes.

To review:
- Use Safari 😛 
- Paste this code (or something similar) in one of the Button examples:
```js
function Demo() {
  const [disabled, setDisabled] = React.useState(true);

  React.useEffect(() => setTimeout(() => setDisabled(false), 1000), []);

  return <Button color="red" text="Button" disabled={disabled} />;
}
```
- The Button should flip from disabled -> enabled after a second, and the text color should be correct. (Try this on the prod docs to see the bug in action)

### Links

- [Jira](https://jira.pinadmin.com/browse/BUG-127975)
