### PR TITLE
Internal: Keep URLs in flow docs

### DIFF
--- a/packages/gestalt-core/build.js
+++ b/packages/gestalt-core/build.js
@@ -142,10 +142,11 @@ const plugins = (name) => [
     preferConst: true,
   }),
   babel({
-    babelrc: false,
     babelHelpers: 'bundled',
+    babelrc: false,
     exclude: 'node_modules/**',
     rootMode: 'upward',
+    shouldPrintComment: (comment) => /[#@]__PURE__/.exec(comment),
   }),
   commonjs(),
 ];

--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -140,11 +140,6 @@ function cleanSource() {
     shell.exec(`find ${src} -type d -name "__fixtures__" -exec rm -rf {} +`);
     shell.exec(`find ${src} -type d -name "__snapshots__" -exec rm -rf {} +`);
 
-    // Remove URLs in source files so links don't show up twice
-    shell.exec(
-      `find ${src} -type f -name "*.js" -exec sed -i -e 's! \\* http\\(s\\)\\{0,1\\}://[^[:space:]]*!!g' {} \\;`,
-    );
-
     // Convert .js to .js.flow so to disallow imports under `src/*`
     shell.exec(
       `find ${src} -type f -name "*.js" -exec sh -c 'mv "$1" "\${1%.js}.js.flow"' _ {} \\;`,


### PR DESCRIPTION
### Summary

When using the flow comments in Pinterest's codebase, I noticed all the URLs to the docs are missing. That's caused by #1561 which strips all the URLs from the `src` file, which is not what we want.

Instead, in this diff, we remove all comments (apart from [terser pure annotation comments](https://terser.org/docs/api-reference.html#annotations)) from the `dist/` directory (build files)

![Screen Shot 2021-09-09 at 5 58 44 AM](https://user-images.githubusercontent.com/127199/132692465-b079c433-3a9c-400b-a81e-09757651f644.png)
