### PR TITLE
Table: updated Docs to use autogenerated prop table

### DIFF
--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -108,7 +108,7 @@ export default function GeneratedPropTable({
         .replace(/ComponentType/g, 'React.ComponentType')
         // Replace "Element" with "React.Element" to match docs convention
         // Includes `<` to avoid picking up `HTMLDivElement` and similar
-        .replace(/Element</g, 'React.Element<')
+        .replace(/^Element</g, 'React.Element<')
         // Replace "Ref" with "React.Ref" to match docs convention
         // Includes `<` to avoid picking up `HTMLDivElement` and similar
         .replace(/Ref</g, 'React.Ref<');

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -2571,16 +2571,16 @@ export async function getStaticProps(): Promise<{|
   });
 
   docGen.Table.props.children.flowType.raw =
-    'React.ChildrenArray<React.Element< typeof Table.Body | typeof Table.Footer | typeof Table.Header >>';
-  docGen.TableHeader.props.children.flowType.raw = 'React.Element< typeof Table.Row >';
+    'React.ChildrenArray<React.Element<typeof Table.Body | typeof Table.Footer | typeof Table.Header>>';
+  docGen.TableHeader.props.children.flowType.raw = 'React.Element<typeof Table.Row>';
   docGen.TableBody.props.children.flowType.raw =
-    'React.ChildrenArray<React.Element< typeof Table.Row | typeof Table.RowExpandable >>';
+    'React.ChildrenArray<React.Element<typeof Table.Row | typeof Table.RowExpandable>>';
   docGen.TableFooter.props.children.flowType.raw =
-    'React.ChildrenArray<React.Element< typeof Table.Row | typeof Table.RowExpandable >>';
+    'React.ChildrenArray<React.Element<typeof Table.Row | typeof Table.RowExpandable>>';
   docGen.TableRow.props.children.flowType.raw =
-    'React.ChildrenArray<React.Element< typeof Table.Cell | typeof Table.HeaderCell | typeof Table.SortableHeaderCell >>';
+    'React.ChildrenArray<React.Element<typeof Table.Cell | typeof Table.HeaderCell | typeof Table.SortableHeaderCell>>';
   docGen.TableRowExpandable.props.children.flowType.raw =
-    'React.ChildrenArray<React.Element< typeof Table.Cell >>';
+    'React.ChildrenArray<React.Element<typeof Table.Cell>>';
 
   return {
     props: {

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -2,16 +2,21 @@
 import type { Node } from 'react';
 import { Table } from 'gestalt';
 import PageHeader from '../components/PageHeader.js';
-import PropTable from '../components/PropTable.js';
 import MainSection from '../components/MainSection.js';
 import Page from '../components/Page.js';
+import { multipledocgen, type DocGen } from '../components/docgen.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 
-export default function TablePage(): Node {
+export default function TablePage({
+  generatedDocGen,
+}: {|
+  generatedDocGen: {| [string]: DocGen |},
+|}): Node {
   return (
     <Page title="Table">
       <PageHeader
         name="Table"
-        description="​​A table is a set of structured data that is easy for a user to scan, examine, and compare. Table data is displayed in a grid format and can be used to structure both interactive and static data."
+        description={generatedDocGen.Table?.description}
         defaultCode={`
 <Table accessibilityLabel="Basic Table">
   <Table.Header>
@@ -76,37 +81,7 @@ export default function TablePage(): Node {
 </Table>
 `}
       />
-      <PropTable
-        Component={Table}
-        props={[
-          {
-            name: 'accessibilityLabel',
-            type: 'string',
-            description: 'Label for screen readers to announce Table.',
-            required: true,
-          },
-          {
-            name: 'children',
-            type: 'React.Node',
-          },
-          {
-            name: 'borderStyle',
-            type: `"sm" | "none"`,
-            description: 'Specify a border width for table: "sm" is 1px',
-            defaultValue: 'none',
-          },
-          {
-            name: 'maxHeight',
-            type: `number | string`,
-            description: `Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%"`,
-          },
-          {
-            name: 'stickyColumns',
-            type: `number`,
-            description: `Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](#Sticky-Column) example for details.`,
-          },
-        ]}
-      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen.Table} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -1534,198 +1509,57 @@ function Example() {
         </MainSection.Subsection>
       </MainSection>
       <MainSection name="Subcomponents">
-        <PropTable
+        <GeneratedPropTable
+          generatedDocGen={generatedDocGen.TableHeader}
+          Component={Table?.Header}
+          name="Table.Header"
+          id="Table.Header"
+        />
+        <GeneratedPropTable
+          generatedDocGen={generatedDocGen.TableBody}
           Component={Table?.Body}
           name="Table.Body"
           id="Table.Body"
-          props={[
-            {
-              name: 'children',
-              type: 'React.Node',
-            },
-          ]}
         />
-        <PropTable
-          name="Table.Cell"
-          id="Table.Cell"
-          Component={Table?.Cell}
-          props={[
-            {
-              name: 'children',
-              type: 'React.Node',
-            },
-            {
-              name: 'colSpan',
-              type: 'number',
-              defaultValue: 1,
-            },
-            {
-              name: 'rowSpan',
-              type: 'number',
-              defaultValue: 1,
-            },
-          ]}
-        />
-        <PropTable
+        <GeneratedPropTable
+          generatedDocGen={generatedDocGen.TableFooter}
+          Component={Table?.Footer}
           name="Table.Footer"
           id="Table.Footer"
-          Component={Table?.Footer}
-          props={[
-            {
-              name: 'children',
-              type: 'React.Node',
-            },
-          ]}
         />
-        <PropTable
-          name="Table.Header"
-          id="Table.Header"
-          Component={Table?.Header}
-          props={[
-            {
-              name: 'children',
-              type: 'React.Node',
-            },
-            {
-              name: 'sticky',
-              type: 'boolean',
-              defaultValue: false,
-              href: 'stickyHeader',
-              description:
-                'If true, the table header will be sticky and the table body will be scrollable',
-            },
-          ]}
+
+        <GeneratedPropTable
+          generatedDocGen={generatedDocGen.TableCell}
+          Component={Table?.Cell}
+          name="Table.Cell"
+          id="Table.Cell"
+          excludeProps={['shouldBeSticky', 'previousTotalWidth', 'shouldHaveShadow']}
         />
-        <PropTable
+        <GeneratedPropTable
+          generatedDocGen={generatedDocGen.TableHeaderCell}
+          Component={Table?.HeaderCell}
           name="Table.HeaderCell"
           id="Table.HeaderCell"
-          Component={Table?.HeaderCell}
-          props={[
-            {
-              name: 'children',
-              type: 'React.Node',
-            },
-            {
-              name: 'scope',
-              defaultValue: 'col',
-              type: '"col" | "row" | "colgroup" | "rowgroup"',
-            },
-            {
-              name: 'colSpan',
-              type: 'number',
-              defaultValue: 1,
-            },
-            {
-              name: 'rowSpan',
-              type: 'number',
-              defaultValue: 1,
-            },
-          ]}
+          excludeProps={['shouldBeSticky', 'previousTotalWidth', 'shouldHaveShadow']}
         />
-        <PropTable
-          name="Table.Row"
-          id="Table.Row"
-          Component={Table?.Row}
-          props={[
-            {
-              name: 'children',
-              type: 'React.Node',
-            },
-          ]}
-        />
-        <PropTable
-          name="Table.RowExpandable"
-          id="Table.RowExpandable"
-          Component={Table?.Row}
-          props={[
-            {
-              name: 'accessibilityCollapseLabel',
-              type: 'string',
-              required: true,
-              defaultValue: null,
-              description: [
-                'Supply a short, descriptive label for screen-readers as a text alternative to the Collapse button.',
-                'Accessibility: It populates aria-label on the `<button>` element for the Collapse button.',
-              ],
-            },
-            {
-              name: 'accessibilityExpandLabel',
-              type: 'string',
-              required: true,
-              defaultValue: null,
-              description: [
-                'Supply a short, descriptive label for screen-readers as a text alternative to the Expand button.',
-                'Accessibility: It populates aria-label on the `<button>` element for the Expand button.',
-              ],
-            },
-            {
-              name: 'children',
-              type: 'React.Node',
-            },
-            {
-              name: 'expandedContents',
-              type: 'React.Node',
-              required: true,
-            },
-            {
-              name: 'hoverStyle',
-              type: '"none" | "gray"',
-              defaultValue: 'gray',
-            },
-            {
-              name: 'id',
-              type: 'string',
-              required: true,
-            },
-            {
-              name: 'onExpand',
-              type: `({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement>
-          | SyntheticKeyboardEvent<HTMLAnchorElement> expanded: boolean }) => void`,
-              description: ['Callback fired when the expand button component is clicked'],
-            },
-          ]}
-        />
-        <PropTable
+        <GeneratedPropTable
+          generatedDocGen={generatedDocGen.TableSortableHeaderCell}
+          Component={Table?.SortableHeaderCell}
           name="Table.SortableHeaderCell"
           id="Table.SortableHeaderCell"
-          Component={Table?.SortableHeaderCell}
-          props={[
-            {
-              name: 'children',
-              type: 'React.Node',
-            },
-            {
-              name: 'scope',
-              defaultValue: 'col',
-              type: '"col" | "row" | "colgroup" | "rowgroup"',
-            },
-            {
-              name: 'colSpan',
-              type: 'number',
-              defaultValue: 1,
-            },
-            {
-              name: 'rowSpan',
-              type: 'number',
-              defaultValue: 1,
-            },
-            {
-              name: 'onSortChange',
-              required: true,
-              type:
-                '({ event: SyntheticMouseEvent<HTMLTableCellElement> | SyntheticKeyboardEvent<HTMLTableCellElement> }) => void',
-            },
-            {
-              name: 'sortOrder',
-              required: true,
-              type: '"asc" | "desc"',
-            },
-            {
-              name: 'status',
-              required: true,
-              type: '"active" | "inactive"',
-            },
-          ]}
+          excludeProps={['shouldBeSticky', 'previousTotalWidth', 'shouldHaveShadow']}
+        />
+        <GeneratedPropTable
+          generatedDocGen={generatedDocGen.TableRow}
+          Component={Table?.Row}
+          name="Table.Row"
+          id="Table.Row"
+        />
+        <GeneratedPropTable
+          generatedDocGen={generatedDocGen.TableRowExpandable}
+          Component={Table?.RowExpandable}
+          name="Table.RowExpandable"
+          id="Table.RowExpandable"
         />
       </MainSection>
       <MainSection name="Variants">
@@ -2717,4 +2551,40 @@ Checkboxes are often used in tables to allow for selecting and editing of multip
       </MainSection>
     </Page>
   );
+}
+
+export async function getStaticProps(): Promise<{|
+  props: {| generatedDocGen: {| [string]: DocGen |} |},
+|}> {
+  const docGen = await multipledocgen({
+    componentName: [
+      'Table',
+      'TableHeader',
+      'TableBody',
+      'TableFooter',
+      'TableCell',
+      'TableHeaderCell',
+      'TableSortableHeaderCell',
+      'TableRow',
+      'TableRowExpandable',
+    ],
+  });
+
+  docGen.Table.props.children.flowType.raw =
+    'React.ChildrenArray<React.Element< typeof Table.Body | typeof Table.Footer | typeof Table.Header >>';
+  docGen.TableHeader.props.children.flowType.raw = 'React.Element< typeof Table.Row >';
+  docGen.TableBody.props.children.flowType.raw =
+    'React.ChildrenArray<React.Element< typeof Table.Row | typeof Table.RowExpandable >>';
+  docGen.TableFooter.props.children.flowType.raw =
+    'React.ChildrenArray<React.Element< typeof Table.Row | typeof Table.RowExpandable >>';
+  docGen.TableRow.props.children.flowType.raw =
+    'React.ChildrenArray<React.Element< typeof Table.Cell | typeof Table.HeaderCell | typeof Table.SortableHeaderCell >>';
+  docGen.TableRowExpandable.props.children.flowType.raw =
+    'React.ChildrenArray<React.Element< typeof Table.Cell >>';
+
+  return {
+    props: {
+      generatedDocGen: docGen,
+    },
+  };
 }

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -33,7 +33,7 @@ type Props = {|
    */
   maxHeight?: number | string,
   /**
-   * Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](https://gestalt.pinterest.systems/table#Sticky-Column) variant for details.
+   * Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](https://gestalt.pinterest.systems/table#Sticky-Column), the [multiple sticky columns](https://gestalt.pinterest.systems/table#Multiple-sticky-columns), the [sticky header and columns](https://gestalt.pinterest.systems/table#Sticky-header-and-sticky-columns), the [expandable row with sticky columns](https://gestalt.pinterest.systems/table#Table-Row-Expandable-with-Sticky-Columns), and the [sortable header cells with sticky columns](https://gestalt.pinterest.systems/table#Sortable-header-cells-with-sticky-columns) variants for details.
    */
   stickyColumns?: ?number,
 |};

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -16,18 +16,38 @@ import TableSortableHeaderCell from './TableSortableHeaderCell.js';
 import { TableContextProvider } from './contexts/TableContext.js';
 
 type Props = {|
+  /**
+   * Must be instances of Table.Header, Table.Body, and/or Table.Footer components. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   */
   children: Node,
+  /**
+   * Label for screen readers to announce Table.
+   */
   accessibilityLabel: string,
+  /**
+   * Specify a border width for table: "sm" is 1px.
+   */
   borderStyle?: 'sm' | 'none',
+  /**
+   * Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%".
+   */
   maxHeight?: number | string,
+  /**
+   * Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](https://gestalt.pinterest.systems/table#Sticky-Column) variant for details.
+   */
   stickyColumns?: ?number,
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * A [Table](https://gestalt.pinterest.systems/table) is a set of structured data that is easy for a user to scan, examine, and compare. Table data is displayed in a grid format and can be used to structure both interactive and static data.
  */
-export default function Table(props: Props): Node {
-  const { accessibilityLabel, borderStyle, children, maxHeight, stickyColumns } = props;
+export default function Table({
+  accessibilityLabel,
+  borderStyle,
+  children,
+  maxHeight,
+  stickyColumns,
+}: Props): Node {
   const [showShadowScroll, setShowShadowScroll] = useState<'left' | 'right' | null>(null);
   const tableRef = useRef<?HTMLElement>(null);
 

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -25,21 +25,21 @@ type Props = {|
    */
   accessibilityLabel: string,
   /**
-   * Specify a border width for table: "sm" is 1px.
+   * Specify a border width for Table: "sm" is 1px.
    */
   borderStyle?: 'sm' | 'none',
   /**
-   * Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%".
+   * Use numbers for pixels: `maxHeight={100}` and strings for percentages: `maxHeight="100%"`.
    */
   maxHeight?: number | string,
   /**
-   * Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](https://gestalt.pinterest.systems/table#Sticky-Column), the [multiple sticky columns](https://gestalt.pinterest.systems/table#Multiple-sticky-columns), the [sticky header and columns](https://gestalt.pinterest.systems/table#Sticky-header-and-sticky-columns), the [expandable row with sticky columns](https://gestalt.pinterest.systems/table#Table-Row-Expandable-with-Sticky-Columns), and the [sortable header cells with sticky columns](https://gestalt.pinterest.systems/table#Sortable-header-cells-with-sticky-columns) variants for details.
+   * Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](https://gestalt.pinterest.systems/table#Sticky-Column), [multiple sticky columns](https://gestalt.pinterest.systems/table#Multiple-sticky-columns), [sticky header and columns](https://gestalt.pinterest.systems/table#Sticky-header-and-sticky-columns), [expandable row with sticky columns](https://gestalt.pinterest.systems/table#Table-Row-Expandable-with-Sticky-Columns), and [sortable header cells with sticky columns](https://gestalt.pinterest.systems/table#Sortable-header-cells-with-sticky-columns) variants for details.
    */
   stickyColumns?: ?number,
 |};
 
 /**
- * A [Table](https://gestalt.pinterest.systems/table) is a set of structured data that is easy for a user to scan, examine, and compare. Table data is displayed in a grid format and can be used to structure both interactive and static data.
+ * [Table](https://gestalt.pinterest.systems/table) is a set of structured data that is easy for a user to scan, examine, and compare. Table data is displayed in a grid format and can be used to structure both interactive and static data.
  */
 export default function Table({
   accessibilityLabel,

--- a/packages/gestalt/src/TableBody.js
+++ b/packages/gestalt/src/TableBody.js
@@ -3,12 +3,16 @@ import type { Node } from 'react';
 import styles from './Table.css';
 
 type Props = {|
+  /**
+   * Must be instances of Table.Row and/or Table.RowExpandable components. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   */
   children: Node,
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * Subcomponent of [Table](https://gestalt.pinterest.systems/table).
+ * Use [Table.Body](https://gestalt.pinterest.systems/table#Table.BodyProps) to group the body content in Table.
  */
-export default function TableBody(props: Props): Node {
-  return <tbody className={styles.tbody}>{props.children}</tbody>;
+export default function TableBody({ children }: Props): Node {
+  return <tbody className={styles.tbody}>{children}</tbody>;
 }

--- a/packages/gestalt/src/TableCell.js
+++ b/packages/gestalt/src/TableCell.js
@@ -4,26 +4,43 @@ import cx from 'classnames';
 import styles from './Table.css';
 
 type Props = {|
+  /**
+   * The content of the table cell.
+   */
   children: Node,
+  /**
+   * `colSpan` defines the number of columns a cell should span.
+   */
   colSpan?: number,
+  /**
+   * `rowSpan` defines the number of rows a cell should span.
+   */
   rowSpan?: number,
+  /**
+   * Private prop required for sticky columns
+   */
   shouldBeSticky?: boolean,
+  /**
+   * Private prop required for sticky columns
+   */
   shouldHaveShadow?: boolean,
+  /**
+   * Private prop required for sticky columns
+   */
   previousTotalWidth?: number,
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * Subcomponent of [Table](https://gestalt.pinterest.systems/table).
  */
-export default function TableCell(props: Props): Node {
-  const {
-    children,
-    colSpan,
-    rowSpan,
-    shouldBeSticky,
-    previousTotalWidth,
-    shouldHaveShadow,
-  } = props;
+export default function TableCell({
+  children,
+  colSpan,
+  rowSpan,
+  shouldBeSticky,
+  previousTotalWidth,
+  shouldHaveShadow,
+}: Props): Node {
   const cs = cx(
     styles.td,
     shouldBeSticky && styles.columnSticky,

--- a/packages/gestalt/src/TableFooter.js
+++ b/packages/gestalt/src/TableFooter.js
@@ -2,12 +2,16 @@
 import type { Node } from 'react';
 
 type Props = {|
+  /**
+   * Must be instances of Table.Row and/or Table.RowExpandable components. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   */
   children: Node,
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * Subcomponent of [Table](https://gestalt.pinterest.systems/table).
+ * Use [Table.Footer](https://gestalt.pinterest.systems/table#Table.FooterProps) to group the footer content in Table.
  */
-export default function TableFooter(props: Props): Node {
-  return <tfoot>{props.children}</tfoot>;
+export default function TableFooter({ children }: Props): Node {
+  return <tfoot>{children}</tfoot>;
 }

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -9,7 +9,7 @@ type Props = {|
    */
   children: Node,
   /**
-   * If true, the table header will be sticky and the table body will be scrollable.
+   * If true, the table header will be sticky and the table body will be scrollable. See the [sticky Header](https://gestalt.pinterest.systems/table#Sticky-header) and the [sticky header and columns](https://gestalt.pinterest.systems/table#v) variants for details.
    */
   sticky?: boolean,
 |};

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -9,7 +9,7 @@ type Props = {|
    */
   children: Node,
   /**
-   * If true, the table header will be sticky and the table body will be scrollable. See the [sticky Header](https://gestalt.pinterest.systems/table#Sticky-header) and the [sticky header and columns](https://gestalt.pinterest.systems/table#v) variants for details.
+   * If true, the table header will be sticky and the table body will be scrollable. See the [sticky Header](https://gestalt.pinterest.systems/table#Sticky-header) and the [sticky header and columns](https://gestalt.pinterest.systems/table#Sticky-header-and-sticky-columns) variants for details.
    */
   sticky?: boolean,
 |};

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -4,14 +4,21 @@ import cx from 'classnames';
 import styles from './Table.css';
 
 type Props = {|
+  /**
+   * Must be an instance of Table.Row. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   */
   children: Node,
+  /**
+   * If true, the table header will be sticky and the table body will be scrollable.
+   */
   sticky?: boolean,
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * Subcomponent of [Table](https://gestalt.pinterest.systems/table).
+ * Use [Table.Header](https://gestalt.pinterest.systems/table#Table.HeaderProps) to group the header content in Table.
  */
-export default function TableHeader(props: Props): Node {
-  const cs = cx(styles.thead, props.sticky && styles.sticky);
-  return <thead className={cs}>{props.children}</thead>;
+export default function TableHeader({ sticky = false, children }: Props): Node {
+  const cs = cx(styles.thead, sticky && styles.sticky);
+  return <thead className={cs}>{children}</thead>;
 }

--- a/packages/gestalt/src/TableHeaderCell.js
+++ b/packages/gestalt/src/TableHeaderCell.js
@@ -9,6 +9,22 @@ type Props = {|
    */
   children: Node,
   /**
+   * `colSpan` defines the number of columns a cell should span.
+   */
+  colSpan?: number,
+  /**
+   * Private prop required for sticky columns
+   */
+  previousTotalWidth?: number,
+  /**
+   * `rowSpan` defines the number of rows a cell should span.
+   */
+  rowSpan?: number,
+  /**
+   * The scope attribute specifies whether a header cell is a header for a column, row, or group of columns or rows. The scope attribute has no visual effect, but is used by screen readers and other assistive technologies.
+   */
+  scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',
+  /**
    * Private prop required for sticky columns
    */
   shouldBeSticky?: boolean,
@@ -16,22 +32,6 @@ type Props = {|
    * Private prop required for sticky columns
    */
   shouldHaveShadow?: boolean,
-  /**
-   * `colSpan` defines the number of columns a cell should span.
-   */
-  colSpan?: number,
-  /**
-   * `rowSpan` defines the number of rows a cell should span.
-   */
-  rowSpan?: number,
-  /**
-   * The scope attribute specifies whether a header cell is a header for a column, row, or group of columns or rows. The scope attribute has no visual effect in ordinary web browsers, but can be used by screen readers.
-   */
-  scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',
-  /**
-   * Private prop required for sticky columns
-   */
-  previousTotalWidth?: number,
 |};
 
 /**
@@ -41,10 +41,10 @@ type Props = {|
 export default function TableHeaderCell({
   children,
   colSpan,
-  scope,
-  rowSpan,
-  shouldBeSticky,
   previousTotalWidth,
+  rowSpan,
+  scope,
+  shouldBeSticky,
   shouldHaveShadow,
 }: Props): Node {
   const cs = cx(

--- a/packages/gestalt/src/TableHeaderCell.js
+++ b/packages/gestalt/src/TableHeaderCell.js
@@ -4,28 +4,49 @@ import cx from 'classnames';
 import styles from './Table.css';
 
 type Props = {|
+  /**
+   * The content of the table cell.
+   */
   children: Node,
+  /**
+   * Private prop required for sticky columns
+   */
   shouldBeSticky?: boolean,
+  /**
+   * Private prop required for sticky columns
+   */
   shouldHaveShadow?: boolean,
+  /**
+   * `colSpan` defines the number of columns a cell should span.
+   */
   colSpan?: number,
+  /**
+   * `rowSpan` defines the number of rows a cell should span.
+   */
   rowSpan?: number,
+  /**
+   * The scope attribute specifies whether a header cell is a header for a column, row, or group of columns or rows. The scope attribute has no visual effect in ordinary web browsers, but can be used by screen readers.
+   */
   scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',
+  /**
+   * Private prop required for sticky columns
+   */
   previousTotalWidth?: number,
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * Subcomponent of [Table](https://gestalt.pinterest.systems/table).
+ * Use [Table.HeaderCell](https://gestalt.pinterest.systems/table#Table.HeaderCellProps) to define a header cell in Table.
  */
-export default function TableHeaderCell(props: Props): Node {
-  const {
-    children,
-    colSpan,
-    scope,
-    rowSpan,
-    shouldBeSticky,
-    previousTotalWidth,
-    shouldHaveShadow,
-  } = props;
+export default function TableHeaderCell({
+  children,
+  colSpan,
+  scope,
+  rowSpan,
+  shouldBeSticky,
+  previousTotalWidth,
+  shouldHaveShadow,
+}: Props): Node {
   const cs = cx(
     styles.th,
     shouldBeSticky && styles.columnSticky,

--- a/packages/gestalt/src/TableRow.js
+++ b/packages/gestalt/src/TableRow.js
@@ -5,13 +5,17 @@ import { Children, cloneElement, useEffect, useRef, useState } from 'react';
 import { useTableContext } from './contexts/TableContext.js';
 
 type Props = {|
+  /**
+   * Must be instances of Table.Cell, Table.HeaderCell, or Table.SortableHeaderCell components. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   */
   children: Node,
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * Subcomponent of [Table](https://gestalt.pinterest.systems/table).
+ * Use [Table.Row](https://gestalt.pinterest.systems/table#Table.RowProps) to define a row in Table.
  */
-export default function TableRow(props: Props): Node {
+export default function TableRow({ children }: Props): Node {
   const { stickyColumns } = useTableContext();
   const rowRef = useRef();
   const [columnWidths, setColumnWidths] = useState([]);
@@ -34,9 +38,7 @@ export default function TableRow(props: Props): Node {
 
   return (
     <tr ref={rowRef}>
-      {Number(stickyColumns) > 0
-        ? Children.map(props.children, renderCellWithIndex)
-        : props.children}
+      {Number(stickyColumns) > 0 ? Children.map(children, renderCellWithIndex) : children}
     </tr>
   );
 }

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -10,11 +10,11 @@ import { useTableContext } from './contexts/TableContext.js';
 
 type Props = {|
   /**
-   * Supply a short, descriptive label for screen-readers as a text alternative to the Expand button. Accessibility: It populates aria-label on the `<button>` element for the Expand button.
+   * Supply a short, descriptive label for screen-readers as a text alternative to the Expand button. Accessibility: It populates `aria-label` on the `<button>` element for the Expand button.
    */
   accessibilityExpandLabel: string,
   /**
-   * Supply a short, descriptive label for screen-readers as a text alternative to the Collapse button. Accessibility: It populates aria-label on the `<button> element` for the Collapse button.
+   * Supply a short, descriptive label for screen-readers as a text alternative to the Collapse button. Accessibility: It populates  `aria-label` on the `<button>` element for the Collapse button.
    */
   accessibilityCollapseLabel: string,
   /**
@@ -22,7 +22,7 @@ type Props = {|
    */
   children: Node,
   /**
-   * The contents to show and/or hide
+   * The contents to show and/or hide on an expandable row.
    */
   expandedContents: Node,
   /**

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -10,11 +10,11 @@ import { useTableContext } from './contexts/TableContext.js';
 
 type Props = {|
   /**
-   * Supply a short, descriptive label for screen-readers as a text alternative to the Expand button. Accessibility: It populates `aria-label` on the `<button>` element for the Expand button.
+   * Supply a short, descriptive label for screen-readers as a text alternative to the expand button.
    */
   accessibilityExpandLabel: string,
   /**
-   * Supply a short, descriptive label for screen-readers as a text alternative to the Collapse button. Accessibility: It populates  `aria-label` on the `<button>` element for the Collapse button.
+   * Supply a short, descriptive label for screen-readers as a text alternative to the collapse button. Accessibility: It populates  `aria-label` on the `<button>` element for the collapse button.
    */
   accessibilityCollapseLabel: string,
   /**

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -1,45 +1,65 @@
 // @flow strict
 import type { Node } from 'react';
-
 import { Children, cloneElement, Fragment, useEffect, useRef, useState } from 'react';
 import cx from 'classnames';
 import styles from './Table.css';
 import Box from './Box.js';
 import IconButton from './IconButton.js';
 import TableCell from './TableCell.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import { useTableContext } from './contexts/TableContext.js';
 
 type Props = {|
+  /**
+   * Supply a short, descriptive label for screen-readers as a text alternative to the Expand button. Accessibility: It populates aria-label on the `<button>` element for the Expand button.
+   */
   accessibilityExpandLabel: string,
+  /**
+   * Supply a short, descriptive label for screen-readers as a text alternative to the Collapse button. Accessibility: It populates aria-label on the `<button> element` for the Collapse button.
+   */
   accessibilityCollapseLabel: string,
+  /**
+   * Must be instances of Table.Cell. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   */
   children: Node,
+  /**
+   * The contents to show and/or hide
+   */
   expandedContents: Node,
-  onExpand?: AbstractEventHandler<
-    | SyntheticMouseEvent<HTMLButtonElement>
-    | SyntheticKeyboardEvent<HTMLButtonElement>
-    | SyntheticMouseEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| expanded: boolean |},
-  >,
+  /**
+   * Callback fired when the expand button component is clicked.
+   */
+  onExpand?: ({|
+    event:
+      | SyntheticMouseEvent<HTMLButtonElement>
+      | SyntheticKeyboardEvent<HTMLButtonElement>
+      | SyntheticMouseEvent<HTMLAnchorElement>
+      | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    expanded: boolean,
+  |}) => void,
+  /**
+   * Sets the background color on hover over the row.
+   */
   hoverStyle?: 'gray' | 'none',
+  /**
+   * Unique id for Table.RowExpandable.
+   */
   id: string,
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * Subcomponent of [Table](https://gestalt.pinterest.systems/table).
+ * Use [Table.RowExpandable](https://gestalt.pinterest.systems/table#Table.RowExpandableProps) to define a row that expands and collapses additional content.
  */
-export default function TableRowExpandable(props: Props): Node {
-  const {
-    accessibilityCollapseLabel,
-    accessibilityExpandLabel,
-    children,
-    expandedContents,
-    onExpand,
-    id,
-  } = props;
+export default function TableRowExpandable({
+  accessibilityCollapseLabel,
+  accessibilityExpandLabel,
+  children,
+  expandedContents,
+  onExpand,
+  id,
+  hoverStyle = 'gray',
+}: Props): Node {
   const [expanded, setExpanded] = useState(false);
-  const hoverStyle = props.hoverStyle || 'gray';
   const cs = hoverStyle === 'gray' ? cx(styles.hoverShadeGray) : null;
   const { stickyColumns } = useTableContext();
   const rowRef = useRef();
@@ -89,9 +109,7 @@ export default function TableRowExpandable(props: Props): Node {
             size="xs"
           />
         </TableCell>
-        {Number(stickyColumns) > 0
-          ? Children.map(props.children, renderCellWithAdjustedIndex)
-          : children}
+        {Number(stickyColumns) > 0 ? Children.map(children, renderCellWithAdjustedIndex) : children}
       </tr>
       {expanded && (
         <tr id={id}>

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -6,44 +6,73 @@ import Box from './Box.js';
 import Icon from './Icon.js';
 import TableHeaderCell from './TableHeaderCell.js';
 import TapArea from './TapArea.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type Props = {|
+  /**
+   * The content of the table cell.
+   */
   children: Node,
+  /**
+   * `colSpan` defines the number of columns a cell should span.
+   */
   colSpan?: number,
-  onSortChange: AbstractEventHandler<
-    | SyntheticMouseEvent<HTMLDivElement>
-    | SyntheticKeyboardEvent<HTMLDivElement>
-    | SyntheticMouseEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| dangerouslyDisableOnNavigation: () => void |},
-  >,
+  /**
+   * Callback fired when the sort button component is clicked.
+   */
+  onSortChange: ({|
+    event:
+      | SyntheticMouseEvent<HTMLDivElement>
+      | SyntheticKeyboardEvent<HTMLDivElement>
+      | SyntheticMouseEvent<HTMLAnchorElement>
+      | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    dangerouslyDisableOnNavigation: () => void,
+  |}) => void,
+  /**
+   * Private prop required for sticky columns
+   */
   previousTotalWidth?: number,
+  /**
+   * `rowSpan` defines the number of rows a cell should span.
+   */
   rowSpan?: number,
+  /**
+   * The scope attribute specifies whether a header cell is a header for a column, row, or group of columns or rows. The scope attribute has no visual effect in ordinary web browsers, but can be used by screen readers.
+   */
   scope?: 'col' | 'colgroup' | 'row' | 'rowgroup',
+  /**
+   * Private prop required for sticky columns
+   */
   shouldBeSticky?: boolean,
+  /**
+   * Private prop required for sticky columns
+   */
   shouldHaveShadow?: boolean,
+  /**
+   * Sets the sorting direction: `sortOrder="asc"` is ascending (A to Z) and `sortOrder="desc"` is descending (Z to A):
+   */
   sortOrder: 'asc' | 'desc',
+  /**
+   * Disables the sorting functionality for a column.
+   */
   status: 'active' | 'inactive',
 |};
 
 /**
- * https://gestalt.pinterest.systems/table
+ * Subcomponent of [Table](https://gestalt.pinterest.systems/table).
+ * Use [Table.SortableHeaderCell](https://gestalt.pinterest.systems/table#Table.SortableHeaderCellProps) to define a header cell with sorting functionality in Table.
  */
-export default function TableSortableHeaderCell(props: Props): Node {
-  const {
-    children,
-    colSpan,
-    scope,
-    rowSpan,
-    status,
-    sortOrder,
-    onSortChange,
-    shouldBeSticky,
-    previousTotalWidth,
-    shouldHaveShadow,
-  } = props;
-
+export default function TableSortableHeaderCell({
+  children,
+  colSpan,
+  scope,
+  rowSpan,
+  status,
+  sortOrder,
+  onSortChange,
+  shouldBeSticky,
+  previousTotalWidth,
+  shouldHaveShadow,
+}: Props): Node {
   const [isFocused, setFocused] = useState(false);
   const [isHovered, setHovered] = useState(false);
 

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -64,14 +64,14 @@ type Props = {|
 export default function TableSortableHeaderCell({
   children,
   colSpan,
-  scope,
+  onSortChange,
+  previousTotalWidth,
   rowSpan,
+  scope,
+  shouldBeSticky,
+  shouldHaveShadow,
   status,
   sortOrder,
-  onSortChange,
-  shouldBeSticky,
-  previousTotalWidth,
-  shouldHaveShadow,
 }: Props): Node {
   const [isFocused, setFocused] = useState(false);
   const [isHovered, setHovered] = useState(false);


### PR DESCRIPTION
### Summary

#### What changed?

Table: updated Docs to use autogenerated prop table

#### Why?

Gestalt is moving in this direction, all components must autogenerate prop tables