### PR TITLE
SelectList: Tweaks to generated props

### DIFF
--- a/docs/components/docgen.js
+++ b/docs/components/docgen.js
@@ -43,3 +43,16 @@ export default async function docgen(component: string): Promise<DocGen> {
 
   return parsed;
 }
+
+export function overrideTypes(docGen: DocGen, typeOverrides: {| [string]: string |}): DocGen {
+  Object.keys(typeOverrides).forEach((key) => {
+    if (docGen?.props?.[key]) {
+      // eslint-disable-next-line no-param-reassign
+      docGen.props[key].flowType = {
+        name: 'union',
+        raw: typeOverrides[key],
+      };
+    }
+  });
+  return docGen;
+}

--- a/docs/pages/selectlist.js
+++ b/docs/pages/selectlist.js
@@ -4,7 +4,7 @@ import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
-import docgen, { type DocGen } from '../components/docgen.js';
+import docgen, { overrideTypes, type DocGen } from '../components/docgen.js';
 
 export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -438,7 +438,11 @@ If users need the ability to choose between a yes/no option, use Checkbox.
 }
 
 export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  const docGen = await docgen('SelectList');
+  const overriddenDocGen = overrideTypes(docGen, {
+    onChange: '({| event: SyntheticInputEvent<HTMLSelectElement>, value: string |}) => void',
+  });
   return {
-    props: { generatedDocGen: await docgen('SelectList') },
+    props: { generatedDocGen: overriddenDocGen },
   };
 }

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -70,7 +70,7 @@ export default function SelectList({
   label,
   name,
   onChange,
-  options = [],
+  options,
   placeholder,
   size = 'md',
   value,
@@ -147,7 +147,7 @@ export default function SelectList({
               {placeholder}
             </option>
           )}
-          {options.map((option) => (
+          {(options ?? []).map((option) => (
             <option key={option.value} value={option.value} disabled={option.disabled}>
               {option.label}
             </option>


### PR DESCRIPTION
Conversion to generated props yielded a couple of errors:
- When we provide a default value for a required prop, docgen interprets that as meaning the prop isn't actually required. If we want to keep our defensive approach of providing a default for a required prop, we have to move that default out of the function signature. This PR moves the default value for `options` from the destructured args to the `.map` call.
- Docgen doesn't resolve types defined elsewhere, so we see `FooType` instead of the definition of FooType. We can solve this in some places by inlining the type definition. However, that approach isn't always the best (and hopefully we can avoid it in the future somehow), so this PR adds a helper to manually override generated prop types.