### PR TITLE
Popover: updated Docs to use autogenerated prop table

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -110,6 +110,7 @@ export default function GeneratedPropTable({
         description: descriptionWithoutTypeOverride?.trim(),
         required,
         defaultValue: defaultValueOverride ?? defaultValue?.value?.replace(/'/g, ''),
+        nullable: flowType?.nullable,
         href,
       };
     })

--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -110,7 +110,7 @@ export default function GeneratedPropTable({
         description: descriptionWithoutTypeOverride?.trim(),
         required,
         defaultValue: defaultValueOverride ?? defaultValue?.value?.replace(/'/g, ''),
-        nullable: flowType?.nullable,
+        nullable: flowType?.nullable || false,
         href,
       };
     })

--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -14,6 +14,7 @@ type Props = {|
     name: string,
     required?: boolean,
     responsive?: boolean,
+    nullable: ?boolean,
     type: string,
   |}>,
   Component?: ComponentType<any>, // flowlint-line unclear-type:off
@@ -176,7 +177,16 @@ export default function PropTable({
                 sortBy(properties, ({ required, name }) => `${required ? 'a' : 'b'}${name}`).reduce(
                   (
                     acc,
-                    { defaultValue, description = '', href, name, required, responsive, type },
+                    {
+                      defaultValue,
+                      description = '',
+                      href,
+                      name,
+                      required,
+                      responsive,
+                      nullable,
+                      type,
+                    },
                     i,
                   ) => {
                     const propNameHasSecondRow = description || responsive;
@@ -207,7 +217,7 @@ export default function PropTable({
                           </Box>
                         </Td>
                         <Td border={!propNameHasSecondRow}>
-                          <code>{unifyQuotes(type)}</code>
+                          <code>{nullable ? `?${unifyQuotes(type)}` : unifyQuotes(type)}</code>
                         </Td>
                         <Td
                           shrink

--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -14,7 +14,7 @@ type Props = {|
     name: string,
     required?: boolean,
     responsive?: boolean,
-    nullable: ?boolean,
+    nullable?: boolean,
     type: string,
   |}>,
   Component?: ComponentType<any>, // flowlint-line unclear-type:off

--- a/docs/components/docgen.js
+++ b/docs/components/docgen.js
@@ -19,6 +19,7 @@ export type DocGen = {|
       description: string,
       flowType: {|
         raw?: string,
+        nullable?: boolean,
         name: string,
       |},
     |},

--- a/docs/pages/popover.js
+++ b/docs/pages/popover.js
@@ -1,11 +1,10 @@
 // @flow strict
 import type { Node } from 'react';
-import { Popover } from 'gestalt';
-import PropTable from '../components/PropTable.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -128,82 +127,7 @@ function PopoverExample() {
 }
   `}
       />
-      <PropTable
-        Component={Popover}
-        props={[
-          {
-            name: 'anchor',
-            type: '?HTMLElement',
-            required: true,
-            description:
-              'The reference element, typically [Button](/button) or [IconButton](/iconbutton), that Popover uses to set its position',
-          },
-          {
-            name: 'onDismiss',
-            type: '() => void',
-            description: `Callback fired when Popover requests to be closed. Must be used to control Popover’s on/off display state.`,
-            required: true,
-          },
-          {
-            name: 'id',
-            type: 'string',
-            description:
-              'Unique id to identify each Popover. Used for [accessibility](#ARIA-attributes) purposes.',
-          },
-          {
-            name: 'idealDirection',
-            type: `'up' | 'right' | 'down' | 'left'`,
-            description:
-              'Specifies the preferred position of Popover relative to its anchor element. See the [ideal direction](#Ideal-direction) variant to learn more.',
-          },
-          {
-            name: 'children',
-            type: 'React.Node',
-            description: 'The content shown in Popover',
-          },
-          {
-            name: 'positionRelativeToAnchor',
-            type: 'boolean',
-            defaultValue: true,
-            description:
-              'Properly positions Popover relative to its anchor element. Set to false when used within [Layer](/layer). See the [with Layer](#With-layer) variant to learn more.',
-          },
-          {
-            name: 'color',
-            type: `"blue" | "orange" | "red" | "white" | "darkGray"`,
-            defaultValue: 'white',
-            description:
-              'The background color of Popover. See the [color and caret](#Color-and-caret) variant to learn more.',
-          },
-          {
-            name: 'role',
-            type: `"dialog" | "menu" | "listbox"`,
-            description:
-              'The underlying ARIA role for Popover. See the [accessibility](#ARIA-attributes) section for more info.',
-          },
-          {
-            name: 'shouldFocus',
-            type: 'boolean',
-            defaultValue: true,
-            description:
-              'Puts the focus on Popover when it’s triggered. See [accessibility](#Accessibility) to learn more.',
-          },
-          {
-            name: 'showCaret',
-            type: 'boolean',
-            defaultValue: false,
-            description:
-              'Shows a caret on Popover. See the [color and caret](#Color-and-caret) variant to learn more.',
-          },
-          {
-            name: 'size',
-            type: `'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number`,
-            description:
-              'The maximum width of Popover. See the [size](#Size) variant to learn more.',
-            defaultValue: 'sm',
-          },
-        ]}
-      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -1,19 +1,19 @@
 // @flow strict
 import type { Node } from 'react';
 import Controller from './Controller.js';
-import { type Role } from './Contents.js';
 
 type Color = 'blue' | 'orange' | 'red' | 'white' | 'darkGray';
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number;
 type IdealDirection = 'up' | 'right' | 'down' | 'left';
+type Role = 'dialog' | 'listbox' | 'menu';
 
 type Props = {|
   /**
-   * The reference element, typically [Button](https://gestalt.pinterest.systems/button) or [IconButton](https://gestalt.pinterest.systems/iconbutton), that Popover uses to set its position
+   * The reference element, typically [Button](https://gestalt.pinterest.systems/button) or [IconButton](https://gestalt.pinterest.systems/iconbutton), that Popover uses to set its position.
    */
   anchor: ?HTMLElement,
   /**
-   * The content shown in Popover
+   * The content shown in Popover.
    */
   children?: Node,
   /**
@@ -25,7 +25,7 @@ type Props = {|
    */
   handleKeyDown?: (event: SyntheticKeyboardEvent<HTMLElement>) => void,
   /**
-   * Unique id to identify each Popover. Used for [accessibility](https://gestalt.pinterest.systems/popover#ARIA-attributes) purposes
+   * Unique id to identify each Popover. Used for [accessibility](https://gestalt.pinterest.systems/popover#ARIA-attributes) purposes.
    */
   id?: string,
   /**
@@ -53,7 +53,7 @@ type Props = {|
    */
   showCaret?: boolean,
   /**
-   * The maximum width of Popover. See the [size](https://gestalt.pinterest.systems/popover#Size) variant to learn more.'
+   * The maximum width of Popover. See the [size](https://gestalt.pinterest.systems/popover#Size) variant to learn more.
    */
   size?: Size,
 |};
@@ -63,22 +63,20 @@ type Props = {|
  *
  * Popover is most appropriate for desktop screens and can contain a variety of elements, such as [Button](/button) and [Images](/image). Popover is also the container used to construct more complex elements like [Dropdown](/dropdown) and the board picker, pictured below, which allow people to choose the board to save a Pin to.
  */
-export default function Popover(props: Props): null | Node {
-  const {
-    anchor,
-    children,
-    handleKeyDown,
-    id,
-    idealDirection,
-    onDismiss,
-    positionRelativeToAnchor = true,
-    color = 'white',
-    role,
-    shouldFocus = true,
-    showCaret = false,
-    size = 'sm',
-  } = props;
-
+export default function Popover({
+  anchor,
+  children,
+  handleKeyDown,
+  id,
+  idealDirection,
+  onDismiss,
+  positionRelativeToAnchor = true,
+  color = 'white',
+  role,
+  shouldFocus = true,
+  showCaret = false,
+  size = 'sm',
+}: Props): null | Node {
   if (!anchor) {
     return null;
   }

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -8,17 +8,53 @@ type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number;
 type IdealDirection = 'up' | 'right' | 'down' | 'left';
 
 type Props = {|
+  /**
+   * The reference element, typically [Button](https://gestalt.pinterest.systems/button) or [IconButton](https://gestalt.pinterest.systems/iconbutton), that Popover uses to set its position
+   */
   anchor: ?HTMLElement,
+  /**
+   * The content shown in Popover
+   */
   children?: Node,
+  /**
+   * The background color of Popover. See the [color and caret](https://gestalt.pinterest.systems/popover#Color-and-caret) variant to learn more.
+   */
   color?: Color,
+  /**
+   *
+   */
   handleKeyDown?: (event: SyntheticKeyboardEvent<HTMLElement>) => void,
+  /**
+   * Unique id to identify each Popover. Used for [accessibility](https://gestalt.pinterest.systems/popover#ARIA-attributes) purposes
+   */
   id?: string,
+  /**
+   * Specifies the preferred position of Popover relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/popover#Ideal-direction) variant to learn more.
+   */
   idealDirection?: IdealDirection,
+  /**
+   * Callback fired when Popover requests to be closed. Must be used to control Popover’s on/off display state.
+   */
   onDismiss: () => void,
+  /**
+   * Properly positions Popover relative to its anchor element. Set to false when used within [Layer](https://gestalt.pinterest.systems/layer). See the [with Layer](https://gestalt.pinterest.systems/popover#With-layer) variant to learn more.
+   */
   positionRelativeToAnchor?: boolean,
+  /**
+   * The underlying ARIA role for Popover. See the [accessibility](https://gestalt.pinterest.systems/popover#ARIA-attributes) section for more info.
+   */
   role?: Role,
+  /**
+   * Puts the focus on Popover when it’s triggered. See [accessibility](https://gestalt.pinterest.systems/popover#Accessibility) to learn more.
+   */
   shouldFocus?: boolean,
+  /**
+   * Shows a caret on Popover. See the [color and caret](https://gestalt.pinterest.systems/popover#Color-and-caret) variant to learn more.
+   */
   showCaret?: boolean,
+  /**
+   * The maximum width of Popover. See the [size](https://gestalt.pinterest.systems/popover#Size) variant to learn more.'
+   */
   size?: Size,
 |};
 


### PR DESCRIPTION
### Summary

#### What changed?

Popover: updated Docs to use autogenerated prop table

#### Why?

Gestalt is moving in this direction, all components must autogenerate prop tables