### PR TITLE
Upsell: Fix Upsell.Form onSubmit API to match convention

### DIFF
--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -120,7 +120,7 @@ card(
       {
         name: 'onSubmit',
         type:
-          '(SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>) => void',
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
         required: true,
         description: `Actions to perform when the form has been submitted.`,
       },
@@ -672,7 +672,8 @@ function Example(props) {
         defaultCode={`
 function FormExample(props) {
   const [value, setValue] = React.useState('');
-  const handleSubmit = () => {
+  const handleSubmit = ({ event }) => {
+    event.preventDefault();
     // your submit logic using state values
   };
 
@@ -713,7 +714,8 @@ function FormExample(props) {
 function Example(props) {
   const [nameValue, setNameValue] = React.useState('');
   const [emailValue, setEmailValue] = React.useState('');
-  const handleSubmit = () => {
+  const handleSubmit = ({ event }) => {
+    event.preventDefault();
     // your submit logic using state values
   };
 
@@ -810,13 +812,6 @@ function OnNavigation() {
     }
   }
 
-  const linkProps = {
-    accessibilityLabel: 'Send ads credit',
-    href: "https://pinterest.com",
-    onClick: onClickHandler,
-    target:"blank",
-  }
-
   return (
     <OnLinkNavigationProvider onNavigation={onNavigation}>
       <Flex direction="column" gap={2}>
@@ -860,8 +855,12 @@ function OnNavigation() {
           message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
           title="Give $30, get $60 in ads credit"
           primaryAction={
-            { ...linkProps,
-              label: 'Send invite'
+            {
+              accessibilityLabel: 'Send ads credit',
+              href: "https://pinterest.com",
+              label: 'Send invite',
+              onClick: onClickHandler,
+              target:"blank",
             }}
         />
       </Flex>

--- a/docs/src/Upsell.doc.js
+++ b/docs/src/Upsell.doc.js
@@ -47,8 +47,8 @@ card(
     props={[
       {
         name: 'children',
-        type: 'typeof UpsellForm',
-        description: `To create forms within Upsell, pass an Upsell.Form as children`,
+        type: 'typeof Upsell.Form',
+        description: `To create forms within Upsell, pass Upsell.Form as children`,
       },
       {
         name: 'dismissButton',
@@ -120,7 +120,7 @@ card(
       {
         name: 'onSubmit',
         type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> }) => void',
+          '({| event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> |}) => void',
         required: true,
         description: `Actions to perform when the form has been submitted.`,
       },

--- a/packages/gestalt/src/UpsellForm.js
+++ b/packages/gestalt/src/UpsellForm.js
@@ -32,7 +32,7 @@ export default function UpsellForm({
   const responsiveMinWidth = useResponsiveMinWidth();
 
   return (
-    <form onSubmit={onSubmit} style={{ width: '100%' }}>
+    <form onSubmit={(event) => onSubmit({ event })} style={{ width: '100%' }}>
       <Flex
         gap={2}
         direction={responsiveMinWidth === 'xs' ? 'column' : 'row'}


### PR DESCRIPTION
Typically our handlers are `({ event }) => {}`. Upsell.Form's onSubmit is `(event) => {}`. This PR fixes that handler's arguments to match our convention.