### PR TITLE
Avatar: fix to bug (White bgcolor on Avatar component looks bad on dark backgrounds)

### DIFF
--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -42,7 +42,6 @@ export default function Avatar(props: Props): Node {
 
   return (
     <Box
-      color="white"
       {...(outline
         ? {
             dangerouslySetInlineStyle: {

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Avatar renders an outline 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "boxShadow": "0 0 0 1px #fff",
@@ -50,7 +50,7 @@ exports[`Avatar renders an outline 1`] = `
 
 exports[`Avatar renders multi-byte character initial 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": "",
@@ -97,7 +97,7 @@ exports[`Avatar renders multi-byte character initial 1`] = `
 
 exports[`Avatar renders the checkmark on verified default 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": 48,
@@ -179,7 +179,7 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
 
 exports[`Avatar renders the correct size - lg 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": 64,
@@ -224,7 +224,7 @@ exports[`Avatar renders the correct size - lg 1`] = `
 
 exports[`Avatar renders the correct size - md 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": 48,
@@ -269,7 +269,7 @@ exports[`Avatar renders the correct size - md 1`] = `
 
 exports[`Avatar renders the correct size - sm 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": 32,
@@ -314,7 +314,7 @@ exports[`Avatar renders the correct size - sm 1`] = `
 
 exports[`Avatar renders the correct size - xl 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": 24,
@@ -359,7 +359,7 @@ exports[`Avatar renders the correct size - xl 1`] = `
 
 exports[`Avatar renders the correct size - xs 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": 24,
@@ -404,7 +404,7 @@ exports[`Avatar renders the correct size - xs 1`] = `
 
 exports[`Avatar renders the correct src 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": "",
@@ -449,7 +449,7 @@ exports[`Avatar renders the correct src 1`] = `
 
 exports[`Avatar renders the verified icon 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": "",
@@ -533,7 +533,7 @@ exports[`Avatar renders the verified icon 1`] = `
 
 exports[`Avatar renders with an empty name shows default icon 1`] = `
 <div
-  className="box circle relative whiteBg"
+  className="box circle relative"
   style={
     Object {
       "height": "",

--- a/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
@@ -23,7 +23,7 @@ exports[`AvatarGroup renders AvatarGroup button with addCollaborators button 1`]
               class=""
             >
               <div
-                class="box circle relative whiteBg"
+                class="box circle relative"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -125,7 +125,7 @@ exports[`AvatarGroup renders AvatarGroup link with addCollaborators button 1`] =
                 class=""
               >
                 <div
-                  class="box circle relative whiteBg"
+                  class="box circle relative"
                   style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
                 >
                   <div
@@ -222,7 +222,7 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
               class=""
             >
               <div
-                class="box circle relative whiteBg"
+                class="box circle relative"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -261,7 +261,7 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
               class=""
             >
               <div
-                class="box circle relative whiteBg"
+                class="box circle relative"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -358,7 +358,7 @@ exports[`AvatarGroup renders display-only AvatarGroup without image 1`] = `
               class=""
             >
               <div
-                class="box circle relative whiteBg"
+                class="box circle relative"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -431,7 +431,7 @@ exports[`AvatarGroup renders fit display-only AvatarGroup with image 1`] = `
                 class=""
               >
                 <div
-                  class="box circle relative whiteBg"
+                  class="box circle relative"
                   style="box-shadow: 0 0 0 1px #fff; width: 100%;"
                 >
                   <div
@@ -488,7 +488,7 @@ exports[`AvatarGroup renders md display-only AvatarGroup with image 1`] = `
               class=""
             >
               <div
-                class="box circle relative whiteBg"
+                class="box circle relative"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -544,7 +544,7 @@ exports[`AvatarGroup renders sm display-only AvatarGroup with image 1`] = `
               class=""
             >
               <div
-                class="box circle relative whiteBg"
+                class="box circle relative"
                 style="box-shadow: 0 0 0 1px #fff; width: 32px; height: 32px;"
               >
                 <div
@@ -600,7 +600,7 @@ exports[`AvatarGroup renders xs display-only AvatarGroup with image 1`] = `
               class=""
             >
               <div
-                class="box circle relative whiteBg"
+                class="box circle relative"
                 style="box-shadow: 0 0 0 1px #fff; width: 24px; height: 24px;"
               >
                 <div

--- a/packages/gestalt/src/__snapshots__/AvatarPair.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarPair.test.js.snap
@@ -29,7 +29,7 @@ exports[`AvatarPair Renders only the first 2 collobarators when multiple are pas
     }
   >
     <div
-      className="box circle relative whiteBg"
+      className="box circle relative"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",
@@ -84,7 +84,7 @@ exports[`AvatarPair Renders only the first 2 collobarators when multiple are pas
     }
   >
     <div
-      className="box circle relative whiteBg"
+      className="box circle relative"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",
@@ -159,7 +159,7 @@ exports[`AvatarPair Renders renders 2 collaborators 1`] = `
     }
   >
     <div
-      className="box circle relative whiteBg"
+      className="box circle relative"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",
@@ -214,7 +214,7 @@ exports[`AvatarPair Renders renders 2 collaborators 1`] = `
     }
   >
     <div
-      className="box circle relative whiteBg"
+      className="box circle relative"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",
@@ -289,7 +289,7 @@ exports[`AvatarPair Renders renders the avatar with text when no image is provid
     }
   >
     <div
-      className="box circle relative whiteBg"
+      className="box circle relative"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",


### PR DESCRIPTION
### Summary

Moving Avatar's default white background color to Box's default transparent. This should prevent some white pixelation on darker backgrounds.

Before
![image](https://user-images.githubusercontent.com/10593890/137012870-28ef2646-99a5-4cc1-9810-cd275cf9e266.png)

After
![image](https://user-images.githubusercontent.com/10593890/137012900-40e1f097-a202-4a42-916b-3d554419456d.png)



<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
