### PR TITLE
Internal: add ability to override default value and type in generated docs

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -1,9 +1,42 @@
 // @flow strict
-import type { Node } from 'react';
-import type { DocGen } from './docgen.js';
-
+import { type Node } from 'react';
+import { type DocGen } from './docgen.js';
 import PropTable from './PropTable.js';
 
+function getTypeOverrideValue(
+  description?: string,
+): {|
+  description?: string,
+  typeOverride?: string,
+|} {
+  const input = description ?? '';
+  const match = input.match(/(?<main>Type: (?<typeOverride>.*))/);
+  const groups = match?.groups ?? {};
+
+  return {
+    description: groups.main ? input.replace(groups.main, '') : description,
+    typeOverride: groups.typeOverride?.replace(/'/g, ''),
+  };
+}
+
+// Provide a default value where the actual one can't be parsed, e.g. Box
+function getDefaultValue(
+  description?: string,
+): {|
+  description?: string,
+  defaultValue?: string,
+|} {
+  const input = description ?? '';
+  const match = input.match(/(?<main>Default: (?<defaultValue>.*))/);
+  const groups = match?.groups ?? {};
+
+  return {
+    description: groups.main ? input.replace(groups.main, '') : description,
+    defaultValue: groups.defaultValue?.replace(/'/g, ''),
+  };
+}
+
+// Support the older-style links in props, where the prop name is a link
 function getHref(
   description?: string,
 ): {|
@@ -36,19 +69,39 @@ export default function GeneratedPropTable({
       if (!flowType || excludeProps.includes(key)) {
         return null;
       }
-      const { description: descriptionWihoutLink, href } = getHref(
-        description?.replace(/https:\/\/gestalt\.pinterest\.systems/, ''),
+
+      // Remove domain so local development (localhost) isn't broken
+      const descriptionWithoutDomain = description?.replace(
+        /https:\/\/gestalt\.pinterest\.systems/,
+        '',
       );
+
+      // Parse out older-style links
+      const { description: descriptionWithoutLink, href } = getHref(descriptionWithoutDomain);
+
+      // Parse out default value override
+      const {
+        description: descriptionWithoutDefault,
+        defaultValue: defaultValueOverride,
+      } = getDefaultValue(descriptionWithoutLink);
+
+      const { description: descriptionWithoutTypeOverride, typeOverride } = getTypeOverrideValue(
+        descriptionWithoutDefault,
+      );
+
+      // Replace "Node" with "React.Node" to match docs convention
+      const transformedType = (
+        flowType.raw?.replace(/^\|/, '').trim() ??
+        flowType.name ??
+        ''
+      ).replace(/Node/g, 'React.Node');
 
       return {
         name: key,
-        type: (flowType.raw?.replace(/^\|/, '').trim() ?? flowType.name ?? '').replace(
-          /Node/g,
-          'React.Node',
-        ),
-        description: descriptionWihoutLink?.trim(),
+        type: typeOverride ?? transformedType,
+        description: descriptionWithoutTypeOverride?.trim(),
         required,
-        defaultValue: defaultValue?.value?.replace(/'/g, ''),
+        defaultValue: defaultValueOverride ?? defaultValue?.value?.replace(/'/g, ''),
         href,
       };
     })


### PR DESCRIPTION
Certain components, like Box, don't have defaults set in JS (they're either set in CSS or browser defaults). This PR essentially reverts part of #1688, re-adding the ability to specify default values in comments.

This PR also adds the ability to override the given type in the comments, which may prove useful while we wait to write the Babel transform to resolve types — or it may not, and we may delete it in the future.