### PR TITLE
Docs: persist scrollbar position for sidebar across pages

### DIFF
--- a/docs/components/CardPage.js
+++ b/docs/components/CardPage.js
@@ -3,7 +3,6 @@ import type { Node } from 'react';
 
 import { useEffect } from 'react';
 import { Box, Flex, Link, Text } from 'gestalt';
-import App from './App.js';
 import SearchContent from './SearchContent.js';
 import Toc from './Toc.js';
 
@@ -22,49 +21,47 @@ export default function CardPage({ cards, page }: Props): Node {
   }, [page]);
 
   return (
-    <App>
-      <Flex>
-        <Box flex="grow" maxWidth={1312}>
-          <SearchContent>
-            <Flex gap={8} direction="column">
-              {cards.map((card, i) => (
-                <Box
-                  id={`card-${i}`}
-                  key={i}
-                  dangerouslySetInlineStyle={{
-                    __style: {
-                      scrollMarginTop: 60,
-                    },
-                  }}
-                >
-                  {card}
-                </Box>
-              ))}
+    <Flex>
+      <Box flex="grow" maxWidth={1312}>
+        <SearchContent>
+          <Flex gap={8} direction="column">
+            {cards.map((card, i) => (
+              <Box
+                id={`card-${i}`}
+                key={i}
+                dangerouslySetInlineStyle={{
+                  __style: {
+                    scrollMarginTop: 60,
+                  },
+                }}
+              >
+                {card}
+              </Box>
+            ))}
+          </Flex>
+        </SearchContent>
+
+        <Box marginTop={12} display="flex">
+          <Link href={editPageUrl} target="blank" inline>
+            <Flex gap={2}>
+              <Text underline>Edit page on GitHub</Text>
             </Flex>
-          </SearchContent>
-
-          <Box marginTop={12} display="flex">
-            <Link href={editPageUrl} target="blank" inline>
-              <Flex gap={2}>
-                <Text underline>Edit page on GitHub</Text>
-              </Flex>
-            </Link>
-          </Box>
+          </Link>
         </Box>
+      </Box>
 
-        <Box
-          minWidth={200}
-          maxWidth={240}
-          marginStart={4}
-          mdMarginStart={6}
-          lgMarginStart={8}
-          display="none"
-          lgDisplay="block"
-          flex="none"
-        >
-          <Toc cards={cards} />
-        </Box>
-      </Flex>
-    </App>
+      <Box
+        minWidth={200}
+        maxWidth={240}
+        marginStart={4}
+        mdMarginStart={6}
+        lgMarginStart={8}
+        display="none"
+        lgDisplay="block"
+        flex="none"
+      >
+        <Toc cards={cards} />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/components/NavLink.js
+++ b/docs/components/NavLink.js
@@ -24,7 +24,6 @@ export default function NavLink({ children, href }: Props): Node {
     if (isModifiedEvent(event) || !isLeftClickEvent(event)) return;
     event.preventDefault();
     router.push(href);
-    window.scrollTo(0, 0);
   };
 
   return (

--- a/docs/components/Navigation.js
+++ b/docs/components/Navigation.js
@@ -21,10 +21,6 @@ function getAlphabetizedComponents() {
 }
 
 function NavList({ sidebarOrganisedBy }: {| sidebarOrganisedBy: string |}) {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
   return (
     <Fragment key={sidebarOrganisedBy}>
       {sidebarOrganisedBy === 'categorized' ? (

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -3,11 +3,16 @@ import { type Node } from 'react';
 import '../docs.css';
 import 'gestalt/dist/gestalt.css';
 import 'gestalt-datepicker/dist/gestalt-datepicker.css';
+import App from '../components/App.js';
 
 // This default export is required in a new `pages/_app.js` file.
 export default function GestaltApp(
   // $FlowFixMe[signature-verification-failure]
   { Component, pageProps }, // eslint-disable-line react/prop-types
 ): Node {
-  return <Component {...pageProps} />;
+  return (
+    <App>
+      <Component {...pageProps} />
+    </App>
+  );
 }


### PR DESCRIPTION
### Summary

@ayeshakmaz noticed we no longer persist the scrollbar position for the sidebar across pages.
More info on this topic: https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/

Also fixes the SSR issue with the sidebar: https://github.com/pinterest/gestalt/pull/1642#issuecomment-904046772

## Before

![docs-fix-sidebar-scroll-position-before](https://user-images.githubusercontent.com/127199/131045187-16cd2ac9-8548-4e6d-bfd0-5292b2dec890.gif)

## After


https://user-images.githubusercontent.com/127199/131045231-0f89508c-9d2f-4143-af28-376350d37ab8.mp4


