### PR TITLE
Toast: Replace `color` with `variant`

### DIFF
--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -32,7 +32,7 @@ card(
         name: 'text',
         type: 'string | React.Node',
         description:
-          'Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Do not specify a Text color within this property, as the color is automatically determined based on the variant',
+          'Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Do not specify a Text color within this property, as the color is automatically determined based on the `variant`.',
         href: 'textOnlyExample',
         required: true,
       },

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -32,7 +32,7 @@ card(
         name: 'text',
         type: 'string | React.Node',
         description:
-          'Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Avoid specifying a Text color within this property, as the color is automatically determined based on the background color',
+          'Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Do not specify a Text color within this property, as the color is automatically determined based on the variant',
         href: 'textOnlyExample',
         required: true,
       },

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -34,6 +34,7 @@ card(
         description:
           'Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Avoid specifying a Text color within this property, as the color is automatically determined based on the background color',
         href: 'textOnlyExample',
+        required: true,
       },
       {
         name: 'thumbnail',

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { Fragment } from 'react';
+import { Fragment, type Node } from 'react';
 import { Button, Link, Image, Text, Toast } from 'gestalt';
 import Combination from '../components/Combination.js';
 import Example from '../components/Example.js';
@@ -31,9 +29,11 @@ card(
         href: 'imageTextButtonExample',
       },
       {
-        name: 'color',
-        type: `'white' | 'red'`,
-        href: 'redColorTextAlertExample',
+        name: 'text',
+        type: 'string | React.Node',
+        description:
+          'Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Avoid specifying a Text color within this property, as the color is automatically determined based on the background color',
+        href: 'textOnlyExample',
       },
       {
         name: 'thumbnail',
@@ -47,11 +47,10 @@ card(
         href: 'imageTextExample',
       },
       {
-        name: 'text',
-        type: 'string | React.Node',
-        description:
-          'Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Avoid specifying a Text color within this property, as the color is automatically determined based on the background color',
-        href: 'textOnlyExample',
+        name: 'variant',
+        type: `'default' | 'error'`,
+        defaultValue: 'default',
+        href: 'errorVariantExample',
       },
     ]}
   />,
@@ -90,32 +89,32 @@ card(
     defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
+
   return (
     <Box>
       <Button
-        text={ showToast ? 'Close toast' : 'Show toast' }
-        onClick={() => setShowToast(!showToast)}
+        onClick={() => setShowToast((currVal) => !currVal)}
+        text={showToast ? 'Close toast' : 'Show toast'}
       />
-      <Layer>
-        <Box
-          fit
-          dangerouslySetInlineStyle={{
-            __style: {
-              bottom: 50,
-              left: '50%',
-              transform: 'translateX(-50%)',
-            },
-          }}
-          paddingX={1}
-          position="fixed"
-        >
-          {showToast && (
-            <Toast
-              text={"Section created!"}
-            />
-          )}
-        </Box>
-      </Layer>
+
+      {showToast && (
+        <Layer>
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                bottom: 50,
+                left: '50%',
+                transform: 'translateX(-50%)',
+              },
+            }}
+            fit
+            paddingX={1}
+            position="fixed"
+          >
+            <Toast text={"Section created!"} />
+          </Box>
+        </Layer>
+      )}
     </Box>
   );
 }`}
@@ -126,30 +125,32 @@ card(
   <Example
     id="complexTextExample"
     name="Example: Complex Text"
-    description="When passing in your own Text component for the text property, be careful not to specify a color property, as the Toast component will automatically pick the right text color based on the Toast's background color."
+    description="When passing in your own Text component for `text`, do not specify `color` on Text. Toast will automatically pick the correct text color for the given `variant`."
     defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
+
   return (
     <Box>
       <Button
-        text={ showToast ? 'Close toast' : 'Show toast' }
-        onClick={() => setShowToast(!showToast)}
+        onClick={() => setShowToast((currVal) => !currVal)}
+        text={showToast ? 'Close toast' : 'Show toast'}
       />
-      <Layer>
-        <Box
-          fit
-          dangerouslySetInlineStyle={{
-            __style: {
-              bottom: 50,
-              left: '50%',
-              transform: 'translateX(-50%)',
-            },
-          }}
-          paddingX={1}
-          position="fixed"
-        >
-          {showToast && (
+
+      {showToast && (
+        <Layer>
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                bottom: 50,
+                left: '50%',
+                transform: 'translateX(-50%)',
+              },
+            }}
+            fit
+            paddingX={1}
+            position="fixed"
+          >
             <Toast
               text={
                 <React.Fragment>
@@ -162,9 +163,9 @@ function ToastExample() {
                 </React.Fragment>
               }
             />
-          )}
-        </Box>
-      </Layer>
+          </Box>
+        </Layer>
+      )}
     </Box>
   );
 }`}
@@ -173,42 +174,40 @@ function ToastExample() {
 
 card(
   <Example
-    id="redColorTextAlertExample"
-    name="Example: Red background color"
+    id="errorVariantExample"
+    name="Example: Error variant"
     defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
+
   return (
     <Box>
       <Button
-        text={ showToast ? 'Close toast' : 'Show toast' }
-        onClick={() => setShowToast(!showToast)}
+        onClick={() => setShowToast((currVal) => !currVal)}
+        text={showToast ? 'Close toast' : 'Show toast'}
       />
-      <Layer>
-        <Box
-          fit
-          dangerouslySetInlineStyle={{
-            __style: {
-              bottom: 50,
-              left: '50%',
-              transform: 'translateX(-50%)',
-            },
-          }}
-          paddingX={1}
-          position="fixed"
-        >
-          {showToast && (
+
+      {showToast && (
+        <Layer>
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                bottom: 50,
+                left: '50%',
+                transform: 'translateX(-50%)',
+              },
+            }}
+            fit
+            paddingX={1}
+            position="fixed"
+          >
             <Toast
-              color="red"
-              text={
-                <React.Fragment>
-                  Oops! Something went wrong. Please try again later.
-                </React.Fragment>
-              }
+              text="Oops! Something went wrong. Please try again later."
+              variant="error"
             />
-          )}
-        </Box>
-      </Layer>
+          </Box>
+        </Layer>
+      )}
     </Box>
   );
 }`}
@@ -222,35 +221,29 @@ card(
     defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
+
   return (
     <Box>
       <Button
-        text={ showToast ? 'Close toast' : 'Show toast' }
-        onClick={() => setShowToast(!showToast)}
+        onClick={() => setShowToast((currVal) => !currVal)}
+        text={showToast ? 'Close toast' : 'Show toast'}
       />
-      <Layer>
-        <Box
-          fit
-          dangerouslySetInlineStyle={{
-            __style: {
-              bottom: 150,
-              left: '50%',
-              transform: 'translateX(-50%)',
-            },
-          }}
-          paddingX={1}
-          position="fixed"
-        >
-          {showToast && (
+
+      {showToast && (
+        <Layer>
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                bottom: 50,
+                left: '50%',
+                transform: 'translateX(-50%)',
+              },
+            }}
+            fit
+            paddingX={1}
+            position="fixed"
+          >
             <Toast
-              thumbnail={
-                <Image
-                  alt="Modern ceramic vase pin."
-                  naturalHeight={564}
-                  naturalWidth={564}
-                  src="https://i.ibb.co/Lx54BCT/stock1.jpg"
-                />
-              }
               text={
                 <React.Fragment>
                   Saved to{' '}
@@ -261,10 +254,18 @@ function ToastExample() {
                   </Text>
                 </React.Fragment>
               }
+              thumbnail={
+                <Image
+                  alt="Modern ceramic vase pin."
+                  naturalHeight={564}
+                  naturalWidth={564}
+                  src="https://i.ibb.co/Lx54BCT/stock1.jpg"
+                />
+              }
             />
-          )}
-        </Box>
-      </Layer>
+          </Box>
+        </Layer>
+      )}
     </Box>
   );
 }`}
@@ -278,50 +279,52 @@ card(
     defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
+
   return (
     <Box>
       <Button
-        text={ showToast ? 'Close toast' : 'Show toast' }
-        onClick={() => setShowToast(!showToast)}
+        onClick={() => setShowToast((currVal) => !currVal)}
+        text={showToast ? 'Close toast' : 'Show toast'}
       />
-      <Layer>
-        <Box
-          fit
-          dangerouslySetInlineStyle={{
-            __style: {
-              bottom: 250,
-              left: '50%',
-              transform: 'translateX(-50%)',
-            },
-          }}
-          paddingX={1}
-          position="fixed"
-        >
-          {showToast && (
-            <Toast
-              thumbnail={
-                <Image
-                  alt="Modern ceramic vase pin."
-                  naturalHeight={564}
-                  naturalWidth={564}
-                  src="https://i.ibb.co/Lx54BCT/stock1.jpg"
-                />
-              }
-              text={
-                <React.Fragment>
-                  Saved to{' '}
-                  <Text inline weight="bold">
-                    <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
-                      Home decor
-                    </Link>
-                  </Text>
-                </React.Fragment>
-              }
-              button={<Button key="button-key" text="Undo" size="lg" />}
-            />
-          )}
-        </Box>
-      </Layer>
+
+      {showToast && (
+        <Layer>
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                bottom: 50,
+                left: '50%',
+                transform: 'translateX(-50%)',
+              },
+            }}
+            fit
+            paddingX={1}
+            position="fixed"
+          >
+              <Toast
+                button={<Button key="button-key" text="Undo" size="lg" />}
+                text={
+                  <React.Fragment>
+                    Saved to{' '}
+                    <Text inline weight="bold">
+                      <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+                        Home decor
+                      </Link>
+                    </Text>
+                  </React.Fragment>
+                }
+                thumbnail={
+                  <Image
+                    alt="Modern ceramic vase pin."
+                    naturalHeight={564}
+                    naturalWidth={564}
+                    src="https://i.ibb.co/Lx54BCT/stock1.jpg"
+                  />
+                }
+              />
+          </Box>
+        </Layer>
+      )}
     </Box>
   );
 }`}

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -112,7 +112,7 @@ function ToastExample() {
             paddingX={1}
             position="fixed"
           >
-            <Toast text={"Section created!"} />
+            <Toast text="Section created!" />
           </Box>
         </Layer>
       )}

--- a/packages/gestalt-codemods/33.0.0/__tests__/heading-replace-truncate-lineClamp.test.js
+++ b/packages/gestalt-codemods/33.0.0/__tests__/heading-replace-truncate-lineClamp.test.js
@@ -7,7 +7,9 @@ jest.mock('../heading-replace-truncate-lineClamp', () => {
 });
 
 describe('heading-replace-truncate-lineClamp', () => {
-  ['heading-replace-truncate-lineClamp'].forEach((test) => {
-    defineTest(__dirname, 'heading-replace-truncate-lineClamp', { quote: 'single' }, test);
-  });
+  ['heading-replace-truncate-lineClamp', 'heading-replace-truncate-lineClamp-renamed'].forEach(
+    (test) => {
+      defineTest(__dirname, 'heading-replace-truncate-lineClamp', { quote: 'single' }, test);
+    },
+  );
 });

--- a/packages/gestalt-codemods/33.0.0/heading-replace-truncate-lineClamp.js
+++ b/packages/gestalt-codemods/33.0.0/heading-replace-truncate-lineClamp.js
@@ -70,6 +70,7 @@ export default function transformer(file, api) {
             console.log(
               `${node.openingElement.name.name} components with ${attr?.name?.name} prop must be converted to lineClamp manually (boolean -> number). Location: ${file.path} @line: ${node.loc.start.line}`,
             );
+            return null;
           }
           const renamedAttr = { ...attr };
           renamedAttr.name.name = 'lineClamp';

--- a/packages/gestalt-codemods/next/__testfixtures__/color-red.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/color-red.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast color="red" text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/color-red.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/color-red.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return <Toast variant="error" text="Toasty McToasterFace" />;
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/color-white.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/color-white.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast color="white" text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/color-white.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/color-white.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return <Toast variant="default" text="Toasty McToasterFace" />;
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/empty-string-color.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/empty-string-color.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast color="" text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/empty-string-color.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/empty-string-color.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return <Toast text="Toasty McToasterFace" />;
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/no-color.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/no-color.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/no-color.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/no-color.output.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/null-color.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/null-color.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast color={null} text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/null-color.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/null-color.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return <Toast text="Toasty McToasterFace" />;
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/renamed.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/renamed.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast as GestaltToast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <GestaltToast color="red" text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/renamed.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/renamed.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Toast as GestaltToast } from 'gestalt';
+
+export default function TestComponent() {
+  return <GestaltToast variant="error" text="Toasty McToasterFace" />;
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/ternary-color.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/ternary-color.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast color={true ? 'red' : 'white'} text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/ternary-color.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/ternary-color.output.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast color={true ? 'red' : 'white'} text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/undefined-color.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/undefined-color.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Toast color={undefined} text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/undefined-color.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/undefined-color.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  return <Toast text="Toasty McToasterFace" />;
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/variable-color.input.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/variable-color.input.js
@@ -1,0 +1,10 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  const colorVar = 'red';
+
+  return (
+    <Toast color={colorVar} text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__testfixtures__/variable-color.output.js
+++ b/packages/gestalt-codemods/next/__testfixtures__/variable-color.output.js
@@ -1,0 +1,10 @@
+// @flow strict
+import { Toast } from 'gestalt';
+
+export default function TestComponent() {
+  const colorVar = 'red';
+
+  return (
+    <Toast color={colorVar} text="Toasty McToasterFace" />
+  );
+}

--- a/packages/gestalt-codemods/next/__tests__/toast-replace-color-variant.test.js
+++ b/packages/gestalt-codemods/next/__tests__/toast-replace-color-variant.test.js
@@ -1,0 +1,23 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../toast-replace-color-variant', () => {
+  return Object.assign(jest.requireActual('../toast-replace-color-variant'), {
+    parser: 'flow',
+  });
+});
+
+describe('toast-replace-color-variant', () => {
+  [
+    'color-red',
+    'color-white',
+    'empty-string-color',
+    'no-color',
+    'null-color',
+    'renamed',
+    'ternary-color',
+    'undefined-color',
+    'variable-color',
+  ].forEach((test) => {
+    defineTest(__dirname, 'toast-replace-color-variant', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/next/toast-replace-color-variant.js
+++ b/packages/gestalt-codemods/next/toast-replace-color-variant.js
@@ -1,0 +1,130 @@
+/*
+ * Converts
+ *  <Toast color="red" /> to <Toast variant="error" />
+ *  <Toast color="white" /> to <Toast variant="default" />
+ *  <Toast color={color} /> to console.log for manual change />
+ */
+
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/next/toast-replace-color-variant.js relative/path/to/your/code
+
+function getNewAttr({ attr, j, previousValue }) {
+  const newAttr = { ...attr };
+  newAttr.name.name = 'variant';
+  const newValue = previousValue === 'red' ? 'error' : 'default';
+  newAttr.value = j.stringLiteral(newValue);
+  return newAttr;
+}
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    // Not Gestalt, bail
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    // Find the local names of Toast imports
+    localIdentifierName = decl.specifiers
+      .filter((node) => node.imported.name === 'Toast')
+      .map((node) => node.local.name);
+    return null;
+  });
+
+  // No Toast imports, bail
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove dynamic Toast properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+
+      const newAttrs = attrs
+        .map((attr) => {
+          const propName = attr?.name?.name;
+
+          // Not truncate, bail
+          if (propName !== 'color') {
+            return attr;
+          }
+
+          const valueType = attr.value.type;
+
+          // string literal
+          if (valueType === 'Literal') {
+            const propValue = attr.value.value;
+
+            if (['red', 'white'].includes(propValue)) {
+              // prop="valid"
+              return getNewAttr({ attr, j, previousValue: propValue });
+            }
+            // prop="invalid" OR prop=""
+            // eslint-disable-next-line no-console
+            console.log(
+              `${node.openingElement.name.name} component with ${attr?.name?.name} prop used an invalid or empty value. Removing prop. Location: ${file.path} @line: ${node.loc.start.line}`,
+            );
+            return null;
+          }
+
+          // expression
+          if (valueType === 'JSXExpressionContainer') {
+            const expressionValue = attr?.value?.expression?.value;
+            const variableName = attr?.value?.expression?.name;
+
+            // prop={undefined} OR prop={null}
+            if (variableName === 'undefined' || expressionValue === null) {
+              // eslint-disable-next-line no-console
+              console.log(
+                `${node.openingElement.name.name} component with ${attr?.name?.name} prop passed "undefined" or "null". Removing prop. Location: ${file.path} @line: ${node.loc.start.line}`,
+              );
+              return null;
+            }
+
+            // prop={'valid'}
+            if (['red', 'white'].includes(expressionValue)) {
+              return getNewAttr({ attr, j, previousValue: expressionValue });
+            }
+
+            // prop={variable} OR prop={condition ? A : B} OR any other expression
+            // eslint-disable-next-line no-console
+            console.log(
+              `${node.openingElement.name.name} component with ${attr?.name?.name} prop used a dynamic value. Please convert to "variant" manually. Location: ${file.path} @line: ${node.loc.start.line}`,
+            );
+            return attr;
+          }
+
+          // eslint-disable-next-line no-console
+          console.log(
+            `${node.openingElement.name.name} component with ${attr?.name?.name} prop of unknown type must be converted to variant manually. Location: ${file.path} @line: ${node.loc.start.line}`,
+          );
+          return attr;
+        })
+        .filter(Boolean);
+
+      fileHasModifications = true;
+      node.openingElement.attributes = newAttrs;
+
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -2,15 +2,16 @@
 import type { Element, Node } from 'react';
 import PropTypes from 'prop-types';
 import Box from './Box.js';
+import Flex from './Flex.js';
 import Mask from './Mask.js';
 import Text from './Text.js';
 
 type Props = {|
   button?: Node,
-  color?: 'white' | 'red',
   text: string | Element<*>,
   thumbnail?: Node,
   thumbnailShape?: 'circle' | 'rectangle' | 'square',
+  variant?: 'default' | 'error',
 |};
 
 /**
@@ -18,40 +19,39 @@ type Props = {|
  */
 export default function Toast({
   button,
-  color = 'white',
   text,
   thumbnail,
   thumbnailShape = 'square',
+  variant = 'default',
 }: Props): Node {
+  const isErrorVariant = variant === 'error';
+  const containerColor = isErrorVariant ? 'red' : 'white';
+  const textColor = isErrorVariant ? 'white' : undefined;
+
   return (
-    <Box marginBottom={3} paddingX={4} maxWidth={360} width="100vw" role="status">
-      <Box color={color} fit padding={6} rounding="pill" borderStyle="shadow">
-        <Box display="flex" marginStart={-2} marginEnd={-2} alignItems="center">
+    <Box marginBottom={3} maxWidth={360} paddingX={4} role="status" width="100vw">
+      <Box borderStyle="shadow" color={containerColor} fit padding={6} rounding="pill">
+        <Flex alignItems="center" gap={4}>
           {thumbnail ? (
-            <Box display="flex" flex="none" justifyContent="center" paddingX={2}>
+            <Flex flex="none" justifyContent="center">
               <Mask
-                rounding={thumbnailShape === 'circle' ? 'circle' : 2}
                 height={thumbnailShape === 'rectangle' ? 64 : 48}
+                rounding={thumbnailShape === 'circle' ? 'circle' : 2}
                 width={48}
               >
                 {thumbnail}
               </Mask>
-            </Box>
+            </Flex>
           ) : null}
-          <Box display="flex" direction="column" flex="grow" justifyContent="center" paddingX={2}>
-            <Text
-              color={color === 'red' ? 'white' : undefined}
-              align={!thumbnail && !button ? 'center' : 'start'}
-            >
+
+          <Flex direction="column" flex="grow" justifyContent="center">
+            <Text align={!thumbnail && !button ? 'center' : 'start'} color={textColor}>
               {text}
             </Text>
-          </Box>
-          {button ? (
-            <Box flex="none" paddingX={2}>
-              {button}
-            </Box>
-          ) : null}
-        </Box>
+          </Flex>
+
+          {button ? <Flex.Item flex="none">{button}</Flex.Item> : null}
+        </Flex>
       </Box>
     </Box>
   );
@@ -59,11 +59,11 @@ export default function Toast({
 
 Toast.propTypes = {
   button: PropTypes.node,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  color: PropTypes.oneOf(['white', 'red']),
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  text: (PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+    .isRequired: React$PropType$Primitive<string | Element<*>>),
   thumbnail: PropTypes.node,
-  // $FlowFixMe[signature-verification-failure] flow 0.135.0 upgrade
-  thumbnailShape: PropTypes.oneOf(['circle', 'rectangle', 'square']),
+  thumbnailShape: (PropTypes.oneOf(['circle', 'rectangle', 'square']): React$PropType$Primitive<
+    'circle' | 'rectangle' | 'square',
+  >),
+  variant: (PropTypes.oneOf(['default', 'error']): React$PropType$Primitive<'default' | 'error'>),
 };

--- a/packages/gestalt/src/Toast.test.js
+++ b/packages/gestalt/src/Toast.test.js
@@ -13,9 +13,9 @@ describe('<Toast />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test('Red Toast', () => {
+  test('Error Toast', () => {
     const tree = create(
-      <Toast color="red" text="Same great profile, slightly new look. Learn more?" />,
+      <Toast text="Same great profile, slightly new look. Learn more?" variant="error" />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Toast /> Red Toast 1`] = `
+exports[`<Toast /> Error Toast 1`] = `
 <div
   className="box marginBottom3 paddingX4"
   role="status"
@@ -15,15 +15,19 @@ exports[`<Toast /> Red Toast 1`] = `
     className="box fit paddingX6 paddingY6 pill redBg shadow"
   >
     <div
-      className="box itemsCenter marginEndN2 marginStartN2 xsDisplayFlex"
+      className="Flex rowGap4 itemsCenter xsDirectionRow"
     >
       <div
-        className="box flexGrow justifyCenter paddingX2 xsDirectionColumn xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
+          className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
         >
-          Same great profile, slightly new look. Learn more?
+          <div
+            className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
+          >
+            Same great profile, slightly new look. Learn more?
+          </div>
         </div>
       </div>
     </div>
@@ -46,56 +50,64 @@ exports[`<Toast /> Text + Image + Button 1`] = `
     className="box fit paddingX6 paddingY6 pill shadow whiteBg"
   >
     <div
-      className="box itemsCenter marginEndN2 marginStartN2 xsDisplayFlex"
+      className="Flex rowGap4 itemsCenter xsDirectionRow"
     >
       <div
-        className="box flexNone justifyCenter paddingX2 xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="Mask rounding2 willChangeTransform"
-          style={
-            Object {
-              "height": 48,
-              "width": 48,
+          className="Flex rowGap0 flexNone justifyCenter xsDirectionRow"
+        >
+          <div
+            className="Mask rounding2 willChangeTransform"
+            style={
+              Object {
+                "height": 48,
+                "width": 48,
+              }
             }
-          }
-        >
-          <img
-            alt=""
-            src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
-          />
+          >
+            <img
+              alt=""
+              src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+            />
+          </div>
         </div>
       </div>
       <div
-        className="box flexGrow justifyCenter paddingX2 xsDirectionColumn xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal"
+          className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
         >
-          Saved to
-           
-          <a
-            className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
-            href="https://www.pinterest.com/search/pins/?q=home%20decor"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyPress={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            rel=""
-            target={null}
+          <div
+            className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal"
           >
-            Home decor
-          </a>
+            Saved to
+             
+            <a
+              className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
+              href="https://www.pinterest.com/search/pins/?q=home%20decor"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              rel=""
+              target={null}
+            >
+              Home decor
+            </a>
+          </div>
         </div>
       </div>
       <div
-        className="box flexNone paddingX2"
+        className="FlexItem flexNone"
       >
         <button
           className="button hideOutline tapTransition lg gray enabled inline accessibilityOutline"
@@ -138,52 +150,60 @@ exports[`<Toast /> Text + Image 1`] = `
     className="box fit paddingX6 paddingY6 pill shadow whiteBg"
   >
     <div
-      className="box itemsCenter marginEndN2 marginStartN2 xsDisplayFlex"
+      className="Flex rowGap4 itemsCenter xsDirectionRow"
     >
       <div
-        className="box flexNone justifyCenter paddingX2 xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="Mask rounding2 willChangeTransform"
-          style={
-            Object {
-              "height": 48,
-              "width": 48,
-            }
-          }
+          className="Flex rowGap0 flexNone justifyCenter xsDirectionRow"
         >
-          <img
-            alt=""
-            src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
-          />
+          <div
+            className="Mask rounding2 willChangeTransform"
+            style={
+              Object {
+                "height": 48,
+                "width": 48,
+              }
+            }
+          >
+            <img
+              alt=""
+              src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+            />
+          </div>
         </div>
       </div>
       <div
-        className="box flexGrow justifyCenter paddingX2 xsDirectionColumn xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal"
+          className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
         >
-          Saved to
-           
-          <a
-            className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
-            href="https://www.pinterest.com/search/pins/?q=home%20decor"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onKeyPress={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            rel=""
-            target={null}
+          <div
+            className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal"
           >
-            Home decor
-          </a>
+            Saved to
+             
+            <a
+              className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
+              href="https://www.pinterest.com/search/pins/?q=home%20decor"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              rel=""
+              target={null}
+            >
+              Home decor
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -206,15 +226,19 @@ exports[`<Toast /> Text Only 1`] = `
     className="box fit paddingX6 paddingY6 pill shadow whiteBg"
   >
     <div
-      className="box itemsCenter marginEndN2 marginStartN2 xsDisplayFlex"
+      className="Flex rowGap4 itemsCenter xsDirectionRow"
     >
       <div
-        className="box flexGrow justifyCenter paddingX2 xsDirectionColumn xsDisplayFlex"
+        className="FlexItem"
       >
         <div
-          className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+          className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
         >
-          Same great profile, slightly new look. Learn more?
+          <div
+            className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+          >
+            Same great profile, slightly new look. Learn more?
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Summary

We'd like to remove direct color specification for Toast, re-aligning to "default" and "error" variants. This PR removes the `color` prop and replaces it with `variant`. The included codemod converts `color="red"` to `variant="error"`, `color="white"` to `variant="default"`.

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-2836)

### Checklist

- [x] Added documentation + accessibility tests