### PR TITLE
Internal: disallow ESLint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "css:validate": "./scripts/cssValidate.js",
     "dev": "(cd docs && yarn dev) & (cd packages/gestalt && yarn watch) & (cd packages/gestalt-datepicker && yarn watch) & (cd packages/eslint-plugin-gestalt && yarn watch) & (cd packages/gestalt-design-tokens && yarn watch)",
     "docs": "(cd docs && yarn start)",
+    "eslint": "eslint --max-warnings 0",
     "flow-generate:css": "(css-modules-flow-types packages/gestalt/src/ >/dev/null) && (css-modules-flow-types packages/gestalt-datepicker/src/ >/dev/null)",
     "format": "prettier --write \"**/*.{css,html,js,md,yml}\"",
     "generate": "./scripts/generateComponent.js",


### PR DESCRIPTION
### Summary

#### What changed?

* Fail ESLint when we find any ESLint warnings

#### Why?

I noticed that adding a `console.log` in code did not fail CI, which was unexpected. We do want the build to fail if someone pushes up code with an accidental `console.log`.