### PR TITLE
Masonry: revert scroll state optimization (#1774)

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -86,11 +86,11 @@ type Props<T> = {|
   /**
    * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsBottom` allows customization of the buffer size below the viewport, specified in pixels.
    */
-   virtualBoundsBottom?: number,
-   /**
-    * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsTop` allows customization of the buffer size above the viewport, specified in pixels.
-    */
-   virtualBoundsTop?: number,
+  virtualBoundsBottom?: number,
+  /**
+   * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsTop` allows customization of the buffer size above the viewport, specified in pixels.
+   */
+  virtualBoundsTop?: number,
   /**
    * Specifies whether or not Masonry dynamically adds/removes content from the grid based on the user's viewport and scroll position. Note that `scrollContainer` must be specified when virtualization is used.
    */

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -86,19 +86,15 @@ type Props<T> = {|
   /**
    * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsBottom` allows customization of the buffer size below the viewport, specified in pixels.
    */
-  virtualBoundsBottom?: number,
-  /**
-   * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsTop` allows customization of the buffer size above the viewport, specified in pixels.
-   */
-  virtualBoundsTop?: number,
+   virtualBoundsBottom?: number,
+   /**
+    * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsTop` allows customization of the buffer size above the viewport, specified in pixels.
+    */
+   virtualBoundsTop?: number,
   /**
    * Specifies whether or not Masonry dynamically adds/removes content from the grid based on the user's viewport and scroll position. Note that `scrollContainer` must be specified when virtualization is used.
    */
   virtualize?: boolean,
-
-  // Prop to help us conditionally/experimentally test a new React.setState(scrollPos) strategy.
-  // See this.handleScroll fn for more details
-  _deferScrollPositionUpdate?: boolean,
 |};
 
 type State<T> = {|
@@ -115,12 +111,6 @@ const RESIZE_DEBOUNCE = 300;
 // Multiplied against container height.
 // The amount of extra buffer space for populating visible items.
 const VIRTUAL_BUFFER_FACTOR = 0.7;
-
-// Duration for the function that we'll use to see if scroll is still happening.
-// One mouse scroll creates many addEventListener('scroll', ()=>{}) type events,
-// so if this timeout is reached (not reset by another scroll event), we know scroll
-// is over and perform post scroll tasks.
-const SCROLL_TIMEOUT_WAIT = 100;
 
 const layoutNumberToCssDimension = (n) => (n !== Infinity ? n : undefined);
 
@@ -142,8 +132,10 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     }
   }, RESIZE_DEBOUNCE);
 
+  // Using throttle here to schedule the handler async, outside of the event
+  // loop that produced the event.
   // $FlowFixMe[signature-verification-failure]
-  updateScrollPosition = () => {
+  updateScrollPosition = throttle(() => {
     if (!this.scrollContainer) {
       return;
     }
@@ -156,25 +148,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     this.setState({
       scrollTop: getScrollPos(scrollContainer),
     });
-  };
-
-  // $FlowFixMe[signature-verification-failure]
-  throttledUpdateScrollPosition = throttle(this.updateScrollPosition);
-
-  scrollTimeoutId: ?TimeoutID = null;
-
-  // The browser scroll event API will fire LOTS of scroll events. This waits until the events
-  // stop coming in to set the final scroll position
-  handleScroll: () => void = () => {
-    if (this.scrollTimeoutId) {
-      clearTimeout(this.scrollTimeoutId);
-    }
-    this.scrollTimeoutId = setTimeout(this.updateScrollPosition, SCROLL_TIMEOUT_WAIT);
-  };
-
-  clearScrollTimeout: () => void = () => {
-    clearTimeout(this.scrollTimeoutId);
-  };
+  });
 
   // $FlowFixMe[signature-verification-failure]
   measureContainerAsync = debounce(() => {
@@ -290,12 +264,8 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     // Make sure async methods are cancelled.
     this.measureContainerAsync.clearTimeout();
     this.handleResize.clearTimeout();
-    // eslint-disable-next-line no-underscore-dangle
-    if (this.props._deferScrollPositionUpdate) {
-      this.clearScrollTimeout();
-    } else {
-      this.throttledUpdateScrollPosition.clearTimeout();
-    }
+    this.updateScrollPosition.clearTimeout();
+
     window.removeEventListener('resize', this.handleResize);
   }
 
@@ -475,7 +445,6 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       items,
       layout,
       minCols,
-      _deferScrollPositionUpdate,
       scrollContainer,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
@@ -623,9 +592,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     return scrollContainer ? (
       <ScrollContainer
         ref={this.setScrollContainerRef}
-        onScroll={
-          _deferScrollPositionUpdate ? this.handleScroll : this.throttledUpdateScrollPosition
-        }
+        onScroll={this.updateScrollPosition}
         scrollContainer={scrollContainer}
       >
         {gridBody}


### PR DESCRIPTION
This reverts commit 417f3dfb5f2fc7890f62f3a2bcd7529aa87ccc54.

#### What changed?
A clean revert of #1774.

#### Why?
While this experiment had some great scroll wins, it was seeing session/engagement loss in both mobile and desktop versions that I couldn't root cause. The only lead I had was to check invocations of `fetchMore()`, but I did a quick smoke test and found that both enabled and controlled called the function a similar number of times.

Experiment will be cleaned up internally to Pinterest, of course.

### Links
- [Jira](https://jira.pinadmin.com/browse/PERF-11249)
- [Web Experiment](https://helium.pinadmin.com/scroll_gestalt_defer_pos_update/combined/homefeed-volume/)
- [Mobile Web Experiment](https://helium.pinadmin.com/mweb_scroll_gestalt_defer_pos_update/combined/days-in-volume/)


### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
