### PR TITLE
Tabs, TextArea: use generated props tables

### DIFF
--- a/docs/pages/tabs.js
+++ b/docs/pages/tabs.js
@@ -1,18 +1,18 @@
 // @flow strict
 import type { Node } from 'react';
-import { Tabs } from 'gestalt';
-import PropTable from '../components/PropTable.js';
 import Example from '../components/Example.js';
-import PageHeader from '../components/PageHeader.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import MainSection from '../components/MainSection.js';
 import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
-export default function DocsPage(): Node {
+export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Tabs">
       <PageHeader
         name="Tabs"
-        description={`Tabs may be used navigate between multiple URLs. Tabs are intended as page-level navigation - if you're looking at just switching panels of content, please use [SegmentedControl](/segmentedcontrol).`}
+        description={generatedDocGen?.description}
         defaultCode={`
     function DefaultExample() {
       const [activeIndex, setActiveIndex] = React.useState(0);
@@ -32,39 +32,9 @@ export default function DocsPage(): Node {
     }
     `}
       />
-      <PropTable
-        Component={Tabs}
-        props={[
-          {
-            name: 'activeTabIndex',
-            type: 'number',
-            required: true,
-          },
-          {
-            name: 'bgColor',
-            type: `"default" | "transparent"`,
-            defaultValue: 'default',
-            description: `If Tabs is displayed in a container with a colored background, use this prop to remove the white tab background. See the [background color](#Background-color) example to learn more.`,
-          },
-          {
-            name: 'onChange',
-            type: `({| +event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>, +activeTabIndex: number, dangerouslyDisableOnNavigation: () => void  |}) => void`,
-            required: true,
-            description:
-              'If your app uses a tool such as react-router to navigate between pages, be sure to use onChange to navigate instead of getting a full page refresh with href',
-          },
-          {
-            name: 'tabs',
-            type: `Array<{| href: string, text: React.Node, id?: string, indicator?: 'dot' | number, ref?: {| current: ?HTMLElement |} |}>`,
-            required: true,
-          },
-          {
-            name: 'wrap',
-            type: 'boolean',
-            description: `By default, flex items will all try to fit onto one line. Use this prop to allow the items to wrap onto multiple lines, from top to bottom.`,
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -423,4 +393,10 @@ SegmentedControl is used to switch between views within a small area of content,
       </MainSection>
     </Page>
   );
+}
+
+export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: { generatedDocGen: await docgen({ componentName: 'Tabs' }) },
+  };
 }

--- a/docs/pages/textarea.js
+++ b/docs/pages/textarea.js
@@ -1,101 +1,20 @@
 // @flow strict
 import type { Node } from 'react';
-import Example from '../components/Example.js';
-import PropTable from '../components/PropTable.js';
-import PageHeader from '../components/PageHeader.js';
 import Card from '../components/Card.js';
+import Example from '../components/Example.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import MainSection from '../components/MainSection.js';
-import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
+import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="TextArea">
       <PageHeader name="TextArea" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'disabled',
-            type: 'boolean',
-            defaultValue: 'false',
-            href: 'disabledExample',
-          },
-          {
-            name: 'errorMessage',
-            type: 'React.Node',
-            href: 'errorMessageExample',
-            description:
-              'For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in Link or TapArea.',
-          },
-          {
-            name: 'ref',
-            type: "React.Ref<'textarea'>",
-            description: 'Forward the ref to the underlying textarea element',
-            href: 'refExample',
-          },
-          {
-            name: 'helperText',
-            type: 'string',
-            description: 'More information about how to complete the form field',
-            href: 'helperText',
-          },
-          {
-            name: 'id',
-            type: 'string',
-            required: true,
-            href: 'basicExample',
-          },
-          {
-            name: 'label',
-            type: 'string',
-          },
-          {
-            name: 'name',
-            type: 'string',
-          },
-          {
-            name: 'onBlur',
-            type: '({ event: SyntheticFocusEvent<HTMLTextAreaElement>, value: string }) => void',
-          },
-          {
-            name: 'onChange',
-            type: '({ event: SyntheticInputEvent<HTMLTextAreaElement>, value: string }) => void',
-            required: true,
-            href: 'basicExample',
-          },
-          {
-            name: 'onFocus',
-            type: '({ event: SyntheticFocusEvent<HTMLTextAreaElement>, value: string }) => void',
-          },
-          {
-            name: 'onKeyDown',
-            type: '({ event: SyntheticKeyboardEvent<HTMLTextAreaElement>, value: string }) => void',
-          },
-          {
-            name: 'placeholder',
-            type: 'string',
-            href: 'basicExample',
-          },
-          {
-            name: 'rows',
-            type: 'number',
-            description:
-              'Number of text rows to display. Note that tags take up more space, and will show fewer rows than specified.',
-            defaultValue: 3,
-          },
-          {
-            name: 'tags',
-            type: 'Array<Element<typeof Tag>>',
-            description: 'List of tags to display in the component',
-            href: 'tagsExample',
-          },
-          {
-            name: 'value',
-            type: 'string',
-            href: 'basicExample',
-          },
-        ]}
-      />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -80,6 +80,10 @@ type Props = {|
    */
   placeholder?: string,
   /**
+   * Ref that is forwarded to the underlying input element.
+   */
+  ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
+  /**
    * md: 40px, lg: 48px
    */
   size?: 'md' | 'lg',

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -4,15 +4,16 @@ import Box from './Box.js';
 import Flex from './Flex.js';
 import TapArea from './TapArea.js';
 import Text from './Text.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
-type OnChangeHandler = AbstractEventHandler<
-  | SyntheticMouseEvent<HTMLAnchorElement>
-  | SyntheticKeyboardEvent<HTMLAnchorElement>
-  | SyntheticMouseEvent<HTMLDivElement>
-  | SyntheticKeyboardEvent<HTMLDivElement>,
-  {| +activeTabIndex: number, dangerouslyDisableOnNavigation: () => void |},
->;
+type OnChangeHandler = ({|
+  event:
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>
+    | SyntheticMouseEvent<HTMLDivElement>
+    | SyntheticKeyboardEvent<HTMLDivElement>,
+  +activeTabIndex: number,
+  dangerouslyDisableOnNavigation: () => void,
+|}) => void;
 
 function Dot() {
   return (
@@ -190,15 +191,36 @@ const TabWithForwardRef: AbstractComponent<TabProps, HTMLElement> = forwardRef<
 TabWithForwardRef.displayName = 'Tab';
 
 type Props = {|
+  /**
+   * The index of the active tab.
+   */
   activeTabIndex: number,
+  /**
+   * If Tabs is displayed in a container with a colored background, use this prop to remove the white tab background. See the [background color example](https://gestalt.pinterest.systems/tabs#Background-color) to learn more.
+   */
   bgColor?: BgColor,
+  /**
+   * If your app uses a tool such as `react-router` to navigate between pages, be sure to use `onChange` to navigate instead of getting a full page refresh with `href`.
+   */
   onChange: OnChangeHandler,
-  tabs: $ReadOnlyArray<{| ...TabType, ref?: {| current: ?HTMLElement |} |}>,
+  /**
+   *
+   */
+  tabs: $ReadOnlyArray<{|
+    href: string,
+    id?: string,
+    indicator?: 'dot' | number,
+    ref?: {| current: ?HTMLElement |},
+    text: Node,
+  |}>,
+  /**
+   * By default, tabs will all try to fit onto one line. Use this prop to allow the items to wrap onto multiple lines, from top to bottom.
+   */
   wrap?: boolean,
 |};
 
 /**
- * https://gestalt.pinterest.systems/tabs
+ * [Tabs](https://gestalt.pinterest.systems/tabs) may be used navigate between multiple URLs. Tabs are intended as page-level navigation - if you're looking at just switching panels of content, please use [SegmentedControl](https://gestalt.pinterest.systems/segmentedcontrol).
  */
 export default function Tabs({
   activeTabIndex,

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -9,29 +9,86 @@ import FormHelperText from './FormHelperText.js';
 import FormLabel from './FormLabel.js';
 import Tag from './Tag.js';
 import styles from './TextArea.css';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 const ROW_HEIGHT = 24;
 const INPUT_PADDING_WITH_TAGS = 20;
 
 type Props = {|
+  /**
+   * Indicate if the input is currently disabled. See the [disabled example](https://gestalt.pinterest.systems/textArea#disabledExample) for more details.
+   */
   disabled?: boolean,
+  /**
+   * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in Link or TapArea. See the [error message example](https://gestalt.pinterest.systems/textArea#errorMessageExample) for more details.
+   */
   errorMessage?: Node,
+  /**
+   * This field is deprecated and will be removed soon. Please do not use.
+   */
   hasError?: boolean,
+  /**
+   * More information about how to complete the form field. See the [helper text example](https://gestalt.pinterest.systems/textArea#helperText) for more details.
+   */
   helperText?: string,
+  /**
+   * A unique identifier for the input.
+   */
   id: string,
+  /**
+   * The label for the input. Be sure to localize the text.
+   */
   label?: string,
+  /**
+   * A unique name for the input.
+   */
   name?: string,
-  onBlur?: AbstractEventHandler<SyntheticFocusEvent<HTMLTextAreaElement>, {| value: string |}>,
-  onChange: AbstractEventHandler<SyntheticInputEvent<HTMLTextAreaElement>, {| value: string |}>,
-  onFocus?: AbstractEventHandler<SyntheticFocusEvent<HTMLTextAreaElement>, {| value: string |}>,
-  onKeyDown?: AbstractEventHandler<
-    SyntheticKeyboardEvent<HTMLTextAreaElement>,
-    {| value: string |},
-  >,
+  /**
+   * Callback triggered when the user blurs the input.!
+   */
+  onBlur?: ({|
+    event: SyntheticFocusEvent<HTMLTextAreaElement>,
+    value: string,
+  |}) => void,
+  /**
+   * Callback triggered when the value of the input changes.
+   */
+  onChange: ({|
+    event: SyntheticInputEvent<HTMLTextAreaElement>,
+    value: string,
+  |}) => void,
+  /**
+   * Callback triggered when the user focuses the input.
+   */
+  onFocus?: ({|
+    event: SyntheticFocusEvent<HTMLTextAreaElement>,
+    value: string,
+  |}) => void,
+  /**
+   * Callback triggered when the user presses any key while the input is focused.
+   */
+  onKeyDown?: ({|
+    event: SyntheticKeyboardEvent<HTMLTextAreaElement>,
+    value: string,
+  |}) => void,
+  /**
+   * Placeholder text shown the the user has not yet input a value.
+   */
   placeholder?: string,
+  /**
+   * Ref that is forwarded to the underlying input element. See the [ref example](https://gestalt.pinterest.systems/textArea#refExample) for more details.
+   */
+  ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
+  /**
+   * Number of text rows to display. Note that tags take up more space, and will show fewer rows than specified.
+   */
   rows?: number,
+  /**
+   * List of tags to display in the component. See the [tags example](https://gestalt.pinterest.systems/textArea#tagsExample) for more details.
+   */
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
+  /**
+   * The current value of the input.
+   */
   value?: string,
 |};
 

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -69,6 +69,10 @@ type Props = {|
    */
   placeholder?: string,
   /**
+   * Ref that is forwarded to the underlying input element.
+   */
+  ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
+  /**
    * List of tags to display in the component.
    */
   tags?: $ReadOnlyArray<Element<typeof Tag>>,


### PR DESCRIPTION
also added the missing `ref` prop for TextField + NumberField (whoops)