### PR TITLE
IconButton: refactor to fix Dropdown positioning shift on rerender + small fix

### DIFF
--- a/packages/gestalt/src/IconButton.css
+++ b/packages/gestalt/src/IconButton.css
@@ -5,6 +5,15 @@
   background: transparent;
 }
 
+.parentButton {
+  composes: noBorder from "./Borders.css";
+  composes: p0 from "./Whitespace.css";
+  composes: paddingX0 from "./boxWhitespace.css";
+  composes: paddingY0 from "./boxWhitespace.css";
+  composes: transparentBg from "./Colors.css";
+}
+
+.parentButton:focus,
 .button:focus {
   outline: 0;
 }

--- a/packages/gestalt/src/IconButton.css.flow
+++ b/packages/gestalt/src/IconButton.css.flow
@@ -4,4 +4,5 @@ declare module.exports: {|
   +'button': string,
   +'disabled': string,
   +'enabled': string,
+  +'parentButton': string,
 |};

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -81,7 +81,6 @@ type unionRefs = HTMLButtonElement | HTMLAnchorElement;
 /**
  * [IconButton](https://gestalt.pinterest.systems/iconbutton) allows users to take actions and make choices with a single click or tap. IconButtons use icons instead of text to convey available actions on a screen. IconButton is typically found in forms, dialogs and toolbars.
  Some buttons are specialized for particular tasks, such as navigation or presenting menus.
-
  */
 const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,
@@ -126,12 +125,6 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
   const [isHovered, setHovered] = useState(false);
 
   const { isFocusVisible } = useFocusVisible();
-
-  const buttonRoleClasses = classnames(styles.button, touchableStyles.tapTransition, {
-    [styles.disabled]: disabled,
-    [styles.enabled]: !disabled,
-    [touchableStyles.tapCompress]: props.role !== 'link' && !disabled && isTapping,
-  });
 
   const renderPogComponent = (selected?: boolean): Node => (
     <Pog
@@ -217,7 +210,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
       aria-expanded={accessibilityExpanded}
       aria-haspopup={accessibilityHaspopup}
       aria-label={accessibilityLabel}
-      className={buttonRoleClasses}
+      className={classnames(styles.parentButton)}
       disabled={disabled}
       onBlur={() => {
         handleBlur();
@@ -240,11 +233,19 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
       onTouchMove={handleTouchMove}
       onTouchStart={handleTouchStart}
       ref={innerRef}
-      style={compressStyle || undefined}
       tabIndex={disabled ? null : tabIndex}
       type="button"
     >
-      {renderPogComponent(selected)}
+      <div
+        className={classnames(styles.button, touchableStyles.tapTransition, {
+          [styles.disabled]: disabled,
+          [styles.enabled]: !disabled,
+          [touchableStyles.tapCompress]: props.role !== 'link' && !disabled && isTapping,
+        })}
+        style={compressStyle || undefined}
+      >
+        {renderPogComponent(selected)}
+      </div>
     </button>
   );
 

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
@@ -349,7 +349,7 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
   >
     <button
       aria-label="Dismiss card"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -365,27 +365,31 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon gray iconBlock"
-          height={16}
-          role="img"
-          viewBox="0 0 24 24"
-          width={16}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon gray iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </div>

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -286,7 +286,7 @@ exports[`<Callout /> message + title + primaryAction + dismissButton 1`] = `
   >
     <button
       aria-label="Dismiss banner"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -302,27 +302,31 @@ exports[`<Callout /> message + title + primaryAction + dismissButton 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon darkGray iconBlock"
-          height={16}
-          role="img"
-          viewBox="0 0 24 24"
-          width={16}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon darkGray iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </div>

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`IconButton renders with disabled state 1`] = `
 <button
   aria-label="Pinterest"
-  className="button tapTransition disabled"
+  className="parentButton"
   disabled={true}
   onBlur={[Function]}
   onClick={[Function]}
@@ -20,27 +20,31 @@ exports[`IconButton renders with disabled state 1`] = `
   type="button"
 >
   <div
-    className="pog transparent"
-    style={
-      Object {
-        "height": 40,
-        "width": 40,
-      }
-    }
+    className="button tapTransition disabled"
   >
-    <svg
-      aria-hidden={true}
-      aria-label=""
-      className="icon gray iconBlock"
-      height={18}
-      role="img"
-      viewBox="0 0 24 24"
-      width={18}
+    <div
+      className="pog transparent"
+      style={
+        Object {
+          "height": 40,
+          "width": 40,
+        }
+      }
     >
-      <path
-        d="test-file-stub"
-      />
-    </svg>
+      <svg
+        aria-hidden={true}
+        aria-label=""
+        className="icon gray iconBlock"
+        height={18}
+        role="img"
+        viewBox="0 0 24 24"
+        width={18}
+      >
+        <path
+          d="test-file-stub"
+        />
+      </svg>
+    </div>
   </div>
 </button>
 `;
@@ -48,7 +52,7 @@ exports[`IconButton renders with disabled state 1`] = `
 exports[`IconButton renders with icon 1`] = `
 <button
   aria-label="Pinterest"
-  className="button tapTransition enabled"
+  className="parentButton"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -64,27 +68,31 @@ exports[`IconButton renders with icon 1`] = `
   type="button"
 >
   <div
-    className="pog transparent"
-    style={
-      Object {
-        "height": 40,
-        "width": 40,
-      }
-    }
+    className="button tapTransition enabled"
   >
-    <svg
-      aria-hidden={true}
-      aria-label=""
-      className="icon gray iconBlock"
-      height={18}
-      role="img"
-      viewBox="0 0 24 24"
-      width={18}
+    <div
+      className="pog transparent"
+      style={
+        Object {
+          "height": 40,
+          "width": 40,
+        }
+      }
     >
-      <path
-        d="test-file-stub"
-      />
-    </svg>
+      <svg
+        aria-hidden={true}
+        aria-label=""
+        className="icon gray iconBlock"
+        height={18}
+        role="img"
+        viewBox="0 0 24 24"
+        width={18}
+      >
+        <path
+          d="test-file-stub"
+        />
+      </svg>
+    </div>
   </div>
 </button>
 `;
@@ -92,7 +100,7 @@ exports[`IconButton renders with icon 1`] = `
 exports[`IconButton renders with svg 1`] = `
 <button
   aria-label="Pinterest"
-  className="button tapTransition enabled"
+  className="parentButton"
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
@@ -108,27 +116,31 @@ exports[`IconButton renders with svg 1`] = `
   type="button"
 >
   <div
-    className="pog transparent"
-    style={
-      Object {
-        "height": 40,
-        "width": 40,
-      }
-    }
+    className="button tapTransition enabled"
   >
-    <svg
-      aria-hidden={true}
-      aria-label=""
-      className="icon gray iconBlock"
-      height={18}
-      role="img"
-      viewBox="0 0 24 24"
-      width={18}
+    <div
+      className="pog transparent"
+      style={
+        Object {
+          "height": 40,
+          "width": 40,
+        }
+      }
     >
-      <path
-        d="M13.00,20.00"
-      />
-    </svg>
+      <svg
+        aria-hidden={true}
+        aria-label=""
+        className="icon gray iconBlock"
+        height={18}
+        role="img"
+        viewBox="0 0 24 24"
+        width={18}
+      >
+        <path
+          d="M13.00,20.00"
+        />
+      </svg>
+    </div>
   </div>
 </button>
 `;
@@ -147,7 +159,7 @@ exports[`IconButton renders with tooltip 1`] = `
   >
     <button
       aria-label="Share"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -163,27 +175,31 @@ exports[`IconButton renders with tooltip 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 40,
-            "width": 40,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon gray iconBlock"
-          height={18}
-          role="img"
-          viewBox="0 0 24 24"
-          width={18}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 40,
+              "width": 40,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon gray iconBlock"
+            height={18}
+            role="img"
+            viewBox="0 0 24 24"
+            width={18}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </div>
@@ -204,7 +220,7 @@ exports[`IconButton renders with tooltip and no accessibilityLabel 1`] = `
   >
     <button
       aria-label="Share"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -220,27 +236,31 @@ exports[`IconButton renders with tooltip and no accessibilityLabel 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 40,
-            "width": 40,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon gray iconBlock"
-          height={18}
-          role="img"
-          viewBox="0 0 24 24"
-          width={18}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 40,
+              "width": 40,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon gray iconBlock"
+            height={18}
+            role="img"
+            viewBox="0 0 24 24"
+            width={18}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </div>

--- a/packages/gestalt/src/__snapshots__/Module.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Module.test.js.snap
@@ -230,7 +230,7 @@ exports[`Module renders an icon button correctly 1`] = `
         >
           <button
             aria-label="Get help"
-            className="button tapTransition enabled"
+            className="parentButton"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -246,27 +246,31 @@ exports[`Module renders an icon button correctly 1`] = `
             type="button"
           >
             <div
-              className="pog lightGray"
-              style={
-                Object {
-                  "height": 24,
-                  "width": 24,
-                }
-              }
+              className="button tapTransition enabled"
             >
-              <svg
-                aria-hidden={true}
-                aria-label=""
-                className="icon darkGray iconBlock"
-                height={12}
-                role="img"
-                viewBox="0 0 24 24"
-                width={12}
+              <div
+                className="pog lightGray"
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
               >
-                <path
-                  d="test-file-stub"
-                />
-              </svg>
+                <svg
+                  aria-hidden={true}
+                  aria-label=""
+                  className="icon darkGray iconBlock"
+                  height={12}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={12}
+                >
+                  <path
+                    d="test-file-stub"
+                  />
+                </svg>
+              </div>
             </div>
           </button>
         </div>

--- a/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
@@ -511,7 +511,7 @@ exports[`ModuleExpandableItem renders correctly with icon button 1`] = `
                 >
                   <button
                     aria-label="Get help"
-                    className="button tapTransition enabled"
+                    className="parentButton"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
@@ -527,27 +527,31 @@ exports[`ModuleExpandableItem renders correctly with icon button 1`] = `
                     type="button"
                   >
                     <div
-                      className="pog lightGray"
-                      style={
-                        Object {
-                          "height": 24,
-                          "width": 24,
-                        }
-                      }
+                      className="button tapTransition enabled"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-label=""
-                        className="icon darkGray iconBlock"
-                        height={12}
-                        role="img"
-                        viewBox="0 0 24 24"
-                        width={12}
+                      <div
+                        className="pog lightGray"
+                        style={
+                          Object {
+                            "height": 24,
+                            "width": 24,
+                          }
+                        }
                       >
-                        <path
-                          d="test-file-stub"
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden={true}
+                          aria-label=""
+                          className="icon darkGray iconBlock"
+                          height={12}
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width={12}
+                        >
+                          <path
+                            d="test-file-stub"
+                          />
+                        </svg>
+                      </div>
                     </div>
                   </button>
                 </div>

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -44,27 +44,31 @@ exports[`Sheet should render all props with nodes 1`] = `
               >
                 <button
                   aria-label="Dismiss"
-                  class="button tapTransition enabled"
+                  class="parentButton"
                   tabindex="0"
                   type="button"
                 >
                   <div
-                    class="pog white"
-                    style="height: 40px; width: 40px;"
+                    class="button tapTransition enabled"
                   >
-                    <svg
-                      aria-hidden="true"
-                      aria-label=""
-                      class="icon darkGray iconBlock"
-                      height="18"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="18"
+                    <div
+                      class="pog white"
+                      style="height: 40px; width: 40px;"
                     >
-                      <path
-                        d="test-file-stub"
-                      />
-                    </svg>
+                      <svg
+                        aria-hidden="true"
+                        aria-label=""
+                        class="icon darkGray iconBlock"
+                        height="18"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="18"
+                      >
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
+                    </div>
                   </div>
                 </button>
               </div>
@@ -137,27 +141,31 @@ exports[`Sheet should render all props with render props 1`] = `
               >
                 <button
                   aria-label="Dismiss"
-                  class="button tapTransition enabled"
+                  class="parentButton"
                   tabindex="0"
                   type="button"
                 >
                   <div
-                    class="pog white"
-                    style="height: 40px; width: 40px;"
+                    class="button tapTransition enabled"
                   >
-                    <svg
-                      aria-hidden="true"
-                      aria-label=""
-                      class="icon darkGray iconBlock"
-                      height="18"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="18"
+                    <div
+                      class="pog white"
+                      style="height: 40px; width: 40px;"
                     >
-                      <path
-                        d="test-file-stub"
-                      />
-                    </svg>
+                      <svg
+                        aria-hidden="true"
+                        aria-label=""
+                        class="icon darkGray iconBlock"
+                        height="18"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="18"
+                      >
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
+                    </div>
                   </div>
                 </button>
               </div>
@@ -221,27 +229,31 @@ exports[`Sheet should render animation in 1`] = `
             >
               <button
                 aria-label="Dismiss"
-                class="button tapTransition enabled"
+                class="parentButton"
                 tabindex="0"
                 type="button"
               >
                 <div
-                  class="pog white"
-                  style="height: 40px; width: 40px;"
+                  class="button tapTransition enabled"
                 >
-                  <svg
-                    aria-hidden="true"
-                    aria-label=""
-                    class="icon darkGray iconBlock"
-                    height="18"
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width="18"
+                  <div
+                    class="pog white"
+                    style="height: 40px; width: 40px;"
                   >
-                    <path
-                      d="test-file-stub"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      aria-label=""
+                      class="icon darkGray iconBlock"
+                      height="18"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="18"
+                    >
+                      <path
+                        d="test-file-stub"
+                      />
+                    </svg>
+                  </div>
                 </div>
               </button>
             </div>
@@ -288,27 +300,31 @@ exports[`Sheet should render animation out 1`] = `
             >
               <button
                 aria-label="Dismiss"
-                class="button tapTransition enabled"
+                class="parentButton"
                 tabindex="0"
                 type="button"
               >
                 <div
-                  class="pog white"
-                  style="height: 40px; width: 40px;"
+                  class="button tapTransition enabled"
                 >
-                  <svg
-                    aria-hidden="true"
-                    aria-label=""
-                    class="icon darkGray iconBlock"
-                    height="18"
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width="18"
+                  <div
+                    class="pog white"
+                    style="height: 40px; width: 40px;"
                   >
-                    <path
-                      d="test-file-stub"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      aria-label=""
+                      class="icon darkGray iconBlock"
+                      height="18"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="18"
+                    >
+                      <path
+                        d="test-file-stub"
+                      />
+                    </svg>
+                  </div>
                 </div>
               </button>
             </div>

--- a/packages/gestalt/src/__snapshots__/TableRowExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableRowExpandable.test.js.snap
@@ -17,7 +17,7 @@ exports[`renders correctly 1`] = `
       aria-controls="expandableRow"
       aria-expanded={false}
       aria-label="Expand"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -33,27 +33,31 @@ exports[`renders correctly 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 24,
-            "width": 24,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon darkGray iconBlock"
-          height={12}
-          role="img"
-          viewBox="0 0 24 24"
-          width={12}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 24,
+              "width": 24,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon darkGray iconBlock"
+            height={12}
+            role="img"
+            viewBox="0 0 24 24"
+            width={12}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </td>
@@ -80,7 +84,7 @@ exports[`renders correctly with explicit hover 1`] = `
       aria-controls="expandableRow"
       aria-expanded={false}
       aria-label="Expand"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -96,27 +100,31 @@ exports[`renders correctly with explicit hover 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 24,
-            "width": 24,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon darkGray iconBlock"
-          height={12}
-          role="img"
-          viewBox="0 0 24 24"
-          width={12}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 24,
+              "width": 24,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon darkGray iconBlock"
+            height={12}
+            role="img"
+            viewBox="0 0 24 24"
+            width={12}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </td>
@@ -143,7 +151,7 @@ exports[`renders correctly without hover 1`] = `
       aria-controls="expandableRow"
       aria-expanded={false}
       aria-label="Expand"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -159,27 +167,31 @@ exports[`renders correctly without hover 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 24,
-            "width": 24,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon darkGray iconBlock"
-          height={12}
-          role="img"
-          viewBox="0 0 24 24"
-          width={12}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 24,
+              "width": 24,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon darkGray iconBlock"
+            height={12}
+            role="img"
+            viewBox="0 0 24 24"
+            width={12}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </td>

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -194,7 +194,7 @@ exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
   >
     <button
       aria-label="Dismiss banner"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -210,27 +210,31 @@ exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon darkGray iconBlock"
-          height={16}
-          role="img"
-          viewBox="0 0 24 24"
-          width={16}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon darkGray iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </div>
@@ -353,7 +357,7 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] 
   >
     <button
       aria-label="Dismiss banner"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -369,27 +373,31 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] 
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon darkGray iconBlock"
-          height={16}
-          role="img"
-          viewBox="0 0 24 24"
-          width={16}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon darkGray iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </div>
@@ -480,7 +488,7 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton 1`] = `
   >
     <button
       aria-label="Dismiss banner"
-      className="button tapTransition enabled"
+      className="parentButton"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -496,27 +504,31 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton 1`] = `
       type="button"
     >
       <div
-        className="pog transparent"
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
+        className="button tapTransition enabled"
       >
-        <svg
-          aria-hidden={true}
-          aria-label=""
-          className="icon darkGray iconBlock"
-          height={16}
-          role="img"
-          viewBox="0 0 24 24"
-          width={16}
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
+            }
+          }
         >
-          <path
-            d="test-file-stub"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon darkGray iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
       </div>
     </button>
   </div>


### PR DESCRIPTION
Reverts #1924, which was a revert of #1914, + small fix

### Summary

#### What changed?

This reverts commit fd0124f7a7e930dd627633d3f00f523ee0fba976.

Small additional fix: 
<img width="206" alt="Screen Shot 2022-02-09 at 11 08 38 PM" src="https://user-images.githubusercontent.com/10593890/153298475-1228d9d0-2860-4425-bb17-f35cc2f386c2.png">

to prevent 
<img width="125" alt="Screen Shot 2022-02-10 at 1 01 38 AM" src="https://user-images.githubusercontent.com/10593890/153311160-9dcf00c5-0f3a-412c-ba86-be9251735648.png">


#### Why?

From my research the integration tests failing that caused the revert of this change are inconsistent. They systematically fail locally on different devapps but not on latest or pinterest.com. I used the Gestalt v45.1.2 in Pinboard and diffed the PR to get testing url. The integration test successfully passed. 

Re-merging this PR with a small fix to try again.

