### PR TITLE
Prevent iconButton firing collapse/expand events on Module.Expandable

### DIFF
--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -415,8 +415,7 @@ card(
 
     Badge text can also be provided, which will be displayed after the \`title\`.
     
-    An IconButton can be provided to be placed after the \`title\` for a supplemental Call To Action (CTA). Be sure to prevent the \`onClick\` event from bubbling up and expanding/collapsing the module by adding \`event.preventDefault();
-    event.stopPropagation();\``}
+    An IconButton can be provided to be placed after the \`title\` for a supplemental Call To Action (CTA).`}
     defaultCode={`
 function ModuleExample3() {
   const [showPopover, setShowPopover] = React.useState(false);
@@ -448,11 +447,7 @@ function ModuleExample3() {
               iconColor="darkGray"
               accessibilityLabel="Get help"
               size="xs"
-              onClick={({event}) => {
-                event.preventDefault();
-                event.stopPropagation();
-                setShowPopover((currVal) => !currVal);
-              }}
+              onClick={({event}) => setShowPopover((currVal) => !currVal)}
               ref={anchorRef}
             />,            
             title: 'Example with icon button',

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -31,7 +31,10 @@ export default function ModuleExpandableItem({
           accessibilityControls={id}
           accessibilityExpanded={!isCollapsed}
           accessibilityLabel={isCollapsed ? accessibilityExpandLabel : accessibilityCollapseLabel}
-          onTap={() => {
+          onTap={({ event }) => {
+            if (event?.target instanceof Element && event.target.closest('button') !== null) {
+              return;
+            }
             onModuleClicked(!isCollapsed);
           }}
         >

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -136,6 +136,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
     // Check to see if space or enter were pressed
     if (!disabled && onTap && keyPressShouldTriggerTap(event)) {
       // Prevent the default action to stop scrolling when space is pressed
+      // TODO: this may be preventing ENTER keypress events coming from Buttons/IconButtons within a TapArea
       event.preventDefault();
       onTap({ event, dangerouslyDisableOnNavigation: () => {} });
     }


### PR DESCRIPTION
### Summary

Fix for https://github.com/pinterest/gestalt/issues/1721
Bonus: simplified the approach by no longer requiring the clients to use `event.preventDefault()` and `event.stopPropagation` on the `onClick` prop for the `IconButton`

### Checklist

- [ ] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
