### PR TITLE
Callout, Upsell: Allow actions to be disabled

### DIFF
--- a/docs/src/Callout.doc.js
+++ b/docs/src/Callout.doc.js
@@ -61,7 +61,7 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
+          '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         required: false,
         defaultValue: null,
         description: `
@@ -73,7 +73,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
+          '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         required: false,
         defaultValue: null,
         description: `
@@ -425,6 +425,9 @@ card(
         Callouts can have either one primary action, or a primary action and a secondary action. These actions can be [Links](/Link), by specifying the \`href\` property, or [Buttons](/Buttons), when no \`href\` is supplied.
 
         For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a Button that opens a [Modal](/Modal) with an application flow. Be sure to localize the labels of the actions.
+
+        If needed, actions can become disabled after clicking by setting \`disabled: true\` in the action data.
+
         `}
     >
       <MainSection.Card

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -71,7 +71,7 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
+          '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         defaultValue: null,
         description: `
           Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [custom navigation](#Custom-navigation) variant for examples.
@@ -82,7 +82,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel: string, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
+          '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
         defaultValue: null,
         description: `
           Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [custom navigation](#Custom-navigation) variant for examples.
@@ -542,7 +542,10 @@ card(
       description={`
       Upsells can have either one primary action, or a primary action and a secondary action. These actions can be buttons, when no \`href\` is supplied, or links, by specifying the \`href\`  property.
 
-      For example, “Learn more” may link to a separate documentation site, while “Send invite” could be a button that opens a [Modal](/Modal) with an invite flow. Be sure to localize the labels of the actions.`}
+      For example, “Learn more” may link to a separate documentation site, while “Send invite” could be a button that opens a [Modal](/Modal) with an invite flow. Be sure to localize the labels of the actions.
+
+      If needed, actions can become disabled after clicking by setting \`disabled: true\` in the action data.
+      `}
     >
       <MainSection.Card
         cardSize="lg"

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -57,7 +57,7 @@ const CalloutAction = ({
   if (isDarkMode && type === 'secondary') {
     color = 'transparentWhiteText';
   }
-  const { accessibilityLabel, label, onClick, href, rel, target } = data;
+  const { accessibilityLabel, disabled, label, onClick, href, rel, target } = data;
 
   return (
     <Box
@@ -74,6 +74,7 @@ const CalloutAction = ({
         <Button
           accessibilityLabel={accessibilityLabel}
           color={color}
+          disabled={disabled}
           href={href}
           fullWidth
           onClick={onClick}
@@ -86,6 +87,7 @@ const CalloutAction = ({
       ) : (
         <Button
           accessibilityLabel={accessibilityLabel}
+          disabled={disabled}
           color={color}
           onClick={onClick}
           fullWidth

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -48,7 +48,7 @@ const UpsellAction = ({
   type: string,
 |}): Node => {
   const color = type === 'primary' ? 'red' : 'gray';
-  const { accessibilityLabel, href, label, onClick, rel, target } = data;
+  const { accessibilityLabel, disabled, href, label, onClick, rel, target } = data;
 
   return (
     <Box
@@ -65,6 +65,7 @@ const UpsellAction = ({
         <Button
           accessibilityLabel={accessibilityLabel}
           color={color}
+          disabled={disabled}
           href={href}
           fullWidth
           onClick={onClick}
@@ -78,6 +79,7 @@ const UpsellAction = ({
         <Button
           accessibilityLabel={accessibilityLabel}
           color={color}
+          disabled={disabled}
           fullWidth
           onClick={onClick}
           role="button"

--- a/packages/gestalt/src/commonTypes.js
+++ b/packages/gestalt/src/commonTypes.js
@@ -4,6 +4,7 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 export type ActionDataType = {|
   accessibilityLabel: string,
+  disabled?: boolean,
   href?: string,
   label: string,
   onClick?: AbstractEventHandler<
@@ -25,6 +26,7 @@ export type DismissButtonType = {|
 // $FlowFixMe[incompatible-exact]
 export const ActionDataPropType: React$PropType$Primitive<ActionDataType> = PropTypes.exact({
   accessibilityLabel: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
   href: PropTypes.string,
   label: PropTypes.string.isRequired,
   // $FlowFixMe[incompatible-type]


### PR DESCRIPTION
### Summary

Allow actions in callouts and upsells to be disabled 
<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
