### PR TITLE
Docs: fix changelog rendering on What's new page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5288,7 +5288,7 @@ Run codemods for breaking changes in order:
 
 ## 0.93.0 (March 13, 2019)
 
-- Mask: add new prop `willChangeTransform` default true which can turn off `willChange:transform` property in CSS (#494)
+- Mask: add new prop `willChangeTransform` default true which can turn off willChange:transform property in CSS (#494)
 
 ## 0.92.0 (March 7, 2019)
 


### PR DESCRIPTION
# Root cause

`transform` followed with a back-tick resulted in our `Markdown` rendering breaking.

# Before

![Screen Shot 2021-12-17 at 7 48 27 AM](https://user-images.githubusercontent.com/127199/146501750-c0eed749-6bab-4cef-97d6-036c012f75dd.png)

# After
![Screen Shot 2021-12-17 at 7 48 38 AM](https://user-images.githubusercontent.com/127199/146501753-1d0fd69e-4853-48d4-b43c-22480862de53.png)
