### PR TITLE
Toast: ship dark gray treatment, use generated docs

### DIFF
--- a/docs/components/Combination.js
+++ b/docs/components/Combination.js
@@ -53,7 +53,12 @@ const toReactAttribute = (key, value) => {
     case 'string':
       return `${key}=${JSON.stringify(value)}`;
     default:
-      return `${key}={${JSON.stringify(value)}}`;
+      try {
+        return `${key}={${JSON.stringify(value)}}`;
+      } catch (err) {
+        // Handle React components and other circular objects gracefully
+        return null;
+      }
   }
 };
 

--- a/docs/pages/text.js
+++ b/docs/pages/text.js
@@ -4,8 +4,7 @@ import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import Page from '../components/Page.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
-import type { DocGen } from '../components/docgen.js';
-import docgen from '../components/docgen.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function TextPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -4,90 +4,46 @@ import { Button, Link, Image, Text, Toast } from 'gestalt';
 import Combination from '../components/Combination.js';
 import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
-import PropTable from '../components/PropTable.js';
 import MainSection from '../components/MainSection.js';
-import CardPage from '../components/CardPage.js';
+import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
+export default function ToastPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="Toast">
+      <PageHeader name="Toast" description={generatedDocGen?.description} />
 
-card(
-  <PageHeader
-    name="Toast"
-    description={`Toasts can educate people on the content of the screen, provide confirmation when people complete an action, or simply communicate a short message.
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
-The Toast component is purely visual. In order to properly handle the showing and dismissing of Toasts, as well as any animations, you will need to implement a Toast manager.`}
-  />,
-);
-
-card(
-  <PropTable
-    props={[
-      {
-        name: 'button',
-        type: 'React.Node',
-        href: 'imageTextButtonExample',
-      },
-      {
-        name: 'text',
-        type: 'string | React.Node',
-        description:
-          'Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Do not specify a Text color within this property, as the color is automatically determined based on the `variant`.',
-        href: 'textOnlyExample',
-        required: true,
-      },
-      {
-        name: 'thumbnail',
-        type: 'React.Node',
-        href: 'imageTextExample',
-      },
-      {
-        name: 'thumbnailShape',
-        type: `'circle' | 'rectangle' | 'square'`,
-        defaultValue: 'square',
-        href: 'imageTextExample',
-      },
-      {
-        name: 'variant',
-        type: `'default' | 'error'`,
-        defaultValue: 'default',
-        href: 'errorVariantExample',
-      },
-    ]}
-  />,
-);
-
-card(
-  <MainSection name="Usage guidelines">
-    <MainSection.Subsection columns={2}>
-      <MainSection.Card
-        cardSize="md"
-        type="do"
-        title="When to Use"
-        description={`
+      <MainSection name="Usage guidelines">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            title="When to Use"
+            description={`
           - Displaying non-critical feedback on the result of an action.
           - Reinforcing success at the surface level.
         `}
-      />
-      <MainSection.Card
-        cardSize="md"
-        type="don't"
-        title="When Not to Use"
-        description={`
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            title="When Not to Use"
+            description={`
           - Providing an update related to anything other than confirmation of a successful action. Consider a [Callout](/Callout) instead.
           - Presenting mandatory and/or critical actions to a user.
-          - Displaying feedback at the element level (e.g., password inputted doesn't meet requirements). Use inline text instead.
+          - Displaying feedback at the element level (e.g., entered password doesn't meet requirements). Use inline text instead.
         `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
+          />
+        </MainSection.Subsection>
+      </MainSection>
 
-card(
-  <Example
-    id="textOnlyExample"
-    name="Example: Simple Text"
-    defaultCode={`
+      <Example
+        id="textOnlyExample"
+        name="Example: Simple Text"
+        defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
 
@@ -119,15 +75,13 @@ function ToastExample() {
     </Box>
   );
 }`}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="complexTextExample"
-    name="Example: Complex Text"
-    description="When passing in your own Text component for `text`, do not specify `color` on Text. Toast will automatically pick the correct text color for the given `variant`."
-    defaultCode={`
+      <Example
+        id="complexTextExample"
+        name="Example: Complex Text"
+        description="When passing in your own Text component for `text`, do not specify `color` on Text. Toast will automatically pick the correct text color for the given `variant`."
+        defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
 
@@ -170,14 +124,12 @@ function ToastExample() {
     </Box>
   );
 }`}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="errorVariantExample"
-    name="Example: Error variant"
-    defaultCode={`
+      <Example
+        id="errorVariantExample"
+        name="Example: Error variant"
+        defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
 
@@ -212,14 +164,12 @@ function ToastExample() {
     </Box>
   );
 }`}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="imageTextExample"
-    name="Example: Image + Text"
-    defaultCode={`
+      <Example
+        id="imageTextExample"
+        name="Example: Image + Text"
+        defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
 
@@ -270,14 +220,12 @@ function ToastExample() {
     </Box>
   );
 }`}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="imageTextButtonExample"
-    name="Example: Image + Text + Button"
-    defaultCode={`
+      <Example
+        id="imageTextButtonExample"
+        name="Example: Image + Text + Button"
+        defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
 
@@ -329,64 +277,16 @@ function ToastExample() {
     </Box>
   );
 }`}
-  />,
-);
+      />
 
-card(
-  <Combination
-    id="combinations-overview"
-    layout="12column"
-    name="Combinations: Overview"
-    showValues={false}
-    text={[
-      'Section created!',
-      <Fragment key="saved-text">
-        Saved to{' '}
-        <Text inline weight="bold">
-          <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
-            Home decor
-          </Link>
-        </Text>
-      </Fragment>,
-    ]}
-    thumbnail={[
-      null,
-      <Image
-        key="image-key"
-        alt="Modern ceramic vase pin."
-        naturalHeight={564}
-        naturalWidth={564}
-        src="https://i.ibb.co/Lx54BCT/stock1.jpg"
-      />,
-    ]}
-    button={[null, <Button key="button-key" text="Undo" size="lg" />]}
-  >
-    {(props) => <Toast {...props} />}
-  </Combination>,
-);
-
-card(
-  <Combination
-    id="combinations-thumbnail"
-    layout="12column"
-    name="Combinations: Thumbnail shapes"
-    showValues={false}
-    thumbnailShape={['circle', 'rectangle', 'square']}
-  >
-    {(props) => (
-      <Toast
-        {...props}
-        thumbnail={
-          <Image
-            key="image-key"
-            alt="Blush and sage plant print."
-            naturalHeight={751}
-            naturalWidth={564}
-            src="https://i.ibb.co/7bQQYkX/stock2.jpg"
-          />
-        }
-        text={
-          <Fragment>
+      <Combination
+        id="combinations-overview"
+        layout="12column"
+        name="Combinations: Overview"
+        showValues={false}
+        text={[
+          'Section created!',
+          <Fragment key="saved-text">
             Saved to{' '}
             <Text inline weight="bold">
               <Link
@@ -397,14 +297,66 @@ card(
                 Home decor
               </Link>
             </Text>
-          </Fragment>
-        }
-        button={<Button key="button-key" text="Undo" size="lg" />}
-      />
-    )}
-  </Combination>,
-);
+          </Fragment>,
+        ]}
+        thumbnail={[
+          null,
+          <Image
+            key="image-key"
+            alt="Modern ceramic vase pin."
+            naturalHeight={564}
+            naturalWidth={564}
+            src="https://i.ibb.co/Lx54BCT/stock1.jpg"
+          />,
+        ]}
+        button={[null, <Button key="button-key" text="Undo" size="lg" />]}
+      >
+        {(props) => <Toast {...props} />}
+      </Combination>
 
-export default function ToastPage(): Node {
-  return <CardPage cards={cards} page="Toast" />;
+      <Combination
+        id="combinations-thumbnail"
+        layout="12column"
+        name="Combinations: Thumbnail shapes"
+        showValues={false}
+        thumbnailShape={['circle', 'rectangle', 'square']}
+      >
+        {(props) => (
+          <Toast
+            {...props}
+            thumbnail={
+              <Image
+                key="image-key"
+                alt="Blush and sage plant print."
+                naturalHeight={751}
+                naturalWidth={564}
+                src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+              />
+            }
+            text={
+              <Fragment>
+                Saved to{' '}
+                <Text inline weight="bold">
+                  <Link
+                    inline
+                    target="blank"
+                    href="https://www.pinterest.com/search/pins/?q=home%20decor"
+                  >
+                    Home decor
+                  </Link>
+                </Text>
+              </Fragment>
+            }
+            button={<Button key="button-key" text="Undo" size="lg" />}
+          />
+        )}
+      </Combination>
+    </Page>
+  );
+}
+
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen('Toast') },
+  };
 }

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -8,17 +8,32 @@ import styles from './Toast.css';
 import { useColorScheme } from './contexts/ColorScheme.js';
 
 type Props = {|
+  /**
+   * Add an optional button for user interaction. Generally not recommended given the ephemeral nature of Toasts.
+   */
   button?: Node,
+  /**
+   * Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Do not specify a Text color within this property, as the color is automatically determined based on the `variant`.
+   */
   text: string | Element<*>,
+  /**
+   * An optional thumbnail image to displayed next to the text.
+   */
   thumbnail?: Node,
+  /**
+   * The masked shape of the thumbnail.
+   */
   thumbnailShape?: 'circle' | 'rectangle' | 'square',
+  /**
+   * Use the `'error'` variant to indicate an error message. Generally not recommended given the ephemeral nature of Toasts.
+   */
   variant?: 'default' | 'error',
-  // Experimental prop to replace the default color with darkGray
-  _dangerouslyUseDarkGray?: boolean,
 |};
 
 /**
- * https://gestalt.pinterest.systems/Toast
+ * [Toasts](https://gestalt.pinterest.systems/Toast) can educate people on the content of the screen, provide confirmation when people complete an action, or simply communicate a short message.
+ *
+ * Toast is purely visual. In order to properly handle the showing and dismissing of Toasts, as well as any animations, you will need to implement a Toast manager.
  */
 export default function Toast({
   button,
@@ -26,34 +41,28 @@ export default function Toast({
   thumbnail,
   thumbnailShape = 'square',
   variant = 'default',
-  _dangerouslyUseDarkGray,
 }: Props): Node {
   const { name: colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
   const isErrorVariant = variant === 'error';
 
-  let containerColor = 'white';
-  let textColor = 'darkGray';
+  let containerColor = isDarkMode ? 'white' : 'darkGray';
+  let textColor = isDarkMode ? 'darkGray' : 'white';
   let textElement = text;
 
-  if (_dangerouslyUseDarkGray) {
-    containerColor = isDarkMode ? 'white' : 'darkGray';
-    textColor = isDarkMode ? 'darkGray' : 'white';
-
-    // If `text` is a Node, we need to override any text colors within to ensure they all match
-    if (typeof text !== 'string') {
-      let textColorOverrideStyles = isDarkMode
-        ? styles.textColorOverrideDarkGray
-        : styles.textColorOverrideWhite;
-      if (isErrorVariant) {
-        textColorOverrideStyles = styles.textColorOverrideWhite;
-      }
-
-      textElement = <span className={textColorOverrideStyles}>{text}</span>;
+  // If `text` is a Node, we need to override any text colors within to ensure they all match
+  if (typeof text !== 'string') {
+    let textColorOverrideStyles = isDarkMode
+      ? styles.textColorOverrideDarkGray
+      : styles.textColorOverrideWhite;
+    if (isErrorVariant) {
+      textColorOverrideStyles = styles.textColorOverrideWhite;
     }
+
+    textElement = <span className={textColorOverrideStyles}>{text}</span>;
   }
 
-  // Error variant does not currently support dark mode and is the same for the experimental treatment
+  // Error variant does not currently support dark mode
   if (isErrorVariant) {
     containerColor = 'red';
     textColor = 'white';

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -47,7 +47,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
   }
 >
   <div
-    className="box fit paddingX6 paddingY6 pill shadow whiteBg"
+    className="box darkGrayBg fit paddingX6 paddingY6 pill shadow"
   >
     <div
       className="Flex rowGap4 itemsCenter xsDirectionRow"
@@ -81,28 +81,32 @@ exports[`<Toast /> Text + Image + Button 1`] = `
           className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
         >
           <div
-            className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize3 white alignStart breakWord fontWeightNormal"
           >
-            Saved to
-             
-            <a
-              className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
-              href="https://www.pinterest.com/search/pins/?q=home%20decor"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              rel=""
-              target={null}
+            <span
+              className="textColorOverrideWhite"
             >
-              Home decor
-            </a>
+              Saved to
+               
+              <a
+                className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
+                href="https://www.pinterest.com/search/pins/?q=home%20decor"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyPress={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                rel=""
+                target={null}
+              >
+                Home decor
+              </a>
+            </span>
           </div>
         </div>
       </div>
@@ -147,7 +151,7 @@ exports[`<Toast /> Text + Image 1`] = `
   }
 >
   <div
-    className="box fit paddingX6 paddingY6 pill shadow whiteBg"
+    className="box darkGrayBg fit paddingX6 paddingY6 pill shadow"
   >
     <div
       className="Flex rowGap4 itemsCenter xsDirectionRow"
@@ -181,28 +185,32 @@ exports[`<Toast /> Text + Image 1`] = `
           className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
         >
           <div
-            className="Text fontSize3 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize3 white alignStart breakWord fontWeightNormal"
           >
-            Saved to
-             
-            <a
-              className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
-              href="https://www.pinterest.com/search/pins/?q=home%20decor"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              rel=""
-              target={null}
+            <span
+              className="textColorOverrideWhite"
             >
-              Home decor
-            </a>
+              Saved to
+               
+              <a
+                className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
+                href="https://www.pinterest.com/search/pins/?q=home%20decor"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyPress={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                rel=""
+                target={null}
+              >
+                Home decor
+              </a>
+            </span>
           </div>
         </div>
       </div>
@@ -223,7 +231,7 @@ exports[`<Toast /> Text Only 1`] = `
   }
 >
   <div
-    className="box fit paddingX6 paddingY6 pill shadow whiteBg"
+    className="box darkGrayBg fit paddingX6 paddingY6 pill shadow"
   >
     <div
       className="Flex rowGap4 itemsCenter xsDirectionRow"
@@ -235,7 +243,7 @@ exports[`<Toast /> Text Only 1`] = `
           className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
         >
           <div
-            className="Text fontSize3 darkGray alignCenter breakWord fontWeightNormal"
+            className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
           >
             Same great profile, slightly new look. Learn more?
           </div>


### PR DESCRIPTION
### Summary

Metrics are flat from [our experiment](https://helium.pinadmin.com/web_toast_color_change_dark_gray), so we're shipping the dark gray Toast treatment (_everything old is new again_).

This PR also switches Toast to use generated docs.

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-3289)