### PR TITLE
TextField: re-add "number" type for now

### DIFF
--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -75,7 +75,7 @@ type Props = {|
   /**
    * The type of input. For numerical input, please use [NumberField](https://gestalt.pinterest.systems/numberfield).
    */
-  type?: 'date' | 'email' | 'password' | 'text' | 'url',
+  type?: 'date' | 'email' | 'number' | 'password' | 'text' | 'url',
   /**
    * md: 40px, lg: 48px
    */


### PR DESCRIPTION
In #1760, we removed the "number" type from TextField. While this is our eventual goal, a lot of components depend on this type. To make it easier to land NumberField in Pinboard, this PR re-adds that type back to TextField, allowing for a more gradual migration path:
- Identify TextFields that can be replaced with NumberField, including wrappers around TextField
- Replace all existing usages
- Remove "number" type from TextField, which will be a breaking change but won't have any usages to codemod