### PR TITLE
Tooltip: add optional accessibilityLabel prop & fix Datapoint a11y integration test

### DIFF
--- a/cypress/integration/accessibility_Datapoint_spec.js
+++ b/cypress/integration/accessibility_Datapoint_spec.js
@@ -5,14 +5,7 @@ describe('Datapoint Accessibility check', () => {
   });
 
   it('Tests accessibility on the Datapoint page', () => {
-    cy.configureAxe({
-      rules: [
-        {
-          id: 'aria-command-name', // Tooltip provides description to the button
-          enabled: false,
-        },
-      ],
-    });
+    cy.configureAxe();
     cy.checkA11y();
   });
 });

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -58,11 +58,10 @@ export default function Datapoint({
       <Flex gap={1} alignItems="center" minHeight={24}>
         <Text size="md">{title}</Text>
         {tooltipText && (
-          <Tooltip text={tooltipText} idealDirection="up">
-            {/* Interactive elements require an a11yLabel on them or their children. In this particular case,
-            screenreaders do read the Tooltip text that provides the context to the interactive children.
-            Therefore no a11yLabel is needed and integration tests can be safely disabled. */}
-            <TapArea accessibilityLabel="" rounding="circle" tapStyle="none">
+          <Tooltip accessibilityLabel="" text={tooltipText} idealDirection="up">
+            {/* Interactive elements require an a11yLabel on them or their children.
+            That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */}
+            <TapArea accessibilityLabel={tooltipText} rounding="circle" tapStyle="none">
               <Icon accessibilityLabel="" size={16} icon="info-circle" color="gray" />
             </TapArea>
           </Tooltip>

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -45,6 +45,10 @@ const reducer = (state, action) => {
 
 type Props = {|
   /**
+   * Label to provide more context around the Tooltip’s function or purpose. By default `text` is used but this prop allows you to override it. Should only be used in very rare cases
+   */
+  accessibilityLabel?: string,
+  /**
    * The anchor element, usually [Icon Button](https://gestalt.pinterest.systems/iconbutton), that triggers Tooltip on hover or focus.
    */
   children: Node,
@@ -74,6 +78,7 @@ type Props = {|
  * [Tooltip](https://gestalt.pinterest.systems/tooltip) is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/iconbutton). It’s displayed continuously as long as the user hovers over or focuses on the element.
  */
 export default function Tooltip({
+  accessibilityLabel,
   children,
   link,
   idealDirection = 'down',
@@ -108,7 +113,7 @@ export default function Tooltip({
   return (
     <Box display={inline ? 'inlineBlock' : 'block'}>
       <Box
-        aria-label={text}
+        aria-label={accessibilityLabel != null ? accessibilityLabel : text}
         ref={childRef}
         onFocus={handleIconMouseEnter}
         onBlur={handleIconMouseLeave}


### PR DESCRIPTION
### Summary

#### What changed?

* Add optional `accessibilityLabel` prop to `Tooltip`
* Fix `Datapoint` accessibility integration test

#### Why?

`aria-command-name` was failing in multiple places in pinboard. The root cause was the `Datapoint` component

### Checklist

Ensure that VoiceOver still works correctly with `Tooltip` / `Datapoint`

![Screen Shot 2022-01-21 at 8 00 48 AM](https://user-images.githubusercontent.com/127199/150560615-5b8a2c13-680d-4b3f-88de-facbe1575c99.png)

