### PR TITLE
Docs: fix broken links 🔗

### DIFF
--- a/docs/components/Markdown.js
+++ b/docs/components/Markdown.js
@@ -70,7 +70,7 @@ const formatComponentName = (listitem) => {
   if (namesAndUpdate.length > 1) {
     const componentLinks = namesAndUpdate[0].replace(/\w+/gm, (match) => {
       if (currentComponents.includes(match)) {
-        return `<a href="https://gestalt.netlify.app/${match}">${match}</a>`;
+        return `<a href="https://gestalt.netlify.app/${match.toLowerCase()}">${match}</a>`;
       }
       return match;
     });

--- a/docs/pages/activationcard.js
+++ b/docs/pages/activationcard.js
@@ -33,7 +33,7 @@ export default function ActivationCardPage({
             type="don't"
             title="When Not to Use"
             description={`
-          - As a single element communicating updates to the state or status of the surface. Use [Callout](/Callout) instead.
+          - As a single element communicating updates to the state or status of the surface. Use [Callout](/callout) instead.
         `}
           />
         </MainSection.Subsection>
@@ -108,7 +108,7 @@ export default function ActivationCardPage({
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[OnLinkNavigationProvider](/OnLinkNavigationProvider)**
+**[OnLinkNavigationProvider](/onlinknavigationprovider)**
 OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
       `}
         />

--- a/docs/pages/avatar.js
+++ b/docs/pages/avatar.js
@@ -29,7 +29,7 @@ export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocG
             type="don't"
             title="When Not to Use"
             description={`
-          - To represent a group of people, companies and/or brands. Use [AvatarGroup](/AvatarGroup) instead.
+          - To represent a group of people, companies and/or brands. Use [AvatarGroup](/avatargroup) instead.
         `}
           />
         </MainSection.Subsection>

--- a/docs/pages/avatargroup.js
+++ b/docs/pages/avatargroup.js
@@ -52,7 +52,7 @@ export default function AvatarGroupPage({ generatedDocGen }: {| generatedDocGen:
             type="don't"
             title="When Not to Use"
             description={`
-            - Displaying a group of people, companies and/or brands in a square format. Use [AvatarPair](/AvatarPair) instead.
+            - Displaying a group of people, companies and/or brands in a square format. Use [AvatarPair](/avatarpair) instead.
           `}
           />
         </MainSection.Subsection>
@@ -159,7 +159,7 @@ function Example() {
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Fixed sizes"
-          description="AvatarGroup is available in 3 fixed height sizes: `xs` (24px) , `sm` (32px), and `md` (48px)."
+          description="AvatarGroup is available in 3 fixed height sizes: `xs` (24px), `sm` (32px), and `md` (48px)."
         >
           <CombinationNew size={['xs', 'sm', 'md']}>
             {({ size }) => (

--- a/docs/pages/avatarpair.js
+++ b/docs/pages/avatarpair.js
@@ -30,7 +30,7 @@ export default function AvatarPairPage({ generatedDocGen }: {| generatedDocGen: 
             type="don't"
             title="When Not to Use"
             description={`
-          - In cases where a square format is not required. Use [AvatarGroup](/AvatarGroup) instead.
+          - In cases where a square format is not required. Use [AvatarGroup](/avatargroup) instead.
         `}
           />
         </MainSection.Subsection>

--- a/docs/pages/badge.js
+++ b/docs/pages/badge.js
@@ -62,7 +62,7 @@ export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGe
 
       <Example
         description={`
-    Components like [Module](/Module) and [Dropdown](/Dropdown) support Badges within the component.`}
+    Components like [Module](/module) and [Dropdown](/dropdown) support Badges within the component.`}
         name="Example: within other components"
         defaultCode={`
 function ModuleExample() {

--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -59,7 +59,7 @@ export default function BoxPage({ generatedDocGen }: {| generatedDocGen: DocGen 
             description={`
         Use Box as a building block when creating other components or layouts that do not rely on flexbox. The included properties should cover any variations needed to create a diverse range of options.
 
-        If you find yourself using Box for flexbox layouts, consider [Flex](/Flex) instead.
+        If you find yourself using Box for flexbox layouts, consider [Flex](/flex) instead.
         `}
             defaultCode={`
 <Box column={12}>
@@ -89,7 +89,7 @@ export default function BoxPage({ generatedDocGen }: {| generatedDocGen: DocGen 
             type="don't"
             description={`Don’t use the \`onClick\`, \`className\` and \`style\` properties.
 
-Box is a pass-through component, meaning that any other properties you provide to it will be directly applied to the underlying \`<div>\`. The above properties are exceptions, however.  We don’t allow  \`onClick\`  for  accessibility reasons, so consider a [Button](/Button) or [TapArea](/TapArea) instead. We remove \`className\` and \`style\` to ensure style encapsulation. If necessary, \`dangerouslySetInlineStyle\` can be used to supply a style not supported by Box props.
+Box is a pass-through component, meaning that any other properties you provide to it will be directly applied to the underlying \`<div>\`. The above properties are exceptions, however.  We don’t allow  \`onClick\`  for  accessibility reasons, so consider a [Button](/button) or [TapArea](/taparea) instead. We remove \`className\` and \`style\` to ensure style encapsulation. If necessary, \`dangerouslySetInlineStyle\` can be used to supply a style not supported by Box props.
 
 If you need to use these features for animation purposes, use a \`<div>\` instead.`}
             defaultCode={`
@@ -696,7 +696,7 @@ function BoxPopoverExample() {
         </MainSection.Subsection>
 
         <MainSection.Subsection
-          description={`The \`ref\` property can be used to anchor a [Popover](/Popover) to a Box.`}
+          description={`The \`ref\` property can be used to anchor a [Popover](/popover) to a Box.`}
           title="Using as a ref"
         >
           <MainSection.Card
@@ -741,7 +741,7 @@ function BoxPopoverExample() {
         </MainSection.Subsection>
 
         <MainSection.Subsection
-          description={`It's possible to use Box with external elements using the CSS \`z-index\` property by capturing those values in controlled objects. The example below shows using a \`FixedZIndex\` for a value that comes from somewhere else, and a \`CompositeZIndex\` to layer the Box on top of it. Visit our [Z-Index documentation](/ZIndex%20Classes) for more details on how to use these utility classes.`}
+          description={`It's possible to use Box with external elements using the CSS \`z-index\` property by capturing those values in controlled objects. The example below shows using a \`FixedZIndex\` for a value that comes from somewhere else, and a \`CompositeZIndex\` to layer the Box on top of it. Visit our [Z-Index documentation](/zindex%20classes) for more details on how to use these utility classes.`}
           title="Z-Index"
         >
           <MainSection.Card
@@ -779,19 +779,19 @@ function Example() {
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-        **[Flex](/Flex)**
+        **[Flex](/flex)**
         Use Flex for flexbox layouts, especially when even spacing between elements is desired, by using the \`gap\` property.
 
-        **[Container](/Container)**
+        **[Container](/container)**
         Use Container to responsively layout content with a max-width on large screens.
 
-        **[ScrollBoundaryContainer](/ScrollBoundaryContainer)**
+        **[ScrollBoundaryContainer](/scrollboundarycontainer)**
         For proper positioning when using anchored components (Popover, Tooltip, etc.) within a container that could scroll, use ScrollBoundaryContainer.
 
-        **[TapArea](/TapArea)**
+        **[TapArea](/taparea)**
         If a tap target is needed in order to click on a portion of the page, use TapArea, since \`onClick\` is not supported on Box.
 
-        **[Sticky](/Sticky)**
+        **[Sticky](/sticky)**
         Use Sticky if a portion of the page should stick to either the top or bottom when scrolling.
       `}
         />

--- a/docs/pages/button.js
+++ b/docs/pages/button.js
@@ -102,7 +102,7 @@ card(
         defaultValue: null,
         description: [
           'Callback invoked when the user clicks (press and release) on Button with the mouse or keyboard. Required with `role="button"` or `type="button"` Buttons.',
-          'See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',
+          'See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
         ],
       },
       {
@@ -203,8 +203,8 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - Directing users to a new page or different part within the same page. Instead, use [Link](/Link).
-          - Limited space available. Consider using an [IconButton](/IconButton) instead.
+          - Directing users to a new page or different part within the same page. Instead, use [Link](/link).
+          - Limited space available. Consider using an [IconButton](/iconbutton) instead.
         `}
       />
     </MainSection.Subsection>
@@ -771,9 +771,9 @@ Use TapArea to make non-button elements interactive, like an Image. This ensures
 **[Tabs](/tabs)**
 Tabs are intended for page-level navigation between multiple URLs.
 
-**[OnLinkNavigationProvider](/OnLinkNavigationProvider)**
+**[OnLinkNavigationProvider](/onlinknavigationprovider)**
 OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
-See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.
+See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.
       `}
     />
   </MainSection>,

--- a/docs/pages/buttongroup.js
+++ b/docs/pages/buttongroup.js
@@ -30,8 +30,8 @@ export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGe
             type="don't"
             title="When Not to Use"
             description={`
-          - Grouping 4 or more actions, consider using an ellipses [IconButton](/IconButton) after 3 options.
-          - Switching between different views. Use [SegmentedControl](/SegmentedControl) instead.
+          - Grouping 4 or more actions, consider using an ellipses [IconButton](/iconbutton) after 3 options.
+          - Switching between different views. Use [SegmentedControl](/segmentedcontrol) instead.
         `}
           />
         </MainSection.Subsection>

--- a/docs/pages/callout.js
+++ b/docs/pages/callout.js
@@ -58,8 +58,8 @@ export default function CalloutPage({ generatedDocGen }: {| generatedDocGen: Doc
             title="When Not to Use"
             description={`
           - When providing messaging/guidance for specific elements or areas within a surface. [Let the team know](https://app.slack.com/client/T024LJUGB/C0HUV5J93) if this is needed.
-          - When displaying information that is intended for promotional/marketing purposes. Use [Upsell](/Upsell) instead.
-          - When interacting with the Callout is required for the user to proceed with a task or flow. Use [Modal](/Modal) instead.
+          - When displaying information that is intended for promotional/marketing purposes. Use [Upsell](/upsell) instead.
+          - When interacting with the Callout is required for the user to proceed with a task or flow. Use [Modal](/modal) instead.
         `}
           />
         </MainSection.Subsection>
@@ -129,7 +129,7 @@ export default function CalloutPage({ generatedDocGen }: {| generatedDocGen: Doc
             cardSize="lg"
             type="don't"
             description={`
-        Use Callouts for marketing new products or features. Use [Upsell](/Upsell) instead.
+        Use Callouts for marketing new products or features. Use [Upsell](/upsell) instead.
         `}
             defaultCode={`
           <Callout
@@ -366,11 +366,11 @@ export default function CalloutPage({ generatedDocGen }: {| generatedDocGen: Doc
         <MainSection.Subsection
           title="Actions"
           description={`
-        Callouts can have either one primary action, or a primary action and a secondary action. These actions can be [Links](/Link), by specifying the \`href\` property, or [Buttons](/Buttons), when no \`href\` is supplied.
+        Callouts can have either one primary action, or a primary action and a secondary action. These actions can be [Links](/link), by specifying the \`href\` property, or [Buttons](/button), when no \`href\` is supplied.
 
-        Callout actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.
+        Callout actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.
 
-        For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a Button that opens a [Modal](/Modal) with an application flow. Be sure to localize the labels of the actions.
+        For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a Button that opens a [Modal](/modal) with an application flow. Be sure to localize the labels of the actions.
 
         If needed, actions can become disabled after clicking by setting \`disabled: true\` in the action data.
 
@@ -516,16 +516,16 @@ function Example(props) {
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-      **[Upsell](/Upsell)**
+      **[Upsell](/upsell)**
       If marketing new products or features, or encouraging upgrades, use Upsell instead.
 
-      **[Toast](/Toast)**
+      **[Toast](/toast)**
       Toast provides feedback on a user interaction, like a confirmation that appears when a Pin has been saved. Unlike Upsell and Callout, Toasts don’t contain actions. They’re also less persistent, and disappear after a certain duration.
 
-      **[ActivationCard](/ActivationCard)**
+      **[ActivationCard](/activationcard)**
       ActivationCards are used in groups to communicate a user’s stage in a series of steps toward an overall action.
 
-      **[OnLinkNavigationProvider](/OnLinkNavigationProvider)**
+      **[OnLinkNavigationProvider](/onlinknavigationprovider)**
       OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
 
     `}

--- a/docs/pages/checkbox.js
+++ b/docs/pages/checkbox.js
@@ -122,8 +122,8 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - Situations where users can only choose one out of multiple, related options. Use [RadioButtons](/RadioButton) instead.
-          - When a selection takes immediate effect, especially on mobile. Use [Switch](/Switch) instead.
+          - Situations where users can only choose one out of multiple, related options. Use [RadioButtons](/radiobutton) instead.
+          - When a selection takes immediate effect, especially on mobile. Use [Switch](/switch) instead.
         `}
       />
     </MainSection.Subsection>
@@ -157,7 +157,7 @@ function CheckboxExample() {
 card(
   <Example
     id="group"
-    description="Here is an example of an accessible group of checkboxes. When creating a group of Checkboxes, be sure to wrap them in a [Fieldset](/Fieldset)."
+    description="Here is an example of an accessible group of checkboxes. When creating a group of Checkboxes, be sure to wrap them in a [Fieldset](/fieldset)."
     name="Example: Group"
     defaultCode={`
 function CheckboxExample() {

--- a/docs/pages/color.js
+++ b/docs/pages/color.js
@@ -42,7 +42,7 @@ card(
 card(
   <MainSection
     name="Full Palettes"
-    description={`In order to ensure accessible contrast for color pairings, we require our \`darkGray\` [Text](/Text) color to be used for any colors 400 and below. For 500 and above, we recommend using \`white\`.`}
+    description={`In order to ensure accessible contrast for color pairings, we require our \`darkGray\` [Text](/text) color to be used for any colors 400 and below. For 500 and above, we recommend using \`white\`.`}
   >
     <MainSection.Subsection title="Colors">
       <Flex gap={12} wrap>

--- a/docs/pages/colorschemeprovider.js
+++ b/docs/pages/colorschemeprovider.js
@@ -89,7 +89,7 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-      **[Link](/Link)** / **[Button](/Button)** / **[IconButton](/IconButton)** / **[TapArea](/TapArea)**  / **[DropDown](/DropDown)** / **[Callout](/Callout)** / **[Upsell](/Upsell)** / **[ActivationCard](/ActivationCard)**
+      **[Link](/link)** / **[Button](/button)** / **[IconButton](/iconbutton)** / **[TapArea](/taparea)**  / **[DropDown](/dropdown)** / **[Callout](/callout)** / **[Upsell](/upsell)** / **[ActivationCard](/activationcard)**
       If these components are under a ColorSchemeProvider, their link behavior defaults to the logic defined in ColorSchemeProvider. In order to disable the onNavigation logic, we can return "dangerouslyDisableOnNavigation" in the \`onClick\` callback. See each component page for more information.
     `}
     />

--- a/docs/pages/combobox.js
+++ b/docs/pages/combobox.js
@@ -99,7 +99,7 @@ card(
         type: 'boolean',
         defaultValue: false,
         description:
-          'When disabled, ComboBox looks inactive and cannot be interacted with. If tags are passed, they will appear disabled as well and cannot be removed. See [tags](#TYags) variant to learn more.',
+          'When disabled, ComboBox looks inactive and cannot be interacted with. If tags are passed, they will appear disabled as well and cannot be removed. See [tags](#Tags) variant to learn more.',
       },
       {
         name: 'helperText',
@@ -223,7 +223,7 @@ card(
       <MainSection.Card
         cardSize="md"
         type="don't"
-        description="Use ComboBox for a simple list of items. Use [SelectList](/SelectList) instead for the added native mobile functionality."
+        description="Use ComboBox for a simple list of items. Use [SelectList](/selectlist) instead for the added native mobile functionality."
       />
     </MainSection.Subsection>
   </MainSection>,
@@ -661,11 +661,11 @@ function ComboBoxExample(props) {
     </MainSection.Subsection>
     <MainSection.Subsection
       description={`
-    Include [Tag](/Tag) elements in the input using the \`tags\` prop.
+    Include [Tag](/tag) elements in the input using the \`tags\` prop.
 
     Note that the \`ComboBox\` component doesn't internally manage tags; therefore, it must be a [controlled component](#Controlled-vs-Uncontrolled). A controlled ComboBox requires three value props: \`options\`,  \`inputValue\`,  and \`tags\`.
 
-    To use ComboBox with [tags](/Tag), it's recommended to create new tags on enter key presses, to remove them on backspaces when the cursor is in the beginning of the field and to filter out empty tags. These best practices are shown in the following example.`}
+    To use ComboBox with [tags](/tag), it's recommended to create new tags on enter key presses, to remove them on backspaces when the cursor is in the beginning of the field and to filter out empty tags. These best practices are shown in the following example.`}
       title="Tags"
     >
       <MainSection.Card
@@ -879,13 +879,13 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[SelectList](/SelectList)**
+**[SelectList](/selectlist)**
 If users need to select from a short, simple list (without needing sections, subtext details, or the ability to filter the list), use SelectList.
 
-**[Dropdown](/Dropdown)**
+**[Dropdown](/dropdown)**
 Dropdown is an element constructed using Popover as its container. Use Dropdown to display a list of actions or options in a Popover.
 
-**[Fieldset](/Fieldset)**
+**[Fieldset](/fieldset)**
 Use Fieldset to group related form items.
     `}
     />

--- a/docs/pages/datepicker.js
+++ b/docs/pages/datepicker.js
@@ -224,7 +224,7 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - When the native date picking experience is preferred (typically mobile and mWeb experiences). In this case, use [TextField](/TextField) with type=”date”.
+          - When the native date picking experience is preferred (typically mobile and mWeb experiences). In this case, use [TextField](/textfield) with type=”date”.
         `}
       />
     </MainSection.Subsection>

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -87,7 +87,7 @@ card(
         name: 'anchor',
         type: '?HTMLElement',
         description:
-          'Ref for the element that the Dropdown will attach to, will most likely be a [Button](/Button). See the [Accessibility](#Accessibility) guidelines to learn more.',
+          'Ref for the element that the Dropdown will attach to, will most likely be a [Button](/button). See the [Accessibility](#Accessibility) guidelines to learn more.',
       },
       {
         name: 'children',
@@ -133,7 +133,7 @@ card(
         name: 'zIndex',
         type: 'interface Indexable { index(): number; }',
         description:
-          'An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](/ZIndex%20Classes)',
+          'An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](/zindex%20classes)',
       },
     ]}
   />,
@@ -144,7 +144,7 @@ const commonDropdownItemProps = [
     name: 'badgeText',
     type: 'string',
     description:
-      "When supplied, will display a [Badge](/Badge) next to the item's label. See the [Badges](#Badges) variant to learn more.",
+      "When supplied, will display a [Badge](/badge) next to the item's label. See the [Badges](#Badges) variant to learn more.",
   },
   {
     name: 'dataTestId',
@@ -216,7 +216,7 @@ card(
           'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
         description: [
           'Callback fired when clicked (pressed and released) with a mouse or keyboard. ',
-          'See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',
+          'See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
         ],
       },
     ]}
@@ -254,7 +254,7 @@ card(
         title="When to Use"
         description={`
           - Displaying a list of actions, options, or links. Usually displays 3 or more options.
-          - Allowing complex functionality that a [SelectList](/SelectList) can't accomplish.
+          - Allowing complex functionality that a [SelectList](/selectlist) can't accomplish.
           - Taking immediate action or navigating users to another view.
         `}
       />
@@ -263,9 +263,9 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - In cases when there are less than 3 items in the list, and there is space to display all options. Consider [RadioButtons](/RadioButton) or [Checkboxes](/Checkbox) instead.
-          - When it is desirable to filter a long list of options. Use [ComboBox](/ComboBox) instead.
-          - Displaying a list of actions or options using the browser's native select functionality. Use [SelectList](/SelectList) instead.
+          - In cases when there are less than 3 items in the list, and there is space to display all options. Consider [RadioButtons](/radiobutton) or [Checkboxes](/checkbox) instead.
+          - When it is desirable to filter a long list of options. Use [ComboBox](/combobox) instead.
+          - Displaying a list of actions or options using the browser's native select functionality. Use [SelectList](/selectlist) instead.
         `}
       />
     </MainSection.Subsection>
@@ -278,7 +278,7 @@ card(
       <MainSection.Card
         cardSize="md"
         type="do"
-        description="Use Dropdown when features such as subtext, custom headers or badges are needed, since this functionality is not available in [SelectList](/SelectList)."
+        description="Use Dropdown when features such as subtext, custom headers or badges are needed, since this functionality is not available in [SelectList](/selectlist)."
         defaultCode={`
       function BestPracticeDropdownExample() {
         const [open, setOpen] = React.useState(false);
@@ -342,7 +342,7 @@ card(
       <MainSection.Card
         cardSize="md"
         type="don't"
-        description="Use Dropdown for a simple list of items. Use [SelectList](/SelectList) instead for the added native mobile functionality. The exception to this is multiple Dropdowns or SelectLists that could be grouped together to create visual inconsistency, such as filters. In this case, use Dropdowns for all."
+        description="Use Dropdown for a simple list of items. Use [SelectList](/selectlist) instead for the added native mobile functionality. The exception to this is multiple Dropdowns or SelectLists that could be grouped together to create visual inconsistency, such as filters. In this case, use Dropdowns for all."
         defaultCode={`
     function SimpleListDropdownExample() {
       const [open, setOpen] = React.useState(false);
@@ -772,7 +772,7 @@ function ActionDropdownExample() {
       <MainSection.Card
         cardSize="md"
         title="Link"
-        description={`If an item navigates to a new page, use Dropdown.Link with the required \`href\` prop. If the item navigates to a page outside of the current context, (either a non-Pinterest site or a different Pinterest sub-site), the \`isExternal\` prop should also be specified to display the "up-right" icon. Optional additional actions to be taken on navigation are handled by \`onClick\`. Dropdown.Link can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.
+        description={`If an item navigates to a new page, use Dropdown.Link with the required \`href\` prop. If the item navigates to a page outside of the current context, (either a non-Pinterest site or a different Pinterest sub-site), the \`isExternal\` prop should also be specified to display the "up-right" icon. Optional additional actions to be taken on navigation are handled by \`onClick\`. Dropdown.Link can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.
 `}
         defaultCode={`
 function LinkDropdownExample() {
@@ -1058,7 +1058,7 @@ function SubtextDropdownExample() {
 
     <MainSection.Subsection
       title="Badges"
-      description={`A [Badge](/Badge) can be used to indicate a new product surface or feature within the Dropdown using \`badgeText\`. Multiple badges within a Dropdown should be avoided when possible.`}
+      description={`A [Badge](/badge) can be used to indicate a new product surface or feature within the Dropdown using \`badgeText\`. Multiple badges within a Dropdown should be avoided when possible.`}
     >
       <MainSection.Card
         cardSize="lg"
@@ -1196,19 +1196,19 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[Button](/Button), [IconButton](/IconButton)**
+**[Button](/button), [IconButton](/iconbutton)**
 It is most common to anchor Dropdown to Button or IconButton.
 
-**[ScrollBoundaryContainer](/ScrollBoundaryContainer)**
+**[ScrollBoundaryContainer](/scrollboundarycontainer)**
 ScrollableContainer is needed for proper positioning when the Dropdown is located within a scrolling container. The use of ScrollableContainer ensures the Dropdown remains attached to its anchor when scrolling.
 
-**[SelectList](/SelectList)**
+**[SelectList](/selectlist)**
 If users need to select from a short, simple list (without needing sections, subtext details, or the ability to filter the list), use SelectList.
 
 **[ComboBox](/combobox)**
 If users need the ability to choose an option by typing in an input and filtering a long list of options, use ComboBox.
 
-**[OnLinkNavigationProvider](/OnLinkNavigationProvider)**
+**[OnLinkNavigationProvider](/onlinknavigationprovider)**
 OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
 `}
     />

--- a/docs/pages/eslint_plugin.js
+++ b/docs/pages/eslint_plugin.js
@@ -25,18 +25,18 @@ card(
       description={`
         Prevent using \`<div>\` inline styling for attributes that are already implemented in Box.
 
-        [Learn more about Box](/Box).
+        [Learn more about Box](/box).
       `}
     />
     <MainSection.Subsection
       title="gestalt/prefer-box-no-disallowed"
       description={`Prevent \`<div>\` tags that don't contain disallowed attributes: className and onClick. Use Gestalt Box, instead. Other attributes are disallowed as well so this Eslint rule doesn't conflict with [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y).
 
-[Read more about Box](/Box).
+[Read more about Box](/box).
 
 It also prevents \`<div>\` tags used to only contain a \`ref\` attribute. \`ref\` is supported in Box and other elements such as Button or TextField.
 
-[Read more about the ref prop in Box](/Box#Using-as-a-ref).
+[Read more about the ref prop in Box](/box#Using-as-a-ref).
 
 With AUTOFIX!
       `}
@@ -63,14 +63,14 @@ With AUTOFIX!
 
         With AUTOFIX!
 
-        [Read more about the as prop in Box](/Box#Using-'as'-property).
+        [Read more about the as prop in Box](/box#Using-'as'-property).
       `}
     />
     <MainSection.Subsection
       title="gestalt/prefer-link"
       description={`Prevent anchor tags that only contain attributes matching supported props in Gestalt Link.
 
-[Read more about Link](/Link).
+[Read more about Link](/link).
 
 With AUTOFIX!
       `}
@@ -113,7 +113,7 @@ card(
 
         With AUTOFIX!
 
-        [Learn more about Box](/Box).
+        [Learn more about Box](/box).
       `}
     />
     <MainSection.Subsection
@@ -139,7 +139,7 @@ card(
       title="gestalt/prefer-flex"
       description={`Prevent \`Box\` usages in those cases where they can be replaced with \`Flex\`.
 
-[Read more about Flex](/Flex).
+[Read more about Flex](/flex).
 
 With AUTOFIX!
       `}
@@ -228,7 +228,7 @@ card(
   <MainSection
     name="Releasing"
     description={`
-    Every commit to master performs a release. See the main docs [releasing information](/Installation#Releasing) for more details.
+    Every commit to master performs a release. See the main docs [releasing information](/installation#Releasing) for more details.
   `}
   />,
 );
@@ -251,7 +251,7 @@ card(
       description={`
         Do not allow role=&apos;link&apos; on Button, TapArea, and IconButton in cases where an alternative with additional functionality must be used instead such as for use with a routing library.
 
-        Deprecation due to: [OnLinkNavigationProvider](/OnLinkNavigationProvider) enables external link navigation in Gestalt components.
+        Deprecation due to: [OnLinkNavigationProvider](/onlinknavigationprovider) enables external link navigation in Gestalt components.
       `}
     />
   </MainSection>,

--- a/docs/pages/fieldset.js
+++ b/docs/pages/fieldset.js
@@ -84,7 +84,7 @@ card(
         name: 'children',
         type: 'React.Node',
         required: true,
-        description: `The content of Fieldset, typically [RadioButtons](/RadioButton), [Checkboxes](/Checkbox) or [TextFields](/TextField).`,
+        description: `The content of Fieldset, typically [RadioButtons](/radiobutton), [Checkboxes](/checkbox) or [TextFields](/textfield).`,
       },
       {
         name: 'id',
@@ -130,7 +130,7 @@ card(
   <MainSection name="Accessibility">
     <MainSection.Subsection
       description={`
-      Wrapping form fields in Fieldset creates an accessible grouping that signals to users when certain form items are related. The \`legend\` should clearly describe what information is needed from the group of items, whether they're [RadioButtons](/RadioButton), [Checkboxes](/Checkbox) or [TextFields](/TextField).
+      Wrapping form fields in Fieldset creates an accessible grouping that signals to users when certain form items are related. The \`legend\` should clearly describe what information is needed from the group of items, whether they're [RadioButtons](/radiobutton), [Checkboxes](/checkbox) or [TextFields](/textfield).
 
       In the example below, the pet RadioButtons are surrounded by a fieldset and include a \`legend\` of "Favorite pet". Learn more about the [use of fieldset and legend](https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-fieldset).`}
     >
@@ -345,7 +345,7 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-      **[Label](/Label)**
+      **[Label](/label)**
       If a label is needed for a single form item (instead of a group of items), use Label.
     `}
     />

--- a/docs/pages/flex.js
+++ b/docs/pages/flex.js
@@ -15,7 +15,7 @@ card(
   <PageHeader
     name="Flex"
     description={`
-      Flex is a layout component with a very limited subset of the props available to [Box](/Box) and a few special props of its own.
+      Flex is a layout component with a very limited subset of the props available to [Box](/box) and a few special props of its own.
 
       Use this component for flex layouts, especially when even spacing between elements is desired (see the 'gap' property!).
     `}

--- a/docs/pages/how_to_work_with_us.js
+++ b/docs/pages/how_to_work_with_us.js
@@ -78,7 +78,7 @@ We always appreciate the help and contributions of other engineers across Pinter
 2. **Tech Design Doc**
    Create a technical design doc (TDD), using [this template](https://paper.dropbox.com/doc/Gestalt-TDD-ComponentName--BF5cp4OG2JXR_Vo7d5hsnVFEAg-A8wHbLtDhwbGjlyOTIg86), for any net-new components or component additions/updates within Gestalt. This allows everyone to discuss the component API and functionality before starting to build.
 3. **Pull request**
-   Once the TDD has been finalized, make a pull request for your changes by following the [development guidelines](/Development). Your changes will be reviewed by the gestalt-core GitHub Team and a Gestalt designer. We ensure each component is built to spec, accessible, performant and works well with other components.
+   Once the TDD has been finalized, make a pull request for your changes by following the [development guidelines](/development). Your changes will be reviewed by the gestalt-core GitHub Team and a Gestalt designer. We ensure each component is built to spec, accessible, performant and works well with other components.
 4. **Release**
    Now the fun part - releasing your component! After someone from the Gestalt team merges your change, feel free to announce it on the [#gestalt-web](https://app.slack.com/client/T024LJUGB/C13KLG5P0/thread/C014X9LTRCN-1614382923.009100) slack channel.`}
     />

--- a/docs/pages/icon.js
+++ b/docs/pages/icon.js
@@ -103,7 +103,7 @@ export default function IconPage({ generatedDocGen }: {| generatedDocGen: DocGen
           title="ARIA attributes"
           columns={2}
           description={`
-If the icon appears without text, the Icon requires \`accessibilityLabel\`, a text description for screen readers to announce and communicate the represented [Icon](/Icon), as shown in the first example.
+If the icon appears without text, the Icon requires \`accessibilityLabel\`, a text description for screen readers to announce and communicate the represented [Icon](/icon), as shown in the first example.
 
 Avoid using the generic words like  "image" or "icon"; instead, use verbs that describe the meaning of the icon, for example: “pins".
 
@@ -213,10 +213,10 @@ Use a descriptive label to describe the Icon
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[IconButton](/IconButton)**
+**[IconButton](/iconbutton)**
 Use IconButton when only an icon is needed to represent an action instead of text.
 
-**[Button](/Button)**
+**[Button](/button)**
 Use Button to allow users to take an action.
     `}
         />

--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -116,7 +116,7 @@ card(
         type: `"darkGray" | "gray" | "red" | "white"`,
         defaultValue: 'gray',
         description:
-          'Primary color to apply to the [Icon](/Icon). See [icon color](#Icon-color) variant to learn more.',
+          'Primary color to apply to the [Icon](/icon). See [icon color](#Icon-color) variant to learn more.',
       },
       {
         name: 'icon',
@@ -130,7 +130,7 @@ card(
         type:
           '({| event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> |}) => void',
         description:
-          'Callback fired when the component is clicked, pressed or tapped. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',
+          'Callback fired when the component is clicked, pressed or tapped. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
       },
       {
         name: 'padding',
@@ -220,7 +220,7 @@ card(
         type: 'link',
         required: true,
         description:
-          'Sets link interaction in the component. See the [role](#Role) variant and [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',
+          'Sets link interaction in the component. See the [role](#Role) variant and [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
       },
       {
         name: 'href',
@@ -251,8 +251,8 @@ card(
         type="do"
         title="When to Use"
         description={`
-- Interface space is limited. Prioritize using a [Button](/Button) if space is available.
-- Triggering a [Modal](/Modal) to complete a related task.
+- Interface space is limited. Prioritize using a [Button](/button) if space is available.
+- Triggering a [Modal](/modal) to complete a related task.
 - Creating visual separation of actions in text-heavy content.
 - Lower-emphasis actions that don't impede users from completing a task.
         `}
@@ -262,7 +262,7 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-- Displaying icons that don't have actions associated with them. Use an [Icon](/Icon) instead.
+- Displaying icons that don't have actions associated with them. Use an [Icon](/icon) instead.
 - Displaying multiple IconButtons on a surface that uses the same icon for different actions.
 - Text is better suited to convey the action and/or the icon isn't quickly recognizable by users.
 - Destructive, high-emphasis actions, e.g "delete", "remove".
@@ -278,7 +278,7 @@ card(
       <MainSection.Card
         cardSize="md"
         type="do"
-        description="Use IconButton to perform low-emphasis actions, such as opening a [Modal](/Modal) to edit a board."
+        description="Use IconButton to perform low-emphasis actions, such as opening a [Modal](/modal) to edit a board."
         defaultCode={`
 function HeadingExample(props) {
   const ModalWithHeading = ({
@@ -489,7 +489,7 @@ function OrderDropdownExample() {
       <MainSection.Card
         cardSize="md"
         type="do"
-        description="Display a [Tooltip](/Tooltip) in conjunction with IconButton to provide context when the icon alone would be insufficient to convey the purpose of the button."
+        description="Display a [Tooltip](/tooltip) in conjunction with IconButton to provide context when the icon alone would be insufficient to convey the purpose of the button."
         defaultCode={`
 <Tooltip text="Send pin">
   <IconButton
@@ -535,7 +535,7 @@ card(
     <MainSection.Subsection
       title="ARIA attributes"
       description={`
-IconButton conveys the component behavior using iconography. IconButton requires \`accessibilityLabel\`, a text description for screen readers to announce and communicate the represented [Icon](/Icon). In the example below, the screen reader reads: "More Options."
+IconButton conveys the component behavior using iconography. IconButton requires \`accessibilityLabel\`, a text description for screen readers to announce and communicate the represented [Icon](/icon). In the example below, the screen reader reads: "More Options."
 
 If IconButton is used as a control button to show/hide a Popover-based component, we recommend passing the following ARIA attributes to assist screen readers:
 
@@ -665,7 +665,7 @@ card(
 
 \`rel\` is optional. Use "nofollow" for external links to specify to web crawlers not follow the link.
 
-IconButtons that act as links can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.`}
+IconButtons that act as links can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.`}
         defaultCode={`
 <Tooltip text="Link">
   <IconButton
@@ -781,7 +781,7 @@ Follow these guidelines for \`bgColor\`
     <MainSection.Subsection
       title="Custom icon"
       columns={2}
-      description="IconButton accepts both Gestalt [Icons](/Icon) and custom icons, as shown in the second example. For custom icons, follow our [custom SVG icons](/iconography_and_svgs#Custom-SVG-icons) guidelines."
+      description="IconButton accepts both Gestalt [Icons](/icon) and custom icons, as shown in the second example. For custom icons, follow our [custom SVG icons](/iconography_and_svgs#Custom-SVG-icons) guidelines."
     >
       <MainSection.Card
         cardSize="md"
@@ -920,7 +920,7 @@ function IconButtonPopoverExample() {
 card(
   <MainSection
     name="Writing"
-    description="When pairing IconButton with [Tooltip](/Tooltip), refer to the Tooltip component for writing guidelines.
+    description="When pairing IconButton with [Tooltip](/tooltip), refer to the Tooltip component for writing guidelines.
 
 "
   >
@@ -945,17 +945,17 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[Button](/Button)**
+**[Button](/button)**
 Button allows users to take actions, and make choices using text labels to express what action will occur when the user interacts with it.
 
-**[Icon](/Icon)**
-IconButtons use icons instead of text to convey available actions on a screen. Use an existing one from the Gestalt [Icon](/Icon) library.
+**[Icon](/icon)**
+IconButtons use icons instead of text to convey available actions on a screen. Use an existing one from the Gestalt [Icon](/icon) library.
 
-**[OnLinkNavigationProvider](/OnLinkNavigationProvider)**
+**[OnLinkNavigationProvider](/onlinknavigationprovider)**
 OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
 
-**[Dropdown](/Dropdown)**
-It's most common to anchor Dropdown to [Button](/Button) or IconButton.
+**[Dropdown](/dropdown)**
+It's most common to anchor Dropdown to [Button](/button) or IconButton.
       `}
     />
   </MainSection>,

--- a/docs/pages/iconography_and_svgs.js
+++ b/docs/pages/iconography_and_svgs.js
@@ -134,9 +134,9 @@ export default function IconPage(): Node {
       <MainSection name="Custom SVG icons">
         <MainSection.Subsection
           description={`
-If you need a new icon for an experiment that is not listed on our [Icon](/Icon) documentation, use the \`dangerouslySetSvgPath\` prop on [Icon](/Icon), [IconButton](/IconButton), and [Pog](/Pog).
+If you need a new icon for an experiment that is not listed on our [Icon](/icon) documentation, use the \`dangerouslySetSvgPath\` prop on [Icon](/icon), [IconButton](/iconbutton), and [Pog](/pog).
 
-However, \`dangerouslySetSvgPath\` only works with one SVG path. For icons with multiple paths and groups, use [Box](/Box) and \`dangerouslySetInlineStyle\` to pass the custom icon as \`backgroundImage\`.
+However, \`dangerouslySetSvgPath\` only works with one SVG path. For icons with multiple paths and groups, use [Box](/box) and \`dangerouslySetInlineStyle\` to pass the custom icon as \`backgroundImage\`.
 
 Once your experiment ships to 100%, ask your designer to follow the directions in the [Icon kit](https://www.figma.com/file/N60WnDx9j6Moz3Dt1rNsq9/Icon-Kit). Once the asset is ready, we can add the Icon to Gestalt.
 

--- a/docs/pages/label.js
+++ b/docs/pages/label.js
@@ -35,7 +35,7 @@ card(
 card(
   <Example
     description={`
-    Whenever you are using a [SelectList](#/SelectList), [Switch](#/Switch), [TextField](#/TextField) or [TextArea](#/TextArea) component, you should use a \`Label\`.
+    Whenever you are using a [SelectList](/selectlist), [Switch](/switch), [TextField](/textfield) or [TextArea](/textarea) component, you should use a \`Label\`.
   `}
     name="Example"
     defaultCode={`

--- a/docs/pages/layer.js
+++ b/docs/pages/layer.js
@@ -86,7 +86,7 @@ function Example() {
 card(
   <Example
     description="
-The example below shows using a \`FixedZIndex\` for the header zIndex and a \`CompositeZIndex\` to stack the Layer on top of it. Visit our [Z-Index documentation](/ZIndex%20Classes) for more details on how to use these utility classes.
+The example below shows using a \`FixedZIndex\` for the header zIndex and a \`CompositeZIndex\` to stack the Layer on top of it. Visit our [Z-Index documentation](/zindex%20classes) for more details on how to use these utility classes.
     "
     name="zIndex"
     defaultCode={`

--- a/docs/pages/link.js
+++ b/docs/pages/link.js
@@ -71,7 +71,7 @@ card(
         type:
           'AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}>',
         description:
-          'Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',
+          'Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
         href: 'Custom-navigation',
       },
       {
@@ -132,7 +132,7 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - Performing actions, such as "Save", "Cancel" or "Delete". Use [Button](/Button) instead.
+          - Performing actions, such as "Save", "Cancel" or "Delete". Use [Button](/button) instead.
           - Submitting a form or opening a modal. Use Button instead.
         `}
       />
@@ -283,7 +283,7 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[OnLinkNavigationProvider](/OnLinkNavigationProvider)**
+**[OnLinkNavigationProvider](/onlinknavigationprovider)**
 OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
       `}
     />

--- a/docs/pages/modal.js
+++ b/docs/pages/modal.js
@@ -43,7 +43,7 @@ sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-ori
             title="When Not to Use"
             description={`
           - Any time a separate, designated URL is desired.
-          - Requesting large forms of information. Consider a [Sheet](/Sheet) or new page instead.
+          - Requesting large forms of information. Consider a [Sheet](/sheet) or new page instead.
           - Any action that should not interrupt users from their current work stream.
           - On top of another modal, since this can create usability issues and confusion.
         `}
@@ -95,7 +95,7 @@ sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-ori
           <MainSection.Card
             cardSize="lg"
             type="don't"
-            description="Use Modal for content that should have a dedicated surface, like login flows. Think about the core areas of your product that could appear in navigation. If a dedicated URL would be beneficial, use a full page instead. If the user interaction is an optional sub-task, consider using a [Sheet](/Sheet)."
+            description="Use Modal for content that should have a dedicated surface, like login flows. Think about the core areas of your product that could appear in navigation. If a dedicated URL would be beneficial, use a full page instead. If the user interaction is an optional sub-task, consider using a [Sheet](/sheet)."
             defaultCode={`
 
 `}
@@ -583,10 +583,10 @@ function PreventCloseExample(props) {
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[Sheet](/Sheet)**
+**[Sheet](/sheet)**
 To allow users to view optional information or complete sub-tasks in a workflow while keeping the context of the current page, use Sheet.
 
-**[Toast](/Toast)**
+**[Toast](/toast)**
 Toast provides temporary feedback on an interaction. Toasts appear at the bottom of a desktop screen or top of a mobile screen, instead of blocking the entire page.
       `}
         />

--- a/docs/pages/onlinknavigationprovider.js
+++ b/docs/pages/onlinknavigationprovider.js
@@ -37,7 +37,7 @@ card(
       description={`
 Components with links use simple \`<a>\` tags. In order to replace the default link behavior with custom ones (e.g. [react-router](https://www.google.com/search?q=react-router&oq=react-router&aqs=chrome..69i57j0l9.2115j0j7&sourceid=chrome&ie=UTF-8)), \`onNavigation\` provides an interface to pass external logic into the 'onClick' event handler in children links.
 
-This example illustrates a custom navigation implementations to externally control the link functionality of Link: setting a default navigation logic with [OnLinkNavigationProvider](/OnLinkNavigationProvider).
+This example illustrates a custom navigation implementations to externally control the link functionality of Link: setting a default navigation logic with [OnLinkNavigationProvider](/onlinknavigationprovider).
 
 If \`onNavigation\` prop is passed to OnLinkNavigationProvider, it's passed down to all children links and sets a customized default link navigation behavior. \`onNavigation\` is a higher-order function: it takes named arguments: \`href\` and \`target\` and returns an event handler function. In the component's \`onClick\` event handler, the \`onClick\` prop gets called first, followed by the function passed down by the OnLinkNavigationProvider.
 
@@ -336,7 +336,7 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-      **[Link](/Link)** / **[Button](/Button)** / **[IconButton](/IconButton)** / **[TapArea](/TapArea)**  / **[DropDown](/DropDown)** / **[Callout](/Callout)** / **[Upsell](/Upsell)** / **[ActivationCard](/ActivationCard)**
+      **[Link](/link)** / **[Button](/button)** / **[IconButton](/iconbutton)** / **[TapArea](/taparea)**  / **[DropDown](/dropdown)** / **[Callout](/callout)** / **[Upsell](/upsell)** / **[ActivationCard](/activationcard)**
       If these components are under a OnLinkNavigationProvider, their link behavior defaults to the logic defined in OnLinkNavigationProvider. In order to disable the onNavigation logic, we can return "dangerouslyDisableOnNavigation" in the \`onClick\` callback. See each component page for more information.
     `}
     />

--- a/docs/pages/pageheader.js
+++ b/docs/pages/pageheader.js
@@ -328,7 +328,7 @@ export default function PageHeaderPage({ generatedDocGen }: {| generatedDocGen: 
 
       <MainSection
         name="Accessibility"
-        description={`Be sure to follow any accessibility guidelines for the components used within PageHeader. The heading within PageHeader will be rendered as a level 1 heading, so ensure there are no other level 1 headings present on the page. For headings level 2-6, use [Heading](/Heading). Learn more about <a href="https://www.w3.org/WAI/tutorials/page-structure/headings/" target="blank">creating accessible headings</a>.`}
+        description={`Be sure to follow any accessibility guidelines for the components used within PageHeader. The heading within PageHeader will be rendered as a level 1 heading, so ensure there are no other level 1 headings present on the page. For headings level 2-6, use [Heading](/heading). Learn more about <a href="https://www.w3.org/WAI/tutorials/page-structure/headings/" target="blank">creating accessible headings</a>.`}
       >
         <MainSection.Card
           cardSize="lg"
@@ -408,7 +408,7 @@ export default function PageHeaderPage({ generatedDocGen }: {| generatedDocGen: 
 
       <MainSection name="Variants">
         <MainSection.Subsection
-          description={`PageHeader supports an optional \`primaryAction\`. It can be a [Button](Button), a [Link](/Link) or an [IconButton](/IconButton) with a [Tooltip](/Tooltip) and optional [Dropdown](/Dropdown). Any Buttons or IconButtons should be \`size="lg"\`.`}
+          description={`PageHeader supports an optional \`primaryAction\`. It can be a [Button](/button), a [Link](/link) or an [IconButton](/iconbutton) with a [Tooltip](/tooltip) and optional [Dropdown](/dropdown). Any Buttons or IconButtons should be \`size="lg"\`.`}
           title="Primary action"
         >
           <MainSection.Card
@@ -506,7 +506,7 @@ function PrimaryActionExample() {
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description={`PageHeader also supports an optional \`secondaryAction\`. It will likely be a [Button](Button) or an [IconButton](/IconButton) with a [Tooltip](/Tooltip) and optional [Dropdown](/Dropdown). Any Buttons or IconButtons should be \`size="lg"\`.`}
+          description={`PageHeader also supports an optional \`secondaryAction\`. It will likely be a [Button](/button) or an [IconButton](/iconbutton) with a [Tooltip](/tooltip) and optional [Dropdown](/dropdown). Any Buttons or IconButtons should be \`size="lg"\`.`}
           title="Secondary action"
         >
           <MainSection.Card
@@ -648,7 +648,7 @@ function SecondaryActionExample() {
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-      **[Heading](/Heading)**
+      **[Heading](/heading)**
       Heading should be used to create level 2-6 headings on a page. If a level 1 heading is needed, use PageHeader.
     `}
         />

--- a/docs/pages/pog.js
+++ b/docs/pages/pog.js
@@ -14,7 +14,7 @@ card(
   <PageHeader
     name="Pog"
     description="
-A lower-level functional component to show the active, hovered, & focused states of an [IconButton](#/IconButton).
+A lower-level functional component to show the active, hovered, & focused states of an [IconButton](/iconbutton).
 
 This abstraction to allow for links that look like an IconButton.
 "

--- a/docs/pages/popover.js
+++ b/docs/pages/popover.js
@@ -13,9 +13,9 @@ card(
   <PageHeader
     name="Popover"
     description={`
-Popover is a floating view that contains a task related to the content on screen. It can be triggered when the user clicks or focuses on an element, typically [Button](/Button) or [IconButton](/IconButton). It can also be triggered automatically, as in the case of user education. Popover is non-modal and can be dismissed by interacting with another part of the screen or an item within Popover.
+Popover is a floating view that contains a task related to the content on screen. It can be triggered when the user clicks or focuses on an element, typically [Button](/button) or [IconButton](/iconbutton). It can also be triggered automatically, as in the case of user education. Popover is non-modal and can be dismissed by interacting with another part of the screen or an item within Popover.
 
-Popover is most appropriate for desktop screens and can contain a variety of elements, such as [Button](/Button) and [Images](/Images). Popover is also the container used to construct more complex elements like [Dropdown](/Dropdown) and the board picker, pictured below, which allow people to choose the board to save a Pin to.
+Popover is most appropriate for desktop screens and can contain a variety of elements, such as [Button](/button) and [Images](/image). Popover is also the container used to construct more complex elements like [Dropdown](/dropdown) and the board picker, pictured below, which allow people to choose the board to save a Pin to.
 `}
     defaultCode={`
 function PopoverExample() {
@@ -144,7 +144,7 @@ card(
         type: '?HTMLElement',
         required: true,
         description:
-          'The reference element, typically [Button](/Button) or [IconButton](/IconButton), that Popover uses to set its position',
+          'The reference element, typically [Button](/button) or [IconButton](/iconbutton), that Popover uses to set its position',
       },
       {
         name: 'onDismiss',
@@ -174,7 +174,7 @@ card(
         type: 'boolean',
         defaultValue: true,
         description:
-          'Properly positions Popover relative to its anchor element. Set to false when used within [Layer](/Layer). See the [with Layer](#With-layer) variant to learn more.',
+          'Properly positions Popover relative to its anchor element. Set to false when used within [Layer](/layer). See the [with Layer](#With-layer) variant to learn more.',
       },
       {
         name: 'color',
@@ -222,8 +222,8 @@ card(
         title="When to Use"
         description={`
           - Providing additional information for related context without cluttering the surface of a workflow.
-          - Bringing attention to specific user interface elements for educational purposes. In this case, likely used with a [Pulsar](/Pulsar).
-          - Accommodating a variety of features, such as Buttons, Images or SearchFields, that are not available in [Dropdown](/Dropdown).
+          - Bringing attention to specific user interface elements for educational purposes. In this case, likely used with a [Pulsar](/pulsar).
+          - Accommodating a variety of features, such as Buttons, Images or SearchFields, that are not available in [Dropdown](/dropdown).
         `}
       />
       <MainSection.Card
@@ -233,8 +233,8 @@ card(
         description={`
           - Displaying critical information that prevents users from accomplishing a task.
           - Displaying information out of context.
-          - As a replacement for [Tooltip](/Tooltip).
-          - For presenting a list of actions or options. Use [Dropdown](/Dropdown) instead.
+          - As a replacement for [Tooltip](/tooltip).
+          - For presenting a list of actions or options. Use [Dropdown](/dropdown) instead.
         `}
       />
     </MainSection.Subsection>
@@ -475,7 +475,7 @@ function PopoverExample() {
       <MainSection.Card
         cardSize="md"
         type="don't"
-        description="Include a caret if Popover was triggered by user interaction, such as clicking or focusing on [Button](/Button) or [IconButton](/IconButton)."
+        description="Include a caret if Popover was triggered by user interaction, such as clicking or focusing on [Button](/button) or [IconButton](/iconbutton)."
         defaultCode={`
 function PopoverExample() {
   const [open, setOpen] = React.useState(false);
@@ -942,9 +942,9 @@ function PopoverExample() {
     <MainSection.Subsection
       title="Anchor"
       description={`
-Popover requires a reference element, typically [Button](/Button) or [IconButton](/IconButton), to set its position. The \`anchor\` ref can be directly set on the reference component itself. If the components don’t support \`ref\`, the anchor ref can be set to a parent [Box](/Box).
+Popover requires a reference element, typically [Button](/button) or [IconButton](/iconbutton), to set its position. The \`anchor\` ref can be directly set on the reference component itself. If the components don’t support \`ref\`, the anchor ref can be set to a parent [Box](/box).
 
-Popover calculates its position based on the bounding box of the \`anchor\`. Therefore, the \`anchor\` ref should only include the trigger element itself, usually [Button](/Button) or [IconButton](/IconButton), or the specific feature component that requires an educational Popover.
+Popover calculates its position based on the bounding box of the \`anchor\`. Therefore, the \`anchor\` ref should only include the trigger element itself, usually [Button](/button) or [IconButton](/iconbutton), or the specific feature component that requires an educational Popover.
 `}
     >
       <MainSection.Card
@@ -1019,7 +1019,7 @@ function PopoverExample() {
     <MainSection.Subsection
       title="With Layer"
       description={`
-Popover is typically used within [Layer](/Layer). Layer renders Popover outside the DOM hierarchy of the parent allowing it to overlay surrounding content. Popover calculates its position based on the bounding box of the \`anchor\`. Within Layer, Popover no longer shares a relative root with the \`anchor\` and requires \`positionRelativeToAnchor=false\` to properly calculate its position relative to the anchor element.
+Popover is typically used within [Layer](/layer). Layer renders Popover outside the DOM hierarchy of the parent allowing it to overlay surrounding content. Popover calculates its position based on the bounding box of the \`anchor\`. Within Layer, Popover no longer shares a relative root with the \`anchor\` and requires \`positionRelativeToAnchor=false\` to properly calculate its position relative to the anchor element.
 
 Using \`Layer\` with Popover eliminates the need to use \`z-index\` to solve stacking context conflicts. Popovers within Modals and Sheets with z-indexes don't require \`zIndex\` in \`Layer\` thanks to the built-in ScrollBoundaryContainer.
 `}
@@ -1235,7 +1235,7 @@ function ScrollBoundaryContainerExample() {
     <MainSection.Subsection
       title="Ideal direction"
       description={`
-Pass in \`idealDirection\` to specify the preferred position of Popover relative to the anchor, such as [Button](/Button) or [IconButton](/IconButton), that triggered it.
+Pass in \`idealDirection\` to specify the preferred position of Popover relative to the anchor, such as [Button](/button) or [IconButton](/iconbutton), that triggered it.
 
 Adjust the \`idealDirection\` as necessary to ensure the visibility of Popover and its contextual information. The default direction is "up", although Popover should be center-aligned directly below the element in most cases. The actual position may change given the available space around the anchor element.
 `}
@@ -1329,7 +1329,7 @@ function Example() {
     <MainSection.Subsection
       title="Within scrolling containers"
       description={`
-[ScrollBoundaryContainer](/ScrollBoundaryContainer) is needed for proper positioning when Popover is anchored to an element that is located within a scrolling container. The use of ScrollBoundaryContainer ensures Popover remains attached to its anchor when scrolling.
+[ScrollBoundaryContainer](/scrollboundarycontainer) is needed for proper positioning when Popover is anchored to an element that is located within a scrolling container. The use of ScrollBoundaryContainer ensures Popover remains attached to its anchor when scrolling.
 `}
     >
       <MainSection.Card
@@ -1442,19 +1442,19 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[Dropdown](/Dropdown)**
+**[Dropdown](/dropdown)**
 Dropdown is an element constructed using Popover as its container. Use Dropdown to display a list of actions or options in a Popover.
 
-**[Toast](/Toast)**
+**[Toast](/toast)**
 Toast provides feedback on an interaction. One example of Toast is the confirmation that appears when a Pin has been saved. Toasts appear at the bottom of a desktop screen or top of a mobile screen instead of being attached to any particular element on the interface.
 
-**[Tooltip](/Tooltip)**
-Tooltip describes the function of an interactive element, typically [IconButton](/IconButton), on hover. While Popovers offer broader content options, such as [Button](/Button) and [Images](/Images), Tooltips are purely text-based.
+**[Tooltip](/tooltip)**
+Tooltip describes the function of an interactive element, typically [IconButton](/iconbutton), on hover. While Popovers offer broader content options, such as [Button](/button) and [Images](/image), Tooltips are purely text-based.
 
-**[Layer](/Layer)**
+**[Layer](/layer)**
 Layer renders Popover outside the DOM hierarchy of the parent and prevents surrounding components overlaying Popover. See the [with Layer](#With-layer) variant to learn more.
 
-**[ScrollBoundaryContainer](/ScrollBoundaryContainer)**
+**[ScrollBoundaryContainer](/scrollboundarycontainer)**
 ScrollBoundaryContainer is needed for proper positioning when Popover is anchored to an element that is located within a scrolling container. The use of ScrollBoundaryContainer ensures that Popover remains attached to its anchor when scrolling. See the [within scrolling containers](#Within-scrolling-containers) variant to learn more.
     `}
     />

--- a/docs/pages/pulsar.js
+++ b/docs/pages/pulsar.js
@@ -64,7 +64,7 @@ card(
         type="do"
         title="When to Use"
         description={`
-          - Calling attention to a specific element within a surface. Note: a Pulsar should be used in conjunction with a [Popover](/Popover).
+          - Calling attention to a specific element within a surface. Note: a Pulsar should be used in conjunction with a [Popover](/popover).
         `}
       />
       <MainSection.Card
@@ -72,8 +72,8 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - In the case of a user error or warning that needs attention. Use [Callout](/Callout) or form errors states instead.
-          - When the focus of the attention is at the surface level. Use [Callout](/Callout) instead.
+          - In the case of a user error or warning that needs attention. Use [Callout](/callout) or form errors states instead.
+          - When the focus of the attention is at the surface level. Use [Callout](/callout) instead.
         `}
       />
     </MainSection.Subsection>

--- a/docs/pages/radiobutton.js
+++ b/docs/pages/radiobutton.js
@@ -105,8 +105,8 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - Any time users can choose more than one option. Use [Checkboxes](/Checkbox) instead.
-          - As a solitary option. RadioButtons should always appear in groups of 2 or more. Consider a [Checkbox](/Checkbox) or [Switch](/Switch) instead.
+          - Any time users can choose more than one option. Use [Checkboxes](/checkbox) instead.
+          - As a solitary option. RadioButtons should always appear in groups of 2 or more. Consider a [Checkbox](/checkbox) or [Switch](/switch) instead.
         `}
       />
     </MainSection.Subsection>
@@ -116,7 +116,7 @@ card(
 card(
   <Example
     description="
-    Here is an example of an accessible group of radio buttons. All radio buttons should be wrapped in a [Fieldset](/Fieldset).
+    Here is an example of an accessible group of radio buttons. All radio buttons should be wrapped in a [Fieldset](/fieldset).
   "
     name="RadioButton Group"
     defaultCode={`

--- a/docs/pages/scrollboundarycontainer.js
+++ b/docs/pages/scrollboundarycontainer.js
@@ -597,13 +597,13 @@ function ScrollBoundaryContainerExample() {
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-      **[Box](/Box)**
-      Box's [\`overflow\` prop](/Box#Overflow) specifies what should happen if the content is larger than the bounding box. Box should not be replaced with ScrollBoundaryContainer if the goal is simply to allow Box to scroll when content overflows. ScrollBoundaryContainer is only needed when anchored components, such as [Tooltip](/Tooltip), [Popover](/Popover), [ComboBox](/ComboBox)  or [Dropdown](/Dropdown), are used within a container that could potentially scroll.
+      **[Box](/box)**
+      Box's [\`overflow\` prop](/box#Overflow) specifies what should happen if the content is larger than the bounding box. Box should not be replaced with ScrollBoundaryContainer if the goal is simply to allow Box to scroll when content overflows. ScrollBoundaryContainer is only needed when anchored components, such as [Tooltip](/tooltip), [Popover](/popover), [ComboBox](/combobox)  or [Dropdown](/dropdown), are used within a container that could potentially scroll.
 
-      **[Modal](/Modal)** / **[Sheet](/Sheet)**
+      **[Modal](/modal)** / **[Sheet](/sheet)**
       Modal and Sheet come with ScrollBoundaryContainer built-in, so any anchored components used in their children tree should work out-of-the-box. Passing an additional ScrollBoundaryContainer will break the existing styling on scroll.
 
-      **[Tooltip](/Tooltip)** / **[Popover](/Popover)** / **[Dropdown](/Dropdown)** / **[ComboBox](/combobox)**
+      **[Tooltip](/tooltip)** / **[Popover](/popover)** / **[Dropdown](/dropdown)** / **[ComboBox](/combobox)**
       ScrollBoundaryContainer must be used around any of these components if they are used within a container that could possibly scroll. This is necessary to ensure the component remains attached to its anchor on scroll. If they are located within scrolling Modal or Sheet components, ScrollBoundaryContainer isn't needed as it's already built-in.
     `}
         />

--- a/docs/pages/selectlist.js
+++ b/docs/pages/selectlist.js
@@ -48,9 +48,9 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
             type="don't"
             title="When Not to Use"
             description={`
-          - When more than 10 options are presented and the ability to filter the list would be beneficial. Use [ComboBox](/ComboBox) instead.
-          - When extra functionality, like groups, subtext or badges, is needed. Use [Dropdown](/Dropdown) instead.
-          - When the options are links and navigate users to different places. Use [Dropdown](/Dropdown) instead.
+          - When more than 10 options are presented and the ability to filter the list would be beneficial. Use [ComboBox](/comboBox) instead.
+          - When extra functionality, like groups, subtext or badges, is needed. Use [Dropdown](/dropdown) instead.
+          - When the options are links and navigate users to different places. Use [Dropdown](/dropdown) instead.
           `}
           />
         </MainSection.Subsection>
@@ -81,7 +81,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
           <MainSection.Card
             cardSize="md"
             type="don't"
-            description="Use SelectList when additional functionality such as subtext or images are needed. Use [Dropdown](/Dropdown) instead."
+            description="Use SelectList when additional functionality such as subtext or images are needed. Use [Dropdown](/dropdown) instead."
             defaultCode={`
 <SelectList
   id="selectlistexample3"
@@ -123,7 +123,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
           <MainSection.Card
             cardSize="md"
             type="don't"
-            description="Use SelectList if there are fewer than 4 items in the list and there is space to display all options. Use [RadioButton](/RadioButton) instead."
+            description="Use SelectList if there are fewer than 4 items in the list and there is space to display all options. Use [RadioButton](/radiobutton) instead."
             defaultCode={`
 <SelectList
   id="selectlistexample5"
@@ -142,7 +142,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
           <MainSection.Card
             cardSize="md"
             type="do"
-            description="Keep the same type of selection for a group of items. An example of this might be a filter bar. If some items could use SelectList and some items need to use [Dropdown](/Dropdown), use Dropdown for all the items in the group."
+            description="Keep the same type of selection for a group of items. An example of this might be a filter bar. If some items could use SelectList and some items need to use [Dropdown](/dropdown), use Dropdown for all the items in the group."
             defaultCode={`
 <Flex gap={2}>
   <SelectList
@@ -180,7 +180,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
           <MainSection.Card
             cardSize="md"
             type="don't"
-            description="Mix [Dropdown](/Dropdown) and SelectList in a group of items."
+            description="Mix [Dropdown](/dropdown) and SelectList in a group of items."
             defaultCode={`
   function SubtextIconButtonFlyoutExample() {
     const [open, setOpen] = React.useState(false);
@@ -267,7 +267,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
         <MainSection.Subsection
           title="Labels"
           description={`
-      SelectList comes with [Label](/Label) built-in: just use the \`label\` prop. We strongly encourage always supplying a label. Be sure to provide a unique \`id\` so the Label is associated with the correct SelectList.`}
+      SelectList comes with [Label](/label) built-in: just use the \`label\` prop. We strongly encourage always supplying a label. Be sure to provide a unique \`id\` so the Label is associated with the correct SelectList.`}
         />
       </MainSection>
 
@@ -316,7 +316,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Helper text"
-          description="Helper text should be used when additional description may be required to understand the SelectList. Common examples include text that is legally required to be displayed, or instructions to fill out a form (e.g. proper formatting). If the text is optional, [Tooltip](/Tooltip) could be used instead."
+          description="Helper text should be used when additional description may be required to understand the SelectList. Common examples include text that is legally required to be displayed, or instructions to fill out a form (e.g. proper formatting). If the text is optional, [Tooltip](/tooltip) could be used instead."
         >
           <MainSection.Card
             cardSize="lg"
@@ -418,16 +418,16 @@ function Example(props) {
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[Dropdown](/Dropdown)**
+**[Dropdown](/dropdown)**
 If additional functionality is needed in the menu, such as subtext, headers or custom styling, use Dropdown.
 
 **[ComboBox](/combobox)**
 If users need the ability to choose an option by entering text to filter a long list of options, use ComboBox.
 
-**[RadioButton](/RadioButton)**
+**[RadioButton](/radiobutton)**
 If users need the ability to choose between fewer than 4 options, use RadioButton.
 
-**[Checkbox](/Checkbox)**
+**[Checkbox](/checkbox)**
 If users need the ability to choose between a yes/no option, use Checkbox.
 `}
         />

--- a/docs/pages/sheet.js
+++ b/docs/pages/sheet.js
@@ -125,8 +125,8 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - Getting user confirmation on an action. Use a [Modal](/Modal) instead.
-          - Displaying system errors or notices. Consider a [Callout](/Callout) instead.
+          - Getting user confirmation on an action. Use a [Modal](/modal) instead.
+          - Displaying system errors or notices. Consider a [Callout](/callout) instead.
           - Any time a separate, designated URL is desired.
         `}
       />
@@ -186,7 +186,7 @@ card(
       <MainSection.Card
         cardSize="lg"
         type="don't"
-        description="Use Sheet if edits or sub-tasks require more than two steps. Bring users to a full page experience or consider using [Modules](/Module) to section out content."
+        description="Use Sheet if edits or sub-tasks require more than two steps. Bring users to a full page experience or consider using [Modules](/module) to section out content."
         defaultCode={`
 
 `}
@@ -194,7 +194,7 @@ card(
       <MainSection.Card
         cardSize="lg"
         type="don't"
-        description="Use Sheet to confirm actions or display alerts. Use a [Modal](/Modal) or [Toast](/Toast) instead."
+        description="Use Sheet to confirm actions or display alerts. Use a [Modal](/modal) or [Toast](/toast) instead."
         defaultCode={`
 
 `}
@@ -1113,10 +1113,10 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[Modal](/Modal)**
+**[Modal](/modal)**
 For alerts, actions or acknowledgments that should block the user’s current flow, use Modal.
 
-**[Toast](/Toast)**
+**[Toast](/toast)**
 Toast provides feedback on an interaction. Toasts appear at the bottom of a desktop screen or top of a mobile screen, instead of being attached to any particular element on the interface.
     `}
     />

--- a/docs/pages/switch.js
+++ b/docs/pages/switch.js
@@ -74,7 +74,7 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - Choosing between related options. Each Switch should be considered a solitary, standalone option. For multiple, related choices, use [Checkboxes](Checkbox) or [RadioButtons](/RadioButton) instead.
+          - Choosing between related options. Each Switch should be considered a solitary, standalone option. For multiple, related choices, use [Checkboxes](/checkbox) or [RadioButtons](/radiobutton) instead.
         `}
       />
     </MainSection.Subsection>
@@ -85,7 +85,7 @@ card(
   <Example
     id="basicExample"
     description={`
-    Whenever you are using a \`Switch\` component, you should use a [Label](#/Label) with it to make your component accessible.
+    Whenever you are using a \`Switch\` component, you should use a [Label](/label) with it to make your component accessible.
   `}
     name="Example: Using a label"
     defaultCode={`

--- a/docs/pages/tabs.js
+++ b/docs/pages/tabs.js
@@ -13,7 +13,7 @@ const card = (c) => cards.push(c);
 card(
   <PageHeader
     name="Tabs"
-    description={`Tabs may be used navigate between multiple URLs. Tabs are intended as page-level navigation - if you're looking at just switching panels of content, please use [SegmentedControl](/SegmentedControl).`}
+    description={`Tabs may be used navigate between multiple URLs. Tabs are intended as page-level navigation - if you're looking at just switching panels of content, please use [SegmentedControl](/segmentedcontrol).`}
     defaultCode={`
     function DefaultExample() {
       const [activeIndex, setActiveIndex] = React.useState(0);
@@ -159,7 +159,7 @@ function TabExample() {
       <MainSection.Card
         cardSize="md"
         type="don't"
-        description="Use Tabs as a way to filter content. Consider using [SegmentedControl](/SegmentedControl) in this use-case."
+        description="Use Tabs as a way to filter content. Consider using [SegmentedControl](/segmentedcontrol) in this use-case."
         defaultCode={`
         function FilterExample() {
           const [activeIndex, setActiveIndex] = React.useState(0);
@@ -438,11 +438,11 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[Link](/Link)**
+**[Link](/link)**
 Link is used to navigate to different areas of the product or to external sites. Link is the preferred component in cases where you want to direct the user to unrelated content.
 
-**[SegmentedControl](/SegmentedControl)**
-SegmentedControl is used to switch between views within a small area of content, such as a [Popover](/Popover). SegmentedControl is preferred when changing state or selection within a view.
+**[SegmentedControl](/segmentedcontrol)**
+SegmentedControl is used to switch between views within a small area of content, such as a [Popover](/popover). SegmentedControl is preferred when changing state or selection within a view.
 `}
     />
   </MainSection>,

--- a/docs/pages/tag.js
+++ b/docs/pages/tag.js
@@ -13,7 +13,7 @@ const card = (c) => cards.push(c);
 card(
   <PageHeader
     name="Tag"
-    description="Tags are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](/TextField#tagsExample), [TextAreas](/TextArea#tagsExample), [ComboBox](/combobox#Tags) or as standalone components."
+    description="Tags are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](/textfield#tagsExample), [TextAreas](/textarea#tagsExample), [ComboBox](/combobox#Tags) or as standalone components."
   />,
 );
 
@@ -63,7 +63,7 @@ card(
         type="do"
         title="When to Use"
         description={`
-          - In conjunction with [TextField](/TextField#tagsExample), [TextArea](/TextArea#tagsExample), and [ComboBox](/ComboBox#Tags), or as a standalone element to display selected options.
+          - In conjunction with [TextField](/textfield#tagsExample), [TextArea](/textarea#tagsExample), and [ComboBox](/combobox#Tags), or as a standalone element to display selected options.
         `}
       />
       <MainSection.Card
@@ -71,7 +71,7 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - As a replacement for the [Badge](/Badge), as the Badge is a singular element that gives context to a specific subject.
+          - As a replacement for the [Badge](/badge), as the Badge is a singular element that gives context to a specific subject.
         `}
       />
     </MainSection.Subsection>

--- a/docs/pages/taparea.js
+++ b/docs/pages/taparea.js
@@ -171,7 +171,7 @@ card(
         description: [
           'Callback fired when a TapArea component is clicked (pressed and released) with a mouse or keyboard.',
           'Required with button-role + button-type buttons.',
-          'See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.',
+          'See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
         ],
         href: 'basic-taparea',
       },
@@ -301,7 +301,7 @@ card(
     id="link_buttons"
     description={`If you have a \`Link\` or \`Button\` inside of TapArea, you can apply \`e.stopPropagation()\` so the \`onTap\` doesn't get triggered.
 
-TapArea with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.
+TapArea with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.
   `}
     name="TapArea with Link/Buttons"
     defaultCode={`
@@ -626,7 +626,7 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[OnLinkNavigationProvider](/OnLinkNavigationProvider)**
+**[OnLinkNavigationProvider](/onlinknavigationprovider)**
 OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
       `}
     />

--- a/docs/pages/textarea.js
+++ b/docs/pages/textarea.js
@@ -116,7 +116,7 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - For inputs that expect a certain format, like a date or email. Use a [DatePicker](/datepicker) or [TextField](/textF=field) instead.
+          - For inputs that expect a certain format, like a date or email. Use a [DatePicker](/datepicker) or [TextField](/textfield) instead.
         `}
       />
     </MainSection.Subsection>
@@ -265,7 +265,7 @@ card(
     id="tagsExample"
     name="Example: Tags"
     description={`
-    You can include [Tag](/Tag) elements in the input using the \`tags\` prop.
+    You can include [Tag](/tag) elements in the input using the \`tags\` prop.
 
     Note that the \`TextArea\` component does not internally manage tags. That should be handled in the application state through the component's event callbacks. We recommend creating new tags on enter key presses, and removing them on backspaces when the cursor is in the beginning of the field. We also recommend filtering out empty tags.
 

--- a/docs/pages/textfield.js
+++ b/docs/pages/textfield.js
@@ -127,7 +127,7 @@ function Example(props) {
         id="tagsExample"
         name="Example: Tags"
         description={`
-    You can include [Tag](/Tag) elements in the input using the \`tags\` prop.
+    You can include [Tag](/tag) elements in the input using the \`tags\` prop.
 
     Note that TextField does not internally manage tags. That should be handled in the application state through the component's event callbacks. We recommend creating new tags on enter key presses, and removing them on backspaces when the cursor is in the beginning of the field. We also recommend filtering out empty tags.
 

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -32,7 +32,7 @@ export default function ToastPage({ generatedDocGen }: {| generatedDocGen: DocGe
             type="don't"
             title="When Not to Use"
             description={`
-          - Providing an update related to anything other than confirmation of a successful action. Consider a [Callout](/Callout) instead.
+          - Providing an update related to anything other than confirmation of a successful action. Consider a [Callout](/callout) instead.
           - Presenting mandatory and/or critical actions to a user.
           - Displaying feedback at the element level (e.g., entered password doesn't meet requirements). Use inline text instead.
         `}

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -12,7 +12,7 @@ card(
   <PageHeader
     name="Tooltip"
     description={`
-Tooltip is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/IconButton). It’s displayed continuously as long as the user hovers over or focuses on the element.`}
+Tooltip is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/iconbutton). It’s displayed continuously as long as the user hovers over or focuses on the element.`}
     defaultCode={`
       <Flex>
         <Tooltip text="Align left">
@@ -53,7 +53,7 @@ card(
       {
         name: 'children',
         type: 'React.Node',
-        description: `The anchor element, usually [Icon Button](/IconButton), that triggers Tooltip on hover or focus`,
+        description: `The anchor element, usually [Icon Button](/iconbutton), that triggers Tooltip on hover or focus`,
         required: true,
       },
       {
@@ -66,7 +66,7 @@ card(
       {
         name: 'inline',
         type: 'boolean',
-        description: `Properly positions Tooltip relative to an inline element, such as [Icon Button](/IconButton) using the inline property. See the [inline](#Inline) variant to learn more.`,
+        description: `Properly positions Tooltip relative to an inline element, such as [Icon Button](/iconbutton) using the inline property. See the [inline](#Inline) variant to learn more.`,
         defaultValue: 'false',
         href: 'Inline',
       },
@@ -114,7 +114,7 @@ card(
         title="When Not to Use"
         description={`
           - Displaying information that is critical to the understanding of an element/feature. Use inline text instead.
-          - Offering context at the surface-level scope. Consider a [Callout](/Callout) instead.
+          - Offering context at the surface-level scope. Consider a [Callout](/callout) instead.
         `}
       />
     </MainSection.Subsection>
@@ -127,7 +127,7 @@ card(
       <MainSection.Card
         cardSize="md"
         type="do"
-        description="Use Tooltip to describe the function of an interactive element, typically [Icon Button](/IconButton), in as few words as possible."
+        description="Use Tooltip to describe the function of an interactive element, typically [Icon Button](/iconbutton), in as few words as possible."
         defaultCode={`
 <Tooltip text="Send Pin">
   <IconButton
@@ -201,7 +201,7 @@ card(
       <MainSection.Card
         cardSize="md"
         type="do"
-        description="Use Tooltip to add supplementary information about a feature, typically paired with an `info-circle` [IconButton](/IconButton)."
+        description="Use Tooltip to add supplementary information about a feature, typically paired with an `info-circle` [IconButton](/iconbutton)."
         defaultCode={`
 <Tooltip text="Total ad spend in the select time period">
   <IconButton
@@ -245,7 +245,7 @@ card(
     <MainSection.Subsection
       title="Labels"
       description={`
-When using Tooltip with [IconButton](/IconButton), avoid repetitive labeling. The \`accessibilityLabel\` provided to IconButton should describe the intent of the button, not the icon itself. For instance, use “Settings” instead of “Cog icon”. Tooltip \`text\` can expand upon that intention, as seen with the \`cog\` IconButton. If Tooltip \`text\` and IconButton \`accessibilityLabel\` contain the same content, pass an empty string to \`accessibilityLabel\`, as seen with the \`send\` IconButton.`}
+When using Tooltip with [IconButton](/iconbutton), avoid repetitive labeling. The \`accessibilityLabel\` provided to IconButton should describe the intent of the button, not the icon itself. For instance, use “Settings” instead of “Cog icon”. Tooltip \`text\` can expand upon that intention, as seen with the \`cog\` IconButton. If Tooltip \`text\` and IconButton \`accessibilityLabel\` contain the same content, pass an empty string to \`accessibilityLabel\`, as seen with the \`send\` IconButton.`}
       columns={2}
     >
       <MainSection.Card
@@ -280,9 +280,9 @@ When using Tooltip with [IconButton](/IconButton), avoid repetitive labeling. Th
     <MainSection.Subsection
       title="Disabled elements"
       description={`
-Tooltips must be paired with an interactive, focusable element, like [Button](/Button) or [IconButton](/IconButton). They cannot be paired with anything disabled or static, because this prevents keyboard users from triggering Tooltip and consuming its content. To test if you’re using Tooltip properly, use your keyboard rather than your mouse to trigger Tooltip.
+Tooltips must be paired with an interactive, focusable element, like [Button](/button) or [IconButton](/iconbutton). They cannot be paired with anything disabled or static, because this prevents keyboard users from triggering Tooltip and consuming its content. To test if you’re using Tooltip properly, use your keyboard rather than your mouse to trigger Tooltip.
 
-If you need to explain why an item is disabled, consider adding plain [Text](/Text) near the disabled item, or an \`info-circle\` [IconButton](/IconButton) adjacent to the disabled element.
+If you need to explain why an item is disabled, consider adding plain [Text](/text) near the disabled item, or an \`info-circle\` [IconButton](/iconbutton) adjacent to the disabled element.
 `}
     />
     <MainSection.Card />
@@ -367,7 +367,7 @@ card(
     </MainSection.Subsection>
     <MainSection.Subsection
       title="Inline"
-      description="Use inline to properly position Tooltip relative to an inline element, such as an [Icon Button](/IconButton)"
+      description="Use inline to properly position Tooltip relative to an inline element, such as an [Icon Button](/iconbutton)"
     >
       <MainSection.Card
         cardSize="lg"
@@ -459,7 +459,7 @@ function SectionsIconButtonDropdownExample() {
     </MainSection.Subsection>
     <MainSection.Subsection
       title="Z-index"
-      description={`Tooltip has [Layer](/Layer) built in, allowing it to overlay surrounding content. Use \`zIndex\` to specify the stacking order of Tooltip along the z-axis in the current stacking context. The example below shows [FixedZIndex](/ZIndex%20Classes#FixedZIndex) used in [Modal](/Modal) and [CompositeZIndex](ZIndex%20Classes#CompositeZIndex) to layer Tooltip on top.
+      description={`Tooltip has [Layer](/layer) built in, allowing it to overlay surrounding content. Use \`zIndex\` to specify the stacking order of Tooltip along the z-axis in the current stacking context. The example below shows [FixedZIndex](/zindex%20classes#FixedZIndex) used in [Modal](/modal) and [CompositeZIndex](ZIndex%20Classes#CompositeZIndex) to layer Tooltip on top.
 
 `}
     >
@@ -860,13 +860,13 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[Popover](/Popover)**
-Popover displays a lightweight task related to the content on screen. One example of Popover is the board picker, which allows people to choose the board to save a Pin to. While Tooltips are purely text-based, Popovers offer broader content options, such as [Buttons](/Buttons) and [Images](/Images).
+**[Popover](/popover)**
+Popover displays a lightweight task related to the content on screen. One example of Popover is the board picker, which allows people to choose the board to save a Pin to. While Tooltips are purely text-based, Popovers offer broader content options, such as [Buttons](/button) and [Images](/image).
 
-**[ScrollBoundaryContainer](/ScrollBoundaryContainer)**
+**[ScrollBoundaryContainer](/scrollboundarycontainer)**
 ScrollBoundaryContainer is needed for proper positioning when Tooltip is anchored to an element that is located within a scrolling container. The use of ScrollBoundaryContainer ensures Tooltip remains attached to its anchor when scrolling. See the [within scrolling containers](#Within-scrolling-containers) variant to learn more.
 
-**[Toast](/Toast)**
+**[Toast](/toast)**
 Toast provides feedback on an interaction. One example of Toast is the confirmation that appears when a Pin has been saved. Toasts appear at the bottom of a desktop screen or top of a mobile screen, instead of being attached to any particular element on the interface.
     `}
     />

--- a/docs/pages/upsell.js
+++ b/docs/pages/upsell.js
@@ -64,7 +64,7 @@ card(
           '{| component: typeof Image | typeof Icon, width?: number, mask: { rounding: "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8, wash: boolean} |}',
         defaultValue: null,
         description:
-          'Either an [Icon](/Icon) or an [Image](/Image) to render at the start of the banner. Width is not used with Icon. Image width defaults to 128px. See the [Icon](#Icon) and [Image](#Image) variants for more info.',
+          'Either an [Icon](/icon) or an [Image](/image) to render at the start of the banner. Width is not used with Icon. Image width defaults to 128px. See the [Icon](#Icon) and [Image](#Image) variants for more info.',
       },
       {
         name: 'message',
@@ -79,7 +79,7 @@ card(
           '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
         defaultValue: null,
         description: `
-          Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.'
+          Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.'
           If no \`href\` is supplied, the action will be a button.
           The \`accessibilityLabel\` should follow the [Accessibility guidelines](#Accessibility).
         `,
@@ -90,7 +90,7 @@ card(
           '{| accessibilityLabel: string, disabled?: boolean, href?: string, label: string, onClick?: AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
         defaultValue: null,
         description: `
-          Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.'
+          Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.'
           If no \`href\` is supplied, the action will be a button.
           The \`accessibilityLabel\` should follow the [Accessibility guidelines](#Accessibility).
         `,
@@ -115,7 +115,7 @@ card(
         name: 'children',
         type: 'React.Node',
         required: true,
-        description: `Contents of the form, typically inputs like [TextField(s)](/TextField).`,
+        description: `Contents of the form, typically inputs like [TextField(s)](/textfield).`,
       },
       {
         name: 'onSubmit',
@@ -162,7 +162,7 @@ card(
         type="don't"
         title="When Not to Use"
         description={`
-          - Anything related to state or status within the surface. Consider a [Callout](/Callout) instead.
+          - Anything related to state or status within the surface. Consider a [Callout](/callout) instead.
           - Promoting or highlighting specific elements / areas within a surface. [Let the team know](https://app.slack.com/client/T024LJUGB/C0HUV5J93) if this is needed.
         `}
       />
@@ -279,7 +279,7 @@ card(
         cardSize="lg"
         type="don't"
         description={`
-          Use Upsells for critical information, such as errors or warnings. Use [Callout](/Callout) instead. Upsells should not be used for general information either.
+          Use Upsells for critical information, such as errors or warnings. Use [Callout](/callout) instead. Upsells should not be used for general information either.
         `}
         defaultCode={`
 <Upsell
@@ -301,7 +301,7 @@ card(
         cardSize="lg"
         type="don't"
         description={`
-        Stack Upsells on a page. In the case that they must be stacked, [Callouts](/Callout) will appear above Upsells.
+        Stack Upsells on a page. In the case that they must be stacked, [Callouts](/callout) will appear above Upsells.
         `}
         defaultCode={`
 <Box>
@@ -396,11 +396,11 @@ card(
       description={`
       \`dismissButton\`, \`primaryAction\`, \`secondaryAction\`, and \`submitButtonAccessibilityLabel\` each require a short, descriptive label for screen readers, which should also be localized.
 
-      In the case of action [Buttons](/Button) or [Links](/Link), alternative text should be provided through the \`accessibilityLabel\` prop to replace vague text like "Visit" or "Learn more" with more descriptive information, like "Learn more about work from home resources". Avoid using the words "button" or "link" in the label, as this becomes repetitive. If the action text is already descriptive, an empty string can be passed.
+      In the case of action [Buttons](/button) or [Links](/link), alternative text should be provided through the \`accessibilityLabel\` prop to replace vague text like "Visit" or "Learn more" with more descriptive information, like "Learn more about work from home resources". Avoid using the words "button" or "link" in the label, as this becomes repetitive. If the action text is already descriptive, an empty string can be passed.
 
-      For the \`dismissButton\` [IconButton](/IconButton), the label provided should indicate the intent, like “Dismiss this banner”.
+      For the \`dismissButton\` [IconButton](/iconbutton), the label provided should indicate the intent, like “Dismiss this banner”.
 
-      The [Image](/Image) or [Icon](/Icon) supplied to \`imageData\` should only supply an \`alt\` or \`accessibilityLabel\`, respectively, if the Image or Icon supplies extra context or information. Icons in Upsells are often purely decorative, and can therefore have an empty string as the \`accessibilityLabel\`.
+      The [Image](/image) or [Icon](/icon) supplied to \`imageData\` should only supply an \`alt\` or \`accessibilityLabel\`, respectively, if the Image or Icon supplies extra context or information. Icons in Upsells are often purely decorative, and can therefore have an empty string as the \`accessibilityLabel\`.
       `}
     >
       <MainSection.Card
@@ -478,7 +478,7 @@ card(
 
     <MainSection.Subsection
       title="Icon"
-      description="The Icon is used to add additional meaning to the Upsell. The icon can reference a Pinterest product, feature or an action from our [Icon library](/Icon)."
+      description="The Icon is used to add additional meaning to the Upsell. The icon can reference a Pinterest product, feature or an action from our [Icon library](/icon)."
     >
       <MainSection.Card
         cardSize="lg"
@@ -506,7 +506,7 @@ card(
 
     <MainSection.Subsection
       title="Image"
-      description="The [Image](/Image) in Upsell is used to add visual interest and draw the user’s attention. Images should relate to the message of the Upsell. Upsell images should use approved photography or be illustrations using our brand colors. Images will always be 128px wide."
+      description="The [Image](/image) in Upsell is used to add visual interest and draw the user’s attention. Images should relate to the message of the Upsell. Upsell images should use approved photography or be illustrations using our brand colors. Images will always be 128px wide."
     >
       <MainSection.Card
         cardSize="lg"
@@ -547,9 +547,9 @@ card(
       description={`
       Upsells can have either one primary action, or a primary action and a secondary action. These actions can be buttons, when no \`href\` is supplied, or links, by specifying the \`href\`  property.
 
-      Upsell actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/OnLinkNavigationProvider) to learn more about link navigation.
+      Upsell actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.
 
-      For example, “Learn more” may link to a separate documentation site, while “Send invite” could be a button that opens a [Modal](/Modal) with an invite flow. Be sure to localize the labels of the actions.
+      For example, “Learn more” may link to a separate documentation site, while “Send invite” could be a button that opens a [Modal](/modal) with an invite flow. Be sure to localize the labels of the actions.
 
       If needed, actions can become disabled after clicking by setting \`disabled: true\` in the action data.
       `}
@@ -787,16 +787,16 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-      **[Callout](/Callout)**
+      **[Callout](/callout)**
       Use Callout when communicating critical information, such as an error or warning. Callout can also be used to present the user with general information and further actions they can take, like the successful creation of a business account.
 
-      **[Toast](/Toast)**
+      **[Toast](/toast)**
       Toast provides feedback on a user interaction, like a confirmation that appears when a Pin has been saved. Unlike Upsell and Callout, Toasts don’t contain actions. They’re also less persistent, and disappear after a certain duration.
 
-      **[OnLinkNavigationProvider](/OnLinkNavigationProvider)**
+      **[OnLinkNavigationProvider](/onlinknavigationprovider)**
       OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
 
-      **[ActivationCard](/ActivationCard)**
+      **[ActivationCard](/activationcard)**
       ActivationCards are used in groups to communicate a user’s stage in a series of steps toward an overall action.
 
     `}

--- a/docs/pages/zindex_classes.js
+++ b/docs/pages/zindex_classes.js
@@ -236,7 +236,7 @@ const canvas = (
         cardSize="lg"
         type="do"
         description={`
-Use Layer instead of z-index when a component needs to visually break out of its parent container, for example, in the case of [modals](/Modal), [sheets](/Sheet) and [tooltips](/Tooltip). See [z-Index in foundational components](#zIndex-in-foundational-components) and [ZIndex in Layer](#zIndex-in-Layer) to learn more.
+Use Layer instead of z-index when a component needs to visually break out of its parent container, for example, in the case of [modals](/modal), [sheets](/sheet) and [tooltips](/tooltip). See [z-Index in foundational components](#zIndex-in-foundational-components) and [ZIndex in Layer](#zIndex-in-Layer) to learn more.
 ~~~jsx
 const modal = (
   <Layer>
@@ -252,7 +252,7 @@ const modal = (
         cardSize="lg"
         type="don't"
         description={`
-Use Box with high fixed z-index values to position your components at the top of the stacking context or use them redundantly with [Layer](/Layer). See [z-Index in foundational components](#zIndex-in-foundational-components) and [ZIndex in Layer](#zIndex-in-Layer) to learn more.
+Use Box with high fixed z-index values to position your components at the top of the stacking context or use them redundantly with [Layer](/layer). See [z-Index in foundational components](#zIndex-in-foundational-components) and [ZIndex in Layer](#zIndex-in-Layer) to learn more.
 ~~~jsx
 import { FixedZIndex } from 'gestalt';
 
@@ -289,11 +289,11 @@ card(
     <MainSection.Subsection
       title="z-index in foundational components"
       description={`
-[Box](/Box), [Sticky](/Sticky), and [Layer](/Layer) are foundational components that have \`zIndex\` props. If any other components need to be positioned within their stacking context, wrap with one of these foundational components to set the z-index.
+[Box](/box), [Sticky](/sticky), and [Layer](/layer) are foundational components that have \`zIndex\` props. If any other components need to be positioned within their stacking context, wrap with one of these foundational components to set the z-index.
 
 Layer creates a new stacking context. Unless there's a conflict with another z-index, don't pass unnecessary \`zIndex\` to Layer.
 
-The following example sets a z-index in the Layer wrapping [Sheet](/Sheet) to position Sheet over the page header in the Docs. Set \`PAGE_HEADER_ZINDEX\` below 10 to see the importance of z-index in this example.`}
+The following example sets a z-index in the Layer wrapping [Sheet](/sheet) to position Sheet over the page header in the Docs. Set \`PAGE_HEADER_ZINDEX\` below 10 to see the importance of z-index in this example.`}
     >
       <MainSection.Card
         cardSize="lg"
@@ -503,13 +503,13 @@ function ScrollBoundaryContainerExample() {
     <MainSection.Subsection
       title="z-index in Layer"
       description={`
-[Modal](/Modal) and [Sheet](/Sheet) always require a parent [Layer](/Layer) to position themselves outside the DOM hierarchy.
+[Modal](/modal) and [Sheet](/sheet) always require a parent [Layer](/layer) to position themselves outside the DOM hierarchy.
 
-Components built on top of [Popover](/Popover), such as [Tooltip](/Tooltip), [Dropdown](/Dropdown) and [ComboBox](/combobox), have a built-in Layer to be positioned outside the DOM hierarchy.  To set the internal z-index value of Layer, these Popover-based components have \`zIndex\` props as well. This is used when placing the Popover-based components within another component wrapped in Layer that has a z-index set.
+Components built on top of [Popover](/popover), such as [Tooltip](/tooltip), [Dropdown](/dropdown) and [ComboBox](/combobox), have a built-in Layer to be positioned outside the DOM hierarchy.  To set the internal z-index value of Layer, these Popover-based components have \`zIndex\` props as well. This is used when placing the Popover-based components within another component wrapped in Layer that has a z-index set.
 
-However, Modal and Sheet have a built-in [ScrollBoundaryContainer](/ScrollBoundaryContainer) wrapping their children, so you shouldn’t need to pass z-index values when using Popover-based children.
+However, Modal and Sheet have a built-in [ScrollBoundaryContainer](/scrollboundarycontainer) wrapping their children, so you shouldn’t need to pass z-index values when using Popover-based children.
 
-The following example sets a z-index in the Layer wrapping [Modal](/Modal) to position Modal over the page header in the Docs. Thanks to ScrollBoundaryContainer, child Tooltips don't require z-index.`}
+The following example sets a z-index in the Layer wrapping [Modal](/modal) to position Modal over the page header in the Docs. Thanks to ScrollBoundaryContainer, child Tooltips don't require z-index.`}
     >
       <MainSection.Card
         cardSize="lg"
@@ -681,7 +681,7 @@ card(
   <MainSection name="Related">
     <MainSection.Subsection
       description={`
-**[Layer](/Layer)**
+**[Layer](/layer)**
 Layer allows you to render children outside the DOM hierarchy of the parent. This is useful for places you might otherwise need to use z-index to overlay the screen, simplifying the stacking context complexity in the app. See [z-Index in foundational components](#zIndex-in-foundational-components) and [ZIndex in Layer](#zIndex-in-Layer) to learn more.
     `}
     />

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
@@ -18,7 +18,7 @@ const rule: ESLintRule = {
       description: 'Button icon restrictions',
       category: 'Gestalt restrictions',
       recommended: false,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltbutton-icon-restrictions',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltbutton-icon-restrictions',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.js
@@ -32,7 +32,7 @@ const rule: ESLintRule = {
       category: 'Gestalt restrictions',
       recommended: false,
       url:
-        'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-box-dangerous-style-duplicates',
+        'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-box-dangerous-style-duplicates',
     },
     fixable: 'code',
     schema: [

--- a/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js
@@ -137,7 +137,7 @@ const rule: ESLintRule = {
       description: `Don't allow props different from the officially-supported Box props and the allowed-list of passthrough React / DOM props`,
       category: 'Gestalt restrictions',
       recommended: false,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-box-disallowed-props',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-box-disallowed-props',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
@@ -30,7 +30,7 @@ const rule: ESLintRule = {
         'Enforce usage of Right-to-Left (RTL)-compliant marginStart/marginEnd over marginLeft/marginRight',
       category: 'Deprecated ESlint rules',
       recommended: false,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-box-marginleft-marginright',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-box-marginleft-marginright',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
@@ -95,7 +95,7 @@ const rule: ESLintRule = {
       description: `Don't allow useless props combinations on Box`,
       category: 'Gestalt restrictions',
       recommended: false,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-box-useless-props',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-box-useless-props',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
+++ b/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
@@ -14,7 +14,7 @@ const rule: ESLintRule = {
       description: 'Disallow medium form fields',
       category: 'Gestalt restrictions',
       recommended: false,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-medium-formfields',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-medium-formfields',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-role-link-components.js
+++ b/packages/eslint-plugin-gestalt/src/no-role-link-components.js
@@ -15,7 +15,7 @@ const rule: ESLintRule = {
       description: 'Disallow role-link on Gestalt components',
       category: 'Deprecated ESlint rules',
       recommended: false,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-role-link-components',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-role-link-components',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/no-spread-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-spread-props.js
@@ -21,7 +21,7 @@ const rule: ESLintRule = {
         'Prevent spreading props in Gestalt components to enable AST codemods and usage-metrics scripts.',
       category: 'Gestalt alternatives',
       recommended: true,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltno-spread-props',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-spread-props',
     },
     fixable: 'code',
     schema: ([]: $ReadOnlyArray<empty>),

--- a/packages/eslint-plugin-gestalt/src/prefer-box-as-tag.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-as-tag.js
@@ -31,7 +31,7 @@ const rule: ESLintRule = {
       )}, instead',
       category: 'Gestalt alternatives`,
       recommended: true,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltprefer-box-as-tag',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-box-as-tag',
     },
     fixable: 'code',
     schema: ([]: $ReadOnlyArray<empty>),

--- a/packages/eslint-plugin-gestalt/src/prefer-box-inline-style.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-inline-style.js
@@ -37,7 +37,7 @@ const rule: ESLintRule = {
       description: 'Warns over div inline styling that is already available as Box props',
       category: 'Gestalt alternatives',
       recommended: false,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltprefer-box-inline-style',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-box-inline-style',
     },
     schema: [
       {

--- a/packages/eslint-plugin-gestalt/src/prefer-box-no-disallowed.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-no-disallowed.js
@@ -29,7 +29,7 @@ const rule: ESLintRule = {
         "Prefer Box: prevent <div> tags that don't contain disallowed attributes: className, onClick. Use Gestalt Box, instead",
       category: 'Gestalt alternatives',
       recommended: true,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltprefer-box-no-disallowed',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-box-no-disallowed',
     },
     fixable: 'code',
     schema: [

--- a/packages/eslint-plugin-gestalt/src/prefer-flex.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-flex.js
@@ -38,7 +38,7 @@ const rule: ESLintRule = {
       description: 'Encourage usage of Flex instead of Box',
       category: 'Gestalt alternatives',
       recommended: true,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltprefer-flex',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-flex',
     },
 
     fixable: 'code',

--- a/packages/eslint-plugin-gestalt/src/prefer-link.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-link.js
@@ -36,7 +36,7 @@ const rule: ESLintRule = {
         'Prefer Link: Prevent anchor tags that only contain attributes matching supported props in Gestalt Link. Use Gestalt Link, instead',
       category: 'Gestalt alternatives',
       recommended: true,
-      url: 'https://gestalt.pinterest.systems/Eslint%20Plugin#gestaltprefer-link',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-link',
     },
     fixable: 'code',
     schema: [

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -35,10 +35,10 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/DatePicker
+ * https://gestalt.pinterest.systems/datepicker
  */
 /**
- * [DatePicker](https://gestalt.pinterest.systems/DatePicker) is used when the user has to select a date or date range.
+ * [DatePicker](https://gestalt.pinterest.systems/datepicker) is used when the user has to select a date or date range.
  *
  * ![DatePicker closed light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/DatePicker-closed%20%230.png)
  * ![DatePicker open light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/DatePicker-open%20%230.png)

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -209,7 +209,7 @@ const UncompletedCard = ({
 };
 
 /**
- * [ActivationCards](https://gestalt.pinterest.systems/ActivationCard) are used in groups to communicate a user’s stage in a series of steps toward an overall action.
+ * [ActivationCards](https://gestalt.pinterest.systems/activationcard) are used in groups to communicate a user’s stage in a series of steps toward an overall action.
  */
 export default function ActivationCard({
   dismissButton,

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -43,7 +43,7 @@ type Props = {|
 |};
 
 /**
- * Use [Avatar](https://gestalt.pinterest.systems/Avatar) to represent a user. Every Avatar image has a subtle color wash.
+ * [Avatar](https://gestalt.pinterest.systems/avatar) is used to represent a user. Every Avatar image has a subtle color wash.
  */
 export default function Avatar(props: Props): Node {
   const [isImageLoaded, setIsImageLoaded] = useState(true);

--- a/packages/gestalt/src/AvatarGroup.js
+++ b/packages/gestalt/src/AvatarGroup.js
@@ -14,62 +14,62 @@ type Props = {|
   /**
    * Label for screen readers to announce AvatarGroup.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/AvatarGroup#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/avatargroup#Accessibility) for details on proper usage.
    */
   accessibilityLabel: string,
   /**
    * Specify the `id` of an associated element (or elements) whose contents or visibility are controlled by a component so that screen reader users can identify the relationship between elements. Optional with button-role component.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/AvatarGroup#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/avatargroup#Accessibility) for details on proper usage.
    */
   accessibilityControls?: string,
   /**
    * Indicate that a component hides or exposes collapsible components and expose whether they are currently expanded or collapsed. Optional with button-role component.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/AvatarGroup#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/avatargroup#Accessibility) for details on proper usage.
    */
   accessibilityExpanded?: boolean,
   /**
    * Indicate that a component controls the appearance of interactive popup elements, such as menu or dialog. Optional with button-role component.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/AvatarGroup#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/avatargroup#Accessibility) for details on proper usage.
    */
   accessibilityHaspopup?: boolean,
   /**
-   * When supplied, it appends an `add` [icon](https://gestalt.pinterest.systems/Icon) to the avatar pile as a call to action to the user. See [Best Practices](https://gestalt.pinterest.systems/AvatarGroup#Best-practices) for more info.
+   * When supplied, it appends an `add` [icon](https://gestalt.pinterest.systems/Icon) to the avatar pile as a call to action to the user. See [Best Practices](https://gestalt.pinterest.systems/avatargroup#Best-practices) for more info.
    */
   addCollaborators?: boolean,
   /**
-   * The user group data. See the [collaborators display](https://gestalt.pinterest.systems/AvatarGroup#Collaborators-display) variant to learn more.
+   * The user group data. See the [collaborators display](https://gestalt.pinterest.systems/avatargroup#Collaborators-display) variant to learn more.
    */
   collaborators: $ReadOnlyArray<{|
     name: string,
     src?: string,
   |}>,
   /**
-   * When supplied, wraps the component in a link, and directs users to the url when item is selected. See the [role](https://gestalt.pinterest.systems/AvatarGroup#Role) variant to learn more.
+   * When supplied, wraps the component in a link, and directs users to the url when item is selected. See the [role](https://gestalt.pinterest.systems/avatargroup#Role) variant to learn more.
    */
   href?: string,
   /**
-   * Callback fired when the component is clicked (pressed and released) with a mouse or keyboard. See the [role](https://gestalt.pinterest.systems/AvatarGroup#Role) variant to learn more and see [TapArea's `onTap`](https://gestalt.pinterest.systems/taparea#Props-onTap) for more info about `OnTapType`.
+   * Callback fired when the component is clicked (pressed and released) with a mouse or keyboard. See the [role](https://gestalt.pinterest.systems/avatargroup#Role) variant to learn more and see [TapArea's `onTap`](https://gestalt.pinterest.systems/taparea#Props-onTap) for more info about `OnTapType`.
    */
   onClick?: OnTapType,
   /**
-   * Forward the ref to the underlying div or anchor element. See the [role](https://gestalt.pinterest.systems/AvatarGroup#Role) variant to learn more.
+   * Forward the ref to the underlying div or anchor element. See the [role](https://gestalt.pinterest.systems/avatargroup#Role) variant to learn more.
    */
   ref?: UnionRefs, // eslint-disable-line react/no-unused-prop-types
   /**
-   * Allows user interaction with the component. See the [role](https://gestalt.pinterest.systems/AvatarGroup#Role) variant to learn more.
+   * Allows user interaction with the component. See the [role](https://gestalt.pinterest.systems/avatargroup#Role) variant to learn more.
    */
   role?: 'link' | 'button',
   /**
-   * The maximum height of AvatarGroup. If size is `fit`, AvatarGroup will fill 100% of the parent container width. See the [fixed size](https://gestalt.pinterest.systems/AvatarGroup#Fixed-sizes) and [responsive size](https://gestalt.pinterest.systems/AvatarGroup#Responsive-sizing) variant to learn more.
+   * The maximum height of AvatarGroup. If size is `fit`, AvatarGroup will fill 100% of the parent container width. See the [fixed size](https://gestalt.pinterest.systems/avatargroup#Fixed-sizes) and [responsive size](https://gestalt.pinterest.systems/avatargroup#Responsive-sizing) variant to learn more.
    */
   size?: 'xs' | 'sm' | 'md' | 'fit',
 |};
 
 /**
- * [AvatarGroup](https://gestalt.pinterest.systems/AvatarGroup) is used to both display a group of user avatars and, optionally, control actions related to the users group.
+ * [AvatarGroup](https://gestalt.pinterest.systems/avatargroup) is used to both display a group of user avatars and, optionally, control actions related to the users group.
  *
  * ![AvatarGroup light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/AvatarGroup%20%230.png)
  * ![AvatarGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/AvatarGroup-dark%20%230.png)

--- a/packages/gestalt/src/AvatarPair.js
+++ b/packages/gestalt/src/AvatarPair.js
@@ -23,7 +23,7 @@ const sizes = {
 };
 
 /**
- * [AvatarPair](https://gestalt.pinterest.systems/AvatarPair) displays two avatars in an overlapping grouping.
+ * [AvatarPair](https://gestalt.pinterest.systems/avatarpair) is used to display two avatars in an overlapping grouping.
  */
 export default function AvatarPair({ collaborators, size = 'fit' }: Props): Node {
   const width = size === 'fit' ? '100%' : sizes[size];

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -19,7 +19,7 @@ type Props = {|
 |};
 
 /**
- * [Badge](https://gestalt.pinterest.systems/Badge) helps to label text.
+ * [Badge](https://gestalt.pinterest.systems/badge) is used to label text.
  */
 export default function Badge({ position = 'middle', text }: Props): Node {
   const { name: colorSchemeName } = useColorScheme();

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -411,7 +411,7 @@ const disallowedProps = [
 type OutputType = Element<As>;
 
 /**
- * [Box](https://gestalt.pinterest.systems/Box) is a component primitive that can be used to build the foundation of pretty much any other component. It keeps details like spacing, borders and colors consistent with the rest of Gestalt, while allowing the developer to focus on the content.
+ * [Box](https://gestalt.pinterest.systems/box) is a component primitive that can be used to build the foundation of pretty much any other component. It keeps details like spacing, borders and colors consistent with the rest of Gestalt, while allowing the developer to focus on the content.
  */
 const BoxWithForwardRef: AbstractComponent<Props, HTMLElement> = forwardRef<Props, HTMLElement>(
   function Box({ as, ...props }: Props, ref): OutputType {

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -102,7 +102,7 @@ const IconEnd = ({
 );
 
 /**
- * https://gestalt.pinterest.systems/Button
+ * https://gestalt.pinterest.systems/button
  */
 const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,

--- a/packages/gestalt/src/ButtonGroup.js
+++ b/packages/gestalt/src/ButtonGroup.js
@@ -10,7 +10,7 @@ type Props = {|
 |};
 
 /**
- * [ButtonGroup](https://gestalt.pinterest.systems/ButtonGroup) is used to display a series of buttons.
+ * [ButtonGroup](https://gestalt.pinterest.systems/buttongroup) is used to display a series of buttons.
  */
 function ButtonGroup({ children }: Props): Node {
   if (Children.count(children) === 0) {

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -157,7 +157,7 @@ const CalloutAction = ({
 };
 
 /**
- * [Callout](https://gestalt.pinterest.systems/Callout) is a banner displaying short messages with helpful information for a task on the page, or something that requires the user’s attention.
+ * [Callout](https://gestalt.pinterest.systems/callout) is a banner displaying short messages with helpful information for a task on the page, or something that requires the user’s attention.
  *
  * ⚠️ Please note: Callout is not currently supported in dark mode.
  */

--- a/packages/gestalt/src/Card.js
+++ b/packages/gestalt/src/Card.js
@@ -16,7 +16,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Card
+ * https://gestalt.pinterest.systems/card
  */
 export default function Card(props: Props): Node {
   const [hovered, setHovered] = useState(false);

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -32,7 +32,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Checkbox
+ * https://gestalt.pinterest.systems/checkbox
  */
 const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -153,7 +153,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Collage
+ * https://gestalt.pinterest.systems/collage
  */
 export default function Collage(props: Props): Node {
   const { columns, cover, gutter, height, layoutKey, renderImage, width } = props;

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -57,7 +57,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Collection
+ * https://gestalt.pinterest.systems/collection
  */
 export default function Collection(props: Props): Node {
   const { Item, layout = [], viewportTop = 0, viewportLeft = 0 } = props;

--- a/packages/gestalt/src/Column.js
+++ b/packages/gestalt/src/Column.js
@@ -14,7 +14,7 @@ type ColumnProps = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Column
+ * https://gestalt.pinterest.systems/column
  */
 export default function Column(props: ColumnProps): Node {
   const { children } = props;

--- a/packages/gestalt/src/Container.js
+++ b/packages/gestalt/src/Container.js
@@ -7,7 +7,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Container
+ * https://gestalt.pinterest.systems/container
  */
 export default function Container(props: Props): Node {
   const { children } = props;

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -23,7 +23,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Datapoint
+ * https://gestalt.pinterest.systems/datapoint
  */
 export default function Datapoint({
   tooltipText,

--- a/packages/gestalt/src/Divider.js
+++ b/packages/gestalt/src/Divider.js
@@ -3,7 +3,7 @@ import type { Node } from 'react';
 import styles from './Divider.css';
 
 /**
- * https://gestalt.pinterest.systems/Divider
+ * https://gestalt.pinterest.systems/divider
  */
 export default function Divider(): Node {
   return <hr className={styles.divider} />;

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -97,7 +97,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Dropdown
+ * https://gestalt.pinterest.systems/dropdown
  */
 export default function Dropdown({
   anchor,

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -25,7 +25,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Dropdown
+ * https://gestalt.pinterest.systems/dropdown
  */
 export default function DropdownItem({
   badgeText,

--- a/packages/gestalt/src/DropdownSection.js
+++ b/packages/gestalt/src/DropdownSection.js
@@ -10,7 +10,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Dropdown
+ * https://gestalt.pinterest.systems/dropdown
  */
 export default function DropdownSection({ label, children }: Props): Node {
   return (

--- a/packages/gestalt/src/Fieldset.js
+++ b/packages/gestalt/src/Fieldset.js
@@ -19,7 +19,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Fieldset
+ * https://gestalt.pinterest.systems/fieldset
  */
 export default function Fieldset({
   id = '',

--- a/packages/gestalt/src/Flex.js
+++ b/packages/gestalt/src/Flex.js
@@ -54,7 +54,7 @@ const allowedProps = [
 ];
 
 /**
- * https://gestalt.pinterest.systems/Flex
+ * https://gestalt.pinterest.systems/flex
  */
 export default function Flex({
   alignItems,

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -15,7 +15,7 @@ export type Props = {|
 const allowedProps = ['alignSelf', 'children', 'flex', 'flexBasis', 'minWidth'];
 
 /**
- * https://gestalt.pinterest.systems/Flex
+ * https://gestalt.pinterest.systems/flex
  */
 export default function FlexItem(props: Props): Node {
   const { passthroughProps, propsStyles } = buildStyles<Props>({

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -38,7 +38,7 @@ const SIZE_SCALE = {
 };
 
 /**
- * https://gestalt.pinterest.systems/Heading
+ * https://gestalt.pinterest.systems/heading
  */
 export default function Heading({
   accessibilityLevel,

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -89,7 +89,7 @@ const flipOnRtlIconNames = [
 ];
 
 /**
- * [Icons](https://gestalt.pinterest.systems/Icon) are the symbolic representation of an action or information, providing visual context and improving usability.
+ * [Icons](https://gestalt.pinterest.systems/icon) are the symbolic representation of an action or information, providing visual context and improving usability.
  */
 export default function Icon({
   accessibilityLabel,

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -60,7 +60,7 @@ type unionProps = IconButtonType | LinkIconButtonType;
 type unionRefs = HTMLButtonElement | HTMLAnchorElement;
 
 /**
- * https://gestalt.pinterest.systems/IconButton
+ * https://gestalt.pinterest.systems/iconbutton
  */
 const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -27,7 +27,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Image
+ * https://gestalt.pinterest.systems/image
  */
 export default class Image extends PureComponent<Props> {
   static defaultProps: {|

--- a/packages/gestalt/src/Label.js
+++ b/packages/gestalt/src/Label.js
@@ -13,7 +13,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Label
+ * https://gestalt.pinterest.systems/label
  */
 export default function Label(props: Props): Node {
   const { children, htmlFor, labelDisplay } = props;

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -9,7 +9,7 @@ import { useScrollBoundaryContainer } from './contexts/ScrollBoundaryContainer.j
 import { getContainerNode } from './utils/positioningUtils.js';
 
 /**
- * https://gestalt.pinterest.systems/Layer
+ * https://gestalt.pinterest.systems/layer
  */
 export default function Layer({
   children,

--- a/packages/gestalt/src/Letterbox.js
+++ b/packages/gestalt/src/Letterbox.js
@@ -21,7 +21,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Letterbox
+ * https://gestalt.pinterest.systems/letterbox
  */
 export default function Letterbox({ children, contentAspectRatio, height, width }: Props): Node {
   const viewportAspectRatio = aspectRatio(width, height);

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -37,7 +37,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Link
+ * https://gestalt.pinterest.systems/link
  */
 const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardRef<
   Props,

--- a/packages/gestalt/src/Mask.js
+++ b/packages/gestalt/src/Mask.js
@@ -16,7 +16,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Mask
+ * https://gestalt.pinterest.systems/mask
  */
 export default function Mask(props: Props): Node {
   const { children, rounding = 0, width, height, willChangeTransform = true, wash = false } = props;

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -112,7 +112,7 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 const layoutNumberToCssDimension = (n) => (n !== Infinity ? n : undefined);
 
 /**
- * https://gestalt.pinterest.systems/Masonry
+ * https://gestalt.pinterest.systems/masonry
  */
 export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<T>> {
   static createMeasurementStore<T1: { ... }, T2>(): MeasurementStore<T1, T2> {

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -7,7 +7,7 @@ import ModuleExpandable from './ModuleExpandable.js';
 import type { PublicModuleProps } from './moduleTypes.js';
 
 /**
- * https://gestalt.pinterest.systems/Module
+ * https://gestalt.pinterest.systems/module
  */
 export default function Module({
   children,

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -13,7 +13,7 @@ function getExpandedId(expandedIndex: ?number): ?number {
 }
 
 /**
- * https://gestalt.pinterest.systems/Module
+ * https://gestalt.pinterest.systems/module
  */
 export default function ModuleExpandable({
   accessibilityExpandLabel,

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -9,7 +9,7 @@ import Text from './Text.js';
 import type { ModuleExpandableItemProps } from './moduleTypes.js';
 
 /**
- * https://gestalt.pinterest.systems/Module
+ * https://gestalt.pinterest.systems/module
  */
 export default function ModuleExpandableItem({
   accessibilityCollapseLabel,

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -8,7 +8,7 @@ import Text from './Text.js';
 import type { ModuleTitleProps } from './moduleTypes.js';
 
 /**
- * https://gestalt.pinterest.systems/Module
+ * https://gestalt.pinterest.systems/module
  */
 export default function ModuleTitle(props: ModuleTitleProps): Node {
   const { iconAccessibilityLabel = '', title, type = 'info' } = props;

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -94,7 +94,7 @@ type Props = {|
 |};
 
 /**
- * [NumberField](https://gestalt.pinterest.systems/NumberField) allows for numerical input.
+ * [NumberField](https://gestalt.pinterest.systems/numberfield) allows for numerical input.
  */
 const NumberFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,

--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -34,7 +34,7 @@ type Props = {|
 |};
 
 /**
- * [PageHeader](https://gestalt.pinterest.systems/PageHeader) is used to indicate the title of the current page, as well as optional actions.
+ * [PageHeader](https://gestalt.pinterest.systems/pageheader) is used to indicate the title of the current page, as well as optional actions.
  */
 export default function PageHeader({
   maxWidth = '100%',

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -56,7 +56,7 @@ const defaultIconButtonIconColors = {
 };
 
 /**
- * https://gestalt.pinterest.systems/Pog
+ * https://gestalt.pinterest.systems/pog
  */
 export default function Pog(props: Props): Node {
   const {

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -23,7 +23,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Popover
+ * https://gestalt.pinterest.systems/popover
  */
 export default function Popover(props: Props): null | Node {
   const {

--- a/packages/gestalt/src/Pulsar.js
+++ b/packages/gestalt/src/Pulsar.js
@@ -9,7 +9,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Pulsar
+ * https://gestalt.pinterest.systems/pulsar
  */
 export default function Pulsar({ paused, size = 136 }: Props): Node {
   return (

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -26,7 +26,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/RadioButton
+ * https://gestalt.pinterest.systems/radiobutton
  */
 const RadioButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,

--- a/packages/gestalt/src/ScrollBoundaryContainer.js
+++ b/packages/gestalt/src/ScrollBoundaryContainer.js
@@ -32,7 +32,7 @@ type Props = {|
 |};
 
 /**
- * [ScrollBoundaryContainer](https://gestalt.pinterest.systems/ScrollBoundaryContainer) is used with anchored components such as Popover, Tooltip, Dropdown or ComboBox. A ScrollBoundaryContainer is needed for proper positioning when the Tooltip is anchored to an element that is located within a scrolling container. The use of ScrollBoundaryContainer ensures the Tooltip remains attached to its anchor when scrolling.
+ * [ScrollBoundaryContainer](https://gestalt.pinterest.systems/scrollboundarycontainer) is used with anchored components such as Popover, Tooltip, Dropdown or ComboBox. A ScrollBoundaryContainer is needed for proper positioning when the Tooltip is anchored to an element that is located within a scrolling container. The use of ScrollBoundaryContainer ensures the Tooltip remains attached to its anchor when scrolling.
  */
 const ScrollBoundaryContainerWithProvider = ({
   children,

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -81,7 +81,7 @@ type Props = {|
 |};
 
 /**
- * [SearchField](https://gestalt.pinterest.systems/SearchField) allows users to search for free-form content.
+ * [SearchField](https://gestalt.pinterest.systems/searchfield) allows users to search for free-form content.
  */
 const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -66,7 +66,7 @@ function SegmentedControlItem({
 }
 
 /**
- * https://gestalt.pinterest.systems/SegmentedControl
+ * https://gestalt.pinterest.systems/segmentedcontrol
  */
 export default function SegmentedControl({
   items,

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -59,7 +59,7 @@ type Props = {|
 |};
 
 /**
- * [SelectList](https://gestalt.pinterest.systems/SelectList) displays a list of actions or options using the browser’s native select.
+ * [SelectList](https://gestalt.pinterest.systems/selectlist) displays a list of actions or options using the browser’s native select.
  */
 export default function SelectList({
   disabled = false,

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -272,7 +272,7 @@ function Sheet(props: SheetProps): Node {
  */
 
 /**
- * https://gestalt.pinterest.systems/Sheet
+ * https://gestalt.pinterest.systems/sheet
  */
 export default function AnimatedSheet(props: AnimatedSheetProps): Node {
   const {

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -18,7 +18,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Spinner
+ * https://gestalt.pinterest.systems/spinner
  */
 export default function Spinner({
   accessibilityLabel,

--- a/packages/gestalt/src/Status.js
+++ b/packages/gestalt/src/Status.js
@@ -58,7 +58,7 @@ type Props = {|
 |};
 
 /**
- * [Status](https://gestalt.pinterest.systems/Status) is an indicator with an icon that provides information to a user.
+ * [Status](https://gestalt.pinterest.systems/status) is an indicator with an icon that provides information to a user.
  */
 export default function Status({ accessibilityLabel, subtext, title, type }: Props): Node {
   const { icon, color } = ICON_COLOR_MAP[type];

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -16,7 +16,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Switch
+ * https://gestalt.pinterest.systems/switch
  */
 export default function Switch({
   disabled = false,

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -24,7 +24,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function Table(props: Props): Node {
   const { accessibilityLabel, borderStyle, children, maxHeight, stickyColumns } = props;

--- a/packages/gestalt/src/TableBody.js
+++ b/packages/gestalt/src/TableBody.js
@@ -7,7 +7,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function TableBody(props: Props): Node {
   return <tbody className={styles.tbody}>{props.children}</tbody>;

--- a/packages/gestalt/src/TableCell.js
+++ b/packages/gestalt/src/TableCell.js
@@ -13,7 +13,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function TableCell(props: Props): Node {
   const {

--- a/packages/gestalt/src/TableFooter.js
+++ b/packages/gestalt/src/TableFooter.js
@@ -6,7 +6,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function TableFooter(props: Props): Node {
   return <tfoot>{props.children}</tfoot>;

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -9,7 +9,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function TableHeader(props: Props): Node {
   const cs = cx(styles.thead, props.sticky && styles.sticky);

--- a/packages/gestalt/src/TableHeaderCell.js
+++ b/packages/gestalt/src/TableHeaderCell.js
@@ -14,7 +14,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function TableHeaderCell(props: Props): Node {
   const {

--- a/packages/gestalt/src/TableRow.js
+++ b/packages/gestalt/src/TableRow.js
@@ -9,7 +9,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function TableRow(props: Props): Node {
   const { stickyColumns } = useTableContext();

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -27,7 +27,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function TableRowExpandable(props: Props): Node {
   const {

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -28,7 +28,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Table
+ * https://gestalt.pinterest.systems/table
  */
 export default function TableSortableHeaderCell(props: Props): Node {
   const {

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -198,7 +198,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Tabs
+ * https://gestalt.pinterest.systems/tabs
  */
 export default function Tabs({
   activeTabIndex,

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -33,7 +33,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Tag
+ * https://gestalt.pinterest.systems/tag
  *
  * ![Tag light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Tag%20%230.png)
  * ![Tag dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Tag-dark%20%230.png)

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -70,7 +70,7 @@ type unionProps = TapAreaType | LinkTapAreaType;
 type unionRefs = HTMLDivElement | HTMLAnchorElement;
 
 /**
- * https://gestalt.pinterest.systems/TapArea
+ * https://gestalt.pinterest.systems/tapArea
  */
 const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -83,7 +83,7 @@ type Props = {|
 |};
 
 /**
- * The [Text](https://gestalt.pinterest.systems/Text) component should be used for all text on the page.
+ * The [Text](https://gestalt.pinterest.systems/text) component should be used for all text on the page.
  *
  * ![Text light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Text%20%230.png)
  * ![Text dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Text-dark%20%230.png)

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -36,7 +36,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/TextArea
+ * https://gestalt.pinterest.systems/textArea
  */
 const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement> = forwardRef<
   Props,

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -87,7 +87,7 @@ type Props = {|
 |};
 
 /**
- * [TextField](https://gestalt.pinterest.systems/TextField) allows for text input.
+ * [TextField](https://gestalt.pinterest.systems/textfield) allows for text input.
  */
 const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -31,7 +31,7 @@ type Props = {|
 |};
 
 /**
- * [Toasts](https://gestalt.pinterest.systems/Toast) can educate people on the content of the screen, provide confirmation when people complete an action, or simply communicate a short message.
+ * [Toasts](https://gestalt.pinterest.systems/toast) can educate people on the content of the screen, provide confirmation when people complete an action, or simply communicate a short message.
  *
  * Toast is purely visual. In order to properly handle the showing and dismissing of Toasts, as well as any animations, you will need to implement a Toast manager.
  */

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -55,7 +55,7 @@ const reducer = (state, action) => {
 };
 
 /**
- * https://gestalt.pinterest.systems/Tooltip
+ * https://gestalt.pinterest.systems/tooltip
  */
 export default function Tooltip({
   children,

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -86,7 +86,7 @@ const UpsellAction = ({
 };
 
 /**
- * https://gestalt.pinterest.systems/Upsell
+ * https://gestalt.pinterest.systems/upsell
  */
 export default function Upsell({
   children,

--- a/packages/gestalt/src/UpsellForm.js
+++ b/packages/gestalt/src/UpsellForm.js
@@ -20,7 +20,7 @@ type Props = {|
 |};
 
 /**
- * https://gestalt.pinterest.systems/Upsell
+ * https://gestalt.pinterest.systems/upsell
  */
 export default function UpsellForm({
   children,

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -173,7 +173,7 @@ const isNewSource = (oldSource: Source, newSource: Source): boolean => {
 };
 
 /**
- * https://gestalt.pinterest.systems/Video
+ * https://gestalt.pinterest.systems/video
  */
 export default class Video extends PureComponent<Props, State> {
   video: ?HTMLVideoElement;

--- a/packages/gestalt/src/contexts/ColorScheme.js
+++ b/packages/gestalt/src/contexts/ColorScheme.js
@@ -120,7 +120,7 @@ const getTheme = (colorScheme: ?ColorScheme) =>
     : lightModeTheme;
 
 /**
- * https://gestalt.pinterest.systems/ColorSchemeProvider
+ * https://gestalt.pinterest.systems/colorschemeprovider
  */
 export default function ColorSchemeProvider({
   children,

--- a/packages/gestalt/src/contexts/OnLinkNavigation.js
+++ b/packages/gestalt/src/contexts/OnLinkNavigation.js
@@ -26,7 +26,7 @@ const OnLinkNavigationContext: Context<OnLinkNavigationContextType | void> = cre
 const { Provider } = OnLinkNavigationContext;
 
 /**
- * https://gestalt.pinterest.systems/OnLinkNavigationProvider
+ * https://gestalt.pinterest.systems/onlinknavigationprovider
  */
 export default function OnLinkNavigationProvider({
   onNavigation,

--- a/packages/gestalt/src/useFocusVisible.js
+++ b/packages/gestalt/src/useFocusVisible.js
@@ -113,7 +113,7 @@ function setupGlobalFocusEvents() {
 }
 
 /**
- * https://gestalt.pinterest.systems/useFocusVisible
+ * https://gestalt.pinterest.systems/usefocusvisible
  */
 export default function useFocusVisible(): {|
   isFocusVisible: boolean,

--- a/packages/gestalt/src/useReducedMotion.js
+++ b/packages/gestalt/src/useReducedMotion.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { addListener, removeListener } from './utils/matchMedia.js';
 
 /**
- * https://gestalt.pinterest.systems/useReducedMotion
+ * https://gestalt.pinterest.systems/usereducedmotion
  */
 export default function useReducedMotion(): boolean {
   const supportsMatchMedia = typeof window !== 'undefined' && window.matchMedia;

--- a/packages/gestalt/src/zIndex.js
+++ b/packages/gestalt/src/zIndex.js
@@ -5,7 +5,7 @@ export interface Indexable {
 }
 
 /**
- * https://gestalt.pinterest.systems/ZIndex%20Classes
+ * https://gestalt.pinterest.systems/zindex%20classes
  */
 export class FixedZIndex implements Indexable {
   +z: number;
@@ -20,7 +20,7 @@ export class FixedZIndex implements Indexable {
 }
 
 /**
- * https://gestalt.pinterest.systems/ZIndex%20Classes
+ * https://gestalt.pinterest.systems/zindex%20classes
  */
 export class CompositeZIndex implements Indexable {
   +deps: $ReadOnlyArray<FixedZIndex | CompositeZIndex>;

--- a/scripts/templates/ComponentName.js
+++ b/scripts/templates/ComponentName.js
@@ -7,13 +7,13 @@ type Props = {|
   /**
    * Prop description.
    *
-   * Link: https://gestalt.pinterest.systems/componentName#prop
+   * Link: https://gestalt.pinterest.systems/componentname#prop
    */
   accessibilityLabel?: string,
 |};
 
 /**
- * [ComponentName] https://gestalt.pinterest.systems/ComponentName component should be used for ... on the page.
+ * [ComponentName] https://gestalt.pinterest.systems/componentname component should be used for ... on the page.
  * ![ComponentName light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/ComponentName-lightName%20%230.png)
  * ![ComponentName dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/ComponentName-dark%20%230.png)
  */


### PR DESCRIPTION
### Summary

The path for all Docs links must be lower case after moving to Next.js. This PR fixes most links in the docs which where still capitalized and returned 404 when clicked.

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
