### PR TITLE
Lint Rules: Fix no-box-useless-props rule

### DIFF
--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-bottom.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-bottom.js
@@ -1,5 +1,0 @@
-import { Box } from 'gestalt';
-
-export default function TestComponent() {
-  return <Box bottom />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-left.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-left.js
@@ -1,5 +1,0 @@
-import { Box } from 'gestalt';
-
-export default function TestComponent() {
-  return <Box left />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-right.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-right.js
@@ -1,5 +1,0 @@
-import { Box } from 'gestalt';
-
-export default function TestComponent() {
-  return <Box right />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-top.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/absolute-top.js
@@ -1,5 +1,0 @@
-import { Box } from 'gestalt';
-
-export default function TestComponent() {
-  return <Box top />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-bottom.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-bottom.js
@@ -1,5 +1,0 @@
-import { Box } from 'gestalt';
-
-export default function TestComponent() {
-  return <Box position="absolute" bottom />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-left.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-left.js
@@ -1,5 +1,0 @@
-import { Box } from 'gestalt';
-
-export default function TestComponent() {
-  return <Box position="absolute" left />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-right.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-right.js
@@ -1,5 +1,0 @@
-import { Box } from 'gestalt';
-
-export default function TestComponent() {
-  return <Box position="absolute" right />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-top.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/absolute-top.js
@@ -1,5 +1,0 @@
-import { Box } from 'gestalt';
-
-export default function TestComponent() {
-  return <Box position="absolute" top />;
-}

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
@@ -11,7 +11,6 @@ export const errorMessages = {
     '`alignContent`, `alignItems`, `direction`, `justifyContent`, and `wrap` must be used with `display="flex"`',
 };
 
-const absoluteProps = ['bottom', 'left', 'right', 'top'];
 const flexProps = ['alignContent', 'alignItems', 'direction', 'justifyContent', 'wrap'];
 
 const rule = {
@@ -51,15 +50,6 @@ const rule = {
           value: node.attributes[key]?.value?.value,
         }));
         const propNames = props.map((prop) => prop.name);
-
-        // ABSOLUTE PROPS
-        const isAbsolutePosition =
-          props.find((prop) => prop.name === 'position')?.value === 'absolute';
-        const hasAbsoluteProps = absoluteProps.some((prop) => propNames.includes(prop));
-
-        if (hasAbsoluteProps && !isAbsolutePosition) {
-          context.report(node, errorMessages.absolute);
-        }
 
         // FIT - MAX WIDTH
         const hasFit = propNames.includes('fit');

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
@@ -22,12 +22,6 @@ function mapPathsToCode(codePath) {
   return readFileSync(path.resolve(__dirname, codePath), 'utf-8');
 }
 
-const absoluteFileNames = ['absolute-bottom', 'absolute-left', 'absolute-right', 'absolute-top'];
-const validAbsoluteCodePaths = absoluteFileNames.map(mapFileNameToPath('valid'));
-const validAbsoluteCode = validAbsoluteCodePaths.map(mapPathsToCode);
-const invalidAbsoluteCodePaths = absoluteFileNames.map(mapFileNameToPath('invalid'));
-const invalidAbsoluteCode = invalidAbsoluteCodePaths.map(mapPathsToCode);
-
 const validFitCodePaths = ['fit', 'fit-max-width'].map(mapFileNameToPath('valid'));
 const validFitCode = validFitCodePaths.map(mapPathsToCode);
 const invalidFitCodePaths = ['fit-max-width'].map(mapFileNameToPath('invalid'));
@@ -47,15 +41,10 @@ const invalidFlexCode = invalidFlexCodePaths.map(mapPathsToCode);
 
 ruleTester.run('no-box-useless-props', rule, {
   valid: [
-    ...validAbsoluteCode.map((validCode) => ({ code: validCode })),
     ...validFitCode.map((validCode) => ({ code: validCode })),
     ...validFlexCode.map((validCode) => ({ code: validCode })),
   ],
   invalid: [
-    ...invalidAbsoluteCode.map((invalidCode) => ({
-      code: invalidCode,
-      errors: [{ message: errorMessages.absolute }],
-    })),
     ...invalidFitCode.map((invalidCode) => ({
       code: invalidCode,
       errors: [{ message: errorMessages.fit }],


### PR DESCRIPTION
Previous version was wrong: `top` `bottom` `left` `right` are useful even if not using `position="absolute"`