### PR TITLE
Eslint plugin: prefer-link fixes and added suggestions

### DIFF
--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-input.js
@@ -1,6 +1,0 @@
-export default function TestElement() {
-  const noop = () => {}
-  return (
-      <a aria-label={noop} aria-selected={noop} href='text' target="_blank" rel="noopener noreferrer nofollow" onBlur={(event) => {}} onFocus={() => {}} onClick={noop} onKeyPress={noop}>Text</a>
-  );
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-multiple-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-multiple-input.js
@@ -1,0 +1,6 @@
+export default function TestElement() {
+  const noop = () => {}
+  return (
+    <a aria-label={noop} aria-selected={noop} href="text" target="_blank" rel="noopener noreferrer nofollow" onBlur={(event) => {}} onFocus={() => {}} onClick={noop} onKeyPress={noop}>Text</a>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-multiple-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-multiple-output.js
@@ -1,0 +1,7 @@
+import { Link } from 'gestalt';
+export default function TestElement() {
+  const noop = () => {}
+  return (
+    <Link href="text" accessibilityLabel={noop} accessibilitySelected={noop} onBlur={({ event }) => {}} onClick={({ event }) => noop(event)} onFocus={() => {}} onKeyPress={({ event }) => noop(event)} rel="nofollow" target="blank">Text</Link>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-multiple-taparea-suggestion.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-multiple-taparea-suggestion.js
@@ -1,0 +1,7 @@
+import { TapArea } from 'gestalt';
+export default function TestElement() {
+  const noop = () => {}
+  return (
+    <TapArea href="text" accessibilityLabel={noop} onBlur={({ event }) => {}} onTap={({ event }) => noop(event)} onFocus={() => {}} rel="nofollow" role="link" target="blank">Text</TapArea>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-output.js
@@ -1,7 +1,0 @@
-import { Link } from 'gestalt';
-export default function TestElement() {
-  const noop = () => {}
-  return (
-      <Link href='text' accessibilityLabel={noop} accessibilitySelected={noop} onBlur={({ event }) => {}} onClick={({ event }) => noop(event)} onFocus={() => {}} onKeyPress={({ event }) => noop(event)} rel="nofollow" target="blank">Text</Link>
-  );
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-single-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-single-input.js
@@ -1,0 +1,6 @@
+export default function TestElement() {
+  const noop = () => {}
+  return (
+    <a href="text" rel="noopener">Text</a>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-single-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-single-output.js
@@ -1,0 +1,7 @@
+import { Link } from 'gestalt';
+export default function TestElement() {
+  const noop = () => {}
+  return (
+    <Link href="text">Text</Link>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-single-taparea-suggestion.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/invalid/no-gestalt-import-single-taparea-suggestion.js
@@ -1,0 +1,7 @@
+import { TapArea } from 'gestalt';
+export default function TestElement() {
+  const noop = () => {}
+  return (
+    <TapArea href="text" role="link">Text</TapArea>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/valid/valid.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-link/valid/valid.js
@@ -8,7 +8,6 @@ export default function TestElement() {
       <a href={undefined} className={undefined} />
       <a href={undefined} style={undefined} />
       <a href={undefined} tabIndex={-1} />
-      <a href={undefined} rel="noopener" />
       <a {...props} />
     </Link>
   );

--- a/packages/eslint-plugin-gestalt/src/helpers/eslintFlowTypes.js
+++ b/packages/eslint-plugin-gestalt/src/helpers/eslintFlowTypes.js
@@ -56,6 +56,7 @@ export type ESLintRuleMetaData = {|
   schema?: any,
   deprecated?: boolean,
   type?: 'problem' | 'suggestion' | 'layout',
+  hasSuggestions?: boolean,
 |};
 
 export type ESLintRule = {|

--- a/packages/eslint-plugin-gestalt/src/prefer-link.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-link.js
@@ -17,7 +17,16 @@ import {
 } from './helpers/eslintASTHelpers.js';
 import { renameTagWithPropsFixer, updateGestaltImportFixer } from './helpers/eslintASTFixers.js';
 import { type ESLintRule } from './helpers/eslintFlowTypes.js';
+
 import preferLinkReducer from './helpers/preferLinkReducer.js';
+
+export const MESSAGES = {
+  fixMessageLink: `Use Link from Gestalt: <Link href="">Text</Link> \n
+  OR use TapArea, see suggestion below to autofix\n
+  OR use Button, <Button role='link' href="" target="" rel="" text=""/>\n
+  OR use IconButton, <IconButton role='link' href="" target="" rel="" icon=""/>`,
+  suggestionMessageTapArea: `Use TapArea to provide a Node with navigation behavior: <TapArea role="link" href="" onTap={}>{ Node }</TapArea>.`,
+};
 
 const rule: ESLintRule = {
   meta: {
@@ -47,8 +56,10 @@ const rule: ESLintRule = {
       },
     ],
     messages: {
-      errorMessage: `Use Link from Gestalt: <Link href="">Text</Link>.`,
+      fixMessageLink: MESSAGES.fixMessageLink,
+      suggestionMessageTapArea: MESSAGES.suggestionMessageTapArea,
     },
+    hasSuggestions: true,
   },
 
   create(context) {
@@ -129,18 +140,49 @@ const rule: ESLintRule = {
         reducerCallbackFn: preferLinkReducer,
       });
 
-      // exit if there are not prop alternatives to suggest/autofix
-      if (!validatorResponse.map((a) => !!a.prop).filter(Boolean).length) return null;
+      const newPropsToAddToLink = ({ alternativeComponent }) => {
+        const newResponse =
+          alternativeComponent === 'Link'
+            ? [...validatorResponse]
+            : [...validatorResponse, { prop: 'role="link"' }];
 
-      const newPropsToAddToLink = validatorResponse
-        ?.map((alternative) => alternative.prop)
-        .sort()
-        .join(' ');
+        switch (alternativeComponent) {
+          case 'Link':
+            return newResponse
+              ?.map((alternative) => alternative.prop)
+              .sort()
+              .join(' ');
 
+          case 'TapArea':
+            return newResponse
+              ?.map((alternative) => {
+                if (
+                  typeof alternative.prop === 'string' &&
+                  alternative.prop.startsWith('accessibilitySelected')
+                ) {
+                  return false;
+                }
+                if (
+                  typeof alternative.prop === 'string' &&
+                  alternative.prop.startsWith('onKeyPress')
+                ) {
+                  return false;
+                }
+                return alternative.prop;
+              })
+              .filter(Boolean)
+              .sort()
+              .join(' ')
+              .replace('onClick', 'onTap');
+
+          default:
+            return '';
+        }
+      };
       // For any other anchor tag modification
       return context.report({
         node,
-        messageId: 'errorMessage',
+        messageId: 'fixMessageLink',
         fix: (fixer) => {
           const tagFixers = renameTagWithPropsFixer({
             context,
@@ -152,7 +194,7 @@ const rule: ESLintRule = {
               context,
               elementNode: node,
               propSorting: false,
-              propsToAdd: newPropsToAddToLink,
+              propsToAdd: newPropsToAddToLink({ alternativeComponent: 'Link' }),
               propsToRemove: [
                 ...supportedAriaAttributes,
                 ...supportedEventAttributes,
@@ -174,6 +216,43 @@ const rule: ESLintRule = {
           importFixerRun = true;
           return fixers;
         },
+        suggest: [
+          {
+            messageId: 'suggestionMessageTapArea',
+            fix: (fixer) => {
+              const tagFixers = renameTagWithPropsFixer({
+                context,
+                elementNode: node,
+                fixer,
+                gestaltImportNode,
+                newComponentName: 'TapArea',
+                modifiedPropsString: buildProps({
+                  context,
+                  elementNode: node,
+                  propSorting: false,
+                  propsToAdd: newPropsToAddToLink({ alternativeComponent: 'TapArea' }),
+                  propsToRemove: [
+                    ...supportedAriaAttributes,
+                    ...supportedEventAttributes,
+                    'rel',
+                    'target',
+                  ],
+                }),
+                tagName: 'a',
+              });
+
+              const importFixers = updateGestaltImportFixer({
+                gestaltImportNode,
+                fixer,
+                newComponentName: 'TapArea',
+                programNode,
+              });
+
+              const fixers = [...tagFixers, importFixers];
+              return fixers;
+            },
+          },
+        ],
       });
     };
 

--- a/packages/eslint-plugin-gestalt/src/prefer-link.test.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-link.test.js
@@ -18,18 +18,41 @@ const validCode = readTestByPath(pathFormatter(validPrepender('valid')));
 const buildInvalidTestNoDisallowed = (name) =>
   readTestByPath(pathFormatter(invalidPrependerNoDisallowed(name)));
 
-const invalidImportInput = buildInvalidTestNoDisallowed('no-gestalt-import-input');
-const invalidImportOutput = buildInvalidTestNoDisallowed('no-gestalt-import-output');
-
-const errorMessageNoDisallowed = `Use Link from Gestalt: <Link href="">Text</Link>.`;
+const invalidImportSingleInput = buildInvalidTestNoDisallowed('no-gestalt-import-single-input');
+const invalidImportSingleOutput = buildInvalidTestNoDisallowed('no-gestalt-import-single-output');
+const invalidImportMultipleInput = buildInvalidTestNoDisallowed('no-gestalt-import-multiple-input');
+const invalidImportMultipleOutput = buildInvalidTestNoDisallowed(
+  'no-gestalt-import-multiple-output',
+);
+const invalidImportSingleTapAreaSuggestion = buildInvalidTestNoDisallowed(
+  'no-gestalt-import-single-taparea-suggestion',
+);
+const invalidImportMultipleTapAreaSuggestion = buildInvalidTestNoDisallowed(
+  'no-gestalt-import-multiple-taparea-suggestion',
+);
 
 ruleTester.run('prefer-link', rule, {
   valid: [{ code: validCode }],
-  invalid: [[invalidImportInput, invalidImportOutput, errorMessageNoDisallowed]].map(
-    ([input, output, errorMessage]) => ({
-      code: input,
-      output,
-      errors: [{ message: errorMessage }],
-    }),
-  ),
+  invalid: [
+    [invalidImportSingleInput, invalidImportSingleOutput, invalidImportSingleTapAreaSuggestion],
+    [
+      invalidImportMultipleInput,
+      invalidImportMultipleOutput,
+      invalidImportMultipleTapAreaSuggestion,
+    ],
+  ].map(([input, output, suggestion]) => ({
+    code: input,
+    output,
+    errors: [
+      {
+        messageId: 'fixMessageLink',
+        suggestions: [
+          {
+            output: suggestion,
+            messageId: 'suggestionMessageTapArea',
+          },
+        ],
+      },
+    ],
+  })),
 });


### PR DESCRIPTION
Eslint plugin: prefer-link fixes (p.e. single href prop now gets converted, better messaging) and added suggestions (to fix to TapArea)

### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
