### PR TITLE
Dropdown: Revert #1900 (Dropdown: prefixed private props (index) with underscore)

### DIFF
--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -54,7 +54,7 @@ const renderDropdownItemsWithIndex = (dropdownChildren, idxBase) =>
   dropdownChildren.map((child, idx) => {
     if (dropdownItemDisplayNames.includes(child.type.displayName)) {
       const index = idx + idxBase;
-      return cloneElement(child, { index });
+      return cloneElement(child, { _index: index });
     }
     return child;
   });


### PR DESCRIPTION
#### Why?

There's a bug in the code that makes integration tests fail. There's a huge queue of PR's to merge so I'll rebase

<img width="585" alt="Screen Shot 2022-02-08 at 12 57 51 AM" src="https://user-images.githubusercontent.com/10593890/152892141-34e44b33-a400-427e-b5ee-1cbf81120bc6.png">

They all pointed out to integration test for Dropdown.Item failing which could be cause by these incorrect private  _index prop.