### PR TITLE
Masonry: FIX this.updateScrollPosition.clearTimeout is not a function

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -289,7 +289,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     if (this.props._deferScrollPositionUpdate) {
       this.clearScrollTimeout();
     } else {
-      this.updateScrollPosition.clearTimeout();
+      this.throttledUpdateScrollPosition.clearTimeout();
     }
     window.removeEventListener('resize', this.handleResize);
   }


### PR DESCRIPTION
### Summary
To add a separate scroll position update strategy in #1774, I split `updateScrollPosition` into two functions- one with the majority of the updating logic, to be called by a new `handleScroll`, and a throttled counterpart to match the original functionality, `throttledUpdateScrollPosition`.

The `throttle` wrapper call that provided `this.updateScrollPosition` with a `.clearTimeout` property no longer wraps `this.updateScrollPosition` -  it wraps `throttledUpdateScrollPosition`. If we want to clear the timeout in the unmount lifecycle, we need to call `this.throttledUpdateScrollPosition.clearTimeout` instead, especially to prevent downstream errors.

![Screen Shot 2021-11-16 at 6 11 54 PM](https://user-images.githubusercontent.com/7406105/142097938-596b7521-c206-4e9c-9449-59ddcb971a9e.png)


### Links

- [Jira](https://jira.pinadmin.com/browse/PERF-10216)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
