### PR TITLE
Dropdown: Remove aria selected from menuitems

### DIFF
--- a/packages/gestalt/src/OptionItem.js
+++ b/packages/gestalt/src/OptionItem.js
@@ -144,7 +144,7 @@ const OptionItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = f
 
   return (
     <div
-      aria-selected={isSelectedItem}
+      aria-selected={role === 'option' ? isSelectedItem : null}
       className={className}
       data-test-id={dataTestId}
       id={`${id}-item-${index}`}

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -25,7 +25,6 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
               class="box flexGrow itemsCenter marginBottom2 marginEnd2 marginStart2 marginTop2 xsDirectionColumn xsDisplayFlex"
             >
               <div
-                aria-selected="false"
                 class="rounding2 hideOutline accessibilityOutline accessibilityOutlineFocusWithin fullWidth pointer"
                 id="ex-1-item-0"
                 role="menuitem"
@@ -68,7 +67,6 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                 </div>
               </div>
               <div
-                aria-selected="false"
                 class="rounding2 hideOutline accessibilityOutline accessibilityOutlineFocusWithin fullWidth pointer"
                 id="ex-1-item-1"
                 role="menuitem"
@@ -111,7 +109,6 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                 </div>
               </div>
               <div
-                aria-selected="false"
                 class="rounding2 hideOutline accessibilityOutline accessibilityOutlineFocusWithin fullWidth pointer"
                 id="ex-1-item-2"
                 role="menuitem"
@@ -177,7 +174,6 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                 </div>
               </div>
               <div
-                aria-selected="false"
                 class="rounding2 hideOutline accessibilityOutline accessibilityOutlineFocusWithin fullWidth pointer"
                 id="ex-1-item-3"
                 role="menuitem"
@@ -234,7 +230,6 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                 </div>
               </div>
               <div
-                aria-selected="false"
                 class="rounding2 hideOutline accessibilityOutline accessibilityOutlineFocusWithin fullWidth pointer"
                 id="ex-1-item-4"
                 role="menuitem"
@@ -314,7 +309,6 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                 </div>
               </div>
               <div
-                aria-selected="false"
                 class="rounding2 hideOutline accessibilityOutline accessibilityOutlineFocusWithin fullWidth pointer"
                 id="ex-1-item-5"
                 role="menuitem"


### PR DESCRIPTION
### Summary

#### What changed?

Updated logic to only add aria-selected when item has role=option, since aria-selected is not valid on role=menuitem

#### Why?

This bug breaks accessibility tests since aria-selected is not valid when role=menuitem, only role=option (needed for ComboBox)

### Links

### Checklist

- [X] Added unit and Flow Tests
- [X] Verified accessibility: keyboard & screen reader interaction
