### PR TITLE
Docs: automatically filter out "_fooProp" internal-only props

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -65,6 +65,11 @@ export default function GeneratedPropTable({
     .map((key: string) => {
       const { flowType, description, required, defaultValue } = generatedDocGen.props[key];
 
+      // Filter out "_fooInternalProp" internal props that we don't want to document
+      if (key.startsWith('_')) {
+        return null;
+      }
+
       // Filter out PropType only types & excluded props
       if (!flowType || excludeProps.includes(key)) {
         return null;


### PR DESCRIPTION
We don't use them often, but occasionally we need internal-only props for use in experiments and other unusual needs. This PR adjusts the automatic docs generation to filter these props out of the props table.