### PR TITLE
Upsell: don't render empty div if no actions and no children

### DIFF
--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -109,6 +109,7 @@ export default function Upsell({
     headingStyles.TextLikeHeadingSm,
     responsiveMinWidth === 'xs' && typography.alignCenter,
   );
+  const hasActions = Boolean(primaryAction || secondaryAction);
 
   return (
     <Box
@@ -182,7 +183,7 @@ export default function Upsell({
             )}
           </Box>
         </Box>
-        {!children && (
+        {!children && hasActions && (
           <Box smDisplay="flex" marginStart="auto" smMarginEnd={4} smPaddingY={3}>
             {secondaryAction && responsiveMinWidth !== 'xs' && (
               <UpsellAction type="secondary" data={secondaryAction} />

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -34,9 +34,6 @@ exports[`<Upsell /> Basic Upsell 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
-    />
   </div>
 </div>
 `;
@@ -840,9 +837,6 @@ exports[`<Upsell /> message + title 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
-    />
   </div>
 </div>
 `;


### PR DESCRIPTION
If Upsell is used with no children and no actions, it will render with an extra div that can add unneeded whitespace at certain widths. This PR adds logic to ensure that div is only shown when it's needed.

_Before_
<img width="832" alt="Screen Shot 2021-09-28 at 11 47 42 AM" src="https://user-images.githubusercontent.com/12059539/135148126-7a60f67f-e36e-4561-ab20-f9021497a38c.png">
![Screen Shot 2021-09-28 at 11 47 58 AM](https://user-images.githubusercontent.com/12059539/135148131-5e255747-ff2f-4fc8-b80a-231e0b35c923.png)

_After_
<img width="832" alt="Screen Shot 2021-09-28 at 11 49 02 AM" src="https://user-images.githubusercontent.com/12059539/135148167-f954b08a-c1b7-487a-89d7-2f714d113a15.png">


