### PR TITLE
Tooltip: Deprecate links in Tooltips

### DIFF
--- a/cypress/integration/accessibility_Icon_spec.js
+++ b/cypress/integration/accessibility_Icon_spec.js
@@ -5,15 +5,6 @@ describe('Icon Accessibility check', () => {
   });
 
   it('Tests accessibility on the Icon page', () => {
-    cy.configureAxe({
-      rules: [
-        {
-          id: 'aria-command-name', // caused by: Tooltip wrapping TapArea on Icon with a11yLabel empty for redundancy with tooltip
-          enabled: false,
-        },
-      ],
-    });
-
     cy.checkA11y();
   });
 });

--- a/cypress/integration/accessibility_Tooltip_spec.js
+++ b/cypress/integration/accessibility_Tooltip_spec.js
@@ -11,10 +11,6 @@ describe('Tooltip Accessibility check', () => {
           id: 'color-contrast',
           enabled: false,
         },
-        {
-          id: 'button-name',
-          enabled: false,
-        },
       ],
     });
     cy.checkA11y();

--- a/docs/pages/icon.js
+++ b/docs/pages/icon.js
@@ -89,7 +89,7 @@ export default function IconPage({ generatedDocGen }: {| generatedDocGen: DocGen
             defaultCode={`
 <Tooltip text="Share pin">
   <TapArea>
-    <Icon icon="share" accessibilityLabel="" color="darkGray" />
+    <Icon icon="share" accessibilityLabel="Share" color="darkGray" />
   </TapArea>
 </Tooltip>`}
           />
@@ -138,7 +138,7 @@ If an icon has a visible label that describes what the icon represents, \`access
       <MainSection name="Variants">
         <MainSection.Subsection title="Primary-color combinations">
           <CombinationNew color={['gray', 'darkGray', 'red']}>
-            {({ color }) => <Icon icon="heart" accessibilityLabel="" color={color} />}
+            {({ color }) => <Icon icon="heart" accessibilityLabel="Favorite Pin" color={color} />}
           </CombinationNew>
         </MainSection.Subsection>
         <MainSection.Subsection

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -76,9 +76,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             type="do"
             description="Use Tooltip to describe the function of an interactive element, typically [Icon Button](/iconbutton), in as few words as possible."
             defaultCode={`
-<Tooltip text="Send Pin">
+<Tooltip text="Share Pin with others">
   <IconButton
-    accessibilityLabel=""
+    accessibilityLabel="Share"
     bgColor="white"
     icon="share"
     iconColor="darkGray"
@@ -106,7 +106,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 <Flex>
   <Tooltip text="Align left">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Alignment"
       bgColor="white"
       icon="text-align-left"
       iconColor="darkGray"
@@ -115,7 +115,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   </Tooltip>
   <Tooltip text="Align center">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Alignment"
       bgColor="white"
       icon="text-align-center"
       iconColor="darkGray"
@@ -124,7 +124,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   </Tooltip>
   <Tooltip text="Align right">
     <IconButton
-      accessibilityLabel="Align right"
+      accessibilityLabel="Alignment"
       bgColor="white"
       icon="text-align-right"
       iconColor="darkGray"
@@ -179,16 +179,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description="Pair Tooltip with a disabled element. See [disabled elements](#Disabled-elements) to learn more."
             defaultCode={`
 <Tooltip
-  link={
-    <Text color="white" size="sm" weight="bold">
-      <Link
-        href="https://help.pinterest.com/en/business/article/get-a-business-account"
-        target="blank"
-      >
-        Learn more
-      </Link>
-    </Text>
-  }
   text="There was a problem converting to a personal account."
 >
   <Button size="lg" disabled text="Convert to personal account" />
@@ -221,9 +211,9 @@ When using Tooltip with [IconButton](/iconbutton), avoid repetitive labeling. Th
           <MainSection.Card
             cardSize="md"
             defaultCode={`
-<Tooltip text="Send Pin">
+<Tooltip text="Share Pin">
   <IconButton
-    accessibilityLabel=""
+    accessibilityLabel="Share"
     bgColor="white"
     icon="share"
     iconColor="darkGray"
@@ -334,7 +324,7 @@ function SectionsIconButtonDropdownExample() {
             accessibilityControls="sections-dropdown-example"
             accessibilityHaspopup
             accessibilityExpanded={open}
-            accessibilityLabel=""
+            accessibilityLabel="Menu"
             bgColor="lightGray"
             icon="ellipsis"
             iconColor="darkGray"
@@ -366,44 +356,6 @@ function SectionsIconButtonDropdownExample() {
     </Box>
   );
 }
-`}
-          />
-        </MainSection.Subsection>
-        <MainSection.Subsection
-          title="Link"
-          description={`
-      Pass in \`link\` to display a link at the bottom of Tooltip.
-
-      ⚠️ Note: this feature will soon be deprecated, as it is not accessible. Please do not use it in new designs or features.
-      `}
-        >
-          <MainSection.Card
-            cardSize="lg"
-            defaultCode={`
-  <Flex gap={2} justifyContent="center" alignItems="center">
-    <Text>Enable expanded targeting</Text>
-    <Tooltip
-      text="Use your Pin to expand your targeting."
-      link={
-        <Text color="white" size="sm" weight="bold">
-          <Link
-            href="https://help.pinterest.com/en/business/article/expanded-targeting"
-            target="blank"
-          >
-            Learn more
-          </Link>
-        </Text>
-      }
-    >
-      <IconButton
-        accessibilityLabel="Additional info."
-        bgColor="white"
-        icon="info-circle"
-        iconColor="darkGray"
-        size="sm"
-      />
-    </Tooltip>
-  </Flex>
 `}
           />
         </MainSection.Subsection>

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -1,6 +1,5 @@
 // @flow strict
 import { type Node, useReducer, useRef } from 'react';
-import useDebouncedCallback from './useDebouncedCallback.js';
 import Controller from './Controller.js';
 import Text from './Text.js';
 import Box from './Box.js';
@@ -8,7 +7,6 @@ import Layer from './Layer.js';
 import { type Indexable } from './zIndex.js';
 
 const noop = () => {};
-const TIMEOUT = 100;
 
 const initialState = { hoveredIcon: false, hoveredText: false, isOpen: false };
 
@@ -76,7 +74,6 @@ type Props = {|
 export default function Tooltip({
   accessibilityLabel,
   children,
-  link,
   idealDirection = 'down',
   inline,
   text,
@@ -88,23 +85,13 @@ export default function Tooltip({
   const childRef = useRef<?HTMLElement>(null);
   const { current: anchor } = childRef;
 
-  const mouseLeaveDelay = link ? TIMEOUT : 0;
-
   const handleIconMouseEnter = () => {
     dispatch({ type: 'hoverInIcon' });
   };
 
-  const handleIconMouseLeave = useDebouncedCallback(() => {
+  const handleIconMouseLeave = () => {
     dispatch({ type: 'hoverOutIcon' });
-  }, mouseLeaveDelay);
-
-  const handleTextMouseEnter = () => {
-    dispatch({ type: 'hoverInText' });
   };
-
-  const handleTextMouseLeave = useDebouncedCallback(() => {
-    dispatch({ type: 'hoverOutText' });
-  }, mouseLeaveDelay);
 
   return (
     <Box display={inline ? 'inlineBlock' : 'block'}>
@@ -131,16 +118,7 @@ export default function Tooltip({
             rounding={2}
             size={null}
           >
-            <Box
-              maxWidth={180}
-              padding={2}
-              onBlur={link ? handleTextMouseLeave : undefined}
-              onFocus={link ? handleTextMouseEnter : undefined}
-              onMouseEnter={link ? handleTextMouseEnter : undefined}
-              onMouseLeave={link ? handleTextMouseLeave : undefined}
-              role="tooltip"
-              tabIndex={0}
-            >
+            <Box maxWidth={180} padding={2} role="tooltip" tabIndex={0}>
               <Text color="white" size="sm">
                 {text}
               </Text>

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -61,10 +61,6 @@ type Props = {|
    */
   inline?: boolean,
   /**
-   * Displays a link at the bottom of Tooltip. See the [link](https://gestalt.pinterest.systems/tooltip#Link) variant to learn more.
-   */
-  link?: Node,
-  /**
    * The text shown in Tooltip to describe its anchor element. See [localization ](https://gestalt.pinterest.systems/tooltip#Localization) to learn more.
    */
   text: string,
@@ -148,7 +144,6 @@ export default function Tooltip({
               <Text color="white" size="sm">
                 {text}
               </Text>
-              {Boolean(link) && <Box marginTop={1}>{link}</Box>}
             </Box>
           </Controller>
         </Layer>

--- a/packages/gestalt/src/Tooltip.jsdom.test.js
+++ b/packages/gestalt/src/Tooltip.jsdom.test.js
@@ -2,8 +2,6 @@
 import { create } from 'react-test-renderer';
 import { fireEvent, render } from '@testing-library/react';
 import Tooltip from './Tooltip.js';
-import Link from './Link.js';
-import Text from './Text.js';
 import { FixedZIndex } from './zIndex.js';
 
 test('Tooltip renders', () => {
@@ -14,33 +12,6 @@ test('Tooltip renders', () => {
   );
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
-});
-
-test('Tooltip renders the link when hovered', () => {
-  const { container, getByText } = render(
-    <Tooltip
-      link={
-        <Link href="https://pinterest.com" target="blank">
-          <Text color="white" size="sm" weight="bold">
-            Learn more
-          </Text>
-        </Link>
-      }
-      text="This is a tooltip"
-    >
-      <div>Hi</div>
-    </Tooltip>,
-  );
-
-  const ariaContainer = container.querySelector('[aria-label]');
-  expect(ariaContainer).not.toBe(null);
-
-  if (ariaContainer) {
-    fireEvent.mouseEnter(ariaContainer);
-  }
-  const { body } = document;
-  const element = getByText('Learn more');
-  expect(body && body.contains(element)).toBeTruthy();
 });
 
 test('Tooltip should render as expected when hovered', () => {


### PR DESCRIPTION
### Summary

#### What changed?

Removed the ability to put a link in a Tooltip

#### Why?

Links in Tooltips are inaccessible for keyboard and screen reader users, and therefore create usability issues

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-2506)

### Checklist

- [X] Removed unit and Flow Tests
- [X] Removed documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
