### PR TITLE
SearchField: Update docs to autogenerated props, design guidelines

### DIFF
--- a/docs/pages/searchfield.js
+++ b/docs/pages/searchfield.js
@@ -81,7 +81,7 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             type="do"
             description="Place SearchField above the content the user will be searching."
             defaultCode={`
-<SearchField accessibilityLabel="Search your Pins" id="bestPracticesDo1" onChange={() => {}} placeholder="Search your Pins" />
+<SearchField accessibilityLabel="Search your Pins" accessibilityClearButtonLabel="Clear search field" id="bestPracticesDo1" onChange={() => {}} placeholder="Search your Pins" />
       `}
           />
           <MainSection.Card
@@ -100,9 +100,17 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             type="do"
             description="Make the `placeholder` specific. Give the user a hint about the content they're searching and/or what parameters they can use to search."
             defaultCode={`
-<Box width="100%">
-  <SearchField accessibilityLabel="Search by audience name or ID" id="bestPracticesDo2" onChange={() => {}} placeholder="Search by audience name or ID" />
-</Box>
+<Flex alignItems="center" flex="grow">
+  <Flex.Item flex="grow">
+    <SearchField
+      accessibilityLabel="Search by audience name or ID"
+      accessibilityClearButtonLabel="Clear search field"
+      id="bestPracticesDo2"
+      onChange={() => {}}
+      placeholder="Search by audience name or ID"
+    />
+  </Flex.Item>
+</Flex>
       `}
           />
           <MainSection.Card
@@ -110,9 +118,17 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             type="don't"
             description="Add critical information to the `placeholder`. The `placeholder` text disappears once the user begins entering data and will therefore be unavailable."
             defaultCode={`
-<Box width="100%">
-  <SearchField accessibilityLabel="Search your Pins" id="bestPracticesDont2" onChange={() => {}} placeholder="Click the submit button to search" />
-</Box>
+<Flex alignItems="center" flex="grow">
+  <Flex.Item flex="grow">
+    <SearchField
+      accessibilityLabel="Search your Pins"
+      accessibilityClearButtonLabel="Clear search field"
+      id="bestPracticesDont2"
+      onChange={() => {}}
+      placeholder="Click the submit button to search"
+    />
+  </Flex.Item>
+</Flex>
 `}
           />
         </MainSection.Subsection>
@@ -124,7 +140,13 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             description="Make sure SearchField is displayed wide enough to completely display common search terms."
             defaultCode={`
 <Box width={300}>
-  <SearchField accessibilityLabel="Search your Pins" id="bestPracticesDo3" onChange={() => {}} value="Homecoming dresses" />
+  <SearchField
+    accessibilityLabel="Search your Pins"
+    accessibilityClearButtonLabel="Clear search field"
+    id="bestPracticesDo3"
+    onChange={() => {}}
+    value="Homecoming dresses"
+  />
 </Box>
 `}
           />
@@ -134,7 +156,13 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             description="Truncate or wrap text within SearchField."
             defaultCode={`
 <Box width={300}>
-  <SearchField accessibilityLabel="Search your Pins" id="bestPracticesDont3" onChange={() => {}} value="Swiss architecure from the 195…" />
+  <SearchField
+    accessibilityLabel="Search your Pins"
+    accessibilityClearButtonLabel="Clear search field"
+    id="bestPracticesDont3"
+    onChange={() => {}}
+    value="Swiss architecure from the 195…"
+  />
 </Box>
 `}
           />
@@ -157,12 +185,12 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
     const [value, setValue] = React.useState('');
 
     return (
-      <Flex gap={4} alignItems="center" flex="grow">
+      <Flex alignItems="center" flex="grow" gap={4}>
         <Icon
-          icon="pinterest"
-          color="red"
-          size={20}
           accessibilityLabel="Pinterest"
+          color="red"
+          icon="pinterest"
+          size={20}
         />
 
         <Flex.Item flex="grow">
@@ -193,7 +221,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
 
       <MainSection name="Localization">
         <MainSection.Subsection
-          title="Localization"
           description={`
       Be sure to localize the \`accessibilityLabel\`, \`accessibilityClearButtonLabel\`, \`errorMessage\`, \`label\` and \`placeholder\` prop values. Also localize \`value\` for those cases when it can be translated.
 
@@ -207,19 +234,19 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
     const [value, setValue] = React.useState('');
 
     return (
-      <Flex gap={4} alignItems="center" flex="grow">
+      <Flex alignItems="center" flex="grow" gap={4}>
         <Icon
-          icon="pinterest"
-          color="red"
-          size={20}
           accessibilityLabel="Pinterest"
+          color="red"
+          icon="pinterest"
+          size={20}
         />
 
         <Flex.Item flex="grow">
           <SearchField
             accessibilityLabel="सभी Pinterest खोजें"
             accessibilityClearButtonLabel="खोज फ़ील्ड साफ़ करें"
-            id="searchFieldA11yExample"
+            id="searchFieldLocalizationExample"
             onChange={({value}) => setValue(value)}
             placeholder="खोजें और एक्सप्लोर करें"
             value={value}
@@ -284,8 +311,8 @@ function SearchFieldExample() {
   const [lgValue, setLgValue] = React.useState('');
 
   return (
-    <Flex gap={12} alignItems="center">
-      <Flex gap={4} direction="column" flex="grow">
+    <Flex alignItems="center" gap={12}>
+      <Flex direction="column" flex="grow" gap={4}>
         <Text>Medium (md)</Text>
         <SearchField
           accessibilityLabel=""
@@ -298,7 +325,7 @@ function SearchFieldExample() {
         />
       </Flex>
 
-      <Flex gap={4} direction="column" flex="grow">
+      <Flex direction="column" flex="grow" gap={4}>
         <Text>Large (lg)</Text>
         <SearchField
           accessibilityLabel=""
@@ -329,7 +356,7 @@ function SearchFieldExample() {
   const [value, setValue] = React.useState('pepper#$%');
 
   return (
-    <Flex flex="grow" alignItems="center">
+    <Flex alignItems="center" flex="grow">
       <Flex.Item flex="grow">
         <SearchField
           accessibilityLabel=""

--- a/docs/pages/searchfield.js
+++ b/docs/pages/searchfield.js
@@ -4,7 +4,7 @@ import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
-import { type DocGen } from '../components/docgen.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -73,11 +73,79 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
         </MainSection.Subsection>
       </MainSection>
 
+      <MainSection name="Best practices">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            showCode={false}
+            type="do"
+            description="Place SearchField above the content the user will be searching."
+            defaultCode={`
+<SearchField accessibilityLabel="Search your Pins" id="bestPracticesDo1" onChange={() => {}} placeholder="Search your Pins" />
+      `}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            description="Hide SearchField behind an IconButton if there is enough space for the full component."
+            defaultCode={`
+<IconButton accessibilityLabel="Search your Pins" icon="search" />
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            description="Make the `placeholder` specific. Give the user a hint about the content they're searching and/or what parameters they can use to search."
+            defaultCode={`
+<Box width="100%">
+  <SearchField accessibilityLabel="Search by audience name or ID" id="bestPracticesDo2" onChange={() => {}} placeholder="Search by audience name or ID" />
+</Box>
+      `}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            description="Add critical information to the `placeholder`. The `placeholder` text disappears once the user begins entering data and will therefore be unavailable."
+            defaultCode={`
+<Box width="100%">
+  <SearchField accessibilityLabel="Search your Pins" id="bestPracticesDont2" onChange={() => {}} placeholder="Click the submit button to search" />
+</Box>
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            description="Make sure SearchField is displayed wide enough to completely display common search terms."
+            defaultCode={`
+<Box width={300}>
+  <SearchField accessibilityLabel="Search your Pins" id="bestPracticesDo3" onChange={() => {}} value="Homecoming dresses" />
+</Box>
+`}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            description="Truncate or wrap text within SearchField."
+            defaultCode={`
+<Box width={300}>
+  <SearchField accessibilityLabel="Search your Pins" id="bestPracticesDont3" onChange={() => {}} value="Swiss architecure from the 195…" />
+</Box>
+`}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
       <MainSection name="Accessibility">
         <MainSection.Subsection
           title="Labels"
           description={`
-      SearchField should ideally have a visible label above the input using the \`label\` prop. However, if need be, \`accessibilityLabel\` can be used to provide screen readers with context about this SearchField.
+      SearchField should ideally have a visible label above the input using the \`label\` prop. However, if need be, \`accessibilityLabel\` can be used to provide screen readers with context about the SearchField.
 
       Be sure to also specify (and localize) a string for the \`accessibilityClearButtonLabel\`.
       `}
@@ -115,6 +183,56 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
         />
 
         <IconButton accessibilityLabel="Profile" icon="person" size="md" />
+      </Flex>
+    );
+  }
+`}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
+      <MainSection name="Localization">
+        <MainSection.Subsection
+          title="Localization"
+          description={`
+      Be sure to localize the \`accessibilityLabel\`, \`accessibilityClearButtonLabel\`, \`errorMessage\`, \`label\` and \`placeholder\` prop values. Also localize \`value\` for those cases when it can be translated.
+
+      Note that localization can lengthen text by 20 to 30 percent.
+      `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+  function SearchFieldExample() {
+    const [value, setValue] = React.useState('');
+
+    return (
+      <Flex gap={4} alignItems="center" flex="grow">
+        <Icon
+          icon="pinterest"
+          color="red"
+          size={20}
+          accessibilityLabel="Pinterest"
+        />
+
+        <Flex.Item flex="grow">
+          <SearchField
+            accessibilityLabel="सभी Pinterest खोजें"
+            accessibilityClearButtonLabel="खोज फ़ील्ड साफ़ करें"
+            id="searchFieldA11yExample"
+            onChange={({value}) => setValue(value)}
+            placeholder="खोजें और एक्सप्लोर करें"
+            value={value}
+          />
+        </Flex.Item>
+
+        <IconButton
+          accessibilityLabel="सूचनाएं"
+          icon="speech-ellipsis"
+          size="md"
+        />
+
+        <IconButton accessibilityLabel="प्रोफ़ाइल" icon="person" size="md" />
       </Flex>
     );
   }
@@ -166,7 +284,7 @@ function SearchFieldExample() {
   const [lgValue, setLgValue] = React.useState('');
 
   return (
-    <Flex gap={8} alignItems="center">
+    <Flex gap={12} alignItems="center">
       <Flex gap={4} direction="column" flex="grow">
         <Text>Medium (md)</Text>
         <SearchField
@@ -231,86 +349,27 @@ function SearchFieldExample() {
           />
         </MainSection.Subsection>
       </MainSection>
+
+      <MainSection name="Related">
+        <MainSection.Subsection
+          description={`
+**[ComboBox](/combobox)**
+ComboBox allows users to filter a list when selecting an option. Choose ComboBox when the user is selecting from a finite list of options.
+
+**[TextField](/textfield)**
+TextField provides an affordance to input small to medium length text. Unless the text is used to search for or filter through content, choose TextField for shorter text input.
+
+**[TextArea](/textarea)**
+TextArea allows for multiline text input, suitable for longer length text. Unless the text is used to search for or filter through content, choose TextArea for longer text input.
+      `}
+        />
+      </MainSection>
     </Page>
   );
 }
 
-/*
-      {
-        name: 'accessibilityClearButtonLabel',
-        type: 'string',
-        description:
-          '',
-      },
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        required: true,
-        description:
-          '',
-      },
-      {
-        name: 'autoComplete',
-        type: `"on" | "off" | "username" | "name"`,
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-      },
-      {
-        name: 'label',
-        type: 'string',
-        description:
-          '',
-      },
-      {
-        name: 'onBlur',
-        type: '({ event: SyntheticEvent<HTMLInputElement> }) => void',
-      },
-      {
-        name: 'onChange',
-        type: `({
-        value: string,
-        syntheticEvent: SyntheticEvent<HTMLInputElement>
-      }) => void`,
-        required: true,
-      },
-      {
-        name: 'onFocus',
-        type: `({
-        value: string,
-        syntheticEvent: SyntheticEvent<HTMLInputElement>
-      }) => void`,
-      },
-      {
-        name: 'onKeyDown',
-        type: '({ event: SyntheticKeyboardEvent<HTMLInputElement>, value: string }) => void',
-        description: '',
-      },
-      {
-        name: 'placeholder',
-        type: 'string',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'input'>",
-        description: '',
-      },
-      {
-        name: 'size',
-        type: '"md" | "lg"',
-        required: false,
-        description: '',
-        defaultValue: 'md',
-      },
-      {
-        name: 'value',
-        type: 'string',
-      },
-      {
-        name: 'errorMessage',
-        type: 'string',
-      },
-    ]}
-*/
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen('SearchField') },
+  };
+}

--- a/docs/pages/searchfield.js
+++ b/docs/pages/searchfield.js
@@ -1,18 +1,18 @@
 // @flow strict
-
-import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
+import { type Node } from 'react';
+import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
-import CardPage from '../components/CardPage.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import { type DocGen } from '../components/docgen.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
-
-card(
-  <PageHeader
-    name="SearchField"
-    defaultCode={`
+export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="SearchField">
+      <PageHeader
+        name="SearchField"
+        description={generatedDocGen?.description}
+        defaultCode={`
   function SearchFieldExample() {
     const [value, setValue] = React.useState('');
 
@@ -24,6 +24,7 @@ card(
           size={20}
           accessibilityLabel="Pinterest"
         />
+
         <Flex.Item flex="grow">
           <SearchField
             accessibilityLabel="Search all of Pinterest"
@@ -34,34 +35,219 @@ card(
             value={value}
           />
         </Flex.Item>
+
         <IconButton
           accessibilityLabel="Notifications"
           icon="speech-ellipsis"
           size="md"
         />
+
         <IconButton accessibilityLabel="Profile" icon="person" size="md" />
       </Flex>
     );
   }
 `}
-  />,
-);
+      />
 
-card(
-  <PropTable
-    props={[
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
+      <MainSection name="Usage guidelines">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            title="When to Use"
+            description={`
+          - To search or filter content within a surface.
+        `}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            title="When Not to Use"
+            description={`
+          - As a means of inputting content to a form. Use [TextField](/textfield) instead.
+          - To act as an auto-complete input. Use [ComboBox](/combobox) instead.
+        `}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
+      <MainSection name="Accessibility">
+        <MainSection.Subsection
+          title="Labels"
+          description={`
+      SearchField should ideally have a visible label above the input using the \`label\` prop. However, if need be, \`accessibilityLabel\` can be used to provide screen readers with context about this SearchField.
+
+      Be sure to also specify (and localize) a string for the \`accessibilityClearButtonLabel\`.
+      `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+  function SearchFieldExample() {
+    const [value, setValue] = React.useState('');
+
+    return (
+      <Flex gap={4} alignItems="center" flex="grow">
+        <Icon
+          icon="pinterest"
+          color="red"
+          size={20}
+          accessibilityLabel="Pinterest"
+        />
+
+        <Flex.Item flex="grow">
+          <SearchField
+            accessibilityLabel="Search all of Pinterest"
+            accessibilityClearButtonLabel="Clear search field"
+            id="searchFieldA11yExample"
+            onChange={({value}) => setValue(value)}
+            placeholder="Search and explore"
+            value={value}
+          />
+        </Flex.Item>
+
+        <IconButton
+          accessibilityLabel="Notifications"
+          icon="speech-ellipsis"
+          size="md"
+        />
+
+        <IconButton accessibilityLabel="Profile" icon="person" size="md" />
+      </Flex>
+    );
+  }
+`}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          title="Visible label"
+          description={`When specified, \`label\` adds a label above the SearchField. If \`label\` is specified, \`accessibilityLabel\` can be an empty string.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function SearchFieldExample() {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <Flex alignItems="center" flex="grow">
+      <Flex.Item flex="grow">
+        <SearchField
+          accessibilityLabel=""
+          accessibilityClearButtonLabel="Clear search field"
+          label="Search Messages"
+          id="searchMessagesLabelExample"
+          onChange={({value}) => setValue(value)}
+          placeholder="Search by name"
+          value={value}
+        />
+        </Flex.Item>
+    </Flex>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="Sizes"
+          description={`There are 2 sizes available: \`md\` (default) and \`lg\`.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function SearchFieldExample() {
+  const [value, setValue] = React.useState('');
+  const [lgValue, setLgValue] = React.useState('');
+
+  return (
+    <Flex gap={8} alignItems="center">
+      <Flex gap={4} direction="column" flex="grow">
+        <Text>Medium (md)</Text>
+        <SearchField
+          accessibilityLabel=""
+          accessibilityClearButtonLabel="Clear search field"
+          label="Search Messages"
+          id="searchMessagesMedium"
+          onChange={({value}) => setValue(value)}
+          placeholder="Search by name"
+          value={value}
+        />
+      </Flex>
+
+      <Flex gap={4} direction="column" flex="grow">
+        <Text>Large (lg)</Text>
+        <SearchField
+          accessibilityLabel=""
+          accessibilityClearButtonLabel="Clear search field"
+          label="Search Messages"
+          id="searchMessagesLarge"
+          onChange={({value}) => setLgValue(value)}
+          placeholder="Search by name"
+          value={lgValue}
+          size="lg"
+        />
+      </Flex>
+    </Flex>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="Error"
+          description={`An \`errorMessage\` can be specified if needed.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function SearchFieldExample() {
+  const [value, setValue] = React.useState('pepper#$%');
+
+  return (
+    <Flex flex="grow" alignItems="center">
+      <Flex.Item flex="grow">
+        <SearchField
+          accessibilityLabel=""
+          accessibilityClearButtonLabel="Clear search field"
+          label="Search Messages"
+          id="searchMessagesError"
+          onChange={({value}) => setValue(value)}
+          placeholder="Search by name"
+          value={value}
+          errorMessage="Invalid search term, please avoid special characters."
+        />
+      </Flex.Item>
+    </Flex>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+    </Page>
+  );
+}
+
+/*
       {
         name: 'accessibilityClearButtonLabel',
         type: 'string',
         description:
-          'String that clients such as VoiceOver will read to describe the clear button element. Always localize the label. See the [Accessibility section](#Accessibility) for more info.',
+          '',
       },
       {
         name: 'accessibilityLabel',
         type: 'string',
         required: true,
         description:
-          'String that clients such as VoiceOver will read to describe the element. Always localize the label. See the [Accessibility section](#Accessibility) for more info.',
+          '',
       },
       {
         name: 'autoComplete',
@@ -76,7 +262,7 @@ card(
         name: 'label',
         type: 'string',
         description:
-          'Text used to label this search field. Should be localized. See the [Visible label variant](#Visible-label) for more info.',
+          '',
       },
       {
         name: 'onBlur',
@@ -100,7 +286,7 @@ card(
       {
         name: 'onKeyDown',
         type: '({ event: SyntheticKeyboardEvent<HTMLInputElement>, value: string }) => void',
-        description: 'Callback for key stroke events.',
+        description: '',
       },
       {
         name: 'placeholder',
@@ -109,13 +295,13 @@ card(
       {
         name: 'ref',
         type: "React.Ref<'input'>",
-        description: 'Forward the ref to the underlying input element',
+        description: '',
       },
       {
         name: 'size',
         type: '"md" | "lg"',
         required: false,
-        description: 'md: 40px, lg: 48px',
+        description: '',
         defaultValue: 'md',
       },
       {
@@ -127,190 +313,4 @@ card(
         type: 'string',
       },
     ]}
-  />,
-);
-
-card(
-  <MainSection name="Usage guidelines">
-    <MainSection.Subsection columns={2}>
-      <MainSection.Card
-        cardSize="md"
-        type="do"
-        title="When to Use"
-        description={`
-          - To search or filter content within a surface.
-        `}
-      />
-      <MainSection.Card
-        cardSize="md"
-        type="don't"
-        title="When Not to Use"
-        description={`
-          - As a means of inputting content to a form. Use [TextField](/textfield) instead.
-          - To act as an auto-complete input. Use [ComboBox](/combobox) instead.
-        `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
-
-card(
-  <MainSection name="Accessibility">
-    <MainSection.Subsection
-      title="Labels"
-      description={`
-      SearchField should ideally have a visible label above the input using the \`label\` prop. However, if need be, \`accessibilityLabel\` can be used to provide screen readers with context about this SearchField.
-
-      Be sure to also specify (and localize) a string for the \`accessibilityClearButtonLabel\`.
-      `}
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
-  function SearchFieldExample() {
-    const [value, setValue] = React.useState('');
-
-    return (
-      <Flex gap={4} alignItems="center" flex="grow">
-        <Icon
-          icon="pinterest"
-          color="red"
-          size={20}
-          accessibilityLabel="Pinterest"
-        />
-        <Flex.Item flex="grow">
-          <SearchField
-            accessibilityLabel="Search all of Pinterest"
-            accessibilityClearButtonLabel="Clear search field"
-            id="searchFieldA11yExample"
-            onChange={({value}) => setValue(value)}
-            placeholder="Search and explore"
-            value={value}
-          />
-        </Flex.Item>
-        <IconButton
-          accessibilityLabel="Notifications"
-          icon="speech-ellipsis"
-          size="md"
-        />
-        <IconButton accessibilityLabel="Profile" icon="person" size="md" />
-      </Flex>
-    );
-  }
-`}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
-
-card(
-  <MainSection name="Variants">
-    <MainSection.Subsection
-      title="Visible label"
-      description={`When specified, \`label\` adds a label above the SearchField. If \`label\` is specified, \`accessibilityLabel\` can be an empty string.`}
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
-function SearchFieldExample() {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Flex alignItems="center" flex="grow">
-    <Flex.Item flex="grow">
-      <SearchField
-        accessibilityLabel=""
-        accessibilityClearButtonLabel="Clear search field"
-        label="Search Messages"
-        id="searchMessagesLabelExample"
-        onChange={({value}) => setValue(value)}
-        placeholder="Search by name"
-        value={value}
-      />
-      </Flex.Item>
-    </Flex>
-  );
-}
-`}
-      />
-    </MainSection.Subsection>
-    <MainSection.Subsection
-      title="Sizes"
-      description={`There are 2 sizes available: \`md\` (default) and \`lg\`.`}
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
-function SearchFieldExample() {
-  const [value, setValue] = React.useState('');
-  const [lgValue, setLgValue] = React.useState('');
-
-  return (
-    <Flex gap={8} alignItems="center">
-      <Flex gap={4} direction="column" flex="grow">
-        <Text>Medium (md)</Text>
-        <SearchField
-          accessibilityLabel=""
-          accessibilityClearButtonLabel="Clear search field"
-          label="Search Messages"
-          id="searchMessagesMedium"
-          onChange={({value}) => setValue(value)}
-          placeholder="Search by name"
-          value={value}
-        />
-      </Flex>
-      <Flex gap={4} direction="column" flex="grow">
-        <Text>Large (lg)</Text>
-        <SearchField
-          accessibilityLabel=""
-          accessibilityClearButtonLabel="Clear search field"
-          label="Search Messages"
-          id="searchMessagesLarge"
-          onChange={({value}) => setLgValue(value)}
-          placeholder="Search by name"
-          value={lgValue}
-          size="lg"
-        />
-      </Flex>
-    </Flex>
-  );
-}
-`}
-      />
-    </MainSection.Subsection>
-    <MainSection.Subsection
-      title="Error"
-      description={`An \`errorMessage\` can be specified if needed.`}
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
-function SearchFieldExample() {
-  const [value, setValue] = React.useState('pepper#$%');
-
-  return (
-    <Flex flex="grow" alignItems="center">
-      <Flex.Item flex="grow">
-        <SearchField
-          accessibilityLabel=""
-          accessibilityClearButtonLabel="Clear search field"
-          label="Search Messages"
-          id="searchMessagesError"
-          onChange={({value}) => setValue(value)}
-          placeholder="Search by name"
-          value={value}
-          errorMessage="Invalid search term, please avoid special characters."
-        />
-      </Flex.Item>
-    </Flex>
-  );
-}
-`}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
-
-export default function SearchFieldPage(): Node {
-  return <CardPage cards={cards} page="SearchField" />;
-}
+*/

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { forwardRef, useState, useRef, useImperativeHandle } from 'react';
+import { forwardRef, type Node, useState, useRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import layout from './Layout.css';
@@ -13,39 +11,84 @@ import FormErrorMessage from './FormErrorMessage.js';
 import FormLabel from './FormLabel.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
+type UnionRefs = HTMLDivElement | HTMLAnchorElement;
+
 type Props = {|
+  /**
+   * String that clients such as VoiceOver will read to describe the element. Always localize the label. See the [Accessibility section](https://gestalt.pinterest.systems/searchfield#Accessibility) for more info.
+   */
   accessibilityLabel: string,
+  /**
+   * String that clients such as VoiceOver will read to describe the clear button element. Always localize the label. See the [Accessibility section](https://gestalt.pinterest.systems/searchfield#Accessibility) for more info.
+   */
   accessibilityClearButtonLabel?: string,
+  /**
+   *
+   */
   autoComplete?: 'on' | 'off' | 'username' | 'name',
+  /**
+   *
+   */
+  errorMessage?: string,
+  /**
+   *
+   */
   id: string,
+  /**
+   * Text used to label this search field. Should be localized. See the [Visible label variant](https://gestalt.pinterest.systems/searchfield#Visible-label) for more info.
+   */
   label?: string,
+  /**
+   *
+   */
   onBlur?: AbstractEventHandler<SyntheticEvent<HTMLInputElement>>,
+  /**
+   *
+   */
   onChange: ({|
     value: string,
     syntheticEvent: SyntheticEvent<HTMLInputElement>,
   |}) => void,
+  /**
+   *
+   */
   onFocus?: ({|
     value: string,
     syntheticEvent: SyntheticEvent<HTMLInputElement>,
   |}) => void,
+  /**
+   * Callback for key stroke events.
+   */
   onKeyDown?: ({|
     event: SyntheticKeyboardEvent<HTMLInputElement>,
     value: string,
   |}) => void,
+  /**
+   *
+   */
   placeholder?: string,
+  /**
+   * Forward the ref to the underlying input element
+   */
+  ref?: UnionRefs, // eslint-disable-line react/no-unused-prop-types
+  /**
+   * md: 40px, lg: 48px
+   */
   size?: 'md' | 'lg',
+  /**
+   *
+   */
   value?: string,
-  errorMessage?: string,
 |};
 
 /**
- * https://gestalt.pinterest.systems/SearchField
+ * [SearchField](https://gestalt.pinterest.systems/SearchField) allows users to search for free-form content.
  */
 const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
->(function SearchField(props, ref): Node {
-  const {
+>(function SearchField(
+  {
     accessibilityLabel,
     accessibilityClearButtonLabel,
     autoComplete,
@@ -59,8 +102,9 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
     size = 'md',
     value,
     errorMessage,
-  } = props;
-
+  }: Props,
+  ref,
+): Node {
   const [hovered, setHovered] = useState<boolean>(false);
   const [focused, setFocused] = useState<boolean>(false);
 

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -23,19 +23,19 @@ type Props = {|
    */
   accessibilityClearButtonLabel?: string,
   /**
-   *
+   * The type of autocomplete used, if any. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for more info.
    */
   autoComplete?: 'on' | 'off' | 'username' | 'name',
   /**
-   *
+   * Error text displayed below the input field.
    */
   errorMessage?: string,
   /**
-   *
+   * Must be unique!
    */
   id: string,
   /**
-   * Text used to label this search field. Should be localized. See the [Visible label variant](https://gestalt.pinterest.systems/searchfield#Visible-label) for more info.
+   * Text used to label the input. Be sure to localize the text. See the [Visible label variant](https://gestalt.pinterest.systems/searchfield#Visible-label) for more info.
    */
   label?: string,
   /**
@@ -43,7 +43,7 @@ type Props = {|
    */
   onBlur?: AbstractEventHandler<SyntheticEvent<HTMLInputElement>>,
   /**
-   *
+   * Primary callback to handle keyboard input.
    */
   onChange: ({|
     value: string,
@@ -57,18 +57,18 @@ type Props = {|
     syntheticEvent: SyntheticEvent<HTMLInputElement>,
   |}) => void,
   /**
-   * Callback for key stroke events.
+   * Secondary callback for keyboard events. Possible uses include validation, form submission, etc.
    */
   onKeyDown?: ({|
     event: SyntheticKeyboardEvent<HTMLInputElement>,
     value: string,
   |}) => void,
   /**
-   *
+   * Text displayed before the user has entered anything.
    */
   placeholder?: string,
   /**
-   * Forward the ref to the underlying input element
+   * Ref that is forwarded to the underlying input element.
    */
   ref?: UnionRefs, // eslint-disable-line react/no-unused-prop-types
   /**
@@ -76,7 +76,7 @@ type Props = {|
    */
   size?: 'md' | 'lg',
   /**
-   *
+   * The current value of the input.
    */
   value?: string,
 |};


### PR DESCRIPTION
### Summary

This PR updates SearchField docs to use a generated props table, and adds new/updated guidance to several sections:
- Props (updated)
- Best Practices (new)
- Localization (new)
- Related components (new)

I tweaked the copy in some places from the Paper doc where it seemed awkward or overly wordy. Happy to keep iterating on that if needed.

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-3160)
- [TDD](https://paper.dropbox.com/doc/Gestalt-doc-SearchField--BShJNCXR~Bq~3G4Atf5G~xKMAg-eHpPNX2DD4I903RaJG0kK)
