### PR TITLE
Table: Update design guidelines in Docs

### DIFF
--- a/cypress/integration/accessibility_Module_spec.js
+++ b/cypress/integration/accessibility_Module_spec.js
@@ -5,6 +5,14 @@ describe('Module Accessibility check', () => {
   });
 
   it('Tests accessibility on the Module page', () => {
+    cy.configureAxe({
+      rules: [
+        {
+          id: 'color-contrast',
+          enabled: false,
+        },
+      ],
+    });
     cy.checkA11y();
   });
 });

--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -120,6 +120,7 @@ export default function PropTable({
   return (
     <Card
       id={propsId}
+      headingSize={proptableName ? 'sm' : 'md'}
       name={proptableName ? `${proptableName} Props` : 'Props'}
       toggle={
         <Tooltip inline text={`${propTableVariant === 'expanded' ? 'Collapse' : 'Expand'} props`}>

--- a/docs/pages/card.js
+++ b/docs/pages/card.js
@@ -81,18 +81,20 @@ function CardExample() {
   return (
     <Box maxWidth={236} padding={2} column={12}>
       <Card image={<Avatar name="James Jones" src="https://i.ibb.co/2Fc00R3/james.jpg" />}>
-        <Text align="center" weight="bold">
-          <Link href="https://pinterest.com">
-            <Box paddingX={3} paddingY={2}>
-              James Jones
-            </Box>
-          </Link>
+        <Flex direction="column" justifyContent="center">
+          <Text align="center" weight="bold">
+            <Link href="https://pinterest.com">
+              <Box paddingX={3} paddingY={2}>
+                James Jones
+              </Box>
+            </Link>
         </Text>
         <Button
           accessibilityLabel="Follow James Jones"
           color="red"
           text="Follow"
         />
+        </Flex>
       </Card>
     </Box>
   );

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -80,7 +80,6 @@ card(
 card(
   <PropTable
     Component={Dropdown}
-    name="Dropdown"
     id="Dropdown"
     props={[
       {
@@ -164,86 +163,6 @@ const commonDropdownItemProps = [
     description: 'Object detailing the label, value, and optional subtext for this item.',
   },
 ];
-
-card(
-  <PropTable
-    Component={Dropdown?.Item}
-    name="Dropdown.Item"
-    id="Dropdown.Item"
-    props={[
-      ...commonDropdownItemProps,
-      {
-        name: 'onSelect',
-        type:
-          '({| event: SyntheticInputEvent<>, item: {label: string, value: string, subtext?: string} |}) => void',
-        required: true,
-        description: 'Callback when the user selects an item using the mouse or keyboard.',
-      },
-      {
-        name: 'selected',
-        type:
-          '{| label: string, value: string, subtext?: string |} | Array<{| label: string, value: string, subtext?: string |}>',
-        description:
-          'Either the selected item info or an array of selected items, used to determine when the "selected" icon appears on an item.',
-      },
-    ]}
-  />,
-);
-
-card(
-  <PropTable
-    Component={Dropdown?.Link}
-    name="Dropdown.Link"
-    id="Dropdown.Link"
-    props={[
-      ...commonDropdownItemProps,
-      {
-        name: 'href',
-        type: 'string',
-        required: true,
-        description:
-          'Directs users to the url when item is selected. See the [Types of items](#Types-of-items) variant to learn more.',
-      },
-      {
-        name: 'isExternal',
-        type: 'boolean',
-        description:
-          'When true, adds an arrow icon to the end of the item to signal this item takes users to an external source and opens the link in a new tab. Do not add if the item navigates users within the app. See the [Best practices](#Best-practices) for more info.',
-      },
-      {
-        name: 'onClick',
-        type:
-          'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
-        description: [
-          'Callback fired when clicked (pressed and released) with a mouse or keyboard. ',
-          'See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
-        ],
-      },
-    ]}
-  />,
-);
-
-card(
-  <PropTable
-    Component={Dropdown?.Section}
-    name="Dropdown.Section"
-    id="Dropdown.Section"
-    props={[
-      {
-        name: 'children',
-        type: 'React.ChildrenArray<React.Element<typeof DropdownItem>>',
-        required: true,
-        description: 'Any Dropdown.Items and/or Dropdown.Links to be rendered',
-      },
-      {
-        name: 'label',
-        type: 'string',
-        required: true,
-        description: 'Label for the section. See the [Sections](#Sections) variant for more info.',
-      },
-    ]}
-  />,
-);
 
 card(
   <MainSection name="Usage guidelines">
@@ -722,6 +641,88 @@ function TruncationDropdownExample() {
       />
     </MainSection.Subsection>
   </MainSection>,
+);
+
+card(<MainSection name="Subcomponents" />);
+
+card(
+  <PropTable
+    Component={Dropdown?.Item}
+    name="Dropdown.Item"
+    id="Dropdown.Item"
+    props={[
+      ...commonDropdownItemProps,
+      {
+        name: 'onSelect',
+        type:
+          '({| event: SyntheticInputEvent<>, item: {label: string, value: string, subtext?: string} |}) => void',
+        required: true,
+        description: 'Callback when the user selects an item using the mouse or keyboard.',
+      },
+      {
+        name: 'selected',
+        type:
+          '{| label: string, value: string, subtext?: string |} | Array<{| label: string, value: string, subtext?: string |}>',
+        description:
+          'Either the selected item info or an array of selected items, used to determine when the "selected" icon appears on an item.',
+      },
+    ]}
+  />,
+);
+
+card(
+  <PropTable
+    Component={Dropdown?.Link}
+    name="Dropdown.Link"
+    id="Dropdown.Link"
+    props={[
+      ...commonDropdownItemProps,
+      {
+        name: 'href',
+        type: 'string',
+        required: true,
+        description:
+          'Directs users to the url when item is selected. See the [Types of items](#Types-of-items) variant to learn more.',
+      },
+      {
+        name: 'isExternal',
+        type: 'boolean',
+        description:
+          'When true, adds an arrow icon to the end of the item to signal this item takes users to an external source and opens the link in a new tab. Do not add if the item navigates users within the app. See the [Best practices](#Best-practices) for more info.',
+      },
+      {
+        name: 'onClick',
+        type:
+          'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
+        description: [
+          'Callback fired when clicked (pressed and released) with a mouse or keyboard. ',
+          'See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
+        ],
+      },
+    ]}
+  />,
+);
+
+card(
+  <PropTable
+    Component={Dropdown?.Section}
+    name="Dropdown.Section"
+    id="Dropdown.Section"
+    props={[
+      {
+        name: 'children',
+        type: 'React.ChildrenArray<React.Element<typeof DropdownItem>>',
+        required: true,
+        description: 'Any Dropdown.Items and/or Dropdown.Links to be rendered',
+      },
+      {
+        name: 'label',
+        type: 'string',
+        required: true,
+        description: 'Label for the section. See the [Sections](#Sections) variant for more info.',
+      },
+    ]}
+  />,
 );
 
 card(

--- a/docs/pages/flex.js
+++ b/docs/pages/flex.js
@@ -2,129 +2,186 @@
 import type { Node } from 'react';
 import { Box, Flex } from 'gestalt';
 import PropTable from '../components/PropTable.js';
-import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
-import CardPage from '../components/CardPage.js';
 import CombinationNew from '../components/CombinationNew.js';
+import Page from '../components/Page.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
-
-card(
-  <PageHeader
-    name="Flex"
-    description={`
+export default function ModulePage(): Node {
+  return (
+    <Page title="Flex">
+      <PageHeader
+        name="Flex"
+        description={`
       Flex is a layout component with a very limited subset of the props available to [Box](/box) and a few special props of its own.
 
       Use this component for flex layouts, especially when even spacing between elements is desired (see the 'gap' property!).
     `}
-  />,
-);
-
-card(
-  <PropTable
-    Component={Flex}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'alignContent',
-        type: `"start" | "end" | "center" | "between" | "around" | "evenly" | "stretch"`,
-        defaultValue: 'stretch',
-        description:
-          "Aligns the flex container's lines within when there is extra space in the cross axis, similar to how justify-content aligns individual items within the main axis.",
-      },
-      {
-        name: 'alignItems',
-        type: `"start" | "end" | "center" | "baseline" | "stretch"`,
-        defaultValue: 'start',
-        description:
-          'Defines the default behaviour for how flex items are laid out along the cross axis on the current line. Think of it as the justify-content version for the cross axis (perpendicular to the main axis).',
-        href: 'layout',
-      },
-      {
-        name: 'alignSelf',
-        type: `"auto" | "start" | "end" | "center" | "baseline" | "stretch"`,
-        defaultValue: 'stretch',
-        description:
-          'Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items.',
-      },
-      {
-        name: 'direction',
-        type: `"row" | "column"`,
-        defaultValue: 'row',
-        description:
-          'Establishes the main axis, thus defining the direction flex items are placed in the flex container.',
-      },
-      {
-        name: 'flex',
-        type: '"grow" | "shrink" | "none"',
-        defaultValue: 'shrink',
-        description: `Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size the Flex relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows the Flex to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves the Flex's size based on child content regardless of its container's size.`,
-      },
-      {
-        name: 'gap',
-        type: '0 .. 12',
-        defaultValue: 0,
-        description: 'Defines spacing between each child along the main axis.',
-      },
-      {
-        name: 'height',
-        type: `number | string`,
-        description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
-      },
-      {
-        name: 'justifyContent',
-        type: `"start" | "end" | "center" | "between" | "around" | "evenly"`,
-        defaultValue: 'center',
-        description:
-          'Defines the alignment along the main axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.',
-        href: 'layout',
-      },
-      {
-        name: 'maxHeight',
-        type: `number | string`,
-      },
-      {
-        name: 'maxWidth',
-        type: `number | string`,
-        description: `Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%"`,
-      },
-      {
-        name: 'minHeight',
-        type: `number | string`,
-        description: `Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%"`,
-      },
-      {
-        name: 'minWidth',
-        type: `number | string`,
-        description: `Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%"`,
-      },
-      {
-        name: 'width',
-        type: `number | string`,
-        description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
-      },
-      {
-        name: 'wrap',
-        type: 'boolean',
-        defaultValue: false,
-        description: `By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.`,
-      },
-    ]}
-  />,
-);
-
-card(
-  <Example
-    description={`
+      />
+      <PropTable
+        Component={Flex}
+        props={[
+          {
+            name: 'children',
+            type: 'React.Node',
+          },
+          {
+            name: 'alignContent',
+            type: `"start" | "end" | "center" | "between" | "around" | "evenly" | "stretch"`,
+            defaultValue: 'stretch',
+            description:
+              "Aligns the flex container's lines within when there is extra space in the cross axis, similar to how justify-content aligns individual items within the main axis.",
+          },
+          {
+            name: 'alignItems',
+            type: `"start" | "end" | "center" | "baseline" | "stretch"`,
+            defaultValue: 'start',
+            description:
+              'Defines the default behaviour for how flex items are laid out along the cross axis on the current line. Think of it as the justify-content version for the cross axis (perpendicular to the main axis).',
+            href: 'layout',
+          },
+          {
+            name: 'alignSelf',
+            type: `"auto" | "start" | "end" | "center" | "baseline" | "stretch"`,
+            defaultValue: 'stretch',
+            description:
+              'Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items.',
+          },
+          {
+            name: 'direction',
+            type: `"row" | "column"`,
+            defaultValue: 'row',
+            description:
+              'Establishes the main axis, thus defining the direction flex items are placed in the flex container.',
+          },
+          {
+            name: 'flex',
+            type: '"grow" | "shrink" | "none"',
+            defaultValue: 'shrink',
+            description: `Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size the Flex relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows the Flex to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves the Flex's size based on child content regardless of its container's size.`,
+          },
+          {
+            name: 'gap',
+            type: '0 .. 12',
+            defaultValue: 0,
+            description: 'Defines spacing between each child along the main axis.',
+          },
+          {
+            name: 'height',
+            type: `number | string`,
+            description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
+          },
+          {
+            name: 'justifyContent',
+            type: `"start" | "end" | "center" | "between" | "around" | "evenly"`,
+            defaultValue: 'center',
+            description:
+              'Defines the alignment along the main axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.',
+            href: 'layout',
+          },
+          {
+            name: 'maxHeight',
+            type: `number | string`,
+          },
+          {
+            name: 'maxWidth',
+            type: `number | string`,
+            description: `Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%"`,
+          },
+          {
+            name: 'minHeight',
+            type: `number | string`,
+            description: `Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%"`,
+          },
+          {
+            name: 'minWidth',
+            type: `number | string`,
+            description: `Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%"`,
+          },
+          {
+            name: 'width',
+            type: `number | string`,
+            description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
+          },
+          {
+            name: 'wrap',
+            type: 'boolean',
+            defaultValue: false,
+            description: `By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.`,
+          },
+        ]}
+      />
+      <MainSection name="Subcomponents" />
+      <PropTable
+        name="Flex.Item"
+        id="Flex.Item"
+        Component={Flex?.Item}
+        props={[
+          {
+            name: 'children',
+            type: 'React.Node',
+          },
+          {
+            name: 'alignSelf',
+            type: `"auto" | "start" | "end" | "center" | "baseline" | "stretch"`,
+            defaultValue: 'stretch',
+            description:
+              'Allows the default alignment (or the one specified by `align-items`) to be overridden for individual flex items.',
+          },
+          {
+            name: 'flex',
+            type: '"grow" | "shrink" | "none"',
+            defaultValue: 'shrink',
+            description: `Defines how a flex item will be sized. \`"grow"\`, equivalent to \`"flex: 1 1 auto"\`, will size the Flex.Item relative to its parent, growing and shrinking based on available space. \`"shrink"\`, equivalent to \`"flex: 0 1 auto"\` (the browser default), allows the Flex.Item to shrink if compressed but not grow if given extra space. Finally, \`"none"\`, equivalent to \`"flex: 0 0 auto"\`, preserves the Flex.Item's size based on child content regardless of its container's size.`,
+          },
+          {
+            name: 'flexBasis',
+            type: `number | string`,
+            description: `Defines the initial main size of the flex item. Use numbers for pixels: \`flexBasis={100}\` and strings for other units: \`flexBasis="100vh"\`.`,
+          },
+          {
+            name: 'minWidth',
+            type: `number | string`,
+            description: `Use numbers for pixels: \`minWidth={100}\` and strings for percentages: \`minWidth="100%"\`. Can be used to fix overflowing children; see [the example](#FlexItem-minWidth) to learn more.`,
+          },
+        ]}
+      />
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          title="Flex Layout"
+          description={`
+      Flex is strictly for flex layouts. If you're new to flex layout, please read the excellent [CSS-Tricks guide to flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
+  `}
+        >
+          <CombinationNew
+            justifyContent={['start', 'end', 'center', 'between', 'around']}
+            alignItems={['start', 'end', 'center', 'baseline', 'stretch']}
+          >
+            {({ justifyContent, alignItems }) => (
+              <Box
+                display="flex"
+                width="75%"
+                height="75%"
+                borderStyle="shadow"
+                justifyContent={justifyContent}
+                alignItems={alignItems}
+              >
+                <Box margin={1} color="gray" height={8} width={8} />
+                <Box margin={1} color="gray" height={16} width={8} />
+                <Box margin={1} color="gray" height={32} width={8} />
+              </Box>
+            )}
+          </CombinationNew>
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Menu"
+          description={`
     With a limited set of props that only relate to flex layouts, Flex is useful for separating layout from other concerns to prevent overloaded Box usage.
   `}
-    name="Example: Menu"
-    defaultCode={`
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Box borderStyle="sm" paddingX={2} paddingY={3} rounding={3} width={130}>
   <Flex alignItems="center" direction="column" gap={4}>
     <Text>Menu Item 1</Text>
@@ -133,53 +190,17 @@ card(
   </Flex>
 </Box>
 `}
-  />,
-);
-
-card(
-  <PropTable
-    name="Flex.Item"
-    id="Flex.Item"
-    Component={Flex?.Item}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'alignSelf',
-        type: `"auto" | "start" | "end" | "center" | "baseline" | "stretch"`,
-        defaultValue: 'stretch',
-        description:
-          'Allows the default alignment (or the one specified by `align-items`) to be overridden for individual flex items.',
-      },
-      {
-        name: 'flex',
-        type: '"grow" | "shrink" | "none"',
-        defaultValue: 'shrink',
-        description: `Defines how a flex item will be sized. \`"grow"\`, equivalent to \`"flex: 1 1 auto"\`, will size the Flex.Item relative to its parent, growing and shrinking based on available space. \`"shrink"\`, equivalent to \`"flex: 0 1 auto"\` (the browser default), allows the Flex.Item to shrink if compressed but not grow if given extra space. Finally, \`"none"\`, equivalent to \`"flex: 0 0 auto"\`, preserves the Flex.Item's size based on child content regardless of its container's size.`,
-      },
-      {
-        name: 'flexBasis',
-        type: `number | string`,
-        description: `Defines the initial main size of the flex item. Use numbers for pixels: \`flexBasis={100}\` and strings for other units: \`flexBasis="100vh"\`.`,
-      },
-      {
-        name: 'minWidth',
-        type: `number | string`,
-        description: `Use numbers for pixels: \`minWidth={100}\` and strings for percentages: \`minWidth="100%"\`. Can be used to fix overflowing children; see [the example](#FlexItem-minWidth) to learn more.`,
-      },
-    ]}
-  />,
-);
-
-card(
-  <Example
-    description={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Applying flex properties to children"
+          description={`
     When using the 'gap' property, Flex wraps each child in a Flex.Item sub-component. If one of more of those children need custom flex properties, you can use Flex.Item directly.
   `}
-    name="Example: Applying flex properties to children"
-    defaultCode={`
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Box borderStyle="sm" paddingX={2} paddingY={3} rounding={3} width="100%">
   <Flex alignItems="center" gap={4} width="100%">
     <Button text="Button 1" />
@@ -190,16 +211,17 @@ card(
   </Flex>
 </Box>
 `}
-  />,
-);
-
-card(
-  <Example
-    description={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Initial item width using flexBasis"
+          description={`
     If an item needs a different width in the flex layout than the content would otherwise indicate, \`flexBasis\` can be used.
   `}
-    name="Example: Initial item width using flexBasis"
-    defaultCode={`
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Box borderStyle="sm" paddingX={2} paddingY={3} rounding={3} width="100%">
   <Flex alignItems="center" gap={4} width="100%">
     <Flex.Item flexBasis={200}>
@@ -214,20 +236,20 @@ card(
   </Flex>
 </Box>
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Example: Overflowing children and minWidth"
-    id="FlexItem-minWidth"
-    description={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Overflowing children and minWidth"
+          description={`
     Extra-wide children can sometimes overflow the Flex parent container, breaking the layout (and skipping truncation, if applicable).
     To fix this, simply wrap the wide child in Flex.Item with \`minWidth={0}\`. Voila!
 
     For more info, check out [this very helpful blog post](https://css-tricks.com/flexbox-truncated-text/#the-solution-is-min-width-0-on-the-flex-child).
   `}
-    defaultCode={`
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Box borderStyle="sm" padding={3} rounding={3}>
   <Flex alignItems="center" gap={3}>
     <Icon accessibilityLabel="Private" icon="lock" />
@@ -240,40 +262,9 @@ card(
   </Flex>
 </Box>
 `}
-  />,
-);
-
-card(
-  <MainSection name="Variants">
-    <MainSection.Subsection
-      description={`
-      Flex is strictly for flex layouts. If you're new to flex layout, please read the excellent [CSS-Tricks guide to flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
-  `}
-      title="Flex Layout"
-    >
-      <CombinationNew
-        justifyContent={['start', 'end', 'center', 'between', 'around']}
-        alignItems={['start', 'end', 'center', 'baseline', 'stretch']}
-      >
-        {(props) => (
-          <Box
-            display="flex"
-            width="75%"
-            height="75%"
-            borderStyle="shadow"
-            justifyContent={props.justifyContent}
-            alignItems={props.alignItems}
-          >
-            <Box margin={1} color="gray" height={8} width={8} />
-            <Box margin={1} color="gray" height={16} width={8} />
-            <Box margin={1} color="gray" height={32} width={8} />
-          </Box>
-        )}
-      </CombinationNew>
-    </MainSection.Subsection>
-  </MainSection>,
-);
-
-export default function FlexPage(): Node {
-  return <CardPage cards={cards} page="Flex" />;
+          />
+        </MainSection.Subsection>
+      </MainSection>
+    </Page>
+  );
 }

--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -82,7 +82,6 @@ function SectionsIconButtonDropdownExample() {
 card(
   <PropTable
     Component={IconButton}
-    name="IconButton"
     id="IconButton"
     props={[
       {

--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -2,129 +2,146 @@
 import type { Node } from 'react';
 import { Module } from 'gestalt';
 import PropTable from '../components/PropTable.js';
-import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
-import CardPage from '../components/CardPage.js';
 import MainSection from '../components/MainSection.js';
+import Page from '../components/Page.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
-
-card(
-  <PageHeader
-    name="Module"
-    description="
+export default function ModulePage(): Node {
+  return (
+    <Page title="Module">
+      <PageHeader
+        name="Module"
+        description="
       A Module is a container that holds content about one subject. Its contents can be visible at all times, or expand and collapse as individual modules or a group of modules.
     "
-  />,
-);
-
-card(
-  <PropTable
-    Component={Module}
-    name="Static Module"
-    id="static-Module"
-    props={[
-      {
-        name: 'badgeText',
-        href: 'static-badge',
-        type: 'string',
-        description:
-          'Add a badge displayed after the title. Will not be displayed if `title` is not provided. Not to be used with `icon` or `iconButton`. Be sure to localize the text.',
-      },
-      {
-        name: 'children',
-        href: 'static-default',
-        type: 'React.Node',
-        description: 'Content to display underneath Module title',
-      },
-      {
-        name: 'icon',
-        href: 'static-icon',
-        type: 'string',
-        description:
-          'Name of icon to display in front of title. Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `iconButton`.',
-      },
-      {
-        name: 'iconAccessibilityLabel',
-        href: 'static-icon',
-        type: 'string',
-        description:
-          'Label to provide information about the icon used for screen readers. Can be used in two scenarios: to describe the error icon that appears when `type` is `error`, and to describe the provided `icon` prop when `type` is `info`. Be sure to localize the label.',
-      },
-      {
-        name: 'iconButton',
-        href: 'static-iconbutton',
-        type: 'React.Element<IconButton>',
-        description:
-          'IconButton element to be placed after the `title` for a supplemental Call To Action (CTA). Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `icon`.',
-      },
-      {
-        name: 'id',
-        href: 'static-default',
-        type: 'string',
-        required: true,
-        description: 'Unique id to identify this Module',
-      },
-      {
-        name: 'title',
-        href: 'static-default',
-        type: 'string',
-        description: 'Title of this Module. Be sure to localize the text.',
-      },
-      {
-        name: 'type',
-        href: 'static-error',
-        type: '"info" | "error"',
-        defaultValue: 'info',
-        description:
-          'If set to `error`, displays error icon and changes title to red text. Be sure to provide an `iconAccessibilityLabel` when set to `error`.',
-      },
-    ]}
-  />,
-);
-
-card(
-  <PropTable
-    Component={Module?.Expandable}
-    name="Expandable Module"
-    id="expandable-module"
-    props={[
-      {
-        name: 'accessibilityExpandLabel',
-        href: 'expandable-default',
-        type: 'string',
-        required: true,
-        description:
-          'Label used to communicate to screen readers which module will be expanded when interacting with the title button. Should be something clear, like "Expand Security Policies Module". Be sure to localize the label.',
-      },
-      {
-        name: 'accessibilityCollapseLabel',
-        href: 'expandable-default',
-        type: 'string',
-        required: true,
-        description:
-          'Label used to communicate to screen readers which module will be collapsed when interacting with the title button. Should be something clear, like "Collapse Security Policies Module". Be sure to localize the label.',
-      },
-      {
-        name: 'expandedIndex',
-        type: '?number',
-        required: false,
-        description: [
-          'The 0-based index indicating the item that should currently be expanded. This must be updated via onExpandedChange to ensure the correct item is expanded.',
-        ],
-      },
-      {
-        name: 'id',
-        href: 'expandable-default',
-        type: 'string',
-        required: true,
-        description: 'Unique id to identify this Module',
-      },
-      {
-        name: 'items',
-        href: 'expandable-items',
-        type: `
+      />
+      <PropTable
+        Component={Module}
+        id="static-Module"
+        props={[
+          {
+            name: 'badgeText',
+            href: 'static-badge',
+            type: 'string',
+            description:
+              'Add a badge displayed after the title. Will not be displayed if `title` is not provided. Not to be used with `icon` or `iconButton`. Be sure to localize the text.',
+          },
+          {
+            name: 'children',
+            href: 'static-default',
+            type: 'React.Node',
+            description: 'Content to display underneath Module title',
+          },
+          {
+            name: 'icon',
+            href: 'static-icon',
+            type: 'string',
+            description:
+              'Name of icon to display in front of title. Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `iconButton`.',
+          },
+          {
+            name: 'iconAccessibilityLabel',
+            href: 'static-icon',
+            type: 'string',
+            description:
+              'Label to provide information about the icon used for screen readers. Can be used in two scenarios: to describe the error icon that appears when `type` is `error`, and to describe the provided `icon` prop when `type` is `info`. Be sure to localize the label.',
+          },
+          {
+            name: 'iconButton',
+            href: 'static-iconbutton',
+            type: 'React.Element<IconButton>',
+            description:
+              'IconButton element to be placed after the `title` for a supplemental Call To Action (CTA). Will not be displayed if `title` is not provided. Not to be used with `badgeText` or `icon`.',
+          },
+          {
+            name: 'id',
+            href: 'static-default',
+            type: 'string',
+            required: true,
+            description: 'Unique id to identify this Module',
+          },
+          {
+            name: 'title',
+            href: 'static-default',
+            type: 'string',
+            description: 'Title of this Module. Be sure to localize the text.',
+          },
+          {
+            name: 'type',
+            href: 'static-error',
+            type: '"info" | "error"',
+            defaultValue: 'info',
+            description:
+              'If set to `error`, displays error icon and changes title to red text. Be sure to provide an `iconAccessibilityLabel` when set to `error`.',
+          },
+        ]}
+      />
+      <MainSection name="Usage guidelines">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            title="When to Use"
+            description={`
+          - Grouping and organizing content to keep the page clean and digestible.
+          - Displaying additional related content about a particular subject.
+          - Enabling users to reveal or hide additional content as necessary (with Expandable variant).
+        `}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            title="When Not to Use"
+            description={`
+          - In a layout that conveys a clear sense of information hierarchy. Use [SegmentedControl](/segmentedcontrol) instead.
+          - When long content can’t be displayed all at once, and scrolling is necessary.
+          - When there is insufficient content to condense, as collapsing can increase cognitive load and interaction cost. Consider the static variant of Module.
+          - When the content is crucial to read in full. Consider the static variant instead.
+        `}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+      <MainSection name="Subcomponents" />
+      <PropTable
+        Component={Module?.Expandable}
+        name="Module.Expandable"
+        id="expandable-module"
+        props={[
+          {
+            name: 'accessibilityExpandLabel',
+            href: 'expandable-default',
+            type: 'string',
+            required: true,
+            description:
+              'Label used to communicate to screen readers which module will be expanded when interacting with the title button. Should be something clear, like "Expand Security Policies Module". Be sure to localize the label.',
+          },
+          {
+            name: 'accessibilityCollapseLabel',
+            href: 'expandable-default',
+            type: 'string',
+            required: true,
+            description:
+              'Label used to communicate to screen readers which module will be collapsed when interacting with the title button. Should be something clear, like "Collapse Security Policies Module". Be sure to localize the label.',
+          },
+          {
+            name: 'expandedIndex',
+            type: '?number',
+            required: false,
+            description: [
+              'The 0-based index indicating the item that should currently be expanded. This must be updated via onExpandedChange to ensure the correct item is expanded.',
+            ],
+          },
+          {
+            name: 'id',
+            href: 'expandable-default',
+            type: 'string',
+            required: true,
+            description: 'Unique id to identify this Module',
+          },
+          {
+            name: 'items',
+            href: 'expandable-items',
+            type: `
         Array<{|
           badgeText?: string,
           children: ?React.Node,
@@ -135,56 +152,28 @@ card(
           title: string,
           type?: "info" | "error" |}>
         `,
-        required: true,
-        description:
-          'Array of modules displayed in a stack. Only one item can be expanded at a time.',
-      },
-      {
-        name: 'onExpandedChange',
-        type: '(?number) => void',
-        required: false,
-        description: [
-          'Callback executed whenever any module item is expanded or collapsed. It receives the index of the currently expanded module, or null if none are expanded.',
-        ],
-      },
-    ]}
-  />,
-);
-
-card(
-  <MainSection name="Usage guidelines">
-    <MainSection.Subsection columns={2}>
-      <MainSection.Card
-        cardSize="md"
-        type="do"
-        title="When to Use"
-        description={`
-          - Grouping and organizing content to keep the page clean and digestible.
-          - Displaying additional related content about a particular subject.
-          - Enabling users to reveal or hide additional content as necessary (with Expandable variant).
-        `}
+            required: true,
+            description:
+              'Array of modules displayed in a stack. Only one item can be expanded at a time.',
+          },
+          {
+            name: 'onExpandedChange',
+            type: '(?number) => void',
+            required: false,
+            description: [
+              'Callback executed whenever any module item is expanded or collapsed. It receives the index of the currently expanded module, or null if none are expanded.',
+            ],
+          },
+        ]}
       />
-      <MainSection.Card
-        cardSize="md"
-        type="don't"
-        title="When Not to Use"
-        description={`
-          - In a layout that conveys a clear sense of information hierarchy. Use [SegmentedControl](/segmentedcontrol) instead.
-          - When long content can’t be displayed all at once, and scrolling is necessary.
-          - When there is insufficient content to condense, as collapsing can increase cognitive load and interaction cost. Consider the static variant of Module.
-          - When the content is crucial to read in full. Consider the static variant instead.
-        `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
-
-card(
-  <Example
-    name="Static"
-    description={`A Module is a container that can hold any content, and can optionally have a \`title\` that describes the content inside. The default, static Module is used to display information that should always be visible.`}
-    id="static-default"
-    defaultCode={`
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          title="Static"
+          description={`A Module is a container that can hold any content, and can optionally have a \`title\` that describes the content inside. The default, static Module is used to display information that should always be visible.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample() {
   return (
     <Flex direction="column" gap={2} maxWidth={800}>
@@ -199,19 +188,19 @@ function ModuleExample() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Static - Icon"
-    description={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Static - Icon"
+          description={`
     An Icon can be provided to be placed before the \`title\`.
 
     It is recommended that icons be used sparingly to convey additional information, and instead should simply reinforce information in the title. Be sure to provide an \`iconAccessibilityLabel\`.
     `}
-    id="static-icon"
-    defaultCode={`
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample() {
   return (
     <Box column={12} maxWidth={800} padding={2}>
@@ -227,17 +216,17 @@ function ModuleExample() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Static - IconButton"
-    description={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Static - IconButton"
+          description={`
     An IconButton can be provided to be placed after the \`title\` for a supplemental Call To Action (CTA).
     `}
-    id="static-iconbutton"
-    defaultCode={`
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample() {
   const [showPopover, setShowPopover] = React.useState(false);
   const anchorRef = React.useRef(null);
@@ -246,7 +235,7 @@ function ModuleExample() {
     <Box column={12} maxWidth={800} padding={2}>
       <Module
         iconButton={
-          <IconButton 
+          <IconButton
             bgColor="lightGray"
             icon="question-mark"
             iconColor="darkGray"
@@ -280,15 +269,15 @@ function ModuleExample() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Static - Badge"
-    description={`Badge text can be provided, which will be displayed after the \`title\`. Note that if no title text is provided, the badge will not be displayed.`}
-    id="static-badge"
-    defaultCode={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Static - Badge"
+          description={`Badge text can be provided, which will be displayed after the \`title\`. Note that if no title text is provided, the badge will not be displayed.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample() {
   return (
     <Box column={12} maxWidth={800} padding={2}>
@@ -303,15 +292,15 @@ function ModuleExample() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Static - Error"
-    id="static-error"
-    description={`When using \`type\` as \`"error"\`, be sure to provide an \`iconAccessibilityLabel\`.`}
-    defaultCode={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Static - Error"
+          description={`When using \`type\` as \`"error"\`, be sure to provide an \`iconAccessibilityLabel\`.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample() {
   const [value, setValue] = React.useState('');
 
@@ -339,15 +328,15 @@ function ModuleExample() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Expandable"
-    id="expandable-default"
-    description={`Modules can also allow for expanding and collapsing content. The \`title\` is required and always present. The collapsed state shows optional \`summary\` content, while the expanded state shows any content desired.`}
-    defaultCode={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Expandable"
+          description={`Modules can also allow for expanding and collapsing content. The \`title\` is required and always present. The collapsed state shows optional \`summary\` content, while the expanded state shows any content desired.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample1() {
   return (
     <Box column={12} maxWidth={800} padding={2}>
@@ -366,15 +355,15 @@ function ModuleExample1() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Expandable - Group"
-    description="Multiple expandable items can be stacked together into a Module group. However, only one Module will be expanded at any time."
-    id="expandable-multiple"
-    defaultCode={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Expandable - Group"
+          description="Multiple expandable items can be stacked together into a Module group. However, only one Module will be expanded at any time."
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample2() {
   return (
     <Box column={12} maxWidth={800} padding={2}>
@@ -403,20 +392,21 @@ function ModuleExample2() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Expandable - Icon, Badge and IconButton"
-    description={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="ExpExpandable - Icon, Badge and IconButton"
+          description={`
     An Icon can be provided to be placed before the \`title\`.
     It is recommended that icons be used sparingly to convey additional information, and instead should simply reinforce information in the title. Be sure to provide an \`iconAccessibilityLabel\`.
 
     Badge text can also be provided, which will be displayed after the \`title\`.
-    
+
     An IconButton can be provided to be placed after the \`title\` for a supplemental Call To Action (CTA).`}
-    defaultCode={`
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample3() {
   const [showPopover, setShowPopover] = React.useState(false);
   const anchorRef = React.useRef(null);
@@ -441,7 +431,7 @@ function ModuleExample3() {
           },
           {
             children: <Text size="md">Children3</Text>,
-            iconButton: <IconButton 
+            iconButton: <IconButton
               bgColor="lightGray"
               icon="question-mark"
               iconColor="darkGray"
@@ -449,7 +439,7 @@ function ModuleExample3() {
               size="xs"
               onClick={({event}) => setShowPopover((currVal) => !currVal)}
               ref={anchorRef}
-            />,            
+            />,
             title: 'Example with icon button',
           }
         ]}>
@@ -471,14 +461,15 @@ function ModuleExample3() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Expandable - Error"
-    description={`When using \`type\` as \`"error"\`, be sure to provide an \`iconAccessibilityLabel\`.`}
-    defaultCode={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Expandable - Error"
+          description={`When using \`type\` as \`"error"\`, be sure to provide an \`iconAccessibilityLabel\`.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample4() {
   const [value, setValue] = React.useState('');
   const moduleType = !value ? 'error' : 'info';
@@ -512,13 +503,12 @@ function ModuleExample4() {
   );
 }
 `}
-  />,
-);
-
-card(
-  <Example
-    name="Example with external control"
-    defaultCode={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection title="Example with external control">
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ModuleExample5() {
   const [extExpandedId, setExtExpandedId] = React.useState(null);
   const mapIds = {
@@ -586,9 +576,9 @@ function ModuleExample5() {
   );
 }
 `}
-  />,
-);
-
-export default function ModulePage(): Node {
-  return <CardPage cards={cards} page="Module" />;
+          />
+        </MainSection.Subsection>
+      </MainSection>
+    </Page>
+  );
 }

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -1,88 +1,18 @@
 // @flow strict
 import type { Node } from 'react';
 import { Table } from 'gestalt';
-import Card from '../components/Card.js';
-import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import PropTable from '../components/PropTable.js';
-import CardPage from '../components/CardPage.js';
 import MainSection from '../components/MainSection.js';
+import Page from '../components/Page.js';
 
-const cards: Array<Node> = [];
-const card = (c) => cards.push(c);
-
-card(
-  <PageHeader
-    name="Table"
-    description="The Table contains the following composable elements: Table, Table.Body, Table.Cell, Table.Footer, Table.Header, Table.HeaderCell, Table.Row, Table.SortableHeaderCell."
-  />,
-);
-
-card(
-  <PropTable
-    Component={Table}
-    props={[
-      {
-        name: 'accessibilityLabel',
-        type: 'string',
-        description: 'Label for screen readers to announce Table.',
-        required: true,
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'borderStyle',
-        type: `"sm" | "none"`,
-        description: 'Specify a border width for table: "sm" is 1px',
-        defaultValue: 'none',
-      },
-      {
-        name: 'maxHeight',
-        type: `number | string`,
-        description: `Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%"`,
-        href: 'stickyHeader',
-      },
-      {
-        name: 'stickyColumns',
-        type: `number`,
-        description: `Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](#stickyColumn) example for details.`,
-      },
-    ]}
-  />,
-);
-
-card(
-  <MainSection name="Usage guidelines">
-    <MainSection.Subsection columns={2}>
-      <MainSection.Card
-        cardSize="md"
-        type="do"
-        title="When to Use"
-        description={`
-          - Displaying a set of structured data in a scannable way, that populates 2 or more rows.
-          - Allowing users to compare information in rows and columns.
-        `}
-      />
-      <MainSection.Card
-        cardSize="md"
-        type="don't"
-        title="When Not to Use"
-        description={`
-          - There will never be enough data to populate at least 2 rows.
-          - Displaying content that doesn’t follow a consistent pattern and can't be broken down into columns.
-          - Providing robust data that doesn't fit in a tabular format. If there is a need to display a more complex data relationship, consider an info-graphic or a non-tabular format.
-        `}
-      />
-    </MainSection.Subsection>
-  </MainSection>,
-);
-
-card(
-  <Example
-    name="Example: Basic Table"
-    defaultCode={`
+export default function TablePage(): Node {
+  return (
+    <Page title="Table">
+      <PageHeader
+        name="Table"
+        description="​​A table is a set of structured data that is easy for a user to scan, examine, and compare. Table data is displayed in a grid format and can be used to structure both interactive and static data."
+        defaultCode={`
 <Table accessibilityLabel="Basic Table">
   <Table.Header>
     <Table.Row>
@@ -145,90 +75,1666 @@ card(
   </Table.Body>
 </Table>
 `}
-  />,
-);
+      />
+      <PropTable
+        Component={Table}
+        props={[
+          {
+            name: 'accessibilityLabel',
+            type: 'string',
+            description: 'Label for screen readers to announce Table.',
+            required: true,
+          },
+          {
+            name: 'children',
+            type: 'React.Node',
+          },
+          {
+            name: 'borderStyle',
+            type: `"sm" | "none"`,
+            description: 'Specify a border width for table: "sm" is 1px',
+            defaultValue: 'none',
+          },
+          {
+            name: 'maxHeight',
+            type: `number | string`,
+            description: `Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%"`,
+          },
+          {
+            name: 'stickyColumns',
+            type: `number`,
+            description: `Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](#stickyColumn) example for details.`,
+          },
+        ]}
+      />
+      <MainSection name="Usage guidelines">
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            title="When to Use"
+            description={`
+          - Displaying a set of structured data in a scannable way, that populates 2 or more rows.
+          - Allowing users to compare information in rows and columns.
+        `}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            title="When Not to Use"
+            description={`
+          - There will never be enough data to populate at least 2 rows.
+          - Displaying content that doesn’t follow a consistent pattern and can't be broken down into columns.
+          - Providing robust data that doesn't fit in a tabular format. If there is a need to display a more complex data relationship, consider an info-graphic or a non-tabular format.
+        `}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+      <MainSection name="Best practices">
+        <MainSection.Subsection title="Style" columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            description="Use accessible Gestalt grays for table text, and reserve colors to sparingly accent important status and information. Avoid over-styling text."
+            defaultCode={`
+function Example() {
+  const HeaderRow = ({ id }) => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>
+            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
+            <Checkbox
+              id={id}
+   onChange={() => {}}
+              indeterminate
+              size="sm"
+            />
+          </Table.HeaderCell>
+          {["Status", "Campaign"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
 
-card(
-  <PropTable
-    Component={Table?.Body}
-    name="Table.Body"
-    id="Table.Body"
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-    ]}
-  />,
-);
+  const BaseRow = ({ id, checked, disabled, text, campaign }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Checkbox
+            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
+            disabled={disabled}
+            size="sm"
+            checked={checked}
+          />
+        </Table.Cell>
+        <Table.Cell>
+          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
+            <Text>{text}</Text>
+          </Label>
+        </Table.Cell>
+        <Table.Cell>
+          <Text color={disabled ? "gray" : "darkGray"}>{campaign}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
 
-card(
-  <PropTable
-    name="Table.Cell"
-    id="Table.Cell"
-    Component={Table?.Cell}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'colSpan',
-        type: 'number',
-        defaultValue: 1,
-      },
-      {
-        name: 'rowSpan',
-        type: 'number',
-        defaultValue: 1,
-      },
-    ]}
-  />,
-);
+  const tableID = "Example of a 'do' for table style";
 
-card(
-  <PropTable
-    name="Table.Footer"
-    id="Table.Footer"
-    Component={Table?.Footer}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-    ]}
-  />,
-);
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow id={tableID}/>
+      <Table.Body>
+        <BaseRow
+          id={tableID}
+          checked={true}
+          text="The best ad"
+          campaign="Engagement"
+        />
+        <BaseRow
+          id={tableID}
+          disabled
+          text="This ad is great"
+          campaign="Awareness"
+        />
+        <BaseRow
+          id={tableID}
+          checked={true}
+          text="Macy's pincycle"
+          campaign="Catalogs"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="Best Buy Wins"
+          campaign="Awareness"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="The third campaign"
+          campaign="Conversions"
+        />
+      </Table.Body>
+    </Table>
+  );
+}
+`}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            description="Overuse color and styling for text in tables; it can make it hard to scan for important status updates and crucial information."
+            defaultCode={`
+function Example() {
+  const HeaderRow = ({ id }) => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>
+            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
+            <Checkbox
+              id={id}
+   onChange={() => {}}
+              indeterminate
+              size="sm"
+            />
+          </Table.HeaderCell>
+          {["Status", "Campaign"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text color={ title === "Campaign" ? "red" : "blue"} weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
 
-card(<Card name="Table.Header" />);
+  const BaseRow = ({ id, checked, disabled, text, campaign, bold, underline, italic, color }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Checkbox
+            id={ id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "") }
+ onChange={() => {}}
+            disabled={disabled}
+            size="sm"
+            checked={checked}
+          />
+        </Table.Cell>
+        <Table.Cell>
+          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
+            <Text
+              weight={bold ? "bold" : "regular"}
+              underline={underline ? true : undefined}
+              italic={italic ? true : undefined}
+            >
+              {text}
+            </Text>
+          </Label>
+        </Table.Cell>
+        <Table.Cell>
+          <Text color={color}>{campaign}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
 
-card(
-  <PropTable
-    name="Table.Header"
-    id="Table.Header"
-    Component={Table?.Header}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'sticky',
-        type: 'boolean',
-        defaultValue: false,
-        href: 'stickyHeader',
-        description:
-          'If true, the table header will be sticky and the table body will be scrollable',
-      },
-    ]}
-  />,
-);
+ const tableID = "Example of a Dont do for table style";
 
-card(
-  <Example
-    id="stickyHeader"
-    name="Example: Sticky header"
-    defaultCode={`
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow id={tableID}/>
+      <Table.Body>
+        <BaseRow
+          id={tableID}
+          checked={true}
+          text="The best ad"
+          campaign="Engagement"
+          color="red"
+        />
+        <BaseRow
+          id={tableID}
+          disabled
+          bold
+          text="This ad is great"
+          campaign="Awareness"
+          color="blue"
+        />
+        <BaseRow
+          id={tableID}
+          checked={true}
+          bold
+          italic
+          text="Macy's pincycle"
+          campaign="Catalogs"
+          color="red"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          underline
+          text="BEST BUY WINS"
+          campaign="Awareness"
+          color="purple"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="The third campaign"
+          campaign="CONVERSIONS"
+          color="green"
+        />
+      </Table.Body>
+    </Table>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection title="Alignment" columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            description={`Align content so that it’s easy to scan, read and compare:
+- Start-align text and combo-content (combinations of text, numbers and/or graphics)
+- End-align numbers only
+- Align headers with their corresponding content
+- Use tabular lining for numbers`}
+            defaultCode={`
+function Example() {
+  const HeaderRow = ({ id }) => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>
+            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
+            <Checkbox
+              id={id}
+   onChange={() => {}}
+              indeterminate
+              size="sm"
+            />
+          </Table.HeaderCell>
+          {["Campaign", "Spend"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text align={title === "Spend" ? "end" : "start"} weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
+
+  const BaseRow = ({ id, checked, disabled, text, spend }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Checkbox
+            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
+            disabled={disabled}
+            size="sm"
+            checked={checked}
+          />
+        </Table.Cell>
+        <Table.Cell>
+          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
+            <Text>{text}</Text>
+          </Label>
+        </Table.Cell>
+        <Table.Cell>
+          <Text align="end">{spend}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
+
+  const tableID = "Example of a 'do' for table alignment";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow id={tableID}/>
+      <Table.Body>
+       <BaseRow
+          id={tableID}
+          checked={true}
+          text="The best ad"
+          spend="$5.50"
+        />
+        <BaseRow
+          id={tableID}
+          disabled
+          text="This ad is great"
+          spend="$3,000.00"
+        />
+        <BaseRow
+          id={tableID}
+          checked={true}
+          text="Macy's pincycle"
+          spend="$1.75"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="Best Buy Wins"
+          spend="$51,650,500.54"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="The third campaign"
+          spend="$67.60"
+        />
+      </Table.Body>
+    </Table>
+  );
+}
+`}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            description={`Don’t
+Align content so that it makes it harder to scan, read, and compare.
+- Center-align content
+- Use proportional figures for numbers as they don’t quite align
+- End-align text and combo-content (combinations of text, numbers and/or graphics)
+- Misalign headers with their corresponding content
+`}
+            defaultCode={`
+function Example() {
+  const HeaderRow = ({ id }) => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>
+            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
+            <Checkbox
+              id={id}
+   onChange={() => {}}
+              indeterminate
+              size="sm"
+            />
+          </Table.HeaderCell>
+          {["Campaign", "Spend"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text align={title === "Campaign" ? "center" : "start"} weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
+
+  const BaseRow = ({ id, checked, disabled, text, subtext, spend }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Checkbox
+            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
+            disabled={disabled}
+            size="sm"
+            checked={checked}
+          />
+        </Table.Cell>
+        <Table.Cell>
+          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
+            <Text align="center">{text}</Text>
+            <Text align="center">{subtext}</Text>
+          </Label>
+        </Table.Cell>
+        <Table.Cell>
+          <Text align="end">{spend}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
+
+  const tableID = "Example of a 'Dont' do for table alignment";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow id={tableID} />
+      <Table.Body>
+       <BaseRow
+          id={tableID}
+          checked={true}
+          text="The best ad"
+          subtext="12/20/21"
+          spend="$5"
+        />
+        <BaseRow
+          id={tableID}
+          disabled
+          text="This ad is great"
+          subtext="01/16/21"
+          spend="$3,000.00"
+        />
+        <BaseRow
+          id={tableID}
+          checked={true}
+          text="Macy's pincycle"
+          subtext="07/15/22"
+          spend="$1.750"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="Best Buy Wins"
+          subtext="06/15/22"
+          spend="$51,650,500.54"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="The third campaign"
+          subtext="06/24/22"
+          spend="$67.60"
+        />
+      </Table.Body>
+    </Table>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            description="Place unit type on a separate column so that amounts can still align and be compared."
+            defaultCode={`
+function Example() {
+  const HeaderRow = () => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          {["Status", "Rate", "Type"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text align={title === "Rate" ? "end" : "start"} weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
+
+  const BaseRow = ({ disabled, type, title, subtext, rate, category }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Status type={type} title={title} subtext={subtext} />
+        </Table.Cell>
+        <Table.Cell>
+          <Text align="end" color={disabled ? "gray" : "darkGray"}>{rate}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text color={disabled ? "gray" : "darkGray"}>{category}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
+
+  const tableID = "Another example of a 'do' for table alignment";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow
+          type="inProgress"
+          title="Active"
+          subtext="Ends 11/20/2021"
+          rate={100}
+          category="CTR"
+        />
+        <BaseRow
+          disabled
+          type="halted"
+          title="Paused"
+          subtext="Ends 11/20/2021"
+          rate="5,000"
+          category="Engagement"
+        />
+        <BaseRow
+          type="warning"
+          title="Warning"
+          subtext="Ends 11/20/2021"
+          rate={2}
+          category="Conversions"
+        />
+        <BaseRow
+          checked={false}
+          type="ok"
+          title="Complete"
+          subtext="Ends 11/20/2021"
+          rate={50}
+          category="CTR"
+        />
+      </Table.Body>
+    </Table>
+  );
+}
+`}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            description="Mix text and graphics with numbers that need to be compared with each other."
+            defaultCode={`
+function Example() {
+  const HeaderRow = () => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          {["Status", "Rate"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text align={title === "Rate" ? "end" : "start"}  weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
+
+  const BaseRow = ({ disabled, type, title, subtext, rate }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Status type={type} title={title} subtext={subtext} />
+        </Table.Cell>
+        <Table.Cell>
+          <Text overflow="noWrap" align="end" color={disabled ? "gray" : "darkGray"}>{rate}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
+
+  const tableID = "Another Example of a 'Dont' do for table alignment";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow
+          type="inProgress"
+          title="Active"
+          subtext="Ends 11/20/2021"
+          rate="100 CTR"
+        />
+        <BaseRow
+          disabled
+          type="halted"
+          title="Paused"
+          subtext="Ends 11/20/2021"
+          rate="5,000 Engagement"
+        />
+        <BaseRow
+          type="warning"
+          title="Warning"
+          subtext="Ends 11/20/2021"
+          rate="2 Conversions"
+        />
+        <BaseRow
+          type="ok"
+          title="Complete"
+          subtext="Ends 11/20/2021"
+          rate="50 CTR"
+        />
+      </Table.Body>
+    </Table>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection title="Content" columns={2}>
+          <MainSection.Card
+            cardSize="md"
+            type="do"
+            description="Make content digestible and scannable:
+- Keep headers clear and concise
+- Include an a visual indicator for cells that don’t have content.
+- Give enough space for content to account for localization.
+- Wrap important content to multiple lines
+- Truncate secondary information, especially if a user is going to get the full content upon click of a link in the table.
+"
+            defaultCode={`
+function Example() {
+  const HeaderRow = () => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          {["Name", "Total"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text align={title === "Total" ? "end" : "start"} weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
+
+  const BaseRow = ({ name, subtext, total, lineClamp }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Text color="darkGray">{name}</Text>
+          <Text color="gray" size="sm" lineClamp={lineClamp}>{subtext}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text align="end">{total}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
+
+  const tableID = "Example of a 'do' for table content";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow
+          name="Video views for all Q3 campaigns and ad groups"
+          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
+          total="--"
+          lineClamp={1}
+        />
+        <BaseRow
+          name="Video views for all Q2 campaigns and ad groups"
+          subtext="David Brown, Carlota Ojeda"
+          total="5,000"
+        />
+        <BaseRow
+          name="Video views for all Q2 ad groups"
+          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
+          total="6,455,434"
+          lineClamp={1}
+        />
+      </Table.Body>
+    </Table>
+  );
+}
+`}
+          />
+          <MainSection.Card
+            cardSize="md"
+            type="don't"
+            description="Add so much content that it’s hard for a user to read, examine and scan:
+- Don’t truncate content that a user needs to examine in relation to other content in the table.
+- Leave cells blank so that it isn’t clear if all data has loaded."
+            defaultCode={`
+function Example() {
+  const HeaderRow = () => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          {["Name", "Total amounts for 2021 through 2022"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text align={title.startsWith("Total") ? "end" : "start"} weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
+
+  const BaseRow = ({ name, subtext, total, lineClamp }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Text color="darkGray">{name}</Text>
+          <Text color="gray" size="sm" lineClamp={lineClamp}>{subtext}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text align="end" lineClamp={lineClamp}>{total}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
+
+  const tableID = "Example of a 'don't' do for table content";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow
+          name="Video views for all Q3 campaigns and ad groups"
+          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
+          total=""
+        />
+        <BaseRow
+          name="Video views for all Q2 campaigns and ad groups"
+          subtext="David Brown, Carlota Ojeda"
+          total="5,000"
+        />
+        <BaseRow
+          name="Video views for all Q2 ad groups"
+          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
+          total="6,455,434"
+          lineClamp={1}
+        />
+      </Table.Body>
+    </Table>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection>
+          <MainSection.Card
+            cardSize="lg"
+            type="do"
+            description="Expand rows if the additional content is simple, doesn’t contain a lot of interaction and doesn’t take up more than 50% of the screen."
+            defaultCode={`
+    function Example() {
+      const [activeA, setActiveA] = React.useState(false);
+      const [activeB, setActiveB] = React.useState(false);
+      const [activeC, setActiveC] = React.useState(false);
+
+      const HeaderRow = () => {
+        return (
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Box display="visuallyHidden">
+                  <Text weight="bold">Open/Close row</Text>
+                </Box>
+              </Table.HeaderCell>
+              {["Name", "Team", "Role", "Office Hours"].map((title, idx) => {
+                return (
+                  <Table.HeaderCell key={idx}>
+                    <Text weight="bold">{title}</Text>
+                  </Table.HeaderCell>
+                );
+              })}
+            </Table.Row>
+          </Table.Header>
+        );
+      };
+
+      const BaseRow = ({ name, team, src, role, hours, active, setActive }) => {
+        return (
+            <Table.RowExpandable
+              accessibilityExpandLabel="Expand"
+              accessibilityCollapseLabel="Collapse"
+              id={name}
+              onExpand={() => {}}
+              expandedContents={
+                <Box
+                  onMouseEnter={() => setActive(true)}
+                  onMouseLeave={() => setActive(false)}
+                  display="flex"
+                  justifyContent="center"
+                  maxWidth={236}
+                  padding={2}
+                  column={12}
+                >
+                  <Card
+                    active={active}
+                    image={
+                      <Box
+                        display="flex"
+                        justifyContent="center"
+                        maxWidth={236}
+                        padding={2}
+                        column={12}
+                      >
+                        <Avatar
+                          size="md"
+                          name={name+"avatar"}
+                          src={src}
+                        />
+                      </Box>
+                    }
+                  >
+                    <Text align="center" weight="bold">
+                      <Link href="https://pinterest.com" target="blank">
+                        <Box paddingX={3} paddingY={2}>
+                          {name+"'s Info"}
+                        </Box>
+                      </Link>
+                    </Text>
+                  </Card>
+                </Box>
+              }
+            >
+            <Table.Cell>
+              <Text>{name}</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>{team}</Text>
+            </Table.Cell>
+             <Table.Cell>
+              <Text>{role}</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>{hours}</Text>
+            </Table.Cell>
+          </Table.RowExpandable>
+        );
+      };
+
+    const tableID = "Another Example of a 'do' for table content";
+
+      return(
+    <Table accessibilityLabel={tableID}>
+          <HeaderRow />
+          <Table.Body>
+           <BaseRow
+              active={activeA}
+              setActive={setActiveA}
+              name="Ayesha Teng"
+              team="Gestalt"
+              src="https://i.ibb.co/QY9qR7h/luna.png"
+              role="Engineer"
+              hours="Monday, Friday"
+            />
+            <BaseRow
+              active={activeB}
+              setActive={setActiveB}
+              name="Ryan Costa"
+              team="Analytics"
+              src="https://i.ibb.co/Hzcfxjt/draco.png"
+              role="Designer"
+              hours="Wednesdays"
+            />
+            <BaseRow
+              active={activeC}
+              setActive={setActiveC}
+              name="Kate Steele"
+              team="Monetization"
+              src="https://i.ibb.co/JvY9DKK/neville.png"
+              role="Design Technologist"
+              hours="Tuesdays, Thursdays"
+            />
+          </Table.Body>
+        </Table>);
+    }
+    `}
+          />
+          <MainSection.Card
+            cardSize="lg"
+            type="don't"
+            description="Use an expand to display dense, highly-interactive content. Use a new page or a [Sheet](/Sheet) for that."
+            defaultCode={`
+function MainExample() {
+  const ExpandedContents = () => {
+    const [tabItem, setTabItem] = React.useState('campaign');
+    const [extExpandedId, setExtExpandedId] = React.useState(null);
+    const mapIds = {
+      'first-0': 0,
+      'first-1': 1,
+      'first-2': 2,
+    };
+    return (
+      <Flex direction="column" gap={6} width={800}>
+        <Tabs
+          activeTabIndex={tabItem === 'campaign' ? 0 : 1}
+          bgColor="transparent"
+          onChange={({ event }) => {
+            setTabItem(tabItem !== 'analytics' ? 'analytics' : 'campaign');
+            event.preventDefault();
+          }}
+          tabs={[
+            { href: '', text: 'Campaign', indicator: tabItem === 'campaign' ? 'dot' : undefined },
+            { href: '', text: 'Analytics', indicator: tabItem === 'analytics' ? 'dot' : undefined },
+          ]}
+        />
+        {tabItem === 'campaign' ? (
+          <Flex direction="column" gap={6} width="100%">
+            <Heading size="sm" accessibilityLevel={2}>
+              Latest boards
+            </Heading>
+            <Flex gap={6} width="100%">
+              <Flex.Item width="50%">
+                <TapArea tapStyle="compress" onTap={() => {}}>
+                  <Mask rounding={4}>
+                    <Collage
+                      columns={3}
+                      height={300}
+                      width={300}
+                      renderImage={({ index, width, height }) => {
+                        const images = [
+                          {
+                            color: 'rgb(111, 91, 77)',
+                            naturalHeight: 751,
+                            naturalWidth: 564,
+                            src: 'https://i.ibb.co/Lx54BCT/stock1.jpg',
+                          },
+                          {
+                            color: 'rgb(231, 186, 176)',
+                            naturalHeight: 200,
+                            naturalWidth: 98,
+                            src: 'https://i.ibb.co/7bQQYkX/stock2.jpg',
+                          },
+                          {
+                            color: '#000',
+                            naturalHeight: 300,
+                            naturalWidth: 200,
+                            src: 'https://i.ibb.co/d0pQsJz/stock3.jpg',
+                          },
+                          {
+                            color: '#000',
+                            naturalHeight: 517,
+                            naturalWidth: 564,
+                            src: 'https://i.ibb.co/SB0pXgS/stock4.jpg',
+                          },
+                          {
+                            color: '#000',
+                            naturalHeight: 806,
+                            naturalWidth: 564,
+                            src: 'https://i.ibb.co/jVR29XV/stock5.jpg',
+                          },
+                          {
+                            color: '#000',
+                            naturalHeight: 200,
+                            naturalWidth: 200,
+                            src: 'https://i.ibb.co/FY2MKr5/stock6.jpg',
+                          },
+                        ];
+                        const image = images[index] || {};
+                        return (
+                          <Mask wash width={width} height={height}>
+                            <Image
+                              alt="collage image"
+                              color={image.color}
+                              fit="cover"
+                              naturalHeight={image.naturalHeight}
+                              naturalWidth={image.naturalWidth}
+                              src={image.src}
+                            />
+                          </Mask>
+                        );
+                      }}
+                    />
+                  </Mask>
+                  <Flex direction="column" gap={2}>
+                    <Heading size="sm" accessibilityLevel={0}>
+                      Uniform
+                    </Heading>
+                    <Flex gap={5}>
+                      <Text size="md">123 Pins</Text>
+                      <Text size="md">4 sections</Text>
+                    </Flex>
+                  </Flex>
+                </TapArea>
+              </Flex.Item>
+              <Flex direction="column" gap={4} width="100%">
+                <TextField
+                  id="name"
+                  onChange={() => {}}
+                  placeholder="Name"
+                  label="Name"
+                  value="December '21"
+                />
+                <TextArea
+                  id="notes"
+                  onChange={() => {}}
+                  placeholder="Notes on updates..."
+                  label="Notes"
+                  value=""
+                />
+                <Flex gap={4}>
+                  <NumberField
+                    id="budget"
+                    onChange={() => {}}
+                    placeholder=""
+                    label="Budget (USD)"
+                    value="100000"
+                  />
+                  <TextField
+                    id="scope"
+                    onChange={() => {}}
+                    placeholder=""
+                    label="Scope"
+                    value="Global"
+                  />
+                </Flex>
+                <Label htmlFor="status">
+                  <Text>Status</Text>
+                </Label>
+                <Switch onChange={() => {}} id="status" switched />
+              </Flex>
+            </Flex>
+            <Flex gap={3}>
+              <Button text="Cancel" />
+              <Flex.Item flex="grow">
+                <Button text="Pause" />
+              </Flex.Item>
+              <Button color="red" text="Edit" />
+            </Flex>
+          </Flex>
+        ) : (
+          <Flex gap={3}>
+            <Module id="Analitycs Overview" title="Analitycs Overview">
+              <Box width={300}>
+                <Datapoint
+                  size="lg"
+                  tooltipText="The number of times your ads were seen, including earned impressions"
+                  title="Total impressions"
+                  value="1K"
+                  trend={{ value: 30, accessibilityLabel: 'Trending up' }}
+                />
+                <Datapoint
+                  size="lg"
+                  tooltipText="The number of times your ads were seen, including earned impressions"
+                  title="Saves"
+                  value="5"
+                  trend={{ value: 5, accessibilityLabel: 'Trending up' }}
+                />
+                <Datapoint
+                  size="lg"
+                  tooltipText="The number of times your ads were seen, including earned impressions"
+                  title="Outbound clicks"
+                  value="10"
+                  trend={{ value: 10, accessibilityLabel: 'Trending up' }}
+                />
+              </Box>
+            </Module>
+            <Flex direction="column" gap={2} maxWidth={800}>
+              <Module
+                id="Ads Overview"
+                title="Ads Overview"
+                iconButton={
+                  <IconButton
+                    role="link"
+                    href="https://analytics.pinterest.com/"
+                    bgColor="lightGray"
+                    icon="arrow-up-right"
+                    iconColor="darkGray"
+                    accessibilityLabel="Get help"
+                    size="xs"
+                    onClick={() => {}}
+                    target="blank"
+                  />
+                }
+              >
+                <Box width={300}>
+                  <Text size="md">Content</Text>
+                </Box>
+              </Module>
+              <Module id="Top Pins" title="Top Pins">
+                <Box width={300}>
+                  <Text size="md">Content</Text>
+                </Box>
+              </Module>
+            </Flex>
+          </Flex>
+        )}
+      </Flex>
+    );
+  };
+
+  function Example() {
+    const HeaderRow = () => (
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>
+            <Box display="visuallyHidden">
+              <Text weight="bold">Open/Close row</Text>
+            </Box>
+          </Table.HeaderCell>
+          {['Campaing', 'Status', 'Budget', 'Scope'].map((title, idx) => (
+            <Table.HeaderCell key={idx}>
+              <Text weight="bold">{title}</Text>
+            </Table.HeaderCell>
+          ))}
+        </Table.Row>
+      </Table.Header>
+    );
+
+    const BaseRow = ({ campaign, status, budget, scope }) => (
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Text weight="bold">Open/Close row</Text>
+          </Box>
+        </Table.HeaderCell>
+        <Table.Cell>
+          <Text>{campaign}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text>{status}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text>{budget}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text>{scope}</Text>
+        </Table.Cell>
+      </Table.Row>
+    );
+
+    const RowExpandable = ({ campaign, status, empty, budget, scope }) => (
+      <Table.RowExpandable
+        accessibilityExpandLabel="Expand"
+        accessibilityCollapseLabel="Collapse"
+        id="row1"
+        onExpand={() => {}}
+        expandedContents={
+          empty ? (
+            <Text>No metrics available. This campaign hasn't started yet.</Text>
+          ) : (
+            <ExpandedContents />
+          )
+        }
+      >
+        <Table.Cell>
+          <Text>{campaign}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text>{status}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text>{budget}</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text>{scope}</Text>
+        </Table.Cell>
+      </Table.RowExpandable>
+    );
+
+    const tableID = "Another example of a 'don't' do for table content";
+
+    return (
+      <Table accessibilityLabel={tableID}>
+        <HeaderRow />
+        <Table.Body>
+          <RowExpandable campaign="December '21" status="Active" budget="$100,000" scope="Global" />
+          <RowExpandable
+            campaign="January '22"
+            status="Draft"
+            budget="$50,000"
+            scope="Japan, Germany, Canada, Spain, Mexico, Thailand, Italy"
+            empty
+          />
+          <RowExpandable
+            campaign="February '22"
+            status="Draft"
+            budget="$50,000"
+            scope="Japan, Germany, Canada"
+            empty
+          />
+        </Table.Body>
+      </Table>
+    );
+  }
+
+  return <Example />;
+}
+    `}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+      <MainSection
+        name="Localization"
+        description={`Be sure to localize \`text\` and \`accessibilityLabel\`.
+
+Note that localization can lengthen text by 20 to 30 percent; follow our guidelines on concise content and headings to account for localization.
+
+Wrap important table content instead of truncating. Use truncation only for secondary content, and include a tooltip to show the full text on hover.
+`}
+      />
+      <MainSection name="Accessibility">
+        <MainSection.Subsection
+          title="Labels"
+          description={`
+Use  \`accessibilityLabel\` to properly announce the content of the table. For example, use “Ad Groups Table” instead of “Table”.
+
+Don’t include the word “table” as part of the label to prevent redundancy: the VoiceOver already appends “table” to the label and the Category “Table” in the rotor already describes the nature of the component.
+
+In terms of structure and content, HTML tables already provide accessible ways to navigate content via cells \`<td>\` and headers \`<th>\`.
+  `}
+        />
+        <MainSection.Subsection
+          title="Keyboard navigation"
+          description={`
+The Tab key should only place the focus on interactive elements like sortable headers, expands and links. If a cell does not contain interactive content, tabbing should skip the cell. Enter, Space and Return activate buttons and other controls after focusing. Arrow keys can be used to scroll table content vertically and horizontally.`}
+        />
+        <MainSection.Subsection
+          columns={2}
+          title="Other considerations"
+          description={`
+Internally, Gestalt Table implements \`visually-hidden\` captions through the \`accessibilityLabel\` prop. Therefore, if we want to add visual captions (at the top or bottom of the Table), we must prevent redundancy. Any top or bottom text that describes the Table should be removed from navigation using \`aria-hidden\`.
+
+See the examples below for more details.`}
+        >
+          <MainSection.Card
+            cardSize="md"
+            title="Top captions"
+            defaultCode={`
+function Example() {
+  const HeaderRow = ({ id }) => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>
+            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
+            <Checkbox
+              id={id}
+   onChange={() => {}}
+              indeterminate
+              size="sm"
+            />
+          </Table.HeaderCell>
+          {["Status", "Campaign"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
+
+  const BaseRow = ({ id, checked, disabled, type, text, subtext, campaign }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Checkbox
+            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
+            disabled={disabled}
+            size="sm"
+            checked={checked}
+          />
+        </Table.Cell>
+        <Table.Cell>
+          <Status type={type} title={text} subtext={subtext} />
+        </Table.Cell>
+        <Table.Cell>
+          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
+            <Text color={disabled ? "gray" : "darkGray"}>{campaign}</Text>
+          </Label>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
+
+  const tableID = "Example of correct accessibility with top caption";
+
+  return (
+    <Flex gap={2} direction="column">
+      <Box aria-hidden>
+        <Heading
+          size="sm"
+          accessibilityLevel="none"
+        >
+          Your Campaigns Summary
+        </Heading>
+      </Box>
+      <Table accessibilityLabel="Your campaigns summary">
+        <HeaderRow id={tableID}/>
+        <Table.Body>
+          <BaseRow
+            id={tableID}
+            checked={true}
+            type="inProgress"
+            text="In progress"
+            subtext="Ends 11/20/2021"
+            campaign="Engagement"
+          />
+          <BaseRow
+            id={tableID}
+            disabled
+            type="halted"
+            text="Paused"
+            subtext="Ends 11/20/2021"
+            campaign="Awareness"
+          />
+          <BaseRow
+            id={tableID}
+            checked={true}
+            type="warning"
+            text="Warning"
+            subtext="Ends 11/20/2021"
+            campaign="Catalogs"
+          />
+          <BaseRow
+            id={tableID}
+            checked={false}
+            type="ok"
+            text="Complete"
+            subtext="Ends 11/20/2021"
+            campaign="Awareness"
+          />
+        </Table.Body>
+      </Table>
+    </Flex>
+  );
+}
+`}
+          />
+          <MainSection.Card
+            cardSize="md"
+            title="Bottom captions"
+            defaultCode={`
+function Example() {
+  const HeaderRow = ({ id }) => {
+    return (
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>
+            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
+            <Checkbox
+              id={id}
+   onChange={() => {}}
+              indeterminate
+              size="sm"
+            />
+          </Table.HeaderCell>
+          {["Status", "Campaign"].map((title, idx) => {
+            return (
+              <Table.HeaderCell key={idx}>
+                <Text weight="bold">{title}</Text>
+              </Table.HeaderCell>
+            );
+          })}
+        </Table.Row>
+      </Table.Header>
+    );
+  };
+
+  const BaseRow = ({ id, checked, disabled, type, text, subtext, campaign }) => {
+    return (
+      <Table.Row>
+        <Table.Cell>
+          <Checkbox
+            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
+            disabled={disabled}
+            size="sm"
+            checked={checked}
+          />
+        </Table.Cell>
+        <Table.Cell>
+          <Status type={type} title={text} subtext={subtext} />
+        </Table.Cell>
+        <Table.Cell>
+          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
+            <Text color={disabled ? "gray" : "darkGray"}>{campaign}</Text>
+          </Label>
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
+
+  const tableID = "Example of correct accessibility with bottom caption";
+
+  return (
+    <Flex gap={2} direction="column">
+      <Table accessibilityLabel="Your campaigns summary">
+        <HeaderRow id={tableID}/>
+        <Table.Body>
+          <BaseRow
+            id={tableID}
+            checked={true}
+            type="inProgress"
+            text="In progress"
+            subtext="Ends 11/20/2021"
+            campaign="Engagement"
+          />
+          <BaseRow
+            id={tableID}
+            disabled
+            type="halted"
+            text="Paused"
+            subtext="Ends 11/20/2021"
+            campaign="Awareness"
+          />
+          <BaseRow
+            id={tableID}
+            checked={true}
+            type="warning"
+            text="Warning"
+            subtext="Ends 11/20/2021"
+            campaign="Catalogs"
+          />
+          <BaseRow
+            id={tableID}
+            checked={false}
+            type="ok"
+            text="Complete"
+            subtext="Ends 11/20/2021"
+            campaign="Awareness"
+          />
+        </Table.Body>
+      </Table>
+      <Box aria-hidden>
+        <Text align="center" size="sm">Your campaigns summary</Text>
+      </Box>
+    </Flex>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+      <MainSection name="Subcomponents">
+        <PropTable
+          Component={Table?.Body}
+          name="Table.Body"
+          id="Table.Body"
+          props={[
+            {
+              name: 'children',
+              type: 'React.Node',
+            },
+          ]}
+        />
+        <PropTable
+          name="Table.Cell"
+          id="Table.Cell"
+          Component={Table?.Cell}
+          props={[
+            {
+              name: 'children',
+              type: 'React.Node',
+            },
+            {
+              name: 'colSpan',
+              type: 'number',
+              defaultValue: 1,
+            },
+            {
+              name: 'rowSpan',
+              type: 'number',
+              defaultValue: 1,
+            },
+          ]}
+        />
+        <PropTable
+          name="Table.Footer"
+          id="Table.Footer"
+          Component={Table?.Footer}
+          props={[
+            {
+              name: 'children',
+              type: 'React.Node',
+            },
+          ]}
+        />
+        <PropTable
+          name="Table.Header"
+          id="Table.Header"
+          Component={Table?.Header}
+          props={[
+            {
+              name: 'children',
+              type: 'React.Node',
+            },
+            {
+              name: 'sticky',
+              type: 'boolean',
+              defaultValue: false,
+              href: 'stickyHeader',
+              description:
+                'If true, the table header will be sticky and the table body will be scrollable',
+            },
+          ]}
+        />
+        <PropTable
+          name="Table.HeaderCell"
+          id="Table.HeaderCell"
+          Component={Table?.HeaderCell}
+          props={[
+            {
+              name: 'children',
+              type: 'React.Node',
+            },
+            {
+              name: 'scope',
+              defaultValue: 'col',
+              type: '"col" | "row" | "colgroup" | "rowgroup"',
+            },
+            {
+              name: 'colSpan',
+              type: 'number',
+              defaultValue: 1,
+            },
+            {
+              name: 'rowSpan',
+              type: 'number',
+              defaultValue: 1,
+            },
+          ]}
+        />
+        <PropTable
+          name="Table.Row"
+          id="Table.Row"
+          Component={Table?.Row}
+          props={[
+            {
+              name: 'children',
+              type: 'React.Node',
+            },
+          ]}
+        />
+        <PropTable
+          name="Table.RowExpandable"
+          id="Table.RowExpandable"
+          Component={Table?.Row}
+          props={[
+            {
+              name: 'accessibilityCollapseLabel',
+              type: 'string',
+              required: true,
+              defaultValue: null,
+              description: [
+                'Supply a short, descriptive label for screen-readers as a text alternative to the Collapse button.',
+                'Accessibility: It populates aria-label on the `<button>` element for the Collapse button.',
+              ],
+            },
+            {
+              name: 'accessibilityExpandLabel',
+              type: 'string',
+              required: true,
+              defaultValue: null,
+              description: [
+                'Supply a short, descriptive label for screen-readers as a text alternative to the Expand button.',
+                'Accessibility: It populates aria-label on the `<button>` element for the Expand button.',
+              ],
+            },
+            {
+              name: 'children',
+              type: 'React.Node',
+            },
+            {
+              name: 'expandedContents',
+              type: 'React.Node',
+              required: true,
+            },
+            {
+              name: 'hoverStyle',
+              type: '"none" | "gray"',
+              defaultValue: 'gray',
+            },
+            {
+              name: 'id',
+              type: 'string',
+              required: true,
+            },
+            {
+              name: 'onExpand',
+              type: `({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement> expanded: boolean }) => void`,
+              description: ['Callback fired when the expand button component is clicked'],
+            },
+          ]}
+        />
+        <PropTable
+          name="Table.SortableHeaderCell"
+          id="Table.SortableHeaderCell"
+          Component={Table?.SortableHeaderCell}
+          props={[
+            {
+              name: 'children',
+              type: 'React.Node',
+            },
+            {
+              name: 'scope',
+              defaultValue: 'col',
+              type: '"col" | "row" | "colgroup" | "rowgroup"',
+            },
+            {
+              name: 'colSpan',
+              type: 'number',
+              defaultValue: 1,
+            },
+            {
+              name: 'rowSpan',
+              type: 'number',
+              defaultValue: 1,
+            },
+            {
+              name: 'onSortChange',
+              required: true,
+              type:
+                '({ event: SyntheticMouseEvent<HTMLTableCellElement> | SyntheticKeyboardEvent<HTMLTableCellElement> }) => void',
+            },
+            {
+              name: 'sortOrder',
+              required: true,
+              type: '"asc" | "desc"',
+            },
+            {
+              name: 'status',
+              required: true,
+              type: '"active" | "inactive"',
+            },
+          ]}
+        />
+      </MainSection>
+      s
+      <MainSection name="Variants">
+        <MainSection.Subsection title="Sticky header">
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Table accessibilityLabel="Sticky header" maxHeight={200}>
   <Table.Header sticky>
     <Table.Row>
@@ -294,16 +1800,17 @@ card(
     </Table.Row>
   </Table.Body>
 </Table>
-`}
-  />,
-);
-
-card(
-  <Example
-    id="stickyColumn"
-    name="Example: Sticky Column"
-    description="Try scrolling horizontally to see the first column remain in place."
-    defaultCode={`
+  `}
+          />
+        </MainSection.Subsection>
+      </MainSection>
+      <MainSection.Subsection
+        title="Sticky Column"
+        description="Try scrolling horizontally to see the first column remain in place."
+      >
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
 <Box width="50%" overflow="auto">
   <Table accessibilityLabel="Sticky Column" maxHeight={200} stickyColumns={1}>
 
@@ -398,15 +1905,15 @@ card(
 </Box>
 
 `}
-  />,
-);
-
-card(
-  <Example
-    id="stickyColumn2"
-    name="Example: Multiple sticky columns"
-    description="Try scrolling horizontally to see the first 3 columns remain in place."
-    defaultCode={`
+        />
+      </MainSection.Subsection>
+      <MainSection.Subsection
+        title="Multiple sticky columns"
+        description="Try scrolling horizontally to see the first 3 columns remain in place."
+      >
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
 <Box width="60%" overflow="auto">
   <Table accessibilityLabel="Multiple sticky columns" maxHeight={200} stickyColumns={3} borderStyle="none">
 
@@ -533,15 +2040,15 @@ card(
 </Box>
 
 `}
-  />,
-);
-
-card(
-  <Example
-    id="stickyColumn3"
-    name="Example: Sticky header and sticky columns"
-    description="Try scrolling horizontally and vertically to see the columns and header remain in place."
-    defaultCode={`
+        />
+      </MainSection.Subsection>
+      <MainSection.Subsection
+        title="Sticky header and sticky columns"
+        description="Try scrolling horizontally and vertically to see the columns and header remain in place."
+      >
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
 <Box width="60%" overflow="auto">
   <Table accessibilityLabel="Sticky header and sticky columns" maxHeight={200} stickyColumns={3} borderStyle="none">
 
@@ -669,119 +2176,16 @@ card(
 </Box>
 
 `}
-  />,
-);
-
-card(
-  <PropTable
-    name="Table.HeaderCell"
-    id="Table.HeaderCell"
-    Component={Table?.HeaderCell}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'scope',
-        defaultValue: 'col',
-        type: '"col" | "row" | "colgroup" | "rowgroup"',
-      },
-      {
-        name: 'colSpan',
-        type: 'number',
-        defaultValue: 1,
-      },
-      {
-        name: 'rowSpan',
-        type: 'number',
-        defaultValue: 1,
-      },
-    ]}
-  />,
-);
-
-card(
-  <PropTable
-    name="Table.Row"
-    id="Table.Row"
-    Component={Table?.Row}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-    ]}
-  />,
-);
-
-card(
-  <Card
-    name="Table.RowExpandable"
-    description="Expandable row that is able to hold content that will displayed depending on the clickable expand/collapse button icon."
-  />,
-);
-
-card(
-  <PropTable
-    name="Table.RowExpandable"
-    id="Table.RowExpandable"
-    Component={Table?.Row}
-    props={[
-      {
-        name: 'accessibilityCollapseLabel',
-        type: 'string',
-        required: true,
-        defaultValue: null,
-        description: [
-          'Supply a short, descriptive label for screen-readers as a text alternative to the Collapse button.',
-          'Accessibility: It populates aria-label on the `<button>` element for the Collapse button.',
-        ],
-      },
-      {
-        name: 'accessibilityExpandLabel',
-        type: 'string',
-        required: true,
-        defaultValue: null,
-        description: [
-          'Supply a short, descriptive label for screen-readers as a text alternative to the Expand button.',
-          'Accessibility: It populates aria-label on the `<button>` element for the Expand button.',
-        ],
-      },
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'expandedContents',
-        type: 'React.Node',
-        required: true,
-      },
-      {
-        name: 'hoverStyle',
-        type: '"none" | "gray"',
-        defaultValue: 'gray',
-      },
-      {
-        name: 'id',
-        type: 'string',
-        required: true,
-      },
-      {
-        name: 'onExpand',
-        type: `({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement>
-          | SyntheticKeyboardEvent<HTMLAnchorElement> expanded: boolean }) => void`,
-        description: ['Callback fired when the expand button component is clicked'],
-      },
-    ]}
-  />,
-);
-
-card(
-  <Example
-    name="Example: Table Row Expandable"
-    defaultCode={`
-    function RowExpandableExample() {
+        />
+      </MainSection.Subsection>
+      <MainSection.Subsection
+        title="Table Row Expandable"
+        description="Expandable row that is able to hold content that will displayed depending on the clickable expand/collapse button icon."
+      >
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
+    function Example() {
       const [textShown, setTextShown] = React.useState(false);
       const showTextOnExpand = () => {
         return <Text>Row expanded</Text>;
@@ -984,15 +2388,16 @@ card(
         </Table>);
     }
     `}
-  />,
-);
-
-card(
-  <Example
-    name="Example: Table Row Expandable with Sticky Columns"
-    description="When specifying `stickyColumns` with expandable rows, include the column of arrows in your count. This example sets `stickyColumns` to 3."
-    defaultCode={`
-    function RowExpandableExample() {
+        />
+      </MainSection.Subsection>
+      <MainSection.Subsection
+        title="Table Row Expandable with Sticky Columns"
+        description="When specifying `stickyColumns` with expandable rows, include the column of arrows in your count. This example sets `stickyColumns` to 3."
+      >
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
+    function Example() {
       const [textShown, setTextShown] = React.useState(false);
       const showTextOnExpand = () => {
         return <Text>Row expanded</Text>;
@@ -1208,69 +2613,15 @@ card(
       </Box> );
     }
     `}
-  />,
-);
-
-card(
-  <Card
-    name="Table.SortableHeaderCell"
-    description="Sortable header cells are clickable in an accessible way and have an icon to display whether the table is currently being sorted by that column."
-  />,
-);
-
-card(
-  <PropTable
-    name="Table.SortableHeaderCell"
-    id="Table.SortableHeaderCell"
-    Component={Table?.SortableHeaderCell}
-    props={[
-      {
-        name: 'children',
-        type: 'React.Node',
-      },
-      {
-        name: 'scope',
-        defaultValue: 'col',
-        type: '"col" | "row" | "colgroup" | "rowgroup"',
-      },
-      {
-        name: 'colSpan',
-        type: 'number',
-        defaultValue: 1,
-      },
-      {
-        name: 'rowSpan',
-        type: 'number',
-        defaultValue: 1,
-      },
-      {
-        name: 'onSortChange',
-        required: true,
-        type:
-          '({ event: SyntheticMouseEvent<HTMLTableCellElement> | SyntheticKeyboardEvent<HTMLTableCellElement> }) => void',
-        href: 'sortableExample',
-      },
-      {
-        name: 'sortOrder',
-        required: true,
-        type: '"asc" | "desc"',
-        href: 'sortableExample',
-      },
-      {
-        name: 'status',
-        required: true,
-        type: '"active" | "inactive"',
-        href: 'sortableExample',
-      },
-    ]}
-  />,
-);
-
-card(
-  <Example
-    id="sortableExample"
-    name="Example: Sortable header cells"
-    defaultCode={`
+        />
+      </MainSection.Subsection>
+      <MainSection.Subsection
+        title="Sortable header cells"
+        description="Sortable header cells are clickable in an accessible way and have an icon to display whether the table is currently being sorted by that column."
+      >
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
     function SortableHeaderExample() {
       const [sortOrder, setSortOrder] = React.useState('desc');
       const [sortCol, setSortCol] = React.useState('name');
@@ -1300,14 +2651,12 @@ card(
       );
     }
 `}
-  />,
-);
-
-card(
-  <Example
-    id="sortableExampleSticky"
-    name="Example: Sortable header cells with sticky columns"
-    defaultCode={`
+        />
+      </MainSection.Subsection>
+      <MainSection.Subsection title="Sortable header cells with sticky columns">
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
     function SortableHeaderExample() {
       const [sortOrder, setSortOrder] = React.useState('desc');
       const [sortCol, setSortCol] = React.useState('name');
@@ -1355,9 +2704,8 @@ card(
       );
     }
 `}
-  />,
-);
-
-export default function TablePage(): Node {
-  return <CardPage cards={cards} page="Table" />;
+        />
+      </MainSection.Subsection>
+    </Page>
+  );
 }

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -207,13 +207,13 @@ function Example() {
         <BaseRow
           id={tableID}
           checked={true}
-          text="Macy's pincycle"
+          text="Mary's pincycle"
           campaign="Catalogs"
         />
         <BaseRow
           id={tableID}
           checked={false}
-          text="Best Buy Wins"
+          text="Best Purchase Wins"
           campaign="Awareness"
         />
         <BaseRow
@@ -315,7 +315,7 @@ function Example() {
           checked={true}
           bold
           italic
-          text="Macy's pincycle"
+          text="Mary's pincycle"
           campaign="Catalogs"
           color="red"
         />
@@ -323,7 +323,7 @@ function Example() {
           id={tableID}
           checked={false}
           underline
-          text="BEST BUY WINS"
+          text="BEST PURCHASE WINS"
           campaign="Awareness"
           color="purple"
         />
@@ -421,13 +421,13 @@ function Example() {
         <BaseRow
           id={tableID}
           checked={true}
-          text="Macy's pincycle"
+          text="Mary's pincycle"
           spend="$1.75"
         />
         <BaseRow
           id={tableID}
           checked={false}
-          text="Best Buy Wins"
+          text="Best Purchase Wins"
           spend="$51,650,500.54"
         />
         <BaseRow
@@ -445,8 +445,7 @@ function Example() {
           <MainSection.Card
             cardSize="md"
             type="don't"
-            description={`Don’t
-Align content so that it makes it harder to scan, read, and compare.
+            description={`Align content so that it makes it harder to scan, read, and compare.
 - Center-align content
 - Use proportional figures for numbers as they don’t quite align
 - End-align text and combo-content (combinations of text, numbers and/or graphics)
@@ -526,14 +525,14 @@ function Example() {
         <BaseRow
           id={tableID}
           checked={true}
-          text="Macy's pincycle"
+          text="Mary's pincycle"
           subtext="07/15/22"
           spend="$1.750"
         />
         <BaseRow
           id={tableID}
           checked={false}
-          text="Best Buy Wins"
+          text="Best Purchase Wins"
           subtext="06/15/22"
           spend="$51,650,500.54"
         />
@@ -1303,7 +1302,7 @@ Wrap important table content instead of truncating. Use truncation only for seco
         <MainSection.Subsection
           title="Labels"
           description={`
-Use  \`accessibilityLabel\` to properly announce the content of the table. For example, use “Ad Groups Table” instead of “Table”.
+Use  \`accessibilityLabel\` to properly announce the content of the table. For example, use "Campaign Status Information".
 
 Don’t include the word “table” as part of the label to prevent redundancy: the VoiceOver already appends “table” to the label and the Category “Table” in the rotor already describes the nature of the component.
 
@@ -1729,7 +1728,6 @@ function Example() {
           ]}
         />
       </MainSection>
-      s
       <MainSection name="Variants">
         <MainSection.Subsection title="Sticky header">
           <MainSection.Card

--- a/docs/pages/upsell.js
+++ b/docs/pages/upsell.js
@@ -42,7 +42,6 @@ card(
 
 card(
   <PropTable
-    name="Upsell"
     Component={Upsell}
     props={[
       {


### PR DESCRIPTION
### Summary

Main change: Added design guidelines to Table component

Other improvement:
Refactor subcomponent proptable heading to show up on the right navigation bar.
Moved the subcomponent props to a sublevel in the right nav sidebar to give more sense of structure and readability it.

## Before

![image](https://user-images.githubusercontent.com/10593890/142275059-eddb0390-8530-4d20-8812-6699c80abce4.png)

## After

![image](https://user-images.githubusercontent.com/10593890/142275077-be4374bd-6a50-4b3c-8c2f-023fee881e5c.png)

The props tables are VERY long, so it might take a lot of scrolling to get to the Guidelines. So I thought that Variants is for engineers as well as the Subcomponent section, so I placed it at the end assuming engineers already go to Variants to figure out doubts etc,

We know engineers wanted the Props at the top… but very long Props sections including subcomponents might be too much to get to the sections designers go more often.

So by calling it Subcomponents we make it more eng focused so it can just go over Variants, which in most cases is also eng focused.

<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
