### PR TITLE
Internal: update straggling references to the old docs domain

### DIFF
--- a/docs/components/Markdown.js
+++ b/docs/components/Markdown.js
@@ -70,7 +70,7 @@ const formatComponentName = (listitem) => {
   if (namesAndUpdate.length > 1) {
     const componentLinks = namesAndUpdate[0].replace(/\w+/gm, (match) => {
       if (currentComponents.includes(match)) {
-        return `<a href="https://gestalt.netlify.app/${match.toLowerCase()}">${match}</a>`;
+        return `<a href="https://gestalt.pinterest.systems/${match.toLowerCase()}">${match}</a>`;
       }
       return match;
     });

--- a/docs/pages/faq.js
+++ b/docs/pages/faq.js
@@ -225,7 +225,7 @@ card(
       <Text>
         When a release will cause breaking changes — in usage or in typing — we provide a codemod to
         ease the upgrade process.{' '}
-        <Link href="https://gestalt.netlify.app/Installation#Codemods" inline>
+        <Link href="https://gestalt.pinterest.systems/Installation#Codemods" inline>
           <Text weight="bold">Read more about Codemods.</Text>
         </Link>
       </Text>

--- a/docs/pages/how_to_work_with_us.js
+++ b/docs/pages/how_to_work_with_us.js
@@ -131,7 +131,7 @@ card(
       description={`
 We are always happy to help answer questions regarding Gestalt component design and usage, design system best practices, accessibility, Icons and colors. Essentially, if it’s part of Gestalt, we’re here to help! If it’s outside of the realm of our design system, we’ll try our best to answer and/or point you to the person who can.
 
-We also offer documentation on this site ([go/GestaltWeb](https://gestalt.netlify.app/)) and a [Figma library](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/01.-Web-Sticker-Sheet?node-id=2219%3A5757) of components that exist within Gestalt.
+We also offer documentation on this site ([go/GestaltWeb](https://gestalt.pinterest.systems/)) and a [Figma library](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/01.-Web-Sticker-Sheet?node-id=2219%3A5757) of components that exist within Gestalt.
 `}
     />
   </MainSection>,

--- a/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.js
@@ -49,7 +49,7 @@ const rule: ESLintRule = {
       },
     ],
     messages: {
-      disallowed: `Unnecessary Box dangerous styles found. https://gestalt.netlify.app/Box\n{{errorMessage}}`,
+      disallowed: `Unnecessary Box dangerous styles found. https://gestalt.pinterest.systems/Box\n{{errorMessage}}`,
     },
   },
 

--- a/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-dangerous-style-duplicates.test.js
@@ -87,7 +87,7 @@ const invalidZIndexInput = buildInvalidTest('invalid-zIndex-input');
 const invalidZIndexOutput = buildInvalidTest('invalid-zIndex-output');
 
 const getErrorMessage = (error) =>
-  `Unnecessary Box dangerous styles found. https://gestalt.netlify.app/Box\n${error ?? ''}`;
+  `Unnecessary Box dangerous styles found. https://gestalt.pinterest.systems/Box\n${error ?? ''}`;
 
 ruleTester.run('no-box-dangerous-style-duplicates', rule, {
   valid: [{ code: validCode }],

--- a/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js
@@ -128,7 +128,7 @@ const allowedPrefixProps = ['data-', 'aria-'];
 const errorMessage = (props: $ReadOnlyArray<string>, localBoxName: string): string =>
   `${props.length === 1 ? `${props[0]} is` : `${props.join(', ')} are`} not allowed on Box${
     localBoxName !== 'Box' ? ` (imported as ${localBoxName})` : ''
-  }. Please see https://gestalt.netlify.app/Box for all allowed props.`;
+  }. Please see https://gestalt.pinterest.systems/Box for all allowed props.`;
 
 const rule: ESLintRule = {
   meta: {

--- a/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.test.js
@@ -58,15 +58,15 @@ ruleTester.run('no-box-disallowedProps', rule, {
   invalid: [
     [
       disallowedProps,
-      'backgroundColor is not allowed on Box. Please see https://gestalt.netlify.app/Box for all allowed props.',
+      'backgroundColor is not allowed on Box. Please see https://gestalt.pinterest.systems/Box for all allowed props.',
     ],
     [
       disallowedPropsRenamed,
-      'backgroundColor is not allowed on Box (imported as GestaltBox). Please see https://gestalt.netlify.app/Box for all allowed props.',
+      'backgroundColor is not allowed on Box (imported as GestaltBox). Please see https://gestalt.pinterest.systems/Box for all allowed props.',
     ],
     [
       disallowedPropsInvalid,
-      'backgroundColor, invalidProp are not allowed on Box. Please see https://gestalt.netlify.app/Box for all allowed props.',
+      'backgroundColor, invalidProp are not allowed on Box. Please see https://gestalt.pinterest.systems/Box for all allowed props.',
     ],
   ].map(([code, errorMessage]) => ({ code, errors: [{ message: errorMessage }] })),
 });

--- a/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
@@ -20,7 +20,7 @@ const disallowedProps = [
 ];
 
 export const errorMessage =
-  'marginLeft/marginRight have been deprecated. Please use marginStart/marginEnd to support Right-to-Left (RTL)\nhttps://gestalt.netlify.app/Box';
+  'marginLeft/marginRight have been deprecated. Please use marginStart/marginEnd to support Right-to-Left (RTL)\nhttps://gestalt.pinterest.systems/Box';
 
 const rule: ESLintRule = {
   meta: {


### PR DESCRIPTION
`s/'gestalt.netlify.app'/'gestalt.pinterest.systems'/`

I guess we missed these when we updated to use the new domain. These are the last references I can find in the repo!