### PR TITLE
Button: Add key to fix Safari bug, take two

### DIFF
--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -124,6 +124,10 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
     text,
   } = props;
 
+  // Key necessary for text color to update on Safari when disabled changes
+  // See https://github.com/pinterest/gestalt/issues/1556 for more context
+  const key = String(disabled);
+
   const innerRef = useRef(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Button ref={inputRef} /> to call inputRef.current.focus()
@@ -207,6 +211,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         disabled={disabled}
         fullWidth={fullWidth}
         href={href}
+        key={key}
         onClick={handleLinkClick}
         ref={innerRef}
         rel={rel}
@@ -232,6 +237,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         aria-label={accessibilityLabel}
         className={buttonRoleClasses}
         disabled={disabled}
+        key={key}
         name={name}
         onBlur={handleBlur}
         onClick={handleClick}
@@ -265,6 +271,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
       aria-label={accessibilityLabel}
       className={buttonRoleClasses}
       disabled={disabled}
+      key={key}
       name={name}
       onBlur={handleBlur}
       onClick={handleClick}


### PR DESCRIPTION
Revert "Revert "Button: Add key to fix Safari bug (#1584)""
This reverts commit e29ab9d2f0dae3e5e870f834140fa3b8450a440b.

We needed to temporarily revert the original PR to ease the Image refactor revert. This PR reverts the revert, bringing the original back to life.