### PR TITLE
Docs: fix favicon

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -31,6 +31,7 @@ gtag('config', 'UA-12967896-44');
 `,
             }}
           />
+          <link rel="shortcut icon" href="/pinterest_favicon.png" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
### Summary

I noticed the favicon was missing from the docs (since upgrading to Next.js).

Before/After:
![image](https://user-images.githubusercontent.com/127199/130529203-46970a64-1e8e-4938-b8ac-46472b30b4b4.png)
