### PR TITLE
Text: Remove `truncate`, document `lineClamp`

### DIFF
--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -48,6 +48,13 @@ card(
         href: 'styles',
       },
       {
+        name: 'lineClamp',
+        type: 'number',
+        description:
+          'Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string.',
+        href: 'overflow',
+      },
+      {
         name: 'overflow',
         type: `"normal" | "breakWord" | "noWrap"`,
         defaultValue: 'breakWord',
@@ -59,14 +66,6 @@ card(
         description: `sm: 12px, md: 14px, lg: 16px`,
         defaultValue: 'lg',
         href: 'size',
-      },
-      {
-        name: 'truncate',
-        type: 'boolean',
-        description:
-          'Truncate the text to a single line. Add the title attribute if `<Text>` only contains text.',
-        href: 'overflow',
-        defaultValue: false,
       },
       {
         name: 'underline',
@@ -166,8 +165,8 @@ card(
     This is a long and Supercalifragilisticexpialidocious sentence.
   </Text>
 
-  <Text weight="bold">truncate:</Text>
-  <Text truncate>
+  <Text weight="bold">lineClamp:</Text>
+  <Text lineClamp={2}>
     This is a long and Supercalifragilisticexpialidocious sentence.
   </Text>
 </Flex>

--- a/docs/src/Text.doc.js
+++ b/docs/src/Text.doc.js
@@ -51,7 +51,7 @@ card(
         name: 'lineClamp',
         type: 'number',
         description:
-          'Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string.',
+          'Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers.',
         href: 'overflow',
       },
       {

--- a/packages/gestalt-codemods/next/__testfixtures__/text-replace-truncate-lineClamp-renamed.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/text-replace-truncate-lineClamp-renamed.input.js
@@ -1,0 +1,14 @@
+// @flow strict
+import { Box, Text as GestaltText } from 'gestalt';
+
+export default function TestBox() {
+  return (
+    <Box>
+      <GestaltText />
+      <GestaltText truncate />
+      <GestaltText truncate={false} />
+      <GestaltText truncate={null} />
+      <GestaltText truncate={undefined} />
+    </Box>
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/text-replace-truncate-lineClamp-renamed.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/text-replace-truncate-lineClamp-renamed.output.js
@@ -1,0 +1,14 @@
+// @flow strict
+import { Box, Text as GestaltText } from 'gestalt';
+
+export default function TestBox() {
+  return (
+    <Box>
+      <GestaltText />
+      <GestaltText lineClamp={1} />
+      <GestaltText />
+      <GestaltText />
+      <GestaltText />
+    </Box>
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/text-replace-truncate-lineClamp.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/text-replace-truncate-lineClamp.input.js
@@ -1,0 +1,14 @@
+// @flow strict
+import { Box, Text } from 'gestalt';
+
+export default function TestBox() {
+  return (
+    <Box>
+      <Text />
+      <Text truncate />
+      <Text truncate={false} />
+      <Text truncate={null} />
+      <Text truncate={undefined} />
+    </Box>
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/text-replace-truncate-lineClamp.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/text-replace-truncate-lineClamp.output.js
@@ -1,0 +1,14 @@
+// @flow strict
+import { Box, Text } from 'gestalt';
+
+export default function TestBox() {
+  return (
+    <Box>
+      <Text />
+      <Text lineClamp={1} />
+      <Text />
+      <Text />
+      <Text />
+    </Box>
+  );
+}

--- a/packages/gestalt-codemods/next/__tests__/text-replace-truncate-lineClamp.test.js
+++ b/packages/gestalt-codemods/next/__tests__/text-replace-truncate-lineClamp.test.js
@@ -1,0 +1,13 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../text-replace-truncate-lineClamp', () => {
+  return Object.assign(jest.requireActual('../text-replace-truncate-lineClamp'), {
+    parser: 'flow',
+  });
+});
+
+describe('text-replace-truncate-lineClamp', () => {
+  ['text-replace-truncate-lineClamp'].forEach((test) => {
+    defineTest(__dirname, 'text-replace-truncate-lineClamp', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/next/text-replace-truncate-lineClamp.js
+++ b/packages/gestalt-codemods/next/text-replace-truncate-lineClamp.js
@@ -1,0 +1,89 @@
+/*
+ * Converts
+ *  <Text truncate /> to <Text lineClamp={1} />
+ *  <Text truncate={truncate} /> to CONSOLE.LOG for manual change />
+ */
+
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/next/text-replace-truncate-lineClamp.js relative/path/to/your/code
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    // Not Gestalt, bail
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    // Find the local names of Text imports
+    localIdentifierName = decl.specifiers
+      .filter((node) => node.imported.name === 'Text')
+      .map((node) => node.local.name);
+    return null;
+  });
+
+  // No Text imports, bail
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove dynamic Text properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+
+      const newAttrs = attrs
+        .map((attr) => {
+          const propName = attr?.name?.name;
+
+          // Not truncate, bail
+          if (propName !== 'truncate') {
+            return attr;
+          }
+
+          const propValue = attr?.value?.expression?.value;
+          const propValueVariableName = attr?.value?.expression?.name;
+
+          // If explicitly set to false or undefined the prop isn't actually doing anything and can be removed
+          if (propValue === false || propValue === null || propValueVariableName === 'undefined') {
+            return null;
+          }
+
+          if (typeof propValueVariableName === 'string') {
+            // eslint-disable-next-line no-console
+            console.log(
+              `${node.openingElement.name.name} components with ${attr?.name?.name} prop must be converted to lineClamp manually (boolean -> number). Location: ${file.path} @line: ${node.loc.start.line}`,
+            );
+          }
+          const renamedAttr = { ...attr };
+          renamedAttr.name.name = 'lineClamp';
+          renamedAttr.value = j.jsxExpressionContainer(j.numericLiteral(1));
+          return renamedAttr;
+        })
+        .filter(Boolean);
+
+      fileHasModifications = true;
+      node.openingElement.attributes = newAttrs;
+
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -344,7 +344,7 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
                 ))
               ) : (
                 <Box width="100%" paddingX={2} paddingY={4}>
-                  <Text truncate color="gray">
+                  <Text lineClamp={1} color="gray">
                     {noResultText}
                   </Text>
                 </Box>

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -61,7 +61,7 @@ export default function ModuleExpandableItem({
                 <Box column={6} marginStart={6}>
                   <Flex direction="column" gap={2}>
                     {summary.map((item, i) => (
-                      <Text key={i} size="md" truncate>
+                      <Text key={i} size="md" lineClamp={1}>
                         {item}
                       </Text>
                     ))}

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -43,7 +43,7 @@ export default function ModuleTitle({
       )}
 
       <Flex.Item minWidth={0}>
-        <Text color={color} truncate weight="bold">
+        <Text color={color} lineClamp={1} weight="bold">
           {title}
         </Text>
       </Flex.Item>

--- a/packages/gestalt/src/OptionItem.js
+++ b/packages/gestalt/src/OptionItem.js
@@ -94,7 +94,12 @@ const OptionItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = f
         <Flex alignItems="center">
           {children || (
             <Fragment>
-              <Text truncate={shouldTruncate} weight={textWeight} color="darkGray" inline>
+              <Text
+                color="darkGray"
+                inline
+                lineClamp={shouldTruncate ? 1 : undefined}
+                weight={textWeight}
+              >
                 {option?.label}
               </Text>
               {badgeText && (

--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -38,7 +38,7 @@ export default function PageHeader({
             </Heading>
             {subtext && (
               <Box marginTop={2}>
-                <Text truncate>{subtext}</Text>
+                <Text lineClamp={1}>{subtext}</Text>
               </Box>
             )}
           </Box>

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -65,12 +65,9 @@ type Props = {|
   color?: Color,
   inline?: boolean,
   italic?: boolean,
-  // Undocumented prop for now.
-  // Will replace `truncate` if experiment ships
   lineClamp?: number,
   overflow?: Overflow,
   size?: Size,
-  truncate?: boolean,
   underline?: boolean,
   weight?: FontWeight,
 |};
@@ -87,7 +84,6 @@ export default function Text({
   lineClamp,
   overflow = 'breakWord',
   size = 'lg',
-  truncate = false,
   underline = false,
   weight = 'normal',
 }: Props): Node {
@@ -109,8 +105,6 @@ export default function Text({
     underline && typography.underline,
     weight === 'bold' && typography.fontWeightBold,
     weight === 'normal' && typography.fontWeightNormal,
-    // `lineClamp` overrides `truncate`
-    truncate && !isNotNullish(lineClamp) && typography.truncate,
     isNotNullish(lineClamp) && typography.lineClamp,
   );
 
@@ -119,9 +113,7 @@ export default function Text({
   return (
     <Tag
       className={cs}
-      title={
-        (truncate || isNotNullish(lineClamp)) && typeof children === 'string' ? children : undefined
-      }
+      title={isNotNullish(lineClamp) && typeof children === 'string' ? children : undefined}
       {...(lineClamp ? { style: { WebkitLineClamp: lineClamp } } : {})}
     >
       {children}
@@ -149,6 +141,5 @@ Text.propTypes = {
     'noWrap',
   ]): React$PropType$Primitive<Overflow>),
   size: (PropTypes.oneOf(['sm', 'md', 'lg']): React$PropType$Primitive<Size>),
-  truncate: PropTypes.bool,
   weight: (PropTypes.oneOf(['bold', 'normal']): React$PropType$Primitive<FontWeight>),
 };

--- a/packages/gestalt/src/Text.test.js
+++ b/packages/gestalt/src/Text.test.js
@@ -17,16 +17,16 @@ test('Text size sm adds the small size class', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Text truncate should add a title when the children are text only', () => {
+test('Text lineClamp should add a title when the children are text only', () => {
   const tree = create(
-    <Text truncate>Shall I compare thee to a summer&#39;s day - William Shakespeare</Text>,
+    <Text lineClamp={1}>Shall I compare thee to a summer&#39;s day - William Shakespeare</Text>,
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-test('Text truncate should not add a title when the children are objects', () => {
+test('Text lineClamp should not add a title when the children are objects', () => {
   const tree = create(
-    <Text truncate>
+    <Text lineClamp={1}>
       <div>Summer reading:</div>
       Shall I compare thee to a summer&#39;s day - William Shakespeare
     </Text>,

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -48,7 +48,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                           class="Flex rowGap0 itemsCenter xsDirectionRow"
                         >
                           <span
-                            class="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                            class="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
                             title="Item 1"
                           >
                             Item 1
@@ -91,7 +91,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                           class="Flex rowGap0 itemsCenter xsDirectionRow"
                         >
                           <span
-                            class="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                            class="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
                             title="Item 2 with a really long, detailed, complex name"
                           >
                             Item 2 with a really long, detailed, complex name
@@ -140,7 +140,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                             class="Flex rowGap0 itemsCenter xsDirectionRow"
                           >
                             <span
-                              class="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                              class="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
                               title="External Item 3 with a really long, detailed, complex name"
                             >
                               External Item 3 with a really long, detailed, complex name
@@ -200,7 +200,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                           class="Flex rowGap0 itemsCenter xsDirectionRow"
                         >
                           <span
-                            class="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                            class="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
                             title="Item 4"
                           >
                             Item 4
@@ -263,7 +263,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                             class="Flex rowGap0 itemsCenter xsDirectionRow"
                           >
                             <span
-                              class="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                              class="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
                               title="Item 5 with a really long, detailed name"
                             >
                               Item 5 with a really long, detailed name
@@ -343,7 +343,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                             class="Flex rowGap0 itemsCenter xsDirectionRow"
                           >
                             <span
-                              class="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                              class="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
                               title="Item 6"
                             >
                               Item 6

--- a/packages/gestalt/src/__snapshots__/Module.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Module.test.js.snap
@@ -23,7 +23,12 @@ exports[`Module renders a badge correctly 1`] = `
           }
         >
           <div
-            className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+            className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+            style={
+              Object {
+                "WebkitLineClamp": 1,
+              }
+            }
             title="Testing"
           >
             Testing
@@ -85,7 +90,12 @@ exports[`Module renders a title correctly 1`] = `
           }
         >
           <div
-            className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+            className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+            style={
+              Object {
+                "WebkitLineClamp": 1,
+              }
+            }
             title="Module Test"
           >
             Module Test
@@ -140,7 +150,12 @@ exports[`Module renders an error correctly 1`] = `
           }
         >
           <div
-            className="Text fontSize3 red alignStart breakWord fontWeightBold truncate"
+            className="Text fontSize3 red alignStart breakWord fontWeightBold lineClamp"
+            style={
+              Object {
+                "WebkitLineClamp": 1,
+              }
+            }
             title="Testing"
           >
             Testing
@@ -201,7 +216,12 @@ exports[`Module renders an icon correctly 1`] = `
           }
         >
           <div
-            className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+            className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+            style={
+              Object {
+                "WebkitLineClamp": 1,
+              }
+            }
             title="Testing"
           >
             Testing

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -56,7 +56,12 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                     }
                   >
                     <div
-                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="Title1"
                     >
                       Title1
@@ -74,7 +79,12 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                     className="FlexItem"
                   >
                     <div
-                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="summary1"
                     >
                       summary1
@@ -161,7 +171,12 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                     }
                   >
                     <div
-                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="Title2"
                     >
                       Title2
@@ -179,7 +194,12 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                     className="FlexItem"
                   >
                     <div
-                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="summary2"
                     >
                       summary2
@@ -283,7 +303,12 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                     }
                   >
                     <div
-                      className="Text fontSize3 red alignStart breakWord fontWeightBold truncate"
+                      className="Text fontSize3 red alignStart breakWord fontWeightBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="Title3"
                     >
                       Title3
@@ -301,7 +326,12 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                     className="FlexItem"
                   >
                     <div
-                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="summary3"
                     >
                       summary3
@@ -392,7 +422,12 @@ exports[`Module Expandable renders correctly with one item 1`] = `
                     }
                   >
                     <div
-                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="Title"
                     >
                       Title
@@ -410,7 +445,12 @@ exports[`Module Expandable renders correctly with one item 1`] = `
                     className="FlexItem"
                   >
                     <div
-                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="summary1"
                     >
                       summary1
@@ -420,7 +460,12 @@ exports[`Module Expandable renders correctly with one item 1`] = `
                     className="FlexItem"
                   >
                     <div
-                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="summary2"
                     >
                       summary2
@@ -430,7 +475,12 @@ exports[`Module Expandable renders correctly with one item 1`] = `
                     className="FlexItem"
                   >
                     <div
-                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="summary3"
                     >
                       summary3
@@ -521,7 +571,12 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                     }
                   >
                     <div
-                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="Title1"
                     >
                       Title1
@@ -613,7 +668,12 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                     }
                   >
                     <div
-                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                      className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="Title2"
                     >
                       Title2
@@ -631,7 +691,12 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                     className="FlexItem"
                   >
                     <div
-                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="summary2"
                     >
                       summary2
@@ -735,7 +800,12 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                     }
                   >
                     <div
-                      className="Text fontSize3 red alignStart breakWord fontWeightBold truncate"
+                      className="Text fontSize3 red alignStart breakWord fontWeightBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="Title3"
                     >
                       Title3
@@ -753,7 +823,12 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                     className="FlexItem"
                   >
                     <div
-                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                      className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 1,
+                        }
+                      }
                       title="summary3"
                     >
                       summary3

--- a/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
@@ -53,7 +53,12 @@ exports[`ModuleExpandableItem renders correctly 1`] = `
                   }
                 >
                   <div
-                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="test title"
                   >
                     test title
@@ -122,7 +127,12 @@ exports[`ModuleExpandableItem renders correctly with badge 1`] = `
                   }
                 >
                   <div
-                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="test title"
                   >
                     test title
@@ -209,7 +219,12 @@ exports[`ModuleExpandableItem renders correctly with children 1`] = `
                   }
                 >
                   <div
-                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="test title"
                   >
                     test title
@@ -295,7 +310,12 @@ exports[`ModuleExpandableItem renders correctly with error 1`] = `
                   }
                 >
                   <div
-                    className="Text fontSize3 red alignStart breakWord fontWeightBold truncate"
+                    className="Text fontSize3 red alignStart breakWord fontWeightBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="test title"
                   >
                     test title
@@ -381,7 +401,12 @@ exports[`ModuleExpandableItem renders correctly with icon 1`] = `
                   }
                 >
                   <div
-                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="test title"
                   >
                     test title
@@ -450,7 +475,12 @@ exports[`ModuleExpandableItem renders correctly with summary 1`] = `
                   }
                 >
                   <div
-                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="test title"
                   >
                     test title
@@ -468,7 +498,12 @@ exports[`ModuleExpandableItem renders correctly with summary 1`] = `
                   className="FlexItem"
                 >
                   <div
-                    className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                    className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="summary1"
                   >
                     summary1
@@ -478,7 +513,12 @@ exports[`ModuleExpandableItem renders correctly with summary 1`] = `
                   className="FlexItem"
                 >
                   <div
-                    className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                    className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="summary2"
                   >
                     summary2
@@ -488,7 +528,12 @@ exports[`ModuleExpandableItem renders correctly with summary 1`] = `
                   className="FlexItem"
                 >
                   <div
-                    className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal truncate"
+                    className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="summary3"
                   >
                     summary3
@@ -557,7 +602,12 @@ exports[`ModuleExpandableItem renders correctly with when expanded 1`] = `
                   }
                 >
                   <div
-                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold truncate"
+                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
                     title="test title"
                   >
                     test title

--- a/packages/gestalt/src/__snapshots__/PageHeader.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/PageHeader.test.js.snap
@@ -274,7 +274,12 @@ exports[`PageHeader renders subtext 1`] = `
           className="box marginTop2"
         >
           <div
-            className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal truncate"
+            className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal lineClamp"
+            style={
+              Object {
+                "WebkitLineClamp": 1,
+              }
+            }
             title="5 followers"
           >
             5 followers
@@ -329,7 +334,12 @@ exports[`PageHeader renders within a max width 1`] = `
           className="box marginTop2"
         >
           <div
-            className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal truncate"
+            className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal lineClamp"
+            style={
+              Object {
+                "WebkitLineClamp": 1,
+              }
+            }
             title="5 followers"
           >
             5 followers

--- a/packages/gestalt/src/__snapshots__/Text.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Text.test.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Text lineClamp should add a title when the children are text only 1`] = `
+<div
+  className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal lineClamp"
+  style={
+    Object {
+      "WebkitLineClamp": 1,
+    }
+  }
+  title="Shall I compare thee to a summer's day - William Shakespeare"
+>
+  Shall I compare thee to a summer's day - William Shakespeare
+</div>
+`;
+
+exports[`Text lineClamp should not add a title when the children are objects 1`] = `
+<div
+  className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal lineClamp"
+  style={
+    Object {
+      "WebkitLineClamp": 1,
+    }
+  }
+>
+  <div>
+    Summer reading:
+  </div>
+  Shall I compare thee to a summer's day - William Shakespeare
+</div>
+`;
+
 exports[`Text orange adds the orange color class 1`] = `
 <div
   className="Text fontSize3 orange alignStart breakWord fontWeightNormal"
@@ -16,24 +46,4 @@ exports[`Text size sm adds the small size class 1`] = `
 <div
   className="Text fontSize1 darkGray alignStart breakWord fontWeightNormal"
 />
-`;
-
-exports[`Text truncate should add a title when the children are text only 1`] = `
-<div
-  className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal truncate"
-  title="Shall I compare thee to a summer's day - William Shakespeare"
->
-  Shall I compare thee to a summer's day - William Shakespeare
-</div>
-`;
-
-exports[`Text truncate should not add a title when the children are objects 1`] = `
-<div
-  className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal truncate"
->
-  <div>
-    Summer reading:
-  </div>
-  Shall I compare thee to a summer's day - William Shakespeare
-</div>
 `;


### PR DESCRIPTION
We previously added an undocumented `lineClamp` prop to Text, allowing us to use `-webkit-line-clamp`. After running [an experiment in Pinboard](https://helium.pinadmin.com/web_pin_rep_line_clamp), we've determined that replacing `truncate` with `lineClamp={1}` will not have detrimental metrics effects.

This PR removes `truncate` and adds documentation for `lineClamp`. It also includes a codemod to transform `<Text truncate />` to `<Text lineClamp={1} />`.