### PR TITLE
Docs: update How to Work With Us page

### DIFF
--- a/docs/pages/how_to_work_with_us.js
+++ b/docs/pages/how_to_work_with_us.js
@@ -9,9 +9,10 @@ export default function DividerPage(): Node {
     <Page title="How to Work with Us">
       <PageHeader
         name="How to Work with Us"
-        description="Guidelines on how to engage the Gestalt team, when to work with us, and how to contribute"
+        description="Guidelines on how to engage the Gestalt team, when to work with us, and how to contribute."
         showSourceLink={false}
       />
+
       <MainSection name="What goes into Gestalt?">
         <MainSection.Subsection
           description={`
@@ -19,6 +20,7 @@ export default function DividerPage(): Node {
     `}
         />
       </MainSection>
+
       <MainSection name="What is the process to request new additions or changes?">
         <MainSection.Subsection
           description={`
@@ -47,88 +49,92 @@ We ask that any ideas that change the functionality of an existing Gestalt compo
     Our engineering team will pair directly with your engineer if they are the ones who will be taking on the work and help them follow the process below. If the Gestalt team is building the component, we will take on the work and follow the same process. As we develop the documentation, Figma files, and code for the updated or new component, we’d love for you to help review and be part of a final sanity check.`}
         />
       </MainSection>
+
       <MainSection name="How can you contribute to Gestalt?">
         <MainSection.Subsection
           title="Making a design contribution"
           description={`
 We love the help and contributions of other designers across Pinterest, and we ask that any ideas that change the functionality of an existing Gestalt component or introduce a net-new component go through the following process:
 1. **Present your idea or suggestion during our Office Hour meetings**
-    Sign up for an Office Hours slot! Explain project goals and show multiple options explored with and without Gestalt components to help us understand your needs. This does not need to be a polished presentation, but should have enough detail that we understand the ask and why it is needed.
+    [Sign up](https://pinch.pinadmin.com/gestaltSignUp) for an Office Hours slot! Explain project goals and show multiple options explored with and without Gestalt components to help us understand your needs. This does not need to be a polished presentation, but should have enough detail that we understand the request and why it is needed.
 2. **Create a Branch in our design library**
     Create a Branch file in our main file. Don't worry, our design team will support you with that. See [Branching in Figma](https://www.figma.com/best-practices/branching-in-figma/) for more details and self-education.
 3. **Present your work in a Design System Crit**
     After your Branch file is ready, our design team will schedule a meeting to present your work.
 4. **Send your Branch to review**
-    Update your Branch based on the feedback you got, and add a Gestalt reviewer (designer) to your Branch. Our design team will approve and merge the Branch when it is ready to implement in our web docs. We will follow up with you!
+    Update your Branch based on the feedback you received, and add a Gestalt reviewer (designer) to your Branch. Our design team will approve and merge the Branch when it is ready to implement in our web docs. We will follow up with you!
 `}
         />
         <MainSection.Subsection
           title="Making an engineering contribution"
           description={`
-We always appreciate the help and contributions of other engineers across Pinterest. It could be new variants, simple bug fixes or building out entire components. Before any code happens though, be sure to follow our [request process](#What-is-the-process-to-request-new-additions-or-changes).
+We always appreciate the help and contributions of other engineers across Pinterest, whether it's new variants, simple bug fixes or building out entire components. Before any code changes happen though, be sure to follow our [request process](#What-is-the-process-to-request-new-additions-or-changes).
 1. **Talk to your designer**
-   Checking in with your designers and assure that changes have been approved by the Gestalt team, via the [request process](#What-is-the-process-to-request-new-additions-or-changes). We don’t recommend starting a PR on new functionality, no matter how small, without confirming this, as you may spend time on changes that won’t be approved to merge into Gestalt.
-2. **Tech Design Doc**
+   Check in with your designer and make sure the changes have been approved by the Gestalt team, via the [request process](#What-is-the-process-to-request-new-additions-or-changes). We don’t recommend starting a PR on new functionality — no matter how small — without confirming this, as you may spend time on changes that won’t be approved to merge into Gestalt.
+2. **Technical Design Doc**
    Create a technical design doc (TDD), using [this template](https://pinch.pinadmin.com/gestaltTDD), for any net-new components or component additions/updates within Gestalt. This allows everyone to discuss the component API and functionality before starting to build.
-3. **Pull request**
-   Once the TDD has been finalized, make a pull request for your changes by following the [development guidelines](/development). Your changes will be reviewed by the gestalt-core GitHub Team and a Gestalt designer. We ensure each component is built to spec, accessible, performant and works well with other components.
-4. **Release**
-   Now the fun part - releasing your component! After someone from the Gestalt team merges your change, feel free to announce it on the [#gestalt-web](https://pinch.pinadmin.com/gestaltSlack) slack channel.
+3. **Implement and Test**
+   Once the TDD has been finalized, it's time to build! If creating a new component, check out our [scaffolding script](https://github.com/pinterest/gestalt/blob/master/scripts/generateComponent.js). Don't forget about tests! If updating an existing component, please remember to update/add unit tests. Use \`.test.js\` to test UI and \`.jsdom.test.js\` to test interactions. Note that accessibility integration tests cover both the component itself and the related docs page. Run the test suites using the [package.json scripts](https://github.com/pinterest/gestalt/blob/master/package.json#L101).
+4. **Pull request**
+    When your work is complete and all tests are passing, make a _draft_ pull request for your changes by following the [development guidelines](/development). This will start the CI process, running a variety of tests. Once those tests are passing (aside from the semver one), mark your PR as _"Ready for review"_ and ping us on [#gestalt-web](https://pinch.pinadmin.com/gestaltSlack). Your changes will be reviewed by an engineer and a designer from the Gestalt team. We ensure each component is built to spec, accessible, performant and works well with other components.
+5. **Release**
+   Now the fun part: releasing your component! After a Gestalt team member merges your change and Pinboard has been updated, feel free to announce your component/changes on the [#gestalt-web](https://pinch.pinadmin.com/gestaltSlack) Slack channel.
 `}
         />
         <MainSection.Subsection
           title="Other ways to contribute"
           description={`
 **Bugs**
-If you think you’ve found a bug with Gestalt components or documentation, first check our [Gestalt Bugs Dashboard](https://jira.pinadmin.com/secure/Dashboard.jspa?selectPageId=29639) to see if it’s already been reported. If it hasn’t, please file a bug within the [Bugs](https://pinch.pinadmin.com/gestaltJiraBugs) JIRA project and set the component=”gestalt”. We are not actively using GitHub issues, so the best way to file is through JIRA.
+If you think you’ve found a bug with Gestalt components or documentation, first check our [Gestalt Bugs Dashboard](https://jira.pinadmin.com/secure/Dashboard.jspa?selectPageId=29639) to see if it’s already been reported. If it hasn’t, please file a bug within the [Bugs](https://pinch.pinadmin.com/gestaltJiraBugs) Jira project and set the Component to ”gestalt”. We do not actively monitor GitHub issues, so the best way to file is through Jira.
 **Surveys**
-The Gestalt team sends out surveys to the design and engineering orgs. Filling out this survey is one way to help inform our team on what is working and what is not working about out design system.
+The Gestalt team sends out twice-yearly surveys to the design and engineering orgs. Filling out this survey is one way to help inform our team on what is working and what is not working about out design system.
 `}
         />
       </MainSection>
+
       <MainSection name="What kind of support can you expect from the team?">
         <MainSection.Subsection
           description={`
-We are always happy to help answer questions regarding Gestalt component design and usage, design system best practices, accessibility, Icons and colors. Essentially, if it’s part of Gestalt, we’re here to help! If it’s outside of the realm of our design system, we’ll try our best to answer and/or point you to the person who can.
+We are always happy to help answer questions regarding Gestalt component design and usage, design system best practices, accessibility, icons and colors. If it’s part of Gestalt, we’re here to help! If it’s outside of the realm of our design system, we’ll try our best to answer and/or point you to the person who can. Feel free to reach out to us on [Slack](http://gestalt.pinterest.systems/how_to_work_with_us#Slack-channels) anytime.
 We also offer documentation on this site ([go/GestaltWeb](https://gestalt.pinterest.systems/)) and a [Figma library](https://pinch/gestaltFigma) of components that exist within Gestalt.
 `}
         />
       </MainSection>
-      <MainSection name="Resources, Slack, and Meetings - oh my!">
+
+      <MainSection name="Resources, Slack, and Meetings — oh my!">
         <MainSection.Subsection
-          title="Dashboards, JIRA, and OKRs"
+          title="Dashboards, Jira, and OKRs"
           description={`
 If you’re curious what we’re working on, you can check out our Gestalt [Sprint Dashboard](https://pinch.pinadmin.com/gestaltSprint), our [full backlog](https://pinch.pinadmin.com/gestaltBacklog), and our [Bugs Dashboard](https://pinch.pinadmin.com/gestaltJiraBugs).
-To see the bigger picture, you can view our [OKRs](https://pinch.pinadmin.com/gestaltOKR) to understand our roadmap and priorities for each quarter. These priorities are determined through our [partnership meetings](#Meetings-and-events), which we use to learn about component needs and coordinate with designers to determine the timelines.
+To see the bigger picture, you can view our [OKRs](https://pinch.pinadmin.com/gestaltOKR) to understand our roadmap and priorities for each quarter. These priorities are determined through [partnership meetings](#Meetings-and-events), which we use to learn about component needs and coordinate with designers to determine timelines.
 `}
         />
         <MainSection.Subsection
           title="Slack channels"
           description={`
 Before reaching out, take a look at our [documentation](https://gestalt.pinterest.systems/) to see if it answers your question, because it will likely get you the fastest answer. Still need help? Try searching Slack for your question, and then feel free to ask if your question hasn’t been answered in the past. You can also reference our [Communication Guidelines](https://pinch.pinadmin.com/gestaltCommsGuidelines) for more info.
-[#gestalt-design](https://pinch.pinadmin.com/gestaltSlackDesign) is the best way to reach the Gestalt design team for design focused questions.
-[#gestalt-web](https://pinch.pinadmin.com/gestaltSlack) is for more engineering-focused questions.
+[#gestalt-design](https://pinch.pinadmin.com/gestaltSlackDesign) is for design-focused questions.
+[#gestalt-web](https://pinch.pinadmin.com/gestaltSlack) is for engineering-focused questions.
 `}
         />
         <MainSection.Subsection
           title="Meetings and events"
           description={`
-Our meetings, events, and timelines can be found on our [Gestalt Event Calendar](https://pinch.pinadmin.com/gestaltCalendar).
-We offer two different meetings for the community to come with questions, comments, ideas, and feedback.
+Our meetings, events, and timelines can be found on the [Gestalt Event Calendar](https://pinch.pinadmin.com/gestaltCalendar). We offer two different meetings for the community to bring questions, comments, ideas, and feedback:
 1. **Gestalt Office Hours**
-    - Purpose
-      For Product designers looking for feedback on their usage of design systems and visual language. This is also a great time to propose new components or component changes.
-    - Audience
-      The audience for office hours is expanding to include both Pinner and Business design.
-    - Cadence
-      Gestalt office hours are now available twice a week, with 2 half-hour slots on both Tuesdays and Thursdays. [Sign up sheet](https://pinch.pinadmin.com/gestaltSignUp)
+    - _Purpose_
+      For product designers seeking feedback on their usage of design systems and visual language. This is also a great time to propose new components or component changes.
+    - _Audience_
+      Primarily Pinner and M10n designers, though engineers are welcome if there are technical concerns as well.
+    - _Cadence_
+      Twice a week on Tuesdays and Thursdays. Please [sign up](https://pinch.pinadmin.com/gestaltSignUp) for a half-hour slot with your discussion topic.
 2.  **Component Crit**
-    - Purpose
-      For Systems designers to get feedback from the larger design org on systems-related designs.
-    - Audience
-      Pinterest designers. The agenda for the Crit can be found in the recurring calendar invite. Please continue to bring component work to office hours.
-    - Cadence
-      Bi-weekly on Friday 1-2pm. Please sign up through the link in the calendar invite.
+    - _Purpose_
+      For systems designers seeking feedback from the larger design org on systems-related designs.
+    - _Audience_
+      Pinterest designers and Gestalt engineers. The agenda for the Crit can be found in the recurring calendar invite. Please continue to bring component work to Office Hours.
+    - _Cadence_
+      Every other Friday. Please sign up through the link in the calendar invite.
 `}
         />
       </MainSection>


### PR DESCRIPTION
Primary motivation: add info about eng testing to the How to Work With Us. This page is getting a bit unwieldy, but that's fine for now — we're getting the info out there, and we'll organize it better as part of the docs redesign.

Also random formatting and copyediting on this page for clarity and style.