### PR TITLE
Internal: fix workflow id for VSCode Gestalt release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,6 @@ jobs:
             await github.rest.actions.createWorkflowDispatch({
               owner: 'pinterest',
               repo: 'vscode-gestalt',
-              workflow_id: 'workflows/publish.yml',
+              workflow_id: 'publish.yml',
               ref: 'main'
             });


### PR DESCRIPTION
### Summary

#### What changed?

`Trigger VSCode Gestalt release` is failing with the following exception:

```
RequestError [HttpError]: Not Found
    at /home/runner/work/_actions/actions/github-script/v5/dist/index.js:4614:21
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:4942:56), <anonymous>:3:1)
    at async main (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:4997:20) {
  name: 'HttpError',
  status: 404,
  response: {
    url: 'https://api.github.com/repos/pinterest/vscode-gestalt/actions/workflows/workflows%2Fpublish.yml/dispatches',
```

#### Why?

Most likely because of the `workflow_id` being incorrect.

#### Similar code which does work

- [Repo 1 yaml](https://github.com/botblock/data/blob/423199b4e90f899283a13bfdf5acb4e3683be276/.github/workflows/deploy.yml#L44-L55)
- [Repo 2 deploy yaml](https://github.com/botblock/static-site/blob/ede36c8b4b927dcb902a6f3e73fed208b5e80624/.github/workflows/deployment-staging.yml#L1)
- [Actual deployment](https://github.com/botblock/static-site/actions/runs/1619365297)

### Links

- #1847 
- #1833