### PR TITLE
Lint rules: Add support for dynamic/dangerous styles in `no-box-useless-props`

### DIFF
--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-dangerous.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-dangerous.js
@@ -1,0 +1,7 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Box alignContent="start" dangerouslySetInlineStyle={{ __style: { display: 'flow-root' } }} />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-dynamic-dangerous.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-dynamic-dangerous.js
@@ -1,0 +1,10 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Box
+      alignContent="start"
+      dangerouslySetInlineStyle={{ __style: { display: true ? 'block' : 'flow-root' } }}
+    />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-dynamic-display.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/invalid/flex-dynamic-display.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box alignContent="start" display={true ? 'inlineBlock' : 'block'} />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dangerous-grid.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dangerous-grid.js
@@ -1,0 +1,10 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Box
+      alignContent="start"
+      dangerouslySetInlineStyle={{ __style: { display: 'grid', height: '50vh' } }}
+    />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dangerous-inline-flex.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dangerous-inline-flex.js
@@ -1,0 +1,7 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Box alignContent="start" dangerouslySetInlineStyle={{ __style: { display: 'inline-flex' } }} />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dangerous-inline-grid.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dangerous-inline-grid.js
@@ -1,0 +1,7 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Box alignContent="start" dangerouslySetInlineStyle={{ __style: { display: 'inline-grid' } }} />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dynamic-dangerous.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dynamic-dangerous.js
@@ -1,0 +1,10 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Box
+      alignContent="start"
+      dangerouslySetInlineStyle={{ __style: { display: true ? 'inline-flex' : 'flow-root' } }}
+    />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dynamic-display.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-dynamic-display.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  return <Box alignContent="start" display={true ? 'flex' : undefined} />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-reference-display.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-useless-props/valid/flex-reference-display.js
@@ -1,0 +1,6 @@
+import { Box } from 'gestalt';
+
+export default function TestComponent() {
+  const displayVar = 'flex';
+  return <Box alignContent="start" display={displayVar} />;
+}

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
@@ -41,8 +41,20 @@ function getAttributeValue(attributeValue): ?(string | $ReadOnlyArray<string>) {
   }
 
   const valueExpression = attributeValue.expression;
+  // ternary
   if (valueExpression.type === 'ConditionalExpression') {
     return getExpressionValues(valueExpression);
+  }
+  // variable
+  if (valueExpression.type === 'Identifier') {
+    // This could be a variable defined within the component/file,
+    // or it could be imported from elsewhere: we don't know. If needed in the future,
+    // we could check to see if the variable is defined in this file, and therefore
+    // check the value. However, as of Aug '21 there are only two instances of `display`
+    // using a variable in Pinboard, and both are passed-in props, so we can't know
+    // the values. For now we'll give variables the benefit of the doubt and treat them
+    // as 'flex' so we don't throw unnecessary errors.
+    return 'flex';
   }
   return undefined;
 }

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
@@ -20,22 +20,35 @@ const validFitCode = validFitCodePaths.map(mapPathsToCode);
 const invalidFitCodePaths = ['fit-max-width'].map(mapFileNameToPath('invalid'));
 const invalidFitCode = invalidFitCodePaths.map(mapPathsToCode);
 
-const flexFileNames = ['flex-direction', 'flex-wrap'];
-const validFlexCodePaths = flexFileNames.map(mapFileNameToPath('valid'));
+const validFlexCodePaths = [
+  'flex-align-content',
+  'flex-align-items',
+  'flex-dangerous-grid',
+  'flex-dangerous-inline-flex',
+  'flex-dangerous-inline-grid',
+  'flex-direction',
+  'flex-dynamic-dangerous',
+  'flex-dynamic-display',
+  'flex-justify-content',
+  'flex-wrap',
+].map(mapFileNameToPath('valid'));
 const validFlexCode = validFlexCodePaths.map(mapPathsToCode);
-const invalidFlexCodePaths = flexFileNames.map(mapFileNameToPath('invalid'));
+const invalidFlexCodePaths = [
+  'flex-align-content',
+  'flex-align-items',
+  'flex-dangerous',
+  'flex-direction',
+  'flex-dynamic-dangerous',
+  'flex-dynamic-display',
+  'flex-justify-content',
+  'flex-wrap',
+].map(mapFileNameToPath('invalid'));
 const invalidFlexCode = invalidFlexCodePaths.map(mapPathsToCode);
-const flexGridFileNames = ['flex-align-content', 'flex-align-items', 'flex-justify-content'];
-const validFlexGridCodePaths = flexGridFileNames.map(mapFileNameToPath('valid'));
-const validFlexGridCode = validFlexGridCodePaths.map(mapPathsToCode);
-const invalidFlexGridCodePaths = flexGridFileNames.map(mapFileNameToPath('invalid'));
-const invalidFlexGridCode = invalidFlexGridCodePaths.map(mapPathsToCode);
 
 ruleTester.run('no-box-useless-props', rule, {
   valid: [
     ...validFitCode.map((validCode) => ({ code: validCode })),
     ...validFlexCode.map((validCode) => ({ code: validCode })),
-    ...validFlexGridCode.map((validCode) => ({ code: validCode })),
   ],
   invalid: [
     ...invalidFitCode.map((invalidCode) => ({
@@ -45,10 +58,6 @@ ruleTester.run('no-box-useless-props', rule, {
     ...invalidFlexCode.map((invalidCode) => ({
       code: invalidCode,
       errors: [{ message: errorMessages.flex }],
-    })),
-    ...invalidFlexGridCode.map((invalidCode) => ({
-      code: invalidCode,
-      errors: [{ message: errorMessages.flexGrid }],
     })),
   ],
 });

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.test.js
@@ -30,6 +30,7 @@ const validFlexCodePaths = [
   'flex-dynamic-dangerous',
   'flex-dynamic-display',
   'flex-justify-content',
+  'flex-reference-display',
   'flex-wrap',
 ].map(mapFileNameToPath('valid'));
 const validFlexCode = validFlexCodePaths.map(mapPathsToCode);


### PR DESCRIPTION
This PR adds support for a few more scenarios, which should eliminate most/all suppressions in Pinboard:
- `display={condition ? 'flex' : 'block'}`
- `dangerouslySetInlineStyle={{ __style: { display: 'grid' }
}}`
- `dangerouslySetInlineStyle={{ __style: { display: condition ? 'grid' : 'block' }
}}`