### PR TITLE
Toast: Add experimental prop for dark gray color

### DIFF
--- a/packages/gestalt/src/Toast.css
+++ b/packages/gestalt/src/Toast.css
@@ -1,0 +1,7 @@
+.textColorOverrideWhite * {
+  color: var(--g-colorGray0) !important; /* stylelint-disable-line declaration-no-important */
+}
+
+.textColorOverrideDarkGray * {
+  color: var(--g-colorGray300) !important; /* stylelint-disable-line declaration-no-important */
+}

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -33,31 +33,32 @@ export default function Toast({
   const isDarkMode = colorSchemeName === 'darkMode';
   const isErrorVariant = variant === 'error';
 
-  let containerColor = _dangerouslyUseDarkGray ? 'darkGray' : 'white';
-  let textColor = _dangerouslyUseDarkGray ? 'white' : 'darkGray';
+  let containerColor = 'white';
+  let textColor = 'darkGray';
+  let textElement = text;
 
+  if (_dangerouslyUseDarkGray) {
+    containerColor = isDarkMode ? 'white' : 'darkGray';
+    textColor = isDarkMode ? 'darkGray' : 'white';
+
+    // If `text` is a Node, we need to override any text colors within to ensure they all match
+    if (typeof text !== 'string') {
+      let textColorOverrideStyles = isDarkMode
+        ? styles.textColorOverrideDarkGray
+        : styles.textColorOverrideWhite;
+      if (isErrorVariant) {
+        textColorOverrideStyles = styles.textColorOverrideWhite;
+      }
+
+      textElement = <span className={textColorOverrideStyles}>{text}</span>;
+    }
+  }
+
+  // Error variant does not currently support dark mode and is the same for the experimental treatment
   if (isErrorVariant) {
-    // Error variant does not currently support dark mode
     containerColor = 'red';
     textColor = 'white';
-  } else if (isDarkMode) {
-    containerColor = 'white';
-    textColor = 'darkGray';
   }
-
-  let textColorOverrideStyles = isDarkMode
-    ? styles.textColorOverrideDarkGray
-    : styles.textColorOverrideWhite;
-  if (isErrorVariant) {
-    textColorOverrideStyles = styles.textColorOverrideWhite;
-  }
-
-  const textElement =
-    _dangerouslyUseDarkGray && typeof text !== 'string' ? (
-      <span className={textColorOverrideStyles}>{text}</span>
-    ) : (
-      text
-    );
 
   return (
     <Box marginBottom={3} maxWidth={360} paddingX={4} role="status" width="100vw">

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -5,6 +5,8 @@ import Box from './Box.js';
 import Flex from './Flex.js';
 import Mask from './Mask.js';
 import Text from './Text.js';
+import styles from './Toast.css';
+import { useColorScheme } from './contexts/ColorScheme.js';
 
 type Props = {|
   button?: Node,
@@ -12,6 +14,8 @@ type Props = {|
   thumbnail?: Node,
   thumbnailShape?: 'circle' | 'rectangle' | 'square',
   variant?: 'default' | 'error',
+  // Experimental prop to replace the default color with darkGray
+  _dangerouslyUseDarkGray?: boolean,
 |};
 
 /**
@@ -23,10 +27,37 @@ export default function Toast({
   thumbnail,
   thumbnailShape = 'square',
   variant = 'default',
+  _dangerouslyUseDarkGray,
 }: Props): Node {
+  const { name: colorSchemeName } = useColorScheme();
+  const isDarkMode = colorSchemeName === 'darkMode';
   const isErrorVariant = variant === 'error';
-  const containerColor = isErrorVariant ? 'red' : 'white';
-  const textColor = isErrorVariant ? 'white' : undefined;
+
+  let containerColor = _dangerouslyUseDarkGray ? 'darkGray' : 'white';
+  let textColor = _dangerouslyUseDarkGray ? 'white' : 'darkGray';
+
+  if (isErrorVariant) {
+    // Error variant does not currently support dark mode
+    containerColor = 'red';
+    textColor = 'white';
+  } else if (isDarkMode) {
+    containerColor = 'white';
+    textColor = 'darkGray';
+  }
+
+  let textColorOverrideStyles = isDarkMode
+    ? styles.textColorOverrideDarkGray
+    : styles.textColorOverrideWhite;
+  if (isErrorVariant) {
+    textColorOverrideStyles = styles.textColorOverrideWhite;
+  }
+
+  const textElement =
+    _dangerouslyUseDarkGray && typeof text !== 'string' ? (
+      <span className={textColorOverrideStyles}>{text}</span>
+    ) : (
+      text
+    );
 
   return (
     <Box marginBottom={3} maxWidth={360} paddingX={4} role="status" width="100vw">
@@ -46,7 +77,7 @@ export default function Toast({
 
           <Flex direction="column" flex="grow" justifyContent="center">
             <Text align={!thumbnail && !button ? 'center' : 'start'} color={textColor}>
-              {text}
+              {textElement}
             </Text>
           </Flex>
 
@@ -66,4 +97,5 @@ Toast.propTypes = {
     'circle' | 'rectangle' | 'square',
   >),
   variant: (PropTypes.oneOf(['default', 'error']): React$PropType$Primitive<'default' | 'error'>),
+  _dangerouslyUseDarkGray: PropTypes.bool,
 };


### PR DESCRIPTION
### Summary

We're looking to move the default Toast color back to dark gray, but this time we'd like to make the change behind an experiment to gauge user behavior changes. This PR adds an undocumented prop to use dark gray instead of white for the toast background. It also adds an override (specific to the experimental color treatment) to ensure that all contained text is the correct color, regardless of any colors set on more complex `text` Node props.

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-2837)

### Checklist

- [x] Checked dark mode, responsiveness, and right-to-left support
