### PR TITLE
Datapoint: text sizing adjustments

### DIFF
--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -33,13 +33,13 @@ export default function Datapoint({
   trendSentiment = 'auto',
   value,
 }: Props): Node {
-  const valueSize = size === 'lg' ? 'lg' : 'sm';
+  const valueSize = size === 'lg' ? 'md' : 'sm';
   const percentChangeGap = size === 'lg' ? 4 : 2;
 
   return (
     <Flex gap={1} direction="column">
       <Flex gap={1} alignItems="center" minHeight={24}>
-        <Text size="sm">{title}</Text>
+        <Text size="md">{title}</Text>
         {tooltipText && (
           <Tooltip text={tooltipText} idealDirection="up">
             {/* Interactive elements require an a11yLabel on them or their children. In this particular case,

--- a/packages/gestalt/src/__snapshots__/Datapoint.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Datapoint.test.js.snap
@@ -19,7 +19,7 @@ exports[`Datapoint renders 1`] = `
         className="FlexItem"
       >
         <div
-          className="Text fontSize1 darkGray alignStart breakWord fontWeightNormal"
+          className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal"
         >
           Title
         </div>
@@ -99,7 +99,7 @@ exports[`Datapoint renders an accessibility label 1`] = `
         className="FlexItem"
       >
         <div
-          className="Text fontSize1 darkGray alignStart breakWord fontWeightNormal"
+          className="Text fontSize2 darkGray alignStart breakWord fontWeightNormal"
         >
           Title
         </div>


### PR DESCRIPTION
Adjusted the size of the title to 14px  (from 12px) and the size of the larger datapoint value to 28px (from 36px)

Before 
![image](https://user-images.githubusercontent.com/10593890/138035739-2edf9fad-98c4-458f-8a96-62ff982cc581.png)

After
![image](https://user-images.githubusercontent.com/10593890/138035709-76c22f1c-3b17-47f4-8b0e-24f7885ad066.png)
