### PR TITLE
Revert "Revert "Dropdown: prefixed private props (index) with undersc…

### DIFF
--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -77,7 +77,7 @@ export default function DropdownPage({
         );
       }`}
       />
-      <GeneratedPropTable generatedDocGen={generatedDocGen.Dropdown} excludeProps={['index']} />
+      <GeneratedPropTable generatedDocGen={generatedDocGen.Dropdown} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -551,14 +551,12 @@ function TruncationDropdownExample() {
         name="Dropdown.Item"
         id="Dropdown.Item"
         generatedDocGen={generatedDocGen.DropdownItem}
-        excludeProps={['index']}
       />
       <GeneratedPropTable
         Component={Dropdown?.Link}
         name="Dropdown.Link"
         id="Dropdown.Link"
         generatedDocGen={generatedDocGen.DropdownLink}
-        excludeProps={['index']}
       />
       <GeneratedPropTable
         Component={Dropdown?.Section}

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -54,7 +54,7 @@ const renderDropdownItemsWithIndex = (dropdownChildren, idxBase) =>
   dropdownChildren.map((child, idx) => {
     if (dropdownItemDisplayNames.includes(child.type.displayName)) {
       const index = idx + idxBase;
-      return cloneElement(child, { index });
+      return cloneElement(child, { _index: index });
     }
     return child;
   });
@@ -75,7 +75,7 @@ const renderChildrenWithIndex = (childrenArray) => {
       return [...acc, childWithIndex];
     }
     if (dropdownItemDisplayNames.includes(childDisplayName)) {
-      const childWithIndex = cloneElement(child, { index: numItemsRendered });
+      const childWithIndex = cloneElement(child, { _index: numItemsRendered });
       numItemsRendered += 1;
       return [...acc, childWithIndex];
     }

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -53,7 +53,8 @@ type Props = {|
     | null,
   /**
    * Private prop used for accessibility purposes
-   */ index?: number,
+   */
+  _index?: number,
 |};
 
 /**
@@ -64,7 +65,7 @@ export default function DropdownItem({
   badgeText,
   children,
   dataTestId,
-  index = 0,
+  _index = 0,
   onSelect,
   option,
   selected,
@@ -77,8 +78,8 @@ export default function DropdownItem({
           dataTestId={dataTestId}
           hoveredItemIndex={hoveredItem}
           id={id}
-          index={index}
-          key={`${option.value + index}`}
+          index={_index}
+          key={`${option.value + _index}`}
           onSelect={onSelect}
           option={option}
           ref={setOptionRef}

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -43,7 +43,8 @@ type Props = {|
   option: OptionItemType,
   /**
    * Private prop used for accessibility purposes
-   */ index?: number,
+   */
+  _index?: number,
 |};
 
 /**
@@ -55,7 +56,7 @@ export default function DropdownLink({
   children,
   dataTestId,
   href,
-  index = 0,
+  _index = 0,
   isExternal,
   onClick,
   option,
@@ -69,9 +70,9 @@ export default function DropdownLink({
           hoveredItemIndex={hoveredItem}
           href={href}
           id={id}
-          index={index}
+          index={_index}
           isExternal={isExternal}
-          key={`${option.value + index}`}
+          key={`${option.value + _index}`}
           onClick={onClick}
           option={option}
           role="menuitem"


### PR DESCRIPTION
…ore (#1900)" (#1923)"

This reverts commit a3d545bbaeab5ea32d8446ddb1b2bc02ee629130 



### Summary

#### What changed?

index private prop in Dropdown.Item and Dropdown.Link are prefixed with underscore ('_') following new pattern

#### Why?

Following new pattern to name private props
