### PR TITLE
Popover: rename handleOnKeyDown to onKeyDown and standardize event type 

### DIFF
--- a/packages/gestalt-codemods/45.0.0/__testfixtures__/rename-popover-handleKeyDown-to-onKeyDown.input.js
+++ b/packages/gestalt-codemods/45.0.0/__testfixtures__/rename-popover-handleKeyDown-to-onKeyDown.input.js
@@ -1,0 +1,6 @@
+// @flow strict
+import {  Popover } from 'gestalt';
+
+export default function Test() {
+  return <Popover handleKeyDown={() => {}}/>;
+}

--- a/packages/gestalt-codemods/45.0.0/__testfixtures__/rename-popover-handleKeyDown-to-onKeyDown.output.js
+++ b/packages/gestalt-codemods/45.0.0/__testfixtures__/rename-popover-handleKeyDown-to-onKeyDown.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import {  Popover } from 'gestalt';
+
+export default function Test() {
+  return <Popover onKeyDown={() => {}}/>;
+}

--- a/packages/gestalt-codemods/45.0.0/__testfixtures__/rename-renamed-popover-handleKeyDown-to-onKeyDown.input.js
+++ b/packages/gestalt-codemods/45.0.0/__testfixtures__/rename-renamed-popover-handleKeyDown-to-onKeyDown.input.js
@@ -1,0 +1,6 @@
+// @flow strict
+import {  Popover as RenamedPopover} from 'gestalt';
+
+export default function Test() {
+  return <RenamedPopover handleKeyDown={() => {}}/>;
+}

--- a/packages/gestalt-codemods/45.0.0/__testfixtures__/rename-renamed-popover-handleKeyDown-to-onKeyDown.output.js
+++ b/packages/gestalt-codemods/45.0.0/__testfixtures__/rename-renamed-popover-handleKeyDown-to-onKeyDown.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import {  Popover as RenamedPopover} from 'gestalt';
+
+export default function Test() {
+  return <RenamedPopover onKeyDown={() => {}}/>;
+}

--- a/packages/gestalt-codemods/45.0.0/__tests__/rename-popover-handleKeyDown-to-onKeyDown.test.js
+++ b/packages/gestalt-codemods/45.0.0/__tests__/rename-popover-handleKeyDown-to-onKeyDown.test.js
@@ -1,0 +1,16 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../rename-popover-handleKeyDown-to-onKeyDown', () =>
+  Object.assign(jest.requireActual('../rename-popover-handleKeyDown-to-onKeyDown'), {
+    parser: 'flow',
+  }),
+);
+
+describe('rename-popover-handleKeyDown-to-onKeyDown', () => {
+  [
+    'rename-popover-handleKeyDown-to-onKeyDown',
+    'rename-renamed-popover-handleKeyDown-to-onKeyDown',
+  ].forEach((test) => {
+    defineTest(__dirname, 'rename-popover-handleKeyDown-to-onKeyDown', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/45.0.0/rename-popover-handleKeyDown-to-onKeyDown.js
+++ b/packages/gestalt-codemods/45.0.0/rename-popover-handleKeyDown-to-onKeyDown.js
@@ -1,0 +1,80 @@
+/*
+ * Converts
+ *  <Popover handleKeyDown /> to <Popover onKeyDown />
+ */
+
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/45.0.0/rename-popover-handleKeyDown-to-onKeyDown.js relative/path/to/your/code
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    // Not Gestalt, return
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    // Find the local names of Popover imports
+    localIdentifierName = decl.specifiers
+      .filter((node) => node.imported.name === 'Popover')
+      .map((node) => node.local.name);
+    return null;
+  });
+
+  // No Popover imports, return
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove dynamic Popover properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+
+      const newAttrs = attrs
+        .map((attr) => {
+          const propName = attr?.name?.name;
+
+          // Not handleKeyDown prop, return
+          if (propName !== 'handleKeyDown') {
+            return attr;
+          }
+
+          const renamedAttr = { ...attr };
+
+          renamedAttr.name.name = 'onKeyDown';
+
+          // eslint-disable-next-line no-console
+          console.log(
+            `Popover prop handleKeyDown has being renamed to onKeyDown. Please, manually refactor the event from (event) to ({ event }) as well.   Location: ${file.path} @line: ${node.loc.start.line}`,
+          );
+
+          return renamedAttr;
+        })
+        .filter(Boolean);
+
+      fileHasModifications = true;
+      node.openingElement.attributes = newAttrs;
+
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -300,7 +300,7 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
   // ==== EVENT HANDLING: Popover ====
 
   const handleKeyDown = useCallback(
-    (event) => {
+    ({ event }) => {
       const { keyCode } = event;
 
       if (keyCode === UP_ARROW) {
@@ -445,7 +445,7 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
         <Layer>
           <Popover
             anchor={innerRef.current}
-            handleKeyDown={handleKeyDown}
+            onKeyDown={handleKeyDown}
             idealDirection="down"
             onDismiss={handleOnDismiss}
             positionRelativeToAnchor={false}

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -22,7 +22,7 @@ type OwnProps = {|
   border?: boolean,
   caret?: boolean,
   children?: ReactNode,
-  handleKeyDown?: (event: SyntheticKeyboardEvent<HTMLElement>) => void,
+  onKeyDown?: ({| event: SyntheticKeyboardEvent<HTMLElement> |}) => void,
   id?: ?string,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   onDismiss: () => void,
@@ -81,11 +81,11 @@ class Controller extends Component<Props, State> {
   }
 
   handleKeyDown: (event: SyntheticKeyboardEvent<HTMLElement>) => void = (event) => {
-    const { handleKeyDown, onDismiss } = this.props;
+    const { onKeyDown, onDismiss } = this.props;
     if (event.keyCode === ESCAPE) {
       onDismiss();
     }
-    if (handleKeyDown) handleKeyDown(event);
+    if (onKeyDown) onKeyDown?.({ event });
   };
 
   handlePageClick: (event: Event) => void = (event) => {

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -178,7 +178,7 @@ export default function Dropdown({
     }
   };
 
-  const handleKeyDown = (event) => {
+  const onKeyDown = ({ event }) => {
     const { keyCode } = event;
     if (keyCode === UP_ARROW) {
       handleKeyNavigation(event, KEYS.UP);
@@ -201,7 +201,7 @@ export default function Dropdown({
     <Popover
       anchor={anchor}
       color="white"
-      handleKeyDown={handleKeyDown}
+      onKeyDown={onKeyDown}
       id={id}
       idealDirection={idealDirection}
       onDismiss={onDismiss}

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -21,9 +21,9 @@ type Props = {|
    */
   color?: Color,
   /**
-   *
+   * Callback for key stroke events allowing keyboard navigation in Popover's children.
    */
-  handleKeyDown?: (event: SyntheticKeyboardEvent<HTMLElement>) => void,
+  onKeyDown?: ({| event: SyntheticKeyboardEvent<HTMLElement> |}) => void,
   /**
    * Unique id to identify each Popover. Used for [accessibility](https://gestalt.pinterest.systems/popover#ARIA-attributes) purposes.
    */
@@ -66,7 +66,7 @@ type Props = {|
 export default function Popover({
   anchor,
   children,
-  handleKeyDown,
+  onKeyDown,
   id,
   idealDirection,
   onDismiss,
@@ -87,7 +87,7 @@ export default function Popover({
       bgColor={color}
       border
       caret={showCaret}
-      handleKeyDown={handleKeyDown}
+      onKeyDown={onKeyDown}
       id={id}
       idealDirection={idealDirection}
       onDismiss={onDismiss}


### PR DESCRIPTION
### Summary

#### What changed?

Popover's `handleOnKeyDown` prop is renamed to `onKeyDown` and the event type is standardized from `(event)` to `({| event |})`

#### Why?

Dropdown implemented `handleOnKeyDown` to support keyboard navigation within Dropdown. ComboBox followed the same implementation. `handleOnKeyDown` has stayed undocumented, and moving forward there were 2 options: keep it private prefixing underscore (`_handleOnKeyDown`) or documenting it.

Popover is a building component and there's a clear use case for building custom components and needing `onKeyDown` to allow keyboard navigation within Popover's children.

NOTE: This is a breaking change as we are changing API, but prop was private so there are no uses in Pinboard and it's safe to merge.
<img width="1319" alt="Screen Shot 2022-02-03 at 7 05 19 PM" src="https://user-images.githubusercontent.com/10593890/152402376-2c3a187f-856f-42c1-a0f2-f4bb15e73a22.png">


### Checklist
- [X ] Added documentation + accessibility tests
