### PR TITLE
Docs: add "How to Hack Gestalt" page

### DIFF
--- a/cypress/integration/accessibility_How To Hack Around Gestalt_spec.js
+++ b/cypress/integration/accessibility_How To Hack Around Gestalt_spec.js
@@ -1,0 +1,20 @@
+describe('How to Hack Around Gestalt Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/how_to_hack_around_gestalt');
+    cy.injectAxe();
+  });
+
+  // Disable the test for now since it's timing out on GitHub CI
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('Tests accessibility on the How To Hack Around Gestalt page', () => {
+    cy.configureAxe({
+      rules: [
+        // {
+        //   id: 'link-name',
+        //   enabled: false,
+        // },
+      ],
+    });
+    cy.checkA11y();
+  });
+});

--- a/docs/components/AppLayout.js
+++ b/docs/components/AppLayout.js
@@ -2,8 +2,10 @@
 import { type Node } from 'react';
 import { Box, Divider } from 'gestalt';
 import Header from './Header.js';
-import Navigation from './Navigation.js';
+import Navigation, { MIN_NAV_WIDTH_PX } from './Navigation.js';
 import Footer from './Footer.js';
+
+const CONTENT_MAX_WIDTH_PX = 1544;
 
 type Props = {|
   children?: Node,
@@ -15,7 +17,7 @@ export default function AppLayout({ children }: Props): Node {
       <Header />
 
       <Box mdDisplay="flex">
-        <Box minWidth={240}>
+        <Box minWidth={MIN_NAV_WIDTH_PX}>
           <Navigation />
         </Box>
 
@@ -32,7 +34,7 @@ export default function AppLayout({ children }: Props): Node {
             lgDisplay="flex"
             justifyContent="center"
           >
-            <Box width="100%" maxWidth={1544}>
+            <Box width="100%" data-test-id="FOO" maxWidth={CONTENT_MAX_WIDTH_PX}>
               {children}
             </Box>
           </Box>

--- a/docs/components/Navigation.js
+++ b/docs/components/Navigation.js
@@ -1,13 +1,13 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { Fragment } from 'react';
+import { Fragment, type Node } from 'react';
 import { Box } from 'gestalt';
 import HeaderMenu from './HeaderMenu.js';
 import SidebarSection from './SidebarSection.js';
 import SidebarSectionLink from './SidebarSectionLink.js';
 import sidebarIndex from './sidebarIndex.js';
 import { useNavigationContext } from './navigationContext.js';
+
+export const MIN_NAV_WIDTH_PX = 255;
 
 function getAlphabetizedComponents() {
   return Array.from(
@@ -58,7 +58,7 @@ export default function Navigation(): Node {
           position="fixed"
           overflow="auto"
           maxHeight="calc(100% - 60px)"
-          minWidth={240}
+          minWidth={MIN_NAV_WIDTH_PX}
         >
           <NavList sidebarOrganisedBy={sidebarOrganisedBy} />
         </Box>

--- a/docs/components/sidebarIndex.js
+++ b/docs/components/sidebarIndex.js
@@ -22,6 +22,7 @@ const sidebarIndex: Array<sidebarIndexType> = [
       'Installation',
       'Development',
       'Eslint Plugin',
+      'How to Hack Gestalt',
       'FAQ',
     ],
   },

--- a/docs/components/sidebarIndex.js
+++ b/docs/components/sidebarIndex.js
@@ -22,7 +22,7 @@ const sidebarIndex: Array<sidebarIndexType> = [
       'Installation',
       'Development',
       'Eslint Plugin',
-      'How to Hack Gestalt',
+      'How to Hack Around Gestalt',
       'FAQ',
     ],
   },

--- a/docs/pages/how_to_hack_around_gestalt.js
+++ b/docs/pages/how_to_hack_around_gestalt.js
@@ -6,9 +6,9 @@ import PageHeader from '../components/PageHeader.js';
 
 export default function DocsPage(): Node {
   return (
-    <Page title="How to Hack Gestalt">
+    <Page title="How to Hack Around Gestalt">
       <PageHeader
-        name="How to Hack Gestalt"
+        name="How to Hack Around Gestalt"
         description="Guidelines for customizing Gestalt components."
         showSourceLink={false}
       />
@@ -16,9 +16,9 @@ export default function DocsPage(): Node {
       <MainSection name="Disclaimer">
         <MainSection.Subsection
           description={`
-    For the vast majority of use cases, please do _not_ use these techniques. **Though please explore our primitive components, like [Box](/box), [TapArea](/taparea), [Pog](/pog), etc first! And feel free to ask us for help!**
+    For the vast majority of use cases, please do _not_ use these techniques. **Please explore building your custom UI element using our primitive components, like [Box](/box), [TapArea](/taparea), [Pog](/pog), etc first! And feel free to ask us for help!**
 
-    Gestalt's components enforce the design system by restricting possible usage. This is by design! However, in certain scenarios — experimental usage, usage on internal tools or other non-Pinner/M10n surfaces, etc — it may be necessary to circumvent those restrictions to build the desired experience. With that in mind, here are some common techniques and the trade-offs for each.
+    Gestalt's components enforce the design system by restricting possible usage. This is by design! However, in certain scenarios — experimental usage, usage on internal tools or other non-Pinner/M10n surfaces, etc — it may be necessary to circumvent those restrictions to build the desired experience. With that in mind, here are some common techniques and their trade-offs.
     `}
         />
       </MainSection>
@@ -28,15 +28,16 @@ export default function DocsPage(): Node {
           title="Forking components"
           description={`
 When a Gestalt component doesn't quite match the desired design spec, a common idea is to fork the component: copy/paste the component's code into the target repo where it can be modified.
-_Pro:_
+**Pro:**
 - Complete freedom to make whatever changes are desired
 
-_Con:_
+**Con:**
 - Duplicate code
 - Drift from the original component can make re-integration difficult/impossible
 - Heavy maintenance burden: any future updates to Gestalt (changes to color, rounding, etc) will need to be made manually, and will likely lead to a broken/outdated UI in the meantime
+- Dark mode and RTL support will need to be handled manually
 
-_Alternative:_ Chat with the Gestalt team about your needs and let's see how we can accommodate them. Often features that we don't support are for accessibility or other reasons — but we're happy to see how we can support you!
+**Alternative:** Chat with the Gestalt team about your needs and let's see how we can accommodate them. Often features that we don't support are for accessibility or other reasons — but we're happy to see how we can support you!
 `}
         />
 
@@ -44,15 +45,16 @@ _Alternative:_ Chat with the Gestalt team about your needs and let's see how we 
           title="Custom components"
           description={`
 Custom components can also be made from scratch, using native DOM elements and CSS/SCSS.
-_Pro:_
+**Pro:**
 - Complete freedom to build whatever UI is desired
 
-_Con:_
+**Con:**
 - Adds to bundle size with custom stylesheets instead of taking advantage of Gestalt's common styles
 - Creates disjointed app feel by not working within the design system
 - Heavy maintenance burden: no support from Gestalt team for future updates
+- Dark mode and RTL support will need to be handled manually
 
-_Alternative:_ Chat with the Gestalt team about your needs and let's see how we can accommodate them. If we can't officially support your needs, at least use Gestalt primitives (Box, TapArea, etc) when building your custom UI to ensure that your feature is accessible and fits in with the rest of the design system.
+**Alternative:** Chat with the Gestalt team about your needs and let's see how we can accommodate them. If we can't officially support your needs, at least use Gestalt primitives (Box, TapArea, etc) when building your custom UI to ensure that your feature is accessible and fits in with the rest of the design system.
         `}
         />
       </MainSection>
@@ -63,14 +65,15 @@ _Alternative:_ Chat with the Gestalt team about your needs and let's see how we 
           description={`
 [Box](/box) provides an "escape hatch" prop, \`dangerouslySetInlineStyle\`, allowing for styles to be set directly on the component. Similarly, [Icon](/icon), [IconButton](/iconbutton), and [Pog](/pog) provide the \`dangerouslySetSvgPath\` to allow for custom icons.
 
-_Pro:_
+**Pro:**
 - Uses Gestalt components for all non-custom styles needed, taking advantage of our hashed classes for smaller stylesheets, adhering to the design system, and getting future upgrades for free
 - We track \`dangerouslySetInlineStyle\` usage, which informs future changes to Gestalt components
 
-_Con:_
+**Con:**
 - Doesn't support pseudo-classes, pseudo-elements, or animations
+- Overridden styles will not respond to dark mode or RTL
 
-_Alternative:_ When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
+**Alternative:** When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
 `}
         >
           <MainSection.Card
@@ -94,11 +97,12 @@ _Alternative:_ When possible, stick to the styles available on Gestalt component
           description={`
 Certain components have styles that can be overridden when wrapped by (or wrapped around) other components.
 
-_Pro:_
+**Pro:**
 - Continues to use Gestalt components for all except the custom styles
 
-_Con:_
+**Con:**
 - Your UI may look disjointed with the rest of the design system
+- Overridden styles will not respond to dark mode or RTL
 
 _Alternative_: When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
 `}
@@ -116,16 +120,60 @@ _Alternative_: When possible, stick to the styles available on Gestalt component
         </MainSection.Subsection>
 
         <MainSection.Subsection
+          title="Refs"
+          description={`
+Components that accept refs (e.g. [Box](/box), [Button](/button), etc) can be customized by manipulating the referenced element.
+
+**Pro:**
+- Uses Gestalt components for all non-custom styles needed, taking advantage of our hashed classes for smaller stylesheets, adhering to the design system, and getting future upgrades for free
+- Directly targets the instance of the component rather than relying on the underlying DOM elements
+
+**Con:**
+- Doesn't support pseudo-classes, pseudo-elements, or animations
+- Typically only targets the outermost element of the component; inner elements of complex components cannot be reached
+- Overridden styles will not respond to dark mode or RTL
+
+**Alternative:** When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
+`}
+        >
+          <MainSection.Card
+            cardSize="lg" // this actually makes the rendered element smaller, which is desired
+            defaultCode={`
+function RefExample() {
+  const buttonRef = React.useRef();
+
+  React.useEffect(() => {
+    if (buttonRef.current) {
+      buttonRef.current.style.backgroundColor = 'aquamarine';
+    }
+  }, [buttonRef]);
+
+  return (
+    <Button
+      accessibilityLabel='Menu'
+      iconEnd="arrow-down"
+      ref={buttonRef}
+      size="lg"
+      text="Menu"
+    />
+  );
+}
+          `}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
           title="CSS selectors"
           description={`
 It is possible to use CSS selectors to peer "under the hood" of Gestalt components and target the underlying DOM elements.
-_Pro:_
+**Pro:**
 - It's CSS, so you can do whatever you want
 
-_Con:_
+**Con:**
 - This is very, very brittle and subject to breaking changes at any point; we do not consider breaking changes to the underlying DOM structure when determining [semver](https://semver.org/) so even \`patch\` changes could break your UI
+- Overridden styles will not respond to dark mode or RTL
 
-_Alternative_: Absolutely anything — this is just about the worst way to hack Gestalt components. Your UI _will_ break in the future.
+_Alternative_: Absolutely anything — this is just about the worst way to hack Gestalt components. Your UI _will_ break in the future. Consider using a [ref](#Refs) if possible.
 `}
         />
       </MainSection>

--- a/docs/pages/how_to_hack_gestalt.js
+++ b/docs/pages/how_to_hack_gestalt.js
@@ -16,7 +16,9 @@ export default function DocsPage(): Node {
       <MainSection name="Disclaimer">
         <MainSection.Subsection
           description={`
-    For the vast majority of use cases, please do _not_ use these techniques. Gestalt's components enforce the design system by restricting possible usage. This is by design! However, in certain scenarios — experimental usage, usage on internal tools or other non-Pinner/M10n surfaces, etc. — it may be necessary to circumvent those restrictions to build the desired experience. With that in mind, here are some of the common techniques and the trade-offs for each.
+    For the vast majority of use cases, please do _not_ use these techniques. **Though please explore our primitive components, like [Box](/box), [TapArea](/taparea), [Pog](/pog), etc first! And feel free to ask us for help!**
+
+    Gestalt's components enforce the design system by restricting possible usage. This is by design! However, in certain scenarios — experimental usage, usage on internal tools or other non-Pinner/M10n surfaces, etc — it may be necessary to circumvent those restrictions to build the desired experience. With that in mind, here are some common techniques and the trade-offs for each.
     `}
         />
       </MainSection>
@@ -57,81 +59,73 @@ _Alternative:_ Chat with the Gestalt team about your needs and let's see how we 
 
       <MainSection name="Modifications to Existing Components">
         <MainSection.Subsection
-          title={`Box's \`dangerouslySetInlineStyle\``}
+          title={`Box's dangerouslySetInlineStyle`}
           description={`
+[Box](/box) provides an "escape hatch" prop, \`dangerouslySetInlineStyle\`, allowing for styles to be set directly on the component. Similarly, [Icon](/icon), [IconButton](/iconbutton), and [Pog](/pog) provide the \`dangerouslySetSvgPath\` to allow for custom icons.
 
-`}
-        />
-        <MainSection.Subsection
-          title="Making an engineering contribution"
-          description={`
-We always appreciate the help and contributions of other engineers across Pinterest, whether it's new variants, simple bug fixes or building out entire components. Before any code changes happen though, be sure to follow our [request process](#What-is-the-process-to-request-new-additions-or-changes).
-1. **Talk to your designer**
-   Check in with your designer and make sure the changes have been approved by the Gestalt team, via the [request process](#What-is-the-process-to-request-new-additions-or-changes). We don’t recommend starting a PR on new functionality — no matter how small — without confirming this, as you may spend time on changes that won’t be approved to merge into Gestalt.
-2. **Technical Design Doc**
-   Create a technical design doc (TDD), using [this template](https://pinch.pinadmin.com/gestaltTDD), for any net-new components or component additions/updates within Gestalt. This allows everyone to discuss the component API and functionality before starting to build.
-3. **Implement and Test**
-   Once the TDD has been finalized, it's time to build! If creating a new component, check out our [scaffolding script](https://github.com/pinterest/gestalt/blob/master/scripts/generateComponent.js). Don't forget about tests! If updating an existing component, please remember to update/add unit tests. Use \`.test.js\` to test UI and \`.jsdom.test.js\` to test interactions. Note that accessibility integration tests cover both the component itself and the related docs page. Run the test suites using the [package.json scripts](https://github.com/pinterest/gestalt/blob/master/package.json#L101).
-4. **Pull request**
-    When your work is complete and all tests are passing, make a _draft_ pull request for your changes by following the [development guidelines](/development). This will start the CI process, running a variety of tests. Once those tests are passing (aside from the semver one), mark your PR as _"Ready for review"_ and ping us on [#gestalt-web](https://pinch.pinadmin.com/gestaltSlack). Your changes will be reviewed by an engineer and a designer from the Gestalt team. We ensure each component is built to spec, accessible, performant and works well with other components.
-5. **Release**
-   Now the fun part: releasing your component! After a Gestalt team member merges your change and Pinboard has been updated, feel free to announce your component/changes on the [#gestalt-web](https://pinch.pinadmin.com/gestaltSlack) Slack channel.
-`}
-        />
-        <MainSection.Subsection
-          title="Other ways to contribute"
-          description={`
-**Bugs**
-If you think you’ve found a bug with Gestalt components or documentation, first check our [Gestalt Bugs Dashboard](https://jira.pinadmin.com/secure/Dashboard.jspa?selectPageId=29639) to see if it’s already been reported. If it hasn’t, please file a bug within the [Bugs](https://pinch.pinadmin.com/gestaltJiraBugs) Jira project and set the Component to ”gestalt”. We do not actively monitor GitHub issues, so the best way to file is through Jira.
-**Surveys**
-The Gestalt team sends out twice-yearly surveys to the design and engineering orgs. Filling out this survey is one way to help inform our team on what is working and what is not working about out design system.
-`}
-        />
-      </MainSection>
+_Pro:_
+- Uses Gestalt components for all non-custom styles needed, taking advantage of our hashed classes for smaller stylesheets, adhering to the design system, and getting future upgrades for free
+- We track \`dangerouslySetInlineStyle\` usage, which informs future changes to Gestalt components
 
-      <MainSection name="What kind of support can you expect from the team?">
-        <MainSection.Subsection
-          description={`
-We are always happy to help answer questions regarding Gestalt component design and usage, design system best practices, accessibility, icons and colors. If it’s part of Gestalt, we’re here to help! If it’s outside of the realm of our design system, we’ll try our best to answer and/or point you to the person who can. Feel free to reach out to us on [Slack](http://gestalt.pinterest.systems/how_to_work_with_us#Slack-channels) anytime.
-We also offer documentation on this site ([go/GestaltWeb](https://gestalt.pinterest.systems/)) and a [Figma library](https://pinch/gestaltFigma) of components that exist within Gestalt.
-`}
-        />
-      </MainSection>
+_Con:_
+- Doesn't support pseudo-classes, pseudo-elements, or animations
 
-      <MainSection name="Resources, Slack, and Meetings — oh my!">
-        <MainSection.Subsection
-          title="Dashboards, Jira, and OKRs"
-          description={`
-If you’re curious what we’re working on, you can check out our Gestalt [Sprint Dashboard](https://pinch.pinadmin.com/gestaltSprint), our [full backlog](https://pinch.pinadmin.com/gestaltBacklog), and our [Bugs Dashboard](https://pinch.pinadmin.com/gestaltJiraBugs).
-To see the bigger picture, you can view our [OKRs](https://pinch.pinadmin.com/gestaltOKR) to understand our roadmap and priorities for each quarter. These priorities are determined through [partnership meetings](#Meetings-and-events), which we use to learn about component needs and coordinate with designers to determine timelines.
+_Alternative:_ When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
 `}
-        />
+        >
+          <MainSection.Card
+            cardSize="lg" // this actually makes the rendered element smaller, which is desired
+            defaultCode={`
+<Box
+  dangerouslySetInlineStyle={{
+    __style: {
+      backgroundColor: 'rebeccapurple',
+    },
+  }}
+  height={100}
+  width={100}
+/>
+          `}
+          />
+        </MainSection.Subsection>
+
         <MainSection.Subsection
-          title="Slack channels"
+          title="Wrapping components"
           description={`
-Before reaching out, take a look at our [documentation](https://gestalt.pinterest.systems/) to see if it answers your question, because it will likely get you the fastest answer. Still need help? Try searching Slack for your question, and then feel free to ask if your question hasn’t been answered in the past. You can also reference our [Communication Guidelines](https://pinch.pinadmin.com/gestaltCommsGuidelines) for more info.
-[#gestalt-design](https://pinch.pinadmin.com/gestaltSlackDesign) is for design-focused questions.
-[#gestalt-web](https://pinch.pinadmin.com/gestaltSlack) is for engineering-focused questions.
+Certain components have styles that can be overridden when wrapped by (or wrapped around) other components.
+
+_Pro:_
+- Continues to use Gestalt components for all except the custom styles
+
+_Con:_
+- Your UI may look disjointed with the rest of the design system
+
+_Alternative_: When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
 `}
-        />
+        >
+          <MainSection.Card
+            cardSize="lg" // this actually makes the rendered element smaller, which is desired
+            defaultCode={`
+<Text color="red">
+  <span style={{ fontFamily: 'cursive' }}>
+    Custom text
+  </span>
+</Text>
+          `}
+          />
+        </MainSection.Subsection>
+
         <MainSection.Subsection
-          title="Meetings and events"
+          title="CSS selectors"
           description={`
-Our meetings, events, and timelines can be found on the [Gestalt Event Calendar](https://pinch.pinadmin.com/gestaltCalendar). We offer two different meetings for the community to bring questions, comments, ideas, and feedback:
-1. **Gestalt Office Hours**
-    - _Purpose_
-      For product designers seeking feedback on their usage of design systems and visual language. This is also a great time to propose new components or component changes.
-    - _Audience_
-      Primarily Pinner and M10n designers, though engineers are welcome if there are technical concerns as well.
-    - _Cadence_
-      Twice a week on Tuesdays and Thursdays. Please [sign up](https://pinch.pinadmin.com/gestaltSignUp) for a half-hour slot with your discussion topic.
-2.  **Component Crit**
-    - _Purpose_
-      For systems designers seeking feedback from the larger design org on systems-related designs.
-    - _Audience_
-      Pinterest designers and Gestalt engineers. The agenda for the Crit can be found in the recurring calendar invite. Please continue to bring component work to Office Hours.
-    - _Cadence_
-      Every other Friday. Please sign up through the link in the calendar invite.
+It is possible to use CSS selectors to peer "under the hood" of Gestalt components and target the underlying DOM elements.
+_Pro:_
+- It's CSS, so you can do whatever you want
+
+_Con:_
+- This is very, very brittle and subject to breaking changes at any point; we do not consider breaking changes to the underlying DOM structure when determining [semver](https://semver.org/) so even \`patch\` changes could break your UI
+
+_Alternative_: Absolutely anything — this is just about the worst way to hack Gestalt components. Your UI _will_ break in the future.
 `}
         />
       </MainSection>

--- a/docs/pages/how_to_hack_gestalt.js
+++ b/docs/pages/how_to_hack_gestalt.js
@@ -6,63 +6,60 @@ import PageHeader from '../components/PageHeader.js';
 
 export default function DocsPage(): Node {
   return (
-    <Page title="How to Work with Us">
+    <Page title="How to Hack Gestalt">
       <PageHeader
-        name="How to Work with Us"
-        description="Guidelines on how to engage the Gestalt team, when to work with us, and how to contribute."
+        name="How to Hack Gestalt"
+        description="Guidelines for customizing Gestalt components."
         showSourceLink={false}
       />
 
-      <MainSection name="What goes into Gestalt?">
+      <MainSection name="Disclaimer">
         <MainSection.Subsection
           description={`
-    The goal of Gestalt is to create a shared library of design best practices, React components, and documentation. Therefore, the best contenders for addition to Gestalt are designs or components that benefit multiple teams and are used regularly throughout our products.
+    For the vast majority of use cases, please do _not_ use these techniques. Gestalt's components enforce the design system by restricting possible usage. This is by design! However, in certain scenarios — experimental usage, usage on internal tools or other non-Pinner/M10n surfaces, etc. — it may be necessary to circumvent those restrictions to build the desired experience. With that in mind, here are some of the common techniques and the trade-offs for each.
     `}
         />
       </MainSection>
 
-      <MainSection name="What is the process to request new additions or changes?">
+      <MainSection name="Creating new components">
         <MainSection.Subsection
+          title="Forking components"
           description={`
-**Please note:** The process below applies to Pinterest employees.
-What we build into Gestalt comes from the teams across Pinterest, so we’d love to pair with you early and often! The process starts in the design phase. Seeing early mocks, wireframes or even product roadmaps in our [partnership meetings](#Meetings-and-events) to learn where your project may be going helps inform our team OKRs. The earlier we see the work, the better we’re able to plan and the higher the likelihood we’ll be able to help.
-We ask that any ideas that change the functionality of an existing Gestalt component or introduce a net-new component go through the following process:
-1. **Present work early in our [partnership meetings](#Meetings-and-events)**
-    - Explain project goals and show multiple options explored with and without Gestalt components to help us understand your needs.
-    - Coordinate with other designers if there are overlapping needs to help us better prioritize in our roadmap.
-    - Be able to explain how this component should be used or not used. This helps us in testing the component against existing components and product surfaces.
-    - Have a rough project timeline available. This allows us to determine if we’re able to accommodate the work.
-2. **Iterate on solutions**
-    We love to see more iteration from the product designer asking for the component, if they have the time. If not, the component will follow our prioritization process. The designer (product designer or Gestalt designer) must ensure all edge cases have been considered.
-3. **Prioritization by the Gestalt team**
-  If our team takes on the work, we will add it to our [backlog](https://pinch.pinadmin.com/gestaltBacklog) and prioritize it appropriately. Typically the determining factor for taking on work is capacity: if your designers or engineers have the capacity, we’d love for them to [contribute to Gestalt](#How-can-you-contribute-to-gestalt-as-an-engineer) with our support. Otherwise, the Gestalt designers and engineers will prioritize the work against our current workload based on the following criteria.
-  Some questions we ask ourselves when prioritizing:
-    1. How many products/surfaces will benefit?
-        - Ideally, we build things into Gestalt that 2 or more teams need with more teams meaning higher priority.
-    2. How easy or difficult is it to build?
-        - How many engineering hours will it take to build?
-        - Are there accessibility concerns that should ideally be handled by Gestalt?
-    3. Is it a dependency to other future work we need to do within Gestalt?
-        - Will this unlock additional functionality that other teams need?
-  We prioritize work following the same cycles as product teams within Pinterest. Knowing other teams needs before prioritization starts will help inform our roadmap. If we do no have capacity for the work, but believe we should add it to Gestalt, we may ask if a product team can continue the work. Otherwise, it will go into our [backlog](https://pinch.pinadmin.com/gestaltBacklog).
-4. **Build or follow along**
-    Our engineering team will pair directly with your engineer if they are the ones who will be taking on the work and help them follow the process below. If the Gestalt team is building the component, we will take on the work and follow the same process. As we develop the documentation, Figma files, and code for the updated or new component, we’d love for you to help review and be part of a final sanity check.`}
+When a Gestalt component doesn't quite match the desired design spec, a common idea is to fork the component: copy/paste the component's code into the target repo where it can be modified.
+_Pro:_
+- Complete freedom to make whatever changes are desired
+
+_Con:_
+- Duplicate code
+- Drift from the original component can make re-integration difficult/impossible
+- Heavy maintenance burden: any future updates to Gestalt (changes to color, rounding, etc) will need to be made manually, and will likely lead to a broken/outdated UI in the meantime
+
+_Alternative:_ Chat with the Gestalt team about your needs and let's see how we can accommodate them. Often features that we don't support are for accessibility or other reasons — but we're happy to see how we can support you!
+`}
+        />
+
+        <MainSection.Subsection
+          title="Custom components"
+          description={`
+Custom components can also be made from scratch, using native DOM elements and CSS/SCSS.
+_Pro:_
+- Complete freedom to build whatever UI is desired
+
+_Con:_
+- Adds to bundle size with custom stylesheets instead of taking advantage of Gestalt's common styles
+- Creates disjointed app feel by not working within the design system
+- Heavy maintenance burden: no support from Gestalt team for future updates
+
+_Alternative:_ Chat with the Gestalt team about your needs and let's see how we can accommodate them. If we can't officially support your needs, at least use Gestalt primitives (Box, TapArea, etc) when building your custom UI to ensure that your feature is accessible and fits in with the rest of the design system.
+        `}
         />
       </MainSection>
 
-      <MainSection name="How can you contribute to Gestalt?">
+      <MainSection name="Modifications to Existing Components">
         <MainSection.Subsection
-          title="Making a design contribution"
+          title={`Box's \`dangerouslySetInlineStyle\``}
           description={`
-We love the help and contributions of other designers across Pinterest, and we ask that any ideas that change the functionality of an existing Gestalt component or introduce a net-new component go through the following process:
-1. **Present your idea or suggestion during our Office Hour meetings**
-    [Sign up](https://pinch.pinadmin.com/gestaltSignUp) for an Office Hours slot! Explain project goals and show multiple options explored with and without Gestalt components to help us understand your needs. This does not need to be a polished presentation, but should have enough detail that we understand the request and why it is needed.
-2. **Create a Branch in our design library**
-    Create a Branch file in our main file. Don't worry, our design team will support you with that. See [Branching in Figma](https://www.figma.com/best-practices/branching-in-figma/) for more details and self-education.
-3. **Present your work in a Design System Crit**
-    After your Branch file is ready, our design team will schedule a meeting to present your work.
-4. **Send your Branch to review**
-    Update your Branch based on the feedback you received, and add a Gestalt reviewer (designer) to your Branch. Our design team will approve and merge the Branch when it is ready to implement in our web docs. We will follow up with you!
+
 `}
         />
         <MainSection.Subsection


### PR DESCRIPTION
This PR adds a new "How to Hack Gestalt" page to the docs. Though we'd prefer that such a page weren't necessary, people can and do hack around Gestalt's restrictions. Some of these techniques are more or less terrible than others, so it could be beneficial to make these trade-offs more explicit to push users towards the less-terrible options.