### PR TITLE
ButtonGroup: simplify logic, use generated props

### DIFF
--- a/docs/pages/buttongroup.js
+++ b/docs/pages/buttongroup.js
@@ -1,73 +1,58 @@
 // @flow strict
-import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
+import { type Node } from 'react';
+import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
-import CardPage from '../components/CardPage.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
+export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="ButtonGroup">
+      <PageHeader name="ButtonGroup" description={generatedDocGen.description} />
 
-card(<PageHeader name="ButtonGroup" description="Group a series of buttons." />);
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
-card(
-  <PropTable
-    props={[
-      {
-        name: 'children',
-        type: 'Node',
-        description: `List of Button's or IconButton's`,
-        href: 'accessibilityLabel',
-      },
-    ]}
-  />,
-);
-
-card(
-  <MainSection name="Usage guidelines">
-    <MainSection.Subsection columns={2}>
-      <MainSection.Card
-        cardSize="md"
-        type="do"
-        title="When to Use"
-        description={`
+      <MainSection name="Usage guidelines">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            title="When to Use"
+            description={`
           - Arranging a group of buttons in a horizontal or vertical stack due to limited space.
           - Showing all the available options at one glance.
         `}
-      />
-      <MainSection.Card
-        cardSize="md"
-        type="don't"
-        title="When Not to Use"
-        description={`
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            title="When Not to Use"
+            description={`
           - Grouping 4 or more actions, consider using an ellipses [IconButton](/IconButton) after 3 options.
           - Switching between different views. Use [SegmentedControl](/SegmentedControl) instead.
         `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
+          />
+        </MainSection.Subsection>
+      </MainSection>
 
-card(
-  <Example
-    name="Example"
-    id="example"
-    defaultCode={`
+      <Example
+        name="Example"
+        id="example"
+        defaultCode={`
 <ButtonGroup>
   <Button text="Button 1" />
   <Button text="Button 2" />
 </ButtonGroup>
 `}
-  />,
-);
+      />
 
-card(
-  <Example
-    name="Wrap"
-    id="wrap"
-    description={`When buttons don't fit within the container, they will automatically wrap to the next line.`}
-    defaultCode={`
+      <Example
+        name="Wrap"
+        id="wrap"
+        description={`When buttons don't fit within the container, they will automatically wrap to the next line.`}
+        defaultCode={`
 <Box width={150} borderStyle="sm">
   <ButtonGroup>
     <Button text="Button 1" />
@@ -76,9 +61,13 @@ card(
   </ButtonGroup>
 </Box>
 `}
-  />,
-);
+      />
+    </Page>
+  );
+}
 
-export default function ButtonGroupPage(): Node {
-  return <CardPage cards={cards} page="ButtonGroup" />;
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen('ButtonGroup') },
+  };
 }

--- a/packages/gestalt/src/ButtonGroup.js
+++ b/packages/gestalt/src/ButtonGroup.js
@@ -1,30 +1,26 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { Children, Fragment } from 'react';
+import { Children, type Node } from 'react';
 import Box from './Box.js';
 
-/**
- * https://gestalt.pinterest.systems/ButtonGroup
- */
-function ButtonGroup({ children }: {| children?: Node |}): Node {
-  const count = Children.count(children);
+type Props = {|
+  /**
+   * One or more Buttons and/or IconButtons.
+   */
+  children?: Node,
+|};
 
-  if (count === 0) {
+/**
+ * [ButtonGroup](https://gestalt.pinterest.systems/ButtonGroup) is used to display a series of buttons.
+ */
+function ButtonGroup({ children }: Props): Node {
+  if (Children.count(children) === 0) {
     return null;
-  }
-  if (count === 1) {
-    return <Fragment>{children}</Fragment>;
   }
 
   return (
-    <Box marginStart={-1} marginEnd={-1} marginTop={-1} marginBottom={-1} display="flex" wrap>
+    <Box margin={-1} display="flex" wrap>
       {Children.map(children, (child) =>
-        child !== null && child !== undefined ? (
-          <Box paddingX={1} paddingY={1}>
-            {child}
-          </Box>
-        ) : null,
+        child !== null && child !== undefined ? <Box padding={1}>{child}</Box> : null,
       )}
     </Box>
   );

--- a/packages/gestalt/src/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ButtonGroup.test.js.snap
@@ -58,24 +58,32 @@ exports[`ButtonGroup Renders container with children when multiple children are 
 exports[`ButtonGroup Renders nothing when no children are passed in 1`] = `null`;
 
 exports[`ButtonGroup Renders the child without container when 1 child is passed in 1`] = `
-<button
-  className="button hideOutline tapTransition md gray enabled inline accessibilityOutline"
-  disabled={false}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onMouseDown={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  tabIndex={0}
-  type="button"
+<div
+  className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
 >
   <div
-    className="Text fontSize3 darkGray alignCenter fontWeightBold"
+    className="box paddingX1 paddingY1"
   >
-    Button 1
+    <button
+      className="button hideOutline tapTransition md gray enabled inline accessibilityOutline"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="Text fontSize3 darkGray alignCenter fontWeightBold"
+      >
+        Button 1
+      </div>
+    </button>
   </div>
-</button>
+</div>
 `;


### PR DESCRIPTION
### Summary

ButtonGroup has logic to handle a single child differently from multiple children, which is odd and seemingly unnecessary. This PR removes that logic, such that the markup is predictable regardless of the number of children.

This also converts the relevant docs page to use a generated props table.

### Links

- [Jira](https://jira.pinadmin.com/browse/BUG-134854)
