### PR TITLE
Docs: allow GitHub link text in page header to wrap

### DIFF
--- a/docs/components/PageHeader.js
+++ b/docs/components/PageHeader.js
@@ -53,7 +53,7 @@ export default function PageHeader({
       }}
     >
       <Box marginBottom={2}>
-        <Flex direction="row" gap={2} justifyContent="between" alignItems="baseline">
+        <Flex alignItems="baseline" direction="row" gap={2} justifyContent="between" wrap>
           <Heading>
             {name}{' '}
             {badge === 'pilot' ? (


### PR DESCRIPTION
### Summary

As noted in [this ticket](https://jira.pinadmin.com/browse/GESTALT-3225), the docs have a UI bug at narrow viewport widths where the GitHub link text gets all wonky. This PR allows that text to (collectively) wrap, so it gets bumped to the next line instead of insisting on staying on the title line

_the bug_
![Screen Shot 2021-09-29 at 9 45 05 AM](https://user-images.githubusercontent.com/12059539/144945722-c52558f1-bb8e-4ffe-9992-7ca08fb172c1.png)

_Fixed!_
<img width="498" alt="Screen Shot 2021-12-06 at 4 44 32 PM" src="https://user-images.githubusercontent.com/12059539/144945668-4eb715ef-0e53-488a-bc77-d4cdae2658f8.png">
.
