### PR TITLE
Status: make `title` optional, add `accessibilityLabel`

### DIFF
--- a/docs/pages/status.js
+++ b/docs/pages/status.js
@@ -82,7 +82,7 @@ If using \`title\` to describe what the icon represents, \`accessibilityLabel\` 
 
       <MainSection
         name="Localization"
-        description={`Be sure to localize the \`title\` and \`subtext\` props. Note that localization can lengthen text by 20 to 30 percent.`}
+        description={`Be sure to localize the \`title\`, \`subtext\` and \`accessibilityLabel\` props. Note that localization can lengthen text by 20 to 30 percent.`}
       />
 
       <MainSection name="Variants">

--- a/docs/pages/status.js
+++ b/docs/pages/status.js
@@ -45,6 +45,42 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
       </MainSection>
 
       <MainSection
+        name="Accessibility"
+        description="Icons are a great way to help users who have difficulties with reading, focus attention, and low vision impairments. For such use cases, Status can be used without accompanying `title` text."
+      >
+        <MainSection.Subsection
+          title="ARIA attributes"
+          columns={2}
+          description={`
+If Status appears without \`title\` text, \`accessibilityLabel\` should be used to provide a text description for screen readers to announce and communicate the represented icon, as shown in the first example.
+
+Avoid using the generic words like  "image" or "icon"; instead, use verbs that describe the meaning of the icon, for example: "there is a problem with this item".
+
+If using \`title\` to describe what the icon represents, \`accessibilityLabel\` does not need to be provided, as shown in the second example.
+`}
+        >
+          <MainSection.Card
+            cardSize="md"
+            defaultCode={`
+<Flex gap={1}>
+  <Status accessibilityLabel="This item has a problem" type="problem" />
+  <Text weight="bold" size="lg">Dynamic retargeting</Text>
+</Flex>`}
+          />
+          <MainSection.Card
+            cardSize="md"
+            defaultCode={`
+<Flex alignItems="end" direction="column" gap={1}>
+  <Status title="This item has a problem" type="problem" />
+  <Text align="center" weight="bold">
+    Dynamic retargeting
+  </Text>
+</Flex>`}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
+      <MainSection
         name="Localization"
         description={`Be sure to localize the \`title\` and \`subtext\` props. Note that localization can lengthen text by 20 to 30 percent.`}
       />

--- a/packages/gestalt/src/Status.js
+++ b/packages/gestalt/src/Status.js
@@ -41,13 +41,17 @@ type StatusType = 'unstarted' | 'inProgress' | 'halted' | 'ok' | 'problem' | 'ca
 
 type Props = {|
   /**
-   * Additional contextual information around the status. See [localization](https://gestalt.pinterest.systems/status#Localization)  to learn more.
+   * If not using `title`, provide an accessibility label to give the user context about the icon. Be sure to [localize](https://gestalt.pinterest.systems/status#Localization) the label.
+   */
+  accessibilityLabel?: string,
+  /**
+   * Additional contextual information around the status. Only for use with `title`. See [localization](https://gestalt.pinterest.systems/status#Localization) to learn more.
    */
   subtext?: string,
   /**
-   * A label to reinforce the meaning of the status icon. See [localization](https://gestalt.pinterest.systems/status#Localization)  to learn more.
+   * A label to reinforce the meaning of the status icon. See [localization](https://gestalt.pinterest.systems/status#Localization) to learn more.
    */
-  title: string,
+  title?: string,
   /**
    * The type of status to display.
    */
@@ -57,17 +61,17 @@ type Props = {|
 /**
  * https://gestalt.pinterest.systems/Status
  */
-export default function Status({ subtext, title, type }: Props): Node {
+export default function Status({ accessibilityLabel, subtext, title, type }: Props): Node {
   const { icon, color } = ICON_COLOR_MAP[type];
 
   return (
     <Flex direction="column">
       <Flex alignItems="center" gap={2}>
-        <Icon accessibilityLabel="" color={color} icon={icon} size={16} />
-        <Text size="md">{title}</Text>
+        <Icon accessibilityLabel={accessibilityLabel ?? ''} color={color} icon={icon} size={16} />
+        {title && <Text size="md">{title}</Text>}
       </Flex>
 
-      {subtext && (
+      {subtext && title && (
         <Box marginStart={6}>
           <Text color="gray" size="md">
             {subtext}

--- a/packages/gestalt/src/Status.test.js
+++ b/packages/gestalt/src/Status.test.js
@@ -3,14 +3,21 @@ import { create } from 'react-test-renderer';
 import Status from './Status.js';
 
 describe('Status', () => {
-  it('renders', () => {
+  it('renders with title', () => {
     const tree = create(<Status title="Unstarted" type="unstarted" />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders with a subtext', () => {
+  it('renders with title and subtext', () => {
     const tree = create(
       <Status subtext="some subtext" title="Unstarted" type="unstarted" />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with accessibilityLabel', () => {
+    const tree = create(
+      <Status accessibilityLabel="some accessibilityLabel" type="unstarted" />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/gestalt/src/__snapshots__/Status.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Status.test.js.snap
@@ -1,6 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Status renders 1`] = `
+exports[`Status renders with accessibilityLabel 1`] = `
+<div
+  className="Flex columnGap0 xsDirectionColumn"
+>
+  <div
+    className="Flex rowGap2 itemsCenter xsDirectionRow"
+  >
+    <div
+      className="FlexItem"
+    >
+      <svg
+        aria-hidden={null}
+        aria-label="some accessibilityLabel"
+        className="icon darkGray iconBlock"
+        height={16}
+        role="img"
+        viewBox="0 0 24 24"
+        width={16}
+      >
+        <path
+          d="test-file-stub"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Status renders with title 1`] = `
 <div
   className="Flex columnGap0 xsDirectionColumn"
 >
@@ -37,7 +65,7 @@ exports[`Status renders 1`] = `
 </div>
 `;
 
-exports[`Status renders with a subtext 1`] = `
+exports[`Status renders with title and subtext 1`] = `
 <div
   className="Flex columnGap0 xsDirectionColumn"
 >


### PR DESCRIPTION
### Summary

There is a need for the Status icons without the text (or with different text), so this PR makes that prop optional. To keep things accessible, this also adds an optional accessibility label prop.

Ideally we would use union types to make one of {accessbilityLabel, title} required, but that doesn't currently work with our generated props tables. That will be a good upgrade once we figure out the union type story.

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-3190)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
