### PR TITLE
Docs: avoid spinner on What's new page

### DIFF
--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -1,80 +1,58 @@
 // @flow strict
 import type { Node } from 'react';
-import { useState, useEffect } from 'react';
-import { Box, Flex, Link, Text, Spinner } from 'gestalt';
+import { Box, Flex, Link, Text } from 'gestalt';
+import path from 'path';
+import fs from 'fs';
+import nextConfig from 'next/config';
 import Markdown from '../components/Markdown.js';
 import PageHeader from '../components/PageHeader.js';
 import Page from '../components/Page.js';
 
-function Changelog() {
-  const [changelogData, setChangelogData] = useState('');
-
-  useEffect(() => {
-    const fetchChangelog = async () => {
-      const result = await fetch(
-        'https://raw.githubusercontent.com/pinterest/gestalt/master/CHANGELOG.md',
-      );
-      setChangelogData(
-        result.ok
-          ? await result.text()
-          : 'There was error loading the changelog, please try again later.',
-      );
-    };
-
-    fetchChangelog();
-  }, []);
-
+export default function Changelog({ changelog }: {| changelog: string |}): Node {
   return (
-    <Box>
-      <PageHeader name="What's New 🎉" showSourceLink={false} />
-      <Flex alignItems="start" direction="column" gap={4}>
-        <Flex gap={4}>
-          <Link inline target="blank" href="https://npmjs.org/package/gestalt">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="https://img.shields.io/npm/v/gestalt.svg?label=gestalt"
-              alt="Gestalt NPM package version badge"
-            />
-          </Link>
+    <Page title="Changelog">
+      <Box>
+        <PageHeader name="What's New 🎉" showSourceLink={false} />
+        <Flex alignItems="start" direction="column" gap={4}>
+          <Flex gap={4}>
+            <Link inline target="blank" href="https://npmjs.org/package/gestalt">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="https://img.shields.io/npm/v/gestalt.svg?label=gestalt"
+                alt="Gestalt NPM package version badge"
+              />
+            </Link>
 
-          <Link inline target="blank" href="https://npmjs.org/package/gestalt-datepicker">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="https://img.shields.io/npm/v/gestalt-datepicker.svg?label=gestalt-datepicker"
-              alt="Gestalt DatePicker NPM package version badge"
-            />
-          </Link>
-        </Flex>
-        <Text>
-          Gestalt is a set of React UI components that enforces Pinterest’s design language. We use
-          it to streamline communication between designers and developers by enforcing a bunch of
-          fundamental UI components. This common set of components helps raise the bar for UX &amp;
-          accessibility across Pinterest.
-        </Text>
-        <Text>
-          Find information below on all new and updated components by version number, as well as
-          available codemods to help upgrade between versions.
-        </Text>
-      </Flex>
-
-      {changelogData ? (
-        <Markdown text={changelogData} type="changelog" />
-      ) : (
-        <Box padding={10}>
-          <Flex gap={2} direction="column" alignItems="center">
-            <Spinner show accessibilityLabel="" />
-            <Text weight="bold">Loading changelog from GitHub...</Text>
+            <Link inline target="blank" href="https://npmjs.org/package/gestalt-datepicker">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="https://img.shields.io/npm/v/gestalt-datepicker.svg?label=gestalt-datepicker"
+                alt="Gestalt DatePicker NPM package version badge"
+              />
+            </Link>
           </Flex>
-        </Box>
-      )}
-    </Box>
+          <Text>
+            Gestalt is a set of React UI components that enforces Pinterest’s design language. We
+            use it to streamline communication between designers and developers by enforcing a bunch
+            of fundamental UI components. This common set of components helps raise the bar for UX
+            &amp; accessibility across Pinterest.
+          </Text>
+          <Text>
+            Find information below on all new and updated components by version number, as well as
+            available codemods to help upgrade between versions.
+          </Text>
+        </Flex>
+
+        <Markdown text={changelog} type="changelog" />
+      </Box>
+    </Page>
   );
 }
 
-export default function DocsPage(): Node {
-  return (
-    <Page title="Changelog">
-      <Changelog />
-    </Page>
-  );
+export async function getStaticProps(): Promise<{| props: {| changelog: string |} |}> {
+  const filePath = path.join(nextConfig().serverRuntimeConfig.GESTALT_ROOT, `CHANGELOG.md`);
+  const changelog = await fs.promises.readFile(filePath, 'utf-8');
+  return {
+    props: { changelog },
+  };
 }


### PR DESCRIPTION
Loads markdown inline instead of fetching it remotely from GitHub.

Follow up from #1820 by @AlbertCarreras 

# Description

With Create React App we had to load the changelog from GitHub.
Now that we're on Next.js, we can fetch the markdown file in  `getStaticProps`.

# Before / After

## Before
![gestalt-whats-new-spinner](https://user-images.githubusercontent.com/127199/146502696-386a0756-8e77-4803-8f9e-0ee69bd2906d.gif)

## After
![gestalt-whats-new-no-spinner](https://user-images.githubusercontent.com/127199/146502706-7966d709-8592-416f-b5d4-9ad23d3341cc.gif)