### PR TITLE
Internal: fix Element type is invalid

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,4 +1,19 @@
 // @flow strict
+
+/*::
+type WebpackConfig = {| watchOptions: {| poll: number | false |} |};
+*/
+
 module.exports = {
   reactStrictMode: true,
+  webpack: (
+    config /*: WebpackConfig */,
+    { dev } /*: {| dev: boolean |} */,
+  ) /*: WebpackConfig */ => ({
+    ...config,
+    watchOptions: {
+      ...config.watchOptions,
+      poll: dev ? 500 : false,
+    },
+  }),
 };


### PR DESCRIPTION
### Summary

Root cause: webpack watcher in Next.js does not re-trigger a new build when a file quickly changes from containing JS => empty ==> containing JS

Fixes #1652 

### Background

#### Rollup

Rollup uses the async version of `fs.writeFile` https://github.com/rollup/rollup/blob/ce951973e1a33fccfb81e8701317c896c26a050d/src/utils/fs.ts#L31 which results in a file momentarily being empty and then containing JS. If they would use `fs.writeFileSync`, the file would never be empty (but this blocks the Node.js process from doing anything else).

#### Next.js / Webpack

Next.js uses Webpack to continuously compile pages. However, when one of the imports of the pages changes from a file with content => empty => file with content, it doesn't re-compile with the second step. The only solution I found is to override the next.js config & use webpack polling. We now check every 500ms whether a change has been made to a file in dev mode.

### Related Links

- https://github.com/vercel/next.js/discussions/17452 
- https://stackoverflow.com/questions/53981805/nextjs-element-type-is-invalid-expected-a-string-for-built-in-components-or
- https://stackoverflow.com/questions/44897070/element-type-is-invalid-expected-a-string-for-built-in-components-or-a-class
- https://stackoverflow.com/questions/54729652/why-am-i-getting-element-type-is-invalid-expected-a-string-for-built-in-compo 
