### PR TITLE
Revert "Dropdown: prefixed private props (index) with underscore (#19…

### DIFF
--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -77,7 +77,7 @@ export default function DropdownPage({
         );
       }`}
       />
-      <GeneratedPropTable generatedDocGen={generatedDocGen.Dropdown} />
+      <GeneratedPropTable generatedDocGen={generatedDocGen.Dropdown} excludeProps={['index']} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -551,12 +551,14 @@ function TruncationDropdownExample() {
         name="Dropdown.Item"
         id="Dropdown.Item"
         generatedDocGen={generatedDocGen.DropdownItem}
+        excludeProps={['index']}
       />
       <GeneratedPropTable
         Component={Dropdown?.Link}
         name="Dropdown.Link"
         id="Dropdown.Link"
         generatedDocGen={generatedDocGen.DropdownLink}
+        excludeProps={['index']}
       />
       <GeneratedPropTable
         Component={Dropdown?.Section}

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -75,7 +75,7 @@ const renderChildrenWithIndex = (childrenArray) => {
       return [...acc, childWithIndex];
     }
     if (dropdownItemDisplayNames.includes(childDisplayName)) {
-      const childWithIndex = cloneElement(child, { _index: numItemsRendered });
+      const childWithIndex = cloneElement(child, { index: numItemsRendered });
       numItemsRendered += 1;
       return [...acc, childWithIndex];
     }

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -53,8 +53,7 @@ type Props = {|
     | null,
   /**
    * Private prop used for accessibility purposes
-   */
-  _index?: number,
+   */ index?: number,
 |};
 
 /**
@@ -65,7 +64,7 @@ export default function DropdownItem({
   badgeText,
   children,
   dataTestId,
-  _index = 0,
+  index = 0,
   onSelect,
   option,
   selected,
@@ -78,8 +77,8 @@ export default function DropdownItem({
           dataTestId={dataTestId}
           hoveredItemIndex={hoveredItem}
           id={id}
-          index={_index}
-          key={`${option.value + _index}`}
+          index={index}
+          key={`${option.value + index}`}
           onSelect={onSelect}
           option={option}
           ref={setOptionRef}

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -43,8 +43,7 @@ type Props = {|
   option: OptionItemType,
   /**
    * Private prop used for accessibility purposes
-   */
-  _index?: number,
+   */ index?: number,
 |};
 
 /**
@@ -56,7 +55,7 @@ export default function DropdownLink({
   children,
   dataTestId,
   href,
-  _index = 0,
+  index = 0,
   isExternal,
   onClick,
   option,
@@ -70,9 +69,9 @@ export default function DropdownLink({
           hoveredItemIndex={hoveredItem}
           href={href}
           id={id}
-          index={_index}
+          index={index}
           isExternal={isExternal}
-          key={`${option.value + _index}`}
+          key={`${option.value + index}`}
           onClick={onClick}
           option={option}
           role="menuitem"


### PR DESCRIPTION
…00)"

This reverts commit 42fb9fb1a04c322cfae96ad3b2016a3bde5c802e.

#### Why?

There's a bug in the code that makes integration tests fail. There's a huge queue of PR's to merge so I'll rebase

<img width="585" alt="Screen Shot 2022-02-08 at 12 57 51 AM" src="https://user-images.githubusercontent.com/10593890/152892141-34e44b33-a400-427e-b5ee-1cbf81120bc6.png">

They all pointed out to integration test for Dropdown.Item failing which could be cause by these incorrect private  _index prop.