### PR TITLE
Link: deprecate private "disabled" prop + codemod

### DIFF
--- a/packages/gestalt-codemods/46.0.0/__testfixtures__/link_deprecate_disabled_prop.input.js
+++ b/packages/gestalt-codemods/46.0.0/__testfixtures__/link_deprecate_disabled_prop.input.js
@@ -1,0 +1,6 @@
+// @flow strict
+import {  Link as RenamedLink} from 'gestalt';
+
+export default function Test() {
+  return <RenamedLink disabled/>;
+}

--- a/packages/gestalt-codemods/46.0.0/__testfixtures__/link_deprecate_disabled_prop.output.js
+++ b/packages/gestalt-codemods/46.0.0/__testfixtures__/link_deprecate_disabled_prop.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import {  Link as RenamedLink} from 'gestalt';
+
+export default function Test() {
+  return <RenamedLink />;
+}

--- a/packages/gestalt-codemods/46.0.0/__testfixtures__/rename-link_deprecate_disabled_prop.input.js
+++ b/packages/gestalt-codemods/46.0.0/__testfixtures__/rename-link_deprecate_disabled_prop.input.js
@@ -1,0 +1,7 @@
+// @flow strict
+import {  Link } from 'gestalt';
+
+export default function Test() {
+  // eslint-disable-next-line jsx-a11y/anchor-is-valid
+  return <Link disabled/>;
+}

--- a/packages/gestalt-codemods/46.0.0/__testfixtures__/rename-link_deprecate_disabled_prop.output.js
+++ b/packages/gestalt-codemods/46.0.0/__testfixtures__/rename-link_deprecate_disabled_prop.output.js
@@ -1,0 +1,7 @@
+// @flow strict
+import {  Link } from 'gestalt';
+
+export default function Test() {
+  // eslint-disable-next-line jsx-a11y/anchor-is-valid
+  return <Link />;
+}

--- a/packages/gestalt-codemods/46.0.0/__tests__/link_deprecate_disabled_prop.test.js
+++ b/packages/gestalt-codemods/46.0.0/__tests__/link_deprecate_disabled_prop.test.js
@@ -1,0 +1,13 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../link_deprecate_disabled_prop', () =>
+  Object.assign(jest.requireActual('../link_deprecate_disabled_prop'), {
+    parser: 'flow',
+  }),
+);
+
+describe('link_deprecate_disabled_prop', () => {
+  ['link_deprecate_disabled_prop', 'rename-link_deprecate_disabled_prop'].forEach((test) => {
+    defineTest(__dirname, 'link_deprecate_disabled_prop', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/46.0.0/link_deprecate_disabled_prop.js
+++ b/packages/gestalt-codemods/46.0.0/link_deprecate_disabled_prop.js
@@ -1,0 +1,72 @@
+/*
+ * Converts
+ *   <Link disabled />
+ * To
+ *   <Link />
+ */
+
+// Run
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/46.0.0/link_deprecate_disabled_prop.js relative/path/to/your/code
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter((node) => node.imported.name === 'Link')
+      .map((node) => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove Dynamic Link properties and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+
+      let tempAttr;
+      let newAttribute;
+      const newAttrs = attrs
+        .map((attr) => {
+          if (attr?.name?.name && attr.name.name === 'disabled') {
+            return null;
+          }
+          return attr;
+        })
+        .filter(Boolean);
+
+      fileHasModifications = true;
+
+      let appendedAttr = tempAttr || false;
+      appendedAttr = tempAttr && newAttribute ? newAttribute : tempAttr;
+
+      node.openingElement.attributes = appendedAttr ? [...newAttrs, ...appendedAttr] : newAttrs;
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -91,10 +91,6 @@ type Props = {|
 - 'self' opens an anchor in the same frame.
    */
   target?: null | 'self' | 'blank',
-  /**
-   * Private prop. When `disabled` is supplied, the href prop in the anchor tag is set to undefined. To be deprecated.
-   */
-  disabled?: boolean,
 |};
 
 /**
@@ -120,7 +116,6 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     hoverStyle = 'underline',
     tapStyle = 'none',
     target = null,
-    disabled,
   }: Props,
   ref,
 ): Element<'a'> {
@@ -177,7 +172,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
       aria-label={accessibilityLabel}
       aria-selected={accessibilitySelected}
       className={className}
-      href={disabled ? undefined : href}
+      href={href}
       id={id}
       onBlur={(event) => {
         handleBlur();


### PR DESCRIPTION
### Summary

#### What changed?

Link: deprecate unused disabled prop + codemod

#### Why?

reference PR https://github.com/pinterest/gestalt/pull/1169

This prop was old code pre InternalLink cmp when Button role='link" used Link cmp and disabled state was needed. After moving to InternalLink, this code became unused.