### PR TITLE
Design tokens: Add font tokens for size, weight, and family

### DIFF
--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -1,6 +1,7 @@
 // @flow strict
 import type { Node } from 'react';
 import { Box } from 'gestalt';
+import { string } from 'prop-types';
 
 type Token = {|
   name: string,
@@ -11,6 +12,7 @@ type Token = {|
 
 type Props = {|
   token: Token,
+  type?: string,
 |};
 
 export const ColorBox = ({ token }: Props): Node => (
@@ -49,6 +51,32 @@ export const TextColorBox = ({ token }: Props): Node => (
   </Box>
 );
 
+export const FontBox = ({ token, type }: Props): Node => {
+  const fontWeightStyle = type === 'weight' ? `var(--${token.name})` : undefined;
+  const fontFamilyStyle = type === 'family' ? `var(--${token.name})` : undefined;
+  const fontSizeStyle = type === 'size' ? `var(--${token.name})` : `var(--font-size-600)`;
+
+  return (
+    <Box
+      dangerouslySetInlineStyle={{
+        __style: {
+          fontWeight: fontWeightStyle,
+          fontFamily: fontFamilyStyle,
+          fontSize: fontSizeStyle,
+        },
+      }}
+      height={50}
+      width={150}
+      display="flex"
+      alignItems="center"
+      justifyContent="between"
+      paddingX={2}
+    >
+      {token.name.includes('japanese') ? 'ゲシュタルト' : 'Gestalt'}
+    </Box>
+  );
+};
+
 type ExampleProps = {|
   token: Token,
   category: string,
@@ -62,6 +90,12 @@ export const TokenExample = ({ token, category }: ExampleProps): Node => {
       return <SpacingBox token={token} />;
     case 'text-color':
       return <TextColorBox token={token} />;
+    case 'font-size':
+      return <FontBox token={token} type="size" />;
+    case 'font-weight':
+      return <FontBox token={token} type="weight" />;
+    case 'font-family':
+      return <FontBox token={token} type="family" />;
     default:
       return <Box>{token.value}</Box>;
   }

--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -1,7 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
 import { Box } from 'gestalt';
-import { string } from 'prop-types';
 
 type Token = {|
   name: string,

--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -9,12 +9,21 @@ type Token = {|
   category: string,
 |};
 
-type Props = {|
+type BaseProps = {|
   token: Token,
+|};
+
+type FontBoxProps = {|
+  ...BaseProps,
   type?: string,
 |};
 
-export const ColorBox = ({ token }: Props): Node => (
+type ExampleProps = {|
+  ...BaseProps,
+  category: string,
+|};
+
+export const ColorBox = ({ token }: BaseProps): Node => (
   <Box
     dangerouslySetInlineStyle={{
       __style: { backgroundColor: `var(--${token.name})` },
@@ -29,11 +38,11 @@ export const ColorBox = ({ token }: Props): Node => (
   />
 );
 
-export const SpacingBox = ({ token }: Props): Node => (
+export const SpacingBox = ({ token }: BaseProps): Node => (
   <Box color="eggplant" width={`${token.value}`} height={`${token.value}`} />
 );
 
-export const TextColorBox = ({ token }: Props): Node => (
+export const TextColorBox = ({ token }: BaseProps): Node => (
   <Box
     dangerouslySetInlineStyle={{
       __style: { color: `var(--${token.name})`, fontSize: '32px' },
@@ -50,7 +59,7 @@ export const TextColorBox = ({ token }: Props): Node => (
   </Box>
 );
 
-export const FontBox = ({ token, type }: Props): Node => {
+export const FontBox = ({ token, type }: FontBoxProps): Node => {
   const fontWeightStyle = type === 'weight' ? `var(--${token.name})` : undefined;
   const fontFamilyStyle = type === 'family' ? `var(--${token.name})` : undefined;
   const fontSizeStyle = type === 'size' ? `var(--${token.name})` : `var(--font-size-600)`;
@@ -75,11 +84,6 @@ export const FontBox = ({ token, type }: Props): Node => {
     </Box>
   );
 };
-
-type ExampleProps = {|
-  token: Token,
-  category: string,
-|};
 
 export const TokenExample = ({ token, category }: ExampleProps): Node => {
   switch (category) {

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -22,6 +22,9 @@ const tokenCategories = [
   { name: 'Spacing', category: 'spacing', id: 'space' },
   { name: 'Background color', category: 'background-color', id: 'background' },
   { name: 'Text color', category: 'text-color', id: 'text' },
+  { name: 'Font size', category: 'font-size', id: 'font-size' },
+  { name: 'Font weight', category: 'font-weight', id: 'font-weight' },
+  { name: 'Font family', category: 'font-family', id: 'font-family' },
 ];
 
 const headers = ['CSS Token Name', 'JavaScript Prop Name', 'Value', 'Example'];

--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -11,13 +11,15 @@ StyleDictionary.registerFileHeader({
 });
 
 StyleDictionary.registerTransform({
-  name: 'size/pxToDp',
+  name: 'size/pxToDpOrSp',
   type: 'value',
   matcher(prop) {
     return prop.value.match(/^-?[\d.]+px$/);
   },
   transformer(prop) {
-    return prop.value.replace(/px$/, 'dp');
+    return prop.name.includes('font')
+      ? prop.value.replace(/px$/, 'sp')
+      : prop.value.replace(/px$/, 'dp');
   },
 });
 
@@ -38,7 +40,7 @@ StyleDictionary.registerFormat({
 
 StyleDictionary.registerTransformGroup({
   name: 'android-custom',
-  transforms: ['attribute/cti', 'name/cti/snake', 'color/hex8android', 'size/pxToDp'],
+  transforms: ['attribute/cti', 'name/cti/snake', 'color/hex8android', 'size/pxToDpOrSp'],
 });
 
 StyleDictionary.buildAllPlatforms();

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -57,6 +57,17 @@
               "category": "space"
             }
           }
+        },
+        {
+          "destination": "font-size.xml",
+          "format": "android/resources",
+          "resourceType": "dimen",
+          "filter": {
+            "attributes": {
+              "category": "font",
+              "type": "size"
+            }
+          }
         }
       ]
     },

--- a/packages/gestalt-design-tokens/tokens/color/base.json
+++ b/packages/gestalt-design-tokens/tokens/color/base.json
@@ -136,7 +136,7 @@
     "gray": {
       "roboflow": {
         "50": { "value": "#F9F9F9" },
-        "100": { "value": "#F3F1F1" },
+        "100": { "value": "#F1F1F1" },
         "200": { "value": "#E9E9E9" },
         "300": { "value": "#CDCDCD" },
         "400": { "value": "#A5A5A5" },

--- a/packages/gestalt-design-tokens/tokens/font/base.json
+++ b/packages/gestalt-design-tokens/tokens/font/base.json
@@ -22,7 +22,8 @@
     },
     "weight": {
       "normal": {
-        "value": "400"
+        "value": "400",
+        "comment": "Default font weight"
       },
       "bold": {
         "value": "700",
@@ -31,16 +32,18 @@
     },
     "family": {
       "default": {
-        "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Helvetica, 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
-        "comment": "Default font family used at Pinterest"
+        "latin": {
+          "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Helvetica, 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
+          "comment": "Default font family used at Pinterest"
+        },
+        "japanese": {
+          "value": "'SF Pro JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Helvetica, 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
+          "comment": "Font family for Japanese"
+        }
       },
-      "monospace": {
+      "code": {
         "value": "SFMono-Medium, 'SF Mono', 'Segoe UI Mono', 'Roboto Mono', 'Ubuntu Mono', Menlo, Consolas, Courier, monospace",
         "comment": "Font family for showing things like code or computer values"
-      },
-      "japanese": {
-        "value": "'SF Pro JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Helvetica, 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
-        "comment": "Font family for Japanese"
       }
     }
   }

--- a/packages/gestalt-design-tokens/tokens/font/base.json
+++ b/packages/gestalt-design-tokens/tokens/font/base.json
@@ -1,0 +1,47 @@
+{
+  "font": {
+    "size": {
+      "100": {
+        "value": "12px"
+      },
+      "200": {
+        "value": "14px"
+      },
+      "300": {
+        "value": "16px"
+      },
+      "400": {
+        "value": "20px"
+      },
+      "500": {
+        "value": "28px"
+      },
+      "600": {
+        "value": "36px"
+      }
+    },
+    "weight": {
+      "normal": {
+        "value": "400"
+      },
+      "bold": {
+        "value": "700",
+        "comment": "Font weight used for column headers, headings, and inline-links"
+      }
+    },
+    "family": {
+      "default": {
+        "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Helvetica, 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
+        "comment": "Default font family used at Pinterest"
+      },
+      "monospace": {
+        "value": "SFMono-Medium, 'SF Mono', 'Segoe UI Mono', 'Roboto Mono', 'Ubuntu Mono', Menlo, Consolas, Courier, monospace",
+        "comment": "Font family for showing things like code or computer values"
+      },
+      "japanese": {
+        "value": "'SF Pro JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Helvetica, 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
+        "comment": "Font family for Japanese"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

#### What changed?
Add tokens for font-size, font-family, and font-weight + documentation
(Also updates our roboflow 100 to #F1F1F1)

#### Why?
Create tokens for all platforms to align on typography decisions 
<!--
What is the purpose of this PR?

Have you [formatted the PR title](https://github.com/pinterest/gestalt/#releasing)? `ComponentName: Description`
-->

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3006)

### Checklist

- [X] Added documentation + accessibility tests
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
