### PR TITLE
TextField: add "tel" option for `type` prop

### DIFF
--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -59,7 +59,7 @@ type Props = {|
   step?: number,
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   textfieldIconButton?: 'clear' | 'expand',
-  type?: 'date' | 'email' | 'number' | 'password' | 'text' | 'url',
+  type?: 'date' | 'email' | 'number' | 'password' | 'tel' | 'text' | 'url',
   value?: string,
 |};
 

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -75,7 +75,7 @@ type Props = {|
   /**
    * The type of input. For numerical input, please use [NumberField](https://gestalt.pinterest.systems/numberfield).
    */
-  type?: 'date' | 'email' | 'number' | 'password' | 'text' | 'url',
+  type?: 'date' | 'email' | 'number' | 'password' | 'tel' | 'text' | 'url',
   /**
    * md: 40px, lg: 48px
    */


### PR DESCRIPTION
We're currently using "number" for telephone numbers, which isn't great. Adding the "tel" option will yield a better UX on mobile right now, and we can explore adding additional props (`pattern`, `maxLength`, etc) in the future if needed.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel