### PR TITLE
Docs: add a couple of tooltips to header elements

### DIFF
--- a/docs/components/DocSearch.js
+++ b/docs/components/DocSearch.js
@@ -1,6 +1,6 @@
 // @flow strict
-import type { Node } from 'react';
-import { useEffect } from 'react';
+import { type Node, useEffect } from 'react';
+import { Tooltip } from 'gestalt';
 
 function filterKeyboardEvent(event: KeyboardEvent) {
   const target = event.target || event.srcElement;
@@ -60,16 +60,18 @@ export default function DocSearch(): Node {
   }, []);
 
   return (
-    <form className="searchbox">
-      <div className="searchbox__wrapper">
-        <input
-          id="algolia-doc-search"
-          className="searchbox__input"
-          type="search"
-          placeholder="Search"
-          aria-label="Search docs"
-        />
-      </div>
-    </form>
+    <Tooltip inline text="Pro tip: press '/' to quickly access search">
+      <form className="searchbox">
+        <div className="searchbox__wrapper">
+          <input
+            id="algolia-doc-search"
+            className="searchbox__input"
+            type="search"
+            placeholder="Search"
+            aria-label="Search docs"
+          />
+        </div>
+      </form>
+    </Tooltip>
   );
 }

--- a/docs/components/Header.js
+++ b/docs/components/Header.js
@@ -45,7 +45,11 @@ function Header() {
 
       <Box alignItems="center" display="flex" flex="shrink" marginStart={2} mdMarginStart={0}>
         <DocSearch />
+
+        {/* > small-screen buttons/links */}
         <HeaderMenu isHeader />
+
+        {/* Small-screen menu button */}
         <Box display="flex" mdDisplay="none" alignItems="center">
           <IconButton
             size="md"

--- a/docs/components/HeaderMenu.js
+++ b/docs/components/HeaderMenu.js
@@ -47,15 +47,17 @@ export default function HeaderMenu({ isHeader }: {| isHeader?: boolean |}): Node
         </Text>
       </Tooltip>
 
-      <Text color="white">
-        <GestaltLink
-          href="https://github.com/pinterest/gestalt"
-          onClick={() => trackButtonClick('GitHub')}
-          target="blank"
-        >
-          <Box padding={2}>GitHub</Box>
-        </GestaltLink>
-      </Text>
+      <Tooltip inline text="Check out the source code on GitHub">
+        <Text color="white">
+          <GestaltLink
+            href="https://github.com/pinterest/gestalt"
+            onClick={() => trackButtonClick('GitHub')}
+            target="blank"
+          >
+            <Box padding={2}>GitHub</Box>
+          </GestaltLink>
+        </Text>
+      </Tooltip>
     </Box>
   );
 }


### PR DESCRIPTION
I couldn't remember what our search keyboard shortcut was, so I figured others probably couldn't either. 😅

The GitHub link tooltip seems a bit obvious, but added to match all other elements in the header