### PR TITLE
SegmentedControl: remove size prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Major
 
-- TextField: Remove type="number" and create codemod  (#1890)
+- TextField: Remove type="number" and create codemod (#1890)
 
 ## 42.3.6 (Jan 31, 2022)
 

--- a/packages/gestalt-codemods/44.0.0/__testfixtures__/segmentedcontrol-size-renamed.input.js
+++ b/packages/gestalt-codemods/44.0.0/__testfixtures__/segmentedcontrol-size-renamed.input.js
@@ -1,0 +1,41 @@
+// @flow strict
+import { useState } from 'react';
+import { Box, Flex, Icon, SegmentedControl as Renamed, Text } from 'gestalt';
+
+export default function SegmentedControlExample() {
+  const [itemIndex, setItemIndex] = useState(0);
+
+  const items = [
+    'News',
+    'You',
+    'Messages',
+    <Icon
+      accessibilityLabel="Pin"
+      color="darkGray"
+      key="foo"
+      icon="pin"
+    />,
+  ];
+
+  const content = [
+    'News content',
+    'You content',
+    'Messages content',
+    'Pins content',
+  ];
+
+  return (
+    <Flex direction="column" gap={2}>
+      <Renamed
+        items={items}
+        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
+        selectedItemIndex={itemIndex}
+        size="md"
+      />
+
+      <Box borderStyle="shadow" padding={6} rounding={2}>
+        <Text>{content[itemIndex]}</Text>
+      </Box>
+    </Flex>
+  );
+}

--- a/packages/gestalt-codemods/44.0.0/__testfixtures__/segmentedcontrol-size-renamed.output.js
+++ b/packages/gestalt-codemods/44.0.0/__testfixtures__/segmentedcontrol-size-renamed.output.js
@@ -1,0 +1,39 @@
+// @flow strict
+import { useState } from 'react';
+import { Box, Flex, Icon, SegmentedControl as Renamed, Text } from 'gestalt';
+
+export default function SegmentedControlExample() {
+  const [itemIndex, setItemIndex] = useState(0);
+
+  const items = [
+    'News',
+    'You',
+    'Messages',
+    <Icon
+      accessibilityLabel="Pin"
+      color="darkGray"
+      key="foo"
+      icon="pin"
+    />,
+  ];
+
+  const content = [
+    'News content',
+    'You content',
+    'Messages content',
+    'Pins content',
+  ];
+
+  return (
+    <Flex direction="column" gap={2}>
+      <Renamed
+        items={items}
+        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
+        selectedItemIndex={itemIndex} />
+
+      <Box borderStyle="shadow" padding={6} rounding={2}>
+        <Text>{content[itemIndex]}</Text>
+      </Box>
+    </Flex>
+  );
+}

--- a/packages/gestalt-codemods/44.0.0/__testfixtures__/segmentedcontrol-size.input.js
+++ b/packages/gestalt-codemods/44.0.0/__testfixtures__/segmentedcontrol-size.input.js
@@ -1,0 +1,41 @@
+// @flow strict
+import { useState } from 'react';
+import { Box, Flex, Icon, SegmentedControl, Text } from 'gestalt';
+
+export default function SegmentedControlExample() {
+  const [itemIndex, setItemIndex] = useState(0);
+
+  const items = [
+    'News',
+    'You',
+    'Messages',
+    <Icon
+      accessibilityLabel="Pin"
+      color="darkGray"
+      key="foo"
+      icon="pin"
+    />,
+  ];
+
+  const content = [
+    'News content',
+    'You content',
+    'Messages content',
+    'Pins content',
+  ];
+
+  return (
+    <Flex direction="column" gap={2}>
+      <SegmentedControl
+        items={items}
+        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
+        selectedItemIndex={itemIndex}
+        size="md"
+      />
+
+      <Box borderStyle="shadow" padding={6} rounding={2}>
+        <Text>{content[itemIndex]}</Text>
+      </Box>
+    </Flex>
+  );
+}

--- a/packages/gestalt-codemods/44.0.0/__testfixtures__/segmentedcontrol-size.output.js
+++ b/packages/gestalt-codemods/44.0.0/__testfixtures__/segmentedcontrol-size.output.js
@@ -1,0 +1,39 @@
+// @flow strict
+import { useState } from 'react';
+import { Box, Flex, Icon, SegmentedControl, Text } from 'gestalt';
+
+export default function SegmentedControlExample() {
+  const [itemIndex, setItemIndex] = useState(0);
+
+  const items = [
+    'News',
+    'You',
+    'Messages',
+    <Icon
+      accessibilityLabel="Pin"
+      color="darkGray"
+      key="foo"
+      icon="pin"
+    />,
+  ];
+
+  const content = [
+    'News content',
+    'You content',
+    'Messages content',
+    'Pins content',
+  ];
+
+  return (
+    <Flex direction="column" gap={2}>
+      <SegmentedControl
+        items={items}
+        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
+        selectedItemIndex={itemIndex} />
+
+      <Box borderStyle="shadow" padding={6} rounding={2}>
+        <Text>{content[itemIndex]}</Text>
+      </Box>
+    </Flex>
+  );
+}

--- a/packages/gestalt-codemods/44.0.0/__tests__/segmentedcontrol-size.js
+++ b/packages/gestalt-codemods/44.0.0/__tests__/segmentedcontrol-size.js
@@ -1,0 +1,13 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../segmentedcontrol-size', () =>
+  Object.assign(jest.requireActual('../segmentedcontrol-size'), {
+    parser: 'flow',
+  }),
+);
+
+describe('segmentedcontrol-size', () => {
+  ['segmentedcontrol-size', 'segmentedcontrol-size-renamed'].forEach((test) => {
+    defineTest(__dirname, 'segmentedcontrol-size', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/44.0.0/segmentedcontrol-size.js
+++ b/packages/gestalt-codemods/44.0.0/segmentedcontrol-size.js
@@ -1,0 +1,53 @@
+/**
+  - Removes `size` prop from SegmentedControl
+ */
+
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/44.0.0/segmentedcontrol-size.js relative/path/to/your/code
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierNames;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierNames = decl.specifiers
+      .filter((node) => node.imported?.name === 'SegmentedControl')
+      .map((node) => node.local?.name);
+
+    return null;
+  });
+
+  // No SegmentedControls here, move along
+  if (!localIdentifierNames || localIdentifierNames.length === 0) {
+    return null;
+  }
+
+  return src
+    .find(j.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+      const nodeName = node.openingElement.name.name;
+
+      // We only care about SegmentedControl
+      if (!localIdentifierNames.includes(nodeName)) {
+        return;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove Dynamic SegmentedControl properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+
+      // Remove SegmentedControl's `size`
+      node.openingElement.attributes = attrs.filter((attr) => attr?.name?.name !== 'size');
+    })
+    .toSource();
+}

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -1,7 +1,6 @@
 // @flow strict
 import type { Node } from 'react';
 import classnames from 'classnames';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import Box from './Box.js';
 import focusStyles from './Focus.css';
 import layout from './Layout.css';
@@ -9,10 +8,7 @@ import styles from './SegmentedControl.css';
 import Text from './Text.js';
 import useFocusVisible from './useFocusVisible.js';
 
-type OnChange = AbstractEventHandler<
-  SyntheticMouseEvent<HTMLButtonElement>,
-  {| activeIndex: number |},
->;
+type OnChange = ({| event: SyntheticMouseEvent<HTMLButtonElement>, activeIndex: number |}) => void;
 
 type Props = {|
   /**
@@ -31,10 +27,6 @@ type Props = {|
    * Index of element in `items` that is currently selected.
    */
   selectedItemIndex: number,
-  /**
-   * The height of the element. md: 40px, lg: 48px
-   */
-  size?: 'md' | 'lg',
 |};
 
 function SegmentedControlItem({
@@ -42,14 +34,12 @@ function SegmentedControlItem({
   item,
   isSelected,
   onChange,
-  size,
   width,
 }: {|
   index: number,
   item: Node,
   isSelected: boolean,
   onChange: OnChange,
-  size?: 'md' | 'lg',
   width: ?string,
 |}) {
   const { isFocusVisible } = useFocusVisible();
@@ -69,7 +59,7 @@ function SegmentedControlItem({
       style={{ width }}
     >
       {typeof item === 'string' ? (
-        <Text color="darkGray" align="center" size={size} weight="bold">
+        <Text color="darkGray" align="center" size="md" weight="bold">
           {item}
         </Text>
       ) : (
@@ -91,14 +81,10 @@ export default function SegmentedControl({
   onChange,
   responsive,
   selectedItemIndex,
-  size = 'md',
 }: Props): Node {
   const buttonWidth = responsive ? undefined : `${Math.floor(100 / Math.max(1, items.length))}%`;
   return (
-    <div
-      className={classnames(styles.SegmentedControl, size === 'md' ? layout.medium : layout.large)}
-      role="tablist"
-    >
+    <div className={classnames(styles.SegmentedControl, layout.medium)} role="tablist">
       {items.map((item, i) => (
         <SegmentedControlItem
           key={i}
@@ -106,7 +92,6 @@ export default function SegmentedControl({
           item={item}
           isSelected={i === selectedItemIndex}
           onChange={onChange}
-          size={size}
           width={buttonWidth}
         />
       ))}

--- a/packages/gestalt/src/SegmentedControl.jsdom.test.js
+++ b/packages/gestalt/src/SegmentedControl.jsdom.test.js
@@ -15,23 +15,4 @@ describe('<SegmentedControl />', () => {
     getByText('Item2').click();
     expect(mockOnChange).toHaveBeenCalled();
   });
-
-  it('adds a "medium" classname by default', () => {
-    const { container } = render(
-      <SegmentedControl items={['Item1', 'Item2']} selectedItemIndex={0} onChange={() => {}} />,
-    );
-    expect(container.querySelector('.medium')).toBeVisible();
-  });
-
-  it('adds a "large" classname when size is set to "lg"', () => {
-    const { container } = render(
-      <SegmentedControl
-        items={['Item1', 'Item2']}
-        selectedItemIndex={0}
-        size="lg"
-        onChange={() => {}}
-      />,
-    );
-    expect(container.querySelector('.large')).toBeVisible();
-  });
 });


### PR DESCRIPTION
### Summary

#### What changed?

Removing the `size` prop from SegmentedControl.

#### Why?

This prop was only used once in Pinboard, where it was set to the default value. Since it is not needed, removing to simplify the component API.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3233)

### Checklist

- [x] Added codemod
- [x] Updated documentation