### PR TITLE
Internal: enable Next.js ESLint plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
     "plugin:flowtype/recommended",
     "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
+    "plugin:@next/next/recommended",
     "plugin:react/recommended",
     "prettier",
     "prettier/flowtype",
@@ -26,6 +27,11 @@
     "react-hooks",
     "import"
   ],
+  "settings": {
+    "next": {
+      "rootDir": "docs/"
+    }
+  },
   "rules": {
     "eslint-comments/no-unused-disable": "error",
     "flowtype/no-mutable-array": "error",
@@ -81,6 +87,12 @@
         "flowtype/no-mutable-array": "off",
         "flowtype/require-exact-type": "off",
         "flowtype/require-valid-file-annotation": "off"
+      }
+    },
+    {
+      "files": ["packages/**/*.js"],
+      "rules": {
+        "@next/next/no-img-element": "off"
       }
     },
     {

--- a/docs/components/DocSearch.js
+++ b/docs/components/DocSearch.js
@@ -40,18 +40,6 @@ function handleKeyDown(event: KeyboardEvent) {
 
 export default function DocSearch(): Node {
   useEffect(() => {
-    if (typeof window === 'undefined' || !window.docsearch) {
-      return;
-    }
-    window.docsearch({
-      apiKey: 'a22bd809b2fb174c5defd3c0f44cab8c',
-      debug: false, // Set debug to true if you want to keep open and inspect the dropdown
-      indexName: 'gestalt',
-      inputSelector: '#algolia-doc-search',
-    });
-  }, []);
-
-  useEffect(() => {
     document.addEventListener('keydown', handleKeyDown, false);
 
     return () => {

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -1,10 +1,11 @@
 // @flow strict
-import { type Node } from 'react';
+import { type Node, Fragment } from 'react';
 import '../docs.css';
 import 'gestalt/dist/gestalt.css';
 import 'gestalt-datepicker/dist/gestalt-datepicker.css';
 import { useRouter } from 'next/router';
 import { Box } from 'gestalt';
+import Script from 'next/script';
 import App from '../components/App.js';
 
 // This default export is required in a new `pages/_app.js` file.
@@ -24,8 +25,41 @@ export default function GestaltApp(
   }
 
   return (
-    <App>
-      <Component {...pageProps} />
-    </App>
+    <Fragment>
+      <Script
+        strategy="lazyOnload"
+        src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+      />
+      <Script id="docsearch" strategy="afterInteractive">
+        {`
+if (typeof window !== 'undefined' && !window.docsearch) {
+  window.docsearch({
+    apiKey: 'a22bd809b2fb174c5defd3c0f44cab8c',
+    debug: false, // Set debug to true if you want to keep open and inspect the dropdown
+    indexName: 'gestalt',
+    inputSelector: '#algolia-doc-search',
+  });
+}
+        `}
+      </Script>
+
+      <Script
+        strategy="lazyOnload"
+        src="https://www.googletagmanager.com/gtag/js?id=UA-12967896-44"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+  dataLayer.push(arguments);
+}
+gtag('js', new Date());
+gtag('config', 'UA-12967896-44');
+        `}
+      </Script>
+      <App>
+        <Component {...pageProps} />
+      </App>
+    </Fragment>
   );
 }

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -13,24 +13,6 @@ class GestaltDocument extends Document {
     return (
       <Html lang="en">
         <Head>
-          <script
-            type="text/javascript"
-            src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
-          />
-          <script async src="https://www.googletagmanager.com/gtag/js?id=UA-12967896-44" />
-          <script
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{
-              __html: `
-window.dataLayer = window.dataLayer || [];
-function gtag() {
-  dataLayer.push(arguments);
-}
-gtag('js', new Date());
-gtag('config', 'UA-12967896-44');
-`,
-            }}
-          />
           <link rel="shortcut icon" href="/pinterest_favicon.png" />
         </Head>
         <body>

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -34,6 +34,7 @@ function Changelog() {
       <Flex alignItems="start" direction="column" gap={4}>
         <Flex gap={4}>
           <Link inline target="blank" href="https://npmjs.org/package/gestalt">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src="https://img.shields.io/npm/v/gestalt.svg?label=gestalt"
               alt="Gestalt NPM package version badge"
@@ -41,6 +42,7 @@ function Changelog() {
           </Link>
 
           <Link inline target="blank" href="https://npmjs.org/package/gestalt-datepicker">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src="https://img.shields.io/npm/v/gestalt-datepicker.svg?label=gestalt-datepicker"
               alt="Gestalt DatePicker NPM package version badge"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-flow": "^7.14.5",
     "@babel/preset-react": "^7.13.13",
     "@babel/register": "^7.11.5",
+    "@next/eslint-plugin-next": "^11.1.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,6 +2692,13 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-11.1.1.tgz#d403282accbe8795aa2341f0e02c2e8bfc92bfb0"
   integrity sha512-UEAzlfKofotLmj9LIgNixAfXpRck9rt/1CU9Q4ZtNDueGBJQP3HUzPHlrLChltWY2TA5MOzDQGL82H0a3+i5Ag==
 
+"@next/eslint-plugin-next@^11.1.2":
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-11.1.2.tgz#f26cf90bcb6cd2e4645e2ba253bbc9aaaa43a170"
+  integrity sha512-cN+ojHRsufr9Yz0rtvjv8WI5En0RPZRJnt0y16Ha7DD+0n473evz8i1ETEJHmOLeR7iPJR0zxRrxeTN/bJMOjg==
+  dependencies:
+    glob "7.1.7"
+
 "@next/polyfill-module@11.1.1":
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-11.1.1.tgz#89d5a70685a52a0fad79f05a1f97a6b15cc727aa"
@@ -8527,6 +8534,18 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"


### PR DESCRIPTION
### Summary

Enables the Next.js ESLint plugin: https://nextjs.org/docs/basic-features/eslint

### Functionality to review

* Google Analytics
* Docsearch
* Images load correctly in the docs

### References

* https://github.com/vercel/next.js/blob/canary/errors/no-script-in-document-page.md
* https://github.com/vercel/next.js/blob/canary/errors/next-script-for-ga.md#using-gtagjs 

