### PR TITLE
[Internal] Automatically launch docs & watcher when you open VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "command": "yarn start",
+      "problemMatcher": [],
+      "label": "Run yarn start on startup",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "runOptions": {
+        "runOn": "folderOpen"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/docs/src/Development.doc.js
+++ b/docs/src/Development.doc.js
@@ -143,7 +143,7 @@ card(
           <ul>
             <li>
               <Text>
-                In VScode type <code>CMD+Shift+p</code>
+                In VSCode type <code>CMD+Shift+p</code>
               </Text>
             </li>
             <li>

--- a/docs/src/Development.doc.js
+++ b/docs/src/Development.doc.js
@@ -138,6 +138,25 @@ card(
             CSS files.
           </Text>
         </li>
+        <li>
+          <Text>If you want to automatically launch the docs when you open VSCode:</Text>
+          <ul>
+            <li>
+              <Text>
+                In VScode type <code>CMD+Shift+p</code>
+              </Text>
+            </li>
+            <li>
+              <Text>Search and select Tasks: &quot;Manage Automatic Tasks in Folder&quot;</Text>
+            </li>
+            <li>
+              <Text>Select Allow &quot;Automatic Tasks in Folder&quot;</Text>
+            </li>
+            <li>
+              <Text>Relaunch VSCode</Text>
+            </li>
+          </ul>
+        </li>
       </ul>
     </Flex>
   </Card>,


### PR DESCRIPTION
### Summary

* Add a VSCode task to launch the docs when you open VSCode.
* Add instructions on how to enable this settings (you only have to do this once)

![vscode-launch-auto-combined](https://user-images.githubusercontent.com/127199/129059392-8a962c28-57c9-47f4-884a-0ed92ff2be70.gif)