### PR TITLE
Masonry: use generated props table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Patch
 
-- Docs: automatically filter out "_fooProp" internal-only props (#1886)
+- Docs: automatically filter out "\_fooProp" internal-only props (#1886)
 
 ## 42.3.1 (Jan 27, 2022)
 

--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -98,6 +98,8 @@ export default function GeneratedPropTable({
       const transformedType = (flowType.raw?.replace(/^\|/, '').trim() ?? flowType.name ?? '')
         // Replace "Node" with "React.Node" to match docs convention
         .replace(/Node/g, 'React.Node')
+        // Replace "ComponentType" with "React.ComponentType" to match docs convention
+        .replace(/ComponentType/g, 'React.ComponentType')
         // Replace "Element" with "React.Element" to match docs convention
         // Includes `<` to avoid picking up `HTMLDivElement` and similar
         .replace(/Element</g, 'React.Element<');

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -9,7 +9,7 @@ import Page from '../components/Page.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 
-export default function ToastPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Toast">
       <PageHeader

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -28,12 +28,12 @@ type Layout =
 
 type Props<T> = {|
   /**
-   * The preferred/target item width. If `flexible` is set, the item width will
+   * The preferred/target item width. If 'flexible' is set, the item width will
    * grow to fill column space, and shrink to fit if below min columns.
    */
   columnWidth?: number,
   /**
-   * The component to render.
+   * A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item.
    */
   comp: ComponentType<{|
     data: T,
@@ -41,39 +41,26 @@ type Props<T> = {|
     isMeasuring: boolean,
   |}>,
   /**
-   * The preferred/target item width. Item width will grow to fill
-   * column space, and shrink to fit if below min columns.
+   * Item width will grow to fill column space and shrink to fit if below min columns.
    */
   flexible?: boolean,
   /**
-   * The amount of space between each item.
+   * The amount of vertical and horizontal space between each item, specified in pixels.
    */
   gutterWidth?: number,
-
   /**
-   * An array of all objects to display in the grid.
+   * An array of items to display that contains the information that `comp` needs to render.
    */
   items: $ReadOnlyArray<T>,
   /**
-   * Measurement Store
-   */
-  // $FlowFixMe[unclear-type]
-  measurementStore?: Cache<T, *>,
-  /**
-   * Minimum number of columns to display.
-   */
-  minCols: number,
-  /**
-   * Layout system to use for items
+   * MasonryUniformRowLayout will make it so that each row is as tall as the tallest item in that row.
    */
   layout?: Layout,
-  // Support legacy loadItems usage.
-  // TODO: Simplify non falsey flowtype.
-
   /**
    * A callback which the grid calls when we need to load more items as the user scrolls.
    * The callback should update the state of the items, and pass those in as props
    * to this component.
+   * Note that `scrollContainer` must be specified.
    */
   loadItems?:
     | false
@@ -83,27 +70,43 @@ type Props<T> = {|
         |},
       ) => void | boolean | { ... }),
   /**
-   * Function that the grid calls to get the scroll container.
+   * Masonry internally caches item sizes/positions using a measurement store. If `measurementStore` is provided, Masonry will use it as its cache and will keep it updated with future measurements. This is often used to prevent re-measurement when users navigate away and back to a grid. Create a new measurement store with `Masonry.createMeasurementStore()`.
+   */
+  // $FlowFixMe[unclear-type]
+  measurementStore?: Cache<T, *>,
+  /**
+   * Minimum number of columns to display.
+   */
+  minCols: number,
+  /**
+   * A function that returns a DOM node that Masonry uses for on-scroll event subscription. This DOM node is intended to be the most immediate ancestor of Masonry in the DOM that will have a scroll bar; in most cases this will be the `window` itself, although sometimes Masonry is used inside containers that have `overflow: auto`. `scrollContainer` is optional, although it is required for features such as `virtualize` and `loadItems`.
    * This is required if the grid is expected to be scrollable.
    */
   scrollContainer?: () => HTMLElement,
+  /**
+   * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsBottom` allows customization of the buffer size below the viewport, specified in pixels.
+   */
+  virtualBoundsBottom?: number,
+  /**
+   * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsTop` allows customization of the buffer size above the viewport, specified in pixels.
+   */
+  virtualBoundsTop?: number,
+  /**
+   * Specifies whether or not Masonry dynamically adds/removes content from the grid based on the user's viewport and scroll position. Note that `scrollContainer` must be specified when virtualization is used.
+   */
+  virtualize?: boolean,
+
   // Prop to help us conditionally/experimentally test a new React.setState(scrollPos) strategy.
   // See this.handleScroll fn for more details
   _deferScrollPositionUpdate?: boolean,
-  virtualBoundsTop?: number,
-  virtualBoundsBottom?: number,
-  /**
-   * Whether or not to use actual virtualization
-   */
-  virtualize?: boolean,
 |};
 
 type State<T> = {|
-  // $FlowFixMe[unclear-type]
-  measurementStore: Cache<T, *>,
   hasPendingMeasurements: boolean,
   isFetching: boolean,
   items: $ReadOnlyArray<T>,
+  // $FlowFixMe[unclear-type]
+  measurementStore: Cache<T, *>,
   scrollTop: number,
   width: ?number,
 |};


### PR DESCRIPTION
Of note:
- Several overrides were needed to match the current props table types and default values.
- getStaticProps serializes the props data to JSON, meaning that any `undefined` values will throw. I added a one-off helper to replace those values with `null`, which we can pull out to a more reusable location if needed for other components. I was specifically seeing issues with the component methods, so this will likely only be an issue for other class components.