### PR TITLE
Dropdown: Prevent focus event bubbling

### DIFF
--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -188,7 +188,14 @@ export default function Dropdown({
       shouldFocus
       size="xl"
     >
-      <Box alignItems="center" direction="column" display="flex" flex="grow" margin={2}>
+      <Box
+        alignItems="center"
+        direction="column"
+        display="flex"
+        flex="grow"
+        margin={2}
+        onFocus={(event) => event.stopPropagation()}
+      >
         {Boolean(headerContent) && <Box padding={2}>{headerContent}</Box>}
 
         <DropdownContextProvider value={{ id, hoveredItem, setHoveredItem, setOptionRef }}>

--- a/packages/gestalt/src/Dropdown.jsdom.test.js
+++ b/packages/gestalt/src/Dropdown.jsdom.test.js
@@ -454,4 +454,23 @@ describe('Dropdown', () => {
     // fireEvent.click(screen.getByText(/External Item 3/));
     // expect(onClickMock).toHaveBeenCalledTimes(1);
   });
+
+  it('stop propagation of on focus event when hovering over options', () => {
+    const handleOnFocus = jest.fn();
+    const mockOnDismiss = jest.fn();
+    const onSelectMock = jest.fn();
+    const element = document.createElement('button');
+
+    render(
+      <div onFocus={handleOnFocus}>
+        <Dropdown anchor={element} id="ex-8" onDismiss={mockOnDismiss}>
+          <Dropdown.Item onSelect={onSelectMock} option={{ value: 'item 1', label: 'Item 1' }} />
+          <Dropdown.Item onSelect={onSelectMock} option={{ value: 'item 2', label: 'Item 2' }} />
+        </Dropdown>
+      </div>,
+    );
+
+    fireEvent.mouseOver(screen.getByText(/Item 2/i));
+    expect(handleOnFocus).toHaveBeenCalledTimes(0);
+  });
 });


### PR DESCRIPTION
### Summary

When changing hover inside a Dropdown a onFocus event is triggered and is bubbling up outside the Dropdown component that can cause issues. This stops the propagation of the event.

### Checklist

- [x] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
