### PR TITLE
Text: use generated docs

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -11,12 +11,28 @@ function getDefaultValue(
   defaultValue?: string,
 |} {
   const input = description ?? '';
-  const match = input.match(/(?<main>Default: '(?<defaultValue>.*)')/);
+  const match = input.match(/(?<main>Default: (?<defaultValue>.*))/);
   const groups = match?.groups ?? {};
 
   return {
     description: groups.main ? input.replace(groups.main, '') : description,
-    defaultValue: groups.defaultValue ?? null,
+    defaultValue: groups.defaultValue?.replace(/'/g, ''),
+  };
+}
+
+function getHref(
+  description?: string,
+): {|
+  description?: string,
+  href?: string,
+|} {
+  const input = description ?? '';
+  const match = input.match(/(?<main>Link: (?<href>.*))/);
+  const groups = match?.groups ?? {};
+
+  return {
+    description: groups.main ? input.replace(groups.main, '') : description,
+    href: groups.href ? [...groups.href.split('#')].pop() : undefined,
   };
 }
 
@@ -38,18 +54,20 @@ export default function GeneratedPropTable({
       }
 
       const { description: descriptionWithoutDefaultValue = '', defaultValue } = getDefaultValue(
-        description,
+        description?.replace(/https:\/\/gestalt\.pinterest\.systems/, ''),
       );
+      const { description: descriptionWihoutLink, href } = getHref(descriptionWithoutDefaultValue);
 
       return {
         name: key,
-        type: (flowType.raw ?? flowType.name ?? '').replace(/Node/g, 'React.Node'),
-        description: descriptionWithoutDefaultValue.replace(
-          /https:\/\/gestalt\.pinterest\.systems/,
-          '',
+        type: (flowType.raw?.replace(/^\|/, '').trim() ?? flowType.name ?? '').replace(
+          /Node/g,
+          'React.Node',
         ),
+        description: descriptionWihoutLink?.trim(),
         required,
         defaultValue,
+        href,
       };
     })
     .filter(Boolean);

--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -8,7 +8,7 @@ import Markdown from './Markdown.js';
 
 type Props = {|
   props: Array<{|
-    defaultValue?: Node,
+    defaultValue?: boolean | string | number | null,
     description?: string | Array<string>,
     href?: string,
     name: string,
@@ -72,6 +72,23 @@ const Td = ({
     </Box>
   </td>
 );
+
+function isNumeric(value) {
+  return /^-?\d+$/.test(value);
+}
+
+const transformDefaultValue = (input) => {
+  if (input === 'true') {
+    return true;
+  }
+  if (input === 'false') {
+    return false;
+  }
+  if (typeof input === 'string' && isNumeric(input)) {
+    return parseFloat(input);
+  }
+  return input;
+};
 
 const sortBy = (list, fn) => list.sort((a, b) => fn(a).localeCompare(fn(b)));
 
@@ -151,6 +168,7 @@ export default function PropTable({
                     i,
                   ) => {
                     const propNameHasSecondRow = description || responsive;
+                    const transformedDefaultValue = transformDefaultValue(defaultValue);
                     acc.push(
                       <tr key={i}>
                         <Td shrink border={!propNameHasSecondRow}>
@@ -175,7 +193,11 @@ export default function PropTable({
                           color={defaultValue != null ? 'darkGray' : 'gray'}
                           border={!propNameHasSecondRow}
                         >
-                          {defaultValue != null ? <code>{JSON.stringify(defaultValue)}</code> : '-'}
+                          {defaultValue != null ? (
+                            <code>{JSON.stringify(transformedDefaultValue)}</code>
+                          ) : (
+                            '-'
+                          )}
                         </Td>
                       </tr>,
                     );

--- a/docs/pages/text.js
+++ b/docs/pages/text.js
@@ -1,95 +1,25 @@
 // @flow strict
 import { type Node } from 'react';
-import PropTable from '../components/PropTable.js';
 import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
-import CardPage from '../components/CardPage.js';
+import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import type { DocGen } from '../components/docgen.js';
+import docgen from '../components/docgen.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
-
-card(
-  <PageHeader
-    name="Text"
-    description="The Text component should be used for all text on the page."
-  />,
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'align',
-        type: `"start" | "end" | "center" | "justify" | "forceLeft" | "forceRight"`,
-        defaultValue: 'start',
-        href: 'align',
-        description:
-          '`"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text.',
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'color',
-        type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
-        defaultValue: 'darkGray',
-        href: 'color',
-      },
-      {
-        name: 'inline',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'inline',
-      },
-      {
-        name: 'italic',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'styles',
-      },
-      {
-        name: 'lineClamp',
-        type: 'number',
-        description:
-          'Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers.',
-        href: 'overflow',
-      },
-      {
-        name: 'overflow',
-        type: `"normal" | "breakWord" | "noWrap"`,
-        defaultValue: 'breakWord',
-        href: 'overflow',
-      },
-      {
-        name: 'size',
-        type: `"sm" | "md" | "lg"`,
-        description: `sm: 12px, md: 14px, lg: 16px`,
-        defaultValue: 'lg',
-        href: 'size',
-      },
-      {
-        name: 'underline',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'styles',
-      },
-      {
-        name: 'weight',
-        type: `"bold" | "normal"`,
-        defaultValue: 'normal',
-        href: 'styles',
-      },
-    ]}
-  />,
-);
-
-card(
-  <Example
-    description="Use this to adjust the positioning of text within wrapper elements."
-    id="align"
-    name="Alignment"
-    defaultCode={`
+export default function TextPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="Text">
+      <PageHeader
+        name="Text"
+        description="The Text component should be used for all text on the page."
+      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+      <Example
+        description="Use this to adjust the positioning of text within wrapper elements."
+        id="align"
+        name="Alignment"
+        defaultCode={`
 <Box maxWidth="16em">
   <Text align="start">Start (default)</Text>
   <Text align="end">End</Text>
@@ -99,17 +29,14 @@ card(
   <Text align="forceRight">Force right</Text>
 </Box>
 `}
-  />,
-);
-
-card(
-  <Example
-    description={`
+      />
+      <Example
+        description={`
     The Text component allows you to specify whether you want \`block\` or \`inline\` text.
   `}
-    id="inline"
-    name="Block vs inline"
-    defaultCode={`
+        id="inline"
+        name="Block vs inline"
+        defaultCode={`
 <Flex alignItems="start" direction="column" gap={4}>
   <Text>Some content in a default block element. (default)</Text>
   <Box>
@@ -119,15 +46,12 @@ card(
   </Box>
 </Flex>
 `}
-  />,
-);
-
-card(
-  <Example
-    description="You can specify which color you want for your text."
-    id="color"
-    name="Colors"
-    defaultCode={`
+      />
+      <Example
+        description="You can specify which color you want for your text."
+        id="color"
+        name="Colors"
+        defaultCode={`
 <Flex alignItems="start" direction="column" gap={4}>
   <Box color="darkGray" padding={1}>
     <Text color="white">White</Text>
@@ -138,15 +62,12 @@ card(
   <Text color="red">Red</Text>
 </Flex>
 `}
-  />,
-);
-
-card(
-  <Example
-    description="Gestalt provides utility options to deal with text overflow."
-    id="overflow"
-    name="Overflow"
-    defaultCode={`
+      />
+      <Example
+        description="Gestalt provides utility options to deal with text overflow."
+        id="overflow"
+        name="Overflow"
+        defaultCode={`
 <Flex direction="column" gap={2} maxWidth={180}>
   <Text weight="bold">breakWord (default):</Text>
   <Text>
@@ -172,16 +93,14 @@ card(
   </Text>
 </Flex>
 `}
-  />,
-);
-card(
-  <Example
-    description={`
+      />
+      <Example
+        description={`
     You can apply \`size\` options to define the size of the text.
   `}
-    id="size"
-    name="Sizes"
-    defaultCode={`
+        id="size"
+        name="Sizes"
+        defaultCode={`
 <Flex alignItems="start" direction="column" gap={2}>
   <Flex alignItems="center" gap={2}>
     <Text inline size="sm">Small</Text>
@@ -211,27 +130,28 @@ card(
   </Flex>
 </Flex>
 `}
-  />,
-);
-
-card(
-  <Example
-    description="
+      />
+      <Example
+        description="
     There are multiple styles, such as bold and italic, that we can
     attach to the Text component.
   "
-    id="styles"
-    name="Styles"
-    defaultCode={`
+        id="styles"
+        name="Styles"
+        defaultCode={`
 <Flex direction="column" gap={2}>
   <Text weight="bold">Bold</Text>
   <Text italic>Italic</Text>
   <Text underline>Underline</Text>
 </Flex>
 `}
-  />,
-);
+      />
+    </Page>
+  );
+}
 
-export default function TextPage(): Node {
-  return <CardPage cards={cards} page="Text" />;
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen('Text') },
+  };
 }

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -21,16 +21,74 @@ type Overflow = 'normal' | 'breakWord' | 'noWrap';
 type Size = 'sm' | 'md' | 'lg';
 
 type Props = {|
-  align?: Align,
+  /**
+   * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text.
+   *
+   * Default: 'start'
+   * Link: https://gestalt.pinterest.systems/text#align
+   */
+  align?: 'start' | 'end' | 'center' | 'justify' | 'forceLeft' | 'forceRight',
   children?: Node,
-  color?: Color,
+  /**
+   * Default: 'darkGray'
+   * Link: https://gestalt.pinterest.systems/text#color
+   */
+  color?:
+    | 'blue'
+    | 'darkGray'
+    | 'eggplant'
+    | 'gray'
+    | 'green'
+    | 'lightGray'
+    | 'maroon'
+    | 'midnight'
+    | 'navy'
+    | 'olive'
+    | 'orange'
+    | 'orchid'
+    | 'pine'
+    | 'purple'
+    | 'red'
+    | 'watermelon'
+    | 'white',
+  /**
+   * Default: false
+   * Link: https://gestalt.pinterest.systems/text#inline
+   */
   inline?: boolean,
+  /**
+   * Default: false
+   * Link: https://gestalt.pinterest.systems/text#styles
+   */
   italic?: boolean,
+  /**
+   * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers.
+   *
+   * Link: https://gestalt.pinterest.systems/text#overflow
+   */
   lineClamp?: number,
+  /**
+   * Default: 'breakWord'
+   * Link: https://gestalt.pinterest.systems/text#overflow
+   */
   overflow?: Overflow,
+  /**
+   * sm: `12px`, md: `14px`, lg: `16px`
+   *
+   * Default: 'lg'
+   * Link: https://gestalt.pinterest.systems/text#size
+   */
   size?: Size,
+  /**
+   * Default: 'false'
+   * Link: https://gestalt.pinterest.systems/text#styles
+   */
   underline?: boolean,
-  weight?: FontWeight,
+  /**
+   * Default: 'normal'
+   * Link: https://gestalt.pinterest.systems/text#styles
+   */
+  weight?: 'bold' | 'normal',
 |};
 
 /**


### PR DESCRIPTION
### Summary

Docs for `<Text />` now use the generated version. See #1669 for the initial PR

### Changes

* Use `react-docgen` docs for `<Text />`
* Add `href` support (some of our docs still had this)
* Fix issue when a flow union starts with `|`
* Support booleans & numbers for default values

### Preview

https://deploy-preview-1671--gestalt.netlify.app/text