### PR TITLE
Internal: add license badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# Gestalt
-
-[![NPM Version](https://img.shields.io/npm/v/gestalt.svg)](https://www.npmjs.com/package/gestalt) [![gestalt](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/simple/x99ctf/master&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/x99ctf/runs)
+# [Gestalt](https://gestalt.pinterest.systems/) &middot; [![NPM Version](https://img.shields.io/npm/v/gestalt.svg)](https://www.npmjs.com/package/gestalt) [![Cypress status](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/simple/x99ctf/master&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/x99ctf/runs) [![License](https://img.shields.io/npm/l/gestalt?style=flat)](https://github.com/pinterest/gestalt/blob/master/LICENSE)
 
 Gestalt is a set of React UI components that enforces Pinterest’s design language. We use it to streamline communication between designers and developers by enforcing a bunch of fundamental UI components. This common set of components helps raise the bar for UX & accessibility across Pinterest.
 
-[Visit the official Gestalt Documentation](https://gestalt.pinterest.systems//)
+[Visit the official Gestalt Documentation](https://gestalt.pinterest.systems/)
 
 ## Installation
 


### PR DESCRIPTION
### Summary

Makes it obvious to see under which license we publish Gestalt