### PR TITLE
Eslint Plugin: Add missing rules to Docs, categorize, and standardize rule config  

### DIFF
--- a/docs/src/Eslint Plugin.doc.js
+++ b/docs/src/Eslint Plugin.doc.js
@@ -10,12 +10,29 @@ card(
   <PageHeader
     name="Eslint Plugin"
     showSourceLink={false}
-    description="Install the package eslint-plugin-gestalt to get lint rules encouraging the correct usage of gestalt components"
+    description="Install the package eslint-plugin-gestalt to get lint rules encouraging the correct usage of Gestalt components"
   />,
 );
 
 card(
-  <MainSection name="Supported Rules">
+  <MainSection name="Gestalt alternatives">
+    <MainSection.Subsection
+      title="gestalt/no-dangerous-style-duplicates"
+      description={`
+        Prevent using dangerouslySetInlineStyle on Box for props that are already directly implemented. Box supports some props already that are not widely known and instead are being implemented with dangerouslySetInlineStyle. This linter checks for usage of already available props as dangerous styles and suggests the alternative.
+      `}
+    />
+    <MainSection.Subsection
+      title="gestalt/prefer-box"
+      description={`
+        Prevent using div inline styling for attributes that are already implemented in Box.
+      `}
+    />
+  </MainSection>,
+);
+
+card(
+  <MainSection name="Gestalt restrictions">
     <MainSection.Subsection
       title="gestalt/button-icon-restrictions"
       description={`
@@ -26,21 +43,37 @@ card(
       `}
     />
     <MainSection.Subsection
-      title="gestalt/no-box-marginleft-marginright"
+      title="gestalt/no-box-disallowed-props"
       description={`
-        Disallow marginLeft/marginRight on Box. In order to have consistent usage of marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd.
+        Prevent props different from 
+        * the officially-supported Box props 
+        * the following list of passthrough React / DOM props: \`id\`, \`key\`,\`onAnimationEnd\`, \`onAnimationIteration\`, \`onAnimationStart\`, \`onBlur\`, \`onClick\`, \`onContextMenu\`, \`onDblClick\`, \`onDoubleClick\`, \`onDrag\`, \`onDragEnd\`, \`onDragEnter\`, \`onDragExit\`, \`onDragLeave\`, \`onDragOver\`, \`onDragStart\`, \`onDrop\`, \`onFocus\`, \`onKeyDown\`, \`onKeyPress\`, \`onKeyUp\`, \`onMouseDown\`, \`onMouseEnter\`, \`onMouseLeave\`, \`onMouseMove\`, \`onMouseOut\`, \`onMouseOver\`, \`onMouseUp\`, \`onScroll\`, \`onSelect\`, \`onTouchCancel\`, \`onTouchEnd\`, \`onTouchMove\`, \`onTouchStart\`, \`onTransitionEnd\`, \`onTransitionStart\`, \`onWheel\`, \`ref\`, \`tabIndex\`.
       `}
     />
     <MainSection.Subsection
-      title="gestalt/no-dangerous-style-duplicates"
+      title="gestalt/no-box-useless-props"
       description={`
-        Prevent using dangerouslySetInlineStyle on Box for props that are already directly implemented. Box supports some props already that are not widely known and instead are being implemented with dangerouslySetInlineStyle. This linter checks for usage of already available props as dangerous styles and suggests the alternative.
+        Prevent useless props combinations on Box in two categories:
+
+        * alignContent, alignItems, direction, justifyContent, or wrap (and, if applicable, their respective responsive props) without display="flex"
+        * fit and maxWidth used together, since fit sets maxWidth under the hood
       `}
     />
     <MainSection.Subsection
       title="gestalt/no-medium-formfields"
       description={`
         Disallow medium form fields. In order to have consistent form fields in production, we update all of their sizes to large and disallow medium.
+      `}
+    />
+  </MainSection>,
+);
+
+card(
+  <MainSection name="Deprecated rules">
+    <MainSection.Subsection
+      title="gestalt/no-box-marginleft-marginright"
+      description={`
+        Disallow marginLeft/marginRight on Box. In order to have consistent usage of marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd.
       `}
     />
     <MainSection.Subsection

--- a/docs/src/Eslint Plugin.doc.js
+++ b/docs/src/Eslint Plugin.doc.js
@@ -15,7 +15,10 @@ card(
 );
 
 card(
-  <MainSection name="Gestalt alternatives">
+  <MainSection
+    name="Gestalt alternatives"
+    description="The following Eslint rules provide guidance on how to replace native HTML elements and attributes with available Gestalt equivalents"
+  >
     <MainSection.Subsection
       title="gestalt/no-dangerous-style-duplicates"
       description={`
@@ -32,7 +35,10 @@ card(
 );
 
 card(
-  <MainSection name="Gestalt restrictions">
+  <MainSection
+    name="Gestalt restrictions"
+    description="The following Eslint rules restrict the usage of Gestalt component props to enforce design consistency and code safety anf best practices."
+  >
     <MainSection.Subsection
       title="gestalt/button-icon-restrictions"
       description={`
@@ -45,8 +51,8 @@ card(
     <MainSection.Subsection
       title="gestalt/no-box-disallowed-props"
       description={`
-        Prevent props different from 
-        * the officially-supported Box props 
+        Prevent props different from
+        * the officially-supported Box props
         * the following list of passthrough React / DOM props: \`id\`, \`key\`,\`onAnimationEnd\`, \`onAnimationIteration\`, \`onAnimationStart\`, \`onBlur\`, \`onClick\`, \`onContextMenu\`, \`onDblClick\`, \`onDoubleClick\`, \`onDrag\`, \`onDragEnd\`, \`onDragEnter\`, \`onDragExit\`, \`onDragLeave\`, \`onDragOver\`, \`onDragStart\`, \`onDrop\`, \`onFocus\`, \`onKeyDown\`, \`onKeyPress\`, \`onKeyUp\`, \`onMouseDown\`, \`onMouseEnter\`, \`onMouseLeave\`, \`onMouseMove\`, \`onMouseOut\`, \`onMouseOver\`, \`onMouseUp\`, \`onScroll\`, \`onSelect\`, \`onTouchCancel\`, \`onTouchEnd\`, \`onTouchMove\`, \`onTouchStart\`, \`onTransitionEnd\`, \`onTransitionStart\`, \`onWheel\`, \`ref\`, \`tabIndex\`.
       `}
     />
@@ -63,23 +69,6 @@ card(
       title="gestalt/no-medium-formfields"
       description={`
         Disallow medium form fields. In order to have consistent form fields in production, we update all of their sizes to large and disallow medium.
-      `}
-    />
-  </MainSection>,
-);
-
-card(
-  <MainSection name="Deprecated rules">
-    <MainSection.Subsection
-      title="gestalt/no-box-marginleft-marginright"
-      description={`
-        Disallow marginLeft/marginRight on Box. In order to have consistent usage of marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd.
-      `}
-    />
-    <MainSection.Subsection
-      title="gestalt/no-role-link-components"
-      description={`
-        Do not allow role=&apos;link&apos; on Button, TapArea, and IconButton in cases where an alternative with additional functionality must be used instead such as for use with a routing library
       `}
     />
   </MainSection>,
@@ -163,6 +152,30 @@ card(
     Every commit to master performs a release. See the main docs [releasing information](/Installation#Releasing) for more details.
   `}
   />,
+);
+
+card(
+  <MainSection
+    name="Deprecated ESlint rules"
+    description="The following Eslint rules are no longer needed."
+  >
+    <MainSection.Subsection
+      title="gestalt/no-box-marginleft-marginright"
+      description={`
+        Disallow marginLeft/marginRight on Box. In order to have consistent usage of marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd.
+
+        Deprecation due to: deprecated props.
+      `}
+    />
+    <MainSection.Subsection
+      title="gestalt/no-role-link-components"
+      description={`
+        Do not allow role=&apos;link&apos; on Button, TapArea, and IconButton in cases where an alternative with additional functionality must be used instead such as for use with a routing library.
+
+        Deprecation due to: [OnLinkNavigationProvider](/OnLinkNavigationProvider) enables external link navigation in Gestalt components.
+      `}
+    />
+  </MainSection>,
 );
 
 export default cards;

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
@@ -12,9 +12,12 @@
 // @flow strict
 const rule = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Button icon restrictions',
+      category: 'Gestalt restrictions',
       recommended: false,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltbutton-icon-restrictions',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js
@@ -1,8 +1,10 @@
 /**
- * Error on disallowed props on `Box`
+ * @fileoverview Error on disallowed props on `Box`
+ * @author Ryan James <rjames@pinterest.com>
  */
 
 // @flow strict
+
 const allowedBaseProps = [
   // React / DOM
   'id',
@@ -130,9 +132,12 @@ const errorMessage = (props: $ReadOnlyArray<string>, localBoxName: string): stri
 
 const rule = {
   meta: {
+    type: 'suggestion',
     docs: {
-      description: 'Do no allow certain props on Box',
+      description: `Don't allow props different from the officially-supported Box props and the allowed-list of passthrough React / DOM props`,
+      category: 'Gestalt restrictions',
       recommended: false,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-box-disallowed-props',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
@@ -23,10 +23,13 @@ export const errorMessage =
 
 const rule = {
   meta: {
+    type: 'suggestion',
     docs: {
       description:
         'Enforce usage of Right-to-Left (RTL)-compliant marginStart/marginEnd over marginLeft/marginRight',
+      category: 'Deprecated rules',
       recommended: false,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-box-marginleft-marginright',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
@@ -27,7 +27,7 @@ const rule = {
     docs: {
       description:
         'Enforce usage of Right-to-Left (RTL)-compliant marginStart/marginEnd over marginLeft/marginRight',
-      category: 'Deprecated rules',
+      category: 'Deprecated ESlint rules',
       recommended: false,
       url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-box-marginleft-marginright',
     },

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
@@ -1,9 +1,9 @@
-// @flow strict
-
 /**
- * Error on useless props on `Box`
+ * @fileoverview Error on useless props on `Box`
+ * @author Ryan James <rjames@pinterest.com>
  */
 
+// @flow strict
 export const errorMessages = {
   fit: '`fit` sets `maxWidth`, so `maxWidth` should not be specified when `fit` is used',
   flex:
@@ -20,9 +20,12 @@ const flexPropNames = ['direction', `smDirection`, `mdDirection`, `lgDirection`,
 
 const rule = {
   meta: {
+    type: 'suggestion',
     docs: {
-      description: 'Do not allow useless props combinations on Box',
+      description: `Don't allow useless props combinations on Box`,
+      category: 'Gestalt restrictions',
       recommended: false,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-box-useless-props',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-dangerous-style-duplicates.js
+++ b/packages/eslint-plugin-gestalt/src/no-dangerous-style-duplicates.js
@@ -58,10 +58,13 @@ const overflowLookup = {
 
 const rule = {
   meta: {
+    type: 'suggestion',
     docs: {
       description:
         'Prevent using dangerouslySetInlineStyle on Box for props that are already directly implemented',
+      category: 'Gestalt alternatives',
       recommended: false,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-dangerous-style-duplicates',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
+++ b/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
@@ -8,9 +8,12 @@
 // @flow strict
 const rule = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Disallow medium form fields',
+      category: 'Gestalt restrictions',
       recommended: false,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-medium-formfields',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-role-link-components.js
+++ b/packages/eslint-plugin-gestalt/src/no-role-link-components.js
@@ -9,9 +9,12 @@
 // @flow strict
 const rule = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Disallow role-link on Gestalt components',
+      category: 'Deprecated rules',
       recommended: false,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-role-link-components',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-role-link-components.js
+++ b/packages/eslint-plugin-gestalt/src/no-role-link-components.js
@@ -12,7 +12,7 @@ const rule = {
     type: 'suggestion',
     docs: {
       description: 'Disallow role-link on Gestalt components',
-      category: 'Deprecated rules',
+      category: 'Deprecated ESlint rules',
       recommended: false,
       url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-role-link-components',
     },

--- a/packages/eslint-plugin-gestalt/src/prefer-box.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box.js
@@ -27,9 +27,12 @@ function getVariableDefinedStyles(ref) {
 
 const rule = {
   meta: {
+    type: 'suggestion',
     docs: {
-      description: 'linter checks for usage of inline styling that is available as Box props',
+      description: 'Warns over div inline styling that is already available as Box props',
+      category: 'Gestalt alternatives',
       recommended: false,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltprefer-box',
     },
     schema: [
       {


### PR DESCRIPTION
### Summary

Updates Eslint Plugin guidelines page in Docs with missing rules to Docs
Categorizes rules in 
- Gestalt alternatives
- Gestalt restrictions
- Deprecated rules

## BEFORE
![image](https://user-images.githubusercontent.com/10593890/127400486-4d3306ed-d090-4f95-95d8-692241a9605c.png)

## AFTER
![image](https://user-images.githubusercontent.com/10593890/127402250-1582df30-87af-4ed2-882d-8af75ce6cf50.png)

Standardize rule config to follow:
```
meta: {
    type: 'suggestion',
    docs: {
      description: '____',
      category: 'Gestalt restrictions',
      recommended: false,
      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#_________',
    },
```

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
