### PR TITLE
Design Tokens: Add dark mode values

### DIFF
--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -1,13 +1,7 @@
 // @flow strict
 import type { Node } from 'react';
 import { Box } from 'gestalt';
-
-type Token = {|
-  name: string,
-  value: string,
-  comment?: string,
-  category: string,
-|};
+import { type Token } from '../pages/design_tokens.js';
 
 type BaseProps = {|
   token: Token,
@@ -71,6 +65,7 @@ export const FontBox = ({ token, type }: FontBoxProps): Node => {
           fontWeight: fontWeightStyle,
           fontFamily: fontFamilyStyle,
           fontSize: fontSizeStyle,
+          color: 'var(--color-text-default)',
         },
       }}
       height={50}

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -7,10 +7,12 @@ import MainSection from '../components/MainSection.js';
 import PageHeader from '../components/PageHeader.js';
 import { TokenExample } from '../components/TokenExample.js';
 import Page from '../components/Page.js';
+import { useAppContext } from '../components/appContext.js';
 
-type Token = {|
+export type Token = {|
   name: string,
   value: string,
+  darkValue?: string,
   comment?: string,
   category: string,
 |};
@@ -39,6 +41,8 @@ const tableHeaders = (
 );
 
 export default function DesignTokensPage(): Node {
+  const { colorScheme } = useAppContext();
+
   return (
     <Page title="Design Tokens Guidelines">
       <PageHeader
@@ -67,7 +71,11 @@ export default function DesignTokensPage(): Node {
                         <Text>{token.name.replace(/-./g, (x) => x[1].toUpperCase())}</Text>
                       </Table.Cell>
                       <Table.Cell>
-                        <Text>{token.value}</Text>
+                        <Text>
+                          {colorScheme === 'dark' && token.darkValue
+                            ? token.darkValue
+                            : token.value}
+                        </Text>
                       </Table.Cell>
                       <Table.Cell>
                         <TokenExample token={token} category={category.category} />

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -7,7 +7,15 @@
       "files": [
         {
           "destination": "variables.css",
-          "format": "css/variables"
+          "format": "css/variables",
+          "options": {
+            "outputReferences": true
+          }
+        },
+        {
+          "destination": "variables-dark.css",
+          "format": "cssDark",
+          "filter": "customDarkColorFilter"
         }
       ]
     },
@@ -18,6 +26,11 @@
         {
           "destination": "variables.json",
           "format": "json/flat"
+        },
+        {
+          "destination": "variables-dark.json",
+          "format": "cssDarkJson",
+          "filter": "customDarkColorFilter"
         }
       ]
     },

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -3,52 +3,64 @@
     "text": {
       "default": {
         "value": "{color.black.cosmicore.900.value}",
+        "darkValue": "{color.gray.roboflow.50.value}",
         "comment": "Default text color"
       },
       "subtle": {
         "value": "{color.gray.roboflow.500.value}",
+        "darkValue": "{color.gray.roboflow.400.value}",
         "comment": "Secondary, subtle text color"
       },
       "success": {
         "value": "{color.green.matchacado.600.value}",
+        "darkValue": "{color.green.matchacado.400.value}",
         "comment": "Text color to indicate success"
       },
       "error": {
         "value": "{color.red.pushpin.500.value}",
+        "darkValue": "{color.red.pushpin.400.value}",
         "comment": "Text color to indicate an error"
       },
       "warning": {
         "value": "{color.yellow.caramellow.500.value}",
+        "darkValue": "{color.yellow.caramellow.400.value}",
         "comment": "Text color to indicate a warning or caution"
       },
       "inverse": {
         "value": "{color.white.mochimalist.0.value}",
-        "comment": "Text color to use on dark backgrounds"
+        "darkValue": "{color.black.cosmicore.900.value}",
+        "comment": "Text color to use on inverted backgrounds"
       },
       "icon": {
         "default": {
           "value": "{color.black.cosmicore.900.value}",
+          "darkValue": "{color.gray.roboflow.50.value}",
           "comment": "Default color for icons"
         },
         "subtle": {
           "value": "{color.gray.roboflow.500.value}",
+          "darkValue": "{color.gray.roboflow.400.value}",
           "comment": "Subtle, secondary color for icons"
         },
         "success": {
           "value": "{color.green.matchacado.600.value}",
+          "darkValue": "{color.green.matchacado.400.value}",
           "comment": "Icon color to indicate success"
         },
         "error": {
           "value": "{color.red.pushpin.500.value}",
+          "darkValue": "{color.red.pushpin.400.value}",
           "comment": "Icon color to indicate an error"
         },
         "warning": {
           "value": "{color.yellow.caramellow.500.value}",
+          "darkValue": "{color.yellow.caramellow.400.value}",
           "comment": "Icon color to indicate a warning or caution"
         },
         "inverse": {
           "value": "{color.white.mochimalist.0.value}",
-          "comment": "Icon color to use on dark backgrounds"
+          "darkValue": "{color.black.cosmicore.900.value}",
+          "comment": "Icon color to use on inverted backgrounds"
         }
       }
     },
@@ -95,52 +107,74 @@
       },
       "shopping": {
         "value": "{color.blue.skycicle.500.value}",
+        "darkValue": "{color.blue.skycicle.400.value}",
         "comment": "Background color to indicate shopping-related features"
       },
       "primary": {
         "base": {
           "value": "{color.red.pushpin.450.value}",
+          "darkValue": "{color.red.pushpin.400.value}",
           "comment": "Primary background color"
         },
         "strong": {
           "value": "{color.red.pushpin.600.value}",
           "comment": "Strong version of the primary background color, used for hover"
+        },
+        "weak": {
+          "value": "{color.red.pushpin.300.value}",
+          "comment": "Weak version of the primary background color, used for hover"
         }
       },
       "secondary": {
         "base": {
           "value": "{color.gray.roboflow.500.value}",
+          "darkValue": "{color.gray.roboflow.400.value}",
           "comment": "Secondary background color"
         },
         "strong": {
           "value": "{color.gray.roboflow.700.value}",
           "comment": "Strong version of secondary background color, used for hover"
+        },
+        "weak": {
+          "value": "{color.gray.roboflow.300.value}",
+          "comment": "Weak version of secondary background color, used for hover"
         }
       },
       "tertiary": {
         "base": {
           "value": "{color.gray.roboflow.200.value}",
+          "darkValue": "{color.gray.roboflow.500.value}",
           "comment": "Tertiary background color"
         },
         "strong": {
           "value": "{color.gray.roboflow.400.value}",
           "comment": "Strong version of tertiary background color, used for hover"
+        },
+        "weak": {
+          "value": "{color.gray.roboflow.300.value}",
+          "comment": "Weak version of tertiary background color, used for hover"
         }
       },
       "selected": {
         "base": {
           "value": "{color.black.cosmicore.900.value}",
+          "darkValue": "{color.gray.roboflow.200.value}",
           "comment": "Background color to indicate selected state, like a selected IconButton"
         },
         "weak": {
           "value": "{color.gray.roboflow.700.value}",
           "comment": "Weak version of the selected background color, used for hover"
+        },
+        "strong": {
+          "value": "{color.gray.roboflow.400.value}",
+          "comment": "Strong version of the selected background color, used for hover"
         }
       },
       "inverse": {
         "base": {
           "value": "{color.white.mochimalist.0.value}",
-          "comment": "Background color for use on dark backgrounds"
+          "darkValue": "{color.black.cosmicore.900.value}",
+          "comment": "Background color for use on inverted backgrounds"
         },
         "strong": {
           "value": "{color.gray.roboflow.200.value}",
@@ -149,10 +183,12 @@
       },
       "brand": {
         "value": "{color.red.pushpin.450.value}",
+        "darkValue": "{color.red.pushpin.400.value}",
         "comment": "Background color to signify the Pinterest brand"
       },
       "education": {
         "value": "{color.blue.skycicle.500.value}",
+        "darkValue": "{color.blue.skycicle.400.value}",
         "comment": "Background color to indicate educational moments or messages"
       }
     }

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.js
@@ -2,7 +2,7 @@
 import type { Context, Element, Node } from 'react';
 
 import { useContext, useEffect, useState, createContext } from 'react';
-import darkTokens from 'gestalt-design-tokens/dist/json/variables-dark.json';
+import darkColorDesignTokens from 'gestalt-design-tokens/dist/json/variables-dark.json';
 
 export type ColorScheme = 'light' | 'dark' | 'userPreference';
 
@@ -109,9 +109,9 @@ const themeToStyles = (theme) => {
     }
   });
   if (theme.name === 'darkMode') {
-    Object.keys(darkTokens).forEach((key) => {
+    Object.keys(darkColorDesignTokens).forEach((key) => {
       if (key.startsWith('color')) {
-        styles += `  --${key}: ${darkTokens[key]};\n`;
+        styles += `  --${key}: ${darkColorDesignTokens[key]};\n`;
       }
     });
   }

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.js
@@ -2,6 +2,7 @@
 import type { Context, Element, Node } from 'react';
 
 import { useContext, useEffect, useState, createContext } from 'react';
+import darkTokens from 'gestalt-design-tokens/dist/json/variables-dark.json';
 
 export type ColorScheme = 'light' | 'dark' | 'userPreference';
 
@@ -107,6 +108,14 @@ const themeToStyles = (theme) => {
       styles += `  --g-${key}: ${theme[key]};\n`;
     }
   });
+  if (theme.name === 'darkMode') {
+    Object.keys(darkTokens).forEach((key) => {
+      if (key.startsWith('color')) {
+        styles += `  --${key}: ${darkTokens[key]};\n`;
+      }
+    });
+  }
+
   return styles;
 };
 
@@ -154,7 +163,8 @@ export default function ColorSchemeProvider({
 ${themeToStyles(darkModeTheme)} }
 }`
               : `${selector} {
-${themeToStyles(theme)} }`,
+${themeToStyles(theme)}
+}`,
         }}
       />
       <div className={className}>{children}</div>

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.js
@@ -2,6 +2,7 @@
 import type { Context, Element, Node } from 'react';
 
 import { useContext, useEffect, useState, createContext } from 'react';
+// $FlowExpectedError[untyped-import]
 import darkColorDesignTokens from 'gestalt-design-tokens/dist/json/variables-dark.json';
 
 export type ColorScheme = 'light' | 'dark' | 'userPreference';

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.js
@@ -163,8 +163,7 @@ export default function ColorSchemeProvider({
 ${themeToStyles(darkModeTheme)} }
 }`
               : `${selector} {
-${themeToStyles(theme)}
-}`,
+${themeToStyles(theme)} }`,
         }}
       />
       <div className={className}>{children}</div>

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
@@ -44,8 +44,7 @@ describe('ColorSchemeProvider', () => {
         --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
         --g-colorTransparentGray500: rgba(0, 0, 0, 0.1);
         --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
-
-      }
+       }
       </style>
     `);
   });
@@ -79,8 +78,7 @@ describe('ColorSchemeProvider', () => {
         --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
         --g-colorTransparentGray500: rgba(0, 0, 0, 0.1);
         --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
-
-      }
+       }
       </style>
     `);
   });
@@ -134,8 +132,7 @@ describe('ColorSchemeProvider', () => {
         --color-background-inverse-base: #111111;
         --color-background-brand: #eb4242;
         --color-background-education: #45a3fe;
-
-      }
+       }
       </style>
     `);
   });
@@ -224,8 +221,7 @@ describe('ColorSchemeProvider', () => {
         --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
         --g-colorTransparentGray500: rgba(0, 0, 0, 0.1);
         --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
-
-      }
+       }
       </style>
     `);
   });

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
@@ -44,7 +44,8 @@ describe('ColorSchemeProvider', () => {
         --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
         --g-colorTransparentGray500: rgba(0, 0, 0, 0.1);
         --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
-       }
+
+      }
       </style>
     `);
   });
@@ -78,7 +79,8 @@ describe('ColorSchemeProvider', () => {
         --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
         --g-colorTransparentGray500: rgba(0, 0, 0, 0.1);
         --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
-       }
+
+      }
       </style>
     `);
   });
@@ -112,7 +114,28 @@ describe('ColorSchemeProvider', () => {
         --g-colorTransparentGray100: rgba(250, 250, 250, 0.6);
         --g-colorTransparentGray500: rgba(0, 0, 0, 0.5);
         --g-colorTransparentWhite: rgba(51, 51, 51, 0.8);
-       }
+        --color-text-default: #f9f9f9;
+        --color-text-subtle: #a5a5a5;
+        --color-text-success: #39d377;
+        --color-text-error: #eb4242;
+        --color-text-warning: #e18d00;
+        --color-text-inverse: #111111;
+        --color-text-icon-default: #f9f9f9;
+        --color-text-icon-subtle: #a5a5a5;
+        --color-text-icon-success: #39d377;
+        --color-text-icon-error: #eb4242;
+        --color-text-icon-warning: #e18d00;
+        --color-text-icon-inverse: #111111;
+        --color-background-shopping: #45a3fe;
+        --color-background-primary-base: #eb4242;
+        --color-background-secondary-base: #a5a5a5;
+        --color-background-tertiary-base: #767676;
+        --color-background-selected-base: #e9e9e9;
+        --color-background-inverse-base: #111111;
+        --color-background-brand: #eb4242;
+        --color-background-education: #45a3fe;
+
+      }
       </style>
     `);
   });
@@ -147,6 +170,26 @@ describe('ColorSchemeProvider', () => {
         --g-colorTransparentGray100: rgba(250, 250, 250, 0.6);
         --g-colorTransparentGray500: rgba(0, 0, 0, 0.5);
         --g-colorTransparentWhite: rgba(51, 51, 51, 0.8);
+        --color-text-default: #f9f9f9;
+        --color-text-subtle: #a5a5a5;
+        --color-text-success: #39d377;
+        --color-text-error: #eb4242;
+        --color-text-warning: #e18d00;
+        --color-text-inverse: #111111;
+        --color-text-icon-default: #f9f9f9;
+        --color-text-icon-subtle: #a5a5a5;
+        --color-text-icon-success: #39d377;
+        --color-text-icon-error: #eb4242;
+        --color-text-icon-warning: #e18d00;
+        --color-text-icon-inverse: #111111;
+        --color-background-shopping: #45a3fe;
+        --color-background-primary-base: #eb4242;
+        --color-background-secondary-base: #a5a5a5;
+        --color-background-tertiary-base: #767676;
+        --color-background-selected-base: #e9e9e9;
+        --color-background-inverse-base: #111111;
+        --color-background-brand: #eb4242;
+        --color-background-education: #45a3fe;
        }
       }
       </style>
@@ -181,7 +224,8 @@ describe('ColorSchemeProvider', () => {
         --g-colorTransparentGray100: rgba(0, 0, 0, 0.1);
         --g-colorTransparentGray500: rgba(0, 0, 0, 0.1);
         --g-colorTransparentWhite: rgba(255, 255, 255, 0.8);
-       }
+
+      }
       </style>
     `);
   });


### PR DESCRIPTION
### Summary

#### What changed?

Add dark mode values for our color design tokens

#### Why?

This isn't the full dark mode palette, but for the moment it matches our current dark mode configuration to allow for Android adoption

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3462)

### Checklist

- [X] Added documentation + accessibility tests
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
