### PR TITLE
Bump ansi-regex to "5.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "xml2js": "^0.4.23"
   },
   "resolutions": {
+    "ansi-regex": "5.0.1",
     "bl": "4.0.3",
     "browserslist": "4.16.5",
     "cacache": "15.0.6",


### PR DESCRIPTION
### Summary

ansi-regex is used in the following dependencies:

- ansi-regex "^0.2.0" - has-ansi@^0.1.0
- ansi-regex "^0.2.1" - strip-ansi@^0.3.0
- ansi-regex "^2.0.0" - has-ansi@^2.0.0, strip-ansi@^3.0.0, strip-ansi@^3.0.1, 
- ansi-regex "^3.0.0" - strip-ansi@^4.0.0
- ansi-regex "^4.0.0" - pretty-format@^24.9.0
- ansi-regex "^4.1.0" - strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0
- ansi-regex "^5.0.0" - pretty-format@^25.2.1, pretty-format@^26.4.2, pretty-format@^26.4.2, pretty-format@^27.0.2, pretty-format@^27.0.2, pretty-format@^27.1.0, strip-ansi@6.0.0, strip-ansi@^6.0.0


SEMVER NOTE: _^1.2.3 permits versions from 1.2.3 all the way up to, but not including, the next major version, 2.0.0._


Given the variety of modules and versions, a resolution for ansi-regex is the likely best option.

This PR adds a resolution for ansi-regex to the latest fixed version. Unfortunately this is a major version change for several modules, so 🤞 nothing breaks.



<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
