### PR TITLE
Button: fix style bug on selected state and role link

### DIFF
--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -209,6 +209,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         ref={innerRef}
         rel={rel}
         tabIndex={tabIndex}
+        selected={selected}
         size={size}
         target={target}
         wrappedComponent="button"

--- a/packages/gestalt/src/InternalLink.js
+++ b/packages/gestalt/src/InternalLink.js
@@ -47,6 +47,7 @@ type Props = {|
   rel?: 'none' | 'nofollow',
   tabIndex: -1 | 0,
   rounding?: Rounding,
+  selected?: boolean,
   size?: 'sm' | 'md' | 'lg',
   tapStyle?: 'none' | 'compress',
   target?: null | 'self' | 'blank',
@@ -79,6 +80,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
     rel,
     tabIndex = 0,
     rounding,
+    selected,
     size,
     tapStyle = 'compress',
     target,
@@ -126,6 +128,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
           [layoutStyles.itemsCenter]: true,
           [buttonStyles.button]: true,
           [buttonStyles.disabled]: disabled,
+          [buttonStyles.selected]: !disabled && selected,
           [buttonStyles.sm]: size === 'sm',
           [buttonStyles.md]: size === 'md',
           [buttonStyles.lg]: size === 'lg',
@@ -133,7 +136,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
       : {},
     isButton && colorClass
       ? {
-          [buttonStyles[colorClass]]: !disabled,
+          [buttonStyles[colorClass]]: !disabled && !selected,
         }
       : {},
     isTapArea
@@ -265,6 +268,7 @@ InternalLinkWithForwardRef.propTypes = {
   rel: (PropTypes.oneOf(['none', 'nofollow']): React$PropType$Primitive<'none' | 'nofollow'>),
   tabIndex: PropTypes.oneOf([-1, 0]),
   rounding: RoundingPropType,
+  selected: PropTypes.bool,
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   tapStyle: (PropTypes.oneOf(['none', 'compress']): React$PropType$Primitive<'none' | 'compress'>),
   target: (PropTypes.oneOf([null, 'self', 'blank']): React$PropType$Primitive<


### PR DESCRIPTION
Buttons with role = link should not have selected state as the link is an interaction. However, some current designs are hybrids of Button that are simple links but act as Tabs and show a selected state.

Standarizing styles across variants to prevent buggy styles.

![image](https://user-images.githubusercontent.com/10593890/132776394-4bc6b5d1-d400-4626-ae00-070c9a0b8bc2.png)
![image](https://user-images.githubusercontent.com/10593890/132776385-6e48122c-4284-4585-b8b8-ca18a93997d5.png)

## BEFORE. last element (light gray) is a selected state button role=link
![image](https://user-images.githubusercontent.com/10593890/132776537-14d5677c-ddda-473c-9100-a648d84c9637.png)

## AFTER last element is a selected state button role=link

![image](https://user-images.githubusercontent.com/10593890/132776126-205f6448-f55f-4d62-8dbc-c8543c520869.png)


### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
