### PR TITLE
Toast: Add role of status for accessibility

### DIFF
--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -12,7 +12,7 @@ card(
   <PageHeader
     badge="pilot"
     name="Design Tokens"
-    description="Design tokens represent the values used within a design system to construct layouts and components, such as spacing and color. Because the tokens are an abstraction, the underlying value can change in different scenarios without affecting the designer or developer experience. [Learn more about Design Tokens](https://uxdesign.cc/design-tokens-cheatsheet-927fc1404099)"
+    description="Design tokens represent the values used within a design system to construct layouts and components, such as spacing and color. Because the tokens are an abstraction, the underlying value can change in different scenarios without affecting the designer or developer experience. [Learn more about Design Tokens](https://uxdesign.cc/design-tokens-cheatsheet-927fc1404099)."
   />,
 );
 
@@ -26,7 +26,7 @@ card(
               <Text weight="bold">CSS Token Name</Text>
             </Table.HeaderCell>
             <Table.HeaderCell>
-              <Text weight="bold">JaveScript Prop Name</Text>
+              <Text weight="bold">Javescript Prop Name</Text>
             </Table.HeaderCell>
             <Table.HeaderCell>
               <Text weight="bold">Value</Text>

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -26,7 +26,7 @@ card(
               <Text weight="bold">CSS Token Name</Text>
             </Table.HeaderCell>
             <Table.HeaderCell>
-              <Text weight="bold">Javescript Prop Name</Text>
+              <Text weight="bold">JavaScript Prop Name</Text>
             </Table.HeaderCell>
             <Table.HeaderCell>
               <Text weight="bold">Value</Text>

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -245,7 +245,7 @@ function ToastExample() {
             <Toast
               thumbnail={
                 <Image
-                  alt="Saved to home decor board"
+                  alt="Modern ceramic vase pin."
                   naturalHeight={564}
                   naturalWidth={564}
                   src="https://i.ibb.co/Lx54BCT/stock1.jpg"
@@ -301,7 +301,7 @@ function ToastExample() {
             <Toast
               thumbnail={
                 <Image
-                  alt="Saved to home decor board"
+                  alt="Modern ceramic vase pin."
                   naturalHeight={564}
                   naturalWidth={564}
                   src="https://i.ibb.co/Lx54BCT/stock1.jpg"
@@ -349,7 +349,7 @@ card(
       null,
       <Image
         key="image-key"
-        alt="Saved to home decor board"
+        alt="Modern ceramic vase pin."
         naturalHeight={564}
         naturalWidth={564}
         src="https://i.ibb.co/Lx54BCT/stock1.jpg"
@@ -375,7 +375,7 @@ card(
         thumbnail={
           <Image
             key="image-key"
-            alt="Saved to home decor board"
+            alt="Blush and sage plant print."
             naturalHeight={751}
             naturalWidth={564}
             src="https://i.ibb.co/7bQQYkX/stock2.jpg"

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -24,7 +24,7 @@ export default function Toast({
   thumbnailShape = 'square',
 }: Props): Node {
   return (
-    <Box marginBottom={3} paddingX={4} maxWidth={360} width="100vw">
+    <Box marginBottom={3} paddingX={4} maxWidth={360} width="100vw" role="status">
       <Box color={color} fit padding={6} rounding="pill" borderStyle="shadow">
         <Box display="flex" marginStart={-2} marginEnd={-2} alignItems="center">
           {thumbnail ? (

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<Toast /> Red Toast 1`] = `
 <div
   className="box marginBottom3 paddingX4"
+  role="status"
   style={
     Object {
       "maxWidth": 360,
@@ -33,6 +34,7 @@ exports[`<Toast /> Red Toast 1`] = `
 exports[`<Toast /> Text + Image + Button 1`] = `
 <div
   className="box marginBottom3 paddingX4"
+  role="status"
   style={
     Object {
       "maxWidth": 360,
@@ -124,6 +126,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
 exports[`<Toast /> Text + Image 1`] = `
 <div
   className="box marginBottom3 paddingX4"
+  role="status"
   style={
     Object {
       "maxWidth": 360,
@@ -191,6 +194,7 @@ exports[`<Toast /> Text + Image 1`] = `
 exports[`<Toast /> Text Only 1`] = `
 <div
   className="box marginBottom3 paddingX4"
+  role="status"
   style={
     Object {
       "maxWidth": 360,


### PR DESCRIPTION
![Kapture 2021-08-30 at 10 27 52](https://user-images.githubusercontent.com/10593890/131355129-ebb1da59-d7ae-43d3-97c7-b3ce1343a855.gif)
### Summary

Based on feedback from Marcy Sutton's audit. Ensure Toasts announce themselves to a screen reader.

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-2950)

### Checklist

- [X] Updated unit and Flow Tests
- [X] Verified accessibility: keyboard & screen reader interaction
