### PR TITLE
Lint rules: Another attempt at fixing `prefer-flex` import count bug

### DIFF
--- a/packages/eslint-plugin-gestalt/src/prefer-flex.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-flex.js
@@ -63,7 +63,6 @@ const rule: ESLintRule = {
     let hasAlignItems = false;
     let hasJustifyContent = false;
     let boxImportName;
-    let unchangedBoxCount = 0;
 
     const importDeclaration = (decl) => {
       // Not a Gestalt import
@@ -88,10 +87,6 @@ const rule: ESLintRule = {
         return;
       }
 
-      // We definitely have a Box, so increment count.
-      // If we'll convert to Flex later, we'll decrement.
-      unchangedBoxCount += 1;
-
       const props = node.attributes.map(({ name, value }) => ({
         key: name?.name,
         value: value?.value,
@@ -112,9 +107,6 @@ const rule: ESLintRule = {
         return;
       }
 
-      // We're replacing with Flex, so let's decrement the count
-      unchangedBoxCount -= 1;
-
       if (props.map(({ key }) => key).includes('alignItems')) {
         hasAlignItems = true;
       }
@@ -127,7 +119,17 @@ const rule: ESLintRule = {
         messageId: 'disallowed',
         fix: (fixer) => {
           // Are there other Box nodes aside from the one we're currently on?
-          const importsToRemove = unchangedBoxCount > 0 ? [] : [boxImportName];
+          // We can only get a count of tags without opening/closing info, and they're not paired.
+          // This count is _before_ this fix runs, but _after_ previous fixes in the file have run (if applicable).
+          // So first we'll determine how many tags are accounted for by the current node.
+          const currentNodeTagCount = node.selfClosing ? 1 : 2;
+          // Next we'll get a count of all the Box tags in the file
+          const boxTagsCount = programNode.tokens
+            .filter(({ type }) => type === 'JSXIdentifier')
+            .filter(({ value }) => value === boxImportName).length;
+          // Once we remove the current node's tags from the overall Box count, are there Boxes left?
+          // If so, we need to keep the Box import. Otherwise we can remove it.
+          const importsToRemove = boxTagsCount - currentNodeTagCount > 0 ? [] : [boxImportName];
 
           let renamedFlexImport;
           // If the file doesn't already import Flex and the Box import was renamed,


### PR DESCRIPTION
My previous assumption was wrong: the fixer runs on every JSXOpeningElement call (duh), and is not somehow magically run after all the elements have been seen. So a return to using `programNode.tokens`, but being a bit smarter about how we determine if there are unchanged Box nodes.