### PR TITLE
Badge: fix layout issues

### DIFF
--- a/packages/gestalt/src/Badge.css
+++ b/packages/gestalt/src/Badge.css
@@ -5,7 +5,7 @@
   composes: fontWeightBold from './Typography.css';
   composes: white from './Colors.css';
   font-size: 10px;
-  height: fit-content;
+  height: min-content;
   margin-top: -4px;
   padding: 2px;
   white-space: nowrap;

--- a/packages/gestalt/src/Badge.css
+++ b/packages/gestalt/src/Badge.css
@@ -5,6 +5,7 @@
   composes: fontWeightBold from './Typography.css';
   composes: white from './Colors.css';
   font-size: 10px;
+  height: fit-content;
   margin-top: -4px;
   padding: 2px;
   white-space: nowrap;

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -28,5 +28,5 @@ export default function Badge({ position = 'middle', text }: Props): Node {
     [colors.darkGray]: colorSchemeName === 'darkMode',
   });
 
-  return <span className={cs}>{text}</span>;
+  return <div className={cs}>{text}</div>;
 }

--- a/packages/gestalt/src/Badge.test.js
+++ b/packages/gestalt/src/Badge.test.js
@@ -10,7 +10,7 @@ it('Badge renders', () => {
 
 it('should render with white text and blue background', () => {
   const instance = create(<Badge text="Badge" />).root;
-  const { className } = instance.find((element) => element.type === 'span').props;
+  const { className } = instance.find((element) => element.type === 'div').props;
 
   expect(className).toContain('blueBg');
 });

--- a/packages/gestalt/src/__snapshots__/Badge.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Badge.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Badge renders 1`] = `
-<span
+<div
   className="Badge middle blueBg"
 >
   Badge
-</span>
+</div>
 `;

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -209,11 +209,11 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                             >
                               , 
                             </div>
-                            <span
+                            <div
                               class="Badge middle blueBg"
                             >
                               New
-                            </span>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -271,11 +271,11 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                               >
                                 , 
                               </div>
-                              <span
+                              <div
                                 class="Badge middle blueBg"
                               >
                                 New
-                              </span>
+                              </div>
                             </div>
                           </div>
                         </div>

--- a/packages/gestalt/src/__snapshots__/Module.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Module.test.js.snap
@@ -50,11 +50,11 @@ exports[`Module renders a badge correctly 1`] = `
               }
             }
           >
-            <span
+            <div
               className="Badge middle blueBg"
             >
               Try it out!
-            </span>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
@@ -154,11 +154,11 @@ exports[`ModuleExpandableItem renders correctly with badge 1`] = `
                       }
                     }
                   >
-                    <span
+                    <div
                       className="Badge middle blueBg"
                     >
                       Try it out!
-                    </span>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Badge currently behaves in funky ways in Flex layouts. Unless `gap` is set, Badge will expand to fill vertical space, and the `position` prop becomes useless. This PR fixes that behavior by setting a specific height on Badge.

Test code:
```js
<Flex>
  <Text>Some text that uses Badge component</Text>
  <Badge text="New" />
</Flex>
```
  

_Before, no gap_
<img width="453" alt="Screen Shot 2022-02-02 at 3 40 32 PM" src="https://user-images.githubusercontent.com/12059539/152256518-ac379055-09d2-4f09-85f4-78938ae85035.png">

_Before, with gap_
<img width="460" alt="Screen Shot 2022-02-02 at 3 40 46 PM" src="https://user-images.githubusercontent.com/12059539/152256531-7a689418-ed17-4126-baaa-e3b02312fa05.png">

_After, no gap_
<img width="460" alt="Screen Shot 2022-02-02 at 3 43 20 PM" src="https://user-images.githubusercontent.com/12059539/152256551-42525e5f-2bfe-46d1-803f-282dfd8d86b1.png">

