### PR TITLE
Internal: enable `no-access-state-in-setstate` lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,6 +71,7 @@
     "react/jsx-fragments": ["error", "element"],
     "react/jsx-key": ["error", { "checkFragmentShorthand": true }],
     "react/jsx-props-no-spreading": "off",
+    "react/no-access-state-in-setstate": "error",
     "react/no-array-index-key": "off",
     "react/react-in-jsx-scope": "off",
     "react/require-default-props": "off",


### PR DESCRIPTION
Accessing state in `this.setState` is an anti-pattern, and can lead to subtle bugs. This PR enables [the lint rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md) (already available as part of `eslint-plugin-react`) to guard against this usage. (We have none currently.)

Given that most of our components are functional, it would be a lot more useful if we had a similar lint rule for `useState`. There is an [open feature request](https://github.com/facebook/react/issues/21448) for this that I'm watching — hopefully someone has time soon to write the rule (I personally don't).