### PR TITLE
Sheet: new onAnimationEnd prop + fix for bug

### DIFF
--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -74,6 +74,12 @@ card(
           "The text used for Sheet's heading. Be sure to localize this text. See the [heading variant](#Heading) for more info.",
       },
       {
+        name: 'onAnimationEnd',
+        type: "({ animationState: 'in' | 'out' }) => void",
+        description:
+          'Callback fired when the Sheet in/out animations end. See the [animation](#Animation) variant to learn more. ',
+      },
+      {
         name: 'onDismiss',
         type: '() => void',
         required: true,
@@ -1033,6 +1039,8 @@ function ClosingExample(props) {
       - Done red button (children)
       - Left arrow red icon button (children)
       - Close button (footer)
+
+      Sheet also provides \`onAnimationEnd\`, a callback that gets triggered at the end of each animation. The callback has access to \`animationState\` to identify the end of each 'in' and 'out' animation for cases where each event don't trigger the same response.
       `}
     >
       <MainSection.Card

--- a/docs/src/Sheet.doc.js
+++ b/docs/src/Sheet.doc.js
@@ -1040,7 +1040,7 @@ function ClosingExample(props) {
       - Left arrow red icon button (children)
       - Close button (footer)
 
-      Sheet also provides \`onAnimationEnd\`, a callback that gets triggered at the end of each animation. The callback has access to \`animationState\` to identify the end of each 'in' and 'out' animation for cases where each event don't trigger the same response.
+      Sheet also provides \`onAnimationEnd\`, a callback that gets triggered at the end of each animation. The callback has access to \`animationState\` to identify the end of each 'in' and 'out' animation for cases where the two events trigger different responses..
       `}
     >
       <MainSection.Card

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -35,6 +35,7 @@ import sheetStyles from './Sheet.css';
 import TrapFocusBehavior from './behaviors/TrapFocusBehavior.js';
 import { ScrollBoundaryContainerWithForwardRef as InternalScrollBoundaryContainer } from './ScrollBoundaryContainer.js';
 import { ScrollBoundaryContainerProvider } from './contexts/ScrollBoundaryContainer.js';
+import { FixedZIndex } from './zIndex.js';
 
 type Size = 'sm' | 'md' | 'lg';
 
@@ -130,7 +131,7 @@ function Sheet(props: SheetProps): Node {
   const [showTopShadow, setShowTopShadow] = useState<boolean>(false);
   const [showBottomShadow, setShowBottomShadow] = useState<boolean>(false);
   const {
-    animationState: animationStateHook,
+    animationState: animationStateFromHook,
     onAnimationEnd: onAnimationEndFromHook,
   } = useAnimation();
   const containerRef = useRef<?HTMLDivElement>(null);
@@ -152,8 +153,8 @@ function Sheet(props: SheetProps): Node {
 
   const handleOnAnimationEnd = useCallback(() => {
     onAnimationEndFromHook?.();
-    onAnimationEnd?.({ animationState: animationStateHook === 'in' ? 'in' : 'out' });
-  }, [animationStateHook, onAnimationEnd, onAnimationEndFromHook]);
+    onAnimationEnd?.({ animationState: animationStateFromHook === 'in' ? 'in' : 'out' });
+  }, [animationStateFromHook, onAnimationEnd, onAnimationEndFromHook]);
 
   // Handle onDismiss triggering from outside click
   const handleOutsideClick = useCallback(() => {
@@ -188,15 +189,15 @@ function Sheet(props: SheetProps): Node {
       <TrapFocusBehavior>
         <div className={sheetStyles.container} ref={containerRef}>
           <Backdrop
-            animationState={animationStateHook}
+            animationState={animationStateFromHook}
             closeOnOutsideClick={closeOnOutsideClick}
             onClick={handleOutsideClick}
           >
             <div
               aria-label={accessibilitySheetLabel}
               className={classnames(sheetStyles.wrapper, focusStyles.hideOutline, {
-                [sheetStyles.wrapperAnimationIn]: animationStateHook === 'in',
-                [sheetStyles.wrapperAnimationOut]: animationStateHook === 'out',
+                [sheetStyles.wrapperAnimationIn]: animationStateFromHook === 'in',
+                [sheetStyles.wrapperAnimationOut]: animationStateFromHook === 'out',
               })}
               onAnimationEnd={handleOnAnimationEnd}
               role="dialog"
@@ -226,7 +227,13 @@ function Sheet(props: SheetProps): Node {
                 )}
                 {!heading && (
                   <Box display="flex" flex="grow" justifyContent="end" marginBottom={8}>
-                    <Box flex="none" paddingX={6} paddingY={7} position="absolute">
+                    <Box
+                      flex="none"
+                      paddingX={6}
+                      paddingY={7}
+                      position="absolute"
+                      zIndex={new FixedZIndex(1)}
+                    >
                       <DismissButton
                         accessibilityDismissButtonLabel={accessibilityDismissButtonLabel}
                         onClick={onDismiss}

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -37,12 +37,16 @@ import { ScrollBoundaryContainerWithForwardRef as InternalScrollBoundaryContaine
 import { ScrollBoundaryContainerProvider } from './contexts/ScrollBoundaryContainer.js';
 
 type Size = 'sm' | 'md' | 'lg';
+
+type OnAnimationEndStateType = 'in' | 'out';
+
 type SheetMainProps = {|
   accessibilityDismissButtonLabel: string,
   accessibilitySheetLabel: string,
   children: Node,
   closeOnOutsideClick?: boolean,
   footer?: Node,
+  onAnimationEnd?: ({| animationState: OnAnimationEndStateType |}) => void,
   onDismiss: () => void,
   size?: Size,
 |};
@@ -117,6 +121,7 @@ function Sheet(props: SheetProps): Node {
     closeOnOutsideClick = true,
     footer,
     heading,
+    onAnimationEnd,
     onDismiss,
     size = 'sm',
     subHeading,
@@ -124,7 +129,10 @@ function Sheet(props: SheetProps): Node {
 
   const [showTopShadow, setShowTopShadow] = useState<boolean>(false);
   const [showBottomShadow, setShowBottomShadow] = useState<boolean>(false);
-  const { animationState, onAnimationEnd } = useAnimation();
+  const {
+    animationState: animationStateHook,
+    onAnimationEnd: onAnimationEndFromHook,
+  } = useAnimation();
   const containerRef = useRef<?HTMLDivElement>(null);
   const contentRef = useRef<?HTMLElement>(null);
 
@@ -141,6 +149,11 @@ function Sheet(props: SheetProps): Node {
       window.removeEventListener('keyup', handleKeyUp);
     };
   }, [onDismiss]);
+
+  const handleOnAnimationEnd = useCallback(() => {
+    onAnimationEndFromHook?.();
+    onAnimationEnd?.({ animationState: animationStateHook === 'in' ? 'in' : 'out' });
+  }, [animationStateHook, onAnimationEnd, onAnimationEndFromHook]);
 
   // Handle onDismiss triggering from outside click
   const handleOutsideClick = useCallback(() => {
@@ -175,17 +188,17 @@ function Sheet(props: SheetProps): Node {
       <TrapFocusBehavior>
         <div className={sheetStyles.container} ref={containerRef}>
           <Backdrop
-            animationState={animationState}
+            animationState={animationStateHook}
             closeOnOutsideClick={closeOnOutsideClick}
             onClick={handleOutsideClick}
           >
             <div
               aria-label={accessibilitySheetLabel}
               className={classnames(sheetStyles.wrapper, focusStyles.hideOutline, {
-                [sheetStyles.wrapperAnimationIn]: animationState === 'in',
-                [sheetStyles.wrapperAnimationOut]: animationState === 'out',
+                [sheetStyles.wrapperAnimationIn]: animationStateHook === 'in',
+                [sheetStyles.wrapperAnimationOut]: animationStateHook === 'out',
               })}
-              onAnimationEnd={onAnimationEnd}
+              onAnimationEnd={handleOnAnimationEnd}
               role="dialog"
               style={{ width: SIZE_WIDTH_MAP[size] }}
               tabIndex={-1}
@@ -255,6 +268,7 @@ Sheet.propTypes = {
   closeOnOutsideClick: PropTypes.bool,
   footer: PropTypes.node,
   heading: PropTypes.string,
+  onAnimationEnd: PropTypes.func,
   onDismiss: PropTypes.func.isRequired,
   size: (PropTypes.oneOf(['sm', 'md', 'lg']): React$PropType$Primitive<Size>),
   subHeading: PropTypes.node,
@@ -273,6 +287,7 @@ export default function AnimatedSheet(props: AnimatedSheetProps): Node {
     accessibilitySheetLabel,
     children,
     closeOnOutsideClick,
+    onAnimationEnd,
     onDismiss,
     footer,
     heading = undefined,
@@ -289,6 +304,7 @@ export default function AnimatedSheet(props: AnimatedSheetProps): Node {
           closeOnOutsideClick={closeOnOutsideClick}
           footer={typeof footer === 'function' ? footer({ onDismissStart }) : footer}
           heading={heading}
+          onAnimationEnd={onAnimationEnd}
           onDismiss={onDismissStart}
           size={size}
           subHeading={

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -217,6 +217,7 @@ exports[`Sheet should render animation in 1`] = `
           >
             <div
               class="absolute box flexNone paddingX6 paddingY7"
+              style="z-index: 1;"
             >
               <button
                 aria-label="Dismiss"
@@ -283,6 +284,7 @@ exports[`Sheet should render animation out 1`] = `
           >
             <div
               class="absolute box flexNone paddingX6 paddingY7"
+              style="z-index: 1;"
             >
               <button
                 aria-label="Dismiss"


### PR DESCRIPTION
### Summary

This PR adds onAnimationEnd to Sheet so events can get triggered once the component is fully rendered or removed. Examples can be placing educational focus on elements inside Sheet.

To detect which animation is (in vs out) the callback `({ animationState }) => void` has access to `animationState`

![Kapture 2021-08-12 at 19 57 13](https://user-images.githubusercontent.com/10593890/129284525-ac4e5a26-bf3a-4441-aa57-a16be879e86a.gif)

ALSO, fix for [BUG-131248 Sheet dismiss button unreachable when heading is missing
](https://jira.pinadmin.com/browse/BUG-131248)
<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
