### PR TITLE
Docs: fix links to zIndex page

### DIFF
--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -741,7 +741,7 @@ function BoxPopoverExample() {
         </MainSection.Subsection>
 
         <MainSection.Subsection
-          description={`It's possible to use Box with external elements using the CSS \`z-index\` property by capturing those values in controlled objects. The example below shows using a \`FixedZIndex\` for a value that comes from somewhere else, and a \`CompositeZIndex\` to layer the Box on top of it. Visit our [Z-Index documentation](/zindex%20classes) for more details on how to use these utility classes.`}
+          description={`It's possible to use Box with external elements using the CSS \`z-index\` property by capturing those values in controlled objects. The example below shows using a \`FixedZIndex\` for a value that comes from somewhere else, and a \`CompositeZIndex\` to layer the Box on top of it. Visit our [Z-Index documentation](/zindex_classes) for more details on how to use these utility classes.`}
           title="Z-Index"
         >
           <MainSection.Card

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -154,7 +154,7 @@ export default function DropdownPage({ generatedDocGen }: {| generatedDocGen: Do
             name: 'zIndex',
             type: 'interface Indexable { index(): number; }',
             description:
-              'An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](/zindex%20classes)',
+              'An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](/zindex_classes)',
           },
         ]}
       />

--- a/docs/pages/layer.js
+++ b/docs/pages/layer.js
@@ -71,7 +71,7 @@ function Example() {
       />
       <Example
         description="
-The example below shows using a \`FixedZIndex\` for the header zIndex and a \`CompositeZIndex\` to stack the Layer on top of it. Visit our [Z-Index documentation](/zindex%20classes) for more details on how to use these utility classes.
+The example below shows using a \`FixedZIndex\` for the header zIndex and a \`CompositeZIndex\` to stack the Layer on top of it. Visit our [Z-Index documentation](/zindex_classes) for more details on how to use these utility classes.
     "
         name="zIndex"
         defaultCode={`

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -452,7 +452,7 @@ function SectionsIconButtonDropdownExample() {
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Z-index"
-          description={`Tooltip has [Layer](/layer) built in, allowing it to overlay surrounding content. Use \`zIndex\` to specify the stacking order of Tooltip along the z-axis in the current stacking context. The example below shows [FixedZIndex](/zindex%20classes#FixedZIndex) used in [Modal](/modal) and [CompositeZIndex](ZIndex%20Classes#CompositeZIndex) to layer Tooltip on top.
+          description={`Tooltip has [Layer](/layer) built in, allowing it to overlay surrounding content. Use \`zIndex\` to specify the stacking order of Tooltip along the z-axis in the current stacking context. The example below shows [FixedZIndex](/zindex_classes#FixedZIndex) used in [Modal](/modal) and [CompositeZIndex](zindex_classes#CompositeZIndex) to layer Tooltip on top.
 
 `}
         >

--- a/packages/gestalt/src/zIndex.js
+++ b/packages/gestalt/src/zIndex.js
@@ -5,7 +5,7 @@ export interface Indexable {
 }
 
 /**
- * https://gestalt.pinterest.systems/zindex%20classes
+ * https://gestalt.pinterest.systems/zindex_classes#FixedZIndex
  */
 export class FixedZIndex implements Indexable {
   +z: number;
@@ -20,7 +20,7 @@ export class FixedZIndex implements Indexable {
 }
 
 /**
- * https://gestalt.pinterest.systems/zindex%20classes
+ * https://gestalt.pinterest.systems/zindex_classes#CompositeZIndex
  */
 export class CompositeZIndex implements Indexable {
   +deps: $ReadOnlyArray<FixedZIndex | CompositeZIndex>;


### PR DESCRIPTION
### Summary

#### What changed?

Fixes links to the zIndex page in our docs

#### Why?

To avoid a broken experience for our users

#### How did you find these?

Thanks to Algolia's new crawler, we can now automatically surface invalid links:

![Screen Shot 2022-01-05 at 9 55 31 AM](https://user-images.githubusercontent.com/127199/148189777-1796c83c-d7a3-483c-8645-e2122bfd85eb.png)

#### Repro

1. Go to https://gestalt.netlify.app/dropdown
2. Click on `zIndex Classes`
3. Results in: 

```
{"errorType":"TypeError","errorMessage":"Request path contains unescaped characters","trace":["TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters","    at new NodeError (internal/errors.js:322:7)","    at new ClientRequest (_http_client.js:155:13)","    at request (http.js:94:10)","    at /var/task/.netlify/functions-internal/___netlify-handler/bridge.js:169:19","    at new Promise (<anonymous>)","    at Bridge.launcher (/var/task/.netlify/functions-internal/___netlify-handler/bridge.js:167:12)","    at async Runtime.handler (/var/task/.netlify/functions-internal/___netlify-handler/___netlify-handler.js:123:40)"]}

```
