### PR TITLE
Design Tokens: Update format for Android

### DIFF
--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -2,4 +2,20 @@
 // $FlowExpectedError[untyped-import]
 const StyleDictionary = require('style-dictionary').extend('config.json');
 
+StyleDictionary.registerTransform({
+  name: 'size/pxToDp',
+  type: 'value',
+  matcher(prop) {
+    return prop.value.match(/^-?[\d.]+px$/);
+  },
+  transformer(prop) {
+    return prop.value.replace(/px$/, 'dp');
+  },
+});
+
+StyleDictionary.registerTransformGroup({
+  name: 'android-custom',
+  transforms: ['attribute/cti', 'name/cti/snake', 'color/hex8android', 'size/pxToDp'],
+});
+
 StyleDictionary.buildAllPlatforms();

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -18,15 +18,21 @@
       }]
     },
     "android": {
-      "transformGroup": "android",
+      "transformGroup": "android-custom",
       "buildPath": "dist/android/",
       "files": [{
         "destination": "colors.xml",
-        "format": "android/colors"
+        "format": "android/colors",
+        "filter": {
+          "attributes": {
+            "category": "color"
+          }
+        }
       },
       {
         "destination": "space.xml",
         "format": "android/resources",
+        "resourceType": "dimen",
         "filter": {
           "attributes": {
             "category": "space"


### PR DESCRIPTION
### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

Update space tokens to use `dimen` format with `dp` for the Android output, as this is what Android [expects for dimensions](https://developer.android.com/guide/topics/resources/more-resources#Dimension) instead of `px`. 

