### PR TITLE
Lint Rules: Better error message for grid props

### DIFF
--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
@@ -7,21 +7,16 @@
 export const errorMessages = {
   fit: '`fit` sets `maxWidth`, so `maxWidth` should not be specified when `fit` is used',
   flex:
-    '`alignContent`, `alignItems`, `direction`, `smDirection`, `mdDirection`, `lgDirection`, `justifyContent`, and `wrap` must be used with `display="flex"`',
+    '`direction`, `smDirection`, `mdDirection`, `lgDirection`, and `wrap` must be used with `display="flex"`',
+  flexGrid:
+    '`alignContent`, `alignItems`, and `justifyContent` must be used with `display="flex"`. You can suppress this error if dangerously setting `display="grid"`',
 };
 
 const displayPropNames = ['display', 'smDisplay', 'mdDisplay', 'lgDisplay'];
 
-const flexPropNames = [
-  'alignContent',
-  'alignItems',
-  'direction',
-  `smDirection`,
-  `mdDirection`,
-  `lgDirection`,
-  'justifyContent',
-  'wrap',
-];
+// These are valid for both flexbox and grid layouts
+const flexGridPropNames = ['alignContent', 'alignItems', 'justifyContent'];
+const flexPropNames = ['direction', `smDirection`, `mdDirection`, `lgDirection`, 'wrap'];
 
 const rule = {
   meta: {
@@ -73,9 +68,14 @@ const rule = {
         const displayProps = props.filter((prop) => displayPropNames.includes(prop.name));
         const isFlexDisplay = displayProps.some((prop) => prop.value === 'flex');
         const hasFlexProps = flexPropNames.some((prop) => propNames.includes(prop));
+        const hasFlexGridProps = flexGridPropNames.some((prop) => propNames.includes(prop));
 
-        if (hasFlexProps && !isFlexDisplay) {
-          context.report(node, errorMessages.flex);
+        if (!isFlexDisplay) {
+          if (hasFlexProps) {
+            context.report(node, errorMessages.flex);
+          } else if (hasFlexGridProps) {
+            context.report(node, errorMessages.flexGrid);
+          }
         }
       },
     };

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
@@ -27,22 +27,22 @@ const validFitCode = validFitCodePaths.map(mapPathsToCode);
 const invalidFitCodePaths = ['fit-max-width'].map(mapFileNameToPath('invalid'));
 const invalidFitCode = invalidFitCodePaths.map(mapPathsToCode);
 
-const flexFileNames = [
-  'flex-align-content',
-  'flex-align-items',
-  'flex-direction',
-  'flex-justify-content',
-  'flex-wrap',
-];
+const flexFileNames = ['flex-direction', 'flex-wrap'];
 const validFlexCodePaths = flexFileNames.map(mapFileNameToPath('valid'));
 const validFlexCode = validFlexCodePaths.map(mapPathsToCode);
 const invalidFlexCodePaths = flexFileNames.map(mapFileNameToPath('invalid'));
 const invalidFlexCode = invalidFlexCodePaths.map(mapPathsToCode);
+const flexGridFileNames = ['flex-align-content', 'flex-align-items', 'flex-justify-content'];
+const validFlexGridCodePaths = flexGridFileNames.map(mapFileNameToPath('valid'));
+const validFlexGridCode = validFlexGridCodePaths.map(mapPathsToCode);
+const invalidFlexGridCodePaths = flexGridFileNames.map(mapFileNameToPath('invalid'));
+const invalidFlexGridCode = invalidFlexGridCodePaths.map(mapPathsToCode);
 
 ruleTester.run('no-box-useless-props', rule, {
   valid: [
     ...validFitCode.map((validCode) => ({ code: validCode })),
     ...validFlexCode.map((validCode) => ({ code: validCode })),
+    ...validFlexGridCode.map((validCode) => ({ code: validCode })),
   ],
   invalid: [
     ...invalidFitCode.map((invalidCode) => ({
@@ -52,6 +52,10 @@ ruleTester.run('no-box-useless-props', rule, {
     ...invalidFlexCode.map((invalidCode) => ({
       code: invalidCode,
       errors: [{ message: errorMessages.flex }],
+    })),
+    ...invalidFlexGridCode.map((invalidCode) => ({
+      code: invalidCode,
+      errors: [{ message: errorMessages.flexGrid }],
     })),
   ],
 });


### PR DESCRIPTION
A few flex props are also valid for use in grid layouts. Although we don't explicitly support grid yet, it can be set using `dangerouslySetInlineStyle`, so this PR improves the error message to note when suppression is recommended.