### PR TITLE
Lint rules: Fix name bug in no-box-useless-props

### DIFF
--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
@@ -69,7 +69,7 @@ function getDangerouslySetStyles(attributeValue): null | { [string]: Object } {
   return styleObject.value?.properties?.reduce(
     (acc, { key, value }) => ({
       ...acc,
-      [key.name]: value,
+      [key?.name]: value,
     }),
     {},
   );


### PR DESCRIPTION
![Screen Shot 2021-08-17 at 5 28 15 PM](https://user-images.githubusercontent.com/12059539/129817692-671ba277-2148-42e9-8cd8-a14208700d92.png)
