### PR TITLE
Link: deprecate unused `disabled` prop + codemod

### DIFF
--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -77,7 +77,7 @@ export default function DropdownPage({
         );
       }`}
       />
-      <GeneratedPropTable generatedDocGen={generatedDocGen.Dropdown} excludeProps={['index']} />
+      <GeneratedPropTable generatedDocGen={generatedDocGen.Dropdown} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -551,14 +551,12 @@ function TruncationDropdownExample() {
         name="Dropdown.Item"
         id="Dropdown.Item"
         generatedDocGen={generatedDocGen.DropdownItem}
-        excludeProps={['index']}
       />
       <GeneratedPropTable
         Component={Dropdown?.Link}
         name="Dropdown.Link"
         id="Dropdown.Link"
         generatedDocGen={generatedDocGen.DropdownLink}
-        excludeProps={['index']}
       />
       <GeneratedPropTable
         Component={Dropdown?.Section}

--- a/packages/gestalt-codemods/46.0.0/__testfixtures__/link_deprecate_disabled_prop.input.js
+++ b/packages/gestalt-codemods/46.0.0/__testfixtures__/link_deprecate_disabled_prop.input.js
@@ -1,0 +1,6 @@
+// @flow strict
+import {  Link as RenamedLink} from 'gestalt';
+
+export default function Test() {
+  return <RenamedLink disabled/>;
+}

--- a/packages/gestalt-codemods/46.0.0/__testfixtures__/link_deprecate_disabled_prop.output.js
+++ b/packages/gestalt-codemods/46.0.0/__testfixtures__/link_deprecate_disabled_prop.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import {  Link as RenamedLink} from 'gestalt';
+
+export default function Test() {
+  return <RenamedLink />;
+}

--- a/packages/gestalt-codemods/46.0.0/__testfixtures__/rename-link_deprecate_disabled_prop.input.js
+++ b/packages/gestalt-codemods/46.0.0/__testfixtures__/rename-link_deprecate_disabled_prop.input.js
@@ -1,0 +1,7 @@
+// @flow strict
+import {  Link } from 'gestalt';
+
+export default function Test() {
+  // eslint-disable-next-line jsx-a11y/anchor-is-valid
+  return <Link disabled/>;
+}

--- a/packages/gestalt-codemods/46.0.0/__testfixtures__/rename-link_deprecate_disabled_prop.output.js
+++ b/packages/gestalt-codemods/46.0.0/__testfixtures__/rename-link_deprecate_disabled_prop.output.js
@@ -1,0 +1,7 @@
+// @flow strict
+import {  Link } from 'gestalt';
+
+export default function Test() {
+  // eslint-disable-next-line jsx-a11y/anchor-is-valid
+  return <Link />;
+}

--- a/packages/gestalt-codemods/46.0.0/__tests__/link_deprecate_disabled_prop.test.js
+++ b/packages/gestalt-codemods/46.0.0/__tests__/link_deprecate_disabled_prop.test.js
@@ -1,0 +1,13 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../link_deprecate_disabled_prop', () =>
+  Object.assign(jest.requireActual('../link_deprecate_disabled_prop'), {
+    parser: 'flow',
+  }),
+);
+
+describe('link_deprecate_disabled_prop', () => {
+  ['link_deprecate_disabled_prop', 'rename-link_deprecate_disabled_prop'].forEach((test) => {
+    defineTest(__dirname, 'link_deprecate_disabled_prop', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/46.0.0/link_deprecate_disabled_prop.js
+++ b/packages/gestalt-codemods/46.0.0/link_deprecate_disabled_prop.js
@@ -1,0 +1,72 @@
+/*
+ * Converts
+ *   <Link disabled />
+ * To
+ *   <Link />
+ */
+
+// Run
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/46.0.0/link_deprecate_disabled_prop.js relative/path/to/your/code
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter((node) => node.imported.name === 'Link')
+      .map((node) => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove Dynamic Text properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+
+      let tempAttr;
+      let newAttribute;
+      const newAttrs = attrs
+        .map((attr) => {
+          if (attr?.name?.name && attr.name.name === 'disabled') {
+            return null;
+          }
+          return attr;
+        })
+        .filter(Boolean);
+
+      fileHasModifications = true;
+
+      let appendedAttr = tempAttr || false;
+      appendedAttr = tempAttr && newAttribute ? newAttribute : tempAttr;
+
+      node.openingElement.attributes = appendedAttr ? [...newAttrs, ...appendedAttr] : newAttrs;
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -75,7 +75,7 @@ const renderChildrenWithIndex = (childrenArray) => {
       return [...acc, childWithIndex];
     }
     if (dropdownItemDisplayNames.includes(childDisplayName)) {
-      const childWithIndex = cloneElement(child, { index: numItemsRendered });
+      const childWithIndex = cloneElement(child, { _index: numItemsRendered });
       numItemsRendered += 1;
       return [...acc, childWithIndex];
     }

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -53,7 +53,8 @@ type Props = {|
     | null,
   /**
    * Private prop used for accessibility purposes
-   */ index?: number,
+   */
+  _index?: number,
 |};
 
 /**
@@ -64,7 +65,7 @@ export default function DropdownItem({
   badgeText,
   children,
   dataTestId,
-  index = 0,
+  _index = 0,
   onSelect,
   option,
   selected,
@@ -77,8 +78,8 @@ export default function DropdownItem({
           dataTestId={dataTestId}
           hoveredItemIndex={hoveredItem}
           id={id}
-          index={index}
-          key={`${option.value + index}`}
+          index={_index}
+          key={`${option.value + _index}`}
           onSelect={onSelect}
           option={option}
           ref={setOptionRef}

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -43,7 +43,8 @@ type Props = {|
   option: OptionItemType,
   /**
    * Private prop used for accessibility purposes
-   */ index?: number,
+   */
+  _index?: number,
 |};
 
 /**
@@ -55,7 +56,7 @@ export default function DropdownLink({
   children,
   dataTestId,
   href,
-  index = 0,
+  _index = 0,
   isExternal,
   onClick,
   option,
@@ -69,9 +70,9 @@ export default function DropdownLink({
           hoveredItemIndex={hoveredItem}
           href={href}
           id={id}
-          index={index}
+          index={_index}
           isExternal={isExternal}
-          key={`${option.value + index}`}
+          key={`${option.value + _index}`}
           onClick={onClick}
           option={option}
           role="menuitem"

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -91,10 +91,6 @@ type Props = {|
 - 'self' opens an anchor in the same frame.
    */
   target?: null | 'self' | 'blank',
-  /**
-   * Private prop. When `disabled` is supplied, the href prop in the anchor tag is set to undefined. To be deprecated.
-   */
-  disabled?: boolean,
 |};
 
 /**
@@ -120,7 +116,6 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     hoverStyle = 'underline',
     tapStyle = 'none',
     target = null,
-    disabled,
   }: Props,
   ref,
 ): Element<'a'> {
@@ -177,7 +172,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
       aria-label={accessibilityLabel}
       aria-selected={accessibilitySelected}
       className={className}
-      href={disabled ? undefined : href}
+      href={href}
       id={id}
       onBlur={(event) => {
         handleBlur();


### PR DESCRIPTION

### Summary

#### What changed?

Link: deprecate unused `disabled` prop + codemod

#### Why?

Before `InternalLink` we used `Link` within Button with role='link' which required passing a disabled prop. After the refactor to use InternalLink this is not needed anymore.
