### PR TITLE
Internal: Fix broken master due to prettier error on CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Major
 
-- TextField: Remove type="number" and create codemod  (#1890)
+- TextField: Remove type="number" and create codemod (#1890)
 
 ## 42.3.6 (Jan 31, 2022)
 

--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /* eslint import/no-dynamic-require: 0, no-console: 0 */
 const path = require('path');
+const prettier = require('prettier');
 const shell = require('shelljs');
 const semver = require('semver');
 const fsPromises = require('fs').promises;
@@ -88,18 +89,25 @@ async function bumpPackageVersion() {
   return { previousVersion, newVersion, releaseType };
 }
 
+async function formatWithPrettier({ filePath, text }) {
+  const options = await prettier.resolveConfig(filePath);
+  return prettier.format(text, options);
+}
+
 async function updateChangelog({ releaseNotes }) {
   const changelogPath = './CHANGELOG.md';
   const previousChangelog = await fsPromises.readFile(changelogPath, {
     encoding: 'utf8',
   });
 
-  await fsPromises.writeFile(
-    changelogPath,
-    `${releaseNotes}
+  const output = await formatWithPrettier({
+    filePath: changelogPath,
+    text: `${releaseNotes}
 
 ${previousChangelog}`,
-  );
+  });
+
+  await fsPromises.writeFile(changelogPath, output);
 }
 
 function commitChanges({ message }) {


### PR DESCRIPTION
### Summary

#### What changed?

1. Run prettier on `CHANGELOG.md` file
2. Prevent future breakages by scripting the prettier run

#### Why?

Master broke due to an extra space in the PR title in #1890

![Screen Shot 2022-02-01 at 7 02 03 AM](https://user-images.githubusercontent.com/127199/151996275-ee9e15d5-0498-4bd1-aa69-3a3b12f0fd08.png)

```
$ prettier --check .
Checking formatting...
[warn] CHANGELOG.md
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```

https://github.com/pinterest/gestalt/runs/5011272978?check_suite_focus=true
