### PR TITLE
IconButton, Tooltip: Update accessibility guidance

### DIFF
--- a/cypress/integration/accessibility_Icon_spec.js
+++ b/cypress/integration/accessibility_Icon_spec.js
@@ -5,15 +5,6 @@ describe('Icon Accessibility check', () => {
   });
 
   it('Tests accessibility on the Icon page', () => {
-    cy.configureAxe({
-      rules: [
-        {
-          id: 'aria-command-name', // caused by: Tooltip wrapping TapArea on Icon with a11yLabel empty for redundancy with tooltip
-          enabled: false,
-        },
-      ],
-    });
-
     cy.checkA11y();
   });
 });

--- a/cypress/integration/accessibility_Tooltip_spec.js
+++ b/cypress/integration/accessibility_Tooltip_spec.js
@@ -11,10 +11,6 @@ describe('Tooltip Accessibility check', () => {
           id: 'color-contrast',
           enabled: false,
         },
-        {
-          id: 'button-name',
-          enabled: false,
-        },
       ],
     });
     cy.checkA11y();

--- a/docs/components/buttons/CollapseExpandCodeButton.js
+++ b/docs/components/buttons/CollapseExpandCodeButton.js
@@ -1,6 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import { IconButton, Tooltip } from 'gestalt';
+import { IconButton } from 'gestalt';
 import trackButtonClick from './trackButtonClick.js';
 
 type Props = {|
@@ -13,17 +13,16 @@ export default function CollapseExpandCodeButton({ expanded, name, onClick }: Pr
   const label = `${expanded ? 'Collapse' : 'Expand'} code example`;
 
   return (
-    <Tooltip inline text={label} idealDirection="up">
-      <IconButton
-        accessibilityLabel={`${label} for ${name}`}
-        iconColor="darkGray"
-        icon={expanded ? 'minimize' : 'maximize'}
-        onClick={() => {
-          trackButtonClick(label, name);
-          onClick();
-        }}
-        size="xs"
-      />
-    </Tooltip>
+    <IconButton
+      accessibilityLabel={`${label} for ${name}`}
+      iconColor="darkGray"
+      icon={expanded ? 'minimize' : 'maximize'}
+      onClick={() => {
+        trackButtonClick(label, name);
+        onClick();
+      }}
+      size="xs"
+      tooltip={{ text: label, inline: true, idealDirection: 'up', accessibilityLabel: '' }}
+    />
   );
 }

--- a/docs/components/buttons/CopyCodeButton.js
+++ b/docs/components/buttons/CopyCodeButton.js
@@ -1,6 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import { IconButton, Tooltip } from 'gestalt';
+import { IconButton } from 'gestalt';
 import trackButtonClick from './trackButtonClick.js';
 
 type Props = {|
@@ -11,17 +11,16 @@ export default function CopyCodeButton({ onClick }: Props): Node {
   const label = 'Copy code';
 
   return (
-    <Tooltip inline text={label} idealDirection="up">
-      <IconButton
-        accessibilityLabel={label}
-        icon="drag-drop"
-        iconColor="darkGray"
-        onClick={() => {
-          trackButtonClick(label);
-          onClick();
-        }}
-        size="xs"
-      />
-    </Tooltip>
+    <IconButton
+      accessibilityLabel={label}
+      icon="drag-drop"
+      iconColor="darkGray"
+      onClick={() => {
+        trackButtonClick(label);
+        onClick();
+      }}
+      size="xs"
+      tooltip={{ text: label, inline: true, idealDirection: 'up', accessibilityLabel: '' }}
+    />
   );
 }

--- a/docs/components/buttons/CopyLinkButton.js
+++ b/docs/components/buttons/CopyLinkButton.js
@@ -1,6 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import { IconButton, Tooltip } from 'gestalt';
+import { IconButton } from 'gestalt';
 import trackButtonClick from './trackButtonClick.js';
 
 type Props = {|
@@ -12,17 +12,16 @@ export default function CopyLinkButton({ name, onClick }: Props): Node {
   const label = 'Copy link';
 
   return (
-    <Tooltip inline text={label}>
-      <IconButton
-        accessibilityLabel={`${label} to ${name}`}
-        icon="link"
-        onClick={() => {
-          trackButtonClick(label, name);
-          onClick();
-        }}
-        size="xs"
-        iconColor="darkGray"
-      />
-    </Tooltip>
+    <IconButton
+      accessibilityLabel={`${label} to ${name}`}
+      icon="link"
+      onClick={() => {
+        trackButtonClick(label, name);
+        onClick();
+      }}
+      size="xs"
+      iconColor="darkGray"
+      tooltip={{ text: label, inline: true, accessibilityLabel: '' }}
+    />
   );
 }

--- a/docs/components/buttons/OpenSandboxButton.js
+++ b/docs/components/buttons/OpenSandboxButton.js
@@ -1,6 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
-import { IconButton, Tooltip } from 'gestalt';
+import { IconButton } from 'gestalt';
 import trackButtonClick from './trackButtonClick.js';
 
 type Props = {|
@@ -11,20 +11,19 @@ export default function OpenSandboxButton({ onClick }: Props): Node {
   const label = 'Open in CodeSandbox';
 
   return (
-    <Tooltip inline text={label} idealDirection="up">
-      <IconButton
-        accessibilityLabel={label}
-        dangerouslySetSvgPath={{
-          __path:
-            'M9.365 21.17v-8.645L1.93 8.248v4.928l3.405 1.974v3.705l4.029 2.314zm1.93.05l4.104-2.363v-3.794l3.427-1.986V8.211l-7.53 4.348v8.661zm6.54-14.666L13.878 4.26l-3.475 2.017L6.9 4.257 2.907 6.583l7.452 4.288 7.477-4.316zM0 18.017V6.04L10.377 0l10.38 6.015v11.983l-10.38 5.98L0 18.018z',
-        }}
-        iconColor="darkGray"
-        onClick={() => {
-          trackButtonClick(label);
-          onClick();
-        }}
-        size="xs"
-      />
-    </Tooltip>
+    <IconButton
+      accessibilityLabel={label}
+      dangerouslySetSvgPath={{
+        __path:
+          'M9.365 21.17v-8.645L1.93 8.248v4.928l3.405 1.974v3.705l4.029 2.314zm1.93.05l4.104-2.363v-3.794l3.427-1.986V8.211l-7.53 4.348v8.661zm6.54-14.666L13.878 4.26l-3.475 2.017L6.9 4.257 2.907 6.583l7.452 4.288 7.477-4.316zM0 18.017V6.04L10.377 0l10.38 6.015v11.983l-10.38 5.98L0 18.018z',
+      }}
+      iconColor="darkGray"
+      onClick={() => {
+        trackButtonClick(label);
+        onClick();
+      }}
+      size="xs"
+      tooltip={{ text: label, inline: true, idealDirection: 'up', accessibilityLabel: '' }}
+    />
   );
 }

--- a/docs/pages/icon.js
+++ b/docs/pages/icon.js
@@ -87,9 +87,9 @@ export default function IconPage({ generatedDocGen }: {| generatedDocGen: DocGen
             type="don't"
             description="Don't create interactive Icons using TapArea. Use [IconButton](/iconbutton) instead."
             defaultCode={`
-<Tooltip text="Share pin">
+<Tooltip text="Share pin" accessibilityLabel="">
   <TapArea>
-    <Icon icon="share" accessibilityLabel="" color="darkGray" />
+    <Icon icon="share" accessibilityLabel="Share Pin" color="darkGray" />
   </TapArea>
 </Tooltip>`}
           />

--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -522,7 +522,7 @@ function OrderDropdownExample() {
         <MainSection.Subsection
           title="ARIA attributes"
           description={`
-IconButton conveys the component behavior using iconography. IconButton requires \`accessibilityLabel\`, a text description for screen readers to announce and communicate the represented [Icon](/icon). In the example below, the screen reader reads: "More Options. The label should describe the intent of the action, not the Icon itself."
+IconButton conveys the component behavior using iconography. IconButton requires \`accessibilityLabel\`, a text description for screen readers to announce and communicate the represented [Icon](/icon). In the example below, the screen reader reads: "Create Pin menu". **The label should describe the intent of the action, not the Icon itself.** For example, use "Edit board" instead of "Pencil".
 
 If IconButton is used as a control button to show/hide a Popover-based component, we recommend passing the following ARIA attributes to assist screen readers:
 

--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -163,7 +163,7 @@ function SectionsIconButtonDropdownExample() {
           },
           {
             name: 'tooltip',
-            type: `{| text: string, inline?: boolean, idealDirection?: 'up' | 'right' | 'down' | 'left', zIndex?: Indexable, |}`,
+            type: `{| text: string, accessibilityLabel?: string, inline?: boolean, idealDirection?: 'up' | 'right' | 'down' | 'left', zIndex?: Indexable, |}`,
             description: `Adds a [Tooltip](/tooltip) on hover/focus of the IconButton. See the [With Tooltip](#With-Tooltip) variant to learn more.`,
           },
         ]}
@@ -522,7 +522,7 @@ function OrderDropdownExample() {
         <MainSection.Subsection
           title="ARIA attributes"
           description={`
-IconButton conveys the component behavior using iconography. IconButton requires \`accessibilityLabel\`, a text description for screen readers to announce and communicate the represented [Icon](/icon). In the example below, the screen reader reads: "More Options."
+IconButton conveys the component behavior using iconography. IconButton requires \`accessibilityLabel\`, a text description for screen readers to announce and communicate the represented [Icon](/icon). In the example below, the screen reader reads: "More Options. The label should describe the intent of the action, not the Icon itself."
 
 If IconButton is used as a control button to show/hide a Popover-based component, we recommend passing the following ARIA attributes to assist screen readers:
 
@@ -763,19 +763,32 @@ Follow these guidelines for \`bgColor\`
         </MainSection.Subsection>
         <MainSection.Subsection
           title="With Tooltip"
-          description="By specifying the `tooltip` property, a [Tooltip](/tooltip) will automatically be triggered when IconButton is hovered or focused."
+          description={`
+            By specifying the \`tooltip\` property, a [Tooltip](/tooltip) will automatically be triggered when IconButton is hovered or focused. If the Tooltip \`text\` does not provide more information than the IconButton \`accessibilityLabel\`, set the tooltip prop's \`accessibilityLabel\` to an empty string, as seen below in the Edit example.
+          `}
         >
           <MainSection.Card
             cardSize="md"
             defaultCode={`
-<IconButton
-  accessibilityLabel="Sharing"
-  icon="share"
-  tooltip={{
-    text: "This Pin is private unless you share it with others.",
-    idealDirection: "up"
-  }}
-/>
+<Flex gap={4}>
+  <IconButton
+    accessibilityLabel="Sharing"
+    icon="share"
+    tooltip={{
+      text: "This Pin is private unless you share it with others.",
+      idealDirection: "up"
+    }}
+  />
+  <IconButton
+    accessibilityLabel="Edit"
+    icon="edit"
+    tooltip={{
+      text: "Edit",
+      accessibilityLabel: "",
+      idealDirection: "up"
+    }}
+  />
+</Flex>
 `}
           />
         </MainSection.Subsection>
@@ -838,7 +851,7 @@ function SectionsIconButtonDropdownExample() {
         ref={anchorRef}
         selected={open}
         size="lg"
-        tooltip={{text: "Create", idealDirection: "up"}}
+        tooltip={{text: "Create", accessibilityLabel: "", idealDirection: "up"}}
       />
       {open && (
         <Dropdown anchor={anchorRef.current} id="sections-dropdown-example" onDismiss={() => setOpen(false)}>
@@ -889,14 +902,14 @@ function IconButtonPopoverExample() {
   return (
     <React.Fragment>
       <IconButton
-        accessibilityLabel="Love Reaction to a Pin"
+        accessibilityLabel="Favorite this Pin"
         bgColor="white"
         icon="heart"
         iconColor="red"
         onClick={() => { setOpen(true), setChecked(!checked) } }
         selected={checked}
         ref={anchorRef}
-        tooltip={{text: "Favorite pin"}}
+        tooltip={{text: "Favorite this pin", accessibilityLabel: ""}}
       />
       {open && checked &&(
         <Popover

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -14,7 +14,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         description={generatedDocGen?.description}
         defaultCode={`
       <Flex>
-        <Tooltip text="Align left">
+        <Tooltip text="Align left" accessibilityLabel="">
           <IconButton
             accessibilityLabel="Align left"
             bgColor="white"
@@ -23,7 +23,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             size="lg"
           />
         </Tooltip>
-        <Tooltip text="Align center">
+        <Tooltip text="Align center" accessibilityLabel="">
           <IconButton
             accessibilityLabel="Align center"
             bgColor="white"
@@ -32,7 +32,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             size="lg"
           />
         </Tooltip>
-        <Tooltip text="Align right">
+        <Tooltip text="Align right" accessibilityLabel="">
           <IconButton
             accessibilityLabel="Align right"
             bgColor="white"
@@ -76,9 +76,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             type="do"
             description="Use Tooltip to describe the function of an interactive element, typically [Icon Button](/iconbutton), in as few words as possible."
             defaultCode={`
-<Tooltip text="Send Pin">
+<Tooltip text="Send Pin" accessibilityLabel="">
   <IconButton
-    accessibilityLabel=""
+    accessibilityLabel="Send Pin"
     bgColor="white"
     icon="share"
     iconColor="darkGray"
@@ -104,25 +104,25 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description="Use Tooltip to distinguish related actions with visually similar iconography."
             defaultCode={`
 <Flex>
-  <Tooltip text="Align left">
+  <Tooltip text="Align left" accessibilityLabel="">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Align left"
       bgColor="white"
       icon="text-align-left"
       iconColor="darkGray"
       size="lg"
     />
   </Tooltip>
-  <Tooltip text="Align center">
+  <Tooltip text="Align center" accessibilityLabel="">
     <IconButton
-      accessibilityLabel=""
+      accessibilityLabel="Align center"
       bgColor="white"
       icon="text-align-center"
       iconColor="darkGray"
       size="lg"
     />
   </Tooltip>
-  <Tooltip text="Align right">
+  <Tooltip text="Align right" accessibilityLabel="">
     <IconButton
       accessibilityLabel="Align right"
       bgColor="white"
@@ -223,7 +223,7 @@ When using Tooltip with [IconButton](/iconbutton), avoid repetitive labeling. Th
             defaultCode={`
 <Tooltip text="Share" accessibilityLabel="">
   <IconButton
-    accessibilityLabel=""
+    accessibilityLabel="Share"
     bgColor="white"
     icon="share"
     iconColor="darkGray"
@@ -298,6 +298,7 @@ If you need to explain why an item is disabled, consider adding plain [Text](/te
         idealDirection={idealDirection}
         inline
         text="Share"
+        accessibilityLabel=""
         >
           <IconButton
             accessibilityLabel="Share this Pin"
@@ -329,12 +330,12 @@ function SectionsIconButtonDropdownExample() {
   return (
     <Box width={600}>
       <Heading accessibilityLevel={4}>Sugar-Free Strawberry-Chocolate Greek Yogurt Bark Three-Step Recipe.
-        <Tooltip inline text="More board options" idealDirection="right">
+        <Tooltip inline text="More board options" idealDirection="right" accessibilityLabel="">
           <IconButton
             accessibilityControls="sections-dropdown-example"
             accessibilityHaspopup
             accessibilityExpanded={open}
-            accessibilityLabel=""
+            accessibilityLabel="More board options"
             bgColor="lightGray"
             icon="ellipsis"
             iconColor="darkGray"

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -201,7 +201,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         <MainSection.Subsection
           title="Labels"
           description={`
-When using Tooltip with [IconButton](/iconbutton), avoid repetitive labeling. The \`accessibilityLabel\` provided to IconButton should describe the intent of the button, not the icon itself. For instance, use “Settings” instead of “Cog icon”. Tooltip \`text\` can expand upon that intention, as seen with the \`cog\` IconButton. If Tooltip \`text\` and IconButton \`accessibilityLabel\` contain the same content, pass an empty string to \`accessibilityLabel\`, as seen with the \`send\` IconButton.`}
+When using Tooltip with [IconButton](/iconbutton), avoid repetitive labeling. The \`accessibilityLabel\` provided to IconButton should describe the intent of the button, not the icon itself. For instance, use “Settings” instead of “Cog icon”. Tooltip \`text\` should expand upon that intention, as seen in the "cog" example below. If Tooltip \`text\` is the same as IconButton \`accessibilityLabel\`, then add \`accessibilityLabel=""\` to the Tooltip, as seen with the "share" example below`}
           columns={2}
         >
           <MainSection.Card
@@ -221,7 +221,7 @@ When using Tooltip with [IconButton](/iconbutton), avoid repetitive labeling. Th
           <MainSection.Card
             cardSize="md"
             defaultCode={`
-<Tooltip text="Send Pin">
+<Tooltip text="Share" accessibilityLabel="">
   <IconButton
     accessibilityLabel=""
     bgColor="white"

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -16,6 +16,7 @@ import { type Indexable } from './zIndex.js';
 
 type TooltipType = {|
   text: string,
+  accessibilityLabel?: string,
   inline?: boolean,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   zIndex?: Indexable,

--- a/packages/gestalt/src/IconButton.test.js
+++ b/packages/gestalt/src/IconButton.test.js
@@ -40,6 +40,22 @@ test('IconButton renders with tooltip', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('IconButton renders with tooltip and no accessibilityLabel', () => {
+  const component = create(
+    <IconButton
+      accessibilityLabel="Share"
+      icon="share"
+      tooltip={{
+        text: 'Share',
+        idealDirection: 'up',
+        accessibilityLabel: '',
+      }}
+    />,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('accessibilityControls', () => {
   const instance = create(
     <IconButton accessibilityLabel="" accessibilityControls="another-element" />,

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -45,7 +45,7 @@ const reducer = (state, action) => {
 
 type Props = {|
   /**
-   * Label to provide more context around the Tooltip’s function or purpose. By default `text` is used but this prop allows you to override it. Should only be used in very rare cases
+   * Label to provide more context around the Tooltip’s function or purpose. By default `text` is used but this prop allows you to override it. Learn more about when to override it in the [Accessibility](https://gestalt.pinterest.systems/tooltip#Labels) section.
    */
   accessibilityLabel?: string,
   /**

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -189,3 +189,60 @@ exports[`IconButton renders with tooltip 1`] = `
   </div>
 </div>
 `;
+
+exports[`IconButton renders with tooltip and no accessibilityLabel 1`] = `
+<div
+  className="box xsDisplayBlock"
+>
+  <div
+    aria-label=""
+    className="box"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <button
+      aria-label="Share"
+      className="button tapTransition enabled"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="pog transparent"
+        style={
+          Object {
+            "height": 40,
+            "width": 40,
+          }
+        }
+      >
+        <svg
+          aria-hidden={true}
+          aria-label=""
+          className="icon gray iconBlock"
+          height={18}
+          role="img"
+          viewBox="0 0 24 24"
+          width={18}
+        >
+          <path
+            d="test-file-stub"
+          />
+        </svg>
+      </div>
+    </button>
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Summary

#### What changed?

Avoid duplicate, redundant tooltips on IconButton by allowing accessibilityLabel to be empty on Tooltip

#### Why?

Right now, we require an accessibilityLabel on IconButton, and when that gets wrapped in a tooltip, we create a redundant experience when the accessibilityLabel and Tooltip text match (simple iconButtons like share). This change recommends people override the tooltip accessibilityLabel to be an empty string, thereby allowing screen readers to only read out the content on the button itself. 

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
