### PR TITLE
Eslint plugin: prefer-box-as-tag rule w/ autofix

### DIFF
--- a/docs/src/Eslint Plugin.doc.js
+++ b/docs/src/Eslint Plugin.doc.js
@@ -22,20 +22,57 @@ card(
     <MainSection.Subsection
       title="gestalt/no-dangerous-style-duplicates"
       description={`
-        Prevent using dangerouslySetInlineStyle on Box for props that are already directly implemented. Box supports some props already that are not widely known and instead are being implemented with dangerouslySetInlineStyle. This linter checks for usage of already available props as dangerous styles and suggests the alternative.
+        Prevent using dangerouslySetInlineStyle on Box for props that are already directly implemented.
+
+        Box supports some props already that are not widely known and instead are being implemented with dangerouslySetInlineStyle.
+
+        This linter checks for usage of already available props as dangerous styles and suggests the alternative.
+
+        [Learn more about Box](/Box).
       `}
     />
     <MainSection.Subsection
       title="gestalt/prefer-box"
       description={`
         Prevent using \`<div>\` inline styling for attributes that are already implemented in Box.
+
+        [Learn more about Box](/Box).
       `}
     />
     <MainSection.Subsection
       title="gestalt/prefer-box-lonely-ref"
       description={`
-        Prevent \`<div>\` tags used to only contain a \`ref\` attribute. Instead, use \`ref\` props supported in Box or other elements such as Button or TextField.
+        Prevent \`<div>\` tags used to only contain a \`ref\` attribute.
+
+        Instead, use \`ref\` props supported in Box or other elements such as Button or TextField.
+
         With AUTOFIX!
+
+        [Read more about the ref prop in Box](/Box#Using-as-a-ref).
+      `}
+    />
+    <MainSection.Subsection
+      title="gestalt/prefer-box-as-tag"
+      description={`
+        Prefer Box: prevent HTML tags supported in Box through the \`as\` prop.
+
+        Supported tags:
+
+        \`article\`,
+        \`aside\`,
+        \`details\`,
+        \`figcaption\`,
+        \`figure\`,
+        \`footer\`,
+        \`header\`,
+        \`main\`,
+        \`nav\`,
+        \`section\`,
+        \`summary\`.
+
+        With AUTOFIX!
+
+        [Read more about the as prop in Box](/Box#Using-'as'-property).
       `}
     />
   </MainSection>,
@@ -59,7 +96,9 @@ card(
       title="gestalt/no-box-disallowed-props"
       description={`
         Prevent props different from
+
         * the officially-supported Box props
+
         * the following list of passthrough React / DOM props: \`id\`, \`key\`,\`onAnimationEnd\`, \`onAnimationIteration\`, \`onAnimationStart\`, \`onBlur\`, \`onClick\`, \`onContextMenu\`, \`onDblClick\`, \`onDoubleClick\`, \`onDrag\`, \`onDragEnd\`, \`onDragEnter\`, \`onDragExit\`, \`onDragLeave\`, \`onDragOver\`, \`onDragStart\`, \`onDrop\`, \`onFocus\`, \`onKeyDown\`, \`onKeyPress\`, \`onKeyUp\`, \`onMouseDown\`, \`onMouseEnter\`, \`onMouseLeave\`, \`onMouseMove\`, \`onMouseOut\`, \`onMouseOver\`, \`onMouseUp\`, \`onScroll\`, \`onSelect\`, \`onTouchCancel\`, \`onTouchEnd\`, \`onTouchMove\`, \`onTouchStart\`, \`onTransitionEnd\`, \`onTransitionStart\`, \`onWheel\`, \`ref\`, \`tabIndex\`.
       `}
     />
@@ -75,7 +114,10 @@ card(
     <MainSection.Subsection
       title="gestalt/no-spread-props"
       description={`
-        Prevent spreading props in Gestalt components to enable AST codemods and usage-metrics scripts. Instead, write the component's props out.
+        Prevent spreading props in Gestalt components to enable AST codemods and usage-metrics scripts.
+
+        Instead, write the component's props out.
+
         With AUTOFIX!
       `}
     />

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-input.js
@@ -1,0 +1,18 @@
+import { Box } from 'gestalt';
+export default function TestElement() {
+  return (
+    <Box>
+      <article aria-label="test" onMouseEnter={() => {}} width={100}></article>
+      <aside data-test-id="test" aria-label="test"></aside>
+      <details data-test-id="test" aria-label="test"></details>
+      <figcaption data-test-id="test" aria-label="test"></figcaption>
+      <figure data-test-id="test" aria-label="test"></figure>
+      <footer data-test-id="test" aria-label="test"></footer>
+      <header data-test-id="test" aria-label="test"></header>
+      <main data-test-id="test" aria-label="test"></main>
+      <nav data-test-id="test" aria-label="test"></nav>
+      <section data-test-id="test" aria-label="test"></section>
+      <summary data-test-id="test" aria-label="test"></summary>
+    </Box>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-output.js
@@ -1,0 +1,18 @@
+import { Box } from 'gestalt';
+export default function TestElement() {
+  return (
+    <Box>
+      <Box aria-label="test" as="article" onMouseEnter={() => {}} width={100}></Box>
+      <Box aria-label="test" as="aside" data-test-id="test"></Box>
+      <Box aria-label="test" as="details" data-test-id="test"></Box>
+      <Box aria-label="test" as="figcaption" data-test-id="test"></Box>
+      <Box aria-label="test" as="figure" data-test-id="test"></Box>
+      <Box aria-label="test" as="footer" data-test-id="test"></Box>
+      <Box aria-label="test" as="header" data-test-id="test"></Box>
+      <Box aria-label="test" as="main" data-test-id="test"></Box>
+      <Box aria-label="test" as="nav" data-test-id="test"></Box>
+      <Box aria-label="test" as="section" data-test-id="test"></Box>
+      <Box aria-label="test" as="summary" data-test-id="test"></Box>
+    </Box>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-single-tag-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-single-tag-input.js
@@ -1,0 +1,10 @@
+import { Box } from 'gestalt';
+export default function TestElement() {
+  return (
+    <Box>
+      <article />
+      <article></article>
+      <article aria-label="test" onMouseEnter={() => {}} width={100}></article>
+    </Box>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-single-tag-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-single-tag-output.js
@@ -1,0 +1,10 @@
+import { Box } from 'gestalt';
+export default function TestElement() {
+  return (
+    <Box>
+      <Box as="article" />
+      <Box as="article"></Box>
+      <Box aria-label="test" as="article" onMouseEnter={() => {}} width={100}></Box>
+    </Box>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/no-gestalt-import-HTML-single-tag-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/no-gestalt-import-HTML-single-tag-input.js
@@ -1,0 +1,9 @@
+export default function TestElement() {
+  return (
+    <div>
+      <article />
+      <article></article>
+      <article aria-label="test" onMouseEnter={() => {}} width={100}></article>
+    </div>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/no-gestalt-import-HTML-single-tag-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/no-gestalt-import-HTML-single-tag-output.js
@@ -1,0 +1,10 @@
+import { Box } from 'gestalt';
+export default function TestElement() {
+  return (
+    <div>
+      <Box as="article" />
+      <Box as="article"></Box>
+      <Box aria-label="test" as="article" onMouseEnter={() => {}} width={100}></Box>
+    </div>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/valid.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/valid.js
@@ -1,0 +1,9 @@
+import { Box } from 'gestalt';
+export default function TestElement() {
+  return (
+    <Box>
+      <ul />
+      <frame />
+    </Box>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/prefer-box-as-tag.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-as-tag.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Prefer Box: prevent HTML tags supported in Box through the `as` prop
+ */
+
+// @flow strict
+import { getHtmlTag, hasImport, buildProps } from './eslintASTHelpers.js';
+import { renameTagWithPropsFixer, updateGestaltImportFixer } from './eslintASTFixers.js';
+import { type ESLintRule } from './eslintFlowTypes.js';
+
+export const SUPPORTED_HTML_TAGS = [
+  'article',
+  'aside',
+  'details',
+  'figcaption',
+  'figure',
+  'footer',
+  'header',
+  'main',
+  'nav',
+  'section',
+  'summary',
+];
+
+const rule: ESLintRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: `Prefer Box: prevent HTML tags supported in Box through the \`as\` prop: ${SUPPORTED_HTML_TAGS.join(
+        ', ',
+      )}, instead',
+      category: 'Gestalt alternatives`,
+      recommended: true,
+      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltprefer-box-as-tag',
+    },
+    fixable: 'code',
+    schema: ([]: $ReadOnlyArray<empty>),
+    messages: {
+      disallowed: `Use <Box as="{{ tagName }}"></Box>.`,
+    },
+  },
+
+  create(context) {
+    let programNode;
+    let gestaltImportNode;
+    let isImportFixerExecuted = false;
+
+    const importDeclarationFnc = (node) => {
+      if (!node) return;
+
+      const isGestaltImportNode = hasImport({ importNode: node, path: 'gestalt' });
+
+      if (!isGestaltImportNode) return;
+
+      gestaltImportNode = node;
+    };
+
+    const jSXElementFnc = (node) => {
+      const tagName = getHtmlTag({ elementNode: node });
+
+      if (!SUPPORTED_HTML_TAGS.includes(tagName)) return null;
+
+      return context.report({
+        node,
+        messageId: 'disallowed',
+        data: { tagName },
+        fix: (fixer) => {
+          const tagFixers = renameTagWithPropsFixer({
+            additionalPropsString: buildProps({
+              context,
+              elementNode: node,
+              newPropsString: `as="${tagName}"`,
+            }),
+            context,
+            fixer,
+            elementNode: node,
+            newComponentName: 'Box',
+            tagName,
+          });
+
+          const importFixers = updateGestaltImportFixer({
+            context,
+            fixer,
+            gestaltImportNode,
+            newComponentName: 'Box',
+            programNode,
+          });
+
+          const fixers = !isImportFixerExecuted ? [...tagFixers, importFixers] : tagFixers;
+          isImportFixerExecuted = true;
+          return fixers;
+        },
+      });
+    };
+
+    return {
+      Program: (node) => {
+        programNode = node;
+      },
+      ImportDeclaration: importDeclarationFnc,
+      JSXElement: jSXElementFnc,
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-gestalt/src/prefer-box-as-tag.test.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-as-tag.test.js
@@ -1,0 +1,77 @@
+// @flow strict
+import { RuleTester } from 'eslint';
+import { readFileSync } from 'fs';
+import path from 'path';
+import rule, { SUPPORTED_HTML_TAGS } from './prefer-box-as-tag.js';
+import { parserOptions } from './testHelpers.js';
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const validCode = readFileSync(
+  path.resolve(__dirname, './__fixtures__/prefer-box-as-tag/valid.js'),
+  'utf-8',
+);
+
+const gestaltImportHTMLMultipleTagWithPropsInput = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-input.js',
+  ),
+  'utf-8',
+);
+
+const gestaltImportHTMLMultipleTagWithPropsOutput = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-output.js',
+  ),
+  'utf-8',
+);
+
+const gestaltImportHTMLSingleTagInput = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-single-tag-input.js',
+  ),
+  'utf-8',
+);
+
+const gestaltImportHTMLSingleTagOutput = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-single-tag-output.js',
+  ),
+  'utf-8',
+);
+
+const noGestaltImportHTMLSingleTagInput = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/prefer-box-as-tag/invalid/no-gestalt-import-HTML-single-tag-input.js',
+  ),
+  'utf-8',
+);
+
+const noGestaltImportHTMLSingleTagOutput = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/prefer-box-as-tag/invalid/no-gestalt-import-HTML-single-tag-output.js',
+  ),
+  'utf-8',
+);
+
+const multipleErrorMessage = SUPPORTED_HTML_TAGS.map((tag) => `Use <Box as="${tag}"></Box>.`);
+const sameErrorMessage = Array(3).fill(`Use <Box as="article"></Box>.`);
+
+ruleTester.run('prefer-box-as-tag', rule, {
+  valid: [{ code: validCode }],
+  invalid: [
+    [noGestaltImportHTMLSingleTagInput, noGestaltImportHTMLSingleTagOutput, sameErrorMessage],
+    [gestaltImportHTMLSingleTagInput, gestaltImportHTMLSingleTagOutput, sameErrorMessage],
+    [
+      gestaltImportHTMLMultipleTagWithPropsInput,
+      gestaltImportHTMLMultipleTagWithPropsOutput,
+      multipleErrorMessage,
+    ],
+  ].map(([input, output, errors]) => ({ code: input, output, errors })),
+});


### PR DESCRIPTION
### Summary
new Eslint rule:

prefer-box-as-tag: Prefer Box: prevent HTML tags supported in Box through the `as` prop

![Kapture 2021-08-11 at 18 46 55](https://user-images.githubusercontent.com/10593890/129113454-be2f34da-d8ff-4028-813f-d5c957e23e0f.gif)

With Eslint rules, this PR initiates an AST helper library.

Context: Gestalt Tooling Ecosystem Exploration Doc

OTHER REFACTORS TO CLEAN UP / STANDARDIZE TESTS
<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
