### PR TITLE
Card, Checkbox, Column: refactor to use generated props tables

### DIFF
--- a/docs/pages/card.js
+++ b/docs/pages/card.js
@@ -1,6 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
@@ -11,31 +11,9 @@ export default function CardPage({ generatedDocGen }: {| generatedDocGen: DocGen
   return (
     <Page title="Card">
       <PageHeader name="Card" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'active',
-            type: '?boolean',
-            defaultValue: false,
-          },
-          {
-            name: 'children',
-            type: 'React.Node',
-          },
-          {
-            name: 'image',
-            type: 'React.Node',
-          },
-          {
-            name: 'onMouseEnter',
-            type: '({ event: SyntheticMouseEvent<HTMLDivElement> })',
-          },
-          {
-            name: 'onMouseLeave',
-            type: '({ event: SyntheticMouseEvent<HTMLDivElement> })',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/checkbox.js
+++ b/docs/pages/checkbox.js
@@ -1,7 +1,7 @@
 // @flow strict
 import type { Node } from 'react';
 import { Checkbox } from 'gestalt';
-import PropTable from '../components/PropTable.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Example from '../components/Example.js';
 import Combination from '../components/Combination.js';
 import PageHeader from '../components/PageHeader.js';
@@ -13,90 +13,9 @@ export default function CheckboxPage({ generatedDocGen }: {| generatedDocGen: Do
   return (
     <Page title="Checkbox">
       <PageHeader name="Checkbox" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'checked',
-            type: 'boolean',
-            defaultValue: false,
-            href: 'combinations',
-          },
-          {
-            name: 'disabled',
-            type: 'boolean',
-            defaultValue: false,
-            href: 'combinations',
-          },
-          {
-            name: 'errorMessage',
-            type: 'string',
-          },
-          {
-            name: 'hasError',
-            type: 'boolean',
-            defaultValue: false,
-            href: 'hasError',
-          },
-          {
-            name: 'id',
-            type: 'string',
-            required: true,
-          },
-          {
-            name: 'image',
-            type: 'React.Node',
-            href: 'images',
-            description:
-              'An optional `Image` component can be supplied to add an image to each checkbox. Spacing is already accounted for; simply specify the width and height.',
-          },
-          {
-            name: 'indeterminate',
-            type: 'boolean',
-            defaultValue: false,
-            description: `Indeterminism is
-purely presentational - the value of
-a checkbox and its indeterminism are independent.`,
-            href: 'combinations',
-          },
-          {
-            name: 'label',
-            type: 'string',
-          },
-          {
-            name: 'name',
-            type: 'string',
-          },
-          {
-            name: 'onChange',
-            type: `({ event: SyntheticInputEvent<>, checked: boolean }) => void`,
-            required: true,
-          },
-          {
-            name: 'onClick',
-            type: `({ event: SyntheticInputEvent<HTMLInputElement>, checked: boolean }) => void`,
-          },
-          {
-            name: 'ref',
-            type: "React.Ref<'input'>",
-            description: 'Forward the ref to the underlying input element',
-            href: 'refExample',
-          },
-          {
-            name: 'size',
-            type: `"sm" | "md"`,
-            defaultValue: 'md',
-            description: `"sm" is 16px & "md" is 24px`,
-            href: 'combinations',
-          },
-          {
-            name: 'subtext',
-            type: 'string',
-            href: 'subtext',
-            description:
-              'Optional description for the checkbox, used to provide more detail about an option',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/column.js
+++ b/docs/pages/column.js
@@ -1,30 +1,21 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Card from '../components/Card.js';
 import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
 
+const ignoredProps = ['smSpan', 'mdSpan', 'lgSpan'];
+
 export default function ColumnPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Column">
       <PageHeader name="Column" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'children',
-            type: 'React.Node',
-          },
-          {
-            name: 'span',
-            type: '0 .. 12',
-            required: true,
-            responsive: true,
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} excludeProps={ignoredProps} />
+
       <Card
         description={`
     Column is a basic layout component to help you size your UI. A full width is composed

--- a/packages/gestalt/src/Card.js
+++ b/packages/gestalt/src/Card.js
@@ -1,39 +1,46 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { useState } from 'react';
+import { type Node, useState } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
 import styles from './Card.css';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type Props = {|
+  /**
+   * Used to force the "active" hover state visually.
+   */
   active?: ?boolean,
+  /**
+   *
+   */
   children?: Node,
+  /**
+   * An optional [Image](https://gestalt.pinterest.systems/image) to be displayed at the top of the layout.
+   */
   image?: Node,
-  onMouseEnter?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
-  onMouseLeave?: AbstractEventHandler<SyntheticMouseEvent<HTMLDivElement>>,
+  /**
+   * Optional callback fired when the user mouses over Card.
+   */
+  onMouseEnter?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
+  /**
+   * Optional callback fired when the user away from Card.
+   */
+  onMouseLeave?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
 |};
 
 /**
- * [Cards](https://gestalt.pinterest.systems/card) are meant to highlight content in grids. It visually shows that items belong together and highlights the items on hover.
+ * [Card](https://gestalt.pinterest.systems/card) is used to highlight content in grids. It visually shows that children elements belong together and can highlight the items on hover.
  */
-export default function Card(props: Props): Node {
+export default function Card({ active, children, image, onMouseEnter, onMouseLeave }: Props): Node {
   const [hovered, setHovered] = useState(false);
-  const { active, children, image, onMouseEnter, onMouseLeave } = props;
 
   const handleMouseEnter = (event) => {
     setHovered(true);
-    if (onMouseEnter) {
-      onMouseEnter({ event });
-    }
+    onMouseEnter?.({ event });
   };
 
   const handleMouseLeave = (event) => {
     setHovered(false);
-    if (onMouseLeave) {
-      onMouseLeave({ event });
-    }
+    onMouseLeave?.({ event });
   };
 
   const classes = classnames(styles.card, {

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { forwardRef, useImperativeHandle, useEffect, useRef, useState } from 'react';
+import { forwardRef, type Node, useImperativeHandle, useEffect, useRef, useState } from 'react';
 import classnames from 'classnames';
 import colors from './Colors.css';
 import styles from './Checkbox.css';
@@ -11,28 +9,71 @@ import FormErrorMessage from './FormErrorMessage.js';
 import Icon from './Icon.js';
 import Label from './Label.js';
 import Text from './Text.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import useFocusVisible from './useFocusVisible.js';
 import focusStyles from './Focus.css';
 
 type Props = {|
+  /**
+   * Is the element currently checked?
+   */
   checked?: boolean,
+  /**
+   * Is the element currently disabled? Disabled Checkboxes do not respond to mouse events and cannot be reached by the keyboard.
+   */
   disabled?: boolean,
+  /**
+   * Displays an error message and error state. Be sure the error message helps the user resolve the problem.
+   */
   errorMessage?: string,
+  /**
+   * This field is deprecated and will be removed soon. Please do not use.
+   */
   hasError?: boolean,
+  /**
+   * A unique identifier for the input.
+   */
   id: string,
+  /**
+   * An optional Image component can be supplied to add an image to each checkbox. Spacing is already accounted for; simply specify the width and height.
+   */
   image?: Node,
+  /**
+   * Used to indicate a state that is neither checked nor unchecked — e.g. a "Select all" checkbox when not all items are selected or unselected.
+   * Indeterminism is purely presentational - the value of a checkbox and its indeterminism are independent.
+   */
   indeterminate?: boolean,
+  /**
+   * The label for the input. Be sure to localize the text.
+   */
   label?: string,
+  /**
+   * A unique name for the input.
+   */
   name?: string,
-  onChange: AbstractEventHandler<SyntheticInputEvent<HTMLInputElement>, {| checked: boolean |}>,
-  onClick?: AbstractEventHandler<SyntheticInputEvent<HTMLInputElement>, {| checked: boolean |}>,
+  /**
+   * Callback triggered when the state of the input changes.
+   */
+  onChange: ({| event: SyntheticInputEvent<HTMLInputElement>, checked: boolean |}) => void,
+  /**
+   * Callback triggered when the user clicks on the input.
+   */
+  onClick?: ({| event: SyntheticInputEvent<HTMLInputElement>, checked: boolean |}) => void,
+  /**
+   * Ref that is forwarded to the underlying input element.
+   */
+  ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
+  /**
+   * sm: 16px, md: 24px
+   */
   size?: 'sm' | 'md',
+  /**
+   * Optional description for the checkbox, used to provide more detail about an option.
+   */
   subtext?: string,
 |};
 
 /**
- * [Checkbox](https://gestalt.pinterest.systems/checkbox)is used over [Switch](https://gestalt.pinterest.systems/switch) when you have a long list (>3) of toggles.
+ * Use [Checkbox](https://gestalt.pinterest.systems/checkbox) instead of [Switch](https://gestalt.pinterest.systems/switch) when displaying 3 or more toggle inputs.
  */
 const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,

--- a/packages/gestalt/src/Column.js
+++ b/packages/gestalt/src/Column.js
@@ -6,7 +6,15 @@ import styles from './Column.css';
 type Columns = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 type ColumnProps = {|
+  /**
+   *
+   */
   children?: Node,
+  /**
+   * The number of units in a 12-unit width that this element will occupy.
+   *
+   * Also available in responsive sizes: `smSpan`, `mdSpan`, `lgSpan`
+   */
   span: Columns,
   smSpan?: Columns,
   mdSpan?: Columns,
@@ -14,7 +22,7 @@ type ColumnProps = {|
 |};
 
 /**
- * [Column](https://gestalt.pinterest.systems/column). Gestalt supports a 12-column system.
+ * Use [Column](https://gestalt.pinterest.systems/column) to implement a 12-column system.
  */
 export default function Column(props: ColumnProps): Node {
   const { children } = props;


### PR DESCRIPTION
Only adding content where needed — these will still need another pass later to modernize the prop descriptions