### PR TITLE
Docs: use inline SVG for header logo

### DIFF
--- a/docs/components/GestaltLogo.js
+++ b/docs/components/GestaltLogo.js
@@ -9,24 +9,25 @@ type Props = {|
 export default function GestaltLogo({ height, width }: Props): Node {
   return (
     <svg
-      width={width ?? 500}
+      aria-label="Home"
+      fill="none"
       height={height ?? 500}
       viewBox="0 0 500 500"
-      fill="none"
+      width={width ?? 500}
       xmlns="http://www.w3.org/2000/svg"
     >
       <path d="M410 249.924H250L410 409.848V249.924Z" fill="#26C0B4" />
       <path
-        fillRule="evenodd"
         clipRule="evenodd"
         d="M90 249.924C90 338.248 161.635 409.848 250 409.848V249.924H90Z"
         fill="#75BFFF"
+        fillRule="evenodd"
       />
       <path
-        fillRule="evenodd"
         clipRule="evenodd"
         d="M250.019 90C161.653 90 90.0186 161.601 90.0186 249.924H250.019V90Z"
         fill="#00857C"
+        fillRule="evenodd"
       />
     </svg>
   );

--- a/docs/components/GestaltLogo.js
+++ b/docs/components/GestaltLogo.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { type Node } from 'react';
+
+type Props = {|
+  height?: number,
+  width?: number,
+|};
+
+export default function GestaltLogo({ height, width }: Props): Node {
+  return (
+    <svg
+      width={width ?? 500}
+      height={height ?? 500}
+      viewBox="0 0 500 500"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M410 249.924H250L410 409.848V249.924Z" fill="#26C0B4" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M90 249.924C90 338.248 161.635 409.848 250 409.848V249.924H90Z"
+        fill="#75BFFF"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M250.019 90C161.653 90 90.0186 161.601 90.0186 249.924H250.019V90Z"
+        fill="#00857C"
+      />
+    </svg>
+  );
+}

--- a/docs/components/Header.js
+++ b/docs/components/Header.js
@@ -1,13 +1,12 @@
 // @flow strict
 import { type Node, useCallback, useEffect, useState } from 'react';
 import { Box, Flex, FixedZIndex, Text, IconButton, Sticky } from 'gestalt';
-import Image from 'next/image';
 import DocSearch from './DocSearch.js';
+import GestaltLogo from './GestaltLogo.js';
 import HeaderMenu from './HeaderMenu.js';
 import Link from './Link.js';
 import trackButtonClick from './buttons/trackButtonClick.js';
 import { useNavigationContext } from './navigationContext.js';
-import gestaltLogo from '../public/gestalt-logo-250.png';
 
 function Header() {
   const { isSidebarOpen, setIsSidebarOpen } = useNavigationContext();
@@ -33,8 +32,8 @@ function Header() {
           >
             <Box paddingX={2}>
               <Flex alignItems="center" gap={2}>
-                <Image alt="Gestalt logo" height={40} src={gestaltLogo} width={40} />
-                {/* slight tweak to vertically center to logo image */}
+                <GestaltLogo height={40} width={40} />
+                {/* slight tweak to vertically center to logo */}
                 <Box dangerouslySetInlineStyle={{ __style: { marginBottom: '1px' } }}>Gestalt</Box>
               </Flex>
             </Box>
@@ -48,7 +47,7 @@ function Header() {
       <Box alignItems="center" display="flex" flex="shrink" marginStart={2} mdMarginStart={0}>
         <DocSearch />
 
-        {/* > small-screen buttons/links */}
+        {/* Medium & larger-screen buttons/links */}
         <HeaderMenu isHeader />
 
         {/* Small-screen menu button */}


### PR DESCRIPTION
As noted by @christianvuerings [in another PR](https://github.com/pinterest/gestalt/pull/1813#discussion_r770368520), using an inline SVG for our logo in the header would allow crisper zoomed display and obviate the need to load the image.