### PR TITLE
Pulsar, RadioButton, Spinner, Switch, Tooltip: use autogenerated props tables

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -72,7 +72,7 @@ export default function GeneratedPropTable({
 
       // Remove domain so local development (localhost) isn't broken
       const descriptionWithoutDomain = description?.replace(
-        /https:\/\/gestalt\.pinterest\.systems/,
+        /https:\/\/gestalt\.pinterest\.systems/g,
         '',
       );
 

--- a/docs/pages/pulsar.js
+++ b/docs/pages/pulsar.js
@@ -1,11 +1,11 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
 import Example from '../components/Example.js';
-import PageHeader from '../components/PageHeader.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import MainSection from '../components/MainSection.js';
-import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -34,21 +34,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   }
 `}
       />
-      <PropTable
-        props={[
-          {
-            name: 'paused',
-            type: 'boolean',
-            defaultValue: false,
-          },
-          {
-            name: 'size',
-            type: `number`,
-            description: `Use numbers for pixel sizes`,
-            defaultValue: 136,
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/radiobutton.js
+++ b/docs/pages/radiobutton.js
@@ -1,84 +1,21 @@
 // @flow strict
 import type { Node } from 'react';
 import { RadioButton } from 'gestalt';
-import Example from '../components/Example.js';
-import PropTable from '../components/PropTable.js';
 import Combination from '../components/Combination.js';
-import PageHeader from '../components/PageHeader.js';
+import Example from '../components/Example.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import MainSection from '../components/MainSection.js';
-import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="RadioButton">
       <PageHeader name="RadioButton" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'checked',
-            type: 'boolean',
-            defaultValue: false,
-            href: 'radio-button-combos',
-          },
-          {
-            name: 'disabled',
-            type: 'boolean',
-            defaultValue: false,
-            href: 'radio-button-combos',
-          },
-          {
-            name: 'id',
-            type: 'string',
-            required: true,
-          },
-          {
-            name: 'image',
-            type: 'React.Node',
-            href: 'images',
-            description:
-              'An optional `<Image/>` component can be supplied to add an image to each radio button. Spacing is already accounted for, simply specify the width and height.',
-          },
-          {
-            name: 'label',
-            type: 'string',
-          },
-          {
-            name: 'name',
-            type: 'string',
-            description: 'The name given for all radio buttons in a single group',
-          },
-          {
-            name: 'onChange',
-            type: '({ event: SyntheticInputEvent<>, checked: boolean }) => void',
-            required: true,
-          },
-          {
-            name: 'value',
-            type: 'string',
-          },
-          {
-            name: 'ref',
-            type: "React.Ref<'input'>",
-            description: 'Forward the ref to the underlying input element',
-            href: 'ref',
-          },
-          {
-            name: 'size',
-            type: `"sm" | "md"`,
-            description: `sm: 16px, md: 24px`,
-            defaultValue: 'md',
-            href: 'ref',
-          },
-          {
-            name: 'subtext',
-            type: 'string',
-            href: 'subtext',
-            description:
-              'Optional description for the radio button, used to provide more detail about an option',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/spinner.js
+++ b/docs/pages/spinner.js
@@ -1,11 +1,11 @@
 // @flow strict
 import type { Node } from 'react';
 import Example from '../components/Example.js';
-import PropTable from '../components/PropTable.js';
-import PageHeader from '../components/PageHeader.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import MainSection from '../components/MainSection.js';
-import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -32,37 +32,9 @@ function SpinnerExample() {
 }
 `}
       />
-      <PropTable
-        props={[
-          {
-            name: 'accessibilityLabel',
-            type: 'string',
-            required: true,
-            description:
-              'String that clients such as VoiceOver will read to describe the element. Always localize the label.',
-          },
-          {
-            name: 'show',
-            type: 'boolean',
-            required: true,
-            defaultValue: false,
-          },
-          {
-            name: 'delay',
-            type: 'boolean',
-            required: false,
-            defaultValue: true,
-            description:
-              'Whether or not to render with a 300ms delay. The delay is for perceived performance so you should rarely need to remove it.',
-          },
-          {
-            name: 'size',
-            type: `"sm" | "md"`,
-            description: `sm: 32px, md: 40px`,
-            defaultValue: 'md',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/switch.js
+++ b/docs/pages/switch.js
@@ -1,51 +1,21 @@
 // @flow strict
 import type { Node } from 'react';
 import { Box, Label, Switch, Text } from 'gestalt';
-import PropTable from '../components/PropTable.js';
-import Example from '../components/Example.js';
 import Combination from '../components/Combination.js';
-import PageHeader from '../components/PageHeader.js';
+import Example from '../components/Example.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import MainSection from '../components/MainSection.js';
-import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Switch">
       <PageHeader name="Switch" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'disabled',
-            type: 'boolean',
-            defaultValue: false,
-            href: 'switchCombinations',
-          },
-          {
-            name: 'id',
-            type: 'string',
-            required: true,
-            href: 'basicExample',
-          },
-          {
-            name: 'name',
-            type: 'string',
-            href: 'basicExample',
-          },
-          {
-            name: 'onChange',
-            type: '({ event: SyntheticInputEvent<>, value: boolean }) => void',
-            required: true,
-            href: 'basicExample',
-          },
-          {
-            name: 'switched',
-            type: 'boolean',
-            defaultValue: false,
-            href: 'switchCombinations',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -1,10 +1,10 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
 import docgen, { type DocGen } from '../components/docgen.js';
-import Page from '../components/Page.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -44,52 +44,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       </Flex>
     `}
       />
-      <PropTable
-        props={[
-          {
-            name: 'children',
-            type: 'React.Node',
-            description: `The anchor element, usually [Icon Button](/iconbutton), that triggers Tooltip on hover or focus`,
-            required: true,
-          },
-          {
-            name: 'idealDirection',
-            type: `'up' | 'right' | 'down' | 'left'`,
-            description: `Specifies the preferred position of Tooltip relative to its anchor element. See the [ideal direction](#Ideal-direction) variant to learn more.`,
-            defaultValue: 'down',
-            href: 'Ideal-direction',
-          },
-          {
-            name: 'inline',
-            type: 'boolean',
-            description: `Properly positions Tooltip relative to an inline element, such as [Icon Button](/iconbutton) using the inline property. See the [inline](#Inline) variant to learn more.`,
-            defaultValue: 'false',
-            href: 'Inline',
-          },
 
-          {
-            name: 'text',
-            type: 'string',
-            description:
-              'The text shown in Tooltip to describe its anchor element. See [localization ](#Localization) to learn more.',
-            required: true,
-          },
-          {
-            name: 'link',
-            type: 'React.Node',
-            description:
-              'Displays a link at the bottom of Tooltip. See the [link](#Link) variant to learn more.',
-            href: 'Link',
-          },
-          {
-            name: 'zIndex',
-            type: 'interface Indexable { index(): number; }',
-            description:
-              'Specifies the stacking order of Tooltip along the z-axis in the current stacking context. See the [z-index](#Z-index) variant to learn more.',
-            href: 'Z-index',
-          },
-        ]}
-      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/packages/gestalt/src/Pulsar.js
+++ b/packages/gestalt/src/Pulsar.js
@@ -4,7 +4,13 @@ import Box from './Box.js';
 import styles from './Pulsar.css';
 
 type Props = {|
+  /**
+   * Used to hide the element.
+   */
   paused?: boolean,
+  /**
+   * The size of the element in pixels.
+   */
   size?: number,
 |};
 

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { forwardRef, useState } from 'react';
+import { forwardRef, type Node, useState } from 'react';
 import classnames from 'classnames';
 import controlStyles from './RadioButtonCheckbox.css';
 import styles from './RadioButton.css';
@@ -13,16 +11,50 @@ import useFocusVisible from './useFocusVisible.js';
 import focusStyles from './Focus.css';
 
 type Props = {|
+  /**
+   * Indicates if the input is checked. See the [combinations example](https://gestalt.pinterest.systems/radiobutton#radio-state-combos) for more details.
+   */
   checked?: boolean,
+  /**
+   * Indicates if the input is disabled. See the [combinations example](https://gestalt.pinterest.systems/radiobutton#radio-state-combos) for more details.
+   */
   disabled?: boolean,
+  /**
+   * A unique identifier for the input.
+   */
   id: string,
+  /**
+   * An optional [Image](https://gestalt.pinterest.systems/image) component can be supplied to add an image to each radio button. Spacing is already accounted for — simply specify the width and height. See the [images example](https://gestalt.pinterest.systems/radiobutton#images) for more details.
+   */
   image?: Node,
+  /**
+   * The displayed label for the input.
+   */
   label?: string,
+  /**
+   * The name given for all radio buttons in a single group.
+   */
   name?: string,
+  /**
+   * Callback triggered when the user interacts with the input.
+   */
   onChange: AbstractEventHandler<SyntheticInputEvent<HTMLInputElement>, {| checked: boolean |}>,
-  subtext?: string,
-  value: string,
+  /**
+   * Ref forwarded to the underlying input element. See [ref example](https://gestalt.pinterest.systems/radiobutton#ref) for more details.
+   */
+  ref?: HTMLInputElement, // eslint-disable-line react/no-unused-prop-types
+  /**
+   * sm: 16px, md: 24px
+   */
   size?: 'sm' | 'md',
+  /**
+   * Optional description for the input, used to provide more detail about an option. See the [subtext example](https://gestalt.pinterest.systems/radiobutton#subtext) for more details.
+   */
+  subtext?: string,
+  /**
+   * The value of the input.
+   */
+  value: string,
 |};
 
 /**

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -11,14 +11,26 @@ const SIZE_NAME_TO_PIXEL = {
 };
 
 type Props = {|
+  /**
+   * String that clients such as VoiceOver will read to describe the element. Always localize the label.
+   */
   accessibilityLabel: string,
+  /**
+   * Whether or not to render with a 300ms delay. The delay is for perceived performance, so you should rarely need to remove it.
+   */
   delay?: boolean,
+  /**
+   * Indicates if Spinner should be visible.
+   */
   show: boolean,
+  /**
+   * sm: 32px, md: 40px
+   */
   size?: 'sm' | 'md',
 |};
 
 /**
- * [Spinners](https://gestalt.pinterest.systems/spinner ) help indicate that a surface's content or portion of content is currently loading.
+ * [Spinner](https://gestalt.pinterest.systems/spinner ) helps indicate that a surface's content or portion of content is currently loading.
  */
 export default function Spinner({
   accessibilityLabel,

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -1,22 +1,35 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { useState } from 'react';
+import { type Node, useState } from 'react';
 import classnames from 'classnames';
 import useFocusVisible from './useFocusVisible.js';
 import focusStyles from './Focus.css';
 import styles from './Switch.css';
 
 type Props = {|
+  /**
+   * Indicates if the input is currently disabled. See [Switch combinations](https://gestalt.pinterest.systems/switch#switchCombinations) for more details.
+   */
   disabled?: boolean,
+  /**
+   * A unique identifier for the element.
+   */
   id: string,
+  /**
+   * A unique name for the element.
+   */
   name?: string,
+  /**
+   * Callback triggered when the user interacts with the input.
+   */
   onChange: ({| event: SyntheticInputEvent<>, value: boolean |}) => void,
+  /**
+   * Indicates the current value of the input. See [Switch combinations](https://gestalt.pinterest.systems/switch#switchCombinations) for more details.
+   */
   switched?: boolean,
 |};
 
 /**
- * Use [switches](https://gestalt.pinterest.systems/switch) for single cell options that can be turned on and off only. If you have a cell with multiple options that can activated, consider using check marks.
+ * Use [Switch](https://gestalt.pinterest.systems/switch) for single cell options that can be turned on and off only. If you have a cell with multiple options that can activated, consider using [Checkbox](https://gestalt.pinterest.systems/checkbox).
  *
  * Switch supports right-to-left(RTL) language locales layout (auto flip on RTL locales like Arabic).
  */

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -1,7 +1,5 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { useReducer, useRef } from 'react';
+import { type Node, useReducer, useRef } from 'react';
 import useDebouncedCallback from './useDebouncedCallback.js';
 import Controller from './Controller.js';
 import Text from './Text.js';
@@ -11,15 +9,6 @@ import { type Indexable } from './zIndex.js';
 
 const noop = () => {};
 const TIMEOUT = 100;
-
-type Props = {|
-  children: Node,
-  link?: Node,
-  idealDirection?: 'up' | 'right' | 'down' | 'left',
-  inline?: boolean,
-  text: string,
-  zIndex?: Indexable,
-|};
 
 const initialState = { hoveredIcon: false, hoveredText: false, isOpen: false };
 
@@ -53,6 +42,33 @@ const reducer = (state, action) => {
       throw new Error();
   }
 };
+
+type Props = {|
+  /**
+   * The anchor element, usually [Icon Button](https://gestalt.pinterest.systems/iconbutton), that triggers Tooltip on hover or focus.
+   */
+  children: Node,
+  /**
+   * Specifies the preferred position of Tooltip relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/tooltip#Ideal-direction) variant to learn more.
+   */
+  idealDirection?: 'up' | 'right' | 'down' | 'left',
+  /**
+   * Properly positions Tooltip relative to an inline element, such as [Icon Button](https://gestalt.pinterest.systems/iconbutton) using the inline property. See the [inline](https://gestalt.pinterest.systems/tooltip#Inline) variant to learn more.
+   */
+  inline?: boolean,
+  /**
+   * Displays a link at the bottom of Tooltip. See the [link](https://gestalt.pinterest.systems/tooltip#Link) variant to learn more.
+   */
+  link?: Node,
+  /**
+   * The text shown in Tooltip to describe its anchor element. See [localization ](https://gestalt.pinterest.systems/tooltip#Localization) to learn more.
+   */
+  text: string,
+  /**
+   * Specifies the stacking order of Tooltip along the z-axis in the current stacking context. See the [z-index](https://gestalt.pinterest.systems/tooltip#Z-index) variant to learn more.
+   */
+  zIndex?: Indexable,
+|};
 
 /**
  * [Tooltip](https://gestalt.pinterest.systems/tooltip) is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/iconbutton). It’s displayed continuously as long as the user hovers over or focuses on the element.


### PR DESCRIPTION
Also a tiny tweak to make sure we replace _all_ Gestalt docs domain instances in the comments, not just the first one