### PR TITLE
Video: add disableRemotePlayback prop

### DIFF
--- a/docs/pages/video.js
+++ b/docs/pages/video.js
@@ -96,6 +96,13 @@ card(
         href: 'videoControlsExample',
       },
       {
+        name: 'disableRemotePlayback',
+        type: 'boolean',
+        description:
+          'Disable remote playback. See [MDN Web Docs: disableRemotePlayback](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/disableRemotePlayback) for more info.',
+        defaultValue: false,
+      },
+      {
         name: 'loop',
         type: 'boolean',
         description: 'The video will start playing over again when finished',

--- a/packages/gestalt/src/Video.flowtest.js
+++ b/packages/gestalt/src/Video.flowtest.js
@@ -11,6 +11,7 @@ const Valid = (
     accessibilityUnmuteLabel="Unmute"
     aspectRatio={1}
     captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+    disableRemotePlayback
     src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
   />
 );

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -33,6 +33,7 @@ type Props = {|
   crossOrigin?: CrossOrigin,
   children?: Node,
   controls?: boolean,
+  disableRemotePlayback?: boolean,
   loop?: boolean,
   objectFit?: ObjectFit,
   onDurationChange?: ({|
@@ -191,6 +192,7 @@ export default class Video extends PureComponent<Props, State> {
     children: PropTypes.node,
     crossOrigin: PropTypes.oneOf(['use-credentials', 'anonymous']),
     controls: PropTypes.bool,
+    disableRemotePlayback: PropTypes.bool,
     loop: PropTypes.bool,
     onDurationChange: PropTypes.func,
     onEnded: PropTypes.func,
@@ -226,11 +228,13 @@ export default class Video extends PureComponent<Props, State> {
   };
 
   static defaultProps: {|
+    disableRemotePlayback: boolean,
     playbackRate: number,
     playing: boolean,
     preload: 'auto' | 'metadata' | 'none',
     volume: number,
   |} = {
+    disableRemotePlayback: false,
     playbackRate: 1,
     playing: false,
     preload: 'auto',
@@ -560,6 +564,7 @@ export default class Video extends PureComponent<Props, State> {
       captions,
       children,
       crossOrigin,
+      disableRemotePlayback,
       loop,
       objectFit,
       playing,
@@ -588,6 +593,7 @@ export default class Video extends PureComponent<Props, State> {
             src={typeof src === 'string' ? src : undefined}
             ref={this.setVideoRef}
             className={styles.video}
+            disableRemotePlayback={disableRemotePlayback}
             onCanPlay={this.handleCanPlay}
             onDurationChange={this.handleDurationChange}
             onEnded={this.handleEnded}

--- a/packages/gestalt/src/Video.jsdom.test.js
+++ b/packages/gestalt/src/Video.jsdom.test.js
@@ -174,4 +174,40 @@ describe('Video loading', () => {
     );
     expect(spy).toHaveBeenCalled();
   });
+
+  it('DisableRemotePlayback is set on <video />', () => {
+    const props = {
+      ...A11Y_LABELS,
+      aspectRatio: 1,
+      captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
+      src: [
+        {
+          type: 'video/mp4',
+          src: 'https://media.w3.org/2010/05/sintel/trailer_hd.mp4',
+        },
+      ],
+      disableRemotePlayback: true,
+    };
+
+    const { container } = render(<Video {...props} />);
+    expect(container.querySelector('video').attributes.disableremoteplayback).toBeDefined();
+  });
+
+  it('DisableRemotePlayback is not set on <video />', () => {
+    const props = {
+      ...A11Y_LABELS,
+      aspectRatio: 1,
+      captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
+      src: [
+        {
+          type: 'video/mp4',
+          src: 'https://media.w3.org/2010/05/sintel/trailer_hd.mp4',
+        },
+      ],
+      disableRemotePlayback: false,
+    };
+
+    const { container } = render(<Video {...props} />);
+    expect(container.querySelector('video').attributes.disableremoteplayback).toBeUndefined();
+  });
 });

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -47,6 +47,7 @@ exports[`Video with callbacks 1`] = `
     <video
       autoPlay={false}
       className="video"
+      disableRemotePlayback={false}
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}
@@ -119,6 +120,7 @@ exports[`Video with children 1`] = `
     <video
       autoPlay={false}
       className="video"
+      disableRemotePlayback={false}
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}
@@ -408,6 +410,7 @@ exports[`Video with crossOrigin 1`] = `
       autoPlay={false}
       className="video"
       crossOrigin="anonymous"
+      disableRemotePlayback={false}
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}
@@ -480,6 +483,7 @@ exports[`Video with media attributes 1`] = `
     <video
       autoPlay={false}
       className="video"
+      disableRemotePlayback={false}
       loop={true}
       muted={true}
       onCanPlay={[Function]}
@@ -553,6 +557,7 @@ exports[`Video with multiple sources 1`] = `
     <video
       autoPlay={false}
       className="video"
+      disableRemotePlayback={false}
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}
@@ -632,6 +637,7 @@ exports[`Video with objectFit 1`] = `
     <video
       autoPlay={false}
       className="video"
+      disableRemotePlayback={false}
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}
@@ -709,6 +715,7 @@ exports[`Video with source 1`] = `
     <video
       autoPlay={false}
       className="video"
+      disableRemotePlayback={false}
       muted={true}
       onCanPlay={[Function]}
       onDurationChange={[Function]}


### PR DESCRIPTION
### Summary

Adds a `disableRemotePlayback` to `<Video />`

### Background

In Pinterest's codebase we use:

```
video::-internal-media-controls-overlay-cast-button {
    display: none;
}
```

Which results in the following warning:

![image](https://user-images.githubusercontent.com/127199/131513655-6a7932a0-0989-4a45-a7a3-891def012828.png)

> [Deprecation] The disableRemotePlayback attribute should be used in order to disable the default Cast integration instead of using -internal-media-controls-overlay-cast-button selector. See https://www.chromestatus.com/feature/5714245488476160 for more details.

In this diff we fix the issue by adding `disableRemotePlayback` as a prop on `Video`, which will allow us to remove the CSS in Pinterest's codebase.

### Links

- https://www.chromestatus.com/feature/5714245488476160
