### PR TITLE
Eslint plugin: added schema options to `prefer-box-no-disallowed` rule

### DIFF
--- a/packages/eslint-plugin-gestalt/src/helpers/eslintASTHelpers.js
+++ b/packages/eslint-plugin-gestalt/src/helpers/eslintASTHelpers.js
@@ -7,6 +7,7 @@ type AnyType = any;
 
 /** =================  HELPERS =================
  */
+
 type GetPropertiesFromVariableType = ({|
   variableNode: GenericNode,
 |}) => AnyType;

--- a/packages/eslint-plugin-gestalt/src/helpers/styleHelpers.js
+++ b/packages/eslint-plugin-gestalt/src/helpers/styleHelpers.js
@@ -74,7 +74,7 @@ const getMatchKeyErrorsReducer: GetMatchKeyErrorsReducerType = ({ context }) => 
     };
 
     function includeKey(keyName) {
-      const { onlyKeys } = context.options[0] || {};
+      const { onlyKeys } = context?.options?.[0] ?? {}; // Access options from Eslint configuration
       return !onlyKeys || onlyKeys.includes(keyName);
     }
 


### PR DESCRIPTION
### Summary

added options to `prefer-box-no-disallowed`
`excludeTests` we can pass `true` and all files ending in '.test.js' we'll be excluded
`excludePaths` we can pass [`app/amp/', `app/sterling/']  and all files containing the strings in their filenames we'll be excluded

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
