### PR TITLE
Toast: fix layout issues

### DIFF
--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -73,7 +73,7 @@ export default function Toast({
       <Box borderStyle="shadow" color={containerColor} fit padding={6} rounding="pill">
         <Flex alignItems="center" gap={4}>
           {thumbnail ? (
-            <Flex flex="none" justifyContent="center">
+            <Flex.Item flex="none">
               <Mask
                 height={thumbnailShape === 'rectangle' ? 64 : 48}
                 rounding={thumbnailShape === 'circle' ? 'circle' : 2}
@@ -81,14 +81,14 @@ export default function Toast({
               >
                 {thumbnail}
               </Mask>
-            </Flex>
+            </Flex.Item>
           ) : null}
 
-          <Flex direction="column" flex="grow" justifyContent="center">
+          <Flex.Item flex="grow">
             <Text align={!thumbnail && !button ? 'center' : 'start'} color={textColor}>
               {textElement}
             </Text>
-          </Flex>
+          </Flex.Item>
 
           {button ? <Flex.Item flex="none">{button}</Flex.Item> : null}
         </Flex>

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -18,16 +18,12 @@ exports[`<Toast /> Error Toast 1`] = `
       className="Flex rowGap4 itemsCenter xsDirectionRow"
     >
       <div
-        className="FlexItem"
+        className="FlexItem flexGrow"
       >
         <div
-          className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
+          className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
         >
-          <div
-            className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
-          >
-            Same great profile, slightly new look. Learn more?
-          </div>
+          Same great profile, slightly new look. Learn more?
         </div>
       </div>
     </div>
@@ -53,61 +49,53 @@ exports[`<Toast /> Text + Image + Button 1`] = `
       className="Flex rowGap4 itemsCenter xsDirectionRow"
     >
       <div
-        className="FlexItem"
+        className="FlexItem flexNone"
       >
         <div
-          className="Flex rowGap0 flexNone justifyCenter xsDirectionRow"
-        >
-          <div
-            className="Mask rounding2 willChangeTransform"
-            style={
-              Object {
-                "height": 48,
-                "width": 48,
-              }
+          className="Mask rounding2 willChangeTransform"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
             }
-          >
-            <img
-              alt=""
-              src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
-            />
-          </div>
+          }
+        >
+          <img
+            alt=""
+            src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+          />
         </div>
       </div>
       <div
-        className="FlexItem"
+        className="FlexItem flexGrow"
       >
         <div
-          className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
+          className="Text fontSize3 white alignStart breakWord fontWeightNormal"
         >
-          <div
-            className="Text fontSize3 white alignStart breakWord fontWeightNormal"
+          <span
+            className="textColorOverrideWhite"
           >
-            <span
-              className="textColorOverrideWhite"
+            Saved to
+             
+            <a
+              className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
+              href="https://www.pinterest.com/search/pins/?q=home%20decor"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              rel=""
+              target={null}
             >
-              Saved to
-               
-              <a
-                className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
-                href="https://www.pinterest.com/search/pins/?q=home%20decor"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyPress={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                onTouchCancel={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                rel=""
-                target={null}
-              >
-                Home decor
-              </a>
-            </span>
-          </div>
+              Home decor
+            </a>
+          </span>
         </div>
       </div>
       <div
@@ -157,61 +145,53 @@ exports[`<Toast /> Text + Image 1`] = `
       className="Flex rowGap4 itemsCenter xsDirectionRow"
     >
       <div
-        className="FlexItem"
+        className="FlexItem flexNone"
       >
         <div
-          className="Flex rowGap0 flexNone justifyCenter xsDirectionRow"
-        >
-          <div
-            className="Mask rounding2 willChangeTransform"
-            style={
-              Object {
-                "height": 48,
-                "width": 48,
-              }
+          className="Mask rounding2 willChangeTransform"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
             }
-          >
-            <img
-              alt=""
-              src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
-            />
-          </div>
+          }
+        >
+          <img
+            alt=""
+            src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+          />
         </div>
       </div>
       <div
-        className="FlexItem"
+        className="FlexItem flexGrow"
       >
         <div
-          className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
+          className="Text fontSize3 white alignStart breakWord fontWeightNormal"
         >
-          <div
-            className="Text fontSize3 white alignStart breakWord fontWeightNormal"
+          <span
+            className="textColorOverrideWhite"
           >
-            <span
-              className="textColorOverrideWhite"
+            Saved to
+             
+            <a
+              className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
+              href="https://www.pinterest.com/search/pins/?q=home%20decor"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              rel=""
+              target={null}
             >
-              Saved to
-               
-              <a
-                className="link hideOutline tapTransition rounding0 block hoverUnderline accessibilityOutline"
-                href="https://www.pinterest.com/search/pins/?q=home%20decor"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyPress={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                onTouchCancel={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                rel=""
-                target={null}
-              >
-                Home decor
-              </a>
-            </span>
-          </div>
+              Home decor
+            </a>
+          </span>
         </div>
       </div>
     </div>
@@ -237,16 +217,12 @@ exports[`<Toast /> Text Only 1`] = `
       className="Flex rowGap4 itemsCenter xsDirectionRow"
     >
       <div
-        className="FlexItem"
+        className="FlexItem flexGrow"
       >
         <div
-          className="Flex columnGap0 flexGrow justifyCenter xsDirectionColumn"
+          className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
         >
-          <div
-            className="Text fontSize3 white alignCenter breakWord fontWeightNormal"
-          >
-            Same great profile, slightly new look. Learn more?
-          </div>
+          Same great profile, slightly new look. Learn more?
         </div>
       </div>
     </div>


### PR DESCRIPTION
I flubbed some of the markup in Toast when converting to use Flex back in September…whoops. This PR fixes the layout to ensure that the elements are properly spaced: thumbnail left-aligned, button right-aligned, text left-aligned and taking up available space in the middle.

[Jira bug](https://jira.pinadmin.com/browse/BUG-135135)

(not quite before/after screenshots, but you get the gist)

_Before_
<img width="348" alt="Screen Shot 2021-11-09 at 4 48 57 PM" src="https://user-images.githubusercontent.com/12059539/141029301-96b59e88-ad10-47ac-8292-142946d46ac3.png">

_After_
<img width="399" alt="Screen Shot 2021-11-09 at 4 49 10 PM" src="https://user-images.githubusercontent.com/12059539/141029305-23d73ae2-3636-4d9f-8317-3b2eba007d14.png">
