### PR TITLE
Docs: fix right sidenav overlap bug

### DIFF
--- a/docs/components/Toc.js
+++ b/docs/components/Toc.js
@@ -1,8 +1,9 @@
 // @flow strict
-import type { Node } from 'react';
-
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type Node, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Flex, Link, Text } from 'gestalt';
+
+const HEADER_HEIGHT_PX = 60;
+const FOOTER_HEIGHT_PX = 112;
 
 function throttle(func, wait) {
   let context;
@@ -148,12 +149,12 @@ export default function Toc({ cards }: Props): Node {
     <Box
       aria-label="component page"
       // Accounting for the footer height as set in App.js
-      dangerouslySetInlineStyle={{ __style: { marginBottom: '90px' } }}
+      dangerouslySetInlineStyle={{ __style: { marginBottom: FOOTER_HEIGHT_PX } }}
       // These margins counter the padding set on the <Box role="main"> in App.js
       marginTop={-4}
       mdMarginTop={-6}
       lgMarginTop={-8}
-      maxHeight="calc(100% - 60px - 90px)"
+      maxHeight={`calc(100% - ${HEADER_HEIGHT_PX}px - ${FOOTER_HEIGHT_PX}px)`}
       minWidth={240}
       overflow="auto"
       paddingY={8} // re-apply just the padding we need


### PR DESCRIPTION
The right sidenav was overlapping the footer on components with a ton of sub-sections, like Table. This PR adjusts bottom margin to account for the increased footer height.

_Before_
<img width="404" alt="Screen Shot 2022-02-02 at 2 33 40 PM" src="https://user-images.githubusercontent.com/12059539/152249090-a98678b8-33ad-4d59-b0f4-73addf84c8e2.png">

_After_
<img width="370" alt="Screen Shot 2022-02-02 at 2 33 54 PM" src="https://user-images.githubusercontent.com/12059539/152249105-54f4e5b1-209e-4446-8845-0b4beb47e03d.png">

