### PR TITLE
Module: iconButton prop

### DIFF
--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -377,12 +377,14 @@ function ModuleExample2() {
 
 card(
   <Example
-    name="Expandable - Icon and Badge"
+    name="Expandable - Icon, Badge and IconButton"
     description={`
     An Icon can be provided to be placed before the \`title\`.
     It is recommended that icons be used sparingly to convey additional information, and instead should simply reinforce information in the title. Be sure to provide an \`iconAccessibilityLabel\`.
 
-    Badge text can also be provided, which will be displayed after the \`title\`.`}
+    Badge text can also be provided, which will be displayed after the \`title\`.
+    
+    An IconButton can be provided to be placed after the \`title\` for a supplemental help CTA.`}
     defaultCode={`
 function ModuleExample3() {
   return (
@@ -403,6 +405,18 @@ function ModuleExample3() {
             children: <Text size="md">Children2</Text>,
             title: 'Example with badge',
           },
+          {
+            children: <Text size="md">Children3</Text>,
+            iconButton: <IconButton 
+              bgColor="lightGray"
+              icon="question-mark"
+              iconColor="darkGray"
+              accessibilityLabel="Get help"
+              size="xs"
+              onClick={() => alert('Help content')}
+            />,            
+            title: 'Example with icon button',
+          }
         ]}>
       </Module.Expandable>
     </Box>

--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -222,6 +222,40 @@ function ModuleExample() {
 
 card(
   <Example
+    name="Static - IconButton"
+    description={`
+    An IconButton can be provided to be placed after the \`title\` for a supplemental help CTA.
+    `}
+    id="static-iconbutton"
+    defaultCode={`
+function ModuleExample() {
+  return (
+    <Box column={12} maxWidth={800} padding={2}>
+      <Module
+        iconButton={
+          <IconButton 
+            bgColor="lightGray"
+            icon="question-mark"
+            iconColor="darkGray"
+            accessibilityLabel="Get help"
+            size="xs"
+            onClick={() => alert('Help content')}
+          />
+        }
+        id="ModuleExample - icon"
+        title="Title"
+        >
+        <Text size="md">This is example content.</Text>
+      </Module>
+    </Box>
+  );
+}
+`}
+  />,
+);
+
+card(
+  <Example
     name="Static - Badge"
     description={`Badge text can be provided, which will be displayed after the \`title\`. Note that if no title text is provided, the badge will not be displayed.`}
     id="static-badge"

--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -239,7 +239,8 @@ card(
     id="static-iconbutton"
     defaultCode={`
 function ModuleExample() {
-  const [showToast, setShowToast] = React.useState(false);
+  const [showPopover, setShowPopover] = React.useState(false);
+  const anchorRef = React.useRef(null);
 
   return (
     <Box column={12} maxWidth={800} padding={2}>
@@ -252,33 +253,28 @@ function ModuleExample() {
             accessibilityLabel="Get help"
             size="xs"
             onClick={({ event }) => {
-              setShowToast((currVal) => !currVal);
+              setShowPopover((currVal) => !currVal);
             }}
+            ref={anchorRef}
           />
         }
-        id="ModuleExample - icon"
+        id="ModuleExample - iconButton"
         title="Title"
         >
         <Text size="md">This is example content.</Text>
       </Module>
 
-      {showToast && (
-        <Layer>
-          <Box
-            dangerouslySetInlineStyle={{
-              __style: {
-                bottom: 50,
-                left: '50%',
-                transform: 'translateX(-50%)',
-              },
-            }}
-            fit
-            paddingX={1}
-            position="fixed"
+      {showPopover && (
+        <Popover
+          anchor={anchorRef.current}
+          idealDirection="right"
+          onDismiss={() => setShowPopover(false)}
+          shouldFocus={false}
           >
-            <Toast text="Help content!" />
-          </Box>
-        </Layer>
+            <Box padding={3}>
+              <Text weight="bold">Help content!</Text>
+            </Box>
+        </Popover>
       )}
     </Box>
   );
@@ -423,7 +419,8 @@ card(
     event.stopPropagation();\``}
     defaultCode={`
 function ModuleExample3() {
-  const [showToast, setShowToast] = React.useState(false);
+  const [showPopover, setShowPopover] = React.useState(false);
+  const anchorRef = React.useRef(null);
 
   return (
     <Box column={12} maxWidth={800} padding={2}>
@@ -454,31 +451,26 @@ function ModuleExample3() {
               onClick={({event}) => {
                 event.preventDefault();
                 event.stopPropagation();
-                setShowToast((currVal) => !currVal);
+                setShowPopover((currVal) => !currVal);
               }}
+              ref={anchorRef}
             />,            
             title: 'Example with icon button',
           }
         ]}>
       </Module.Expandable>
 
-      {showToast && (
-        <Layer>
-          <Box
-            dangerouslySetInlineStyle={{
-              __style: {
-                bottom: 50,
-                left: '50%',
-                transform: 'translateX(-50%)',
-              },
-            }}
-            fit
-            paddingX={1}
-            position="fixed"
+      {showPopover && (
+        <Popover
+          anchor={anchorRef.current}
+          idealDirection="right"
+          onDismiss={() => setShowPopover(false)}
+          shouldFocus={false}
           >
-            <Toast text="Help content!" />
-          </Box>
-        </Layer>
+            <Box padding={3}>
+              <Text weight="bold">Help content!</Text>
+            </Box>
+        </Popover>
       )}
     </Box>
   );

--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -30,7 +30,7 @@ card(
         href: 'static-badge',
         type: 'string',
         description:
-          'Add a badge displayed after the title. Will not be displayed if `title` is not provided. Be sure to localize the text.',
+          'Add a badge displayed after the title. Will not be displayed if `title` is not provided. Not to be used with `icon` or `iconButton`. Be sure to localize the text.',
       },
       {
         name: 'children',
@@ -42,14 +42,22 @@ card(
         name: 'icon',
         href: 'static-icon',
         type: 'string',
-        description: 'Name of icon to display in front of title',
+        description:
+          'Name of icon to display in front of title. Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `iconButton`.',
       },
       {
         name: 'iconAccessibilityLabel',
         href: 'static-icon',
         type: 'string',
         description:
-          'Label to provide information about the icon used for screen readers. Be sure to localize the label.',
+          'Label to provide information about the icon used for screen readers. Can be used in two scenarios: to describe the error icon that appears when `type` is `error`, and to describe the provided `icon` prop when `type` is `info`. Be sure to localize the label.',
+      },
+      {
+        name: 'iconButton',
+        href: 'static-iconbutton',
+        type: 'React.Element<IconButton>',
+        description:
+          'IconButton element to be placed after the `title` for a supplemental help CTA. Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `icon`.',
       },
       {
         name: 'id',
@@ -69,7 +77,8 @@ card(
         href: 'static-error',
         type: '"info" | "error"',
         defaultValue: 'info',
-        description: 'If set to `error`, displays error icon and changes title to red text',
+        description:
+          'If set to `error`, displays error icon and changes title to red text. Be sure to provide an `iconAccessibilityLabel` when set to `error`.',
       },
     ]}
   />,
@@ -121,6 +130,7 @@ card(
           children: ?React.Node,
           icon?: $Keys<typeof icons>,
           iconAccessibilityLabel?: string,
+          iconButton?: Element<typeof IconButton>,
           summary?: Array<string>,
           title: string,
           type?: "info" | "error" |}>
@@ -281,7 +291,7 @@ card(
   <Example
     name="Static - Error"
     id="static-error"
-    description={`When using \`type\` as "error", be sure to provide an \`iconAccessibilityLabel\`.`}
+    description={`When using \`type\` as \`"error"\`, be sure to provide an \`iconAccessibilityLabel\`.`}
     defaultCode={`
 function ModuleExample() {
   const [value, setValue] = React.useState('');
@@ -431,7 +441,7 @@ function ModuleExample3() {
 card(
   <Example
     name="Expandable - Error"
-    description={`When using \`type\` as "error", be sure to provide an \`iconAccessibilityLabel\`.`}
+    description={`When using \`type\` as \`"error"\`, be sure to provide an \`iconAccessibilityLabel\`.`}
     defaultCode={`
 function ModuleExample4() {
   const [value, setValue] = React.useState('');

--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -57,7 +57,7 @@ card(
         href: 'static-iconbutton',
         type: 'React.Element<IconButton>',
         description:
-          'IconButton element to be placed after the `title` for a supplemental help CTA. Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `icon`.',
+          'IconButton element to be placed after the `title` for a supplemental Call To Action (CTA). Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `icon`.',
       },
       {
         name: 'id',
@@ -234,7 +234,7 @@ card(
   <Example
     name="Static - IconButton"
     description={`
-    An IconButton can be provided to be placed after the \`title\` for a supplemental help CTA.
+    An IconButton can be provided to be placed after the \`title\` for a supplemental Call To Action (CTA).
     `}
     id="static-iconbutton"
     defaultCode={`
@@ -415,7 +415,7 @@ card(
 
     Badge text can also be provided, which will be displayed after the \`title\`.
     
-    An IconButton can be provided to be placed after the \`title\` for a supplemental help CTA. Be sure to prevent the \`onClick\` event from bubbling up and expanding/collapsing the module by adding \`event.preventDefault();
+    An IconButton can be provided to be placed after the \`title\` for a supplemental Call To Action (CTA). Be sure to prevent the \`onClick\` event from bubbling up and expanding/collapsing the module by adding \`event.preventDefault();
     event.stopPropagation();\``}
     defaultCode={`
 function ModuleExample3() {

--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -281,6 +281,7 @@ card(
   <Example
     name="Static - Error"
     id="static-error"
+    description={`When using \`type\` as "error", be sure to provide an \`iconAccessibilityLabel\`.`}
     defaultCode={`
 function ModuleExample() {
   const [value, setValue] = React.useState('');
@@ -290,6 +291,7 @@ function ModuleExample() {
       <Module
         id="ModuleExample - error"
         title="Personal Info"
+        iconAccessibilityLabel={!value ? "This module contains an error" : null}
         type={!value ? "error" : "info"}
       >
         <Flex direction="column" gap={4}>
@@ -429,11 +431,13 @@ function ModuleExample3() {
 card(
   <Example
     name="Expandable - Error"
+    description={`When using \`type\` as "error", be sure to provide an \`iconAccessibilityLabel\`.`}
     defaultCode={`
 function ModuleExample4() {
   const [value, setValue] = React.useState('');
   const moduleType = !value ? 'error' : 'info';
   const summaryInfo = !value ? 'Name is missing' : 'Name: ' + value;
+  const iconAccessibilityLabel = !value ? "This module contains an error" : null;
 
   return (
     <Box column={12} maxWidth={800} padding={2}>
@@ -452,7 +456,7 @@ function ModuleExample4() {
                 value={value}
               />
             </Text>,
-            iconAccessibilityLabel: "error icon",
+            iconAccessibilityLabel,
             summary: [summaryInfo],
             title: 'Personal Info',
             type: moduleType

--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -239,6 +239,8 @@ card(
     id="static-iconbutton"
     defaultCode={`
 function ModuleExample() {
+  const [showToast, setShowToast] = React.useState(false);
+
   return (
     <Box column={12} maxWidth={800} padding={2}>
       <Module
@@ -249,7 +251,9 @@ function ModuleExample() {
             iconColor="darkGray"
             accessibilityLabel="Get help"
             size="xs"
-            onClick={() => alert('Help content')}
+            onClick={({ event }) => {
+              setShowToast((currVal) => !currVal);
+            }}
           />
         }
         id="ModuleExample - icon"
@@ -257,6 +261,25 @@ function ModuleExample() {
         >
         <Text size="md">This is example content.</Text>
       </Module>
+
+      {showToast && (
+        <Layer>
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                bottom: 50,
+                left: '50%',
+                transform: 'translateX(-50%)',
+              },
+            }}
+            fit
+            paddingX={1}
+            position="fixed"
+          >
+            <Toast text="Help content!" />
+          </Box>
+        </Layer>
+      )}
     </Box>
   );
 }
@@ -396,9 +419,12 @@ card(
 
     Badge text can also be provided, which will be displayed after the \`title\`.
     
-    An IconButton can be provided to be placed after the \`title\` for a supplemental help CTA.`}
+    An IconButton can be provided to be placed after the \`title\` for a supplemental help CTA. Be sure to prevent the \`onClick\` event from bubbling up and expanding/collapsing the module by adding \`event.preventDefault();
+    event.stopPropagation();\``}
     defaultCode={`
 function ModuleExample3() {
+  const [showToast, setShowToast] = React.useState(false);
+
   return (
     <Box column={12} maxWidth={800} padding={2}>
       <Module.Expandable
@@ -425,12 +451,35 @@ function ModuleExample3() {
               iconColor="darkGray"
               accessibilityLabel="Get help"
               size="xs"
-              onClick={() => alert('Help content')}
+              onClick={({event}) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setShowToast((currVal) => !currVal);
+              }}
             />,            
             title: 'Example with icon button',
           }
         ]}>
       </Module.Expandable>
+
+      {showToast && (
+        <Layer>
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                bottom: 50,
+                left: '50%',
+                transform: 'translateX(-50%)',
+              },
+            }}
+            fit
+            paddingX={1}
+            position="fixed"
+          >
+            <Toast text="Help content!" />
+          </Box>
+        </Layer>
+      )}
     </Box>
   );
 }

--- a/packages/gestalt/src/Module.flowtest.js
+++ b/packages/gestalt/src/Module.flowtest.js
@@ -5,13 +5,24 @@ import Module from './Module.js';
 const ValidWithMinimumProps = <Module id="module-id" />;
 
 const ValidWithBaseProps = (
-  <Module id="module-id" title="Module Title" type="error">
+  <Module
+    id="module-id"
+    iconAccessibilityLabel="There is an error"
+    title="Module Title"
+    type="error"
+  >
     <hr />
   </Module>
 );
 
 const ValidWithBadgeTextProps = (
-  <Module badgeText="badge-text" id="module-id" title="Module Title" type="error">
+  <Module
+    badgeText="badge-text"
+    iconAccessibilityLabel="There is an error"
+    id="module-id"
+    title="Module Title"
+    type="error"
+  >
     <hr />
   </Module>
 );
@@ -30,6 +41,7 @@ const ValidWithIconProps = (
 
 const ValidWithIconButtonProps = (
   <Module
+    iconAccessibilityLabel="There is an error"
     iconButton={
       <IconButton
         bgColor="lightGray"

--- a/packages/gestalt/src/Module.flowtest.js
+++ b/packages/gestalt/src/Module.flowtest.js
@@ -1,0 +1,84 @@
+// @flow strict
+import IconButton from './IconButton.js';
+import Module from './Module.js';
+
+const ValidWithMinimumProps = <Module id="module-id" />;
+
+const ValidWithBaseProps = (
+  <Module id="module-id" title="Module Title" type="error">
+    <hr />
+  </Module>
+);
+
+const ValidWithBadgeTextProps = (
+  <Module badgeText="badge-text" id="module-id" title="Module Title" type="error">
+    <hr />
+  </Module>
+);
+
+const ValidWithIconProps = (
+  <Module
+    icon="lock"
+    iconAccessibilityLabel="Module is Locked"
+    id="module-id"
+    title="Module Title"
+    type="error"
+  >
+    <hr />
+  </Module>
+);
+
+const ValidWithIconButtonProps = (
+  <Module
+    iconButton={
+      <IconButton
+        bgColor="lightGray"
+        icon="question-mark"
+        iconColor="darkGray"
+        accessibilityLabel="Get help"
+        size="xs"
+        onClick={() => {}}
+      />
+    }
+    id="module-id"
+    title="Module Title"
+    type="error"
+  >
+    <hr />
+  </Module>
+);
+
+const InvalidWithMutuallyExclusiveProps = (
+  // $FlowExpectedError[incompatible-type]
+  <Module
+    badgeText="badge-text"
+    icon="lock"
+    iconAccessibilityLabel="Module is Locked"
+    iconButton={
+      <IconButton
+        bgColor="lightGray"
+        icon="question-mark"
+        iconColor="darkGray"
+        accessibilityLabel="Get help"
+        size="xs"
+        onClick={() => {}}
+      />
+    }
+    id="module-id"
+    title="Module Title"
+    type="error"
+  >
+    <hr />
+  </Module>
+);
+
+// $FlowExpectedError[incompatible-type]
+const InvalidWithMissingProps = <Module />;
+
+// $FlowExpectedError[incompatible-type]
+const InvalidWithNonExistingProp = <Module id="module-id" nonexisting={33} />;
+
+const InvalidTypeProp = (
+  // $FlowExpectedError[incompatible-type]
+  <Module id="module-id" title={<h1>Module Title</h1>} />
+);

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -4,7 +4,7 @@ import Box from './Box.js';
 import Flex from './Flex.js';
 import ModuleTitle from './ModuleTitle.js';
 import ModuleExpandable from './ModuleExpandable.js';
-import { type BaseModuleTitleProps } from './moduleTypes.js';
+import type { BaseModuleTitleProps } from './moduleTypes.js';
 
 type Props = {|
   ...BaseModuleTitleProps,
@@ -15,28 +15,29 @@ type Props = {|
 /**
  * https://gestalt.pinterest.systems/Module
  */
-export default function Module({
-  badgeText,
-  children,
-  icon,
-  iconAccessibilityLabel,
-  id,
-  title,
-  type = 'info',
-}: Props): Node {
+export default function Module({ children, id, title, type = 'info', ...props }: Props): Node {
+  let moduleTitle;
+  if (title) {
+    if (props.badgeText) {
+      moduleTitle = <ModuleTitle badgeText={props.badgeText} title={title} type={type} />;
+    } else if (props.icon || props.iconAccessibilityLabel) {
+      moduleTitle = (
+        <ModuleTitle
+          icon={props.icon}
+          iconAccessibilityLabel={props.iconAccessibilityLabel}
+          title={title}
+          type={type}
+        />
+      );
+    } else if (props.iconButton) {
+      moduleTitle = <ModuleTitle iconButton={props.iconButton} title={title} type={type} />;
+    }
+  }
+
   return (
     <Box borderStyle="shadow" id={id} padding={6} rounding={4}>
       <Flex direction="column" gap={6}>
-        {title && (
-          <ModuleTitle
-            badgeText={badgeText}
-            icon={icon}
-            iconAccessibilityLabel={iconAccessibilityLabel}
-            title={title}
-            type={type}
-          />
-        )}
-
+        {moduleTitle}
         {/* Flex.Item necessary to prevent gap from being applied to each child */}
         <Flex.Item>{children}</Flex.Item>
       </Flex>

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -9,7 +9,14 @@ import type { PublicModuleProps } from './moduleTypes.js';
 /**
  * https://gestalt.pinterest.systems/Module
  */
-export default function Module({ children, id, title, type, ...props }: PublicModuleProps): Node {
+export default function Module({
+  children,
+  iconAccessibilityLabel,
+  id,
+  title,
+  type,
+  ...props
+}: PublicModuleProps): Node {
   return (
     <Box borderStyle="shadow" id={id} padding={6} rounding={4}>
       <Flex direction="column" gap={6}>
@@ -17,9 +24,7 @@ export default function Module({ children, id, title, type, ...props }: PublicMo
           <ModuleTitle
             badgeText={props.badgeText ? props.badgeText : undefined}
             icon={props.icon ? props.icon : undefined}
-            iconAccessibilityLabel={
-              props.iconAccessibilityLabel ? props.iconAccessibilityLabel : undefined
-            }
+            iconAccessibilityLabel={iconAccessibilityLabel}
             iconButton={props.iconButton ? props.iconButton : undefined}
             title={title}
             type={type}

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -18,19 +18,21 @@ type Props = {|
 export default function Module({ children, id, title, type = 'info', ...props }: Props): Node {
   let moduleTitle;
   if (title) {
+    const commonProps = { title, type };
     if (props.badgeText) {
-      moduleTitle = <ModuleTitle badgeText={props.badgeText} title={title} type={type} />;
+      moduleTitle = <ModuleTitle {...commonProps} badgeText={props.badgeText} />;
     } else if (props.icon || props.iconAccessibilityLabel) {
       moduleTitle = (
         <ModuleTitle
+          {...commonProps}
           icon={props.icon}
           iconAccessibilityLabel={props.iconAccessibilityLabel}
-          title={title}
-          type={type}
         />
       );
     } else if (props.iconButton) {
-      moduleTitle = <ModuleTitle iconButton={props.iconButton} title={title} type={type} />;
+      moduleTitle = <ModuleTitle {...commonProps} iconButton={props.iconButton} />;
+    } else {
+      moduleTitle = <ModuleTitle {...commonProps} />;
     }
   }
 

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -4,42 +4,27 @@ import Box from './Box.js';
 import Flex from './Flex.js';
 import ModuleTitle from './ModuleTitle.js';
 import ModuleExpandable from './ModuleExpandable.js';
-import type { BaseModuleTitleProps } from './moduleTypes.js';
-
-type Props = {|
-  ...BaseModuleTitleProps,
-  children?: Node,
-  id: string,
-|};
+import type { PublicModuleProps } from './moduleTypes.js';
 
 /**
  * https://gestalt.pinterest.systems/Module
  */
-export default function Module({ children, id, title, type = 'info', ...props }: Props): Node {
-  let moduleTitle;
-  if (title) {
-    const commonProps = { title, type };
-    if (props.badgeText) {
-      moduleTitle = <ModuleTitle {...commonProps} badgeText={props.badgeText} />;
-    } else if (props.icon || props.iconAccessibilityLabel) {
-      moduleTitle = (
-        <ModuleTitle
-          {...commonProps}
-          icon={props.icon}
-          iconAccessibilityLabel={props.iconAccessibilityLabel}
-        />
-      );
-    } else if (props.iconButton) {
-      moduleTitle = <ModuleTitle {...commonProps} iconButton={props.iconButton} />;
-    } else {
-      moduleTitle = <ModuleTitle {...commonProps} />;
-    }
-  }
-
+export default function Module({ children, id, title, type, ...props }: PublicModuleProps): Node {
   return (
     <Box borderStyle="shadow" id={id} padding={6} rounding={4}>
       <Flex direction="column" gap={6}>
-        {moduleTitle}
+        {title && (
+          <ModuleTitle
+            badgeText={props.badgeText ? props.badgeText : undefined}
+            icon={props.icon ? props.icon : undefined}
+            iconAccessibilityLabel={
+              props.iconAccessibilityLabel ? props.iconAccessibilityLabel : undefined
+            }
+            iconButton={props.iconButton ? props.iconButton : undefined}
+            title={title}
+            type={type}
+          />
+        )}
         {/* Flex.Item necessary to prevent gap from being applied to each child */}
         <Flex.Item>{children}</Flex.Item>
       </Flex>

--- a/packages/gestalt/src/Module.test.js
+++ b/packages/gestalt/src/Module.test.js
@@ -2,6 +2,7 @@
 import renderer from 'react-test-renderer';
 import Module from './Module.js';
 import Text from './Text.js';
+import IconButton from './IconButton.js';
 
 describe('Module', () => {
   test('renders the base correctly', () => {
@@ -54,8 +55,32 @@ describe('Module', () => {
           id="module-test"
           title="Testing"
           icon="lock"
-          iconAccessibilityLabel="locked"
+          iconAccessibilityLabel="there is an error"
           type="error"
+        >
+          <Text>Testing</Text>
+        </Module>,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders an icon button correctly', () => {
+    const tree = renderer
+      .create(
+        <Module
+          id="module-test"
+          title="Testing"
+          iconButton={
+            <IconButton
+              bgColor="lightGray"
+              icon="question-mark"
+              iconColor="darkGray"
+              accessibilityLabel="Get help"
+              size="xs"
+              onClick={() => {}}
+            />
+          }
         >
           <Text>Testing</Text>
         </Module>,

--- a/packages/gestalt/src/ModuleExpandable.flowtest.js
+++ b/packages/gestalt/src/ModuleExpandable.flowtest.js
@@ -1,31 +1,153 @@
 // @flow strict
 import ModuleExpandable from './ModuleExpandable.js';
+import IconButton from './IconButton.js';
 
-const Valid = (
+const ValidWithMinimumProps = (
   <ModuleExpandable
-    id="uniqueTestID"
+    accessibilityExpandLabel="click to expand"
+    accessibilityCollapseLabel="click to collapse"
+    id="module-expandable-id"
+    items={[]}
+  />
+);
+
+const ValidWithBaseProps = (
+  <ModuleExpandable
+    id="module-expandable-id"
     accessibilityExpandLabel="click to expand"
     accessibilityCollapseLabel="click to collapse"
     expandedIndex={0}
     onExpandedChange={() => {}}
     items={[
       {
-        title: 'Title',
-        icon: 'lock',
-        iconAccessibilityLabel: 'test label',
-        summary: ['summary1', 'summary2', 'summary3'],
-        type: 'info',
         children: 'test children',
+        summary: ['summary1', 'summary2', 'summary3'],
+        title: 'Title',
+        type: 'info',
+      },
+    ]}
+  />
+);
+
+const ValidWithBadgeTextProps = (
+  <ModuleExpandable
+    id="module-expandable-id"
+    accessibilityExpandLabel="click to expand"
+    accessibilityCollapseLabel="click to collapse"
+    expandedIndex={0}
+    onExpandedChange={() => {}}
+    items={[
+      {
+        badgeText: 'badge-text',
+        children: 'test children',
+        summary: ['summary1', 'summary2', 'summary3'],
+        title: 'Title',
+        type: 'info',
+      },
+    ]}
+  />
+);
+
+const ValidWithIconProps = (
+  <ModuleExpandable
+    id="module-expandable-id"
+    accessibilityExpandLabel="click to expand"
+    accessibilityCollapseLabel="click to collapse"
+    expandedIndex={0}
+    onExpandedChange={() => {}}
+    items={[
+      {
+        children: 'test children',
+        icon: 'lock',
+        iconAccessibilityLabel: 'Module is Locked',
+        summary: ['summary1', 'summary2', 'summary3'],
+        title: 'Title',
+        type: 'info',
+      },
+    ]}
+  />
+);
+
+const ValidWithIconButtonProps = (
+  <ModuleExpandable
+    id="module-expandable-id"
+    accessibilityExpandLabel="click to expand"
+    accessibilityCollapseLabel="click to collapse"
+    expandedIndex={0}
+    onExpandedChange={() => {}}
+    items={[
+      {
+        children: 'test children',
+        iconButton: (
+          <IconButton
+            bgColor="lightGray"
+            icon="question-mark"
+            iconColor="darkGray"
+            accessibilityLabel="Get help"
+            size="xs"
+            onClick={() => {}}
+          />
+        ),
+        summary: ['summary1', 'summary2', 'summary3'],
+        title: 'Title',
+        type: 'info',
+      },
+    ]}
+  />
+);
+
+const InvalidWithMutuallyExclusiveProps = (
+  <ModuleExpandable
+    id="module-expandable-id"
+    accessibilityExpandLabel="click to expand"
+    accessibilityCollapseLabel="click to collapse"
+    expandedIndex={0}
+    onExpandedChange={() => {}}
+    items={[
+      // $FlowExpectedError[incompatible-type]
+      {
+        badgeText: 'badge-text',
+        children: 'test children',
+        icon: 'lock',
+        iconAccessibilityLabel: 'Module is Locked',
+        iconButton: (
+          <IconButton
+            bgColor="lightGray"
+            icon="question-mark"
+            iconColor="darkGray"
+            accessibilityLabel="Get help"
+            size="xs"
+            onClick={() => {}}
+          />
+        ),
+        summary: ['summary1', 'summary2', 'summary3'],
+        title: 'Title',
+        type: 'info',
       },
     ]}
   />
 );
 
 // $FlowExpectedError[prop-missing]
-const MissingProp = <ModuleExpandable />;
+const InvalidWithMissingProps = <ModuleExpandable />;
 
-// $FlowExpectedError[prop-missing]
-const NonExistingProp = <ModuleExpandable nonexisting={33} />;
+const InvalidWithNonExistingProp = (
+  // $FlowExpectedError[prop-missing]
+  <ModuleExpandable
+    accessibilityExpandLabel="click to expand"
+    accessibilityCollapseLabel="click to collapse"
+    id="module-id"
+    nonexisting={33}
+  />
+);
 
-// $FlowExpectedError[prop-missing]
-const InvalidTypeProp = <ModuleExpandable size="xxl" />;
+const InvalidTypeProp = (
+  <ModuleExpandable
+    accessibilityExpandLabel="click to expand"
+    accessibilityCollapseLabel="click to collapse"
+    // $FlowExpectedError[incompatible-type]
+    id={123}
+    // $FlowExpectedError[incompatible-type]
+    items={{ title: 'Title' }}
+  />
+);

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -29,7 +29,7 @@ export default function ModuleExpandable({
     setExpandedId(getExpandedId(expandedIndex));
   }, [expandedIndex, setExpandedId]);
 
-  const onModuleClickedHandler = useCallback(
+  const buildOnModuleClickHandler = useCallback(
     (index: number) => (isExpanded: boolean): void => {
       if (onExpandedChange) {
         onExpandedChange(isExpanded ? null : index);
@@ -56,7 +56,7 @@ export default function ModuleExpandable({
               iconButton={props.iconButton ? props.iconButton : undefined}
               id={`${id}-${index}`}
               isCollapsed={expandedId !== index}
-              onModuleClicked={onModuleClickedHandler(index)}
+              onModuleClicked={buildOnModuleClickHandler(index)}
               summary={summary}
               title={title}
               type={type}

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -42,7 +42,7 @@ export default function ModuleExpandable({
   return (
     <Box borderStyle="shadow" rounding={4}>
       {items.map((props: PublicModuleExpandableItemProps, index) => {
-        const { children, summary, title, type } = props;
+        const { children, iconAccessibilityLabel, summary, title, type } = props;
 
         return (
           <Fragment key={index}>
@@ -52,9 +52,7 @@ export default function ModuleExpandable({
               accessibilityExpandLabel={accessibilityExpandLabel}
               badgeText={props.badgeText ? props.badgeText : undefined}
               icon={props.icon ? props.icon : undefined}
-              iconAccessibilityLabel={
-                props.iconAccessibilityLabel ? props.iconAccessibilityLabel : undefined
-              }
+              iconAccessibilityLabel={iconAccessibilityLabel}
               iconButton={props.iconButton ? props.iconButton : undefined}
               id={`${id}-${index}`}
               isCollapsed={expandedId !== index}

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -3,20 +3,14 @@ import { Fragment, type Node, useCallback, useState, useEffect } from 'react';
 import Box from './Box.js';
 import Divider from './Divider.js';
 import ModuleExpandableItem from './ModuleExpandableItem.js';
-import { type ModuleExpandableItemBaseProps } from './moduleTypes.js';
+import type {
+  PublicModuleExpandableProps,
+  PublicModuleExpandableItemProps,
+} from './moduleTypes.js';
 
 function getExpandedId(expandedIndex: ?number): ?number {
   return Number.isFinite(expandedIndex) ? expandedIndex : null;
 }
-
-type Props = {|
-  accessibilityExpandLabel: string,
-  accessibilityCollapseLabel: string,
-  expandedIndex?: ?number,
-  id: string,
-  items: $ReadOnlyArray<ModuleExpandableItemBaseProps>,
-  onExpandedChange?: (?number) => void,
-|};
 
 /**
  * https://gestalt.pinterest.systems/Module
@@ -28,7 +22,7 @@ export default function ModuleExpandable({
   id,
   items,
   onExpandedChange,
-}: Props): Node {
+}: PublicModuleExpandableProps): Node {
   const [expandedId, setExpandedId] = useState<?number>(getExpandedId(expandedIndex));
 
   useEffect(() => {
@@ -47,53 +41,30 @@ export default function ModuleExpandable({
 
   return (
     <Box borderStyle="shadow" rounding={4}>
-      {items.map((props: ModuleExpandableItemBaseProps, index) => {
+      {items.map((props: PublicModuleExpandableItemProps, index) => {
         const { children, summary, title, type } = props;
-
-        const commonProps = {
-          accessibilityCollapseLabel,
-          accessibilityExpandLabel,
-          id: `${id}-${index}`,
-          isCollapsed: expandedId !== index,
-          onModuleClicked: onModuleClickedHandler(index),
-          summary,
-          title,
-          type,
-        };
-
-        let moduleExpandableItem;
-        if (props.badgeText) {
-          moduleExpandableItem = (
-            <ModuleExpandableItem {...commonProps} badgeText={props.badgeText}>
-              {children}
-            </ModuleExpandableItem>
-          );
-        } else if (props.icon || props.iconAccessibilityLabel) {
-          moduleExpandableItem = (
-            <ModuleExpandableItem
-              {...commonProps}
-              icon={props.icon}
-              iconAccessibilityLabel={props.iconAccessibilityLabel}
-            >
-              {children}
-            </ModuleExpandableItem>
-          );
-        } else if (props.iconButton) {
-          moduleExpandableItem = (
-            <ModuleExpandableItem {...commonProps} iconButton={props.iconButton}>
-              {children}
-            </ModuleExpandableItem>
-          );
-        } else {
-          moduleExpandableItem = (
-            <ModuleExpandableItem {...commonProps}>{children}</ModuleExpandableItem>
-          );
-        }
 
         return (
           <Fragment key={index}>
             {index > 0 && <Divider />}
-            {moduleExpandableItem}
+            <ModuleExpandableItem
+              accessibilityCollapseLabel={accessibilityCollapseLabel}
+              accessibilityExpandLabel={accessibilityExpandLabel}
+              badgeText={props.badgeText ? props.badgeText : undefined}
+              icon={props.icon ? props.icon : undefined}
+              iconAccessibilityLabel={
+                props.iconAccessibilityLabel ? props.iconAccessibilityLabel : undefined
+              }
+              iconButton={props.iconButton ? props.iconButton : undefined}
+              id={`${id}-${index}`}
+              isCollapsed={expandedId !== index}
+              onModuleClicked={onModuleClickedHandler(index)}
+              summary={summary}
+              title={title}
+              type={type}
+            >
+              {children}
+            </ModuleExpandableItem>
           </Fragment>
         );
       })}

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -9,18 +9,6 @@ function getExpandedId(expandedIndex: ?number): ?number {
   return Number.isFinite(expandedIndex) ? expandedIndex : null;
 }
 
-type ModuleExpandableRowProps = {|
-  ...ModuleExpandableItemBaseProps,
-  accessibilityExpandLabel: string,
-  accessibilityCollapseLabel: string,
-  expandedId: ?number,
-  id: string,
-  index: number,
-  onExpandedChange?: (?number) => void,
-  setExpandedId: (?number) => void,
-  shouldDisplayDivider: boolean,
-|};
-
 type Props = {|
   accessibilityExpandLabel: string,
   accessibilityCollapseLabel: string,
@@ -29,93 +17,6 @@ type Props = {|
   items: $ReadOnlyArray<ModuleExpandableItemBaseProps>,
   onExpandedChange?: (?number) => void,
 |};
-
-function ModuleExpandableRow({
-  accessibilityCollapseLabel,
-  accessibilityExpandLabel,
-  children,
-  expandedId,
-  id,
-  index,
-  onExpandedChange,
-  setExpandedId,
-  shouldDisplayDivider,
-  summary,
-  title,
-  type,
-  ...props
-}: ModuleExpandableRowProps): Node {
-  const onModuleClicked = useCallback(
-    (isExpanded: boolean): void => {
-      if (onExpandedChange) {
-        onExpandedChange(isExpanded ? null : index);
-      }
-      setExpandedId(isExpanded ? null : index);
-    },
-    [index, onExpandedChange, setExpandedId],
-  );
-  const isCollapsed = expandedId !== index;
-  const moduleItemId = `${id}-${index}`;
-
-  let moduleExpandableItem;
-  if (props.badgeText) {
-    moduleExpandableItem = (
-      <ModuleExpandableItem
-        accessibilityCollapseLabel={accessibilityCollapseLabel}
-        accessibilityExpandLabel={accessibilityExpandLabel}
-        badgeText={props.badgeText}
-        id={moduleItemId}
-        isCollapsed={isCollapsed}
-        onModuleClicked={onModuleClicked}
-        summary={summary}
-        title={title}
-        type={type}
-      >
-        {children}
-      </ModuleExpandableItem>
-    );
-  } else if (props.icon || props.iconAccessibilityLabel) {
-    moduleExpandableItem = (
-      <ModuleExpandableItem
-        accessibilityCollapseLabel={accessibilityCollapseLabel}
-        accessibilityExpandLabel={accessibilityExpandLabel}
-        icon={props.icon}
-        iconAccessibilityLabel={props.iconAccessibilityLabel}
-        id={moduleItemId}
-        isCollapsed={isCollapsed}
-        onModuleClicked={onModuleClicked}
-        summary={summary}
-        title={title}
-        type={type}
-      >
-        {children}
-      </ModuleExpandableItem>
-    );
-  } else if (props.iconButton) {
-    moduleExpandableItem = (
-      <ModuleExpandableItem
-        accessibilityCollapseLabel={accessibilityCollapseLabel}
-        accessibilityExpandLabel={accessibilityExpandLabel}
-        iconButton={props.iconButton}
-        id={moduleItemId}
-        isCollapsed={isCollapsed}
-        onModuleClicked={onModuleClicked}
-        summary={summary}
-        title={title}
-        type={type}
-      >
-        {children}
-      </ModuleExpandableItem>
-    );
-  }
-
-  return (
-    <Fragment>
-      {shouldDisplayDivider && <Divider />}
-      {moduleExpandableItem}
-    </Fragment>
-  );
-}
 
 /**
  * https://gestalt.pinterest.systems/Module
@@ -134,22 +35,68 @@ export default function ModuleExpandable({
     setExpandedId(getExpandedId(expandedIndex));
   }, [expandedIndex, setExpandedId]);
 
+  const onModuleClickedHandler = useCallback(
+    (index: number) => (isExpanded: boolean): void => {
+      if (onExpandedChange) {
+        onExpandedChange(isExpanded ? null : index);
+      }
+      setExpandedId(isExpanded ? null : index);
+    },
+    [onExpandedChange],
+  );
+
   return (
     <Box borderStyle="shadow" rounding={4}>
-      {items.map((props: ModuleExpandableItemBaseProps, index) => (
-        <ModuleExpandableRow
-          {...props}
-          accessibilityExpandLabel={accessibilityExpandLabel}
-          accessibilityCollapseLabel={accessibilityCollapseLabel}
-          expandedId={expandedId}
-          key={index}
-          id={id}
-          index={index}
-          onExpandedChange={onExpandedChange}
-          setExpandedId={setExpandedId}
-          shouldDisplayDivider={index > 0}
-        />
-      ))}
+      {items.map((props: ModuleExpandableItemBaseProps, index) => {
+        const { children, summary, title, type } = props;
+
+        const commonProps = {
+          accessibilityCollapseLabel,
+          accessibilityExpandLabel,
+          id: `${id}-${index}`,
+          isCollapsed: expandedId !== index,
+          onModuleClicked: onModuleClickedHandler(index),
+          summary,
+          title,
+          type,
+        };
+
+        let moduleExpandableItem;
+        if (props.badgeText) {
+          moduleExpandableItem = (
+            <ModuleExpandableItem {...commonProps} badgeText={props.badgeText}>
+              {children}
+            </ModuleExpandableItem>
+          );
+        } else if (props.icon || props.iconAccessibilityLabel) {
+          moduleExpandableItem = (
+            <ModuleExpandableItem
+              {...commonProps}
+              icon={props.icon}
+              iconAccessibilityLabel={props.iconAccessibilityLabel}
+            >
+              {children}
+            </ModuleExpandableItem>
+          );
+        } else if (props.iconButton) {
+          moduleExpandableItem = (
+            <ModuleExpandableItem {...commonProps} iconButton={props.iconButton}>
+              {children}
+            </ModuleExpandableItem>
+          );
+        } else {
+          moduleExpandableItem = (
+            <ModuleExpandableItem {...commonProps}>{children}</ModuleExpandableItem>
+          );
+        }
+
+        return (
+          <Fragment key={index}>
+            {index > 0 && <Divider />}
+            {moduleExpandableItem}
+          </Fragment>
+        );
+      })}
     </Box>
   );
 }

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Fragment, type Node, useState, useEffect } from 'react';
+import { Fragment, type Node, useCallback, useState, useEffect } from 'react';
 import Box from './Box.js';
 import Divider from './Divider.js';
 import ModuleExpandableItem from './ModuleExpandableItem.js';
@@ -9,6 +9,18 @@ function getExpandedId(expandedIndex: ?number): ?number {
   return Number.isFinite(expandedIndex) ? expandedIndex : null;
 }
 
+type ModuleExpandableRowProps = {|
+  ...ModuleExpandableItemBaseProps,
+  accessibilityExpandLabel: string,
+  accessibilityCollapseLabel: string,
+  expandedId: ?number,
+  id: string,
+  index: number,
+  onExpandedChange?: (?number) => void,
+  setExpandedId: (?number) => void,
+  shouldDisplayDivider: boolean,
+|};
+
 type Props = {|
   accessibilityExpandLabel: string,
   accessibilityCollapseLabel: string,
@@ -17,6 +29,93 @@ type Props = {|
   items: $ReadOnlyArray<ModuleExpandableItemBaseProps>,
   onExpandedChange?: (?number) => void,
 |};
+
+function ModuleExpandableRow({
+  accessibilityCollapseLabel,
+  accessibilityExpandLabel,
+  children,
+  expandedId,
+  id,
+  index,
+  onExpandedChange,
+  setExpandedId,
+  shouldDisplayDivider,
+  summary,
+  title,
+  type,
+  ...props
+}: ModuleExpandableRowProps): Node {
+  const onModuleClicked = useCallback(
+    (isExpanded: boolean): void => {
+      if (onExpandedChange) {
+        onExpandedChange(isExpanded ? null : index);
+      }
+      setExpandedId(isExpanded ? null : index);
+    },
+    [index, onExpandedChange, setExpandedId],
+  );
+  const isCollapsed = expandedId !== index;
+  const moduleItemId = `${id}-${index}`;
+
+  let moduleExpandableItem;
+  if (props.badgeText) {
+    moduleExpandableItem = (
+      <ModuleExpandableItem
+        accessibilityCollapseLabel={accessibilityCollapseLabel}
+        accessibilityExpandLabel={accessibilityExpandLabel}
+        badgeText={props.badgeText}
+        id={moduleItemId}
+        isCollapsed={isCollapsed}
+        onModuleClicked={onModuleClicked}
+        summary={summary}
+        title={title}
+        type={type}
+      >
+        {children}
+      </ModuleExpandableItem>
+    );
+  } else if (props.icon || props.iconAccessibilityLabel) {
+    moduleExpandableItem = (
+      <ModuleExpandableItem
+        accessibilityCollapseLabel={accessibilityCollapseLabel}
+        accessibilityExpandLabel={accessibilityExpandLabel}
+        icon={props.icon}
+        iconAccessibilityLabel={props.iconAccessibilityLabel}
+        id={moduleItemId}
+        isCollapsed={isCollapsed}
+        onModuleClicked={onModuleClicked}
+        summary={summary}
+        title={title}
+        type={type}
+      >
+        {children}
+      </ModuleExpandableItem>
+    );
+  } else if (props.iconButton) {
+    moduleExpandableItem = (
+      <ModuleExpandableItem
+        accessibilityCollapseLabel={accessibilityCollapseLabel}
+        accessibilityExpandLabel={accessibilityExpandLabel}
+        iconButton={props.iconButton}
+        id={moduleItemId}
+        isCollapsed={isCollapsed}
+        onModuleClicked={onModuleClicked}
+        summary={summary}
+        title={title}
+        type={type}
+      >
+        {children}
+      </ModuleExpandableItem>
+    );
+  }
+
+  return (
+    <Fragment>
+      {shouldDisplayDivider && <Divider />}
+      {moduleExpandableItem}
+    </Fragment>
+  );
+}
 
 /**
  * https://gestalt.pinterest.systems/Module
@@ -37,34 +136,20 @@ export default function ModuleExpandable({
 
   return (
     <Box borderStyle="shadow" rounding={4}>
-      {items.map(
-        ({ badgeText, children, icon, iconAccessibilityLabel, summary, title, type }, index) => (
-          <Fragment key={index}>
-            {index > 0 && <Divider />}
-
-            <ModuleExpandableItem
-              accessibilityCollapseLabel={accessibilityCollapseLabel}
-              accessibilityExpandLabel={accessibilityExpandLabel}
-              badgeText={badgeText}
-              icon={icon}
-              iconAccessibilityLabel={iconAccessibilityLabel}
-              id={`${id}-${index}`}
-              isCollapsed={expandedId !== index}
-              onModuleClicked={(isExpanded) => {
-                if (onExpandedChange) {
-                  onExpandedChange(isExpanded ? null : index);
-                }
-                setExpandedId(isExpanded ? null : index);
-              }}
-              summary={summary}
-              title={title}
-              type={type}
-            >
-              {children}
-            </ModuleExpandableItem>
-          </Fragment>
-        ),
-      )}
+      {items.map((props: ModuleExpandableItemBaseProps, index) => (
+        <ModuleExpandableRow
+          {...props}
+          accessibilityExpandLabel={accessibilityExpandLabel}
+          accessibilityCollapseLabel={accessibilityCollapseLabel}
+          expandedId={expandedId}
+          key={index}
+          id={id}
+          index={index}
+          onExpandedChange={onExpandedChange}
+          setExpandedId={setExpandedId}
+          shouldDisplayDivider={index > 0}
+        />
+      ))}
     </Box>
   );
 }

--- a/packages/gestalt/src/ModuleExpandable.jsdom.test.js
+++ b/packages/gestalt/src/ModuleExpandable.jsdom.test.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { render, fireEvent, screen } from '@testing-library/react';
 import ModuleExpandable from './ModuleExpandable.js';
+import IconButton from './IconButton.js';
 
 describe('ModuleExpandable', () => {
   const props = {
@@ -27,6 +28,27 @@ describe('ModuleExpandable', () => {
         iconAccessibilityLabel: 'error icon label',
         type: 'error',
       },
+      {
+        title: 'Title4',
+        summary: ['summary4'],
+        children: 'Children4',
+        badgeText: 'badge text',
+      },
+      {
+        title: 'Title5',
+        summary: ['summary5'],
+        children: 'Children5',
+        iconButton: (
+          <IconButton
+            bgColor="lightGray"
+            icon="question-mark"
+            iconColor="darkGray"
+            accessibilityLabel="Get help"
+            size="xs"
+            onClick={() => {}}
+          />
+        ),
+      },
     ],
   };
 
@@ -46,6 +68,16 @@ describe('ModuleExpandable', () => {
     expect(screen.getByRole('img', { name: /Error icon/i })).toBeInTheDocument();
     expect(screen.queryByText(/summary3/i)).toBeInTheDocument();
     expect(screen.queryByText(/Children3/i)).toBeNull();
+
+    expect(screen.getByText(/Title4/i)).toBeInTheDocument();
+    expect(screen.getByText(/badge text/i)).toBeInTheDocument();
+    expect(screen.queryByText(/summary4/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Children4/i)).toBeNull();
+
+    expect(screen.getByText(/Title5/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Get help/i })).toBeInTheDocument();
+    expect(screen.queryByText(/summary5/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Children5/i)).toBeNull();
   });
 
   it('should expand the module correctly when clicked', () => {
@@ -58,16 +90,22 @@ describe('ModuleExpandable', () => {
     expect(screen.getByText(/Children1/i)).toBeInTheDocument();
     expect(screen.queryByText(/Children2/i)).toBeNull();
     expect(screen.queryByText(/Children3/i)).toBeNull();
+    expect(screen.queryByText(/Children4/i)).toBeNull();
+    expect(screen.queryByText(/Children5/i)).toBeNull();
 
     fireEvent.click(expandButtons[1]);
     expect(screen.queryByText(/Children1/i)).toBeNull();
     expect(screen.getByText(/Children2/i)).toBeInTheDocument();
     expect(screen.queryByText(/Children3/i)).toBeNull();
+    expect(screen.queryByText(/Children4/i)).toBeNull();
+    expect(screen.queryByText(/Children5/i)).toBeNull();
 
     fireEvent.click(expandButtons[2]);
     expect(screen.queryByText(/Children1/i)).toBeNull();
     expect(screen.queryByText(/Children2/i)).toBeNull();
     expect(screen.getByText(/Children3/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Children4/i)).toBeNull();
+    expect(screen.queryByText(/Children5/i)).toBeNull();
   });
 
   it('should expand the module correctly with expandedId', () => {
@@ -82,6 +120,8 @@ describe('ModuleExpandable', () => {
     expect(screen.getByText(/Children1/i)).toBeInTheDocument();
     expect(screen.queryByText(/Children2/i)).toBeNull();
     expect(screen.queryByText(/Children3/i)).toBeNull();
+    expect(screen.queryByText(/Children4/i)).toBeNull();
+    expect(screen.queryByText(/Children5/i)).toBeNull();
 
     // Click on Item with index 0 to collapse the item
     const button1 = screen.getByRole('button', {
@@ -94,7 +134,7 @@ describe('ModuleExpandable', () => {
     const expandButtons = screen.getAllByRole('button', {
       name: /click to expand/i,
     });
-    expect(expandButtons).toHaveLength(3);
+    expect(expandButtons).toHaveLength(5);
     fireEvent.click(expandButtons[1]);
     expect(newProps.onExpandedChange).toHaveBeenCalledWith(1);
   });

--- a/packages/gestalt/src/ModuleExpandableItem.flowtest.js
+++ b/packages/gestalt/src/ModuleExpandableItem.flowtest.js
@@ -1,18 +1,30 @@
 // @flow strict
 import ModuleExpandableItem from './ModuleExpandableItem.js';
+import IconButton from './IconButton.js';
 
 const Valid = (
   <ModuleExpandableItem
-    id="uniqueTestID"
-    accessibilityExpandLabel="click to expand"
     accessibilityCollapseLabel="click to collapse"
-    title="test title"
+    accessibilityExpandLabel="click to expand"
+    badgeText="badge-text"
+    id="uniqueTestID"
     icon="lock"
     iconAccessibilityLabel="test label"
-    summary={['summary1', 'summary2', 'summary3']}
+    iconButton={
+      <IconButton
+        bgColor="lightGray"
+        icon="question-mark"
+        iconColor="darkGray"
+        accessibilityLabel="Get help"
+        size="xs"
+        onClick={() => {}}
+      />
+    }
     isCollapsed={false}
-    type="info"
     onModuleClicked={() => {}}
+    summary={['summary1', 'summary2', 'summary3']}
+    title="test title"
+    type="info"
   >
     <div>test children</div>
   </ModuleExpandableItem>

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -34,19 +34,21 @@ export default function ModuleExpandableItem({
 }: Props): Node {
   let moduleTitle;
   if (title) {
+    const commonProps = { title, type };
     if (props.badgeText) {
-      moduleTitle = <ModuleTitle badgeText={props.badgeText} title={title} type={type} />;
+      moduleTitle = <ModuleTitle {...commonProps} badgeText={props.badgeText} />;
     } else if (props.icon || props.iconAccessibilityLabel) {
       moduleTitle = (
         <ModuleTitle
+          {...commonProps}
           icon={props.icon}
           iconAccessibilityLabel={props.iconAccessibilityLabel}
-          title={title}
-          type={type}
         />
       );
     } else if (props.iconButton) {
-      moduleTitle = <ModuleTitle iconButton={props.iconButton} title={title} type={type} />;
+      moduleTitle = <ModuleTitle {...commonProps} iconButton={props.iconButton} />;
+    } else {
+      moduleTitle = <ModuleTitle {...commonProps} />;
     }
   }
 

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -23,17 +23,33 @@ type Props = {|
 export default function ModuleExpandableItem({
   accessibilityCollapseLabel,
   accessibilityExpandLabel,
-  badgeText,
   children,
-  icon,
-  iconAccessibilityLabel,
   id,
   isCollapsed,
   onModuleClicked,
   summary,
   title,
   type = 'info',
+  ...props
 }: Props): Node {
+  let moduleTitle;
+  if (title) {
+    if (props.badgeText) {
+      moduleTitle = <ModuleTitle badgeText={props.badgeText} title={title} type={type} />;
+    } else if (props.icon || props.iconAccessibilityLabel) {
+      moduleTitle = (
+        <ModuleTitle
+          icon={props.icon}
+          iconAccessibilityLabel={props.iconAccessibilityLabel}
+          title={title}
+          type={type}
+        />
+      );
+    } else if (props.iconButton) {
+      moduleTitle = <ModuleTitle iconButton={props.iconButton} title={title} type={type} />;
+    }
+  }
+
   return (
     <Box padding={6}>
       <Flex direction="column" gap={6}>
@@ -47,15 +63,7 @@ export default function ModuleExpandableItem({
         >
           <Flex>
             <Box alignItems="baseline" display="flex" flex="grow" marginEnd={6}>
-              <Box column={isCollapsed && summary ? 6 : 12}>
-                <ModuleTitle
-                  badgeText={badgeText}
-                  icon={icon}
-                  iconAccessibilityLabel={iconAccessibilityLabel}
-                  title={title}
-                  type={type}
-                />
-              </Box>
+              <Box column={isCollapsed && summary ? 6 : 12}>{moduleTitle}</Box>
 
               {summary && isCollapsed && (
                 <Box column={6} marginStart={6}>

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -6,16 +6,7 @@ import Icon from './Icon.js';
 import ModuleTitle from './ModuleTitle.js';
 import TapArea from './TapArea.js';
 import Text from './Text.js';
-import { type ModuleExpandableItemBaseProps } from './moduleTypes.js';
-
-type Props = {|
-  ...ModuleExpandableItemBaseProps,
-  accessibilityExpandLabel: string,
-  accessibilityCollapseLabel: string,
-  id: string,
-  isCollapsed: boolean,
-  onModuleClicked: (boolean) => void,
-|};
+import type { ModuleExpandableItemProps } from './moduleTypes.js';
 
 /**
  * https://gestalt.pinterest.systems/Module
@@ -31,27 +22,7 @@ export default function ModuleExpandableItem({
   title,
   type = 'info',
   ...props
-}: Props): Node {
-  let moduleTitle;
-  if (title) {
-    const commonProps = { title, type };
-    if (props.badgeText) {
-      moduleTitle = <ModuleTitle {...commonProps} badgeText={props.badgeText} />;
-    } else if (props.icon || props.iconAccessibilityLabel) {
-      moduleTitle = (
-        <ModuleTitle
-          {...commonProps}
-          icon={props.icon}
-          iconAccessibilityLabel={props.iconAccessibilityLabel}
-        />
-      );
-    } else if (props.iconButton) {
-      moduleTitle = <ModuleTitle {...commonProps} iconButton={props.iconButton} />;
-    } else {
-      moduleTitle = <ModuleTitle {...commonProps} />;
-    }
-  }
-
+}: ModuleExpandableItemProps): Node {
   return (
     <Box padding={6}>
       <Flex direction="column" gap={6}>
@@ -65,7 +36,18 @@ export default function ModuleExpandableItem({
         >
           <Flex>
             <Box alignItems="baseline" display="flex" flex="grow" marginEnd={6}>
-              <Box column={isCollapsed && summary ? 6 : 12}>{moduleTitle}</Box>
+              <Box column={isCollapsed && summary ? 6 : 12}>
+                <ModuleTitle
+                  badgeText={props.badgeText ? props.badgeText : undefined}
+                  icon={props.icon ? props.icon : undefined}
+                  iconAccessibilityLabel={
+                    props.iconAccessibilityLabel ? props.iconAccessibilityLabel : undefined
+                  }
+                  iconButton={props.iconButton ? props.iconButton : undefined}
+                  title={title}
+                  type={type}
+                />
+              </Box>
 
               {summary && isCollapsed && (
                 <Box column={6} marginStart={6}>

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -15,6 +15,7 @@ export default function ModuleExpandableItem({
   accessibilityCollapseLabel,
   accessibilityExpandLabel,
   children,
+  iconAccessibilityLabel,
   id,
   isCollapsed,
   onModuleClicked,
@@ -40,9 +41,7 @@ export default function ModuleExpandableItem({
                 <ModuleTitle
                   badgeText={props.badgeText ? props.badgeText : undefined}
                   icon={props.icon ? props.icon : undefined}
-                  iconAccessibilityLabel={
-                    props.iconAccessibilityLabel ? props.iconAccessibilityLabel : undefined
-                  }
+                  iconAccessibilityLabel={iconAccessibilityLabel}
                   iconButton={props.iconButton ? props.iconButton : undefined}
                   title={title}
                   type={type}

--- a/packages/gestalt/src/ModuleExpandableItem.jsdom.test.js
+++ b/packages/gestalt/src/ModuleExpandableItem.jsdom.test.js
@@ -40,6 +40,31 @@ describe('ModuleExpandableItem', () => {
     expect(screen.queryByText(/Children/i)).toBeNull();
   });
 
+  it('should render badge correctly', () => {
+    const props = {
+      ...baseProps,
+      badgeText: 'badge text',
+    };
+    render(<ModuleExpandableItem {...props}>Children</ModuleExpandableItem>);
+    expect(screen.getByText(/test title/i)).toBeInTheDocument();
+    expect(screen.queryByText(/badge text/i)).toBeInTheDocument();
+    expect(screen.queryByText(/summary1/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Children/i)).toBeNull();
+  });
+
+  it('should render icon button correctly', () => {
+    const props = {
+      ...baseProps,
+      icon: 'lock',
+      iconAccessibilityLabel: 'test label',
+    };
+    render(<ModuleExpandableItem {...props}>Children</ModuleExpandableItem>);
+    expect(screen.getByText(/test title/i)).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /test label/i })).toBeInTheDocument();
+    expect(screen.queryByText(/summary1/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Children/i)).toBeNull();
+  });
+
   it('should render the expanded state correctly', () => {
     const props = {
       ...baseProps,

--- a/packages/gestalt/src/ModuleExpandableItem.test.js
+++ b/packages/gestalt/src/ModuleExpandableItem.test.js
@@ -1,5 +1,6 @@
 // @flow strict
 import renderer from 'react-test-renderer';
+import IconButton from './IconButton.js';
 import ModuleExpandableItem from './ModuleExpandableItem.js';
 
 describe('ModuleExpandableItem', () => {
@@ -57,6 +58,33 @@ describe('ModuleExpandableItem', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test('renders correctly with icon button', () => {
+    const tree = renderer
+      .create(
+        <ModuleExpandableItem
+          id="uniqueTestID"
+          accessibilityExpandLabel="click to expand"
+          accessibilityCollapseLabel="click to collapse"
+          title="test title"
+          isCollapsed
+          iconButton={
+            <IconButton
+              bgColor="lightGray"
+              icon="question-mark"
+              iconColor="darkGray"
+              accessibilityLabel="Get help"
+              size="xs"
+              onClick={() => {}}
+            />
+          }
+          type="info"
+          onModuleClicked={() => {}}
+        />,
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test('renders correctly with summary', () => {
     const tree = renderer
       .create(
@@ -83,6 +111,7 @@ describe('ModuleExpandableItem', () => {
           accessibilityExpandLabel="click to expand"
           accessibilityCollapseLabel="click to collapse"
           title="test title"
+          iconAccessibilityLabel="there is an error"
           isCollapsed
           type="error"
           onModuleClicked={() => {}}

--- a/packages/gestalt/src/ModuleTitle.flowtest.js
+++ b/packages/gestalt/src/ModuleTitle.flowtest.js
@@ -1,0 +1,32 @@
+// @flow strict
+import ModuleTitle from './ModuleTitle.js';
+import IconButton from './IconButton.js';
+
+const Valid = (
+  <ModuleTitle
+    badgeText="badge-text"
+    icon="lock"
+    iconAccessibilityLabel="test label"
+    iconButton={
+      <IconButton
+        bgColor="lightGray"
+        icon="question-mark"
+        iconColor="darkGray"
+        accessibilityLabel="Get help"
+        size="xs"
+        onClick={() => {}}
+      />
+    }
+    title="test title"
+    type="info"
+  />
+);
+
+// $FlowExpectedError[prop-missing]
+const MissingProp = <ModuleTitle />;
+
+// $FlowExpectedError[prop-missing]
+const NonExistingProp = <ModuleTitle nonexisting={33} />;
+
+// $FlowExpectedError[prop-missing]
+const InvalidTypeProp = <ModuleTitle size="xxl" />;

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -5,7 +5,7 @@ import Box from './Box.js';
 import Flex from './Flex.js';
 import Icon from './Icon.js';
 import Text from './Text.js';
-import { type BaseModuleTitleProps, type TypeOptions } from './moduleTypes.js';
+import type { BaseModuleTitleProps, TypeOptions } from './moduleTypes.js';
 
 type Props = {|
   ...BaseModuleTitleProps,
@@ -16,47 +16,54 @@ type Props = {|
 /**
  * https://gestalt.pinterest.systems/Module
  */
-export default function ModuleTitle({
-  badgeText,
-  icon,
-  iconAccessibilityLabel,
-  title,
-  type = 'info',
-}: Props): Node {
+export default function ModuleTitle(props: Props): Node {
+  const { title, type = 'info' } = props;
+
   const TYPE_ICON_ATTRIBUTES = {
-    info: {
-      icon,
-      color: 'darkGray',
-    },
+    info: props.icon
+      ? {
+          icon: props.icon,
+          color: 'darkGray',
+          accessibilityLabel: props.iconAccessibilityLabel,
+        }
+      : {},
     error: {
       icon: 'workflow-status-problem',
       color: 'red',
     },
   };
 
-  const { color, icon: iconName } = TYPE_ICON_ATTRIBUTES[type];
+  const { accessibilityLabel = '', color, icon: iconName } = TYPE_ICON_ATTRIBUTES[type];
 
   return (
-    <Flex gap={2}>
+    <Flex alignItems="center" gap={2}>
       {iconName && (
-        <Icon accessibilityLabel={iconAccessibilityLabel ?? ''} color={color} icon={iconName} />
+        <Flex.Item minWidth={0}>
+          <Icon accessibilityLabel={accessibilityLabel} color={color} icon={iconName} />
+        </Flex.Item>
       )}
 
-      <Flex.Item minWidth={0}>
-        <Text color={color} lineClamp={1} weight="bold">
-          {title}
-        </Text>
-      </Flex.Item>
-
-      {badgeText && (
-        <Box
-          dangerouslySetInlineStyle={{ __style: { top: '1px' } }}
-          marginStart={2}
-          position="relative"
-        >
-          <Badge text={badgeText} />
-        </Box>
+      {title && (
+        <Flex.Item minWidth={0}>
+          <Text color={color} lineClamp={1} weight="bold">
+            {title}
+          </Text>
+        </Flex.Item>
       )}
+
+      {props.badgeText && (
+        <Flex.Item minWidth={0}>
+          <Box
+            dangerouslySetInlineStyle={{ __style: { top: '1px' } }}
+            marginStart={2}
+            position="relative"
+          >
+            <Badge text={props.badgeText} />
+          </Box>
+        </Flex.Item>
+      )}
+
+      {props.iconButton && <Flex.Item minWidth={0}>{props.iconButton}</Flex.Item>}
     </Flex>
   );
 }

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -1,22 +1,16 @@
 // @flow strict
-import { type Node } from 'react';
+import type { Node } from 'react';
 import Badge from './Badge.js';
 import Box from './Box.js';
 import Flex from './Flex.js';
 import Icon from './Icon.js';
 import Text from './Text.js';
-import type { BaseModuleTitleProps, TypeOptions } from './moduleTypes.js';
-
-type Props = {|
-  ...BaseModuleTitleProps,
-  title: string, // overwriting to be required
-  type: TypeOptions, // overwriting to be required
-|};
+import type { ModuleTitleProps } from './moduleTypes.js';
 
 /**
  * https://gestalt.pinterest.systems/Module
  */
-export default function ModuleTitle(props: Props): Node {
+export default function ModuleTitle(props: ModuleTitleProps): Node {
   const { title, type = 'info' } = props;
 
   const TYPE_ICON_ATTRIBUTES = {

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -11,30 +11,22 @@ import type { ModuleTitleProps } from './moduleTypes.js';
  * https://gestalt.pinterest.systems/Module
  */
 export default function ModuleTitle(props: ModuleTitleProps): Node {
-  const { title, type = 'info' } = props;
+  const { iconAccessibilityLabel = '', title, type = 'info' } = props;
 
-  const TYPE_ICON_ATTRIBUTES = {
-    info: props.icon
-      ? {
-          icon: props.icon,
-          color: 'darkGray',
-          accessibilityLabel: props.iconAccessibilityLabel,
-        }
-      : {},
-    error: {
-      icon: 'workflow-status-problem',
-      color: 'red',
-      accessibilityLabel: props.iconAccessibilityLabel,
-    },
-  };
-
-  const { accessibilityLabel = '', color, icon: iconName } = TYPE_ICON_ATTRIBUTES[type];
+  const decoration = ['icon', 'badgeText', 'iconButton'].find((prop) => !!props[prop]);
+  const hasError = type === 'error';
+  const hasIcon = hasError || decoration === 'icon';
+  const color = hasError ? 'red' : 'darkGray';
 
   return (
     <Flex alignItems="center" gap={2}>
-      {iconName && (
+      {hasIcon && (
         <Flex.Item minWidth={0}>
-          <Icon accessibilityLabel={accessibilityLabel} color={color} icon={iconName} />
+          <Icon
+            accessibilityLabel={iconAccessibilityLabel}
+            color={color}
+            icon={hasError ? 'workflow-status-problem' : props.icon}
+          />
         </Flex.Item>
       )}
 
@@ -46,7 +38,7 @@ export default function ModuleTitle(props: ModuleTitleProps): Node {
         </Flex.Item>
       )}
 
-      {props.badgeText && (
+      {decoration === 'badgeText' && props.badgeText && (
         <Flex.Item minWidth={0}>
           <Box
             dangerouslySetInlineStyle={{ __style: { top: '1px' } }}
@@ -58,7 +50,7 @@ export default function ModuleTitle(props: ModuleTitleProps): Node {
         </Flex.Item>
       )}
 
-      {props.iconButton && <Flex.Item minWidth={0}>{props.iconButton}</Flex.Item>}
+      {decoration === 'iconButton' && <Flex.Item minWidth={0}>{props.iconButton}</Flex.Item>}
     </Flex>
   );
 }

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -24,6 +24,7 @@ export default function ModuleTitle(props: ModuleTitleProps): Node {
     error: {
       icon: 'workflow-status-problem',
       color: 'red',
+      accessibilityLabel: props.iconAccessibilityLabel,
     },
   };
 

--- a/packages/gestalt/src/__snapshots__/Module.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Module.test.js.snap
@@ -12,7 +12,7 @@ exports[`Module renders a badge correctly 1`] = `
       className="FlexItem"
     >
       <div
-        className="Flex rowGap2 xsDirectionRow"
+        className="Flex rowGap2 itemsCenter xsDirectionRow"
       >
         <div
           className="FlexItem"
@@ -36,6 +36,11 @@ exports[`Module renders a badge correctly 1`] = `
         </div>
         <div
           className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
         >
           <div
             className="box marginStart2 relative"
@@ -79,7 +84,7 @@ exports[`Module renders a title correctly 1`] = `
       className="FlexItem"
     >
       <div
-        className="Flex rowGap2 xsDirectionRow"
+        className="Flex rowGap2 itemsCenter xsDirectionRow"
       >
         <div
           className="FlexItem"
@@ -122,14 +127,19 @@ exports[`Module renders an error correctly 1`] = `
       className="FlexItem"
     >
       <div
-        className="Flex rowGap2 xsDirectionRow"
+        className="Flex rowGap2 itemsCenter xsDirectionRow"
       >
         <div
           className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
         >
           <svg
             aria-hidden={null}
-            aria-label="locked"
+            aria-label="there is an error"
             className="icon red iconBlock"
             height={16}
             role="img"
@@ -176,6 +186,105 @@ exports[`Module renders an error correctly 1`] = `
 </div>
 `;
 
+exports[`Module renders an icon button correctly 1`] = `
+<div
+  className="box paddingX6 paddingY6 rounding4 shadow"
+  id="module-test"
+>
+  <div
+    className="Flex columnGap6 xsDirectionColumn"
+  >
+    <div
+      className="FlexItem"
+    >
+      <div
+        className="Flex rowGap2 itemsCenter xsDirectionRow"
+      >
+        <div
+          className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
+        >
+          <div
+            className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+            style={
+              Object {
+                "WebkitLineClamp": 1,
+              }
+            }
+            title="Testing"
+          >
+            Testing
+          </div>
+        </div>
+        <div
+          className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
+        >
+          <button
+            aria-label="Get help"
+            className="button tapTransition enabled"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <div
+              className="pog lightGray"
+              style={
+                Object {
+                  "height": 24,
+                  "width": 24,
+                }
+              }
+            >
+              <svg
+                aria-hidden={true}
+                aria-label=""
+                className="icon darkGray iconBlock"
+                height={12}
+                role="img"
+                viewBox="0 0 24 24"
+                width={12}
+              >
+                <path
+                  d="test-file-stub"
+                />
+              </svg>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="FlexItem"
+    >
+      <div
+        className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal"
+      >
+        Testing
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Module renders an icon correctly 1`] = `
 <div
   className="box paddingX6 paddingY6 rounding4 shadow"
@@ -188,10 +297,15 @@ exports[`Module renders an icon correctly 1`] = `
       className="FlexItem"
     >
       <div
-        className="Flex rowGap2 xsDirectionRow"
+        className="Flex rowGap2 itemsCenter xsDirectionRow"
       >
         <div
           className="FlexItem"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
         >
           <svg
             aria-hidden={null}

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -45,7 +45,7 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                 className="box xsCol6"
               >
                 <div
-                  className="Flex rowGap2 xsDirectionRow"
+                  className="Flex rowGap2 itemsCenter xsDirectionRow"
                 >
                   <div
                     className="FlexItem"
@@ -160,7 +160,7 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                 className="box xsCol6"
               >
                 <div
-                  className="Flex rowGap2 xsDirectionRow"
+                  className="Flex rowGap2 itemsCenter xsDirectionRow"
                 >
                   <div
                     className="FlexItem"
@@ -275,10 +275,15 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                 className="box xsCol6"
               >
                 <div
-                  className="Flex rowGap2 xsDirectionRow"
+                  className="Flex rowGap2 itemsCenter xsDirectionRow"
                 >
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <svg
                       aria-hidden={true}
@@ -411,7 +416,7 @@ exports[`Module Expandable renders correctly with one item 1`] = `
                 className="box xsCol6"
               >
                 <div
-                  className="Flex rowGap2 xsDirectionRow"
+                  className="Flex rowGap2 itemsCenter xsDirectionRow"
                 >
                   <div
                     className="FlexItem"
@@ -560,7 +565,7 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                 className="box xsCol12"
               >
                 <div
-                  className="Flex rowGap2 xsDirectionRow"
+                  className="Flex rowGap2 itemsCenter xsDirectionRow"
                 >
                   <div
                     className="FlexItem"
@@ -657,7 +662,7 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                 className="box xsCol6"
               >
                 <div
-                  className="Flex rowGap2 xsDirectionRow"
+                  className="Flex rowGap2 itemsCenter xsDirectionRow"
                 >
                   <div
                     className="FlexItem"
@@ -772,10 +777,15 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                 className="box xsCol6"
               >
                 <div
-                  className="Flex rowGap2 xsDirectionRow"
+                  className="Flex rowGap2 itemsCenter xsDirectionRow"
                 >
                   <div
                     className="FlexItem"
+                    style={
+                      Object {
+                        "minWidth": 0,
+                      }
+                    }
                   >
                     <svg
                       aria-hidden={true}

--- a/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
@@ -42,7 +42,7 @@ exports[`ModuleExpandableItem renders correctly 1`] = `
               className="box xsCol12"
             >
               <div
-                className="Flex rowGap2 xsDirectionRow"
+                className="Flex rowGap2 itemsCenter xsDirectionRow"
               >
                 <div
                   className="FlexItem"
@@ -116,7 +116,7 @@ exports[`ModuleExpandableItem renders correctly with badge 1`] = `
               className="box xsCol12"
             >
               <div
-                className="Flex rowGap2 xsDirectionRow"
+                className="Flex rowGap2 itemsCenter xsDirectionRow"
               >
                 <div
                   className="FlexItem"
@@ -140,6 +140,11 @@ exports[`ModuleExpandableItem renders correctly with badge 1`] = `
                 </div>
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <div
                     className="box marginStart2 relative"
@@ -208,7 +213,7 @@ exports[`ModuleExpandableItem renders correctly with children 1`] = `
               className="box xsCol12"
             >
               <div
-                className="Flex rowGap2 xsDirectionRow"
+                className="Flex rowGap2 itemsCenter xsDirectionRow"
               >
                 <div
                   className="FlexItem"
@@ -282,14 +287,19 @@ exports[`ModuleExpandableItem renders correctly with error 1`] = `
               className="box xsCol12"
             >
               <div
-                className="Flex rowGap2 xsDirectionRow"
+                className="Flex rowGap2 itemsCenter xsDirectionRow"
               >
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <svg
-                    aria-hidden={true}
-                    aria-label=""
+                    aria-hidden={null}
+                    aria-label="there is an error"
                     className="icon red iconBlock"
                     height={16}
                     role="img"
@@ -373,10 +383,15 @@ exports[`ModuleExpandableItem renders correctly with icon 1`] = `
               className="box xsCol12"
             >
               <div
-                className="Flex rowGap2 xsDirectionRow"
+                className="Flex rowGap2 itemsCenter xsDirectionRow"
               >
                 <div
                   className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
                 >
                   <svg
                     aria-hidden={null}
@@ -411,6 +426,130 @@ exports[`ModuleExpandableItem renders correctly with icon 1`] = `
                   >
                     test title
                   </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ModuleExpandableItem renders correctly with icon button 1`] = `
+<div
+  className="box paddingX6 paddingY6"
+>
+  <div
+    className="Flex columnGap6 xsDirectionColumn"
+  >
+    <div
+      className="FlexItem"
+    >
+      <div
+        aria-controls="uniqueTestID"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-label="click to expand"
+        className="hideOutline tapTransition rounding0 accessibilityOutline fullWidth pointer"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <div
+          className="Flex rowGap0 xsDirectionRow"
+        >
+          <div
+            className="box flexGrow itemsBaseline marginEnd6 xsDisplayFlex"
+          >
+            <div
+              className="box xsCol12"
+            >
+              <div
+                className="Flex rowGap2 itemsCenter xsDirectionRow"
+              >
+                <div
+                  className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
+                >
+                  <div
+                    className="Text fontSize3 darkGray alignStart breakWord fontWeightBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 1,
+                      }
+                    }
+                    title="test title"
+                  >
+                    test title
+                  </div>
+                </div>
+                <div
+                  className="FlexItem"
+                  style={
+                    Object {
+                      "minWidth": 0,
+                    }
+                  }
+                >
+                  <button
+                    aria-label="Get help"
+                    className="button tapTransition enabled"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <div
+                      className="pog lightGray"
+                      style={
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        }
+                      }
+                    >
+                      <svg
+                        aria-hidden={true}
+                        aria-label=""
+                        className="icon darkGray iconBlock"
+                        height={12}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={12}
+                      >
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>
@@ -464,7 +603,7 @@ exports[`ModuleExpandableItem renders correctly with summary 1`] = `
               className="box xsCol6"
             >
               <div
-                className="Flex rowGap2 xsDirectionRow"
+                className="Flex rowGap2 itemsCenter xsDirectionRow"
               >
                 <div
                   className="FlexItem"
@@ -591,7 +730,7 @@ exports[`ModuleExpandableItem renders correctly with when expanded 1`] = `
               className="box xsCol12"
             >
               <div
-                className="Flex rowGap2 xsDirectionRow"
+                className="Flex rowGap2 itemsCenter xsDirectionRow"
               >
                 <div
                   className="FlexItem"

--- a/packages/gestalt/src/moduleTypes.js
+++ b/packages/gestalt/src/moduleTypes.js
@@ -1,16 +1,32 @@
 // @flow strict
-import { type Node } from 'react';
+import type { Element, Node } from 'react';
 import icons from './icons/index.js';
+import IconButton from './IconButton.js';
 
 export type TypeOptions = 'error' | 'info';
 
-export type BaseModuleTitleProps = {|
-  badgeText?: string,
-  icon?: $Keys<typeof icons>,
-  iconAccessibilityLabel?: string,
+type BaseModuleProps = {|
   title?: string,
   type?: TypeOptions,
 |};
+
+type ModuleBadgeProps = {|
+  ...BaseModuleProps,
+  badgeText?: string,
+|};
+
+type ModuleIconProps = {|
+  ...BaseModuleProps,
+  icon?: $Keys<typeof icons>,
+  iconAccessibilityLabel?: string,
+|};
+
+type ModuleIconButtonProps = {|
+  ...BaseModuleProps,
+  iconButton?: Element<typeof IconButton>,
+|};
+
+export type BaseModuleTitleProps = ModuleBadgeProps | ModuleIconProps | ModuleIconButtonProps;
 
 export type ModuleExpandableItemBaseProps = {|
   ...BaseModuleTitleProps,

--- a/packages/gestalt/src/moduleTypes.js
+++ b/packages/gestalt/src/moduleTypes.js
@@ -11,25 +11,24 @@ type BaseBadgeProps = {|
 
 type BaseIconProps = {|
   icon?: $Keys<typeof icons>,
-  iconAccessibilityLabel?: string,
 |};
 
 type BaseIconButtonProps = {|
   iconButton?: Element<typeof IconButton>,
 |};
 
-type MutuallyExclusiveProps = BaseBadgeProps | BaseIconProps | BaseIconButtonProps;
+type BaseMutuallyExclusiveProps = BaseBadgeProps | BaseIconProps | BaseIconButtonProps;
+type BaseCombinedProps = {| ...BaseBadgeProps, ...BaseIconProps, ...BaseIconButtonProps |};
 
 // Props for ModuleTitle
 type BaseModuleTitleProps = {|
-  title?: string,
+  iconAccessibilityLabel?: string,
+  title: string,
   type?: TypeOptions,
 |};
 export type ModuleTitleProps = {|
   ...BaseModuleTitleProps,
-  ...BaseBadgeProps,
-  ...BaseIconProps,
-  ...BaseIconButtonProps,
+  ...BaseCombinedProps,
 |};
 
 // Props for Module
@@ -37,11 +36,12 @@ type BaseModuleProps = {|
   ...BaseModuleTitleProps,
   children?: Node,
   id: string,
+  title?: string, // overwriting to be optional
 |};
 
 export type PublicModuleProps = {|
   ...BaseModuleProps,
-  ...MutuallyExclusiveProps,
+  ...BaseMutuallyExclusiveProps,
 |};
 
 // Props for ModuleExpandable
@@ -49,19 +49,16 @@ type BaseModuleExpandableItemProps = {|
   ...BaseModuleTitleProps,
   children?: Node,
   summary?: $ReadOnlyArray<string>,
-  title: string, // overwriting to be required
 |};
 
 export type PublicModuleExpandableItemProps = {|
   ...BaseModuleExpandableItemProps,
-  ...MutuallyExclusiveProps,
+  ...BaseMutuallyExclusiveProps,
 |};
 
 export type ModuleExpandableItemProps = {|
   ...BaseModuleExpandableItemProps,
-  ...BaseBadgeProps,
-  ...BaseIconProps,
-  ...BaseIconButtonProps,
+  ...BaseCombinedProps,
   accessibilityCollapseLabel: string,
   accessibilityExpandLabel: string,
   id: string,

--- a/packages/gestalt/src/moduleTypes.js
+++ b/packages/gestalt/src/moduleTypes.js
@@ -5,32 +5,82 @@ import IconButton from './IconButton.js';
 
 export type TypeOptions = 'error' | 'info';
 
-type BaseModuleProps = {|
-  title?: string,
-  type?: TypeOptions,
-|};
-
-type ModuleBadgeProps = {|
-  ...BaseModuleProps,
+type BaseBadgeProps = {|
   badgeText?: string,
 |};
 
-type ModuleIconProps = {|
-  ...BaseModuleProps,
+type BaseIconProps = {|
   icon?: $Keys<typeof icons>,
   iconAccessibilityLabel?: string,
 |};
 
-type ModuleIconButtonProps = {|
-  ...BaseModuleProps,
+type BaseIconButtonProps = {|
   iconButton?: Element<typeof IconButton>,
 |};
 
-export type BaseModuleTitleProps = ModuleBadgeProps | ModuleIconProps | ModuleIconButtonProps;
+// Props for ModuleTitle
+type BaseModuleTitleProps = {|
+  title?: string,
+  type?: TypeOptions,
+|};
+export type ModuleTitleProps = {|
+  ...BaseModuleTitleProps,
+  ...BaseBadgeProps,
+  ...BaseIconProps,
+  ...BaseIconButtonProps,
+|};
 
-export type ModuleExpandableItemBaseProps = {|
+// Props for Module
+type BaseModuleProps = {|
   ...BaseModuleTitleProps,
   children?: Node,
-  summary?: $ReadOnlyArray<string>,
+  id: string,
+|};
+
+type ModuleBadgeProps = {|
+  ...BaseModuleProps,
+  ...BaseBadgeProps,
+|};
+
+type ModuleIconProps = {|
+  ...BaseModuleProps,
+  ...BaseIconProps,
+|};
+
+type ModuleIconButtonProps = {|
+  ...BaseModuleProps,
+  ...BaseIconButtonProps,
+|};
+
+export type PublicModuleProps = ModuleBadgeProps | ModuleIconProps | ModuleIconButtonProps;
+
+// Props for ModuleExpandable
+type BaseModuleExpandableItemProps = {| summary?: $ReadOnlyArray<string> |};
+
+export type PublicModuleExpandableItemProps = {|
+  ...PublicModuleProps,
+  ...BaseModuleExpandableItemProps,
   title: string, // overwriting to be required
+|};
+
+export type ModuleExpandableItemProps = {|
+  ...BaseModuleExpandableItemProps,
+  ...BaseModuleTitleProps,
+  ...BaseBadgeProps,
+  ...BaseIconProps,
+  ...BaseIconButtonProps,
+  ...BaseModuleProps,
+  accessibilityCollapseLabel: string,
+  accessibilityExpandLabel: string,
+  isCollapsed: boolean,
+  onModuleClicked: (boolean) => void,
+|};
+
+export type PublicModuleExpandableProps = {|
+  accessibilityCollapseLabel: string,
+  accessibilityExpandLabel: string,
+  expandedIndex?: ?number,
+  id: string,
+  items: $ReadOnlyArray<PublicModuleExpandableItemProps>,
+  onExpandedChange?: (?number) => void,
 |};

--- a/packages/gestalt/src/moduleTypes.js
+++ b/packages/gestalt/src/moduleTypes.js
@@ -18,6 +18,8 @@ type BaseIconButtonProps = {|
   iconButton?: Element<typeof IconButton>,
 |};
 
+type MutuallyExclusiveProps = BaseBadgeProps | BaseIconProps | BaseIconButtonProps;
+
 // Props for ModuleTitle
 type BaseModuleTitleProps = {|
   title?: string,
@@ -37,41 +39,32 @@ type BaseModuleProps = {|
   id: string,
 |};
 
-type ModuleBadgeProps = {|
+export type PublicModuleProps = {|
   ...BaseModuleProps,
-  ...BaseBadgeProps,
+  ...MutuallyExclusiveProps,
 |};
-
-type ModuleIconProps = {|
-  ...BaseModuleProps,
-  ...BaseIconProps,
-|};
-
-type ModuleIconButtonProps = {|
-  ...BaseModuleProps,
-  ...BaseIconButtonProps,
-|};
-
-export type PublicModuleProps = ModuleBadgeProps | ModuleIconProps | ModuleIconButtonProps;
 
 // Props for ModuleExpandable
-type BaseModuleExpandableItemProps = {| summary?: $ReadOnlyArray<string> |};
+type BaseModuleExpandableItemProps = {|
+  ...BaseModuleTitleProps,
+  children?: Node,
+  summary?: $ReadOnlyArray<string>,
+  title: string, // overwriting to be required
+|};
 
 export type PublicModuleExpandableItemProps = {|
-  ...PublicModuleProps,
   ...BaseModuleExpandableItemProps,
-  title: string, // overwriting to be required
+  ...MutuallyExclusiveProps,
 |};
 
 export type ModuleExpandableItemProps = {|
   ...BaseModuleExpandableItemProps,
-  ...BaseModuleTitleProps,
   ...BaseBadgeProps,
   ...BaseIconProps,
   ...BaseIconButtonProps,
-  ...BaseModuleProps,
   accessibilityCollapseLabel: string,
   accessibilityExpandLabel: string,
+  id: string,
   isCollapsed: boolean,
   onModuleClicked: (boolean) => void,
 |};


### PR DESCRIPTION
### Summary

Add an `IconButton` element to be placed after the title for a supplemental help CTA. Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `icon`.

Also, refactor types so that these props are mutually exclusive: `badgeText`, `icon` and `iconButton`.

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-3079)
- [TDD](https://paper.dropbox.com/doc/Gestalt-TDD-Modules-help-IconButton--BS4TjZGhn~rEVeVBa3YZgGeqAg-SFDuQbfYhXfiOdorq2vrn)
- [Figma](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/01-.-Web-Sticker-Sheet?node-id=4068%3A7200)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
