### PR TITLE
Internal: fix gestalt-design-tokens variables import

### DIFF
--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -1,5 +1,3 @@
-@import "gestalt-design-tokens/dist/css/variables.css";
-
 :root {
   /* primary colors */
   --g-colorRed0: #ff5247;

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -1,4 +1,5 @@
 // @flow strict
+import 'gestalt-design-tokens/dist/css/variables.css';
 import ActivationCard from './ActivationCard.js';
 import Avatar from './Avatar.js';
 import AvatarGroup from './AvatarGroup.js';


### PR DESCRIPTION
### Before
`@import` in the middle of the file
![image](https://user-images.githubusercontent.com/127199/130301868-b782e1af-081d-458e-b021-cc6b3d185da5.png)


### After
CSS gets inlined
![image](https://user-images.githubusercontent.com/127199/130301738-27ab32b0-e4ec-4bb7-b9b2-38491c89fff8.png)

