### PR TITLE
Internal: add resolution for `node-forge` to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "immer": "8.0.1",
     "lodash": "4.17.21",
     "multicast-dns": "7.2.3",
+    "node-forge": "^1.0.0",
     "normalize-url": "4.5.1",
     "serialize-javascript": "3.1.0",
     "trim-newlines": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12450,10 +12450,10 @@ node-fetch@^2.0.0, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0, node
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^0.10.0, node-forge@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.0.tgz#850cec9230f62f9a7cd8ddd08dc74b4be52573ad"
+  integrity sha512-M4AsdaP0bGNaSPtatd/+f76asocI0cFaURRdeQVZvrJBrYp2Qohv5hDbGHykuNqCb1BYjWHjdS6HlN50qbztwA==
 
 node-html-parser@1.4.9:
   version "1.4.9"


### PR DESCRIPTION
This package is pretty deep in dependency chains, so easier to add a resolution. Needs to be at least `1.0.0`.
[Alerts · pinterest_gestalt.pdf](https://github.com/pinterest/gestalt/files/7842081/Alerts.pinterest_gestalt.pdf)

