### PR TITLE
Docs: small layout and changelog loading improvements

### DIFF
--- a/docs/components/Footer.js
+++ b/docs/components/Footer.js
@@ -6,40 +6,37 @@ import trackButtonClick from './buttons/trackButtonClick.js';
 export default function Footer(): Node {
   return (
     <Box color="lightGray" padding={4} mdPadding={6} lgPadding={8} role="contentinfo">
-      <Box paddingX={2} paddingY={1}>
-        <Flex alignItems="center" gap={4} justifyContent="between">
-          <Text color="darkGray" weight="bold">
-            <Link
-              href="https://www.pinterest.com"
-              onClick={() => trackButtonClick('Pinterest logo')}
-              target="blank"
-            >
-              <Box paddingX={2}>
-                <Flex alignItems="center" gap={2}>
-                  <Icon
-                    icon="pinterest"
-                    color="red"
-                    size={24}
-                    accessibilityLabel="Pinterest Logo"
-                  />
-                  Pinterest
-                </Flex>
-              </Box>
-            </Link>
-          </Text>
-
-          <Text>
-            <Link href="https://www.pinterestcareers.com/" target="blank">
+      <Box paddingX={2} paddingY={1} display="flex" direction="column" mdDirection="row">
+        <Box column={12} mdColumn={3} padding={2}>
+          <Flex alignItems="center" gap={2}>
+            <Box aria-hidden>
+              <Icon icon="pinterest" color="red" size={24} accessibilityLabel="" />
+            </Box>
+            <Text color="darkGray" weight="bold">
+              <Link
+                accessibilityLabel="Visit Pinterest.com"
+                href="https://www.pinterest.com"
+                onClick={() => trackButtonClick('Pinterest logo')}
+              >
+                Pinterest
+              </Link>
+            </Text>
+          </Flex>
+        </Box>
+        <Box column={12} mdColumn={6} padding={2}>
+          <Text inline>
+            <Link inline href="https://www.pinterestcareers.com/" target="blank">
               Interested in working with Gestalt? Check out our Careers page!
             </Link>
           </Text>
-
-          <Text>
-            <Link href="https://www.netlify.com/" target="blank">
+        </Box>
+        <Box column={12} mdColumn={3} padding={2} display="flex">
+          <Text inline>
+            <Link inline href="https://www.netlify.com/" target="blank">
               This site is powered by Netlify
             </Link>
           </Text>
-        </Flex>
+        </Box>
       </Box>
     </Box>
   );

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -1,13 +1,13 @@
 // @flow strict
 import type { Node } from 'react';
 import { useState, useEffect } from 'react';
-import { Box, Flex, Link, Text } from 'gestalt';
+import { Box, Flex, Link, Text, Spinner } from 'gestalt';
 import Markdown from '../components/Markdown.js';
 import PageHeader from '../components/PageHeader.js';
 import Page from '../components/Page.js';
 
 function Changelog() {
-  const [changelogData, setChangelogData] = useState('Loading changelog from GitHub...');
+  const [changelogData, setChangelogData] = useState('');
 
   useEffect(() => {
     const fetchChangelog = async () => {
@@ -57,7 +57,16 @@ function Changelog() {
         </Text>
       </Flex>
 
-      <Markdown text={changelogData} type="changelog" />
+      {changelogData ? (
+        <Markdown text={changelogData} type="changelog" />
+      ) : (
+        <Box padding={10}>
+          <Flex gap={2} direction="column" alignItems="center">
+            <Spinner show accessibilityLabel="" />
+            <Text weight="bold">Loading changelog from GitHub...</Text>
+          </Flex>
+        </Box>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## What changed

-  Added loading spinner for changelog
- Refactor footer to change row to direction layout in small screens 


Before 
![image](https://user-images.githubusercontent.com/10593890/146252116-5f1bf1a7-085a-49f2-86c2-56ad91a7ad2d.png)
![image](https://user-images.githubusercontent.com/10593890/146252252-7ef7338f-bf61-46cf-bdaa-362e7c25557b.png)

After
![image](https://user-images.githubusercontent.com/10593890/146258741-072e8617-7834-4b61-a5c0-83dfd4c154ab.png)
![image](https://user-images.githubusercontent.com/10593890/146252838-b897094d-92ec-4abc-9dc0-4149b472dc50.png)

