### PR TITLE
Docs: fix SSR on what's new page

### DIFF
--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -1,9 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
 import { Box, Flex, Link, Text } from 'gestalt';
-import path from 'path';
-import fs from 'fs';
-import nextConfig from 'next/config';
 import Markdown from '../components/Markdown.js';
 import PageHeader from '../components/PageHeader.js';
 import Page from '../components/Page.js';
@@ -49,10 +46,11 @@ export default function Changelog({ changelog }: {| changelog: string |}): Node 
   );
 }
 
-export async function getStaticProps(): Promise<{| props: {| changelog: string |} |}> {
-  const filePath = path.join(nextConfig().serverRuntimeConfig.GESTALT_ROOT, `CHANGELOG.md`);
-  const changelog = await fs.promises.readFile(filePath, 'utf-8');
+export async function getServerSideProps(): Promise<{| props: {| changelog: string |} |}> {
+  const result = await fetch(
+    'https://raw.githubusercontent.com/pinterest/gestalt/master/CHANGELOG.md',
+  );
   return {
-    props: { changelog },
+    props: { changelog: await result.text() },
   };
 }


### PR DESCRIPTION
### Summary

#### What changed?

Use `getServerSideProps` to load the changelog markdown file on the Gestalt docs page.
For more context see #1844.

#### Why?

Fixes a bug with setting a user preference and reloading a page.

#### Repro steps

1. Go to `/`
2. Enable dark mode
3. Reload the page

Expected result: dark mode is enabled

#### Before

#### After
