### PR TITLE
Internal: Update GitHub actions to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
         node_version: [16]
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
       - id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16
       - name: Setup npm


### PR DESCRIPTION
### Summary

#### What changed?

Updates GitHub actions to the latest version

#### Why?

Security & reliability of the Gestalt CI pipeline

### Links

Beta releases explain the changes:

- https://github.com/actions/setup-node/releases/tag/v2.0.0
- https://github.com/actions/setup-node/releases/tag/v2.1.0
- https://github.com/actions/setup-node/releases/tag/v2.1.1
- https://github.com/actions/setup-node/releases/tag/v2.1.2
- https://github.com/actions/setup-node/releases/tag/v2.1.3
