### PR TITLE
PageHeader: generated docs, add note about padding

### DIFF
--- a/docs/pages/pageheader.js
+++ b/docs/pages/pageheader.js
@@ -1,20 +1,19 @@
 // @flow strict
-import type { Node } from 'react';
-import { PageHeader } from 'gestalt';
-import PropTable from '../components/PropTable.js';
-import DocsPageHeader from '../components/PageHeader.js';
+import { type Node } from 'react';
+import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import docgen, { type DocGen } from '../components/docgen.js';
+import DocsPageHeader from '../components/PageHeader.js'; // renaming to avoid confusion
 import MainSection from '../components/MainSection.js';
-import CardPage from '../components/CardPage.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
-
-card(
-  <DocsPageHeader
-    name="PageHeader"
-    description="PageHeader is used to indicate the title of the current page, as well as optional actions."
-    shadedCodeExample
-    defaultCode={`
+export default function TextPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="PageHeader">
+      <DocsPageHeader
+        name="PageHeader"
+        description="PageHeader is used to indicate the title of the current page, as well as optional actions."
+        shadedCodeExample
+        defaultCode={`
       function IntroPageHeaderExample() {
         const [open, setOpen] = React.useState(false);
         const [selected, setSelected] = React.useState([]);
@@ -88,67 +87,32 @@ card(
         );
       }
     `}
-  />,
-);
+      />
 
-card(
-  <PropTable
-    Component={PageHeader}
-    props={[
-      {
-        name: 'title',
-        type: 'string',
-        required: true,
-        description:
-          'Page title, will always be a level 1 heading. Content should be [localized](#Localization).',
-      },
-      {
-        name: 'maxWidth',
-        type: `number | string`,
-        description: `Use numbers for pixels: \`maxWidth={100}\` and strings for percentages: \`maxWidth="100%"\`. See the [max width](#Max-width) variant for more info.`,
-      },
-      {
-        name: 'primaryAction',
-        type: `Element<typeof Button | typeof IconButton | typeof Link | typeof Tooltip>`,
-        description: `The primary action of the page. Can be [Button](/Button), [Link](/Link), [Tooltip](/Tooltip) surrounding an IconButton or a combination of IconButton, Tooltip and [Dropdown](/Dropdown).`,
-      },
-      {
-        name: 'secondaryAction',
-        type: `Element<typeof Button | typeof IconButton | typeof Link | typeof Tooltip>`,
-        description: `A secondary action for the page. Can be [Button](/Button), [Link](/Link), [Tooltip](/Tooltip) surrounding an IconButton or a combination of IconButton, Tooltip and [Dropdown](/Dropdown).`,
-      },
-      {
-        name: 'subtext',
-        type: `string`,
-        description: `Used for metadata related to the current page, not designed to describe the title or the current surface. Content should be [localized](#Localization).`,
-      },
-    ]}
-  />,
-);
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
-card(
-  <MainSection name="Best practices">
-    <MainSection.Subsection>
-      <MainSection.Card
-        cardSize="lg"
-        type="do"
-        description="Use only one primary style action in PageHeader ."
-        defaultCode={`
+      <MainSection name="Best practices">
+        <MainSection.Subsection>
+          <MainSection.Card
+            cardSize="lg"
+            type="do"
+            description="Use only one primary style action in PageHeader ."
+            defaultCode={`
 <PageHeader
   title="Product groups"
   subtext="S. E. All products USD"
   primaryAction={<Button color="red" size="lg" text="Create group" />}
 />;
         `}
-        shaded
-      />
-      <MainSection.Card
-        cardSize="lg"
-        type="do"
-        description={`
+            shaded
+          />
+          <MainSection.Card
+            cardSize="lg"
+            type="do"
+            description={`
         Ensure the title of PageHeader matches the title of the item that navigated the user to this page. For instance, if the user selects "Settings" from an overflow menu, the title of PageHeader should also say "Settings".
         `}
-        defaultCode={`
+            defaultCode={`
 <PageHeader
   title="Settings"
   primaryAction={
@@ -158,15 +122,15 @@ card(
   }
 />;
         `}
-        shaded
-      />
-      <MainSection.Card
-        cardSize="lg"
-        type="do"
-        description={`
-        Plan for most PageHeaders to be full width. A \`maxWidth\` should only be supplied when the content of the page is center aligned.
+            shaded
+          />
+          <MainSection.Card
+            cardSize="lg"
+            type="do"
+            description={`
+        Plan for most PageHeaders to be full width. A \`maxWidth\` should only be supplied when the content of the page is center aligned. Content should match PageHeader's 32px start/end padding.
         `}
-        defaultCode={`
+            defaultCode={`
 <Flex direction="column" flex="grow">
   <PageHeader
     title="Settings"
@@ -242,13 +206,13 @@ card(
   </Box>
 </Flex>;
         `}
-        shaded
-      />
-      <MainSection.Card
-        cardSize="lg"
-        type="don't"
-        description="Supply more than one primary style action."
-        defaultCode={`
+            shaded
+          />
+          <MainSection.Card
+            cardSize="lg"
+            type="don't"
+            description="Supply more than one primary style action."
+            defaultCode={`
 <PageHeader
   title="Product groups"
   subtext="S. E. All products USD"
@@ -256,15 +220,15 @@ card(
   secondaryAction={<Button color="red" size="lg" text="Promote" />}
 />;
         `}
-        shaded
-      />
-      <MainSection.Card
-        cardSize="lg"
-        type="don't"
-        description={`
+            shaded
+          />
+          <MainSection.Card
+            cardSize="lg"
+            type="don't"
+            description={`
         Use subtext to add a description about the page. It should only be used for metadata.
         `}
-        defaultCode={`
+            defaultCode={`
 <PageHeader
   title="Product groups"
   subtext="Product groups are created in order to relate certain products together for tracking purposes"
@@ -272,15 +236,15 @@ card(
   secondaryAction={<Button text="Promote" size="lg" />}
 />;
         `}
-        shaded
-      />
-      <MainSection.Card
-        cardSize="lg"
-        type="don't"
-        description={`
+            shaded
+          />
+          <MainSection.Card
+            cardSize="lg"
+            type="don't"
+            description={`
         Use \`maxWidth\` when the content of the page is not center aligned.
         `}
-        defaultCode={`
+            defaultCode={`
 <Flex gap={4} direction="column" flex="grow">
   <PageHeader
     title="Settings"
@@ -357,20 +321,18 @@ card(
   </Box>
 </Flex>;
         `}
-        shaded
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
+            shaded
+          />
+        </MainSection.Subsection>
+      </MainSection>
 
-card(
-  <MainSection
-    name="Accessibility"
-    description={`Be sure to follow any accessibility guidelines for the components used within PageHeader. The heading within PageHeader will be rendered as a level 1 heading, so ensure there are no other level 1 headings present on the page. For headings level 2-6, use [Heading](/Heading). Learn more about <a href="https://www.w3.org/WAI/tutorials/page-structure/headings/" target="blank">creating accessible headings</a>.`}
-  >
-    <MainSection.Card
-      cardSize="lg"
-      defaultCode={`
+      <MainSection
+        name="Accessibility"
+        description={`Be sure to follow any accessibility guidelines for the components used within PageHeader. The heading within PageHeader will be rendered as a level 1 heading, so ensure there are no other level 1 headings present on the page. For headings level 2-6, use [Heading](/Heading). Learn more about <a href="https://www.w3.org/WAI/tutorials/page-structure/headings/" target="blank">creating accessible headings</a>.`}
+      >
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
 <Flex direction="column" flex="grow">
   <PageHeader
     title="Settings"
@@ -423,39 +385,35 @@ card(
   </Box>
 </Flex>;
         `}
-      shaded
-    />
-  </MainSection>,
-);
+          shaded
+        />
+      </MainSection>
 
-card(
-  <MainSection
-    name="Localization"
-    description={`Be sure to localize the \`title\`, \`subtext\` and actions within PageHeader.`}
-  >
-    <MainSection.Card
-      shaded
-      cardSize="lg"
-      defaultCode={`
+      <MainSection
+        name="Localization"
+        description={`Be sure to localize the \`title\`, \`subtext\` and actions within PageHeader.`}
+      >
+        <MainSection.Card
+          shaded
+          cardSize="lg"
+          defaultCode={`
 <PageHeader
   title="Langer Seitentitel, der in einigen Sprachen möglicherweise abgeschnitten wird"
   subtext="2.131 Produkte"
   primaryAction={<Button color="red" size="lg" text="Schnell erstellen" />}
 />;
   `}
-    />
-  </MainSection>,
-);
+        />
+      </MainSection>
 
-card(
-  <MainSection name="Variants">
-    <MainSection.Subsection
-      description={`PageHeader supports an optional \`primaryAction\`. It can be a [Button](Button), a [Link](/Link) or an [IconButton](/IconButton) with a [Tooltip](/Tooltip) and optional [Dropdown](/Dropdown). Any Buttons or IconButtons should be \`size="lg"\`.`}
-      title="Primary action"
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          description={`PageHeader supports an optional \`primaryAction\`. It can be a [Button](Button), a [Link](/Link) or an [IconButton](/IconButton) with a [Tooltip](/Tooltip) and optional [Dropdown](/Dropdown). Any Buttons or IconButtons should be \`size="lg"\`.`}
+          title="Primary action"
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function PrimaryActionExample() {
   const [open, setOpen] = React.useState(false);
   const [selected, setSelected] = React.useState([]);
@@ -544,16 +502,16 @@ function PrimaryActionExample() {
   );
 }
         `}
-        shaded
-      />
-    </MainSection.Subsection>
-    <MainSection.Subsection
-      description={`PageHeader also supports an optional \`secondaryAction\`. It will likely be a [Button](Button) or an [IconButton](/IconButton) with a [Tooltip](/Tooltip) and optional [Dropdown](/Dropdown). Any Buttons or IconButtons should be \`size="lg"\`.`}
-      title="Secondary action"
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
+            shaded
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          description={`PageHeader also supports an optional \`secondaryAction\`. It will likely be a [Button](Button) or an [IconButton](/IconButton) with a [Tooltip](/Tooltip) and optional [Dropdown](/Dropdown). Any Buttons or IconButtons should be \`size="lg"\`.`}
+          title="Secondary action"
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function SecondaryActionExample() {
   const [open, setOpen] = React.useState(false);
   const [selected, setSelected] = React.useState([]);
@@ -635,34 +593,34 @@ function SecondaryActionExample() {
   );
 }
         `}
-        shaded
-      />
-    </MainSection.Subsection>
+            shaded
+          />
+        </MainSection.Subsection>
 
-    <MainSection.Subsection
-      description={`\`subtext\` should be used to add metadata about the content on the page, not to describe the page itself.`}
-      title="Subtext"
-    >
-      <MainSection.Card
-        shaded
-        cardSize="lg"
-        defaultCode={`
+        <MainSection.Subsection
+          description={`\`subtext\` should be used to add metadata about the content on the page, not to describe the page itself.`}
+          title="Subtext"
+        >
+          <MainSection.Card
+            shaded
+            cardSize="lg"
+            defaultCode={`
 <PageHeader
   title="Create product group"
   subtext="2,131 products"
   primaryAction={<Button color="red" size="lg" text="Quick create" />}
 />;
         `}
-      />
-    </MainSection.Subsection>
+          />
+        </MainSection.Subsection>
 
-    <MainSection.Subsection
-      description={`\`maxWidth\` should be set when the content of the page is centered and/or has a maximum width itself.`}
-      title="Max width"
-    >
-      <MainSection.Card
-        cardSize="lg"
-        defaultCode={`
+        <MainSection.Subsection
+          description={`\`maxWidth\` should be set when the content of the page is centered and/or has a maximum width itself.`}
+          title="Max width"
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Box width="100%" color="lightGray" padding={2}>
   <Box color="white" marginBottom={4} >
     <PageHeader
@@ -683,22 +641,24 @@ function SecondaryActionExample() {
   </Flex>
 </Box>;
       `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
+          />
+        </MainSection.Subsection>
+      </MainSection>
 
-card(
-  <MainSection name="Related">
-    <MainSection.Subsection
-      description={`
+      <MainSection name="Related">
+        <MainSection.Subsection
+          description={`
       **[Heading](/Heading)**
       Heading should be used to create level 2-6 headings on a page. If a level 1 heading is needed, use PageHeader.
     `}
-    />
-  </MainSection>,
-);
+        />
+      </MainSection>
+    </Page>
+  );
+}
 
-export default function PageHeaderPage(): Node {
-  return <CardPage cards={cards} page="PageHeader" />;
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen('PageHeader') },
+  };
 }

--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -11,11 +11,26 @@ import Text from './Text.js';
 import { type Dimension } from './boxTypes.js';
 
 type Props = {|
-  title: string,
+  /**
+   * Use numbers for pixels: \`maxWidth={100}\` and strings for percentages: \`maxWidth="100%"\`. See the [max width](https://gestalt.pinterest.systems/pageheader#Max-width) variant for more info.
+   */
   maxWidth?: Dimension,
+  /**
+   * The primary action of the page. Can be [Button](https://gestalt.pinterest.systems/button), [Link](https://gestalt.pinterest.systems/link), [Tooltip](https://gestalt.pinterest.systems/tooltip) surrounding IconButton or a combination of IconButton, Tooltip and [Dropdown](https://gestalt.pinterest.systems/dropdown).
+   */
   primaryAction?: Element<typeof Button | typeof IconButton | typeof Link | typeof Tooltip>,
+  /**
+   * A secondary action for the page. Can be [Button](https://gestalt.pinterest.systems/button), [Link](https://gestalt.pinterest.systems/link), [Tooltip](https://gestalt.pinterest.systems/tooltip) surrounding IconButton or a combination of IconButton, Tooltip and [Dropdown](https://gestalt.pinterest.systems/dropdown).
+   */
   secondaryAction?: Element<typeof Button | typeof IconButton | typeof Link | typeof Tooltip>,
+  /**
+   * Used for metadata related to the current page, not designed to describe the title or the current surface. Content should be [localized](https://gestalt.pinterest.systems/pageheader#Localization).
+   */
   subtext?: string,
+  /**
+   * Page title. Will always be a level 1 heading. Content should be [localized](https://gestalt.pinterest.systems/pageheader#Localization).
+   */
+  title: string,
 |};
 
 /**
@@ -42,6 +57,7 @@ export default function PageHeader({
               </Box>
             )}
           </Box>
+
           {primaryAction && (
             <Flex alignItems="center" gap={2} flex="none">
               {secondaryAction}


### PR DESCRIPTION
From #1743, it's clear that we need to be more explicit about proper content padding when PageHeader is used. This PR adds the highlighted copy:
<img width="984" alt="Screen Shot 2021-10-20 at 2 47 25 PM" src="https://user-images.githubusercontent.com/12059539/138177325-d900ed3c-8404-456f-b6a5-07a9abb5f608.png">

I also converted the docs page to use auto generated props, 'cause why not?! 😅 