### PR TITLE
Masonry: delay updating React scroll state until scroll events stop coming in

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -1,16 +1,17 @@
 // @flow strict
 import type { ComponentType, Node } from 'react';
+
 import { Component as ReactComponent } from 'react';
 import debounce from './debounce.js';
 import FetchItems from './FetchItems.js';
 import styles from './Masonry.css';
 import ScrollContainer from './ScrollContainer.js';
+import throttle from './throttle.js';
 import type { Cache } from './Cache.js';
 import MeasurementStore from './MeasurementStore.js';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './scrollUtils.js';
 import { DefaultLayoutSymbol, UniformRowLayoutSymbol } from './legacyLayoutSymbols.js';
 import defaultLayout from './defaultLayout.js';
-import throttle from './throttle.js';
 import uniformRowLayout from './uniformRowLayout.js';
 import fullWidthLayout from './fullWidthLayout.js';
 import LegacyMasonryLayout from './layouts/MasonryLayout.js';
@@ -89,8 +90,6 @@ type Props<T> = {|
   deferScrollPositionUpdate?: boolean,
   virtualBoundsTop?: number,
   virtualBoundsBottom?: number,
-  virtualBoundsTop?: number,
-  virtualBoundsBottom?: number,
   /**
    * Whether or not to use actual virtualization
    */
@@ -115,11 +114,7 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 // One mouse scroll creates many addEventListener('scroll', ()=>{}) type events,
 // so if this timeout is reached (not reset by another scroll event), we know scroll
 // is over and perform post scroll tasks.
-<<<<<<< HEAD
 const SCROLL_TIMEOUT_WAIT = 100;
-=======
-const SCROLL_TIMEOUT_WAIT=100;
->>>>>>> e766dbd8... chore: minor code review changes. Smoke tested w/Pinterest
 
 const layoutNumberToCssDimension = (n) => (n !== Infinity ? n : undefined);
 

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -285,6 +285,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     // Make sure async methods are cancelled.
     this.measureContainerAsync.clearTimeout();
     this.handleResize.clearTimeout();
+    // eslint-disable-next-line no-underscore-dangle
     if (this.props._deferScrollPositionUpdate) {
       this.clearScrollTimeout();
     } else {

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -87,7 +87,9 @@ type Props<T> = {|
    * This is required if the grid is expected to be scrollable.
    */
   scrollContainer?: () => HTMLElement,
-  deferScrollPositionUpdate?: boolean,
+  // Prop to help us conditionally/experimentally test a new React.setState(scrollPos) strategy.
+  // See this.handleScroll fn for more details
+  _deferScrollPositionUpdate?: boolean,
   virtualBoundsTop?: number,
   virtualBoundsBottom?: number,
   /**
@@ -157,7 +159,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
 
   scrollTimeoutId: ?TimeoutID = null;
 
-  // The browser scroll event API will fire LOTS of events. This waits until the events
+  // The browser scroll event API will fire LOTS of scroll events. This waits until the events
   // stop coming in to set the final scroll position
   handleScroll: () => void = () => {
     if (this.scrollTimeoutId) {
@@ -283,7 +285,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     // Make sure async methods are cancelled.
     this.measureContainerAsync.clearTimeout();
     this.handleResize.clearTimeout();
-    if (this.props.deferScrollPositionUpdate) {
+    if (this.props._deferScrollPositionUpdate) {
       this.clearScrollTimeout();
     } else {
       this.updateScrollPosition.clearTimeout();
@@ -466,7 +468,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       items,
       layout,
       minCols,
-      deferScrollPositionUpdate,
+      _deferScrollPositionUpdate,
       scrollContainer,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
@@ -615,7 +617,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       <ScrollContainer
         ref={this.setScrollContainerRef}
         onScroll={
-          deferScrollPositionUpdate ? this.handleScroll : this.throttledUpdateScrollPosition
+          _deferScrollPositionUpdate ? this.handleScroll : this.throttledUpdateScrollPosition
         }
         scrollContainer={scrollContainer}
       >


### PR DESCRIPTION
### Summary
**TLDR:** This changes the `updateScrollPosition` strategy in Masonry from: making sure that updating isn't called multiple times w/in 100ms, to: not calling `updateScrollPosition` at all until scroll callbacks stop occurring.

The browser API for scroll callbacks is called multiple times per scroll events. Therefore, any code called within the scroll handler callback can very easily slow down scroll. This seems to be the idea behind the `throttle`ing here, to ensure multiple callbacks aren't called within 100ms of each other: 

https://github.com/pinterest/gestalt/blob/6021664f7341a7f3f7a52887e388c1203da77e41/packages/gestalt/src/Masonry.js#L135

https://github.com/valbooth28/gestalt/blob/aefb6127eacbe19a23bdfdc0ecf8d326c4eb6dac/packages/gestalt/src/throttle.js#L10

At the start of a scroll, however, no scroll callback has been called, so the React state update is called _immediately_, slowing down the 1,2,3... invocations of the `addEventListener('scroll'` events. When scrolling a page during Performance Profiling in Chrome DevTools, it is explicitly highlighted as slowing down the handler:

![Scroll Before](https://user-images.githubusercontent.com/7406105/141012906-9cd5a098-5129-4376-ba35-9afc1ba7a488.png)
![Scroll Before 2](https://user-images.githubusercontent.com/7406105/141012913-53f49238-7f64-4e3c-9c7b-686c8f82c28a.png)


### Links

- [Jira](https://jira.pinadmin.com/browse/PERF-10133)
- Further documentation about Scroll RUM data logging seen in the gifs available upon request

### Manual Testing
#### Before
_See above screenshots as well. PWT values are milliseconds per frame (or 1/FPS)_

![scroll PWT before](https://user-images.githubusercontent.com/7406105/141031555-cf9b578b-d981-421e-83f6-f2623aad1e0d.gif)


#### After
_PWT values are milliseconds per frame (or 1/FPS)_
![Scroll After Code](https://user-images.githubusercontent.com/7406105/141013787-eaf956bb-8daf-4c32-b57a-512c45aeaa5d.png)

![scroll PWT after](https://user-images.githubusercontent.com/7406105/141031583-ba45c489-e8eb-4cff-a3d9-3e9a0b578a81.gif)


### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
