### PR TITLE
ComboBox: updated Docs to use autogenerated prop table

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -102,7 +102,10 @@ export default function GeneratedPropTable({
         .replace(/ComponentType/g, 'React.ComponentType')
         // Replace "Element" with "React.Element" to match docs convention
         // Includes `<` to avoid picking up `HTMLDivElement` and similar
-        .replace(/Element</g, 'React.Element<');
+        .replace(/Element</g, 'React.Element<')
+        // Replace "Ref" with "React.Ref" to match docs convention
+        // Includes `<` to avoid picking up `HTMLDivElement` and similar
+        .replace(/Ref</g, 'React.Ref<');
 
       return {
         name: key,

--- a/docs/pages/combobox.js
+++ b/docs/pages/combobox.js
@@ -2,7 +2,7 @@
 import type { Node } from 'react';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
-import docgen, { overrideTypes, type DocGen } from '../components/docgen.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 
@@ -751,32 +751,7 @@ Use Fieldset to group related form items.
 }
 
 export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
-  const generatedDocGen = await docgen({ componentName: 'ComboBox' });
-
-  const ComboBoxItemTypeNote = `*ComboBoxItemType = {|
-  label: string,
-  subtext?: string,
-  value: string,
-|}`;
-
-  const overriddenDocGen = overrideTypes(generatedDocGen, {
-    options: `${generatedDocGen.props.options.flowType.raw || 'ComboBoxItemType'}
-    ${ComboBoxItemTypeNote}`,
-    onSelect: `${generatedDocGen.props.onSelect.flowType.raw || 'ComboBoxItemType'}
-    ${ComboBoxItemTypeNote}`,
-    selectedOption: `${generatedDocGen.props.selectedOption.flowType.raw || 'ComboBoxItemType'}
-    ${ComboBoxItemTypeNote}`,
-  });
-
-  overriddenDocGen.props.ref = {
-    defaultValue: null,
-    description:
-      'Forward the ref to the underlying component container element. See the [Ref](https://gestalt.pinterest.systems/combobox#Ref) variant to learn more about focus management.',
-    flowType: { name: 'string', raw: 'React.Ref<"input">' },
-    required: false,
-  };
-
   return {
-    props: { generatedDocGen: overriddenDocGen },
+    props: { generatedDocGen: await docgen({ componentName: 'ComboBox' }) },
   };
 }

--- a/docs/pages/combobox.js
+++ b/docs/pages/combobox.js
@@ -1,10 +1,10 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
-import docgen, { type DocGen } from '../components/docgen.js';
+import docgen, { overrideTypes, type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 
 export default function ComboBoxPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -56,135 +56,8 @@ function ComboBoxExample(props) {
 }
 `}
       />
-      <PropTable
-        props={[
-          {
-            name: 'options',
-            type: 'Array<{| label: string, value: string, subtext: string |}>',
-            description:
-              'The data for each selection option. See [subtext](#With-subtext) variant to learn more',
-            required: true,
-          },
-          {
-            name: 'inputValue',
-            type: 'string',
-            description:
-              'The user input in ComboBox for controlled components. See [controlled ComboBox](#Controlled-vs-Uncontrolled) variant to learn more.',
-          },
-          {
-            name: 'id',
-            type: 'string',
-            description:
-              'Unique id to identify each ComboBox. Used for [accessibility](#Accessibility) purposes.',
-            required: true,
-          },
-          {
-            name: 'label',
-            type: 'string',
-            description: 'Provide a label to identify the ComboBox field.',
-            required: true,
-          },
-          {
-            name: 'labelDisplay',
-            type: `'visible'|'hidden'`,
-            defaultValue: 'visible',
-            description:
-              'Whether the label should be visible or not. If `hidden`, the label is still available for screen reader users, but does not appear visually. See the [label visibility variant](#Label-visibility) for more info.',
-          },
-          {
-            name: 'disabled',
-            type: 'boolean',
-            defaultValue: false,
-            description:
-              'When disabled, ComboBox looks inactive and cannot be interacted with. If tags are passed, they will appear disabled as well and cannot be removed. See [tags](#Tags) variant to learn more.',
-          },
-          {
-            name: 'helperText',
-            type: 'string',
-            description: 'Provides additional information about how to select a ComboBox option.',
-          },
-          {
-            name: 'accessibilityClearButtonLabel',
-            type: 'string',
-            required: true,
-            description: "Label to describe the clear button's purpose.",
-          },
-          {
-            name: 'errorMessage',
-            type: 'string',
-            description:
-              'Provide feedback when an error on selection occurs. See [error message](#Error-message) variant.',
-          },
-          {
-            name: 'noResultText',
-            type: 'string',
-            required: true,
-            description: 'The text shown when the input value returns no matches',
-          },
-          {
-            name: 'onBlur',
-            type:
-              '({ event: SyntheticFocusEvent<HTMLInputElement> | SyntheticEvent<HTMLInputElement> , value: string }) => void',
-            description: 'Callback when you focus outside the component ',
-          },
-          {
-            name: 'onChange',
-            type: '({ event: SyntheticInputEvent<>, value: string }) => void',
-            description: 'Callback when user types into the control input field',
-          },
-          {
-            name: 'onClear',
-            type: '() => void',
-            description: 'Callback when user clicks on clear button',
-          },
-          {
-            name: 'onFocus',
-            type: '({ event: SyntheticFocusEvent<>, value: string }) => void',
-            description: 'Callback when you focus on the component',
-          },
-          {
-            name: 'onKeyDown',
-            type: '({ event: SyntheticKeyboardEvent<HTMLTextAreaElement>, value: string }) => void',
-            description: 'Callback for key stroke events. See [tags](#Tags) variant to learn more.',
-          },
-          {
-            name: 'onSelect',
-            type: '({ event: SyntheticInputEvent<>, value: string }) => void',
-            description: 'Callback when an item is selected',
-          },
-          {
-            name: 'placeholder',
-            type: 'string',
-            description:
-              'Specify a short description that suggests the expected input for the field',
-          },
-          {
-            name: 'selectedOption',
-            type: '{| label: string, value: string, subtext: string |}',
-            description:
-              'The selected option in ComboBox for controlled components. See [controlled ComboBox](#Controlled-vs-Uncontrolled) variant to learn more.',
-          },
-          {
-            name: 'size',
-            type: '"md" | "lg"',
-            description:
-              'Defines the height of ComboBox: md: 40px, lg: 48px. Width is defined by parent component.',
-            defaultValue: 'md',
-          },
-          {
-            name: 'tags',
-            type: 'Array<Element<typeof Tag>>',
-            description:
-              'List of tags to display in the component. See [tags](#Tags) variant to learn more.',
-          },
-          {
-            name: 'ref',
-            type: "React.Ref<'input'>",
-            description:
-              'Forward the ref to the underlying component container element. See [focus management](#Ref) variant to learn more',
-          },
-        ]}
-      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -834,7 +707,10 @@ function ComboBoxExample(props) {
 }`}
           />
         </MainSection.Subsection>
-        <MainSection.Subsection title="Error message">
+        <MainSection.Subsection
+          title="Error message"
+          description="For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/link) or [TapArea](https://gestalt.pinterest.systems/taparea)"
+        >
           <MainSection.Card
             cardSize="lg"
             defaultCode={`
@@ -875,7 +751,32 @@ Use Fieldset to group related form items.
 }
 
 export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  const generatedDocGen = await docgen({ componentName: 'ComboBox' });
+
+  const ComboBoxItemTypeNote = `*ComboBoxItemType = {|
+  label: string,
+  subtext?: string,
+  value: string,
+|}`;
+
+  const overriddenDocGen = overrideTypes(generatedDocGen, {
+    options: `${generatedDocGen.props.options.flowType.raw || 'ComboBoxItemType'}
+    ${ComboBoxItemTypeNote}`,
+    onSelect: `${generatedDocGen.props.onSelect.flowType.raw || 'ComboBoxItemType'}
+    ${ComboBoxItemTypeNote}`,
+    selectedOption: `${generatedDocGen.props.selectedOption.flowType.raw || 'ComboBoxItemType'}
+    ${ComboBoxItemTypeNote}`,
+  });
+
+  overriddenDocGen.props.ref = {
+    defaultValue: null,
+    description:
+      'Forward the ref to the underlying component container element. See the [Ref](https://gestalt.pinterest.systems/combobox#Ref) variant to learn more about focus management.',
+    flowType: { name: 'string', raw: 'React.Ref<"input">' },
+    required: false,
+  };
+
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'ComboBox' }) },
+    props: { generatedDocGen: overriddenDocGen },
   };
 }

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -19,7 +19,7 @@ import Popover from './Popover.js';
 import Text from './Text.js';
 import InternalTextField from './InternalTextField.js';
 import Tag from './Tag.js';
-import ComboBoxItem, { type ComboBoxItemType } from './ComboBoxItem.js';
+import ComboBoxItem from './ComboBoxItem.js';
 import { ESCAPE, TAB, ENTER, UP_ARROW, DOWN_ARROW } from './keyCodes.js';
 import handleContainerScrolling, {
   KEYS,
@@ -27,6 +27,11 @@ import handleContainerScrolling, {
 } from './utils/keyboardNavigation.js';
 
 type Size = 'md' | 'lg';
+type OptionType = {|
+  label: string,
+  subtext?: string,
+  value: string,
+|};
 
 type Props = {|
   /**
@@ -110,11 +115,7 @@ type Props = {|
    */
   onSelect?: ({|
     event: SyntheticInputEvent<HTMLElement> | SyntheticKeyboardEvent<HTMLElement>,
-    item: {|
-      label: string,
-      subtext?: string,
-      value: string,
-    |},
+    item: OptionType,
   |}) => void,
   /**
    * Specify a short description that suggests the expected input for the field.
@@ -128,11 +129,7 @@ type Props = {|
   /**
    * The selected option in ComboBox for controlled components. See [controlled ComboBox](https://gestalt.pinterest.systems/combobox#Controlled-vs-Uncontrolled) variant to learn more.
    */
-  selectedOption?: {|
-    label: string,
-    subtext?: string,
-    value: string,
-  |},
+  selectedOption?: OptionType,
   /**
    * Defines the height of ComboBox: md: 40px, lg: 48px. Width is defined by parent component.
    */
@@ -186,8 +183,8 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
 
   const [hoveredItemIndex, setHoveredItemIndex] = useState<null | number>(null);
   const [showOptionsList, setShowOptionsList] = useState<boolean>(false);
-  const [selectedItem, setSelectedItem] = useState<?ComboBoxItemType>(null);
-  const [suggestedOptions, setSuggestedOptions] = useState<$ReadOnlyArray<ComboBoxItemType>>(
+  const [selectedItem, setSelectedItem] = useState<?OptionType>(null);
+  const [suggestedOptions, setSuggestedOptions] = useState<$ReadOnlyArray<OptionType>>(
     options,
   );
   const [textfieldInput, setTextfieldInput] = useState<string>('');

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -28,42 +28,100 @@ import handleContainerScrolling, {
 type Size = 'md' | 'lg';
 
 type Props = {|
-  // REQUIRED
+  /**
+   * Label to describe the clear button's purpose.
+   */
   accessibilityClearButtonLabel: string,
+  /**
+   * Unique id to identify each ComboBox. Used for [accessibility](https://gestalt.pinterest.systems/combobox#Accessibility) purposes.
+   */
   id: string,
+  /**
+   * Provide a label to identify the ComboBox field.
+   */
   label: string,
+  /**
+   * The data for each selection option. See [subtext](https://gestalt.pinterest.systems/combobox#With-subtext) variant to learn more.
+   */
   options: $ReadOnlyArray<ComboBoxItemType>,
+  /**
+   * The text shown when the input value returns no matches.
+   */
   noResultText: string,
-  // OPTIONAL
+  /**
+   * When disabled, ComboBox looks inactive and cannot be interacted with. If tags are passed, they will appear disabled as well and cannot be removed. See [tags](https://gestalt.pinterest.systems/combobox#Tags) variant to learn more.
+   */
   disabled?: boolean,
+  /**
+   * Provide feedback when an error on selection occurs. See [error message](https://gestalt.pinterest.systems/combobox#Error-message) variant.
+   */
   errorMessage?: Node,
+  /**
+   * Provides additional information about how to select a ComboBox option.
+   */
   helperText?: string,
+  /**
+   * The user input in ComboBox for controlled components. See [controlled ComboBox](https://gestalt.pinterest.systems/combobox#Controlled-vs-Uncontrolled) variant to learn more.
+   */
   inputValue?: string | null,
+  /**
+   * Whether the label should be visible or not. If `hidden`, the label is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems/combobox#Label-visibility) for more info.
+   */
   labelDisplay?: 'visible' | 'hidden',
+  /**
+   * Callback when you focus outside the component.
+   */
   onBlur?: ({|
     event: SyntheticFocusEvent<HTMLInputElement> | SyntheticEvent<HTMLInputElement>,
     value: string,
   |}) => void,
+  /**
+   * Callback when user types into the control input field.
+   */
   onChange?: ({|
     value: string,
     event: SyntheticInputEvent<HTMLInputElement>,
   |}) => void,
+  /**
+   * Callback when user clicks on clear button.
+   */
   onClear?: () => void,
+  /**
+   * Callback when you focus on the component.
+   */
   onFocus?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
     value: string,
   |}) => void,
+  /**
+   * Callback for key stroke events. See [tags](#Tags) variant to learn more.
+   */
   onKeyDown?: ({|
     event: SyntheticKeyboardEvent<HTMLInputElement>,
     value: string,
   |}) => void,
+  /**
+   * Callback when an item is selected.
+   */
   onSelect?: ({|
     event: SyntheticInputEvent<HTMLElement> | SyntheticKeyboardEvent<HTMLElement>,
     item: ComboBoxItemType,
   |}) => void,
+  /**
+   * Specify a short description that suggests the expected input for the field.
+   */
   placeholder?: string,
+  /**
+   * The selected option in ComboBox for controlled components. See [controlled ComboBox](https://gestalt.pinterest.systems/combobox#Controlled-vs-Uncontrolled) variant to learn more.
+   */
   selectedOption?: ComboBoxItemType,
+  /**
+   * Defines the height of ComboBox: md: 40px, lg: 48px. Width is defined by parent component.
+   */
   size?: Size,
+  /**
+   * List of tags to display in the component. See [tags](https://gestalt.pinterest.systems/combobox#Tags) variant to learn more.
+   */
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
 |};
 

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -11,6 +11,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type Ref,
 } from 'react';
 import Box from './Box.js';
 import Layer from './Layer.js';
@@ -43,7 +44,11 @@ type Props = {|
   /**
    * The data for each selection option. See [subtext](https://gestalt.pinterest.systems/combobox#With-subtext) variant to learn more.
    */
-  options: $ReadOnlyArray<ComboBoxItemType>,
+  options: $ReadOnlyArray<{|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>,
   /**
    * The text shown when the input value returns no matches.
    */
@@ -105,16 +110,29 @@ type Props = {|
    */
   onSelect?: ({|
     event: SyntheticInputEvent<HTMLElement> | SyntheticKeyboardEvent<HTMLElement>,
-    item: ComboBoxItemType,
+    item: {|
+      label: string,
+      subtext?: string,
+      value: string,
+    |},
   |}) => void,
   /**
    * Specify a short description that suggests the expected input for the field.
    */
   placeholder?: string,
+  // The ref prop is unused and listed here just for documentation purposes.
+  /**
+   * Forward the ref to the underlying component container element. See the [Ref](https://gestalt.pinterest.systems/combobox#Ref) variant to learn more about focus management.
+   */
+  ref?: Ref<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
    * The selected option in ComboBox for controlled components. See [controlled ComboBox](https://gestalt.pinterest.systems/combobox#Controlled-vs-Uncontrolled) variant to learn more.
    */
-  selectedOption?: ComboBoxItemType,
+  selectedOption?: {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |},
   /**
    * Defines the height of ComboBox: md: 40px, lg: 48px. Width is defined by parent component.
    */

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -3,8 +3,6 @@ import {
   cloneElement,
   forwardRef,
   Fragment,
-  type Element,
-  type Node,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -12,6 +10,8 @@ import {
   useRef,
   useState,
   type Ref,
+  type Element,
+  type Node,
 } from 'react';
 import Box from './Box.js';
 import Layer from './Layer.js';
@@ -39,26 +39,6 @@ type Props = {|
    */
   accessibilityClearButtonLabel: string,
   /**
-   * Unique id to identify each ComboBox. Used for [accessibility](https://gestalt.pinterest.systems/combobox#Accessibility) purposes.
-   */
-  id: string,
-  /**
-   * Provide a label to identify the ComboBox field.
-   */
-  label: string,
-  /**
-   * The data for each selection option. See [subtext](https://gestalt.pinterest.systems/combobox#With-subtext) variant to learn more.
-   */
-  options: $ReadOnlyArray<{|
-    label: string,
-    subtext?: string,
-    value: string,
-  |}>,
-  /**
-   * The text shown when the input value returns no matches.
-   */
-  noResultText: string,
-  /**
    * When disabled, ComboBox looks inactive and cannot be interacted with. If tags are passed, they will appear disabled as well and cannot be removed. See [tags](https://gestalt.pinterest.systems/combobox#Tags) variant to learn more.
    */
   disabled?: boolean,
@@ -75,9 +55,21 @@ type Props = {|
    */
   inputValue?: string | null,
   /**
+   * Unique id to identify each ComboBox. Used for [accessibility](https://gestalt.pinterest.systems/combobox#Accessibility) purposes.
+   */
+  id: string,
+  /**
+   * Provide a label to identify the ComboBox field.
+   */
+  label: string,
+  /**
    * Whether the label should be visible or not. If `hidden`, the label is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems/combobox#Label-visibility) for more info.
    */
   labelDisplay?: 'visible' | 'hidden',
+  /**
+   * The text shown when the input value returns no matches.
+   */
+  noResultText: string,
   /**
    * Callback when you focus outside the component.
    */
@@ -89,8 +81,8 @@ type Props = {|
    * Callback when user types into the control input field.
    */
   onChange?: ({|
-    value: string,
     event: SyntheticInputEvent<HTMLInputElement>,
+    value: string,
   |}) => void,
   /**
    * Callback when user clicks on clear button.
@@ -115,8 +107,20 @@ type Props = {|
    */
   onSelect?: ({|
     event: SyntheticInputEvent<HTMLElement> | SyntheticKeyboardEvent<HTMLElement>,
-    item: OptionType,
+    item: {|
+      label: string,
+      subtext?: string,
+      value: string,
+    |},
   |}) => void,
+  /**
+   * The data for each selection option. See [subtext](https://gestalt.pinterest.systems/combobox#With-subtext) variant to learn more.
+   */
+  options: $ReadOnlyArray<{|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>,
   /**
    * Specify a short description that suggests the expected input for the field.
    */
@@ -149,10 +153,11 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
 >(function ComboBox(
   {
     accessibilityClearButtonLabel,
-    disabled,
+    disabled = false,
     errorMessage,
     helperText,
     id,
+    inputValue: controlledInputValue = null,
     label,
     labelDisplay = 'visible',
     noResultText,
@@ -164,10 +169,9 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
     onSelect,
     options,
     placeholder,
-    size,
-    tags,
+    size = 'md',
     selectedOption,
-    inputValue: controlledInputValue = null,
+    tags,
   }: Props,
   ref,
 ): Node {
@@ -184,9 +188,7 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
   const [hoveredItemIndex, setHoveredItemIndex] = useState<null | number>(null);
   const [showOptionsList, setShowOptionsList] = useState<boolean>(false);
   const [selectedItem, setSelectedItem] = useState<?OptionType>(null);
-  const [suggestedOptions, setSuggestedOptions] = useState<$ReadOnlyArray<OptionType>>(
-    options,
-  );
+  const [suggestedOptions, setSuggestedOptions] = useState<$ReadOnlyArray<OptionType>>(options);
   const [textfieldInput, setTextfieldInput] = useState<string>('');
 
   const isControlledInput = !(controlledInputValue === null || controlledInputValue === undefined);


### PR DESCRIPTION
### Summary

#### What changed?

ComboBox: updated Docs to use autogenerated prop table

#### Why?

Gestalt is moving in this direction, all components must autogenerate prop tables