### PR TITLE
Dropdown: updated Docs to use autogenerated prop table

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node } from 'react';
+import { type Node, type ComponentType } from 'react';
 import { type DocGen } from './docgen.js';
 import PropTable from './PropTable.js';
 
@@ -54,9 +54,15 @@ function getHref(
 }
 
 export default function GeneratedPropTable({
+  Component,
+  id,
+  name,
   generatedDocGen,
   excludeProps = [],
 }: {|
+  Component?: ComponentType<any>, // flowlint-line unclear-type:off
+  name?: string,
+  id?: string,
   generatedDocGen: DocGen,
   excludeProps?: $ReadOnlyArray<string>,
 |}): Node {
@@ -119,5 +125,5 @@ export default function GeneratedPropTable({
     })
     .filter(Boolean);
 
-  return <PropTable props={props} />;
+  return <PropTable Component={Component} name={name} id={id} props={props} />;
 }

--- a/docs/components/docgen.js
+++ b/docs/components/docgen.js
@@ -63,16 +63,18 @@ export async function multipledocgen({
 }: {|
   componentName: Array<string> | string,
   alternativeSubdirectory?: string,
-|}): Promise<Array<DocGen>> {
-  const parsedPropTables = await Promise.all(
+|}): Promise<{| [string]: DocGen |}> {
+  const docGenMap = {};
+  await Promise.all(
     (Array.isArray(componentName) ? componentName : [componentName]).map(async (cmp) => {
       const filePath = getFilePath(cmp, alternativeSubdirectory);
       const contents = await fs.promises.readFile(filePath, 'utf-8');
-      return getParsedContent(contents);
+      docGenMap[cmp] = getParsedContent(contents);
+      return cmp;
     }),
   );
 
-  return parsedPropTables;
+  return docGenMap;
 }
 
 export function overrideTypes(docGen: DocGen, typeOverrides: {| [string]: string |}): DocGen {

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -10,13 +10,13 @@ import GeneratedPropTable from '../components/GeneratedPropTable.js';
 export default function DropdownPage({
   generatedDocGen,
 }: {|
-  generatedDocGen: Array<DocGen>,
+  generatedDocGen: {| [string]: DocGen |},
 |}): Node {
   return (
     <Page title="Dropdown">
       <PageHeader
         name="Dropdown"
-        description={generatedDocGen[0]?.description}
+        description={generatedDocGen.Dropdown?.description}
         badge="pilot"
         defaultCode={`
       function IntroMenuButtonDropdownExample() {
@@ -77,7 +77,7 @@ export default function DropdownPage({
         );
       }`}
       />
-      <GeneratedPropTable generatedDocGen={generatedDocGen[0]} excludeProps={['index']} />
+      <GeneratedPropTable generatedDocGen={generatedDocGen.Dropdown} excludeProps={['index']} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -550,19 +550,21 @@ function TruncationDropdownExample() {
         Component={Dropdown?.Item}
         name="Dropdown.Item"
         id="Dropdown.Item"
-        generatedDocGen={generatedDocGen[1]}
+        generatedDocGen={generatedDocGen.DropdownItem}
+        excludeProps={['index']}
       />
       <GeneratedPropTable
         Component={Dropdown?.Link}
         name="Dropdown.Link"
         id="Dropdown.Link"
-        generatedDocGen={generatedDocGen[2]}
+        generatedDocGen={generatedDocGen.DropdownLink}
+        excludeProps={['index']}
       />
       <GeneratedPropTable
         Component={Dropdown?.Section}
         name="Dropdown.Section"
         id="Dropdown.Section"
-        generatedDocGen={generatedDocGen[3]}
+        generatedDocGen={generatedDocGen.DropdownSection}
       />
       <MainSection name="Variants">
         <MainSection.Subsection title="Types of items" columns={2}>
@@ -1053,15 +1055,15 @@ OnLinkNavigationProvider allows external link navigation control across all chil
 }
 
 export async function getStaticProps(): Promise<{|
-  props: {| generatedDocGen: Array<DocGen> | DocGen |},
+  props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
   const docGen = await multipledocgen({
     componentName: ['Dropdown', 'DropdownItem', 'DropdownLink', 'DropdownSection'],
   });
 
-  docGen[0].props.children.flowType.raw =
+  docGen.Dropdown.props.children.flowType.raw =
     'React.ChildrenArray<React.Element<typeof DropdownItem | typeof DropdownSection>>';
-  docGen[3].props.children.flowType.raw =
+  docGen.DropdownSection.props.children.flowType.raw =
     'React.ChildrenArray<React.Element<typeof DropdownItem | typeof DropdownSection>>';
 
   return {

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -6,6 +6,7 @@ import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 
 const commonDropdownItemProps = [
   {
@@ -99,64 +100,8 @@ export default function DropdownPage({ generatedDocGen }: {| generatedDocGen: Do
         );
       }`}
       />
-      <PropTable
-        Component={Dropdown}
-        id="Dropdown"
-        props={[
-          {
-            name: 'anchor',
-            type: '?HTMLElement',
-            description:
-              'Ref for the element that the Dropdown will attach to, will most likely be a [Button](/button). See the [Accessibility](#Accessibility) guidelines to learn more.',
-          },
-          {
-            name: 'children',
-            required: true,
-            type:
-              'React.ChildrenArray<React.Element<typeof DropdownItem | typeof DropdownSection>>',
-            description:
-              'Must be instances of Dropdown.Item, Dropdown.Link or Dropdown.Section components. See the [Types of items](#Types-of-items) variant to learn more.',
-          },
-          {
-            name: 'headerContent',
-            type: 'React.Node',
-            description:
-              'Content to display at the top of the Dropdown before any items or sections. See the [Custom header](#Custom-header) variant to learn more.',
-          },
-          {
-            name: 'id',
-            type: 'string',
-            required: true,
-            description:
-              'Unique id to identify each Dropdown. Used for [Accessibility](#Accessibility) purposes.',
-          },
-          {
-            name: 'idealDirection',
-            type: `'up' | 'right' | 'down' | 'left'`,
-            description: 'Preferred direction for the Dropdown to open.',
-            defaultValue: 'down',
-          },
-          {
-            name: 'isWithinFixedContainer',
-            type: 'boolean',
-            defaultValue: false,
-            description:
-              'Enables correct behavior when Dropdown is used within a fixed container. To achieve this it removes the Layer component around Popover and enables positioning relative to its anchor element. Should only be used in cases where Layer breaks the Dropdown positionings such as when the anchor element is within a sticky component.',
-          },
-          {
-            name: 'onDismiss',
-            type: '() => void',
-            required: true,
-            description: 'Callback fired when the menu is closed.',
-          },
-          {
-            name: 'zIndex',
-            type: 'interface Indexable { index(): number; }',
-            description:
-              'An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](/zindex_classes)',
-          },
-        ]}
-      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -77,8 +77,7 @@ export default function DropdownPage({
         );
       }`}
       />
-      <GeneratedPropTable generatedDocGen={generatedDocGen[0]} />
-
+      <GeneratedPropTable generatedDocGen={generatedDocGen[0]} excludeProps={['index']} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -1056,11 +1055,18 @@ OnLinkNavigationProvider allows external link navigation control across all chil
 export async function getStaticProps(): Promise<{|
   props: {| generatedDocGen: Array<DocGen> | DocGen |},
 |}> {
+  const docGen = await multipledocgen({
+    componentName: ['Dropdown', 'DropdownItem', 'DropdownLink', 'DropdownSection'],
+  });
+
+  docGen[0].props.children.flowType.raw =
+    'React.ChildrenArray<React.Element<typeof DropdownItem | typeof DropdownSection>>';
+  docGen[3].props.children.flowType.raw =
+    'React.ChildrenArray<React.Element<typeof DropdownItem | typeof DropdownSection>>';
+
   return {
     props: {
-      generatedDocGen: await multipledocgen({
-        componentName: ['Dropdown', 'DropdownItem', 'DropdownLink', 'DropdownSection'],
-      }),
+      generatedDocGen: docGen,
     },
   };
 }

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -1,45 +1,22 @@
 // @flow strict
 import { type Node } from 'react';
 import { Dropdown } from 'gestalt';
-import PropTable from '../components/PropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
-import docgen, { type DocGen } from '../components/docgen.js';
+import { multipledocgen, type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 
-const commonDropdownItemProps = [
-  {
-    name: 'badgeText',
-    type: 'string',
-    description:
-      "When supplied, will display a [Badge](/badge) next to the item's label. See the [Badges](#Badges) variant to learn more.",
-  },
-  {
-    name: 'dataTestId',
-    type: 'string',
-    description: 'When supplied, will add a data-test-id prop to the dom element.',
-  },
-  {
-    name: 'children',
-    type: 'React.Node',
-    description:
-      'If needed, users can supply custom content to each Dropdown Item. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](#Custom-item-content) variant to learn more.',
-  },
-  {
-    name: 'option',
-    type: '{| label: string, value: string, subtext?: string |}',
-    required: true,
-    description: 'Object detailing the label, value, and optional subtext for this item.',
-  },
-];
-
-export default function DropdownPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+export default function DropdownPage({
+  generatedDocGen,
+}: {|
+  generatedDocGen: Array<DocGen>,
+|}): Node {
   return (
     <Page title="Dropdown">
       <PageHeader
         name="Dropdown"
-        description={generatedDocGen?.description}
+        description={generatedDocGen[0]?.description}
         badge="pilot"
         defaultCode={`
       function IntroMenuButtonDropdownExample() {
@@ -100,7 +77,7 @@ export default function DropdownPage({ generatedDocGen }: {| generatedDocGen: Do
         );
       }`}
       />
-      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+      <GeneratedPropTable generatedDocGen={generatedDocGen[0]} />
 
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
@@ -570,77 +547,23 @@ function TruncationDropdownExample() {
         </MainSection.Subsection>
       </MainSection>
       <MainSection name="Subcomponents" />
-      <PropTable
+      <GeneratedPropTable
         Component={Dropdown?.Item}
         name="Dropdown.Item"
         id="Dropdown.Item"
-        props={[
-          ...commonDropdownItemProps,
-          {
-            name: 'onSelect',
-            type:
-              '({| event: SyntheticInputEvent<>, item: {label: string, value: string, subtext?: string} |}) => void',
-            required: true,
-            description: 'Callback when the user selects an item using the mouse or keyboard.',
-          },
-          {
-            name: 'selected',
-            type:
-              '{| label: string, value: string, subtext?: string |} | Array<{| label: string, value: string, subtext?: string |}>',
-            description:
-              'Either the selected item info or an array of selected items, used to determine when the "selected" icon appears on an item.',
-          },
-        ]}
+        generatedDocGen={generatedDocGen[1]}
       />
-      <PropTable
+      <GeneratedPropTable
         Component={Dropdown?.Link}
         name="Dropdown.Link"
         id="Dropdown.Link"
-        props={[
-          ...commonDropdownItemProps,
-          {
-            name: 'href',
-            type: 'string',
-            required: true,
-            description:
-              'Directs users to the url when item is selected. See the [Types of items](#Types-of-items) variant to learn more.',
-          },
-          {
-            name: 'isExternal',
-            type: 'boolean',
-            description:
-              'When true, adds an arrow icon to the end of the item to signal this item takes users to an external source and opens the link in a new tab. Do not add if the item navigates users within the app. See the [Best practices](#Best-practices) for more info.',
-          },
-          {
-            name: 'onClick',
-            type:
-              'AbstractEventHandler<| SyntheticMouseEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLButtonElement>, {| dangerouslyDisableOnNavigation: () => void |}',
-            description: [
-              'Callback fired when clicked (pressed and released) with a mouse or keyboard. ',
-              'See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
-            ],
-          },
-        ]}
+        generatedDocGen={generatedDocGen[2]}
       />
-      <PropTable
+      <GeneratedPropTable
         Component={Dropdown?.Section}
         name="Dropdown.Section"
         id="Dropdown.Section"
-        props={[
-          {
-            name: 'children',
-            type: 'React.ChildrenArray<React.Element<typeof DropdownItem>>',
-            required: true,
-            description: 'Any Dropdown.Items and/or Dropdown.Links to be rendered',
-          },
-          {
-            name: 'label',
-            type: 'string',
-            required: true,
-            description:
-              'Label for the section. See the [Sections](#Sections) variant for more info.',
-          },
-        ]}
+        generatedDocGen={generatedDocGen[3]}
       />
       <MainSection name="Variants">
         <MainSection.Subsection title="Types of items" columns={2}>
@@ -1130,8 +1053,14 @@ OnLinkNavigationProvider allows external link navigation control across all chil
   );
 }
 
-export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+export async function getStaticProps(): Promise<{|
+  props: {| generatedDocGen: Array<DocGen> | DocGen |},
+|}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Dropdown' }) },
+    props: {
+      generatedDocGen: await multipledocgen({
+        componentName: ['Dropdown', 'DropdownItem', 'DropdownLink', 'DropdownSection'],
+      }),
+    },
   };
 }

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -89,7 +89,7 @@ type Props = {|
    */
   anchor?: ?HTMLElement,
   /**
-   * Must be instances of Dropdown.Item, Dropdown.Link or Dropdown.Section components. See the [Types of items](https://gestalt.netlify.app/dropdown#Types-of-items) variant to learn more.
+   * Must be instances of [Dropdown.Item](https://gestalt.netlify.app/dropdown#Types-of-items), [Dropdown.Link](https://gestalt.netlify.app/dropdown#Types-of-items) or [Dropdown.Section](https://gestalt.netlify.app/dropdown#Sections) components. See the [Types of items](https://gestalt.netlify.app/dropdown#Types-of-items) variant to learn more.
    */
   children: Node,
   /**
@@ -113,7 +113,7 @@ type Props = {|
    */
   onDismiss: () => void,
   /**
-   * An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](https://gestalt.netlify.app/zindex_classes)'
+   * An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](https://gestalt.netlify.app/zindex_classes)
    */
   zIndex?: Indexable,
 |};

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -83,16 +83,38 @@ const renderChildrenWithIndex = (childrenArray) => {
   }, []);
 };
 
-type IdealDirection = 'up' | 'right' | 'down' | 'left';
-
 type Props = {|
+  /**
+   * Ref for the element that the Dropdown will attach to, will most likely be a [Button](/button). See the [Accessibility](https://gestalt.netlify.app/dropdown#Accessibility) guidelines to learn more.
+   */
   anchor?: ?HTMLElement,
+  /**
+   * Must be instances of Dropdown.Item, Dropdown.Link or Dropdown.Section components. See the [Types of items](https://gestalt.netlify.app/dropdown#Types-of-items) variant to learn more.
+   */
   children: Node,
+  /**
+   * Enables correct behavior when Dropdown is used within a fixed container. To achieve this it removes the Layer component around Popover and enables positioning relative to its anchor element. Should only be used in cases where Layer breaks the Dropdown positionings such as when the anchor element is within a sticky component.
+   */
   isWithinFixedContainer?: boolean,
+  /**
+   * Content to display at the top of the Dropdown before any items or sections. See the [Custom header](https://gestalt.netlify.app/dropdown#Custom-header) variant to learn more.
+   */
   headerContent?: Node,
+  /**
+   * Unique id to identify each Dropdown. Used for [Accessibility](https://gestalt.netlify.app/dropdown#Accessibility) purposes.
+   */
   id: string,
-  idealDirection?: IdealDirection,
+  /**
+   * Preferred direction for the Dropdown to open.
+   */
+  idealDirection?: 'up' | 'right' | 'down' | 'left',
+  /**
+   * Callback fired when the menu is closed.
+   */
   onDismiss: () => void,
+  /**
+   * An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](https://gestalt.netlify.app/zindex_classes)'
+   */
   zIndex?: Indexable,
 |};
 

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -3,29 +3,40 @@ import { type Node } from 'react';
 import OptionItem, { type OptionItemType } from './OptionItem.js';
 import { DropdownContextConsumer } from './DropdownContext.js';
 
-type PublicProps = {|
+type Props = {|
+  /**
+   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/dropdown#Badges) variant to learn more.
+   */
   badgeText?: string,
+  /**
+   * If needed, users can supply custom content to each Dropdown Item. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](https://gestalt.pinterest.systems/dropdown#Custom-item-content) variant to learn more.
+   */
   children?: Node,
+  /**
+   * When supplied, will add a data-test-id prop to the dom element.
+   */
   dataTestId?: string,
-  onSelect: ({|
+  /**
+   * Callback when the user selects an item using the mouse or keyboard.
+   */ onSelect: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
     item: OptionItemType,
   |}) => void,
+  /**
+   * Object detailing the label, value, and optional subtext for this item.
+   */
   option: OptionItemType,
+  /**
+   * Either the selected item info or an array of selected items, used to determine when the "selected" icon appears on an item.
+   */
   selected?: OptionItemType | $ReadOnlyArray<OptionItemType> | null,
-|};
-
-type PrivateProps = {|
-  index?: number,
-|};
-
-type Props = {|
-  ...PublicProps,
-  ...PrivateProps,
+  /**
+   * Private prop used for accessibility purposes
+   */ index?: number,
 |};
 
 /**
- * https://gestalt.pinterest.systems/dropdown
+ * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown)
  */
 export default function DropdownItem({
   badgeText,

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -57,7 +57,8 @@ type Props = {|
 |};
 
 /**
- * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown)
+ * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown).
+  Use [Dropdown.Item](https://gestalt.pinterest.systems/dropdown#Types-of-items) for action & selection, when the Dropdown item triggers an action or makes a selection.
  */
 export default function DropdownItem({
   badgeText,

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -1,7 +1,13 @@
 // @flow strict
 import { type Node } from 'react';
-import OptionItem, { type OptionItemType } from './OptionItem.js';
+import OptionItem from './OptionItem.js';
 import { DropdownContextConsumer } from './DropdownContext.js';
+
+type OptionItemType = {|
+  label: string,
+  subtext?: string,
+  value: string,
+|};
 
 type Props = {|
   /**
@@ -20,7 +26,11 @@ type Props = {|
    * Callback when the user selects an item using the mouse or keyboard.
    */ onSelect: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
-    item: OptionItemType,
+    item: {|
+      label: string,
+      subtext?: string,
+      value: string,
+    |},
   |}) => void,
   /**
    * Object detailing the label, value, and optional subtext for this item.
@@ -29,7 +39,18 @@ type Props = {|
   /**
    * Either the selected item info or an array of selected items, used to determine when the "selected" icon appears on an item.
    */
-  selected?: OptionItemType | $ReadOnlyArray<OptionItemType> | null,
+  selected?:
+    | {|
+        label: string,
+        subtext?: string,
+        value: string,
+      |}
+    | $ReadOnlyArray<{|
+        label: string,
+        subtext?: string,
+        value: string,
+      |}>
+    | null,
   /**
    * Private prop used for accessibility purposes
    */ index?: number,

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -4,28 +4,46 @@ import OptionItem, { type OptionItemType } from './OptionItem.js';
 import { DropdownContextConsumer } from './DropdownContext.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
-type PublicProps = {|
+type Props = {|
+  /**
+   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/dropdown#Badges) variant to learn more.
+   */
   badgeText?: string,
+  /**
+   * If needed, users can supply custom content to each Dropdown Item. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](https://gestalt.pinterest.systems/dropdown#Custom-item-content) variant to learn more.
+   */
   children?: Node,
+  /**
+   * When supplied, will add a data-test-id prop to the dom element.
+   */
   dataTestId?: string,
+  /**
+   * Directs users to the url when item is selected. See the [Types of items](https://gestalt.pinterest.systems/dropdown#Types-of-items) variant to learn more.
+   */
   href: string,
+  /**
+   * When true, adds an arrow icon to the end of the item to signal this item takes users to an external source and opens the link in a new tab. Do not add if the item navigates users within the app. See the [Best practices](https://gestalt.pinterest.systems/dropdown#Best-practices) for more info.
+   */
   isExternal?: boolean,
+  /**
+   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
+   */
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
     {| dangerouslyDisableOnNavigation: () => void |},
   >,
+  /**
+   * Object detailing the label, value, and optional subtext for this item.
+   */
   option: OptionItemType,
+  /**
+   * Private prop used for accessibility purposes
+   */ index?: number,
 |};
 
-type PrivateProps = {|
-  index?: number,
-|};
-
-type Props = {|
-  ...PublicProps,
-  ...PrivateProps,
-|};
-
+/**
+ * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown)
+ */
 export default function DropdownLink({
   badgeText,
   children,

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -2,7 +2,6 @@
 import { type Node } from 'react';
 import OptionItem from './OptionItem.js';
 import { DropdownContextConsumer } from './DropdownContext.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type OptionItemType = {|
   label: string,
@@ -34,10 +33,10 @@ type Props = {|
   /**
    * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
    */
-  onClick?: AbstractEventHandler<
-    SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| dangerouslyDisableOnNavigation: () => void |},
-  >,
+  onClick?: ({|
+    event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    dangerouslyDisableOnNavigation: () => void,
+  |}) => void,
   /**
    * Object detailing the label, value, and optional subtext for this item.
    */
@@ -48,7 +47,8 @@ type Props = {|
 |};
 
 /**
- * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown)
+ * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown).
+   Use [Dropdown.Link](https://gestalt.pinterest.systems/dropdown#Types-of-items) for navigation, when the Dropdown item navigates to a new page.
  */
 export default function DropdownLink({
   badgeText,

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -1,8 +1,14 @@
 // @flow strict
 import { type Node } from 'react';
-import OptionItem, { type OptionItemType } from './OptionItem.js';
+import OptionItem from './OptionItem.js';
 import { DropdownContextConsumer } from './DropdownContext.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+
+type OptionItemType = {|
+  label: string,
+  subtext?: string,
+  value: string,
+|};
 
 type Props = {|
   /**
@@ -10,7 +16,7 @@ type Props = {|
    */
   badgeText?: string,
   /**
-   * If needed, users can supply custom content to each Dropdown Item. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](https://gestalt.pinterest.systems/dropdown#Custom-item-content) variant to learn more.
+   * If needed, users can supply custom content to each Dropdown Link. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](https://gestalt.pinterest.systems/dropdown#Custom-item-content) variant to learn more.
    */
   children?: Node,
   /**

--- a/packages/gestalt/src/DropdownSection.js
+++ b/packages/gestalt/src/DropdownSection.js
@@ -16,7 +16,8 @@ type Props = {|
 |};
 
 /**
- * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown)
+ * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown).
+  Use [Dropdown.Section](https://gestalt.pinterest.systems/dropdown#Sections) to create hierarchy within a single Dropdown.
  */
 export default function DropdownSection({ label, children }: Props): Node {
   return (

--- a/packages/gestalt/src/DropdownSection.js
+++ b/packages/gestalt/src/DropdownSection.js
@@ -5,12 +5,18 @@ import Text from './Text.js';
 import styles from './Dropdown.css';
 
 type Props = {|
+  /**
+   * Any [Dropdown.Items](https://gestalt.pinterest.systems/dropdown#Dropdown.ItemProps) and/or [Dropdown.Links](https://gestalt.pinterest.systems/dropdown#Dropdown.LinkProps) to be rendered
+   */
   children: Node,
+  /**
+   * Label for the section. See the [Sections](https://gestalt.pinterest.systems/dropdown#Sections) variant for more info.
+   */
   label: string,
 |};
 
 /**
- * https://gestalt.pinterest.systems/dropdown
+ * Subcomponent of [Dropdown](https://gestalt.pinterest.systems/dropdown)
  */
 export default function DropdownSection({ label, children }: Props): Node {
   return (


### PR DESCRIPTION
### Summary

#### What changed?

Dropdown: updated Docs to use autogenerated prop table

Added a second `docgen` function (`multipledocgen`) that allows retrieving multiple components' proptables in the same docs page to allow more flexibility for designers to redesign and improve subcomponent discoverability
#### Why?

Gestalt is moving in this direction, all components must autogenerate prop tables


