### PR TITLE
Internal: fix steps is not defined exception on VSCode Gestalt release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,5 @@ jobs:
               owner: 'pinterest',
               repo: 'vscode-gestalt',
               workflow_id: 'workflows/publish.yml',
-              ref: 'main',
-              inputs: {
-                version: `${steps.release.outputs.VERSION}`
-              }
+              ref: 'main'
             });


### PR DESCRIPTION
### Summary

#1833 introduced a bug - now, the last step of a Gestalt release results in an error:
https://github.com/pinterest/gestalt/runs/4723953815?check_suite_focus=true

```
Run actions/github-script@v5
  with:
    github-token: ***
    script: await github.rest.actions.createWorkflowDispatch({
    owner: 'pinterest',
    repo: 'vscode-gestalt',
    workflow_id: 'workflows/publish.yml',
    ref: 'main',
    inputs: {
      version: `${steps.release.outputs.VERSION}`
    }
  });
  
    debug: false
    user-agent: actions/github-script
    result-encoding: json
ReferenceError: steps is not defined
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:4942:56), <anonymous>:9:17)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:4943:12)
    at main (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:4997:26)
    at Module.272 (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:4981:1)
    at __webpack_require__ (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:24:31)
    at startup (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:43:19)
    at /home/runner/work/_actions/actions/github-script/v5/dist/index.js:49:18
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:52:10)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
```

This PR aims to fix that error.

Thanks to @AlbertCarreras for flagging the issue.

## Notes

* I find it tricky to test Github actions before pushing them up. Perhaps I can use https://github.com/nektos/act in the future.
