### PR TITLE
IconButton: Add Tooltip prop

### DIFF
--- a/cypress/integration/accessibility_IconButton_spec.js
+++ b/cypress/integration/accessibility_IconButton_spec.js
@@ -8,10 +8,6 @@ describe('IconButton Accessibility check', () => {
     cy.configureAxe({
       rules: [
         {
-          id: 'button-name',
-          enabled: false,
-        },
-        {
           id: 'color-contrast',
           enabled: false,
         },

--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -321,6 +321,7 @@ function HeadingExample(props) {
         icon="edit"
         onClick={() => setShouldShow(true)}
         size="lg"
+        tooltip={{text: "Edit Pin"}}
       />
       {shouldShow && (
         <Layer zIndex={modalZIndex}>
@@ -366,21 +367,21 @@ function OrderDropdownExample() {
     <Flex gap={2}>
       <Tooltip text="Go back to previous page">
         <IconButton
-          accessibilityLabel=""
+          accessibilityLabel="Backe"
           icon="arrow-back"
           size="md"
         />
       </Tooltip>
-      <Tooltip text="Share pin">
+      <Tooltip text="Send pin">
         <IconButton
-          accessibilityLabel=""
+          accessibilityLabel="Share"
           icon="share"
           size="md"
         />
       </Tooltip>
-      <Tooltip text="Edit pin">
+      <Tooltip text="Edit board details">
         <IconButton
-          accessibilityLabel=""
+          accessibilityLabel="Edit"
           icon="edit"
           size="md"
         />
@@ -395,6 +396,7 @@ function OrderDropdownExample() {
         ref={anchorRef}
         selected={open}
         size="md"
+        tooltip={{text: "More options"}}
       />
       <Button text="Visit" size="md"/>
       <Button color="red" text="Save" size="md"/>
@@ -433,37 +435,37 @@ function OrderDropdownExample() {
             description="Display more than 4 icon buttons in a single row as it can cause cognitive load and usability issues."
             defaultCode={`
 <Flex gap={2}>
-  <Tooltip text="Go back to previous page">
+  <Tooltip text="Navigate to previous page">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Back"
       icon="arrow-back"
       size="md"
     />
   </Tooltip>
-  <Tooltip text="Share pin">
+  <Tooltip text="Send pin">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Share"
       icon="share"
       size="md"
     />
   </Tooltip>
-  <Tooltip text="Edit pin">
+  <Tooltip text="Edit board details and sections">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Customize"
       icon="edit"
       size="md"
     />
   </Tooltip>
-  <Tooltip text="Create new pin">
+  <Tooltip text="Create new pin or board">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Create"
       icon="add"
       size="md"
     />
   </Tooltip>
-  <Tooltip text="Search board">
+  <Tooltip text="Search this board">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Search"
       icon="search"
       size="md"
     />
@@ -479,13 +481,12 @@ function OrderDropdownExample() {
             type="do"
             description="Display a [Tooltip](/tooltip) in conjunction with IconButton to provide context when the icon alone would be insufficient to convey the purpose of the button."
             defaultCode={`
-<Tooltip text="Send pin">
   <IconButton
-    accessibilityLabel=""
+    accessibilityLabel="Share"
     icon="share"
     size="lg"
+    tooltip={{text: "Send pin to others"}}
   />
-</Tooltip>
 `}
           />
           <MainSection.Card
@@ -648,15 +649,14 @@ function Example(props) {
 
 IconButtons that act as links can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.`}
             defaultCode={`
-<Tooltip text="Link">
-  <IconButton
-    accessibilityLabel="This IconButton is an example of IconButton acting as a link"
-    icon="visit"
-    role="link"
-    target="blank"
-    href="https://www.pinterest.com"
-  />
-</Tooltip>
+<IconButton
+  accessibilityLabel="This IconButton is an example of IconButton acting as a link"
+  icon="visit"
+  role="link"
+  target="blank"
+  href="https://www.pinterest.com"
+  tooltip={{text: "Link example"}}
+/>
 `}
           />
           <MainSection.Card
@@ -664,13 +664,12 @@ IconButtons that act as links can be paired with OnLinkNavigationProvider. See [
             title="role = button"
             description="If IconButton acts as a button, pass role-specific [props](#role_buttonProps)."
             defaultCode={`
-<Tooltip text="Button">
-  <IconButton
-    accessibilityLabel="This IconButton is an example of IconButton acting as a button"
-    icon="share"
-    onClick={() => {}}
-  />
-</Tooltip>
+<IconButton
+  accessibilityLabel="This IconButton is an example of IconButton acting as a button"
+  icon="share"
+  onClick={() => {}}
+  tooltip={{text: "Button Example"}}
+/>
 `}
           />
         </MainSection.Subsection>

--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -41,6 +41,7 @@ function SectionsIconButtonDropdownExample() {
         ref={anchorRef}
         selected={open}
         size="lg"
+        tooltip={{text: "Create", idealDirection: "up"}}
       />
       {open && (
         <Dropdown anchor={anchorRef.current} id="sections-dropdown-example" onDismiss={() => setOpen(false)}>
@@ -163,7 +164,7 @@ function SectionsIconButtonDropdownExample() {
           {
             name: 'tooltip',
             type: `{| text: string, inline?: boolean, idealDirection?: 'up' | 'right' | 'down' | 'left', zIndex?: Indexable, |}`,
-            description: `Adds a Tooltip on hover/focus of the IconButton. See the [With Tooltip](#With-Tooltip) variant to learn more.`,
+            description: `Adds a [Tooltip](/tooltip) on hover/focus of the IconButton. See the [With Tooltip](#With-Tooltip) variant to learn more.`,
           },
         ]}
       />
@@ -367,7 +368,7 @@ function OrderDropdownExample() {
     <Flex gap={2}>
       <Tooltip text="Go back to previous page">
         <IconButton
-          accessibilityLabel="Backe"
+          accessibilityLabel="Back"
           icon="arrow-back"
           size="md"
         />
@@ -559,6 +560,7 @@ function Example() {
         ref={anchorRef}
         selected={open}
         size="lg"
+        tooltip={{text: "Create Pin", idealDirection: "up"}}
       />
       {open && (
         <Dropdown
@@ -619,6 +621,7 @@ function Example(props) {
           size="xs"
           tabIndex="-1"
           target="blank"
+          tooltip={{text: "Edit name"}}
         />
       </Flex>
     </Flex>
@@ -784,23 +787,21 @@ Follow these guidelines for \`bgColor\`
           <MainSection.Card
             cardSize="md"
             defaultCode={`
-<Tooltip text="Built-in Gestalt Icon">
-  <IconButton
-    accessibilityLabel="Go to next steps"
-    icon="directional-arrow-right"
-  />
-</Tooltip>
+<IconButton
+  accessibilityLabel="Go to next steps"
+  icon="directional-arrow-right"
+  tooltip={{text: "Built-in Gestalt Icon"}}
+/>
 `}
           />
           <MainSection.Card
             cardSize="md"
             defaultCode={`
-<Tooltip text="Custom Icon">
-  <IconButton
-    accessibilityLabel="Go to next steps"
-    dangerouslySetSvgPath={{ __path: 'M23 5v14a4 4 0 0 1-4 4H5a4 4 0 0 1-4-4v-5.5h10.258l-1.94 1.939a1.5 1.5 0 0 0 2.121 2.122L17 12l-5.561-5.561a1.501 1.501 0 0 0-2.121 2.122l1.94 1.939H1V5a4 4 0 0 1 4-4h14a4 4 0 0 1 4 4'}}
-  />
-</Tooltip>
+<IconButton
+  accessibilityLabel="Go to next steps"
+  dangerouslySetSvgPath={{ __path: 'M23 5v14a4 4 0 0 1-4 4H5a4 4 0 0 1-4-4v-5.5h10.258l-1.94 1.939a1.5 1.5 0 0 0 2.121 2.122L17 12l-5.561-5.561a1.501 1.501 0 0 0-2.121 2.122l1.94 1.939H1V5a4 4 0 0 1 4-4h14a4 4 0 0 1 4 4'}}
+  tooltip={{text: "Custom Icon"}}
+/>
 `}
           />
         </MainSection.Subsection>
@@ -837,6 +838,7 @@ function SectionsIconButtonDropdownExample() {
         ref={anchorRef}
         selected={open}
         size="lg"
+        tooltip={{text: "Create", idealDirection: "up"}}
       />
       {open && (
         <Dropdown anchor={anchorRef.current} id="sections-dropdown-example" onDismiss={() => setOpen(false)}>
@@ -894,6 +896,7 @@ function IconButtonPopoverExample() {
         onClick={() => { setOpen(true), setChecked(!checked) } }
         selected={checked}
         ref={anchorRef}
+        tooltip={{text: "Favorite pin"}}
       />
       {open && checked &&(
         <Popover

--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -160,6 +160,11 @@ function SectionsIconButtonDropdownExample() {
             description:
               'The maximum height and width of IconButton. See the [size](#Size) variant to learn more.',
           },
+          {
+            name: 'tooltip',
+            type: `{| text: string, inline?: boolean, idealDirection?: 'up' | 'right' | 'down' | 'left', zIndex?: Indexable, |}`,
+            description: `Adds a Tooltip on hover/focus of the IconButton. See the [With Tooltip](#With-Tooltip) variant to learn more.`,
+          },
         ]}
       />
       <PropTable
@@ -753,6 +758,24 @@ Follow these guidelines for \`bgColor\`
               />
             )}
           </CombinationNew>
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="With Tooltip"
+          description="By specifying the `tooltip` property, a [Tooltip](/tooltip) will automatically be triggered when IconButton is hovered or focused."
+        >
+          <MainSection.Card
+            cardSize="md"
+            defaultCode={`
+<IconButton
+  accessibilityLabel="Sharing"
+  icon="share"
+  tooltip={{
+    text: "This Pin is private unless you share it with others.",
+    idealDirection: "up"
+  }}
+/>
+`}
+          />
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Custom icon"

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -14,6 +14,21 @@ import useTapFeedback from './useTapFeedback.js';
 import useFocusVisible from './useFocusVisible.js';
 import { type Indexable } from './zIndex.js';
 
+type TooltipType = {|
+  text: string,
+  inline?: boolean,
+  idealDirection?: 'up' | 'right' | 'down' | 'left',
+  zIndex?: Indexable,
+|};
+
+const TooltipComponent = ({
+  children,
+  tooltipProps,
+}: {|
+  children: Node,
+  tooltipProps: TooltipType,
+|}): Node => (tooltipProps.text ? <Tooltip {...tooltipProps}>{children}</Tooltip> : children);
+
 type BaseIconButton = {|
   accessibilityLabel: string,
   bgColor?:
@@ -37,12 +52,7 @@ type BaseIconButton = {|
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   padding?: 1 | 2 | 3 | 4 | 5,
   tabIndex?: -1 | 0,
-  tooltip?: {|
-    text: string,
-    inline?: boolean,
-    idealDirection?: 'up' | 'right' | 'down' | 'left',
-    zIndex?: Indexable,
-  |},
+  tooltip?: TooltipType,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
@@ -237,9 +247,6 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     </button>
   );
 
-  const renderTooltipComponent = (children: Node): Node =>
-    tooltip?.text ? <Tooltip {...tooltip}>{children}</Tooltip> : children;
-
   let buttonComponentToRender = null;
 
   if (props.role === 'link') {
@@ -256,7 +263,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
   }
 
   if (tooltip) {
-    return renderTooltipComponent(buttonComponentToRender);
+    return <TooltipComponent tooltipProps={tooltip}>{buttonComponentToRender}</TooltipComponent>;
   }
   return buttonComponentToRender;
 });

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -183,7 +183,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     setHovered(false);
   };
 
-  const linkIconButton = (href, rel, target) => (
+  const createLinkIconButton = (href, rel, target) => (
     <InternalLink
       accessibilityLabel={accessibilityLabel}
       disabled={disabled}
@@ -205,7 +205,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     </InternalLink>
   );
 
-  const iconButton = (
+  const createIconButton = (
     accessibilityControls,
     accessibilityExpanded,
     accessibilityHaspopup,
@@ -251,21 +251,21 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
 
   if (props.role === 'link') {
     const { href, rel, target } = props;
-    buttonComponentToRender = linkIconButton(href, rel, target);
+    buttonComponentToRender = createLinkIconButton(href, rel, target);
   } else {
     const { accessibilityControls, accessibilityExpanded, accessibilityHaspopup, selected } = props;
-    buttonComponentToRender = iconButton(
+    buttonComponentToRender = createIconButton(
       accessibilityControls,
       accessibilityExpanded,
       accessibilityHaspopup,
       selected,
     );
   }
-
-  if (tooltip) {
-    return <TooltipComponent tooltipProps={tooltip}>{buttonComponentToRender}</TooltipComponent>;
-  }
-  return buttonComponentToRender;
+  return tooltip ? (
+    <TooltipComponent tooltipProps={tooltip}>{buttonComponentToRender}</TooltipComponent>
+  ) : (
+    buttonComponentToRender
+  );
 });
 
 IconButtonWithForwardRef.displayName = 'IconButton';

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -137,9 +137,6 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     />
   );
 
-  const renderTooltipComponent = (children: Node): Node =>
-    tooltip && tooltip.text ? <Tooltip {...tooltip}>{children}</Tooltip> : children;
-
   const handleClick = (event, dangerouslyDisableOnNavigation) =>
     onClick
       ? onClick({
@@ -176,39 +173,34 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     setHovered(false);
   };
 
-  if (props.role === 'link') {
-    const { href, rel, target } = props;
-
-    const linkIconButton = (
-      <InternalLink
-        accessibilityLabel={accessibilityLabel}
-        disabled={disabled}
-        href={href}
-        onClick={handleLinkClick}
-        onBlur={handleOnBlur}
-        onFocus={handleOnFocus}
-        onMouseDown={handleOnMouseDown}
-        onMouseUp={handleOnMouseUp}
-        onMouseEnter={handleOnMouseEnter}
-        onMouseLeave={handleOnMouseLeave}
-        ref={innerRef}
-        rel={rel}
-        tabIndex={tabIndex}
-        target={target}
-        wrappedComponent="iconButton"
-      >
-        {renderPogComponent()}
-      </InternalLink>
-    );
-    if (tooltip) {
-      return renderTooltipComponent(linkIconButton);
-    }
-    return linkIconButton;
-  }
-
-  const { accessibilityControls, accessibilityExpanded, accessibilityHaspopup, selected } = props;
+  const linkIconButton = (href, rel, target) => (
+    <InternalLink
+      accessibilityLabel={accessibilityLabel}
+      disabled={disabled}
+      href={href}
+      onClick={handleLinkClick}
+      onBlur={handleOnBlur}
+      onFocus={handleOnFocus}
+      onMouseDown={handleOnMouseDown}
+      onMouseUp={handleOnMouseUp}
+      onMouseEnter={handleOnMouseEnter}
+      onMouseLeave={handleOnMouseLeave}
+      ref={innerRef}
+      rel={rel}
+      tabIndex={tabIndex}
+      target={target}
+      wrappedComponent="iconButton"
+    >
+      {renderPogComponent()}
+    </InternalLink>
+  );
 
   const iconButton = (
+    accessibilityControls,
+    accessibilityExpanded,
+    accessibilityHaspopup,
+    selected,
+  ) => (
     <button
       aria-controls={accessibilityControls}
       aria-expanded={accessibilityExpanded}
@@ -245,10 +237,28 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     </button>
   );
 
-  if (tooltip) {
-    return renderTooltipComponent(iconButton);
+  const renderTooltipComponent = (children: Node): Node =>
+    tooltip?.text ? <Tooltip {...tooltip}>{children}</Tooltip> : children;
+
+  let buttonComponentToRender = null;
+
+  if (props.role === 'link') {
+    const { href, rel, target } = props;
+    buttonComponentToRender = linkIconButton(href, rel, target);
+  } else {
+    const { accessibilityControls, accessibilityExpanded, accessibilityHaspopup, selected } = props;
+    buttonComponentToRender = iconButton(
+      accessibilityControls,
+      accessibilityExpanded,
+      accessibilityHaspopup,
+      selected,
+    );
   }
-  return iconButton;
+
+  if (tooltip) {
+    return renderTooltipComponent(buttonComponentToRender);
+  }
+  return buttonComponentToRender;
 });
 
 IconButtonWithForwardRef.displayName = 'IconButton';

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -6,11 +6,13 @@ import classnames from 'classnames';
 import icons from './icons/index.js';
 import InternalLink from './InternalLink.js';
 import Pog from './Pog.js';
+import Tooltip from './Tooltip.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import styles from './IconButton.css';
 import touchableStyles from './Touchable.css';
 import useTapFeedback from './useTapFeedback.js';
 import useFocusVisible from './useFocusVisible.js';
+import { type Indexable } from './zIndex.js';
 
 type BaseIconButton = {|
   accessibilityLabel: string,
@@ -35,6 +37,12 @@ type BaseIconButton = {|
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   padding?: 1 | 2 | 3 | 4 | 5,
   tabIndex?: -1 | 0,
+  tooltip?: {|
+    text: string,
+    inline?: boolean,
+    idealDirection?: 'up' | 'right' | 'down' | 'left',
+    zIndex?: Indexable,
+  |},
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
@@ -78,6 +86,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     onClick,
     padding,
     tabIndex = 0,
+    tooltip,
     size,
   } = props;
 
@@ -128,6 +137,9 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     />
   );
 
+  const renderTooltipComponent = (children: Node): Node =>
+    tooltip ? <Tooltip {...tooltip}>{children}</Tooltip> : null;
+
   const handleClick = (event, dangerouslyDisableOnNavigation) =>
     onClick
       ? onClick({
@@ -167,7 +179,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
   if (props.role === 'link') {
     const { href, rel, target } = props;
 
-    return (
+    const linkIconButton = (
       <InternalLink
         accessibilityLabel={accessibilityLabel}
         disabled={disabled}
@@ -188,11 +200,15 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
         {renderPogComponent()}
       </InternalLink>
     );
+    if (tooltip) {
+      return renderTooltipComponent(linkIconButton);
+    }
+    return linkIconButton;
   }
 
   const { accessibilityControls, accessibilityExpanded, accessibilityHaspopup, selected } = props;
 
-  return (
+  const iconButton = (
     <button
       aria-controls={accessibilityControls}
       aria-expanded={accessibilityExpanded}
@@ -228,6 +244,11 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
       {renderPogComponent(selected)}
     </button>
   );
+
+  if (tooltip) {
+    return renderTooltipComponent(iconButton);
+  }
+  return iconButton;
 });
 
 IconButtonWithForwardRef.displayName = 'IconButton';

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -138,7 +138,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
   );
 
   const renderTooltipComponent = (children: Node): Node =>
-    tooltip ? <Tooltip {...tooltip}>{children}</Tooltip> : null;
+    tooltip && tooltip.text ? <Tooltip {...tooltip}>{children}</Tooltip> : children;
 
   const handleClick = (event, dangerouslyDisableOnNavigation) =>
     onClick

--- a/packages/gestalt/src/IconButton.test.js
+++ b/packages/gestalt/src/IconButton.test.js
@@ -25,6 +25,21 @@ test('IconButton renders with svg', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('IconButton renders with tooltip', () => {
+  const component = create(
+    <IconButton
+      accessibilityLabel="Share"
+      icon="share"
+      tooltip={{
+        text: 'This Pin is private unless you share it with others.',
+        idealDirection: 'up',
+      }}
+    />,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('accessibilityControls', () => {
   const instance = create(
     <IconButton accessibilityLabel="" accessibilityControls="another-element" />,

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -132,3 +132,60 @@ exports[`IconButton renders with svg 1`] = `
   </div>
 </button>
 `;
+
+exports[`IconButton renders with tooltip 1`] = `
+<div
+  className="box xsDisplayBlock"
+>
+  <div
+    aria-label="This Pin is private unless you share it with others."
+    className="box"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <button
+      aria-label="Share"
+      className="button tapTransition enabled"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="pog transparent"
+        style={
+          Object {
+            "height": 40,
+            "width": 40,
+          }
+        }
+      >
+        <svg
+          aria-hidden={true}
+          aria-label=""
+          className="icon gray iconBlock"
+          height={18}
+          role="img"
+          viewBox="0 0 24 24"
+          width={18}
+        >
+          <path
+            d="test-file-stub"
+          />
+        </svg>
+      </div>
+    </button>
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Summary

#### What changed?

Add `tooltip` object prop to allow for easy addition of a Tooltip to an IconButton

#### Why?

eventually we want to make Tooltips required on IconButtons to help provide clarity around the intention of an IconButton. This is an initial step to make this easier, as well as an initial step toward creating HelpButton

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-2900)

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
