### PR TITLE
Docs: add autogenerated docs for AvatarGroup (forwardRef), automatically get default value & add ability to link to specific prop in docs

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -4,22 +4,6 @@ import type { DocGen } from './docgen.js';
 
 import PropTable from './PropTable.js';
 
-function getDefaultValue(
-  description?: string,
-): {|
-  description?: string,
-  defaultValue?: string,
-|} {
-  const input = description ?? '';
-  const match = input.match(/(?<main>Default: (?<defaultValue>.*))/);
-  const groups = match?.groups ?? {};
-
-  return {
-    description: groups.main ? input.replace(groups.main, '') : description,
-    defaultValue: groups.defaultValue?.replace(/'/g, ''),
-  };
-}
-
 function getHref(
   description?: string,
 ): {|
@@ -46,17 +30,15 @@ export default function GeneratedPropTable({
   // Using Object.keys because of https://github.com/facebook/flow/issues/2174
   const props = Object.keys(generatedDocGen.props)
     .map((key: string) => {
-      const { flowType, description, required } = generatedDocGen.props[key];
+      const { flowType, description, required, defaultValue } = generatedDocGen.props[key];
 
       // Filter out PropType only types & excluded props
       if (!flowType || excludeProps.includes(key)) {
         return null;
       }
-
-      const { description: descriptionWithoutDefaultValue = '', defaultValue } = getDefaultValue(
+      const { description: descriptionWihoutLink, href } = getHref(
         description?.replace(/https:\/\/gestalt\.pinterest\.systems/, ''),
       );
-      const { description: descriptionWihoutLink, href } = getHref(descriptionWithoutDefaultValue);
 
       return {
         name: key,
@@ -66,7 +48,7 @@ export default function GeneratedPropTable({
         ),
         description: descriptionWihoutLink?.trim(),
         required,
-        defaultValue,
+        defaultValue: defaultValue?.value?.replace(/'/g, ''),
         href,
       };
     })

--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -99,6 +99,7 @@ export default function PropTable({
   Component,
 }: Props): Node {
   const { propTableVariant, setPropTableVariant } = useAppContext();
+  const propsId = `${id}Props`;
 
   if (process.env.NODE_ENV === 'development' && Component) {
     const { displayName, propTypes } = Component; // eslint-disable-line react/forbid-foreign-prop-types
@@ -120,7 +121,7 @@ export default function PropTable({
 
   return (
     <Card
-      id={`${id}Props`}
+      id={propsId}
       name={proptableName ? `${proptableName} Props` : 'Props'}
       toggle={
         <Tooltip inline text={`${propTableVariant === 'expanded' ? 'Collapse' : 'Expand'} props`}>
@@ -172,18 +173,27 @@ export default function PropTable({
                     acc.push(
                       <tr key={i}>
                         <Td shrink border={!propNameHasSecondRow}>
-                          <Flex gap={2}>
-                            <Text overflow="normal" underline={!!href}>
-                              {href ? (
-                                <Link href={`#${href}`}>
+                          <Box
+                            id={`${propsId}-${name}`}
+                            dangerouslySetInlineStyle={{
+                              __style: {
+                                scrollMarginTop: 60,
+                              },
+                            }}
+                          >
+                            <Flex gap={2}>
+                              <Text overflow="normal" underline={!!href}>
+                                {href ? (
+                                  <Link href={`#${href}`}>
+                                    <code>{name}</code>
+                                  </Link>
+                                ) : (
                                   <code>{name}</code>
-                                </Link>
-                              ) : (
-                                <code>{name}</code>
-                              )}
-                            </Text>
-                            {required && <Badge text="Required" />}
-                          </Flex>
+                                )}
+                              </Text>
+                              {required && <Badge text="Required" />}
+                            </Flex>
+                          </Box>
                         </Td>
                         <Td border={!propNameHasSecondRow}>
                           <code>{unifyQuotes(type)}</code>

--- a/docs/components/docgen.js
+++ b/docs/components/docgen.js
@@ -11,6 +11,10 @@ export type DocGen = {|
   methods: $ReadOnlyArray<string>,
   props: {|
     [key: string]: {|
+      defaultValue: ?{|
+        value: string,
+        computed: boolean,
+      |},
       required: boolean,
       description: string,
       flowType: {|

--- a/docs/pages/avatargroup.js
+++ b/docs/pages/avatargroup.js
@@ -1,146 +1,66 @@
 // @flow strict
 import React, { type Node } from 'react';
 import { AvatarGroup } from 'gestalt';
-import PropTable from '../components/PropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
-import CardPage from '../components/CardPage.js';
 import CombinationNew from '../components/CombinationNew.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import Page from '../components/Page.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
-
-card(
-  <PageHeader
-    name="AvatarGroup"
-    description="AvatarGroup is used to both display a group of user avatars and, optionally, control actions related to the users group."
-    defaultCode={`
-<Box width={300} height={125}>
-  <AvatarGroup size="fit" accessibilityLabel="Collaborators: Keerthi, Alberto, Shanice."
-    collaborators={[
-      {
-        name: 'Keerthi',
-        src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-      },
-      {
-        name: 'Alberto',
-        src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
-      },
+export default function AvatarGroupPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="AvatarGroup">
+      <PageHeader
+        name="AvatarGroup"
+        description="AvatarGroup is used to both display a group of user avatars and, optionally, control actions related to the users group."
+        defaultCode={`
+  <Box width={300} height={125}>
+    <AvatarGroup size="fit" accessibilityLabel="Collaborators: Keerthi, Alberto, Shanice."
+      collaborators={[
         {
-        name: 'Shanice',
-        src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-      },
-    ]}
-  />
-</Box>
-`}
-  />,
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        required: true,
-        description: `Label for the component used for screen readers.
-
-See the [Accessibility guidelines](#Accessibility) for details on proper usage.`,
-      },
-      {
-        name: 'collaborators',
-        type: 'Array<{| name: string, src?: string |}>',
-        required: true,
-        description: `The user group data. See the [collaborators display](#Collaborators-display) variant to learn more.`,
-      },
-      {
-        name: 'size',
-        type: `"xs" | "sm" | "md" | "fit"`,
-        defaultValue: 'fit',
-        description: `The maximum height of AvatarGroup. If size is \`fit\`, AvatarGroup will fill 100% of the parent container width. See the [fixed size](#Fixed-sizes) and [responsive size](#Responsive-sizing) variant to learn more.`,
-      },
-      {
-        name: 'role',
-        type: `"button" | "link"`,
-        description: `Allows user interaction with the component. See the [role](#Role) variant to learn more.`,
-      },
-
-      {
-        name: 'accessibilityControls',
-        type: 'string',
-        description: `Specify the \`id\` of an associated element (or elements) whose contents or visibility are controlled by a component so that screen reader users can identify the relationship between elements. Optional with button-role component.
-
-See the [Accessibility guidelines](#Accessibility) for details on proper usage.`,
-      },
-      {
-        name: 'accessibilityExpanded',
-        type: 'boolean',
-        description: `Indicate that a component hides or exposes collapsible components and expose whether they are currently expanded or collapsed. Optional with button-role component.
-
-See the [Accessibility guidelines](#Accessibility) for details on proper usage.`,
-      },
-      {
-        name: 'accessibilityHaspopup',
-        type: 'boolean',
-        description: `Indicate that a component controls the appearance of interactive popup elements, such as menu or dialog. Optional with button-role component.
-
-See the [Accessibility guidelines](#Accessibility) for details on proper usage.`,
-      },
-      {
-        name: 'onClick',
-        type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) => void',
-        description: `Callback fired when the component is clicked (pressed and released) with a mouse or keyboard. See the [role](#Role) variant to learn more.`,
-      },
-      {
-        name: 'href',
-        type: 'string',
-        description: `When supplied, wraps the component in a link, and directs users to the url when item is selected. See the [role](#Role) variant to learn more.`,
-      },
-      {
-        name: 'addCollaborators',
-        type: 'boolean',
-        description: `When supplied, it appends an \`add\` [icon](/Icon) to the avatar pile as a call to action to the user. See [Best Practices](#Best-practices) for more info.`,
-      },
-      {
-        name: 'ref',
-        type: `React.Ref<'div'> | React.Ref<'a'>`,
-        description: `Forward the ref to the underlying div or anchor element. See the [role](#Role) variant to learn more.`,
-      },
-    ]}
-  />,
-);
-
-card(
-  <MainSection name="Usage guidelines">
-    <MainSection.Subsection columns={2}>
-      <MainSection.Card
-        cardSize="md"
-        type="do"
-        title="When to Use"
-        description={`
-          - For the general display of groups of people, companies and/or brands.
-          - In cases where an affordance for adding collaborators is needed.
-        `}
+          name: 'Keerthi',
+          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+        },
+        {
+          name: 'Alberto',
+          src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
+        },
+          {
+          name: 'Shanice',
+          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+        },
+      ]}
+    />
+  </Box>
+  `}
       />
-      <MainSection.Card
-        cardSize="md"
-        type="don't"
-        title="When Not to Use"
-        description={`
-          - Displaying a group of people, companies and/or brands in a square format. Use [AvatarPair](/AvatarPair) instead.
-        `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
-
-card(
-  <MainSection name="Accessibility">
-    <MainSection.Subsection
-      title="ARIA attributes"
-      description={`
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+      <MainSection name="Usage guidelines">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            title="When to Use"
+            description={`
+            - For the general display of groups of people, companies and/or brands.
+            - In cases where an affordance for adding collaborators is needed.
+          `}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            title="When Not to Use"
+            description={`
+            - Displaying a group of people, companies and/or brands in a square format. Use [AvatarPair](/AvatarPair) instead.
+          `}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+      <MainSection name="Accessibility">
+        <MainSection.Subsection
+          title="ARIA attributes"
+          description={`
 AvatarGroup requires \`accessibilityLabel\`. AvatarGroup is a group of elements that require a parent label describing both the data presented and the call to action in the case of button and link roles. As seen in the example below, the screen-reader reads: "Collaborators: Keerthi, Alberto, and 10 more. Add collaborators to this board."
 
 
@@ -149,11 +69,11 @@ If AvatarGroup is used as a control button to show/hide Popover-component, we re
 - \`accessibilityControls\`: informs the screen reader that AvatarGroup controls the display of an anchored Popover-component. It populates [aria-controls](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html).
 - \`accessibilityHaspopup\`: informs the screen reader that there’s a Popover-component attached to AvatarGroup. It populates [aria-haspopup](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html).
 - \`accessibilityExpanded\`: informs the screen reader whether an anchored Popover-component is currently open or closed. It populates [aria-expanded](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html).
-`}
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
+  `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function Example() {
   const [open, setOpen] = React.useState(false);
   const [selectedBoard, setSelectedBoard] = React.useState('Fashion');
@@ -231,53 +151,49 @@ function Example() {
     </React.Fragment>
   );
 }
-  `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
-
-card(<MainSection name="Localization" description="Be sure to localize  `accessibilityLabel`." />);
-
-card(
-  <MainSection name="Variants">
-    <MainSection.Subsection
-      title="Fixed sizes"
-      description="AvatarGroup is available in 3 fixed height sizes: `xs` (24px) , `sm` (32px), and `md` (48px)."
-    >
-      <CombinationNew size={['xs', 'sm', 'md']}>
-        {({ size }) => (
-          <AvatarGroup
-            accessibilityLabel="Collaborators: Keerthi, Alberto, and Shanice."
-            size={size}
-            collaborators={[
-              {
-                name: 'Keerthi',
-                src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-              },
-              {
-                name: 'Alberto',
-                src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
-              },
-              {
-                name: 'Shanice',
-                src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-              },
-            ]}
+    `}
           />
-        )}
-      </CombinationNew>
-    </MainSection.Subsection>
-    <MainSection.Subsection
-      title="Responsive sizing"
-      description="AvatarGroup is a responsive component. Avatar Groups that are not given a size prop or use size `fit` will expand to fit to the width of their parent container. A common use case is to achieve column-based sizing.
+        </MainSection.Subsection>
+      </MainSection>
+      <MainSection name="Localization" description="Be sure to localize  `accessibilityLabel`." />
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          title="Fixed sizes"
+          description="AvatarGroup is available in 3 fixed height sizes: `xs` (24px) , `sm` (32px), and `md` (48px)."
+        >
+          <CombinationNew size={['xs', 'sm', 'md']}>
+            {({ size }) => (
+              <AvatarGroup
+                accessibilityLabel="Collaborators: Keerthi, Alberto, and Shanice."
+                size={size}
+                collaborators={[
+                  {
+                    name: 'Keerthi',
+                    src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+                  },
+                  {
+                    name: 'Alberto',
+                    src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
+                  },
+                  {
+                    name: 'Shanice',
+                    src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+                  },
+                ]}
+              />
+            )}
+          </CombinationNew>
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Responsive sizing"
+          description="AvatarGroup is a responsive component. Avatar Groups that are not given a size prop or use size `fit` will expand to fit to the width of their parent container. A common use case is to achieve column-based sizing.
 
-      Resize the width or number of avatars to see the AvatarGroup change to match the width of the Column it's been placed in.
-"
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
+        Resize the width or number of avatars to see the AvatarGroup change to match the width of the Column it's been placed in.
+  "
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Box width={600} height={100}>
   <Flex>
     <Box column={5}>
@@ -309,116 +225,116 @@ card(
     </Box>
   </Flex>
 </Box>
- `}
-      />
-    </MainSection.Subsection>
-    <MainSection.Subsection
-      title="Collaborators display"
-      description="AvatarGroup displays up to three user avatars. More users, if present, will be displayed as a numerical count for the `md` and `fit` sizes."
-    >
-      <CombinationNew
-        hideTitle
-        addCollaborators={[false, true]}
-        collaborators={[
-          [
-            {
-              name: 'Keerthi',
-              src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-            },
-          ],
-          [
-            {
-              name: 'Keerthi',
-              src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-            },
-            {
-              name: 'Alberto',
-              src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
-            },
-          ],
-          [
-            {
-              name: 'Keerthi',
-              src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-            },
-            {
-              name: 'Alberto',
-              src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
-            },
-            {
-              name: 'Shanice',
-              src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-            },
-          ],
-          [
-            {
-              name: 'Keerthi',
-              src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-            },
-            {
-              name: 'Alberto',
-              src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
-            },
-            {
-              name: 'Shanice',
-              src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-            },
-            ...new Array(10),
-          ],
-          [
-            {
-              name: 'Keerthi',
-              src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-            },
-            {
-              name: 'Alberto',
-              src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
-            },
-            {
-              name: 'Shanice',
-              src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-            },
-            ...new Array(100),
-          ],
-        ]}
-      >
-        {({ addCollaborators, collaborators }) => {
-          const accessibilityLabel =
-            collaborators.length <= 3
-              ? `Collaborators: ${collaborators.map((x) => x?.name).join(', and ')}.`
-              : `Collaborators: ${collaborators
-                  .slice(0, 2)
-                  .map((x) => x?.name)
-                  .join(', ')} ${
-                  collaborators.length > 3 ? `and ${collaborators.length - 2} more.` : '.'
-                }`;
-          return addCollaborators ? (
-            <AvatarGroup
-              accessibilityLabel={`${accessibilityLabel} Add collaborators to this board.`}
-              size="md"
-              collaborators={collaborators}
-              addCollaborators
-              onClick={() => {}}
-              role="button"
-            />
-          ) : (
-            <AvatarGroup
-              accessibilityLabel={accessibilityLabel}
-              size="md"
-              collaborators={collaborators}
-            />
-          );
-        }}
-      </CombinationNew>
-    </MainSection.Subsection>
-    <MainSection.Subsection
-      columns={2}
-      title="Role"
-      description="AvatarGroup can be display only, but can also act as a button or link. It will only be clickable if role is set to `button` or `link`. For button role, `onClick` is required. For link role, `href` is required."
-    >
-      <MainSection.Card
-        cardSize="md"
-        defaultCode={`
+   `}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Collaborators display"
+          description="AvatarGroup displays up to three user avatars. More users, if present, will be displayed as a numerical count for the `md` and `fit` sizes."
+        >
+          <CombinationNew
+            hideTitle
+            addCollaborators={[false, true]}
+            collaborators={[
+              [
+                {
+                  name: 'Keerthi',
+                  src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+                },
+              ],
+              [
+                {
+                  name: 'Keerthi',
+                  src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+                },
+                {
+                  name: 'Alberto',
+                  src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
+                },
+              ],
+              [
+                {
+                  name: 'Keerthi',
+                  src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+                },
+                {
+                  name: 'Alberto',
+                  src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
+                },
+                {
+                  name: 'Shanice',
+                  src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+                },
+              ],
+              [
+                {
+                  name: 'Keerthi',
+                  src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+                },
+                {
+                  name: 'Alberto',
+                  src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
+                },
+                {
+                  name: 'Shanice',
+                  src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+                },
+                ...new Array(10),
+              ],
+              [
+                {
+                  name: 'Keerthi',
+                  src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+                },
+                {
+                  name: 'Alberto',
+                  src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
+                },
+                {
+                  name: 'Shanice',
+                  src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+                },
+                ...new Array(100),
+              ],
+            ]}
+          >
+            {({ addCollaborators, collaborators }) => {
+              const accessibilityLabel =
+                collaborators.length <= 3
+                  ? `Collaborators: ${collaborators.map((x) => x?.name).join(', and ')}.`
+                  : `Collaborators: ${collaborators
+                      .slice(0, 2)
+                      .map((x) => x?.name)
+                      .join(', ')} ${
+                      collaborators.length > 3 ? `and ${collaborators.length - 2} more.` : '.'
+                    }`;
+              return addCollaborators ? (
+                <AvatarGroup
+                  accessibilityLabel={`${accessibilityLabel} Add collaborators to this board.`}
+                  size="md"
+                  collaborators={collaborators}
+                  addCollaborators
+                  onClick={() => {}}
+                  role="button"
+                />
+              ) : (
+                <AvatarGroup
+                  accessibilityLabel={accessibilityLabel}
+                  size="md"
+                  collaborators={collaborators}
+                />
+              );
+            }}
+          </CombinationNew>
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          columns={2}
+          title="Role"
+          description="AvatarGroup can be display only, but can also act as a button or link. It will only be clickable if role is set to `button` or `link`. For button role, `onClick` is required. For link role, `href` is required."
+        >
+          <MainSection.Card
+            cardSize="md"
+            defaultCode={`
 function ButtonExample() {
   const [open, setOpen] = React.useState(false);
   const [selectedBoard, setSelectedBoard] = React.useState('Fashion');
@@ -487,11 +403,11 @@ const List = () => (
     </React.Fragment>
   );
 }
-  `}
-      />
-      <MainSection.Card
-        cardSize="md"
-        defaultCode={`
+    `}
+          />
+          <MainSection.Card
+            cardSize="md"
+            defaultCode={`
 function LinkExample() {
   const [open, setOpen] = React.useState(false);
   const [selectedBoard, setSelectedBoard] = React.useState('Fashion');
@@ -519,12 +435,16 @@ function LinkExample() {
       />
   );
 }
-  `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
+    `}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+    </Page>
+  );
+}
 
-export default function AvatarGroupPage(): Node {
-  return <CardPage cards={cards} page="AvatarGroup" />;
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen('AvatarGroup') },
+  };
 }

--- a/packages/gestalt/src/AvatarGroup.js
+++ b/packages/gestalt/src/AvatarGroup.js
@@ -7,27 +7,70 @@ import AddCollaboratorsButton from './AvatarGroupAddCollaboratorsButton.js';
 import CollaboratorAvatar from './AvatarGroupCollaboratorAvatar.js';
 import CollaboratorsCount from './AvatarGroupCollaboratorsCount.js';
 import Flex from './Flex.js';
-import { type CollaboratorDataType } from './Avatar.js';
-import { type Size, SizeProptype } from './AvatarGroupConstants.js';
 
 const MAX_COLLABORATOR_AVATARS = 3;
 
 type Role = 'link' | 'button';
-
-type Props = {|
-  accessibilityLabel: string,
-  accessibilityControls?: string,
-  accessibilityExpanded?: boolean,
-  accessibilityHaspopup?: boolean,
-  addCollaborators?: boolean,
-  collaborators: $ReadOnlyArray<CollaboratorDataType>,
-  href?: string,
-  onClick?: OnTapType,
-  role?: Role,
-  size?: Size,
-|};
+type Size = 'xs' | 'sm' | 'md' | 'fit';
 
 type UnionRefs = HTMLDivElement | HTMLAnchorElement;
+type Props = {|
+  /**
+   * Label for the component used for screen readers.
+   *
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/AvatarGroup#Accessibility) for details on proper usage.
+   */
+  accessibilityLabel: string,
+  /**
+   * Specify the `id` of an associated element (or elements) whose contents or visibility are controlled by a component so that screen reader users can identify the relationship between elements. Optional with button-role component.
+   *
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/AvatarGroup#Accessibility) for details on proper usage.
+   */
+  accessibilityControls?: string,
+  /**
+   * Indicate that a component hides or exposes collapsible components and expose whether they are currently expanded or collapsed. Optional with button-role component.
+   *
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/AvatarGroup#Accessibility) for details on proper usage.
+   */
+  accessibilityExpanded?: boolean,
+  /**
+   * Indicate that a component controls the appearance of interactive popup elements, such as menu or dialog. Optional with button-role component.
+   *
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/AvatarGroup#Accessibility) for details on proper usage.
+   */
+  accessibilityHaspopup?: boolean,
+  /**
+   * When supplied, it appends an `add` [icon](https://gestalt.pinterest.systems/Icon) to the avatar pile as a call to action to the user. See [Best Practices](https://gestalt.pinterest.systems/AvatarGroup#Best-practices) for more info.
+   */
+  addCollaborators?: boolean,
+  /**
+   * The user group data. See the [collaborators display](https://gestalt.pinterest.systems/AvatarGroup#Collaborators-display) variant to learn more.
+   */
+  collaborators: $ReadOnlyArray<{|
+    name: string,
+    src?: string,
+  |}>,
+  /**
+   * When supplied, wraps the component in a link, and directs users to the url when item is selected. See the [role](https://gestalt.pinterest.systems/AvatarGroup#Role) variant to learn more.
+   */
+  href?: string,
+  /**
+   * Callback fired when the component is clicked (pressed and released) with a mouse or keyboard. See the [role](https://gestalt.pinterest.systems/AvatarGroup#Role) variant to learn more and see [TapArea's `onTap`](https://gestalt.pinterest.systems/taparea#Props-onTap) for more info about `OnTapType`.
+   */
+  onClick?: OnTapType,
+  /**
+   * Forward the ref to the underlying div or anchor element. See the [role](https://gestalt.pinterest.systems/AvatarGroup#Role) variant to learn more.
+   */
+  ref?: UnionRefs, // eslint-disable-line react/no-unused-prop-types
+  /**
+   * Allows user interaction with the component. See the [role](https://gestalt.pinterest.systems/AvatarGroup#Role) variant to learn more.
+   */
+  role?: Role,
+  /**
+   * The maximum height of AvatarGroup. If size is `fit`, AvatarGroup will fill 100% of the parent container width. See the [fixed size](https://gestalt.pinterest.systems/AvatarGroup#Fixed-sizes) and [responsive size](https://gestalt.pinterest.systems/AvatarGroup#Responsive-sizing) variant to learn more.
+   */
+  size?: 'xs' | 'sm' | 'md' | 'fit',
+|};
 
 /**
  * https://gestalt.pinterest.systems/AvatarGroup
@@ -47,7 +90,7 @@ const AvatarGroupWithForwardRef: React$AbstractComponent<Props, UnionRefs> = for
     onClick,
     role,
     size = 'fit',
-  },
+  }: Props,
   ref,
 ): Node {
   const [hovered, setHovered] = useState(false);
@@ -180,7 +223,7 @@ AvatarGroupWithForwardRef.propTypes = {
   href: PropTypes.string,
   onClick: PropTypes.func,
   role: (PropTypes.oneOf(['link', 'button']): React$PropType$Primitive<Role>),
-  size: SizeProptype,
+  size: (PropTypes.oneOf(['xs', 'sm', 'md', 'fit']): React$PropType$Primitive<Size>),
 };
 
 AvatarGroupWithForwardRef.displayName = 'AvatarGroup';

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -100,21 +100,19 @@ function Header({
 /**
  * https://gestalt.pinterest.systems/modal
  */
-export default function Modal(props: Props): Node {
-  const {
-    _dangerouslyDisableScrollBoundaryContainer = false,
-    accessibilityModalLabel,
-    align = 'center',
-    children,
-    closeOnOutsideClick = true,
-    onDismiss,
-    footer,
-    heading,
-    role = 'dialog',
-    size = 'sm',
-    subHeading = undefined,
-  } = props;
-
+export default function Modal({
+  _dangerouslyDisableScrollBoundaryContainer = false,
+  accessibilityModalLabel,
+  align = 'center',
+  children,
+  closeOnOutsideClick = true,
+  onDismiss,
+  footer,
+  heading,
+  role = 'dialog',
+  size = 'sm',
+  subHeading,
+}: Props): Node {
   const [showTopShadow, setShowTopShadow] = useState(false);
   const [showBottomShadow, setShowBottomShadow] = useState(false);
   const contentRef = useRef<?HTMLElement>(null);

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -24,13 +24,11 @@ type Props = {|
   /**
    * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text.
    *
-   * Default: 'start'
    * Link: https://gestalt.pinterest.systems/text#align
    */
   align?: 'start' | 'end' | 'center' | 'justify' | 'forceLeft' | 'forceRight',
   children?: Node,
   /**
-   * Default: 'darkGray'
    * Link: https://gestalt.pinterest.systems/text#color
    */
   color?:
@@ -52,12 +50,10 @@ type Props = {|
     | 'watermelon'
     | 'white',
   /**
-   * Default: false
    * Link: https://gestalt.pinterest.systems/text#inline
    */
   inline?: boolean,
   /**
-   * Default: false
    * Link: https://gestalt.pinterest.systems/text#styles
    */
   italic?: boolean,
@@ -68,24 +64,20 @@ type Props = {|
    */
   lineClamp?: number,
   /**
-   * Default: 'breakWord'
    * Link: https://gestalt.pinterest.systems/text#overflow
    */
   overflow?: Overflow,
   /**
    * sm: `12px`, md: `14px`, lg: `16px`
    *
-   * Default: 'lg'
    * Link: https://gestalt.pinterest.systems/text#size
    */
   size?: Size,
   /**
-   * Default: 'false'
    * Link: https://gestalt.pinterest.systems/text#styles
    */
   underline?: boolean,
   /**
-   * Default: 'normal'
    * Link: https://gestalt.pinterest.systems/text#styles
    */
   weight?: 'bold' | 'normal',


### PR DESCRIPTION
### Summary

@AlbertCarreras noticed that `AvatarGroup` didn't export any types when using the generated docs. That was due to the fact that the component had a `forwardRef`.

# Changes
* **Use autogenerated docs for AvatarGroup** (forwardRef)
* **Automatically get default value**: `react-docgen` already knows about the value so no need to duplicate it.
* **Add ability to link to specific prop in proptable**: makes it easy to reference other props from other components

# Found issues

## `Modal` had 2 more types with default values

Since we previously were setting these manually, we didn't discover these

### Before
![image](https://user-images.githubusercontent.com/127199/132861988-ccc9fb65-c282-40eb-a03b-1af7353882af.png)

### After
![image](https://user-images.githubusercontent.com/127199/132862030-b75c6f68-fd42-4f72-9e21-ac007f644ef3.png)
