### PR TITLE
Link/Button/IconButton/TapArea +composed components: rename `disableOnNavigation` to `dangerouslyDisableOnNavigation`

### DIFF
--- a/docs/pages/activationcard.js
+++ b/docs/pages/activationcard.js
@@ -44,7 +44,7 @@ card(
       {
         name: 'link',
         type:
-          '{| accessibilityLabel: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }, {| disableOnNavigation: () => void |}) => void |}',
+          '{| accessibilityLabel: string , href: string, label: string, onClick?: ({ event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement | SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> }, {| dangerouslyDisableOnNavigation: () => void |}) => void |}',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/pages/button.js
+++ b/docs/pages/button.js
@@ -97,7 +97,7 @@ card(
       {
         name: 'onClick',
         type:
-          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/pages/colorschemeprovider.js
+++ b/docs/pages/colorschemeprovider.js
@@ -89,7 +89,7 @@ card(
     <MainSection.Subsection
       description={`
       **[Link](/Link)** / **[Button](/Button)** / **[IconButton](/IconButton)** / **[TapArea](/TapArea)**  / **[DropDown](/DropDown)** / **[Callout](/Callout)** / **[Upsell](/Upsell)** / **[ActivationCard](/ActivationCard)**
-      If these components are under a ColorSchemeProvider, their link behavior defaults to the logic defined in ColorSchemeProvider. In order to disable the onNavigation logic, we can return "disableOnNavigation" in the \`onClick\` callback. See each component page for more information.
+      If these components are under a ColorSchemeProvider, their link behavior defaults to the logic defined in ColorSchemeProvider. In order to disable the onNavigation logic, we can return "dangerouslyDisableOnNavigation" in the \`onClick\` callback. See each component page for more information.
     `}
     />
   </MainSection>,

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -208,7 +208,7 @@ card(
       {
         name: 'onClick',
         type:
-          'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
+          'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
         description: [
           'Callback fired when clicked (pressed and released) with a mouse or keyboard. ',
           'See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',

--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -128,7 +128,7 @@ card(
       {
         name: 'onClick',
         type:
-          '({| event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> |}) => void',
+          '({| event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> |}) => void',
         description:
           'Callback fired when the component is clicked, pressed or tapped. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',
       },

--- a/docs/pages/link.js
+++ b/docs/pages/link.js
@@ -69,7 +69,7 @@ card(
       {
         name: 'onClick',
         type:
-          'AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}>',
+          'AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}>',
         description:
           'Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',
         href: 'Custom-navigation',

--- a/docs/pages/onlinknavigationprovider.js
+++ b/docs/pages/onlinknavigationprovider.js
@@ -336,7 +336,7 @@ card(
     <MainSection.Subsection
       description={`
       **[Link](/Link)** / **[Button](/Button)** / **[IconButton](/IconButton)** / **[TapArea](/TapArea)**  / **[DropDown](/DropDown)** / **[Callout](/Callout)** / **[Upsell](/Upsell)** / **[ActivationCard](/ActivationCard)**
-      If these components are under a OnLinkNavigationProvider, their link behavior defaults to the logic defined in OnLinkNavigationProvider. In order to disable the onNavigation logic, we can return "disableOnNavigation" in the \`onClick\` callback. See each component page for more information.
+      If these components are under a OnLinkNavigationProvider, their link behavior defaults to the logic defined in OnLinkNavigationProvider. In order to disable the onNavigation logic, we can return "dangerouslyDisableOnNavigation" in the \`onClick\` callback. See each component page for more information.
     `}
     />
   </MainSection>,

--- a/docs/pages/tabs.js
+++ b/docs/pages/tabs.js
@@ -52,7 +52,7 @@ card(
       },
       {
         name: 'onChange',
-        type: `({| +event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>, +activeTabIndex: number, disableOnNavigation: () => void  |}) => void`,
+        type: `({| +event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>, +activeTabIndex: number, dangerouslyDisableOnNavigation: () => void  |}) => void`,
         required: true,
         description:
           'If your app uses a tool such as react-router to navigate between pages, be sure to use onChange to navigate instead of getting a full page refresh with href',

--- a/docs/pages/taparea.js
+++ b/docs/pages/taparea.js
@@ -133,7 +133,7 @@ card(
       {
         name: 'onMouseDown',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: ['Callback fired when a click event begins.'],
@@ -149,7 +149,7 @@ card(
       {
         name: 'onMouseEnter',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) => void',
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> }) => void',
         required: false,
         defaultValue: null,
         description: ['Callback fired when a mouse pointer moves onto a TapArea component.'],
@@ -165,7 +165,7 @@ card(
       {
         name: 'onTap',
         type:
-          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| disableOnNavigation: () => void |}> }) }) => void',
+          '({ event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> }) }) => void',
         required: false,
         defaultValue: null,
         description: [

--- a/docs/pages/upsell.js
+++ b/docs/pages/upsell.js
@@ -76,7 +76,7 @@ card(
       {
         name: 'primaryAction',
         type:
-          '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
+          '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
         defaultValue: null,
         description: `
           Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.'
@@ -87,7 +87,7 @@ card(
       {
         name: 'secondaryAction',
         type:
-          '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| disableOnNavigation: () => void |}',
+          '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
         defaultValue: null,
         description: `
           Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.'

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -21,7 +21,7 @@ type LinkData = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   rel?: 'none' | 'nofollow',
   target?: null | 'self' | 'blank',

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -50,7 +50,7 @@ type BaseButton = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   tabIndex?: -1 | 0,
   size?: 'sm' | 'md' | 'lg',
@@ -187,13 +187,16 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
     </Text>
   );
 
-  const handleClick = (event, disableOnNavigation) =>
+  const handleClick = (event, dangerouslyDisableOnNavigation) =>
     onClick
-      ? onClick({ event, disableOnNavigation: disableOnNavigation ?? (() => {}) })
+      ? onClick({
+          event,
+          dangerouslyDisableOnNavigation: dangerouslyDisableOnNavigation ?? (() => {}),
+        })
       : undefined;
 
-  const handleLinkClick = ({ event, disableOnNavigation }) =>
-    handleClick(event, disableOnNavigation);
+  const handleLinkClick = ({ event, dangerouslyDisableOnNavigation }) =>
+    handleClick(event, dangerouslyDisableOnNavigation);
 
   if (props.role === 'link') {
     const { href, rel = 'none', target = null } = props;

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -46,7 +46,7 @@ type Props = {|
       | SyntheticMouseEvent<HTMLAnchorElement>
       | SyntheticKeyboardEvent<HTMLAnchorElement>
       | SyntheticKeyboardEvent<HTMLButtonElement>,
-      {| disableOnNavigation: () => void |},
+      {| dangerouslyDisableOnNavigation: () => void |},
     >,
     rel?: 'none' | 'nofollow',
     target?: null | 'self' | 'blank',
@@ -66,7 +66,7 @@ type Props = {|
       | SyntheticMouseEvent<HTMLAnchorElement>
       | SyntheticKeyboardEvent<HTMLAnchorElement>
       | SyntheticKeyboardEvent<HTMLButtonElement>,
-      {| disableOnNavigation: () => void |},
+      {| dangerouslyDisableOnNavigation: () => void |},
     >,
     rel?: 'none' | 'nofollow',
     target?: null | 'self' | 'blank',

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -12,7 +12,7 @@ type PublicProps = {|
   isExternal?: boolean,
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   option: OptionItemType,
 |};

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -31,7 +31,7 @@ type BaseIconButton = {|
     | SyntheticKeyboardEvent<HTMLButtonElement>
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   padding?: 1 | 2 | 3 | 4 | 5,
@@ -129,13 +129,16 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     );
   };
 
-  const handleClick = (event, disableOnNavigation) =>
+  const handleClick = (event, dangerouslyDisableOnNavigation) =>
     onClick
-      ? onClick({ event, disableOnNavigation: disableOnNavigation ?? (() => {}) })
+      ? onClick({
+          event,
+          dangerouslyDisableOnNavigation: dangerouslyDisableOnNavigation ?? (() => {}),
+        })
       : undefined;
 
-  const handleLinkClick = ({ event, disableOnNavigation }) =>
-    handleClick(event, disableOnNavigation);
+  const handleLinkClick = ({ event, dangerouslyDisableOnNavigation }) =>
+    handleClick(event, dangerouslyDisableOnNavigation);
 
   const handleOnBlur = () => {
     setFocused(false);

--- a/packages/gestalt/src/InternalLink.js
+++ b/packages/gestalt/src/InternalLink.js
@@ -35,7 +35,7 @@ type Props = {|
   mouseCursor?: 'copy' | 'grab' | 'grabbing' | 'move' | 'noDrop' | 'pointer' | 'zoomIn' | 'zoomOut',
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   onBlur?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
   onFocus?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
@@ -169,7 +169,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
     if (onClick && keyPressShouldTriggerTap(event)) {
       // Prevent the default action to stop scrolling when space is pressed
       event.preventDefault();
-      onClick({ event, disableOnNavigation: () => {} });
+      onClick({ event, dangerouslyDisableOnNavigation: () => {} });
     }
   };
 
@@ -186,13 +186,13 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
       }}
       onClick={(event) => {
         let defaultOnNavigationIsEnabled = true;
-        const disableOnNavigation = () => {
+        const dangerouslyDisableOnNavigation = () => {
           defaultOnNavigationIsEnabled = false;
         };
 
         onClick?.({
           event,
-          disableOnNavigation,
+          dangerouslyDisableOnNavigation,
         });
         if (defaultOnNavigation && defaultOnNavigationIsEnabled) {
           defaultOnNavigation({ event });

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -25,7 +25,7 @@ type Props = {|
   onBlur?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   onFocus?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
   rel?: 'none' | 'nofollow',
@@ -107,7 +107,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     if (onClick && keyPressShouldTriggerTap(event)) {
       // Prevent the default action to stop scrolling when space is pressed
       event.preventDefault();
-      onClick({ event, disableOnNavigation: () => {} });
+      onClick({ event, dangerouslyDisableOnNavigation: () => {} });
     }
   };
 
@@ -126,14 +126,14 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
       }}
       onClick={(event) => {
         let defaultOnNavigationIsEnabled = true;
-        const disableOnNavigation = () => {
+        const dangerouslyDisableOnNavigation = () => {
           defaultOnNavigationIsEnabled = false;
         };
 
         if (onClick) {
           onClick({
             event,
-            disableOnNavigation,
+            dangerouslyDisableOnNavigation,
           });
         }
         if (defaultOnNavigation && defaultOnNavigationIsEnabled) {

--- a/packages/gestalt/src/OptionItem.js
+++ b/packages/gestalt/src/OptionItem.js
@@ -31,7 +31,7 @@ type Props = {|
   isExternal?: boolean,
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   onSelect?: ({|
     item: OptionItemType,

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -16,7 +16,7 @@ type Props = {|
     | SyntheticKeyboardEvent<HTMLDivElement>
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   previousTotalWidth?: number,
   rowSpan?: number,

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -12,7 +12,7 @@ type OnChangeHandler = AbstractEventHandler<
   | SyntheticKeyboardEvent<HTMLAnchorElement>
   | SyntheticMouseEvent<HTMLDivElement>
   | SyntheticKeyboardEvent<HTMLDivElement>,
-  {| +activeTabIndex: number, disableOnNavigation: () => void |},
+  {| +activeTabIndex: number, dangerouslyDisableOnNavigation: () => void |},
 >;
 
 function Dot() {
@@ -136,8 +136,8 @@ export const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwa
         onMouseUp={() => setPressed(false)}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        onTap={({ event, disableOnNavigation }) => {
-          onChange({ activeTabIndex: index, event, disableOnNavigation });
+        onTap={({ event, dangerouslyDisableOnNavigation }) => {
+          onChange({ activeTabIndex: index, event, dangerouslyDisableOnNavigation });
         }}
         role="link"
         rounding={TAB_ROUNDING}

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -28,7 +28,7 @@ export type OnTapType = AbstractEventHandler<
   | SyntheticKeyboardEvent<HTMLDivElement>
   | SyntheticMouseEvent<HTMLAnchorElement>
   | SyntheticKeyboardEvent<HTMLAnchorElement>,
-  {| disableOnNavigation: () => void |},
+  {| dangerouslyDisableOnNavigation: () => void |},
 >;
 
 type BaseTapArea = {|
@@ -137,17 +137,20 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
     if (!disabled && onTap && keyPressShouldTriggerTap(event)) {
       // Prevent the default action to stop scrolling when space is pressed
       event.preventDefault();
-      onTap({ event, disableOnNavigation: () => {} });
+      onTap({ event, dangerouslyDisableOnNavigation: () => {} });
     }
   };
 
-  const handleClick = (event, disableOnNavigation) =>
+  const handleClick = (event, dangerouslyDisableOnNavigation) =>
     !disabled && onTap
-      ? onTap({ event, disableOnNavigation: disableOnNavigation ?? (() => {}) })
+      ? onTap({
+          event,
+          dangerouslyDisableOnNavigation: dangerouslyDisableOnNavigation ?? (() => {}),
+        })
       : undefined;
 
-  const handleLinkClick = ({ event, disableOnNavigation }) =>
-    handleClick(event, disableOnNavigation);
+  const handleLinkClick = ({ event, dangerouslyDisableOnNavigation }) =>
+    handleClick(event, dangerouslyDisableOnNavigation);
 
   const handleOnBlur = (event) => {
     if (!disabled && onBlur) {

--- a/packages/gestalt/src/commonTypes.js
+++ b/packages/gestalt/src/commonTypes.js
@@ -12,7 +12,7 @@ export type ActionDataType = {|
     | SyntheticMouseEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLAnchorElement>
     | SyntheticKeyboardEvent<HTMLButtonElement>,
-    {| disableOnNavigation: () => void |},
+    {| dangerouslyDisableOnNavigation: () => void |},
   >,
   rel?: 'none' | 'nofollow',
   target?: null | 'self' | 'blank',


### PR DESCRIPTION
### Summary

Link/Button/IconButton/TapArea +composed components: rename `disableOnNavigation` to `dangerouslyDisableOnNavigation`

Prefixed `dangerously`, à la React, to decentivize/alert about the usage this navigation functionality.

No codemod included, to prevent update in codebase, grep for `disableOnNavigation` strings in  your VSCode editor and replace all instances with `dangerouslyDisableOnNavigation`.

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
