### PR TITLE
Dropdown: fix bug due to positioning shift on rerender

### DIFF
--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Children, cloneElement, type Node, useState } from 'react';
+import { useEffect, Children, cloneElement, type Node, useState } from 'react';
 import Box from './Box.js';
 import Popover from './Popover.js';
 import Layer from './Layer.js';
@@ -110,6 +110,7 @@ export default function Dropdown({
   zIndex,
 }: Props): Node {
   const [hoveredItem, setHoveredItem] = useState<number>(0);
+  const [showDropdown, setShowDropdown] = useState<boolean>(false);
 
   const dropdownChildrenArray = Children.toArray(children);
   const allowedChildrenOptions = getChildrenOptions(dropdownChildrenArray);
@@ -175,6 +176,11 @@ export default function Dropdown({
     }
   };
 
+  useEffect(() => {
+    // This setTimeout is necessary to prevent a 1px shift in the Dropdown position on rerender due to a different initial Button position during compression. 85ms is the timing of the ease-out compression transition in Button.
+    setTimeout(() => setShowDropdown(true), 85);
+  }, []);
+
   const dropdown = (
     <Popover
       anchor={anchor}
@@ -197,8 +203,10 @@ export default function Dropdown({
       </Box>
     </Popover>
   );
-
-  return isWithinFixedContainer ? dropdown : <Layer zIndex={zIndex}>{dropdown}</Layer>;
+  if (showDropdown) {
+    return isWithinFixedContainer ? dropdown : <Layer zIndex={zIndex}>{dropdown}</Layer>;
+  }
+  return null;
 }
 
 Dropdown.Item = DropdownItem;

--- a/packages/gestalt/src/Dropdown.jsdom.test.js
+++ b/packages/gestalt/src/Dropdown.jsdom.test.js
@@ -1,11 +1,17 @@
 // @flow strict
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { DOWN_ARROW, ENTER, ESCAPE, TAB, UP_ARROW } from './keyCodes.js';
 import Dropdown from './Dropdown.js';
 
 describe('Dropdown', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   it('renders a menu of 6 items', () => {
@@ -52,6 +58,10 @@ describe('Dropdown', () => {
         />
       </Dropdown>,
     );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     expect(baseElement).toMatchSnapshot();
   });
@@ -104,6 +114,10 @@ describe('Dropdown', () => {
         </Dropdown.Section>
       </Dropdown>,
     );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     const sectionLabels = screen.getAllByRole('presentation');
     expect(sectionLabels).toHaveLength(2);
@@ -163,6 +177,10 @@ describe('Dropdown', () => {
       </Dropdown>,
     );
 
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
     expect(screen.getByText('This is my custom header')).toBeVisible();
   });
 
@@ -210,6 +228,10 @@ describe('Dropdown', () => {
         />
       </Dropdown>,
     );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     fireEvent.keyDown(window.document, {
       keyCode: ESCAPE,
@@ -262,9 +284,14 @@ describe('Dropdown', () => {
       </Dropdown>,
     );
 
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
     fireEvent.keyDown(window.document, {
       keyCode: TAB,
     });
+
     expect(mockOnDismiss).toHaveBeenCalledTimes(1);
   });
 
@@ -312,6 +339,10 @@ describe('Dropdown', () => {
         />
       </Dropdown>,
     );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     expect(document.activeElement).toHaveAttribute('id', 'ex-6-item-0');
 
@@ -376,6 +407,10 @@ describe('Dropdown', () => {
       </Dropdown>,
     );
 
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
     expect(document.activeElement).toHaveAttribute('id', 'ex-7-item-0');
 
     fireEvent.keyDown(window.document, {
@@ -435,6 +470,10 @@ describe('Dropdown', () => {
         />
       </Dropdown>,
     );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     expect(document.activeElement).toHaveAttribute('id', 'ex-8-item-0');
 

--- a/packages/gestalt/src/Touchable.css
+++ b/packages/gestalt/src/Touchable.css
@@ -39,6 +39,7 @@
 }
 
 .tapTransition {
+  /* Compression must be considered when compressed components are used to anchor Popovers. setTimeout is necessary to prevent positioning shifts on rerender */
   transition: transform 85ms ease-out;
 }
 

--- a/packages/gestalt/src/__snapshots__/InternalLabel.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/InternalLabel.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InternalLabel renders 1`] = `
+<label
+  className="label"
+  htmlFor="email"
+>
+  Email
+</label>
+`;
+
+exports[`InternalLabel renders with label hidden 1`] = `
+<label
+  className="label visuallyHidden"
+  htmlFor="email"
+>
+  Email
+</label>
+`;


### PR DESCRIPTION
### Summary

#### What changed?

Fixed bug due to Dropdown's positioning shift on rerender.

Solution: added timeout to render Dropdown with a delay equivalent to the ease-out compression transition in Button. This prevents Dropdown to use the anchor's position based on the initial Button position on compression.

Alternative solution that doesn't work: Add event listeners to keyup, keydown, transitionstart, and transitionend inside Dropdown that control the component's rendering. All of them had some sort of incompatibility with mouse/keyboard navigation. For example, transitionstart and transitionend would work to detect the compression but keyboard navigation doesn't compress Button. Therefore, keyup, keydown must be also used. However, with keydown the Dropdown doesn't open as the event happens before the Dropdown gets mounted. With keyup, however, the Button's  focus stays in Button if we keep the Enter key  pressed continuously as the focus doesn't move to the Dropdown creating an infinite toggling loop in the Button state.

The most straightforward and clear solution was to implement timeout, solution that works for all cases.

Updated tests with useFakeTimers to advance timers.

#### Why?

Bug:  https://jira.pinadmin.com/browse/BUG-121306

Steps to reproduce:
1. Visit Dropdown in Gestalt: https://gestalt.netlify.app/Dropdown
2.  Open the example and hover over an option
3. View the slight jump

https://www.loom.com/share/ea724aa7420a47a098fc693c36e16ef0

The root cause is within Dropdown, not Popover. ComboBox doesn’t have this issue for instance. What’s happening is that Button is the anchor for Popover and Button compresses, setting the anchor position on compression. On hover on the second option item, Dropdown rerenders and the anchor has a slightly different uncompressed position.