### PR TITLE
Docs: Update Algolia API keys

### DIFF
--- a/docs/components/DocSearch.js
+++ b/docs/components/DocSearch.js
@@ -44,7 +44,8 @@ export default function DocSearch(): Node {
       return;
     }
     window.docsearch({
-      apiKey: 'a22bd809b2fb174c5defd3c0f44cab8c',
+      appId: 'GS3KDMZW6P',
+      apiKey: '88c1825a5951ee68c92b4fbf4e85ec7f',
       debug: false, // Set debug to true if you want to keep open and inspect the dropdown
       indexName: 'gestalt',
       inputSelector: '#algolia-doc-search',


### PR DESCRIPTION
### Summary

#### What changed?

Update Algolia API keys

**Note** :  Only r+ the PR, do not merge it yourself. I need to do some extra validation.

#### Why?

Our docs search engine (Algolia) asked us to update our API keys.

![image](https://user-images.githubusercontent.com/127199/147954505-14602488-a6ac-489c-a750-db60bb8b609d.png)

### Links

- https://docsearch.algolia.com/docs/migrating-from-legacy/#what-do-i-need-to-do-to-migrate 


