### PR TITLE
Collage, Container, Datapoint, Fieldset, Heading: use generated props tables

### DIFF
--- a/docs/pages/avatargroup.js
+++ b/docs/pages/avatargroup.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import { type Node } from 'react';
 import { AvatarGroup } from 'gestalt';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';

--- a/docs/pages/collage.js
+++ b/docs/pages/collage.js
@@ -1,6 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import docgen, { type DocGen } from '../components/docgen.js';
@@ -10,63 +10,9 @@ export default function CollagePage({ generatedDocGen }: {| generatedDocGen: Doc
   return (
     <Page title="Collage">
       <PageHeader name="Collage" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'columns',
-            type: 'number',
-            description:
-              'Number of columns (2 - 4). Note that Collage assumes at least 2 * `columns` images will be provided. If fewer images are provided, care will be needed to avoid TypeErrors.',
-            required: true,
-            href: 'columns',
-          },
-          {
-            name: 'cover',
-            type: 'boolean',
-            description: 'Whether or not the first image is a cover image',
-            defaultValue: false,
-            href: 'coverImage',
-          },
-          {
-            name: 'gutter',
-            type: 'number',
-            description: 'The amount of vertical & horizontal space between images',
-            defaultValue: 0,
-            href: 'gutter',
-          },
-          {
-            name: 'height',
-            type: 'number',
-            description: 'Height of the collage',
-            required: true,
-            href: 'basicExample',
-          },
-          {
-            name: 'layoutKey',
-            type: 'number',
-            description: `
-        Depending on the number of columns of the collage, there may be multiple layouts available.
-        If there are N layouts available, (layoutKey % N) will determine which layout is used.
-        `,
-            defaultValue: 0,
-            href: 'layoutKey',
-          },
-          {
-            name: 'renderImage',
-            type: '({| width: number, height: number, index: number |}) => React.Node',
-            description: 'Render prop for the collage images',
-            required: true,
-            href: 'basicExample',
-          },
-          {
-            name: 'width',
-            type: 'number',
-            description: 'Width of the collage',
-            required: true,
-            href: 'basicExample',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <Example
         id="basicExample"
         name="Basic example"

--- a/docs/pages/container.js
+++ b/docs/pages/container.js
@@ -1,7 +1,7 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
 import Example from '../components/Example.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
@@ -10,14 +10,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   return (
     <Page title="Container">
       <PageHeader name="Container" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'children',
-            type: 'React.Node',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <Example
         description="
     On small screens, the container is the width of the screen. On large screens, it centers the content with a max-width of 800px.

--- a/docs/pages/datapoint.js
+++ b/docs/pages/datapoint.js
@@ -1,7 +1,6 @@
 // @flow strict
-import React, { type Node } from 'react';
-import { Datapoint } from 'gestalt';
-import PropTable from '../components/PropTable.js';
+import { type Node } from 'react';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
 import docgen, { type DocGen } from '../components/docgen.js';
@@ -18,47 +17,7 @@ export default function DatapointPage({ generatedDocGen }: {| generatedDocGen: D
 `}
         badge="pilot"
       />
-      <PropTable
-        Component={Datapoint}
-        props={[
-          {
-            name: 'tooltipText',
-            type: 'string',
-            description:
-              'Contextual information displayed in a tooltip to describe the Datapoint. See the [tooltipText](#Tooltip-text) variant to learn more.',
-          },
-          {
-            name: 'size',
-            type: `'md' | 'lg'`,
-            defaultValue: 'md',
-            description:
-              'Used to set the size of the datapoint. See the [size](#Size) variant to learn more.',
-          },
-          {
-            name: 'title',
-            type: 'string',
-            description: 'The header for the component.',
-            required: true,
-          },
-          {
-            name: 'trend',
-            type: '{| accessibilityLabel: string, value: number |}',
-            description: `Object detailing the trend value (change in time - e.g., +30%), and accessibilityLabel to describe the trend's icon (e.g., "Trending up").  See the [trend](#Trend) variant to learn more.`,
-          },
-          {
-            name: 'trendSentiment',
-            type: `'good' | 'bad' | 'neutral' | 'auto'`,
-            defaultValue: 'auto',
-            description: `A visual indicator whether the trend is considered "good", "bad" or "neutral". By setting \`trendSentiment\` to \`auto\`, a positive trend will be considered "good", a negative trend will be considered "bad" and a trend of zero will be considered "neutral".  See the [trendSentiment](#Trend-sentiment) variant to learn more.`,
-          },
-          {
-            name: 'value',
-            type: 'string',
-            description: 'The main datapoint value (e.g., 1.23M)',
-            required: true,
-          },
-        ]}
-      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/fieldset.js
+++ b/docs/pages/fieldset.js
@@ -1,7 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import { Fieldset } from 'gestalt';
-import PropTable from '../components/PropTable.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
 import docgen, { type DocGen } from '../components/docgen.js';
@@ -60,44 +59,9 @@ export default function FieldsetPage({ generatedDocGen }: {| generatedDocGen: Do
       }
 `}
       />
-      <PropTable
-        Component={Fieldset}
-        props={[
-          {
-            name: 'legend',
-            type: 'string',
-            required: true,
-            description:
-              'Caption that clearly and concisely describes the form elements grouped in the fieldset.',
-          },
-          {
-            name: 'legendDisplay',
-            type: "'visible' | 'hidden'",
-            defaultValue: 'visible',
-            description:
-              'Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [legend visibility variant](#Legend-visibility) for more info.',
-          },
-          {
-            name: 'children',
-            type: 'React.Node',
-            required: true,
-            description: `The content of Fieldset, typically [RadioButtons](/radiobutton), [Checkboxes](/checkbox) or [TextFields](/textfield).`,
-          },
-          {
-            name: 'id',
-            type: 'string',
-            required: false,
-            description:
-              'A unique identifier for this Fieldset. `id` must be specified when an errorMessage is added',
-          },
-          {
-            name: 'errorMessage',
-            type: 'React.Node',
-            description:
-              'For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in Link or TapArea.',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/heading.js
+++ b/docs/pages/heading.js
@@ -1,6 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import docgen, { type DocGen } from '../components/docgen.js';
@@ -10,58 +10,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   return (
     <Page title="Heading">
       <PageHeader name="Heading" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'accessibilityLevel',
-            type: '1 | 2 | 3 | 4 | 5 | 6 | "none"',
-            description: 'Allows you to override the default heading level for the given `size`',
-            href: 'levels',
-          },
-          {
-            name: 'align',
-            type: `"start" | "end" | "center" | "justify" | "forceLeft" | "forceRight"`,
-            defaultValue: 'start',
-            href: 'align',
-            description:
-              '`"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text.',
-          },
-          {
-            name: 'children',
-            type: 'React.Node',
-          },
-          {
-            name: 'color',
-            type: `"blue" | "darkGray" | "eggplant" | "gray" | "green" | "lightGray" | "maroon" | "midnight" | "navy" | "olive" | "orange" | "orchid" | "pine" | "purple" | "red" | "watermelon" | "white"`,
-            defaultValue: 'darkGray',
-            href: 'colors',
-          },
-          {
-            name: 'id',
-            type: 'string',
-          },
-          {
-            name: 'lineClamp',
-            type: 'number',
-            description:
-              'Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers.',
-            href: 'overflowTruncation',
-          },
-          {
-            name: 'overflow',
-            type: '"normal" | "breakWord"',
-            defaultValue: 'breakWord',
-            href: 'overflowTruncation',
-          },
-          {
-            name: 'size',
-            type: `"sm" | "md" | "lg"`,
-            description: `sm: 20px, md: 28px, lg: 36px`,
-            defaultValue: 'lg',
-            href: 'sizes',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <Example
         id="sizes"
         name="Example: Sizes"

--- a/packages/gestalt/src/AvatarGroup.flowtest.js
+++ b/packages/gestalt/src/AvatarGroup.flowtest.js
@@ -1,5 +1,4 @@
 // @flow strict
-import React from 'react';
 import AvatarGroup from './AvatarGroup.js';
 
 const Valid = (

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -140,15 +140,15 @@ function getCollageLayout({
 
 type Props = {|
   /**
-   * Number of columns (2 - 4). Note that Collage assumes at least 2 * `columns` images will be provided. If fewer images are provided, care will be needed to avoid TypeErrors. See [example below](#columns) for more details.
+   * Number of columns (2 - 4). Note that Collage assumes at least 2 * `columns` images will be provided. If fewer images are provided, care will be needed to avoid TypeErrors. See [Columns example](https://gestalt.pinterest.systems#columns) for more details.
    */
   columns: Column,
   /**
-   * Whether or not the first image is a cover image. See [example below](#coverImage) for more details.
+   * Whether or not the first image is a cover image. See [Cover Image example](https://gestalt.pinterest.systems#coverImage) for more details.
    */
   cover?: boolean,
   /**
-   * The amount of vertical and horizontal space between images. See [example below](#gutter) for more details.
+   * The amount of vertical and horizontal space between images. See [Gutter example](https://gestalt.pinterest.systems#gutter) for more details.
    */
   gutter?: number,
   /**
@@ -156,7 +156,7 @@ type Props = {|
    */
   height: number,
   /**
-   * Depending on the number of columns of the collage, there may be multiple layouts available. If there are N layouts available, (layoutKey % N) will determine which layout is used. See [example below](#layoutKey) for more details.
+   * Depending on the number of columns of the collage, there may be multiple layouts available. If there are N layouts available, (layoutKey % N) will determine which layout is used. See [Layout Key example](https://gestalt.pinterest.systems#layoutKey) for more details.
    */
   layoutKey?: number,
   /**

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -139,16 +139,37 @@ function getCollageLayout({
 }
 
 type Props = {|
+  /**
+   * Number of columns (2 - 4). Note that Collage assumes at least 2 * `columns` images will be provided. If fewer images are provided, care will be needed to avoid TypeErrors. See [example below](#columns) for more details.
+   */
   columns: Column,
+  /**
+   * Whether or not the first image is a cover image. See [example below](#coverImage) for more details.
+   */
   cover?: boolean,
+  /**
+   * The amount of vertical and horizontal space between images. See [example below](#gutter) for more details.
+   */
   gutter?: number,
+  /**
+   * Height of the collage.
+   */
   height: number,
+  /**
+   * Depending on the number of columns of the collage, there may be multiple layouts available. If there are N layouts available, (layoutKey % N) will determine which layout is used. See [example below](#layoutKey) for more details.
+   */
   layoutKey?: number,
+  /**
+   * Callback to render the collage images.
+   */
   renderImage: ({|
     width: number,
     height: number,
     index: number,
   |}) => Node,
+  /**
+   * Width of the collage.
+   */
   width: number,
 |};
 

--- a/packages/gestalt/src/Container.js
+++ b/packages/gestalt/src/Container.js
@@ -3,14 +3,16 @@ import type { Node } from 'react';
 import Box from './Box.js';
 
 type Props = {|
+  /**
+   *
+   */
   children?: Node,
 |};
 
 /**
  * [Containers](https://gestalt.pinterest.systems/container ) are useful in responsively laying out content on different screens.
  */
-export default function Container(props: Props): Node {
-  const { children } = props;
+export default function Container({ children }: Props): Node {
   return (
     <Box justifyContent="center" display="flex">
       <Box maxWidth={800} width="100%">

--- a/packages/gestalt/src/Datapoint.flowtest.js
+++ b/packages/gestalt/src/Datapoint.flowtest.js
@@ -1,5 +1,4 @@
 // @flow strict
-import React from 'react';
 import Datapoint from './Datapoint.js';
 
 const Valid = (

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -15,7 +15,7 @@ type TrendObject = {|
 
 type Props = {|
   /**
-   * Used to set the size of the datapoint. See the [size](#Size) variant to learn more.
+   * Used to set the size of the datapoint. See the [size](https://gestalt.pinterest.systems#Size) variant to learn more.
    */
   size?: 'md' | 'lg',
   /**
@@ -23,15 +23,15 @@ type Props = {|
    */
   title: string,
   /**
-   * Contextual information displayed in a tooltip to describe the Datapoint. See the [tooltipText](#Tooltip-text) variant to learn more.
+   * Contextual information displayed in a tooltip to describe the Datapoint. See the [tooltipText](https://gestalt.pinterest.systems#Tooltip-text) variant to learn more.
    */
   tooltipText?: string,
   /**
-   * Object detailing the trend value (change in time - e.g., +30%), and accessibilityLabel to describe the trend's icon (e.g., "Trending up").  See the [trend](#Trend) variant to learn more.
+   * Object detailing the trend value (change in time - e.g., +30%), and accessibilityLabel to describe the trend's icon (e.g., "Trending up").  See the [trend](https://gestalt.pinterest.systems#Trend) variant to learn more.
    */
   trend?: TrendObject,
   /**
-   * A visual indicator whether the trend is considered "good", "bad" or "neutral". By setting \`trendSentiment\` to \`auto\`, a positive trend will be considered "good", a negative trend will be considered "bad" and a trend of zero will be considered "neutral".  See the [trendSentiment](#Trend-sentiment) variant to learn more.
+   * A visual indicator whether the trend is considered "good", "bad" or "neutral". By setting \`trendSentiment\` to \`auto\`, a positive trend will be considered "good", a negative trend will be considered "bad" and a trend of zero will be considered "neutral".  See the [trendSentiment](https://gestalt.pinterest.systems#Trend-sentiment) variant to learn more.
    */
   trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto',
   /**

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -1,12 +1,12 @@
 // @flow strict
-import React, { type Node } from 'react';
-import Text from './Text.js';
-import Heading from './Heading.js';
-import Flex from './Flex.js';
-import Icon from './Icon.js';
-import Tooltip from './Tooltip.js';
-import TapArea from './TapArea.js';
+import { type Node } from 'react';
 import DatapointTrend from './DatapointTrend.js';
+import Flex from './Flex.js';
+import Heading from './Heading.js';
+import Icon from './Icon.js';
+import TapArea from './TapArea.js';
+import Text from './Text.js';
+import Tooltip from './Tooltip.js';
 
 type TrendObject = {|
   accessibilityLabel: string,
@@ -14,11 +14,29 @@ type TrendObject = {|
 |};
 
 type Props = {|
-  tooltipText?: string,
+  /**
+   * Used to set the size of the datapoint. See the [size](#Size) variant to learn more.
+   */
   size?: 'md' | 'lg',
+  /**
+   * The header text for the component.
+   */
   title: string,
+  /**
+   * Contextual information displayed in a tooltip to describe the Datapoint. See the [tooltipText](#Tooltip-text) variant to learn more.
+   */
+  tooltipText?: string,
+  /**
+   * Object detailing the trend value (change in time - e.g., +30%), and accessibilityLabel to describe the trend's icon (e.g., "Trending up").  See the [trend](#Trend) variant to learn more.
+   */
   trend?: TrendObject,
+  /**
+   * A visual indicator whether the trend is considered "good", "bad" or "neutral". By setting \`trendSentiment\` to \`auto\`, a positive trend will be considered "good", a negative trend will be considered "bad" and a trend of zero will be considered "neutral".  See the [trendSentiment](#Trend-sentiment) variant to learn more.
+   */
   trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto',
+  /**
+   * The datapoint value (e.g., 1.23M)
+   */
   value: string,
 |};
 
@@ -28,16 +46,13 @@ type Props = {|
  * ⚠️ Please note: Datapoint is not currently supported in dark mode.
  */
 export default function Datapoint({
-  tooltipText,
   size = 'md',
   title,
+  tooltipText,
   trend,
   trendSentiment = 'auto',
   value,
 }: Props): Node {
-  const valueSize = size === 'lg' ? 'md' : 'sm';
-  const percentChangeGap = size === 'lg' ? 4 : 2;
-
   return (
     <Flex gap={1} direction="column">
       <Flex gap={1} alignItems="center" minHeight={24}>
@@ -53,8 +68,8 @@ export default function Datapoint({
           </Tooltip>
         )}
       </Flex>
-      <Flex gap={percentChangeGap} alignItems="center">
-        <Heading accessibilityLevel="none" size={valueSize}>
+      <Flex gap={size === 'lg' ? 4 : 2} alignItems="center">
+        <Heading accessibilityLevel="none" size={size === 'lg' ? 'md' : 'sm'}>
           {value}
         </Heading>
         {trend && (

--- a/packages/gestalt/src/Datapoint.test.js
+++ b/packages/gestalt/src/Datapoint.test.js
@@ -1,5 +1,4 @@
 // @flow strict
-import React from 'react';
 import { create } from 'react-test-renderer';
 import Datapoint from './Datapoint.js';
 

--- a/packages/gestalt/src/DatapointTrend.js
+++ b/packages/gestalt/src/DatapointTrend.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import { type Node } from 'react';
 import Text from './Text.js';
 import Flex from './Flex.js';
 import Icon from './Icon.js';

--- a/packages/gestalt/src/DatapointTrend.test.js
+++ b/packages/gestalt/src/DatapointTrend.test.js
@@ -1,5 +1,4 @@
 // @flow strict
-import React from 'react';
 import { create } from 'react-test-renderer';
 import DatapointTrend from './DatapointTrend.js';
 

--- a/packages/gestalt/src/Fieldset.js
+++ b/packages/gestalt/src/Fieldset.js
@@ -1,20 +1,35 @@
 // @flow strict
 import type { Node } from 'react';
 import classnames from 'classnames';
-import Text from './Text.js';
-import labelStyles from './Label.css';
-import formStyles from './FormElement.css';
-import formLabelStyles from './FormLabel.css';
-import boxWhitespaceStyles from './boxWhitespace.css';
-import whitespaceStyles from './Whitespace.css';
 import boxStyles from './Box.css';
+import boxWhitespaceStyles from './boxWhitespace.css';
 import FormErrorMessage from './FormErrorMessage.js';
+import formLabelStyles from './FormLabel.css';
+import formStyles from './FormElement.css';
+import labelStyles from './Label.css';
+import Text from './Text.js';
+import whitespaceStyles from './Whitespace.css';
 
 type Props = {|
+  /**
+   * The content of Fieldset, typically [RadioButtons](/radiobutton), [Checkboxes](/checkbox) or [TextFields](/textfield).
+   */
   children: Node,
+  /**
+   * A unique identifier for this Fieldset. `id` must be specified when an errorMessage is added.
+   */
   id?: string,
+  /**
+   * When needed, pass a string with a helpful error message (be sure to localize!).
+   */
   errorMessage?: string,
+  /**
+   * Caption that clearly and concisely describes the form elements grouped in the fieldset.
+   */
   legend: string,
+  /**
+   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [legend visibility variant](#Legend-visibility) for more info.
+   */
   legendDisplay?: 'visible' | 'hidden',
 |};
 

--- a/packages/gestalt/src/Fieldset.js
+++ b/packages/gestalt/src/Fieldset.js
@@ -12,7 +12,7 @@ import whitespaceStyles from './Whitespace.css';
 
 type Props = {|
   /**
-   * The content of Fieldset, typically [RadioButtons](/radiobutton), [Checkboxes](/checkbox) or [TextFields](/textfield).
+   * The content of Fieldset, typically [RadioButtons](https://gestalt.pinterest.systems/radiobutton), [Checkboxes](https://gestalt.pinterest.systems/checkbox) or [TextFields](https://gestalt.pinterest.systems/textfield).
    */
   children: Node,
   /**
@@ -28,7 +28,7 @@ type Props = {|
    */
   legend: string,
   /**
-   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [legend visibility variant](#Legend-visibility) for more info.
+   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [legend visibility variant](https://gestalt.pinterest.systems#Legend-visibility) for more info.
    */
   legendDisplay?: 'visible' | 'hidden',
 |};

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -32,7 +32,7 @@ type Props = {|
    */
   accessibilityLevel?: AccessibilityLevel,
   /**
-   * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text. See [example below](#align) for more details.
+   * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text. See [Align example](https://gestalt.pinterest.systems#align) for more details.
    */
   align?: 'start' | 'end' | 'center' | 'justify' | 'forceLeft' | 'forceRight',
   /**
@@ -40,7 +40,7 @@ type Props = {|
    */
   children?: Node,
   /**
-   * The color of the text. See [example below](#colors) for more details.
+   * The color of the text. See [Colors example](https://gestalt.pinterest.systems#colors) for more details.
    */
   color?:
     | 'blue'
@@ -65,15 +65,15 @@ type Props = {|
    */
   id?: string,
   /**
-   * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers. See [example below](#overflowTruncation) for more details.
+   * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers. See [Truncation example](https://gestalt.pinterest.systems#overflowTruncation) for more details.
    */
   lineClamp?: number,
   /**
-   * How truncation is handled when text overflows the line. See [example below](#overflowTruncation) for more details.
+   * How truncation is handled when text overflows the line. See [Truncation example](https://gestalt.pinterest.systems#overflowTruncation) for more details.
    */
   overflow?: Overflow,
   /**
-   * The font size of the text. See [example below](#sizes) for more details.
+   * The font size of the text. See [Sizes example](https://gestalt.pinterest.systems#sizes) for more details.
    * sm: 20px, md: 28px, lg: 36px
    */
   size?: Size,

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -4,26 +4,11 @@ import cx from 'classnames';
 import colors from './Colors.css';
 import styles from './Heading.css';
 import typography from './Typography.css';
-import { allowedColors, type Align, type Color } from './textTypes.js';
+import { allowedColors } from './textTypes.js';
 
 function isNotNullish(val): boolean {
   return val !== null && val !== undefined;
 }
-
-type AccessibilityLevel = 1 | 2 | 3 | 4 | 5 | 6 | 'none';
-type Overflow = 'normal' | 'breakWord';
-type Size = 'sm' | 'md' | 'lg';
-
-type Props = {|
-  align?: Align,
-  accessibilityLevel?: AccessibilityLevel,
-  children?: Node,
-  color?: Color,
-  id?: string,
-  lineClamp?: number,
-  overflow?: Overflow,
-  size?: Size,
-|};
 
 const defaultHeadingLevels = {
   sm: 3,
@@ -36,6 +21,63 @@ const SIZE_SCALE = {
   md: 2,
   lg: 3,
 };
+
+type AccessibilityLevel = 1 | 2 | 3 | 4 | 5 | 6 | 'none';
+type Overflow = 'normal' | 'breakWord';
+type Size = 'sm' | 'md' | 'lg';
+
+type Props = {|
+  /**
+   * Allows you to override the default heading level for the given `size`.
+   */
+  accessibilityLevel?: AccessibilityLevel,
+  /**
+   * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text. See [example below](#align) for more details.
+   */
+  align?: 'start' | 'end' | 'center' | 'justify' | 'forceLeft' | 'forceRight',
+  /**
+   *
+   */
+  children?: Node,
+  /**
+   * The color of the text. See [example below](#colors) for more details.
+   */
+  color?:
+    | 'blue'
+    | 'darkGray'
+    | 'eggplant'
+    | 'gray'
+    | 'green'
+    | 'lightGray'
+    | 'maroon'
+    | 'midnight'
+    | 'navy'
+    | 'olive'
+    | 'orange'
+    | 'orchid'
+    | 'pine'
+    | 'purple'
+    | 'red'
+    | 'watermelon'
+    | 'white',
+  /**
+   * A unique identifier for the element.
+   */
+  id?: string,
+  /**
+   * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers. See [example below](#overflowTruncation) for more details.
+   */
+  lineClamp?: number,
+  /**
+   * How truncation is handled when text overflows the line. See [example below](#overflowTruncation) for more details.
+   */
+  overflow?: Overflow,
+  /**
+   * The font size of the text. See [example below](#sizes) for more details.
+   * sm: 20px, md: 28px, lg: 36px
+   */
+  size?: Size,
+|};
 
 /**
  * [Heading](https://gestalt.pinterest.systems/heading) allows you to show headings on the page & has a bigger line height than regular text.


### PR DESCRIPTION
Refactor docs to use generated props tables: Collage, Container, Datapoint, Fieldset, Heading

Also, removed unneeded React imports (probably from an older version of the scaffolding script)