### PR TITLE
Link: updated Docs to use autogenerated prop table

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -117,6 +117,7 @@ export default function GeneratedPropTable({
         // Replace "Ref" with "React.Ref" to match docs convention
         // Includes `<` to avoid picking up `HTMLDivElement` and similar
         .replace(/Ref</g, 'React.Ref<');
+
       return {
         name: key,
         type: typeOverride ?? transformedType,

--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -101,7 +101,12 @@ export default function GeneratedPropTable({
       );
 
       // Trim leading `|`
-      const transformedType = (flowType.raw?.replace(/^\|/, '').trim() ?? flowType.name ?? '')
+      const transformedType = (
+        flowType.raw?.replace(/^\|/, '').trim() ??
+        flowType?.value ??
+        flowType.name ??
+        ''
+      )
         // Replace "Node" with "React.Node" to match docs convention
         .replace(/Node/g, 'React.Node')
         // Replace "ComponentType" with "React.ComponentType" to match docs convention
@@ -112,7 +117,6 @@ export default function GeneratedPropTable({
         // Replace "Ref" with "React.Ref" to match docs convention
         // Includes `<` to avoid picking up `HTMLDivElement` and similar
         .replace(/Ref</g, 'React.Ref<');
-
       return {
         name: key,
         type: typeOverride ?? transformedType,

--- a/docs/components/docgen.js
+++ b/docs/components/docgen.js
@@ -21,6 +21,7 @@ export type DocGen = {|
         raw?: string,
         nullable?: boolean,
         name: string,
+        value?: string,
       |},
     |},
   |},

--- a/docs/pages/link.js
+++ b/docs/pages/link.js
@@ -70,7 +70,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Accessible Tab Link"
-          description="Use `accessibilitySelected` and `role='Tab'` when using Link as a tab."
+          description={`Use \`accessibilitySelected\` and \`role="Tab"\` when using Link as a tab.`}
         >
           <MainSection.Card
             cardSize="lg"
@@ -112,7 +112,7 @@ function TabExample() {
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Link and Text"
-          description="Use Link within [text](https://gestalt.pinterest.systems/text) to get the correct font and underline color."
+          description="Use Link within [Text](https://gestalt.pinterest.systems/text) to get the correct font and underline color."
         >
           <MainSection.Card
             cardSize="lg"
@@ -135,7 +135,7 @@ function TabExample() {
         </MainSection.Subsection>
         <MainSection.Subsection
           title="tapStyle and hoverStyle"
-          description="Use `accessibilitySelected` and `role='Tab'` when using Link as a tab."
+          description={`Use \`accessibilitySelected\` and \`role="Tab"\` when using Link as a tab.`}
         >
           <MainSection.Card
             cardSize="lg"

--- a/docs/pages/link.js
+++ b/docs/pages/link.js
@@ -1,113 +1,16 @@
 // @flow strict
 import type { Node } from 'react';
-import PropTable from '../components/PropTable.js';
-import Example from '../components/Example.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 import Page from '../components/Page.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Link">
-      {' '}
       <PageHeader name="Link" description={generatedDocGen?.description} />
-      <PropTable
-        props={[
-          {
-            name: 'accessibilitySelected',
-            type: 'boolean',
-            href: 'tab',
-          },
-          {
-            name: 'children',
-            type: 'React.Node',
-          },
-          {
-            name: 'hoverStyle',
-            type: `'none' | 'underline'`,
-            defaultValue: 'underline',
-            href: 'Permutations',
-          },
-          {
-            name: 'href',
-            type: 'string',
-            required: true,
-            href: 'basicExample',
-          },
-          {
-            name: 'id',
-            type: 'string',
-            description: 'id attribute of the anchor tag',
-          },
-          {
-            name: 'inline',
-            type: 'boolean',
-            defaultValue: false,
-            href: 'advancedExample',
-          },
-          {
-            name: 'onBlur',
-            type: '() => void',
-          },
-          {
-            name: 'accessibilityLabel',
-            type: 'string',
-            required: false,
-            defaultValue: null,
-            description: [
-              "Supply a short, descriptive label for screen-readers to replace link texts that don't provide sufficient context about the link component behavior. Texts like `Click Here,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text.",
-              'Accessibility: It populates aria-label. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text.',
-            ],
-            href: 'accessibility',
-          },
-          {
-            name: 'onClick',
-            type:
-              'AbstractEventHandler<SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}>',
-            description:
-              'Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
-            href: 'Custom-navigation',
-          },
-          {
-            name: 'onFocus',
-            type: '() => void',
-          },
-          {
-            name: 'ref',
-            type: "React.Ref<'a'>",
-            description: 'Forward the ref to the underlying anchor element',
-          },
-          {
-            name: 'rel',
-            type: `"none" | "nofollow"`,
-            defaultValue: 'none',
-          },
-          {
-            name: 'role',
-            type: `"tab"`,
-            href: 'tab',
-          },
-          {
-            name: 'rounding',
-            type: `"pill" | "circle" | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8`,
-            defaultValue: '0',
-            href: 'advancedExample',
-          },
-          {
-            name: 'tapStyle',
-            type: `"none" | "compress"`,
-            defaultValue: 'none',
-            href: 'Permutations',
-          },
-          {
-            name: 'target',
-            type: `"null" | "self" | "blank"`,
-            defaultValue: 'null',
-            href: 'PreventDefault',
-          },
-        ]}
-      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen} excludeProps={['disabled']} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -130,36 +33,16 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           />
         </MainSection.Subsection>
       </MainSection>
-      <Example
-        description={`
-    You should wrap \`Link\` components inside of a \`Text\` component to get the correct font & underline color.
-  `}
-        name="Example"
-        defaultCode={`
+      <MainSection name="Accessibility">
+        <MainSection.Subsection
+          title="Accessible Content"
+          description={`When providing the content for the link, avoid phrases like "click here" or "go to".`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Box>
-  <Link href="https://pinterest.com">
-    <Box padding={2}>
-      <Text color="red" weight="bold">
-        Incorrect underline color: Pinterest.com
-      </Text>
-    </Box>
-  </Link>
-  <Text color="red" weight="bold">
-    <Link href="https://pinterest.com">
-      <Box padding={2}>Correct underline color: Pinterest.com</Box>
-    </Link>
-  </Text>
-</Box>`}
-      />
-      <Example
-        id="accessibility"
-        description={`
-    When providing the content for the link, avoid phrases like "click here" or "go to".
-  `}
-        name="Accessible Content"
-        defaultCode={`
-<Box>
-  <Heading>Bad ❌</Heading>
+  <Heading accessibilityLevel="none">Bad ❌</Heading>
   <Text>
     For more information,{' '}
     <Text inline weight="bold">
@@ -170,7 +53,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     .
   </Text>
   <Box paddingY={4}>
-    <Heading>Good ✅</Heading>
+    <Heading accessibilityLevel="none">Good ✅</Heading>
     <Text>
       Visit{' '}
       <Text inline weight="bold">
@@ -183,14 +66,15 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   </Box>
 </Box>
 `}
-      />
-      <Example
-        id="tab"
-        description={`
-    Use accessibilitySelected and role when using it as a Tab.
-  `}
-        name="Accessible Tab Link"
-        defaultCode={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Accessible Tab Link"
+          description="Use `accessibilitySelected` and `role='Tab'` when using Link as a tab."
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function TabExample() {
   const [activeIndex, setActiveIndex] = React.useState(0);
   return (
@@ -222,11 +106,40 @@ function TabExample() {
     </Box>
   );
 }`}
-      />
-      <Example
-        id="Permutations"
-        name="Permutations: tapStyle and hoverStyle"
-        defaultCode={`
+          />
+        </MainSection.Subsection>
+      </MainSection>
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          title="Link and Text"
+          description="Use Link within [text](https://gestalt.pinterest.systems/text) to get the correct font and underline color."
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+<Box>
+  <Link href="https://pinterest.com">
+    <Box padding={2}>
+      <Text color="red" weight="bold">
+        Incorrect underline color: Pinterest.com
+      </Text>
+    </Box>
+  </Link>
+  <Text color="red" weight="bold">
+    <Link href="https://pinterest.com">
+      <Box padding={2}>Correct underline color: Pinterest.com</Box>
+    </Link>
+  </Text>
+</Box>`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="tapStyle and hoverStyle"
+          description="Use `accessibilitySelected` and `role='Tab'` when using Link as a tab."
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function PermutationsExample() {
   return (
     <Box>
@@ -256,7 +169,9 @@ function PermutationsExample() {
   );
 }
 `}
-      />
+          />
+        </MainSection.Subsection>
+      </MainSection>
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
@@ -264,7 +179,7 @@ function PermutationsExample() {
 OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
       `}
         />
-      </MainSection>{' '}
+      </MainSection>
     </Page>
   );
 }

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -22,11 +22,11 @@ type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill';
 
 type Props = {|
   /**
-   * Supply a short, descriptive label for screen-readers to replace link texts that don't provide sufficient context about the link component behavior. Texts like `Click Here,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text. It populates aria-label. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text. See the [Accessibility guidelines](https://gestalt.pinterest.systems/link#Accessibility) for more information.
+   * Supply a short, descriptive label for screen-readers to replace link texts that don't provide sufficient context about the link component behavior. Texts like "Click Here", or "Read More" can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text. It populates `aria-label`. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text. See the [Accessibility guidelines](https://gestalt.pinterest.systems/link#Accessibility) for more information.
    */
   accessibilityLabel?: string,
   /**
-   * Use `accessibilitySelected` and role when using it as a tab. See the [Accessibility guidelines](https://gestalt.pinterest.systems/link#Accessible-Tab-Link) for more information.
+   * Use `accessibilitySelected` and `role` when using it as a tab. See the [Accessibility guidelines](https://gestalt.pinterest.systems/link#Accessible-Tab-Link) for more information.
    */
   accessibilitySelected?: boolean,
   /**
@@ -69,7 +69,7 @@ type Props = {|
    */
   ref?: Ref<'a'>,
   /**
-   * Establishes the relationship of the linked URL. Use `rel=”nofollow”` for offsite links to inform search engines to ignore and not follow them.
+   * Establishes the relationship of the linked URL. Use `rel="nofollow"` for offsite links to inform search engines to ignore and not follow them.
    */
   rel?: 'none' | 'nofollow',
   /**

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -1,43 +1,104 @@
 // @flow strict
-import type { AbstractComponent, Node, Element } from 'react';
-
-import { forwardRef, useImperativeHandle, useRef } from 'react';
+import {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type AbstractComponent,
+  type Node,
+  type Element,
+  type Ref,
+} from 'react';
 import classnames from 'classnames';
 import { useOnLinkNavigation } from './contexts/OnLinkNavigationProvider.js';
 import touchableStyles from './Touchable.css';
 import styles from './Link.css';
 import useTapFeedback, { keyPressShouldTriggerTap } from './useTapFeedback.js';
-import getRoundingClassName, { type Rounding } from './getRoundingClassName.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import getRoundingClassName from './getRoundingClassName.js';
 import focusStyles from './Focus.css';
 import useFocusVisible from './useFocusVisible.js';
 import layoutStyles from './Layout.css';
 
+type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill';
+
 type Props = {|
+  /**
+   * Supply a short, descriptive label for screen-readers to replace link texts that don't provide sufficient context about the link component behavior. Texts like `Click Here,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text. It populates aria-label. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text. See the [Accessibility guidelines](https://gestalt.pinterest.systems/link#Accessibility) for more information.
+   */
   accessibilityLabel?: string,
+  /**
+   * Use `accessibilitySelected` and role when using it as a tab. See the [Accessibility guidelines](https://gestalt.pinterest.systems/link#Accessible-Tab-Link) for more information.
+   */
   accessibilitySelected?: boolean,
+  /**
+   * Link is a wrapper around components (or children), most commonly text, so that they become hyperlinks. See the [Link and Text](https://gestalt.pinterest.systems/link#Link-and-Text) variant for more information.
+   */
   children?: Node,
+  /**
+   * When `underline` is supplied, Link's text is underlined on hover. See the [tapStyle and hoverStyle](https://gestalt.pinterest.systems/link#tapStyle-and-hoverStyle) variant for more information.
+   */
   hoverStyle?: 'none' | 'underline',
+  /**
+   * The URL that the hyperlink points to.
+   */
   href: string,
+  /**
+   * Unique id attribute of the anchor tag.
+   */
   id?: string,
+  /**
+   * Properly positions Link relative to an inline element, such as [Text](https://gestalt.pinterest.systems/text), using the inline property.
+   */
   inline?: boolean,
-  onBlur?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
-  onClick?: AbstractEventHandler<
-    SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| dangerouslyDisableOnNavigation: () => void |},
-  >,
-  onFocus?: AbstractEventHandler<SyntheticFocusEvent<HTMLAnchorElement>>,
+  /**
+   * Callback triggered when when the element loses focus.
+   */
+  onBlur?: ({| event: SyntheticFocusEvent<HTMLAnchorElement> |}) => void,
+  /**
+   * Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
+   */
+  onClick?: ({|
+    event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    dangerouslyDisableOnNavigation: () => void,
+  |}) => void,
+  /**
+   * Callback triggered when the element gains focus.
+   */
+  onFocus?: ({| event: SyntheticFocusEvent<HTMLAnchorElement> |}) => void,
+  /**
+   * Ref that is forwarded to the underlying anchor element.
+   */
+  ref?: Ref<'a'>,
+  /**
+   * Establishes the relationship of the linked URL. Use `rel=”nofollow”` for offsite links to inform search engines to ignore and not follow them.
+   */
   rel?: 'none' | 'nofollow',
+  /**
+   * When supplied, Link acts a tab. See the [Accessible Tab Link](https://gestalt.pinterest.systems/link#Accessible-Tab-Link) for more information.
+   */
   role?: 'tab',
+  /**
+   * Sets a border radius for Link. Select a rounding option that aligns with its children.
+   */
   rounding?: Rounding,
+  /**
+   * When `compress` is supplied, Link is visually compressed on click. See the [tapStyle and hoverStyle](https://gestalt.pinterest.systems/link#tapStyle-and-hoverStyle) variant for more information.
+   */
   tapStyle?: 'none' | 'compress',
+  /**
+   * Define the frame or window to open the anchor defined on href:
+- 'null' opens the anchor in the same window.
+- 'blank' opens the anchor in a new window.
+- 'self' opens an anchor in the same frame.
+   */
   target?: null | 'self' | 'blank',
-  // private props to be internally used, therefore, not documented
+  /**
+   * Private prop. When `disabled` is supplied, the href prop in the anchor tag is set to undefined. To be deprecated.
+   */
   disabled?: boolean,
 |};
 
 /**
- * The [Link](https://gestalt.pinterest.systems/link) component allows you to show links on the page, open them in a new window, and change the color.
+ * The [Link](https://gestalt.pinterest.systems/link) component allows you to show links on the page and open them in a new window.
  */
 const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardRef<
   Props,


### PR DESCRIPTION
### Summary

#### What changed?

Link: updated Docs to use autogenerated prop table

#### Why?

Gestalt is moving in this direction, all components must autogenerate prop tables