### PR TITLE
Revert "Button: Add key to fix Safari bug, take two"

### DIFF
--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -122,10 +122,6 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
     text,
   } = props;
 
-  // Key necessary for text color to update on Safari when disabled changes
-  // See https://github.com/pinterest/gestalt/issues/1556 for more context
-  const key = String(disabled);
-
   const innerRef = useRef(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Button ref={inputRef} /> to call inputRef.current.focus()
@@ -209,7 +205,6 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         disabled={disabled}
         fullWidth={fullWidth}
         href={href}
-        key={key}
         onClick={handleLinkClick}
         ref={innerRef}
         rel={rel}
@@ -235,7 +230,6 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         aria-label={accessibilityLabel}
         className={buttonRoleClasses}
         disabled={disabled}
-        key={key}
         name={name}
         onBlur={handleBlur}
         onClick={handleClick}
@@ -269,7 +263,6 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
       aria-label={accessibilityLabel}
       className={buttonRoleClasses}
       disabled={disabled}
-      key={key}
       name={name}
       onBlur={handleBlur}
       onClick={handleClick}


### PR DESCRIPTION
Reverts pinterest/gestalt#1587

This solution is hacky and is leading to unintended downstream effects, namely breaking unit and integration tests in Pinboard.

We've decided to not fix this bug, as it's actually a Safari bug and [has been fixed in 14.7](https://github.com/mui-org/material-ui/issues/26251#issuecomment-867109199).

There are a few less-hacky hacks that various other libraries have tried, which we may explore in the future if needed:
- https://github.com/CirclesUBI/circles-myxogastria/pull/219/files
- https://github.com/microsoft/fluentui/pull/18851