### PR TITLE
Dropdown: add dangerouslyRemoveLayer prop

### DIFF
--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -96,6 +96,14 @@ card(
         description:
           'Must be instances of Dropdown.Item, Dropdown.Link or Dropdown.Section components. See the [Types of items](#Types-of-items) variant to learn more.',
       },
+
+      {
+        name: 'dangerouslyRemoveLayer',
+        type: 'boolean',
+        defaultValue: false,
+        description:
+          'Removes the Layer component around Popover. Should only be used in cases where Layer breaks the Dropdown positionings such as when the anchor element is within a sticky component.',
+      },
       {
         name: 'headerContent',
         type: 'React.Node',

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -90,6 +90,7 @@ type IdealDirection = 'up' | 'right' | 'down' | 'left';
 type Props = {|
   anchor?: ?HTMLElement,
   children: Node,
+  dangerouslyRemoveLayer?: boolean,
   headerContent?: Node,
   id: string,
   idealDirection?: IdealDirection,
@@ -103,6 +104,7 @@ type Props = {|
 export default function Dropdown({
   anchor,
   children,
+  dangerouslyRemoveLayer = false,
   headerContent,
   id,
   idealDirection = 'down',
@@ -175,30 +177,30 @@ export default function Dropdown({
     }
   };
 
-  return (
-    <Layer zIndex={zIndex}>
-      <Popover
-        anchor={anchor}
-        color="white"
-        handleKeyDown={handleKeyDown}
-        id={id}
-        idealDirection={idealDirection}
-        onDismiss={onDismiss}
-        positionRelativeToAnchor={false}
-        role="menu"
-        shouldFocus
-        size="xl"
-      >
-        <Box alignItems="center" direction="column" display="flex" flex="grow" margin={2}>
-          {Boolean(headerContent) && <Box padding={2}>{headerContent}</Box>}
+  const dropdown = (
+    <Popover
+      anchor={anchor}
+      color="white"
+      handleKeyDown={handleKeyDown}
+      id={id}
+      idealDirection={idealDirection}
+      onDismiss={onDismiss}
+      positionRelativeToAnchor={false}
+      role="menu"
+      shouldFocus
+      size="xl"
+    >
+      <Box alignItems="center" direction="column" display="flex" flex="grow" margin={2}>
+        {Boolean(headerContent) && <Box padding={2}>{headerContent}</Box>}
 
-          <DropdownContextProvider value={{ id, hoveredItem, setHoveredItem, setOptionRef }}>
-            {renderChildrenWithIndex(dropdownChildrenArray)}
-          </DropdownContextProvider>
-        </Box>
-      </Popover>
-    </Layer>
+        <DropdownContextProvider value={{ id, hoveredItem, setHoveredItem, setOptionRef }}>
+          {renderChildrenWithIndex(dropdownChildrenArray)}
+        </DropdownContextProvider>
+      </Box>
+    </Popover>
   );
+
+  return dangerouslyRemoveLayer ? dropdown : <Layer zIndex={zIndex}>{dropdown}</Layer>;
 }
 
 Dropdown.propTypes = {


### PR DESCRIPTION
Layer is built-in Dropdown. However, in some cases we don't need this Layer and it does break the Dropdown positioning. For example, sticky headers.

Adding this prop so Dropdown can be adopted in those cases.


### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
