### PR TITLE
Eslint plugin: add zIndex props coverage to gestalt/no-box-dangerous-style-duplicates

### DIFF
--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-dangerous-style-duplicates/invalid/invalid-zIndex-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-dangerous-style-duplicates/invalid/invalid-zIndex-input.js
@@ -1,0 +1,5 @@
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return <Box dangerouslySetInlineStyle={{ __style: { zIndex: 1000 } }} />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-dangerous-style-duplicates/invalid/invalid-zIndex-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-box-dangerous-style-duplicates/invalid/invalid-zIndex-output.js
@@ -1,0 +1,5 @@
+import { Box, FixedZIndex } from 'gestalt';
+
+export default function TestElement() {
+  return <Box zIndex={new FixedZIndex(1000)} />;
+}

--- a/packages/eslint-plugin-gestalt/src/helpers/styleHelpers.js
+++ b/packages/eslint-plugin-gestalt/src/helpers/styleHelpers.js
@@ -292,6 +292,12 @@ const getMatchKeyErrorsReducer: GetMatchKeyErrorsReducerType = ({ context }) => 
           handleAlternative({ alternative: `role="${value}"` });
           break;
 
+        case 'zIndex':
+          handleAlternative({
+            alternative: value ? `zIndex={new FixedZIndex(${value})}` : undefined,
+          });
+          break;
+
         default:
           break;
       }

--- a/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.js
@@ -55,7 +55,7 @@ const rule: ESLintRule = {
     let programNode;
     let gestaltImportNode;
     let isImportFixerExecuted = false;
-    let addfixedZIndex = false;
+    let addFixedZIndex = false;
 
     const importDeclarationFnc = (node) => {
       if (!node) return;
@@ -143,7 +143,7 @@ const rule: ESLintRule = {
       const newPropsToAddToBox = validatorResponse
         ?.map((alternative) => {
           if (typeof alternative.prop === 'string' && alternative.prop.startsWith('zIndex')) {
-            addfixedZIndex = true;
+            addFixedZIndex = true;
           }
           return alternative.prop;
         })
@@ -225,7 +225,7 @@ const rule: ESLintRule = {
               });
 
               const fixers =
-                addfixedZIndex && !isImportFixerExecuted ? [...tagFixers, importFixers] : tagFixers;
+                addFixedZIndex && !isImportFixerExecuted ? [...tagFixers, importFixers] : tagFixers;
               isImportFixerExecuted = true;
 
               return fixers;

--- a/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.test.js
@@ -83,6 +83,8 @@ const invalidWidthInput = buildInvalidTest('invalid-width-input');
 const invalidWidthOutput = buildInvalidTest('invalid-width-output');
 const invalidWrapInput = buildInvalidTest('invalid-wrap-input');
 const invalidWrapOutput = buildInvalidTest('invalid-wrap-output');
+const invalidZIndexInput = buildInvalidTest('invalid-zIndex-input');
+const invalidZIndexOutput = buildInvalidTest('invalid-zIndex-output');
 
 const getErrorMessage = (error) =>
   `Unnecessary Box dangerous styles found. https://gestalt.netlify.app/Box\n${error ?? ''}`;
@@ -164,6 +166,11 @@ ruleTester.run('no-box-dangerous-style-duplicates', rule, {
     [invalidRoleInput, invalidRoleOutput, generateDefaultMessage(`role="banner"`)],
     [invalidTopInput, invalidTopOutput, generateDefaultMessage(`top`)],
     [invalidWrapInput, invalidWrapOutput, generateDefaultMessage(`wrap`)],
+    [
+      invalidZIndexInput,
+      invalidZIndexOutput,
+      generateDefaultMessage(`zIndex={new FixedZIndex(1000)}`),
+    ],
   ].map(([input, output, errors, options]) => ({
     code: input,
     options: options ?? [],


### PR DESCRIPTION
### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
