### PR TITLE
Lint rules: Add `no-box-useless-props` rule

### DIFF
--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-bottom.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-bottom.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box bottom />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-left.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-left.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box left />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-right.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-right.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box right />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-top.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-top.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box top />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/fit-max-width.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/fit-max-width.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box fit maxWidth="50%" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-align-content.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-align-content.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box alignContent="start" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-align-items.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-align-items.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box alignItems="start" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-direction.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-direction.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box direction="column" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-justify-content.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-justify-content.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box justifyContent="between" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-wrap.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-wrap.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box wrap />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-bottom.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-bottom.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box position="absolute" bottom />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-left.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-left.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box position="absolute" left />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-right.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-right.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box position="absolute" right />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-top.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-top.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box position="absolute" top />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/fit-max-width.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/fit-max-width.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box maxWidth="50%" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/fit.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/fit.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box fit />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-align-content.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-align-content.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box alignContent="start" display="flex" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-align-items.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-align-items.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box alignItems="start" display="flex" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-direction.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-direction.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box direction="column" display="flex" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-justify-content.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-justify-content.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box justifyContent="between" display="flex" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-wrap.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-wrap.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box wrap display="flex" />;
+}

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
@@ -1,0 +1,84 @@
+// @flow strict
+
+/**
+ * Error on useless props on `Box`
+ */
+
+export const errorMessages = {
+  absolute: '`bottom`, `left`, `right`, and `top` must be used with position="absolute"',
+  fit: '`fit` sets `maxWidth`, so `maxWidth` should not be specified when `fit` is used',
+  flex:
+    '`alignContent`, `alignItems`, `direction`, `justifyContent`, and `wrap` must be used with `display="flex"`',
+};
+
+const absoluteProps = ['bottom', 'left', 'right', 'top'];
+const flexProps = ['alignContent', 'alignItems', 'direction', 'justifyContent', 'wrap'];
+
+const rule = {
+  meta: {
+    docs: {
+      description: 'Do not allow useless props combinations on Box',
+      recommended: false,
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  // $FlowFixMe[unclear-type]
+  create(context: Object): Object {
+    let localBoxName = false;
+
+    return {
+      ImportDeclaration(decl) {
+        if (decl.source.value !== 'gestalt') {
+          return;
+        }
+        localBoxName = decl.specifiers.find((node) => {
+          return node.imported.name === 'Box';
+        })?.local?.name;
+      },
+      JSXOpeningElement(node) {
+        if (!localBoxName || node?.name?.name !== localBoxName) {
+          return;
+        }
+
+        const props = Object.keys(node.attributes).map((key: string) => ({
+          name: node.attributes[key]?.name?.name,
+          value: node.attributes[key]?.value?.value,
+        }));
+        const propNames = props.map((prop) => prop.name);
+
+        // ABSOLUTE PROPS
+        const isAbsolutePosition =
+          props.find((prop) => prop.name === 'position')?.value === 'absolute';
+        const hasAbsoluteProps = absoluteProps.some((prop) => propNames.includes(prop));
+
+        if (hasAbsoluteProps && !isAbsolutePosition) {
+          context.report(node, errorMessages.absolute);
+        }
+
+        // FIT - MAX WIDTH
+        const hasFit = propNames.includes('fit');
+        const hasMaxWidth = propNames.includes('maxWidth');
+
+        if (hasFit && hasMaxWidth) {
+          context.report(node, errorMessages.fit);
+        }
+
+        // FLEX PROPS
+        const isFlexDisplay = props.find((prop) => prop.name === 'display')?.value === 'flex';
+        const hasFlexProps = flexProps.some((prop) => propNames.includes(prop));
+
+        if (hasFlexProps && !isFlexDisplay) {
+          context.report(node, errorMessages.flex);
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
@@ -1,0 +1,68 @@
+// @flow strict
+import { RuleTester } from 'eslint';
+import { readFileSync } from 'fs';
+import path from 'path';
+import rule, { errorMessages } from './no-box-useless-props.js';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const mapFileNameToPath = (pathPart) => (fileName) => {
+  return `./__fixtures__/no-box-useless-props/${pathPart}/${fileName}.js`;
+};
+
+function mapPathsToCode(codePath) {
+  return readFileSync(path.resolve(__dirname, codePath), 'utf-8');
+}
+
+const absoluteFileNames = ['absolute-bottom', 'absolute-left', 'absolute-right', 'absolute-top'];
+const validAbsoluteCodePaths = absoluteFileNames.map(mapFileNameToPath('valid'));
+const validAbsoluteCode = validAbsoluteCodePaths.map(mapPathsToCode);
+const invalidAbsoluteCodePaths = absoluteFileNames.map(mapFileNameToPath('invalid'));
+const invalidAbsoluteCode = invalidAbsoluteCodePaths.map(mapPathsToCode);
+
+const validFitCodePaths = ['fit', 'fit-max-width'].map(mapFileNameToPath('valid'));
+const validFitCode = validFitCodePaths.map(mapPathsToCode);
+const invalidFitCodePaths = ['fit-max-width'].map(mapFileNameToPath('invalid'));
+const invalidFitCode = invalidFitCodePaths.map(mapPathsToCode);
+
+const flexFileNames = [
+  'flex-align-content',
+  'flex-align-items',
+  'flex-direction',
+  'flex-justify-content',
+  'flex-wrap',
+];
+const validFlexCodePaths = flexFileNames.map(mapFileNameToPath('valid'));
+const validFlexCode = validFlexCodePaths.map(mapPathsToCode);
+const invalidFlexCodePaths = flexFileNames.map(mapFileNameToPath('invalid'));
+const invalidFlexCode = invalidFlexCodePaths.map(mapPathsToCode);
+
+ruleTester.run('no-box-useless-props', rule, {
+  valid: [
+    ...validAbsoluteCode.map((validCode) => ({ code: validCode })),
+    ...validFitCode.map((validCode) => ({ code: validCode })),
+    ...validFlexCode.map((validCode) => ({ code: validCode })),
+  ],
+  invalid: [
+    ...invalidAbsoluteCode.map((invalidCode) => ({
+      code: invalidCode,
+      errors: [{ message: errorMessages.absolute }],
+    })),
+    ...invalidFitCode.map((invalidCode) => ({
+      code: invalidCode,
+      errors: [{ message: errorMessages.fit }],
+    })),
+    ...invalidFlexCode.map((invalidCode) => ({
+      code: invalidCode,
+      errors: [{ message: errorMessages.flex }],
+    })),
+  ],
+});


### PR DESCRIPTION
### Summary

We see a lot of unfortunate Box props usage, where props are applied that are either useless without other props, or conflict with other props. This is provides a frustrating DX.

This PR adds a lint rule to check for three categories of useless props:
- `alignContent`, `alignItems`, `direction`, `justifyContent`, or `wrap` without `display="flex"`
- `bottom`, `left`, `right`, or `top` without `position="absolute"`
- `fit` and `maxWidth` used together, since `fit` sets `maxWidth` under the hood

The rule and tests are written to be easily extensible, so we can provide further guidance with future updates.

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-2910)
