### PR TITLE
ComboBox: removed minWidth

### DIFF
--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -240,7 +240,6 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
         aria-expanded={showOptionsList}
         aria-haspopup
         aria-owns={id}
-        minWidth={280}
         position="relative"
         role="combobox"
       >

--- a/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
@@ -10,7 +10,6 @@ exports[`ComboBox Controlled ComboBox renders basic controlled components 1`] = 
       aria-owns="test"
       class="box relative"
       role="combobox"
-      style="min-width: 280px;"
     >
       <span>
         <label
@@ -89,7 +88,6 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
       aria-owns="test"
       class="box relative"
       role="combobox"
-      style="min-width: 280px;"
     >
       <span>
         <label
@@ -623,7 +621,6 @@ exports[`ComboBox Uncontrolled ComboBox renders default 1`] = `
       aria-owns="test"
       class="box relative"
       role="combobox"
-      style="min-width: 280px;"
     >
       <span>
         <label
@@ -702,7 +699,6 @@ exports[`ComboBox Uncontrolled ComboBox renders disabled state 1`] = `
       aria-owns="test"
       class="box relative"
       role="combobox"
-      style="min-width: 280px;"
     >
       <span>
         <label


### PR DESCRIPTION
### Summary

ComboBox: removed minWidth

minWidth of 280 px was added with no design specs backing it. Removing it so designers can use it with less size restrictions.

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
