### PR TITLE
ComboBox: add reference to Typeahead

### DIFF
--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -146,6 +146,7 @@ type Props = {|
 
 /**
  * [ComboBox](https://gestalt.pinterest.systems/combobox) is the combination of a [Textfield](https://gestalt.pinterest.systems/textfield) and an associated [Dropdown](https://gestalt.pinterest.systems/dropdown) that allows the user to filter a list when selecting an option. ComboBox allows users to type the full option, type part of the option and narrow the results, or select an option from the list.
+ * Note: this is a new version of the deprecated component "Typeahead".
  */
 const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,


### PR DESCRIPTION
We see some users still searching for "Typeahead", which currently yields no results since we no longer mention that component. This PR adds a small reference in ComboBox's description such that it will pop up in search results.

(Note that given the infrequency of Algolia's crawls currently, this won't take effect until the Wednesday after it's merged)

<img width="594" alt="Screen Shot 2022-02-08 at 11 27 36 AM" src="https://user-images.githubusercontent.com/12059539/153061455-ec67dcc3-22c3-4e50-af45-3480873abe35.png">