### PR TITLE
Divider: Add vertical example to docs

### DIFF
--- a/docs/pages/divider.js
+++ b/docs/pages/divider.js
@@ -3,7 +3,7 @@ import type { Node } from 'react';
 import PropTable from '../components/PropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import CardPage from '../components/CardPage.js';
-import MainSection from '../components/MainSection';
+import MainSection from '../components/MainSection.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);

--- a/docs/pages/divider.js
+++ b/docs/pages/divider.js
@@ -1,9 +1,9 @@
 // @flow strict
 import type { Node } from 'react';
-import Example from '../components/Example.js';
 import PropTable from '../components/PropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import CardPage from '../components/CardPage.js';
+import MainSection from '../components/MainSection';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -18,13 +18,18 @@ card(
 card(<PropTable props={[]} />);
 
 card(
-  <Example
-    description="
-    You can use this component for a visual divider between two elements.
-  "
-    name="Example"
-    defaultCode={`
-<Box color="white">
+  <MainSection name="Variants">
+    <MainSection.Subsection
+      title="Orientation"
+      columns={2}
+      description="You can use this component for a visual divider between two elements. Placing it within a [Flex](/flex) layout with a direction of `row` will cause the Divider to become vertical.
+      "
+    >
+      <MainSection.Card
+        cardSize="md"
+        title="Horizontal"
+        defaultCode={`
+<Box color="white" width="100%">
   <Box padding={2}>
     <Text>Some content</Text>
   </Box>
@@ -34,7 +39,24 @@ card(
   </Box>
 </Box>
 `}
-  />,
+      />
+      <MainSection.Card
+        cardSize="md"
+        title="Vertical"
+        defaultCode={`
+<Flex>
+  <Box padding={2}>
+    <Text>Some content</Text>
+  </Box>
+  <Divider />
+  <Box padding={2}>
+    <Text>Other content</Text>
+  </Box>
+</Flex>
+`}
+      />
+    </MainSection.Subsection>
+  </MainSection>,
 );
 
 export default function DividerPage(): Node {


### PR DESCRIPTION
### Summary

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->
showcase vertical dividers with Flex

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
