### PR TITLE
Table: add required accessibilityLabel to fix a11y

### DIFF
--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -153,6 +153,18 @@ export default function PropTable({
               tableLayout: 'auto',
             }}
           >
+            <Box
+              width={1}
+              height={1}
+              overflow="hidden"
+              position="absolute"
+              as="caption"
+              dangerouslySetInlineStyle={{
+                __style: { clip: 'rect(1px, 1px, 1px, 1px)', whiteSpace: 'nowrap' },
+              }}
+            >
+              {proptableName ? `${proptableName} subcomponent props` : 'Component props'}
+            </Box>
             <thead>
               <tr>
                 <Th>Name</Th>

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -20,7 +20,7 @@ card(
 card(
   <MainSection name="Token Values">
     <MainSection.Subsection title="Spacing">
-      <Table>
+      <Table accessibilityLabel="Spacing token values">
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>

--- a/docs/pages/eslint_plugin.js
+++ b/docs/pages/eslint_plugin.js
@@ -50,6 +50,7 @@ With AUTOFIX!
 
         \`article\`,
         \`aside\`,
+        \`caption\`,
         \`details\`,
         \`figcaption\`,
         \`figure\`,

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -77,7 +77,7 @@ card(
   <Example
     name="Example: Basic Table"
     defaultCode={`
-<Table>
+<Table accessibilityLabel="Basic Table">
   <Table.Header>
     <Table.Row>
       <Table.HeaderCell>
@@ -223,7 +223,7 @@ card(
     id="stickyHeader"
     name="Example: Sticky header"
     defaultCode={`
-<Table maxHeight={200}>
+<Table accessibilityLabel="Sticky header" maxHeight={200}>
   <Table.Header sticky>
     <Table.Row>
       <Table.HeaderCell>
@@ -299,7 +299,7 @@ card(
     description="Try scrolling horizontally to see the first column remain in place."
     defaultCode={`
 <Box width="50%" overflow="auto">
-  <Table maxHeight={200} stickyColumns={1}>
+  <Table accessibilityLabel="Sticky Column" maxHeight={200} stickyColumns={1}>
 
     <Table.Header>
       <Table.Row>
@@ -402,7 +402,7 @@ card(
     description="Try scrolling horizontally to see the first 3 columns remain in place."
     defaultCode={`
 <Box width="60%" overflow="auto">
-  <Table maxHeight={200} stickyColumns={3} borderStyle="none">
+  <Table accessibilityLabel="Multiple sticky columns" maxHeight={200} stickyColumns={3} borderStyle="none">
 
     <Table.Header>
       <Table.Row>
@@ -537,7 +537,7 @@ card(
     description="Try scrolling horizontally and vertically to see the columns and header remain in place."
     defaultCode={`
 <Box width="60%" overflow="auto">
-  <Table maxHeight={200} stickyColumns={3} borderStyle="none">
+  <Table accessibilityLabel="Sticky header and sticky columns" maxHeight={200} stickyColumns={3} borderStyle="none">
 
     <Table.Header sticky>
       <Table.Row>
@@ -782,7 +782,7 @@ card(
       };
 
       return(
-        <Table>
+        <Table accessibilityLabel="Table Row Expandable">
 
           <Table.Header>
             <Table.Row>
@@ -994,7 +994,7 @@ card(
 
       return(
       <Box width="60%" overflow="auto">
-        <Table stickyColumns={3}>
+        <Table accessibilityLabel="Table Row Expandable with Sticky Columns" stickyColumns={3}>
 
           <Table.Header>
             <Table.Row>
@@ -1279,7 +1279,7 @@ card(
       }
 
       return (
-        <Table>
+        <Table accessibilityLabel="Sortable header cells">
           <Table.Header>
             <Table.Row>
               <Table.SortableHeaderCell onSortChange={() => onSortChange('name')} sortOrder={sortOrder} status={sortCol === 'name' ? 'active' : 'inactive'}>
@@ -1317,7 +1317,7 @@ card(
 
       return (
         <Box width="70%" overflow="auto">
-          <Table stickyColumns={2}>
+          <Table accessibilityLabel="Sortable header cells with sticky columns" stickyColumns={2}>
             <Table.Header>
               <Table.Row>
                 <Table.SortableHeaderCell onSortChange={() => onSortChange('name')} sortOrder={sortOrder} status={sortCol === 'name' ? 'active' : 'inactive'}>

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-input.js
@@ -4,6 +4,7 @@ export default function TestElement() {
     <Box>
       <article aria-label="test" onMouseEnter={() => {}} width={100}></article>
       <aside data-test-id="test" aria-label="test"></aside>
+      <caption data-test-id="test" aria-label="test"></caption>
       <details data-test-id="test" aria-label="test"></details>
       <figcaption data-test-id="test" aria-label="test"></figcaption>
       <figure data-test-id="test" aria-label="test"></figure>

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-box-as-tag/invalid/gestalt-import-HTML-multiple-tag-with-props-output.js
@@ -4,6 +4,7 @@ export default function TestElement() {
     <Box>
       <Box aria-label="test" as="article" onMouseEnter={() => {}} width={100}></Box>
       <Box aria-label="test" as="aside" data-test-id="test"></Box>
+      <Box aria-label="test" as="caption" data-test-id="test"></Box>
       <Box aria-label="test" as="details" data-test-id="test"></Box>
       <Box aria-label="test" as="figcaption" data-test-id="test"></Box>
       <Box aria-label="test" as="figure" data-test-id="test"></Box>

--- a/packages/eslint-plugin-gestalt/src/prefer-box-as-tag.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-as-tag.js
@@ -10,6 +10,7 @@ import { type ESLintRule } from './helpers/eslintFlowTypes.js';
 export const SUPPORTED_HTML_TAGS = [
   'article',
   'aside',
+  'caption',
   'details',
   'figcaption',
   'figure',

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -110,6 +110,7 @@ type Props = {
   as?:
     | 'article'
     | 'aside'
+    | 'caption'
     | 'details'
     | 'div'
     | 'figcaption'

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -17,6 +17,7 @@ import { TableContextProvider } from './contexts/TableContext.js';
 
 type Props = {|
   children: Node,
+  accessibilityLabel: string,
   borderStyle?: 'sm' | 'none',
   maxHeight?: number | string,
   stickyColumns?: ?number,
@@ -26,7 +27,7 @@ type Props = {|
  * https://gestalt.pinterest.systems/Table
  */
 export default function Table(props: Props): Node {
-  const { borderStyle, children, maxHeight, stickyColumns } = props;
+  const { accessibilityLabel, borderStyle, children, maxHeight, stickyColumns } = props;
   const [showShadowScroll, setShowShadowScroll] = useState<'left' | 'right' | null>(null);
   const tableRef = useRef<?HTMLElement>(null);
 
@@ -66,6 +67,18 @@ export default function Table(props: Props): Node {
       ref={tableRef}
     >
       <table className={classNames}>
+        <Box
+          width={1}
+          height={1}
+          overflow="hidden"
+          position="absolute"
+          as="caption"
+          dangerouslySetInlineStyle={{
+            __style: { clip: 'rect(1px, 1px, 1px, 1px)', whiteSpace: 'nowrap' },
+          }}
+        >
+          {accessibilityLabel}
+        </Box>
         <TableContextProvider stickyColumns={stickyColumns}>{children}</TableContextProvider>
       </table>
     </Box>

--- a/packages/gestalt/src/Table.test.js
+++ b/packages/gestalt/src/Table.test.js
@@ -5,7 +5,7 @@ import Table from './Table.js';
 test('renders correctly', () => {
   const tree = renderer
     .create(
-      <Table>
+      <Table accessibilityLabel="test">
         <div>rest of table</div>
       </Table>,
     )
@@ -16,7 +16,7 @@ test('renders correctly', () => {
 test('renders correctly with border', () => {
   const tree = renderer
     .create(
-      <Table borderStyle="sm">
+      <Table borderStyle="sm" accessibilityLabel="test">
         <div>rest of table</div>
       </Table>,
     )
@@ -27,7 +27,7 @@ test('renders correctly with border', () => {
 test('renders correctly with maxHeight', () => {
   const tree = renderer
     .create(
-      <Table maxHeight={100}>
+      <Table maxHeight={100} accessibilityLabel="test">
         <div>rest of table</div>
       </Table>,
     )
@@ -38,7 +38,7 @@ test('renders correctly with maxHeight', () => {
 test('renders correctly with stickyColumns', () => {
   const tree = renderer
     .create(
-      <Table stickyColumns={2}>
+      <Table stickyColumns={2} accessibilityLabel="test">
         <div>rest of table</div>
       </Table>,
     )

--- a/packages/gestalt/src/TableRowExpandable.jsdom.test.js
+++ b/packages/gestalt/src/TableRowExpandable.jsdom.test.js
@@ -11,7 +11,7 @@ const mockOnExpand = jest.fn();
 
 test('TableRowExpandable handles expand contents call', () => {
   const { getByText } = render(
-    <Table>
+    <Table accessibilityLabel="test">
       <TableBody>
         <TableRowExpandable
           accessibilityExpandLabel="Expand"
@@ -37,7 +37,7 @@ test('TableRowExpandable handles expand contents call', () => {
 
 test('TableRowExpandable handles onExpand callback', () => {
   const { getByText } = render(
-    <Table>
+    <Table accessibilityLabel="test">
       <TableBody>
         <TableRowExpandable
           accessibilityExpandLabel="Expand"

--- a/packages/gestalt/src/__snapshots__/Table.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Table.test.js.snap
@@ -12,6 +12,19 @@ exports[`renders correctly 1`] = `
   <table
     className="table"
   >
+    <caption
+      className="absolute box overflowHidden"
+      style={
+        Object {
+          "clip": "rect(1px, 1px, 1px, 1px)",
+          "height": 1,
+          "whiteSpace": "nowrap",
+          "width": 1,
+        }
+      }
+    >
+      test
+    </caption>
     <div>
       rest of table
     </div>
@@ -31,6 +44,19 @@ exports[`renders correctly with border 1`] = `
   <table
     className="table"
   >
+    <caption
+      className="absolute box overflowHidden"
+      style={
+        Object {
+          "clip": "rect(1px, 1px, 1px, 1px)",
+          "height": 1,
+          "whiteSpace": "nowrap",
+          "width": 1,
+        }
+      }
+    >
+      test
+    </caption>
     <div>
       rest of table
     </div>
@@ -50,6 +76,19 @@ exports[`renders correctly with maxHeight 1`] = `
   <table
     className="table"
   >
+    <caption
+      className="absolute box overflowHidden"
+      style={
+        Object {
+          "clip": "rect(1px, 1px, 1px, 1px)",
+          "height": 1,
+          "whiteSpace": "nowrap",
+          "width": 1,
+        }
+      }
+    >
+      test
+    </caption>
     <div>
       rest of table
     </div>
@@ -69,6 +108,19 @@ exports[`renders correctly with stickyColumns 1`] = `
   <table
     className="table"
   >
+    <caption
+      className="absolute box overflowHidden"
+      style={
+        Object {
+          "clip": "rect(1px, 1px, 1px, 1px)",
+          "height": 1,
+          "whiteSpace": "nowrap",
+          "width": 1,
+        }
+      }
+    >
+      test
+    </caption>
     <div>
       rest of table
     </div>

--- a/packages/gestalt/src/boxTypes.js
+++ b/packages/gestalt/src/boxTypes.js
@@ -16,6 +16,7 @@ export type AlignSelf = 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stre
 export type As =
   | 'article'
   | 'aside'
+  | 'caption'
   | 'details'
   | 'div'
   | 'figcaption'


### PR DESCRIPTION
### Summary

Tables are opaque objects that read as follows: 

Rotor
![image](https://user-images.githubusercontent.com/10593890/136269420-8528a2f2-4f6f-420b-bbda-e7cac0953551.png)

Voice over
![image](https://user-images.githubusercontent.com/10593890/136269247-0d1f4362-a45e-469d-a870-d4e0b5560571.png)

Followed the recommendations on https://a11y-101.com/development/tables

Added a required prop `accessibilityLabel` that feeds a hidden caption tag within table.

After the fix, 

Rotor
![image](https://user-images.githubusercontent.com/10593890/136271378-64ab1321-ed6e-423e-b0de-08635ea4a9d8.png)

Voice over
![image](https://user-images.githubusercontent.com/10593890/136270040-c3ba3091-582a-4260-bf81-cd5cc85f6c7c.png)

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
