### PR TITLE
Design tokens: Add Color alias tokens

### DIFF
--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -1,0 +1,71 @@
+// @flow strict
+import type { Node } from 'react';
+import { Box, Text } from 'gestalt';
+
+type Token = {|
+  name: string,
+  value: string,
+  comment: string,
+  category: string,
+|};
+
+type Props = {|
+  token: Token,
+|};
+
+export const ColorBox = ({ token }: Props): Node => {
+  return (
+    <Box
+      dangerouslySetInlineStyle={{
+        __style: { backgroundColor: `var(--${token?.name})` },
+      }}
+      height={50}
+      width={250}
+      display="flex"
+      alignItems="center"
+      justifyContent="between"
+      paddingX={2}
+    />
+  );
+};
+
+export const SpacingBox = ({ token }: Props): Node => {
+  return <Box color="eggplant" width={`${token.value}`} height={`${token.value}`} />;
+};
+
+export const TextColorBox = ({ token }: Props): Node => {
+  return (
+    <Box
+      dangerouslySetInlineStyle={{
+        __style: { color: `var(--${token.name}) !important`, fontSize: '32px' },
+      }}
+      height={50}
+      width={150}
+      display="flex"
+      alignItems="center"
+      justifyContent="between"
+      paddingX={2}
+      color={token.name.includes('inverse') ? 'darkGray' : undefined}
+    >
+      Gestalt
+    </Box>
+  );
+};
+
+type ExampleProps = {|
+  token: Token,
+  category: string,
+|};
+
+export const TokenExample = ({ token, category }: ExampleProps): Node => {
+  switch (category) {
+    case 'background-color':
+      return <ColorBox token={token} />;
+    case 'spacing':
+      return <SpacingBox token={token} />;
+    case 'text-color':
+      return <TextColorBox token={token} />;
+    default:
+      return <Box>{token.value}</Box>;
+  }
+};

--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -16,7 +16,7 @@ type Props = {|
 export const ColorBox = ({ token }: Props): Node => (
   <Box
     dangerouslySetInlineStyle={{
-      __style: { backgroundColor: `var(--${token?.name})` },
+      __style: { backgroundColor: `var(--${token.name})` },
     }}
     height={50}
     width={250}
@@ -24,6 +24,7 @@ export const ColorBox = ({ token }: Props): Node => (
     alignItems="center"
     justifyContent="between"
     paddingX={2}
+    borderStyle={token.name.includes('inverse') ? 'sm' : 'none'}
   />
 );
 
@@ -33,7 +34,7 @@ export const SpacingBox = ({ token }: Props): Node => (
 export const TextColorBox = ({ token }: Props): Node => (
   <Box
     dangerouslySetInlineStyle={{
-      __style: { color: `var(--${token.name}) !important`, fontSize: '32px' },
+      __style: { color: `var(--${token.name})`, fontSize: '32px' },
     }}
     height={50}
     width={150}

--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -1,6 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import { Box, Text } from 'gestalt';
+import { Box } from 'gestalt';
 
 type Token = {|
   name: string,
@@ -13,44 +13,39 @@ type Props = {|
   token: Token,
 |};
 
-export const ColorBox = ({ token }: Props): Node => {
-  return (
-    <Box
-      dangerouslySetInlineStyle={{
-        __style: { backgroundColor: `var(--${token?.name})` },
-      }}
-      height={50}
-      width={250}
-      display="flex"
-      alignItems="center"
-      justifyContent="between"
-      paddingX={2}
-    />
-  );
-};
+export const ColorBox = ({ token }: Props): Node => (
+  <Box
+    dangerouslySetInlineStyle={{
+      __style: { backgroundColor: `var(--${token?.name})` },
+    }}
+    height={50}
+    width={250}
+    display="flex"
+    alignItems="center"
+    justifyContent="between"
+    paddingX={2}
+  />
+);
 
-export const SpacingBox = ({ token }: Props): Node => {
-  return <Box color="eggplant" width={`${token.value}`} height={`${token.value}`} />;
-};
-
-export const TextColorBox = ({ token }: Props): Node => {
-  return (
-    <Box
-      dangerouslySetInlineStyle={{
-        __style: { color: `var(--${token.name}) !important`, fontSize: '32px' },
-      }}
-      height={50}
-      width={150}
-      display="flex"
-      alignItems="center"
-      justifyContent="between"
-      paddingX={2}
-      color={token.name.includes('inverse') ? 'darkGray' : undefined}
-    >
-      Gestalt
-    </Box>
-  );
-};
+export const SpacingBox = ({ token }: Props): Node => (
+  <Box color="eggplant" width={`${token.value}`} height={`${token.value}`} />
+);
+export const TextColorBox = ({ token }: Props): Node => (
+  <Box
+    dangerouslySetInlineStyle={{
+      __style: { color: `var(--${token.name}) !important`, fontSize: '32px' },
+    }}
+    height={50}
+    width={150}
+    display="flex"
+    alignItems="center"
+    justifyContent="between"
+    paddingX={2}
+    color={token.name.includes('inverse') ? 'darkGray' : undefined}
+  >
+    Gestalt
+  </Box>
+);
 
 type ExampleProps = {|
   token: Token,

--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -31,6 +31,7 @@ export const ColorBox = ({ token }: Props): Node => (
 export const SpacingBox = ({ token }: Props): Node => (
   <Box color="eggplant" width={`${token.value}`} height={`${token.value}`} />
 );
+
 export const TextColorBox = ({ token }: Props): Node => (
   <Box
     dangerouslySetInlineStyle={{

--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -5,7 +5,7 @@ import { Box } from 'gestalt';
 type Token = {|
   name: string,
   value: string,
-  comment: string,
+  comment?: string,
   category: string,
 |};
 

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -3,7 +3,7 @@
 import type { Node } from 'react';
 import { Flex, Table, Text } from 'gestalt';
 // $FlowExpectedError[untyped-import]
-import tokens from 'gestalt-design-tokens/dist/js/token.js';
+import tokens from 'gestalt-design-tokens/dist/js/tokens.js';
 import MainSection from '../components/MainSection.js';
 import PageHeader from '../components/PageHeader.js';
 import CardPage from '../components/CardPage.js';

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -2,7 +2,6 @@
 
 import type { Node } from 'react';
 import { Flex, Table, Text } from 'gestalt';
-// $FlowExpectedError[untyped-import]
 import tokens from 'gestalt-design-tokens/dist/js/tokens.js';
 import MainSection from '../components/MainSection.js';
 import PageHeader from '../components/PageHeader.js';
@@ -12,7 +11,7 @@ import { TokenExample } from '../components/TokenExample.js';
 type Token = {|
   name: string,
   value: string,
-  comment: string,
+  comment?: string,
   category: string,
 |};
 
@@ -25,21 +24,16 @@ const tokenCategories = [
   { name: 'Text color', category: 'text-color', id: 'text' },
 ];
 
+const headers = ['CSS Token Name', 'JavaScript Prop Name', 'Value', 'Example'];
+
 const tableHeaders = (
   <Table.Header>
     <Table.Row>
-      <Table.HeaderCell>
-        <Text weight="bold">CSS Token Name</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">JavaScript Prop Name</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">Value</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">Example</Text>
-      </Table.HeaderCell>
+      {headers.map((header) => (
+        <Table.HeaderCell>
+          <Text weight="bold">{header}</Text>
+        </Table.HeaderCell>
+      ))}
     </Table.Row>
   </Table.Header>
 );

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -1,9 +1,10 @@
 // @flow strict
 import type { Node } from 'react';
-import { Table, Text, Box } from 'gestalt';
+import { Heading, Table, Text, Box } from 'gestalt';
 import MainSection from '../components/MainSection.js';
 import PageHeader from '../components/PageHeader.js';
 import CardPage from '../components/CardPage.js';
+import ColorTile from '../components/ColorTile.js';
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
@@ -205,6 +206,100 @@ card(
               <Text>-64px</Text>
             </Table.Cell>
             <Table.Cell>{null}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </MainSection.Subsection>
+    <MainSection.Subsection title="Color">
+      <Table accessibilityLabel="Spacing token values">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text weight="bold">CSS Token Name</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">JavaScript Prop Name</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Value</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Example</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Text>--color-text-default</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>colorTextDefault</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>#111111</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Box padding={4}>
+                <Heading size="md" accessibilityLevel="none">
+                  Gestalt
+                </Heading>
+              </Box>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>--color-text-inverse</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>colorTextInverse</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>#FFFFFF</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Box color="darkGray" padding={4}>
+                <Heading size="md" accessibilityLevel="none" color="white">
+                  Gestalt
+                </Heading>
+              </Box>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>--color-text-success</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>colorTextSuccess</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>#</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Box padding={4}>
+                <Heading size="md" accessibilityLevel="none" color="pine">
+                  Gestalt
+                </Heading>
+              </Box>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>--color-text-error</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>colorTextError</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>#</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Box padding={4}>
+                <Heading size="md" accessibilityLevel="none" color="red">
+                  Gestalt
+                </Heading>
+              </Box>
+            </Table.Cell>
           </Table.Row>
         </Table.Body>
       </Table>

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -30,7 +30,7 @@ const tableHeaders = (
   <Table.Header>
     <Table.Row>
       {headers.map((header) => (
-        <Table.HeaderCell>
+        <Table.HeaderCell key={`header-${header}`}>
           <Text weight="bold">{header}</Text>
         </Table.HeaderCell>
       ))}

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -1,13 +1,48 @@
 // @flow strict
+
 import type { Node } from 'react';
-import { Heading, Table, Text, Box } from 'gestalt';
+import { Box, Flex, Heading, Table, Text } from 'gestalt';
 import MainSection from '../components/MainSection.js';
 import PageHeader from '../components/PageHeader.js';
 import CardPage from '../components/CardPage.js';
-import ColorTile from '../components/ColorTile.js';
+import { TokenExample } from '../components/TokenExample.js';
+// $FlowExpectedError[untyped-import]
+import tokens from 'gestalt-design-tokens/dist/js/token.js';
+
+type Token = {|
+  name: string,
+  value: string,
+  comment: string,
+  category: string,
+|};
 
 const cards: Array<Node> = [];
 const card = (c) => cards.push(c);
+
+const tokenCategories = [
+  { name: 'Spacing', category: 'spacing', id: 'space' },
+  { name: 'Background color', category: 'background-color', id: 'background' },
+  { name: 'Text color', category: 'text-color', id: 'text' },
+];
+
+const tableHeaders = (
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>
+        <Text weight="bold">CSS Token Name</Text>
+      </Table.HeaderCell>
+      <Table.HeaderCell>
+        <Text weight="bold">JavaScript Prop Name</Text>
+      </Table.HeaderCell>
+      <Table.HeaderCell>
+        <Text weight="bold">Value</Text>
+      </Table.HeaderCell>
+      <Table.HeaderCell>
+        <Text weight="bold">Example</Text>
+      </Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+);
 
 card(
   <PageHeader
@@ -20,290 +55,36 @@ card(
 
 card(
   <MainSection name="Token Values">
-    <MainSection.Subsection title="Spacing">
-      <Table accessibilityLabel="Spacing token values">
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell>
-              <Text weight="bold">CSS Token Name</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text weight="bold">JavaScript Prop Name</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text weight="bold">Value</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text weight="bold">Example</Text>
-            </Table.HeaderCell>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-0</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>space0</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>0px</Text>
-            </Table.Cell>
-            <Table.Cell>{null}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-100</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>space100</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>4px</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box color="eggplant" width="4px" height="4px" />
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-200</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>space200</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>8px</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box color="eggplant" width="8px" height="8px" />
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-300</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>space300</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>16px</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box color="eggplant" width="16px" height="16px" />
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-400</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>space400</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>24px</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box color="eggplant" width="24px" height="24px" />
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-500</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>space500</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>32px</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box color="eggplant" width="32px" height="32px" />
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-600</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>space600</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>64px</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box color="eggplant" width="64px" height="64px" />
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-negative-100</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>spaceNegative100</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>-4px</Text>
-            </Table.Cell>
-            <Table.Cell>{null}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-negative-200</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>spaceNegative200</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>-8px</Text>
-            </Table.Cell>
-            <Table.Cell>{null}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-negative-300</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>spaceNegative300</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>-16px</Text>
-            </Table.Cell>
-            <Table.Cell>{null}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-negative-400</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>spaceNegative400</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>-24px</Text>
-            </Table.Cell>
-            <Table.Cell>{null}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-negative-500</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>spaceNegative500</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>-32px</Text>
-            </Table.Cell>
-            <Table.Cell>{null}</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--space-negative-600</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>spaceNegative600</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>-64px</Text>
-            </Table.Cell>
-            <Table.Cell>{null}</Table.Cell>
-          </Table.Row>
-        </Table.Body>
-      </Table>
-    </MainSection.Subsection>
-    <MainSection.Subsection title="Color">
-      <Table accessibilityLabel="Spacing token values">
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell>
-              <Text weight="bold">CSS Token Name</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text weight="bold">JavaScript Prop Name</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text weight="bold">Value</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text weight="bold">Example</Text>
-            </Table.HeaderCell>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--color-text-default</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>colorTextDefault</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>#111111</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box padding={4}>
-                <Heading size="md" accessibilityLevel="none">
-                  Gestalt
-                </Heading>
-              </Box>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--color-text-inverse</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>colorTextInverse</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>#FFFFFF</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box color="darkGray" padding={4}>
-                <Heading size="md" accessibilityLevel="none" color="white">
-                  Gestalt
-                </Heading>
-              </Box>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--color-text-success</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>colorTextSuccess</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>#</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box padding={4}>
-                <Heading size="md" accessibilityLevel="none" color="pine">
-                  Gestalt
-                </Heading>
-              </Box>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>--color-text-error</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>colorTextError</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>#</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Box padding={4}>
-                <Heading size="md" accessibilityLevel="none" color="red">
-                  Gestalt
-                </Heading>
-              </Box>
-            </Table.Cell>
-          </Table.Row>
-        </Table.Body>
-      </Table>
-    </MainSection.Subsection>
+    {tokenCategories.map((category) => (
+      <MainSection.Subsection title={category.name}>
+        <Table accessibilityLabel={`${category.name} Values`}>
+          {tableHeaders}
+          <Table.Body>
+            {tokens
+              .filter((token) => token.name.includes(`${category.id}`))
+              .map((token: Token) => (
+                <Table.Row key={`token${token.name}`}>
+                  <Table.Cell>
+                    <Flex direction="column" gap={2}>
+                      <Text>${token.name}</Text>
+                      <Text color="gray">{token.comment || ''}</Text>
+                    </Flex>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text>{token.name.replace(/-./g, (x) => x[1].toUpperCase())}</Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text>{token.value}</Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <TokenExample token={token} category={category.category} />
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+          </Table.Body>
+        </Table>
+      </MainSection.Subsection>
+    ))}
   </MainSection>,
 );
 

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -1,13 +1,13 @@
 // @flow strict
 
 import type { Node } from 'react';
-import { Box, Flex, Heading, Table, Text } from 'gestalt';
+import { Flex, Table, Text } from 'gestalt';
+// $FlowExpectedError[untyped-import]
+import tokens from 'gestalt-design-tokens/dist/js/token.js';
 import MainSection from '../components/MainSection.js';
 import PageHeader from '../components/PageHeader.js';
 import CardPage from '../components/CardPage.js';
 import { TokenExample } from '../components/TokenExample.js';
-// $FlowExpectedError[untyped-import]
-import tokens from 'gestalt-design-tokens/dist/js/token.js';
 
 type Token = {|
   name: string,
@@ -56,7 +56,7 @@ card(
 card(
   <MainSection name="Token Values">
     {tokenCategories.map((category) => (
-      <MainSection.Subsection title={category.name}>
+      <MainSection.Subsection key={`table${category.name}`} title={category.name}>
         <Table accessibilityLabel={`${category.name} Values`}>
           {tableHeaders}
           <Table.Body>

--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -1,6 +1,16 @@
 // @flow strict
 // $FlowExpectedError[untyped-import]
 const StyleDictionary = require('style-dictionary').extend('config.json');
+const { fileHeader, formattedVariables } = StyleDictionary.formatHelpers;
+
+StyleDictionary.registerFileHeader({
+  name: 'flowCustomHeader',
+  fileHeader: (defaultMessage) => {
+    // defaultMessage contains the 2 lines that appear in the default file header
+
+    return [`@flow strict`, ...defaultMessage];
+  },
+});
 
 StyleDictionary.registerTransform({
   name: 'size/pxToDp',
@@ -15,7 +25,7 @@ StyleDictionary.registerTransform({
 
 StyleDictionary.registerFormat({
   name: 'customJSArrayFormat',
-  formatter: ({ dictionary }) => {
+  formatter: ({ dictionary, file }) => {
     const tokenArray = dictionary.allTokens.map((token) =>
       JSON.stringify({
         name: token.name,
@@ -24,7 +34,7 @@ StyleDictionary.registerFormat({
         category: token.attributes.category,
       }),
     );
-    return `module.exports = [${tokenArray}]`;
+    return fileHeader({ file }) + `module.exports = [${tokenArray}]`;
   },
 });
 

--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -13,6 +13,21 @@ StyleDictionary.registerTransform({
   },
 });
 
+StyleDictionary.registerFormat({
+  name: 'customJSArrayFormat',
+  formatter: function ({ dictionary }) {
+    let tokenArray = dictionary.allTokens.map((token) => {
+      return JSON.stringify({
+        name: token.name,
+        value: token.value,
+        comment: token.comment,
+        category: token.attributes.category,
+      });
+    });
+    return `module.exports = [${tokenArray}]`;
+  },
+});
+
 StyleDictionary.registerTransformGroup({
   name: 'android-custom',
   transforms: ['attribute/cti', 'name/cti/snake', 'color/hex8android', 'size/pxToDp'],

--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -32,7 +32,7 @@ StyleDictionary.registerFormat({
         category: token.attributes.category,
       }),
     );
-    return `${fileHeader({ file })} module.exports = [${tokenArray}]`;
+    return `${fileHeader({ file, commentStyle: 'short' })} module.exports = [${tokenArray}]`;
   },
 });
 

--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -15,15 +15,15 @@ StyleDictionary.registerTransform({
 
 StyleDictionary.registerFormat({
   name: 'customJSArrayFormat',
-  formatter: function ({ dictionary }) {
-    let tokenArray = dictionary.allTokens.map((token) => {
-      return JSON.stringify({
+  formatter: ({ dictionary }) => {
+    const tokenArray = dictionary.allTokens.map((token) =>
+      JSON.stringify({
         name: token.name,
         value: token.value,
         comment: token.comment,
         category: token.attributes.category,
-      });
-    });
+      }),
+    );
     return `module.exports = [${tokenArray}]`;
   },
 });

--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -1,15 +1,13 @@
 // @flow strict
 // $FlowExpectedError[untyped-import]
 const StyleDictionary = require('style-dictionary').extend('config.json');
-const { fileHeader, formattedVariables } = StyleDictionary.formatHelpers;
+
+const { fileHeader } = StyleDictionary.formatHelpers;
 
 StyleDictionary.registerFileHeader({
   name: 'flowCustomHeader',
-  fileHeader: (defaultMessage) => {
-    // defaultMessage contains the 2 lines that appear in the default file header
-
-    return [`@flow strict`, ...defaultMessage];
-  },
+  // defaultMessage contains the 2 lines that appear in the default file header
+  fileHeader: (defaultMessage) => [`@flow strict`, ...defaultMessage],
 });
 
 StyleDictionary.registerTransform({
@@ -34,7 +32,7 @@ StyleDictionary.registerFormat({
         category: token.attributes.category,
       }),
     );
-    return fileHeader({ file }) + `module.exports = [${tokenArray}]`;
+    return `${fileHeader({ file })} module.exports = [${tokenArray}]`;
   },
 });
 

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -23,11 +23,15 @@
     },
     "js": {
       "transformGroup": "css",
+      "showFileHeader": true,
       "buildPath": "dist/js/",
       "files": [
         {
           "destination": "tokens.js",
-          "format": "customJSArrayFormat"
+          "format": "customJSArrayFormat",
+          "options": {
+            "fileHeader": "flowCustomHeader"
+          }
         }
       ]
     },

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -21,6 +21,16 @@
         }
       ]
     },
+    "js": {
+      "transformGroup": "css",
+      "buildPath": "dist/js/",
+      "files": [
+        {
+          "destination": "token.js",
+          "format": "customJSArrayFormat"
+        }
+      ]
+    },
     "android": {
       "transformGroup": "android-custom",
       "buildPath": "dist/android/",

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -26,7 +26,7 @@
       "buildPath": "dist/js/",
       "files": [
         {
-          "destination": "token.js",
+          "destination": "tokens.js",
           "format": "customJSArrayFormat"
         }
       ]

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -27,106 +27,133 @@
       },
       "icon": {
         "default": {
-          "value": "{color.black.cosmicore.900.value}"
+          "value": "{color.black.cosmicore.900.value}",
+          "comment": "Default color for icons"
         },
         "subtle": {
-          "value": "{color.gray.roboflow.500.value}"
+          "value": "{color.gray.roboflow.500.value}",
+          "comment": "Subtle, secondary color for icons"
         },
         "success": {
-          "value": "{color.green.matchacado.600.value}"
+          "value": "{color.green.matchacado.600.value}",
+          "comment": "Icon color to indicate success"
         },
         "error": {
-          "value": "{color.red.pushpin.500.value}"
+          "value": "{color.red.pushpin.500.value}",
+          "comment": "Icon color to indicate an error"
         },
         "warning": {
-          "value": "{color.yellow.caramellow.500.value}"
+          "value": "{color.yellow.caramellow.500.value}",
+          "comment": "Icon color to indicate a warning or caution"
         },
         "inverse": {
-          "value": "{color.white.mochimalist.0.value}"
+          "value": "{color.white.mochimalist.0.value}",
+          "comment": "Icon color to use on dark backgrounds"
         }
       }
     },
     "background": {
       "info": {
         "base": {
-          "value": "{color.blue.skycicle.500.value}"
+          "value": "{color.blue.skycicle.500.value}",
+          "comment": "Background color to indicate neutral information"
         },
         "weak": {
-          "value": "{color.blue.skycicle.50.value}"
+          "value": "{color.blue.skycicle.50.value}",
+          "comment": "Weak background color to indicate neutral information, can be used behind text"
         }
       },
       "error": {
         "base": {
-          "value": "{color.red.pushpin.500.value}"
+          "value": "{color.red.pushpin.500.value}",
+          "comment": "Background color to indicate errors"
         },
         "weak": {
-          "value": "{color.red.pushpin.50.value}"
+          "value": "{color.red.pushpin.50.value}",
+          "comment": "Weak background color to indicate errors, can be used behind text"
         }
       },
       "warning": {
         "base": {
-          "value": "{color.yellow.caramellow.500.value}"
+          "value": "{color.yellow.caramellow.500.value}",
+          "comment": "Background color to indicate warnings"
         },
         "weak": {
-          "value": "{color.orange.firetini.50.value}"
+          "value": "{color.orange.firetini.50.value}",
+          "comment": "Weak background color to indicate warnings, can be used behind text"
         }
       },
       "success": {
         "base": {
-          "value": "{color.green.matchacado.500.value}"
+          "value": "{color.green.matchacado.500.value}",
+          "comment": "Background color to indicate success"
         },
         "weak": {
-          "value": "{color.green.matchacado.50.value}"
+          "value": "{color.green.matchacado.50.value}",
+          "comment": "Weak background color to indicate success, can be used behind text"
         }
       },
-      "elevated": {
-        "value": "{color.black.cosmicore.900.value}"
-      },
       "shopping": {
-        "value": "{color.blue.skycicle.500.value}"
+        "value": "{color.blue.skycicle.500.value}",
+        "comment": "Background color to indicate shopping-related features"
       },
       "primary": {
         "base": {
-          "value": "{color.red.pushpin.450.value}"
+          "value": "{color.red.pushpin.450.value}",
+          "comment": "Primary background color"
         },
         "strong": {
-          "value": "{color.red.pushpin.600.value}"
+          "value": "{color.red.pushpin.600.value}",
+          "comment": "Strong version of the primary background color, used for hover"
         }
       },
       "secondary": {
         "base": {
-          "value": "{color.gray.roboflow.500.value}"
+          "value": "{color.gray.roboflow.500.value}",
+          "comment": "Secondary background color"
         },
         "strong":{
-          "value": "{color.gray.roboflow.700.value}"
+          "value": "{color.gray.roboflow.700.value}",
+          "comment": "Strong version of secondary background color, used for hover"
         }
       },
       "tertiary": {
         "base": {
-          "value": "{color.gray.roboflow.200.value}"
+          "value": "{color.gray.roboflow.200.value}",
+          "comment": "Tertiary background color"
         },
         "strong": {
-          "value": "{color.gray.roboflow.400.value}"
+          "value": "{color.gray.roboflow.400.value}",
+          "comment": "Strong version of tertiary background color, used for hover"
         }
       },
       "selected": {
         "base": {
-          "value": "{color.black.cosmicore.900.value}"
+          "value": "{color.black.cosmicore.900.value}",
+          "comment": "Background color to indicate selected state, like a selected IconButton"
         },
         "weak": {
-          "value": "{color.gray.roboflow.700.value}"
+          "value": "{color.gray.roboflow.700.value}",
+          "comment": "Weak version of the selected background color, used for hover"
         }
       },
       "inverse": {
         "base": {
-          "value": "{color.white.mochimalist.0.value}"
+          "value": "{color.white.mochimalist.0.value}",
+          "comment": "Background color for use on dark backgrounds"
         },
         "strong": {
-          "value": "{color.gray.roboflow.200.value}"
+          "value": "{color.gray.roboflow.200.value}",
+          "comment": "Strong version of inverse background color, used for hover"
         }
       },
       "brand": {
-        "value": "{color.red.pushpin.450.value}"
+        "value": "{color.red.pushpin.450.value}",
+        "comment": "Background color to signify the Pinterest brand"
+      },
+      "education": {
+        "value": "{color.blue.skycicle.500.value}",
+        "comment": "Background color to indicate educational moments or messages"
       }
     }
   }

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -1,0 +1,24 @@
+{
+  "color": {
+    "text": {
+      "default": {
+        "value": "{color.black.cosmicore.900.value}"
+      },
+      "subtle": {
+        "value": "{color.gray.roboflow.500.value}"
+      },
+      "success": {
+        "value": "{color.green.matchacado.600.value}"
+      },
+      "error": {
+        "value": "{color.red.pushpin.450.value}"
+      },
+      "warning": {
+        "value": "{color.yellow.caramellow.500.value}"
+      },
+      "inverse": {
+        "value": "{color.white.mochimalist.0.value}"
+      }
+    }
+  }
+}

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -2,22 +2,131 @@
   "color": {
     "text": {
       "default": {
-        "value": "{color.black.cosmicore.900.value}"
+        "value": "{color.black.cosmicore.900.value}",
+        "comment": "Default text color"
       },
       "subtle": {
-        "value": "{color.gray.roboflow.500.value}"
+        "value": "{color.gray.roboflow.500.value}",
+        "comment": "Secondary, subtle text color"
       },
       "success": {
-        "value": "{color.green.matchacado.600.value}"
+        "value": "{color.green.matchacado.600.value}",
+        "comment": "Text color to indicate success"
       },
       "error": {
-        "value": "{color.red.pushpin.450.value}"
+        "value": "{color.red.pushpin.500.value}",
+        "comment": "Text color to indicate an error"
       },
       "warning": {
-        "value": "{color.yellow.caramellow.500.value}"
+        "value": "{color.yellow.caramellow.500.value}",
+        "comment": "Text color to indicate a warning or caution"
       },
       "inverse": {
-        "value": "{color.white.mochimalist.0.value}"
+        "value": "{color.white.mochimalist.0.value}",
+        "comment": "Text color to use on dark backgrounds"
+      },
+      "icon": {
+        "default": {
+          "value": "{color.black.cosmicore.900.value}"
+        },
+        "subtle": {
+          "value": "{color.gray.roboflow.500.value}"
+        },
+        "success": {
+          "value": "{color.green.matchacado.600.value}"
+        },
+        "error": {
+          "value": "{color.red.pushpin.500.value}"
+        },
+        "warning": {
+          "value": "{color.yellow.caramellow.500.value}"
+        },
+        "inverse": {
+          "value": "{color.white.mochimalist.0.value}"
+        }
+      }
+    },
+    "background": {
+      "info": {
+        "base": {
+          "value": "{color.blue.skycicle.500.value}"
+        },
+        "weak": {
+          "value": "{color.blue.skycicle.50.value}"
+        }
+      },
+      "error": {
+        "base": {
+          "value": "{color.red.pushpin.500.value}"
+        },
+        "weak": {
+          "value": "{color.red.pushpin.50.value}"
+        }
+      },
+      "warning": {
+        "base": {
+          "value": "{color.yellow.caramellow.500.value}"
+        },
+        "weak": {
+          "value": "{color.orange.firetini.50.value}"
+        }
+      },
+      "success": {
+        "base": {
+          "value": "{color.green.matchacado.500.value}"
+        },
+        "weak": {
+          "value": "{color.green.matchacado.50.value}"
+        }
+      },
+      "elevated": {
+        "value": "{color.black.cosmicore.900.value}"
+      },
+      "shopping": {
+        "value": "{color.blue.skycicle.500.value}"
+      },
+      "primary": {
+        "base": {
+          "value": "{color.red.pushpin.450.value}"
+        },
+        "strong": {
+          "value": "{color.red.pushpin.600.value}"
+        }
+      },
+      "secondary": {
+        "base": {
+          "value": "{color.gray.roboflow.500.value}"
+        },
+        "strong":{
+          "value": "{color.gray.roboflow.700.value}"
+        }
+      },
+      "tertiary": {
+        "base": {
+          "value": "{color.gray.roboflow.200.value}"
+        },
+        "strong": {
+          "value": "{color.gray.roboflow.400.value}"
+        }
+      },
+      "selected": {
+        "base": {
+          "value": "{color.black.cosmicore.900.value}"
+        },
+        "weaker": {
+          "value": "{color.gray.roboflow.700.value}"
+        }
+      },
+      "inverse": {
+        "base": {
+          "value": "{color.white.mochimalist.0.value}"
+        },
+        "strong": {
+          "value": "{color.gray.roboflow.200.value}"
+        }
+      },
+      "brand": {
+        "value": "{color.red.pushpin.450.value}"
       }
     }
   }

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -113,7 +113,7 @@
         "base": {
           "value": "{color.black.cosmicore.900.value}"
         },
-        "weaker": {
+        "weak": {
           "value": "{color.gray.roboflow.700.value}"
         }
       },

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -112,7 +112,7 @@
           "value": "{color.gray.roboflow.500.value}",
           "comment": "Secondary background color"
         },
-        "strong":{
+        "strong": {
           "value": "{color.gray.roboflow.700.value}",
           "comment": "Strong version of secondary background color, used for hover"
         }

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -7,7 +7,7 @@
   --g-colorGray100: #efefef;
   --g-colorGray150: #ddd;
   --g-colorGray200: #767676;
-  --g-colorGray300: #111;
+  --g-colorGray300: var(--color-text-default);
   --g-colorGray400: #000;
 
   /* secondary colors */
@@ -67,7 +67,7 @@
 /* white */
 
 .white {
-  color: var(--g-colorGray0);
+  color: var(--color-text-inverted);
 }
 
 .whiteBg {
@@ -113,7 +113,7 @@
 /* darkGray */
 
 .darkGray {
-  color: var(--g-colorGray300);
+  color: var(--color-text-default);
 }
 
 .darkGrayBg {

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -67,7 +67,7 @@
 /* white */
 
 .white {
-  color: var(--color-text-inverted);
+  color: var(--color-text-inverse);
 }
 
 .whiteBg {

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -7,7 +7,7 @@
   --g-colorGray100: #efefef;
   --g-colorGray150: #ddd;
   --g-colorGray200: #767676;
-  --g-colorGray300: var(--color-text-default);
+  --g-colorGray300: #111;
   --g-colorGray400: #000;
 
   /* secondary colors */
@@ -67,7 +67,7 @@
 /* white */
 
 .white {
-  color: var(--color-text-inverse);
+  color: var(--g-colorGray0);
 }
 
 .whiteBg {
@@ -113,7 +113,7 @@
 /* darkGray */
 
 .darkGray {
-  color: var(--color-text-default);
+  color: var(--g-colorGray300);
 }
 
 .darkGrayBg {


### PR DESCRIPTION
### Summary
Add Color alias tokens for Background and Text, re-work how the Design Tokens page is rendered, add JS output from design tokens package 
<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](link to Jira ticket(s))
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
