### PR TITLE
Video: add backgroundColor prop

### DIFF
--- a/docs/pages/video.js
+++ b/docs/pages/video.js
@@ -43,6 +43,12 @@ card(
         href: 'videoControlsExample',
       },
       {
+        name: 'backgroundColor',
+        type: "'black' | 'transparent'",
+        description: "Background color used to fill the video's placeholder",
+        defaultValue: 'black',
+      },
+      {
         name: 'accessibilityPauseLabel',
         type: 'string',
         description: 'Accessibility label for the pause button if controls are shown',

--- a/packages/gestalt/src/Video.css
+++ b/packages/gestalt/src/Video.css
@@ -8,7 +8,6 @@
 .player {
   composes: relative from "./Layout.css";
   composes: xsCol12 from "./Column.css";
-  composes: blackBg from "./Colors.css";
 }
 
 .playhead {

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -19,6 +19,7 @@ type Source =
 
 type ObjectFit = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
 type CrossOrigin = 'anonymous' | 'use-credentials';
+type BackgroundColor = 'black' | 'transparent';
 
 type Props = {|
   accessibilityHideCaptionsLabel?: string,
@@ -30,7 +31,7 @@ type Props = {|
   accessibilityPlayLabel: string,
   accessibilityUnmuteLabel: string,
   aspectRatio: number,
-  backgroundColor: 'black' | 'transparent',
+  backgroundColor: BackgroundColor,
   captions: string,
   crossOrigin?: CrossOrigin,
   children?: Node,
@@ -190,7 +191,10 @@ export default class Video extends PureComponent<Props, State> {
     accessibilityPlayLabel: PropTypes.string,
     accessibilityUnmuteLabel: PropTypes.string,
     aspectRatio: PropTypes.number.isRequired,
-    backgroundColor: PropTypes.oneOf(['black', 'transparent']),
+    backgroundColor: (PropTypes.oneOf([
+      'black',
+      'transparent',
+    ]): React$PropType$Primitive<BackgroundColor>),
     captions: PropTypes.string.isRequired,
     children: PropTypes.node,
     crossOrigin: PropTypes.oneOf(['use-credentials', 'anonymous']),
@@ -232,7 +236,7 @@ export default class Video extends PureComponent<Props, State> {
 
   static defaultProps: {|
     disableRemotePlayback: boolean,
-    backgroundColor: 'black' | 'transparent',
+    backgroundColor: BackgroundColor,
     playbackRate: number,
     playing: boolean,
     preload: 'auto' | 'metadata' | 'none',

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -1,11 +1,12 @@
 // @flow strict
 import type { Node } from 'react';
-
+import classnames from 'classnames';
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import VideoControls from './VideoControls.js';
 import ColorSchemeProvider from './contexts/ColorScheme.js';
 import styles from './Video.css';
+import colors from './Colors.css';
 import Box from './Box.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
@@ -29,6 +30,7 @@ type Props = {|
   accessibilityPlayLabel: string,
   accessibilityUnmuteLabel: string,
   aspectRatio: number,
+  backgroundColor: 'black' | 'transparent',
   captions: string,
   crossOrigin?: CrossOrigin,
   children?: Node,
@@ -188,6 +190,7 @@ export default class Video extends PureComponent<Props, State> {
     accessibilityPlayLabel: PropTypes.string,
     accessibilityUnmuteLabel: PropTypes.string,
     aspectRatio: PropTypes.number.isRequired,
+    backgroundColor: PropTypes.oneOf(['black', 'transparent']),
     captions: PropTypes.string.isRequired,
     children: PropTypes.node,
     crossOrigin: PropTypes.oneOf(['use-credentials', 'anonymous']),
@@ -229,12 +232,14 @@ export default class Video extends PureComponent<Props, State> {
 
   static defaultProps: {|
     disableRemotePlayback: boolean,
+    backgroundColor: 'black' | 'transparent',
     playbackRate: number,
     playing: boolean,
     preload: 'auto' | 'metadata' | 'none',
     volume: number,
   |} = {
     disableRemotePlayback: false,
+    backgroundColor: 'black',
     playbackRate: 1,
     playing: false,
     preload: 'auto',
@@ -561,6 +566,7 @@ export default class Video extends PureComponent<Props, State> {
   render(): Node {
     const {
       aspectRatio,
+      backgroundColor,
       captions,
       children,
       crossOrigin,
@@ -576,10 +582,15 @@ export default class Video extends PureComponent<Props, State> {
     } = this.props;
     const { currentTime, duration, fullscreen, captionsButton } = this.state;
     const paddingBottom = (fullscreen && '0') || `${(1 / aspectRatio) * 100}%`;
+
+    const playerClasses = classnames(styles.player, {
+      [colors.blackBg]: backgroundColor === 'black',
+      [colors.transparentBg]: backgroundColor === 'transparent',
+    });
     return (
       <div
         ref={this.setPlayerRef}
-        className={styles.player}
+        className={playerClasses}
         style={{ paddingBottom, height: fullscreen ? '100%' : 0 }}
       >
         <ColorSchemeProvider id="Video" colorScheme="light">

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Video with callbacks 1`] = `
 <div
-  className="player"
+  className="player blackBg"
   style={
     Object {
       "height": 0,
@@ -75,7 +75,7 @@ exports[`Video with callbacks 1`] = `
 
 exports[`Video with children 1`] = `
 <div
-  className="player"
+  className="player blackBg"
   style={
     Object {
       "height": 0,
@@ -364,7 +364,7 @@ exports[`Video with children 1`] = `
 
 exports[`Video with crossOrigin 1`] = `
 <div
-  className="player"
+  className="player blackBg"
   style={
     Object {
       "height": 0,
@@ -438,7 +438,7 @@ exports[`Video with crossOrigin 1`] = `
 
 exports[`Video with media attributes 1`] = `
 <div
-  className="player"
+  className="player blackBg"
   style={
     Object {
       "height": 0,
@@ -512,7 +512,7 @@ exports[`Video with media attributes 1`] = `
 
 exports[`Video with multiple sources 1`] = `
 <div
-  className="player"
+  className="player blackBg"
   style={
     Object {
       "height": 0,
@@ -592,7 +592,7 @@ exports[`Video with multiple sources 1`] = `
 
 exports[`Video with objectFit 1`] = `
 <div
-  className="player"
+  className="player blackBg"
   style={
     Object {
       "height": 0,
@@ -670,7 +670,7 @@ exports[`Video with objectFit 1`] = `
 
 exports[`Video with source 1`] = `
 <div
-  className="player"
+  className="player blackBg"
   style={
     Object {
       "height": 0,


### PR DESCRIPTION
Add backgroundColor prop to fill the video's placeholder
Previously black color by default, now we can pass an alternative color: transparent.

This provides a fix for Box/Mask: Box/Mask containing Video shows unexpected corner border when hiding overflowing content
![image](https://user-images.githubusercontent.com/10593890/128248302-b4d2ef9d-afc8-4280-a163-f9c97889386e.png)

Fixes bugs:
- https://jira.pinadmin.com/browse/BUG-123359

BEFORE 
![image](https://user-images.githubusercontent.com/10593890/128253024-30ad6056-f568-402e-9fbd-9e19a8b71f7f.png)
AFTER
![image](https://user-images.githubusercontent.com/10593890/128253072-c23ad33c-dda8-4193-8687-1a5ee5460edf.png)

BEFORE
![image](https://user-images.githubusercontent.com/10593890/128253273-344e91e4-e20f-4875-b4be-359ff71070d1.png)
AFTER
![image](https://user-images.githubusercontent.com/10593890/128253238-ae01b890-d964-492d-8dcd-dbeb7263a67b.png)

### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
