### PR TITLE
NumberField: add new component

### DIFF
--- a/cypress/integration/accessibility_NumberField_spec.js
+++ b/cypress/integration/accessibility_NumberField_spec.js
@@ -1,0 +1,10 @@
+describe('NumberField Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/numberfield');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the NumberField page', () => {
+    cy.checkA11y();
+  });
+});

--- a/docs/components/sidebarIndex.js
+++ b/docs/components/sidebarIndex.js
@@ -79,6 +79,7 @@ const sidebarIndex: Array<sidebarIndexType> = [
       'Fieldset',
       'IconButton',
       'Label',
+      'NumberField',
       'Pog',
       'Popover',
       'RadioButton',

--- a/docs/pages/numberfield.js
+++ b/docs/pages/numberfield.js
@@ -178,7 +178,9 @@ function Example(props) {
         id="ref example"
         name="Example: ref"
         description={`
-    Set a ref on NumberField to use the [Constraint validation API](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation) or to anchor a Popover-based element.
+    Set a ref on NumberField to use the [Constraint Validation API](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation) or to anchor a Popover-based element.
+
+    Note that while the arrow buttons will not exceed the min/max (if set), the user is free to enter any number using the keyboard. Validation should be performed explicitly using the Constraint Validation API to ensure the value is within the specified range.
   `}
         defaultCode={`
 function Example(props) {
@@ -206,6 +208,7 @@ function Example(props) {
       }}
       placeholder="Enter a number from 1–9"
       ref={ref}
+      step={2}
       value={value}
     />
   );

--- a/docs/pages/numberfield.js
+++ b/docs/pages/numberfield.js
@@ -1,0 +1,246 @@
+// @flow strict
+import { type Node } from 'react';
+import Example from '../components/Example.js';
+import PageHeader from '../components/PageHeader.js';
+import Card from '../components/Card.js';
+import MainSection from '../components/MainSection.js';
+import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import docgen, { type DocGen } from '../components/docgen.js';
+
+export default function NumberFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="NumberField">
+      <PageHeader name="NumberField" description={generatedDocGen?.description} />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
+      <MainSection name="Usage guidelines">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            title="When to Use"
+            description={`
+          - Any time succinct numerical data needs to be entered by a user.
+        `}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            title="When Not to Use"
+            description={`
+          - Situations where text needs to be entered. Use [TextField](/textfield) or [TextArea](/textarea) instead.`}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
+      <Example
+        id="basicExample"
+        name="Example"
+        description={`
+    NumberField will expand to fill the width of the parent container.
+  `}
+        defaultCode={`
+function Example(props) {
+  const [value, setValue] = React.useState('')
+
+  return (
+    <NumberField
+      id="basicExampleNumberField"
+      label="Enter your favorite number"
+      onChange={({ value }) => {
+        setValue(value);
+      }}
+      placeholder="We recommend 42"
+      value={value}
+    />
+  );
+}
+`}
+      />
+
+      <Example
+        id="disabledExample"
+        name="Example: Disabled"
+        defaultCode={`
+function Example(props) {
+  const [value, setValue] = React.useState('')
+
+  return (
+    <NumberField
+      disabled
+      id="disabledNumberField"
+      label="Disabled"
+      onChange={({ value }) => setValue(value)}
+      placeholder="This input is disabled"
+      value={value}
+    />
+  );
+}
+`}
+      />
+
+      <Example
+        id="helperText"
+        name="Example: Helper Text"
+        description={`Whenever you want to provide more information about a form field, you should use \`helperText\`.`}
+        defaultCode={`
+function Example(props) {
+  const [value, setValue] = React.useState('')
+
+  return (
+    <Box padding={2} color="white">
+      <NumberField
+        id="helperTextNumberField"
+        helperText="Digits only please, e.g. 8675309"
+        label="Phone number"
+        onChange={({ value }) => setValue(value)}
+        value={value}
+      />
+    </Box>
+  );
+}
+`}
+      />
+
+      <Example
+        id="errorMessageExample"
+        name="Example: Error message"
+        description={`
+    NumberField can display an error message.
+    Simply pass in an \`errorMessage\` when there is an error present and we will handle the rest.`}
+        defaultCode={`
+function Example(props) {
+  const [value, setValue] = React.useState('')
+
+  return (
+    <NumberField
+      id="errorMessageNumberField"
+      errorMessage={!value ? "This field can't be blank!" : null}
+      onChange={({ value }) => setValue(value)}
+      label="With an error message"
+      value={value}
+    />
+  );
+}
+`}
+      />
+
+      <Example
+        id="min-max-step example"
+        name="Example: min/max/step"
+        description={`
+    NumberField provides additional props specific to numerical input.
+
+    \`min\` and \`max\` can be used to define the acceptable bounds of the input (see the [ref example](#ref%20example) for more about using these for validation).
+
+    \`step\` determines the amount incremented or decremented when using the input's arrow buttons. Set this as a float to allow decimal input.
+  `}
+        defaultCode={`
+function Example(props) {
+  const [value1, setValue1] = React.useState('');
+  const [value2, setValue2] = React.useState('');
+
+  return (
+    <Flex direction="column" gap={2}>
+      <NumberField
+        id="minMaxStepExampleNumberField1"
+        label="Stepping in intervals of 5"
+        max={25}
+        min={5}
+        onChange={({ value }) => {
+          setValue1(value);
+        }}
+        placeholder="Use the arrow buttons to increase/decrease the input value"
+        step={5}
+        value={value1}
+      />
+      <NumberField
+        id="minMaxStepExampleNumberField2"
+        label="Stepping in intervals of 0.1"
+        max={2}
+        min={-2}
+        onChange={({ value }) => {
+          setValue2(value);
+        }}
+        placeholder="Use the arrow buttons to increase/decrease the input value"
+        step={0.1}
+        value={value2}
+      />
+    </Flex>
+  );
+}
+`}
+      />
+
+      <Example
+        id="ref example"
+        name="Example: ref"
+        description={`
+    Set a ref on NumberField to use the [Constraint validation API](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation) or to anchor a Popover-based element.
+  `}
+        defaultCode={`
+function Example(props) {
+  const [value, setValue] = React.useState('');
+  const [errorMessage, setErrorMessage] = React.useState(undefined);
+  const ref = React.useRef();
+
+  React.useEffect(() => {
+    if (ref.current && ref.current.checkValidity() === false) {
+      setErrorMessage("That episode doesn't exist (yet)!");
+    } else {
+      setErrorMessage(undefined);
+    }
+  }, [value]);
+
+  return (
+    <NumberField
+      errorMessage={errorMessage}
+      id="refExampleNumberField"
+      label="Enter a Star Wars episode number"
+      max={9}
+      min={1}
+      onChange={({ value }) => {
+        setValue(value);
+      }}
+      placeholder="Enter a number from 1–9"
+      ref={ref}
+      value={value}
+    />
+  );
+}
+`}
+      />
+
+      <Card
+        description={`
+    NumberField intentionally lacks support for autofocus. Generally speaking,
+    autofocus interrupts normal page flow for screen readers making it an
+    anti-pattern for accessibility.
+  `}
+        name="Autofocus"
+      />
+
+      <Card
+        description={`
+    NumberField is commonly used as an input in forms alongside submit buttons.
+    In these cases, users expect that pressing Enter or Return with the input
+    focused will submit the form.
+
+    Out of the box, NumberField doesn't expose an \`onSubmit\` handler or
+    individual key event handlers due to the complexities of handling these
+    properly. Instead, developers are encouraged to wrap NumberField
+    in a \`<form>\` and attach an \`onSubmit\` handler to that \`<form>\`.
+  `}
+        name="onSubmit"
+      />
+    </Page>
+  );
+}
+
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen('NumberField') },
+  };
+}

--- a/docs/pages/textfield.js
+++ b/docs/pages/textfield.js
@@ -1,143 +1,47 @@
 // @flow strict
-import type { Node } from 'react';
+import { type Node } from 'react';
 import Example from '../components/Example.js';
-import PropTable from '../components/PropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import Card from '../components/Card.js';
-import CardPage from '../components/CardPage.js';
 import MainSection from '../components/MainSection.js';
+import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
+export default function TextFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="TextField">
+      <PageHeader name="TextField" description={generatedDocGen?.description} />
 
-card(<PageHeader name="TextField" description="TextField allows for text input." />);
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
-card(
-  <PropTable
-    props={[
-      {
-        name: 'autoComplete',
-        type: `"current-password" | "new-password" | "on" | "off" | "username" | "email"`,
-      },
-      {
-        name: 'disabled',
-        type: 'boolean',
-        defaultValue: 'false',
-        href: 'disabledExample',
-      },
-      {
-        name: 'errorMessage',
-        type: 'React.Node',
-        href: 'errorMessageExample',
-        description:
-          'For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in Link or TapArea.',
-      },
-      {
-        name: 'helperText',
-        type: 'string',
-        description: 'More information about how to complete the form field',
-        href: 'helperText',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'label',
-        type: 'string',
-      },
-      {
-        name: 'name',
-        type: 'string',
-      },
-      {
-        name: 'onBlur',
-        type: '({ event: SyntheticFocusEvent<HTMLInputElement>, value: string }) => void',
-      },
-      {
-        name: 'onChange',
-        type: '({ event: SyntheticInputEvent<HTMLInputElement>, value: string }) => void',
-        required: true,
-        href: 'basicExample',
-      },
-      {
-        name: 'onFocus',
-        type: '({ event: SyntheticFocusEvent<HTMLInputElement>, value: string }) => void',
-      },
-      {
-        name: 'onKeyDown',
-        type: '({ event: SyntheticKeyboardEvent<HTMLInputElement>, value: string }) => void',
-      },
-      {
-        name: 'placeholder',
-        type: 'string',
-        href: 'basicExample',
-      },
-      {
-        name: 'ref',
-        type: "React.Ref<'input'>",
-        description: 'Forward the ref to the underlying input element',
-      },
-      {
-        name: 'size',
-        type: '"md" | "lg"',
-        required: false,
-        description: 'md: 40px, lg: 48px',
-        defaultValue: 'md',
-      },
-      {
-        name: 'tags',
-        type: 'Array<Element<typeof Tag>>',
-        description: 'List of tags to display in the component',
-        href: 'tagsExample',
-      },
-      {
-        name: 'type',
-        type: `"date" | "email" | "number" | "password" | "text" | "url"`,
-        defaultValue: 'text',
-        href: 'basicExample',
-      },
-      {
-        name: 'value',
-        type: 'string',
-        href: 'basicExample',
-      },
-    ]}
-  />,
-);
-
-card(
-  <MainSection name="Usage guidelines">
-    <MainSection.Subsection columns={2}>
-      <MainSection.Card
-        cardSize="md"
-        type="do"
-        title="When to Use"
-        description={`
-          - Anytime succinct data needs to be inputted by a user, like a date, email address, name, or Pin title.
+      <MainSection name="Usage guidelines">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            title="When to Use"
+            description={`
+          - Any time succinct data needs to be entered by a user, like a date, email address, name, or Pin title.
         `}
-      />
-      <MainSection.Card
-        cardSize="md"
-        type="don't"
-        title="When Not to Use"
-        description={`
-          - Situations where long amounts of text need to be entered, since the full content of the TextField will be obscured. Use [TextArea](/textarea) instead.`}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            title="When Not to Use"
+            description={`
+          - Situations where long amounts of text need to be entered, since the full content of the TextField will be truncated. Use [TextArea](/textarea) instead.`}
+          />
+        </MainSection.Subsection>
+      </MainSection>
 
-card(
-  <Example
-    id="basicExample"
-    name="Example"
-    description={`
-    A \`TextField\` will expand to fill the width of the parent container.
+      <Example
+        id="basicExample"
+        name="Example"
+        description={`
+    TextField will expand to fill the width of the parent container.
   `}
-    defaultCode={`
+        defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('')
   return (
@@ -153,14 +57,12 @@ function Example(props) {
   );
 }
 `}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="disabledExample"
-    name="Example: Disabled"
-    defaultCode={`
+      <Example
+        id="disabledExample"
+        name="Example: Disabled"
+        defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('')
   return (
@@ -175,15 +77,13 @@ function Example(props) {
   );
 }
 `}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="helperText"
-    name="Example: Helper Text"
-    description={`Whenever you want to provide more information about a form field, you should use \`helperText\`.`}
-    defaultCode={`
+      <Example
+        id="helperText"
+        name="Example: Helper Text"
+        description={`Whenever you want to provide more information about a form field, you should use \`helperText\`.`}
+        defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('')
   return (
@@ -199,17 +99,15 @@ function Example(props) {
   );
 }
 `}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="errorMessageExample"
-    name="Example: Error message"
-    description={`
-    A TextField can display its own error message.
-    To use our errors, simply pass in an \`errorMessage\` when there is an error present and we will handle the rest.`}
-    defaultCode={`
+      <Example
+        id="errorMessageExample"
+        name="Example: Error message"
+        description={`
+    TextField can display an error message.
+    Simply pass in an \`errorMessage\` when there is an error present and we will handle the rest. Be sure to localize the text!`}
+        defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('')
   return (
@@ -223,20 +121,18 @@ function Example(props) {
   );
 }
 `}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="tagsExample"
-    name="Example: Tags"
-    description={`
+      <Example
+        id="tagsExample"
+        name="Example: Tags"
+        description={`
     You can include [Tag](/Tag) elements in the input using the \`tags\` prop.
 
-    Note that the \`TextField\` component does not internally manage tags. That should be handled in the application state through the component's event callbacks. We recommend creating new tags on enter key presses, and removing them on backspaces when the cursor is in the beginning of the field. We also recommend filtering out empty tags.
+    Note that TextField does not internally manage tags. That should be handled in the application state through the component's event callbacks. We recommend creating new tags on enter key presses, and removing them on backspaces when the cursor is in the beginning of the field. We also recommend filtering out empty tags.
 
     This example showcases the recommended behavior. In addition, it creates new tags by splitting the input on spaces, commas, semicolons.`}
-    defaultCode={`
+        defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('');
   const [tags, setTags] = React.useState(['a@pinterest.com', 'b@pinterest.com']);
@@ -297,17 +193,15 @@ function Example(props) {
   );
 }
 `}
-  />,
-);
+      />
 
-card(
-  <Example
-    id="ref example"
-    name="Example: ref"
-    description={`
-    A \`TextField\` with an anchor ref to a Popover component
+      <Example
+        id="ref example"
+        name="Example: ref"
+        description={`
+    TextField with an anchor ref to a Popover component
   `}
-    defaultCode={`
+        defaultCode={`
 function TextFieldPopoverExample() {
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef();
@@ -338,36 +232,36 @@ function TextFieldPopoverExample() {
   );
 }
 `}
-  />,
-);
+      />
 
-card(
-  <Card
-    description={`
-    \`TextField\` intentionally lacks support for autofocus. Generally speaking,
+      <Card
+        description={`
+    TextField intentionally lacks support for autofocus. Generally speaking,
     autofocus interrupts normal page flow for screen readers making it an
     anti-pattern for accessibility.
   `}
-    name="Autofocus"
-  />,
-);
+        name="Autofocus"
+      />
 
-card(
-  <Card
-    description={`
-    \`TextField\` is commonly used as an input in forms alongside submit buttons.
+      <Card
+        description={`
+    TextField is commonly used as an input in forms alongside submit buttons.
     In these cases, users expect that pressing Enter or Return with the input
     focused will submit the form.
 
-    Out of the box, \`TextField\` doesn't expose an \`onSubmit\` handler or
+    Out of the box, TextField doesn't expose an \`onSubmit\` handler or
     individual key event handlers due to the complexities of handling these
-    properly. Instead, developers are encouraged to wrap the \`TextField\`
-    in a \`form\` and attach an \`onSubmit\` handler to that \`form\`.
+    properly. Instead, developers are encouraged to wrap TextField
+    in a \`<form>\` and attach an \`onSubmit\` handler to that \`<form>\`.
   `}
-    name="onSubmit"
-  />,
-);
+        name="onSubmit"
+      />
+    </Page>
+  );
+}
 
-export default function TextFieldPage(): Node {
-  return <CardPage cards={cards} page="TextField" />;
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen('TextField') },
+  };
 }

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -34,6 +34,8 @@ type Props = {|
   helperText?: string,
   label?: string,
   labelDisplay?: LabelDisplay,
+  max?: number,
+  min?: number,
   name?: string,
   onBlur?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
@@ -54,6 +56,7 @@ type Props = {|
   |}) => void,
   placeholder?: string,
   size?: 'md' | 'lg',
+  step?: number,
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   textfieldIconButton?: 'clear' | 'expand',
   type?: 'date' | 'email' | 'number' | 'password' | 'text' | 'url',
@@ -63,8 +66,8 @@ type Props = {|
 const InternalTextFieldWithForwardRef: React$AbstractComponent<
   Props,
   HTMLInputElement,
-> = forwardRef<Props, HTMLInputElement>(function TextField(props: Props, ref): Node {
-  const {
+> = forwardRef<Props, HTMLInputElement>(function TextField(
+  {
     accessibilityControls,
     accessibilityActiveDescendant,
     accessibilityClearButtonLabel,
@@ -76,6 +79,8 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
     id,
     label,
     labelDisplay,
+    max,
+    min,
     name,
     onBlur,
     onChange,
@@ -85,12 +90,14 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
     onKeyDown,
     placeholder,
     size = 'md',
+    step,
     tags,
     textfieldIconButton,
     type = 'text',
     value,
-  } = props;
-
+  }: Props,
+  ref,
+): Node {
   // ==== REFS ====
 
   const innerRef = useRef(null);
@@ -160,6 +167,8 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
       className={tags ? unstyledClasses : styledClasses}
       disabled={disabled}
       id={id}
+      max={type === 'number' ? max : undefined}
+      min={type === 'number' ? min : undefined}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}
@@ -170,6 +179,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
       // https://stackoverflow.com/questions/14447668/input-type-number-is-not-showing-a-number-keypad-on-ios
       pattern={type === 'number' ? '\\d*' : undefined}
       placeholder={placeholder}
+      step={type === 'number' ? step : undefined}
       {...(tags ? {} : { ref: innerRef })}
       type={type}
       value={value}

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -6,7 +6,8 @@ import InternalTextField from './InternalTextField.js';
 // So we parse what we get from InternalTextField and we stringify what we give it.
 // $FlowExpectedError[unclear-type] We don't need a more specific type, and `event` polymorphism is problematic
 const parseHandlerValue = (handler?: Function) => ({ event, value }) => {
-  handler?.({ event, value: parseFloat(value) });
+  const parsedValue = parseFloat(value);
+  handler?.({ event, value: Number.isFinite(parsedValue) ? parsedValue : undefined });
 };
 
 type Props = {|
@@ -89,7 +90,7 @@ type Props = {|
   /**
    * The current value of the input.
    */
-  value?: number,
+  value?: number | typeof undefined,
 |};
 
 /**

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -52,28 +52,28 @@ type Props = {|
    */
   onBlur?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
-    value: number,
+    value: number | void,
   |}) => void,
   /**
    * Callback triggered when the value of the input changes, whether by keyboard entry or the input's arrows.
    */
   onChange: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
-    value: number,
+    value: number | void,
   |}) => void,
   /**
    * Callback triggered when the user focuses the input.
    */
   onFocus?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
-    value: number,
+    value: number | void,
   |}) => void,
   /**
    * Callback triggered when the user presses any key while the input is focused.
    */
   onKeyDown?: ({|
     event: SyntheticKeyboardEvent<HTMLInputElement>,
-    value: number,
+    value: number | void,
   |}) => void,
   /**
    * Placeholder text shown the the user has not yet input a value.

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -90,7 +90,7 @@ type Props = {|
   /**
    * The current value of the input.
    */
-  value?: number | typeof undefined,
+  value?: number | void,
 |};
 
 /**

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -1,13 +1,19 @@
 // @flow strict
-import { forwardRef, type Element, type Node } from 'react';
-import Tag from './Tag.js';
+import { forwardRef, type Node } from 'react';
 import InternalTextField from './InternalTextField.js';
+
+// <input> deals with strings, but we only want numbers for this component.
+// So we parse what we get from InternalTextField and we stringify what we give it.
+// $FlowExpectedError[unclear-type] We don't need a more specific type, and `event` polymorphism is problematic
+const parseHandlerValue = (handler?: Function) => ({ event, value }) => {
+  handler?.({ event, value: parseFloat(value) });
+};
 
 type Props = {|
   /**
-   * Indicate if autocomplete should be available on the input, and the type of autocomplete.
+   * Indicate if autocomplete should be available on the input.
    */
-  autoComplete?: 'current-password' | 'new-password' | 'on' | 'off' | 'username' | 'email',
+  autoComplete?: 'on' | 'off',
   /**
    * Indicate if the input is disabled.
    */
@@ -17,11 +23,7 @@ type Props = {|
    */
   errorMessage?: Node,
   /**
-   * This field is deprecated and will be removed soon. Please do not use.
-   */
-  hasError?: boolean,
-  /**
-   * More information about how to complete the form field.
+   * More information for the user about how to complete the form field.
    */
   helperText?: string,
   /**
@@ -33,6 +35,14 @@ type Props = {|
    */
   label?: string,
   /**
+   * The upper bound of valid input, inclusive.
+   */
+  max?: number,
+  /**
+   * The lower bound of valid input, inclusive.
+   */
+  min?: number,
+  /**
    * A unique name for the input.
    */
   name?: string,
@@ -41,66 +51,63 @@ type Props = {|
    */
   onBlur?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
-    value: string,
+    value: number,
   |}) => void,
   /**
-   * Callback triggered when the value of the input changes.
+   * Callback triggered when the value of the input changes, whether by keyboard entry or the input's arrows.
    */
   onChange: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
-    value: string,
+    value: number,
   |}) => void,
   /**
    * Callback triggered when the user focuses the input.
    */
   onFocus?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
-    value: string,
+    value: number,
   |}) => void,
   /**
    * Callback triggered when the user presses any key while the input is focused.
    */
   onKeyDown?: ({|
     event: SyntheticKeyboardEvent<HTMLInputElement>,
-    value: string,
+    value: number,
   |}) => void,
   /**
    * Placeholder text shown the the user has not yet input a value.
    */
   placeholder?: string,
   /**
-   * List of tags to display in the component.
-   */
-  tags?: $ReadOnlyArray<Element<typeof Tag>>,
-  /**
-   * The type of input. For numerical input, please use [NumberField](https://gestalt.pinterest.systems/numberfield).
-   */
-  type?: 'date' | 'email' | 'password' | 'text' | 'url',
-  /**
    * md: 40px, lg: 48px
    */
   size?: 'md' | 'lg',
   /**
+   * Indicates the amount the value will increase or decrease when using the input's arrows.
+   */
+  step?: number,
+  /**
    * The current value of the input.
    */
-  value?: string,
+  value?: number,
 |};
 
 /**
- * [TextField](https://gestalt.pinterest.systems/TextField) allows for text input.
+ * [NumberField](https://gestalt.pinterest.systems/NumberField) allows for numerical input.
  */
-const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
+const NumberFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
->(function TextField(
+>(function NumberField(
   {
     autoComplete,
     disabled = false,
     errorMessage,
-    hasError = false,
     helperText,
     id,
     label,
+    max,
+    min,
     name,
     onBlur,
     onChange,
@@ -108,8 +115,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     onKeyDown,
     placeholder,
     size = 'md',
-    tags,
-    type = 'text',
+    step,
     value,
   }: Props,
   ref,
@@ -119,25 +125,27 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
       autoComplete={autoComplete}
       disabled={disabled}
       errorMessage={errorMessage}
-      hasError={hasError}
       helperText={helperText}
       id={id}
       label={label}
+      max={max}
+      min={min}
       name={name}
-      onBlur={onBlur}
-      onChange={onChange}
-      onFocus={onFocus}
-      onKeyDown={onKeyDown}
+      onBlur={parseHandlerValue(onBlur)}
+      onChange={parseHandlerValue(onChange)}
+      onFocus={parseHandlerValue(onFocus)}
+      onKeyDown={parseHandlerValue(onKeyDown)}
       placeholder={placeholder}
       size={size}
+      step={step}
       ref={ref}
-      tags={tags}
-      type={type}
-      value={value}
+      type="number"
+      // See comment above — we need to stringify what we give InternalTextField
+      value={value === undefined ? value : String(value)}
     />
   );
 });
 
-TextFieldWithForwardRef.displayName = 'TextField';
+NumberFieldWithForwardRef.displayName = 'NumberField';
 
-export default TextFieldWithForwardRef;
+export default NumberFieldWithForwardRef;

--- a/packages/gestalt/src/NumberField.jsdom.test.js
+++ b/packages/gestalt/src/NumberField.jsdom.test.js
@@ -1,0 +1,158 @@
+// @flow strict
+import { createRef } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import NumberField from './NumberField.js';
+
+describe('NumberField', () => {
+  it('renders error message on errorMessage prop change', () => {
+    const { getByText, rerender } = render(
+      <NumberField id="test" onChange={jest.fn()} onFocus={jest.fn()} onBlur={jest.fn()} />,
+    );
+    expect(() => {
+      getByText('Error message');
+    }).toThrow('Unable to find an element with the text: Error message');
+
+    rerender(
+      <NumberField
+        errorMessage="Error message"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />,
+    );
+    expect(getByText('Error message')).toBeVisible();
+  });
+
+  it('reads the error message on focus', () => {
+    const { getByDisplayValue } = render(
+      <NumberField
+        errorMessage="Error message"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+        value={42}
+      />,
+    );
+    const input = getByDisplayValue('42');
+    fireEvent.focus(input);
+    expect(input).toHaveDescription('Error message');
+  });
+
+  it('forwards a ref to <input />', () => {
+    const ref = createRef();
+    render(
+      <NumberField
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+        value={42}
+        ref={ref}
+      />,
+    );
+    expect(ref.current instanceof HTMLInputElement).toEqual(true);
+    expect(ref.current?.value).toEqual('42');
+  });
+
+  it('handles blur events', () => {
+    const mockBlur = jest.fn();
+    const { getByDisplayValue } = render(
+      <NumberField id="test" onBlur={mockBlur} onChange={jest.fn()} value={42} />,
+    );
+
+    fireEvent.blur(getByDisplayValue('42'));
+    expect(mockBlur).toHaveBeenCalled();
+  });
+
+  it('handles change events', () => {
+    const mockChange = jest.fn();
+    const { container } = render(<NumberField id="test" onChange={mockChange} value={42} />);
+
+    const input = container.querySelector('input');
+    expect(input).not.toBe(null);
+
+    if (input) {
+      fireEvent.change(input, {
+        target: { value: 43 },
+      });
+    }
+    expect(mockChange).toHaveBeenCalled();
+  });
+
+  it('handles focus events', () => {
+    const mockFocus = jest.fn();
+    const { getByDisplayValue } = render(
+      <NumberField id="test" onChange={jest.fn()} onFocus={mockFocus} value={42} />,
+    );
+
+    fireEvent.focus(getByDisplayValue('42'));
+    expect(mockFocus).toHaveBeenCalled();
+  });
+
+  it('handles key down events', () => {
+    const mockKeyDown = jest.fn();
+    const { container } = render(
+      <NumberField id="test" onChange={() => {}} onKeyDown={mockKeyDown} value={42} />,
+    );
+
+    const input = container.querySelector('input');
+    expect(input).not.toBe(null);
+
+    if (input) {
+      fireEvent.keyDown(input, {
+        target: { value: 43 },
+      });
+    }
+    expect(mockKeyDown).toHaveBeenCalled();
+  });
+
+  it('shows a label for the number field', () => {
+    const { getByText } = render(
+      <NumberField id="test" label="Label for the number field" onChange={() => {}} value={42} />,
+    );
+    expect(getByText('Label for the number field')).toBeVisible();
+  });
+
+  it('shows helper text for the number field', () => {
+    const { getByText } = render(
+      <NumberField
+        id="test"
+        label="Label for the number field"
+        helperText="Helper text for the number field"
+        onChange={() => {}}
+        value={42}
+      />,
+    );
+    expect(getByText('Helper text for the number field')).toBeVisible();
+  });
+
+  it('hides the helper text for the number field when an error message is shown', () => {
+    const { getByText } = render(
+      <NumberField
+        id="test"
+        label="Label for the number field"
+        helperText="Helper text for the number field"
+        errorMessage="Error message for the number field"
+        onChange={() => {}}
+        value={42}
+      />,
+    );
+    expect(() => {
+      getByText('Helper text for the number field');
+    }).toThrow('Unable to find an element with the text: Helper text for the number field');
+  });
+
+  it('adds a "medium" classname by default', () => {
+    const { container } = render(<NumberField id="test" onChange={() => {}} value={42} />);
+    expect(container.querySelector('.medium')).toBeVisible();
+  });
+
+  it('adds a "large" classname when size is set to "lg"', () => {
+    const { container } = render(
+      <NumberField id="test" onChange={() => {}} value={42} size="lg" />,
+    );
+    expect(container.querySelector('.large')).toBeVisible();
+  });
+});

--- a/packages/gestalt/src/NumberField.test.js
+++ b/packages/gestalt/src/NumberField.test.js
@@ -1,0 +1,64 @@
+// @flow strict
+import { create } from 'react-test-renderer';
+import NumberField from './NumberField.js';
+
+describe('NumberField', () => {
+  it('Renders an FormErrorMessage if an error message is passed in', () => {
+    const component = create(
+      <NumberField errorMessage="Error message" id="test" onChange={jest.fn()} />,
+    );
+    expect(JSON.stringify(component.toJSON())).toContain('Error message');
+  });
+
+  it('Does not render an FormErrorMessage when errorMessage is null', () => {
+    const component = create(<NumberField id="test" onChange={jest.fn()} />);
+    expect(JSON.stringify(component.toJSON())).not.toContain('Error message');
+  });
+
+  it('NumberField normal', () => {
+    const tree = create(
+      <NumberField id="test" onChange={jest.fn()} onFocus={jest.fn()} onBlur={jest.fn()} />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('NumberField with error', () => {
+    const tree = create(
+      <NumberField
+        errorMessage="error message"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('NumberField with name', () => {
+    const tree = create(
+      <NumberField
+        name="email"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('NumberField with autocomplete', () => {
+    const tree = create(
+      <NumberField
+        autoComplete="on"
+        name="email"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/gestalt/src/TextField.test.js
+++ b/packages/gestalt/src/TextField.test.js
@@ -59,6 +59,7 @@ describe('TextField', () => {
   it('TextField with autocomplete', () => {
     const tree = create(
       <TextField
+        autoComplete="email"
         name="email"
         id="test"
         onChange={jest.fn()}

--- a/packages/gestalt/src/__snapshots__/NumberField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/NumberField.test.js.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NumberField NumberField normal 1`] = `
+<span>
+  <div
+    className="box relative"
+  >
+    <input
+      aria-describedby={null}
+      aria-invalid="false"
+      className="textField base enabled normal medium truncate"
+      disabled={false}
+      id="test"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      pattern="\\\\d*"
+      type="number"
+    />
+  </div>
+</span>
+`;
+
+exports[`NumberField NumberField with autocomplete 1`] = `
+<span>
+  <div
+    className="box relative"
+  >
+    <input
+      aria-describedby={null}
+      aria-invalid="false"
+      autoComplete="on"
+      className="textField base enabled normal medium truncate"
+      disabled={false}
+      id="test"
+      name="email"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      pattern="\\\\d*"
+      type="number"
+    />
+  </div>
+</span>
+`;
+
+exports[`NumberField NumberField with error 1`] = `
+<span>
+  <div
+    className="box relative"
+  >
+    <input
+      aria-describedby={null}
+      aria-invalid="true"
+      className="textField base enabled errored medium truncate"
+      disabled={false}
+      id="test"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      pattern="\\\\d*"
+      type="number"
+    />
+  </div>
+  <div
+    className="box marginTop2"
+  >
+    <div
+      className="Text fontSize1 red alignStart breakWord fontWeightNormal"
+    >
+      <span
+        className="formErrorMessage"
+        id="test-error"
+      >
+        error message
+      </span>
+    </div>
+  </div>
+</span>
+`;
+
+exports[`NumberField NumberField with name 1`] = `
+<span>
+  <div
+    className="box relative"
+  >
+    <input
+      aria-describedby={null}
+      aria-invalid="false"
+      className="textField base enabled normal medium truncate"
+      disabled={false}
+      id="test"
+      name="email"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      pattern="\\\\d*"
+      type="number"
+    />
+  </div>
+</span>
+`;

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -30,6 +30,7 @@ exports[`TextField TextField with autocomplete 1`] = `
     <input
       aria-describedby={null}
       aria-invalid="false"
+      autoComplete="email"
       className="textField base enabled normal medium truncate"
       disabled={false}
       id="test"

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -36,6 +36,7 @@ import MasonryDefaultLayout from './layouts/MasonryLayout.js';
 import MasonryUniformRowLayout from './layouts/UniformRowLayout.js';
 import Modal from './Modal.js';
 import Module from './Module.js';
+import NumberField from './NumberField.js';
 import OnLinkNavigationProvider from './contexts/OnLinkNavigation.js';
 import PageHeader from './PageHeader.js';
 import Pog from './Pog.js';
@@ -106,6 +107,7 @@ export {
   MasonryUniformRowLayout,
   Modal,
   Module,
+  NumberField,
   OnLinkNavigationProvider,
   PageHeader,
   Pog,


### PR DESCRIPTION
### Summary

We've had requests to add a version of TextField that is specific to numerical input. This makes numbers easier to work with in a couple of ways:
- Inputs (`value`) and outputs (in handlers) are all numbers, not strings, so the dev doesn't need to parse and stringify
- Add min/max/step props, mirroring those `<input>` attributes

This PR also converts TextField to use generated docs, and cleans up some copy slightly. Converting the docs page to our newer style is out of scope, as is converting NumberField's docs to the newer style (since it's so similar to TextField, so copy/paste/modify).

### Links

- [Jira](https://jira.pinadmin.com/browse/PDS-2860)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
