### PR TITLE
Eslint Plugin: Add missing ComboBox to "no-medium-formfields" Eslint rule

### DIFF
--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/invalid/invalid-combobox-default.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/invalid/invalid-combobox-default.js
@@ -1,0 +1,5 @@
+import { ComboBox } from 'gestalt';
+
+export default function TestElement() {
+  return <ComboBox />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/invalid/invalid-combobox-medium.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/invalid/invalid-combobox-medium.js
@@ -1,0 +1,5 @@
+import { ComboBox } from 'gestalt';
+
+export default function TestElement() {
+  return <ComboBox size="md" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/invalid/invalid-combobox-renamed.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/invalid/invalid-combobox-renamed.js
@@ -1,0 +1,5 @@
+import { ComboBox as GestaltComboBox } from 'gestalt';
+
+export default function TestElement() {
+  return <GestaltComboBox size="md" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/valid.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-medium-formfields/valid.js
@@ -1,5 +1,12 @@
-import { TextField } from 'gestalt';
+import { Box, ComboBox, TextField, SelectList, SearchField } from 'gestalt';
 
 export default function TestElement() {
-  return <TextField size="lg" />;
-}
+  return (
+    <Box>
+      <ComboBox size="lg" />
+      <TextField size="lg" />
+      <SelectList size="lg" />
+      <SearchField size="lg" />
+    </Box>
+  )
+};

--- a/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
+++ b/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
@@ -24,7 +24,7 @@ const rule = {
   create(context: Object): Object {
     let importedComponent = false;
     let localIdentifierName;
-    const componentNames = ['SearchField', 'SelectList', 'TextField'];
+    const componentNames = ['SearchField', 'SelectList', 'TextField', 'ComboBox'];
 
     return {
       ImportDeclaration(decl) {

--- a/packages/eslint-plugin-gestalt/src/no-medium-formfields.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-medium-formfields.test.js
@@ -18,6 +18,24 @@ const validCode = readFileSync(
   path.resolve(__dirname, './__fixtures__/no-medium-formfields/valid.js'),
   'utf-8',
 );
+const invalidComboBoxDefault = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/no-medium-formfields/invalid/invalid-combobox-default.js',
+  ),
+  'utf-8',
+);
+const invalidComboBoxMedium = readFileSync(
+  path.resolve(__dirname, './__fixtures__/no-medium-formfields/invalid/invalid-combobox-medium.js'),
+  'utf-8',
+);
+const invalidComboBoxRenamed = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/no-medium-formfields/invalid/invalid-combobox-renamed.js',
+  ),
+  'utf-8',
+);
 const invalidTextfieldDefault = readFileSync(
   path.resolve(
     __dirname,
@@ -65,6 +83,9 @@ ruleTester.run('no-medium-formfields', rule, {
     invalidTextfieldDefault,
     invalidTextfieldMedium,
     invalidTextfieldRenamed,
+    invalidComboBoxDefault,
+    invalidComboBoxMedium,
+    invalidComboBoxRenamed,
     invalidSearchFieldDefault,
     invalidSelectListDefault,
   ].map((code) => ({


### PR DESCRIPTION
Eslint Plugin: Add missing ComboBox to "no-medium-formfields" Eslint rule

"ComboBox" is part of the form field family. 
Tests upgraded as well.

### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
