### PR TITLE
[Internal] Remove deprecated prettier VSCode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
   "grunt.autoDetect": "off",
   "javascript.validate.enable": false,
   "npm.packageManager": "yarn",
-  "prettier.packageManager": "yarn",
   "typescript.validate.enable": false
 }


### PR DESCRIPTION
`prettier.packageManager` is deprecated
![Screen Shot 2021-08-11 at 6 42 58 AM](https://user-images.githubusercontent.com/127199/129058769-5b97d19b-ea33-4c68-9ea6-430ee52b84fd.png)
