### PR TITLE
Internal: publish a new version of VSCode Gestalt for every Gestalt change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,17 @@ jobs:
           yarn publish --registry=https://registry.npmjs.org --no-git-tag-version --new-version ${{ steps.release.outputs.VERSION }}
           cd ../eslint-plugin-gestalt
           yarn publish --registry=https://registry.npmjs.org --no-git-tag-version --new-version ${{ steps.release.outputs.VERSION }}
+      - name: Trigger VSCode Gestalt release
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'pinterest',
+              repo: 'vscode-gestalt',
+              workflow_id: 'workflows/publish.yml',
+              ref: 'main',
+              inputs: {
+                version: `${steps.release.outputs.VERSION}`
+              }
+            });


### PR DESCRIPTION
### Summary

#### What changed?

Every change to Gestalt triggers a VSCode Gestalt release.

#### Why?

So VSCode Gestalt always has the latest snippets

### Links

- https://github.com/pinterest/vscode-gestalt/pull/6

### Note for reviewers

Since there was no way for me to test the integration, it could be that the new trigger fails. However, we added the trigger as the last step so packages will still be published