### PR TITLE
Internal: avoid TabWithForwardRef export to fix generated types

### DIFF
--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -105,7 +105,7 @@ const colors = {
   },
 };
 
-export const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef<
+const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef<
   TabProps,
   HTMLElement,
 >(function Tab({ bgColor, href, indicator, id, index, isActive, onChange, text }: TabProps, ref) {

--- a/packages/gestalt/src/Tabs.test.js
+++ b/packages/gestalt/src/Tabs.test.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { create } from 'react-test-renderer';
-import Tabs, { TabWithForwardRef } from './Tabs.js';
+import Tabs from './Tabs.js';
 
 describe('<Tabs />', () => {
   // TODO: we no longer support this, but we should
@@ -24,7 +24,7 @@ describe('<Tabs />', () => {
   //   expect(tabs[2].props['aria-selected']).toEqual(false);
   // });
 
-  test('Adds id only if given', () => {
+  test('Adds id when given', () => {
     const instance = create(
       <Tabs
         activeTabIndex={0}
@@ -36,10 +36,7 @@ describe('<Tabs />', () => {
       />,
     ).root;
 
-    const tabs = instance.findAllByType(TabWithForwardRef);
-
-    expect(tabs[0].props.id).toEqual('news-tab');
-    expect(tabs[1].props.id).toBeUndefined();
+    expect(instance.findByProps({ id: 'news-tab' })).toBeDefined();
   });
 
   test('matches snapshot with default props', () => {


### PR DESCRIPTION
### Summary

#### What changed?

No longer export `TabWithForwardRef` from the `Tabs.js` file

#### Why?

1. When running `react-docgen` on the `Tabs.js` file, we received the following output:

    ```
    out/gestalt/packages/gestalt/src/Tabs.js: Multiple exported component definitions found.
    ```
    The issue is that we have multiple exports in `Tabs.js`. `TabWithForwardRef` is only exported for a certain test and we can achieve similar test coverage by looking for certain props instead.
2. It allows the VSCode Gestalt to generate a `Tabs` code snippet . 

