### PR TITLE
Heading, Text: Update internal usages to use new size values

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -209,7 +209,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
       {label && (
         <Label htmlFor={id}>
           <Box marginBottom={2}>
-            <Text size="sm">{label}</Text>
+            <Text size="100">{label}</Text>
           </Box>
         </Label>
       )}
@@ -264,7 +264,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
       />
       {(!!errorMessage || !!helperText) && (
         <Box marginTop={2}>
-          <Text color={errorMessage ? 'red' : 'gray'} size="sm">
+          <Text color={errorMessage ? 'red' : 'gray'} size="100">
             {errorMessage || helperText}
           </Text>
         </Box>

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -120,7 +120,7 @@ function CompletedCard({ dismissButton, message, status, statusMessage, title }:
         )}
         <Box>
           <Box>
-            <Heading size="sm">{title}</Heading>
+            <Heading size="400">{title}</Heading>
           </Box>
           {message && (
             <Box flex="grow" direction="column" alignContent="start" marginTop={2}>
@@ -178,7 +178,7 @@ function UncompletedCard({
         </Box>
       </Box>
       <Box marginTop={6}>
-        <Heading size="sm">{title}</Heading>
+        <Heading size="400">{title}</Heading>
       </Box>
       {message && (
         <Box flex="grow" direction="column" alignContent="start" marginTop={2}>

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -124,7 +124,7 @@ function CompletedCard({ dismissButton, message, status, statusMessage, title }:
           </Box>
           {message && (
             <Box flex="grow" direction="column" alignContent="start" marginTop={2}>
-              <Text color="gray" size="md">
+              <Text color="gray" size="200">
                 {message}
               </Text>
             </Box>
@@ -172,7 +172,7 @@ function UncompletedCard({
           </Box>
         )}
         <Box alignSelf="center" marginTop={isStarted ? 0 : 1}>
-          <Text color={isStarted ? 'darkGray' : 'gray'} weight="bold" size="md">
+          <Text color={isStarted ? 'darkGray' : 'gray'} weight="bold" size="200">
             {statusMessage}
           </Text>
         </Box>
@@ -182,7 +182,7 @@ function UncompletedCard({
       </Box>
       {message && (
         <Box flex="grow" direction="column" alignContent="start" marginTop={2}>
-          <Text color="gray" size="md">
+          <Text color="gray" size="200">
             {message}
           </Text>
         </Box>

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -205,12 +205,12 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
         {label && (
           <Label htmlFor={id}>
             <Box paddingX={1}>
-              <Text color={disabled ? 'gray' : undefined} size={size === 'sm' ? 'md' : 'lg'}>
+              <Text color={disabled ? 'gray' : undefined} size={size === 'sm' ? '200' : '300'}>
                 {label}
               </Text>
               {subtext && (
                 <Box paddingY={1}>
-                  <Text color="gray" size={size === 'sm' ? 'md' : 'lg'}>
+                  <Text color="gray" size={size === 'sm' ? '200' : '300'}>
                     <Box display="visuallyHidden">:</Box> {subtext}
                   </Text>
                 </Box>
@@ -221,7 +221,7 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
       </Box>
       {errorMessage && (
         <Box marginTop={2}>
-          <Text color="red" size="sm">
+          <Text color="red" size="100">
             <FormErrorMessage id={id} text={errorMessage} />
           </Text>
         </Box>

--- a/packages/gestalt/src/ComboBoxItem.js
+++ b/packages/gestalt/src/ComboBoxItem.js
@@ -78,7 +78,7 @@ const ComboBoxItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> =
             {label}
           </Text>
           {subtext && (
-            <Text size="md" inline color="gray" lineClamp={2}>
+            <Text size="200" inline color="gray" lineClamp={2}>
               {subtext}
             </Text>
           )}

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -68,9 +68,9 @@ export default function Datapoint({
         )}
       </Flex>
       <Flex gap={size === 'lg' ? 4 : 2} alignItems="center">
-        <Heading accessibilityLevel="none" size={size === 'lg' ? 'md' : 'sm'}>
+        <Text size={size === 'lg' ? '500' : '400'} weight="bold">
           {value}
-        </Heading>
+        </Text>
         {trend && (
           <DatapointTrend
             sentiment={trendSentiment}

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -2,7 +2,6 @@
 import { type Node } from 'react';
 import DatapointTrend from './DatapointTrend.js';
 import Flex from './Flex.js';
-import Heading from './Heading.js';
 import Icon from './Icon.js';
 import TapArea from './TapArea.js';
 import Text from './Text.js';

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -56,7 +56,7 @@ export default function Datapoint({
   return (
     <Flex gap={1} direction="column">
       <Flex gap={1} alignItems="center" minHeight={24}>
-        <Text size="md">{title}</Text>
+        <Text size="200">{title}</Text>
         {tooltipText && (
           <Tooltip accessibilityLabel="" text={tooltipText} idealDirection="up">
             {/* Interactive elements require an a11yLabel on them or their children.

--- a/packages/gestalt/src/DatapointTrend.js
+++ b/packages/gestalt/src/DatapointTrend.js
@@ -46,7 +46,7 @@ export default function DatapointTrend({
         />
       )}
 
-      <Text size="md" color={color} weight="bold">
+      <Text size="200" color={color} weight="bold">
         {`${Math.abs(value)}%`}
       </Text>
     </Flex>

--- a/packages/gestalt/src/DropdownSection.js
+++ b/packages/gestalt/src/DropdownSection.js
@@ -23,7 +23,7 @@ export default function DropdownSection({ label, children }: Props): Node {
   return (
     <div className={styles.DropdownSection} aria-label={label}>
       <Box padding={2} display="flex" role="presentation">
-        <Text size="sm">{label}</Text>
+        <Text size="100">{label}</Text>
       </Box>
       {children}
     </div>

--- a/packages/gestalt/src/Fieldset.js
+++ b/packages/gestalt/src/Fieldset.js
@@ -60,7 +60,7 @@ export default function Fieldset({
           },
         )}
       >
-        <Text size="sm">{legend}</Text>
+        <Text size="100">{legend}</Text>
       </legend>
       {children}
       {errorMessage && <FormErrorMessage id={id} text={errorMessage} />}

--- a/packages/gestalt/src/FormErrorMessage.js
+++ b/packages/gestalt/src/FormErrorMessage.js
@@ -12,7 +12,7 @@ type Props = {|
 export default function FormErrorMessage({ id, text = '' }: Props): Node {
   return (
     <Box marginTop={2}>
-      <Text color="red" size="sm">
+      <Text color="red" size="100">
         {/* Class used to ensure all children are font size "sm" */}
         <span className={styles.formErrorMessage} id={`${id}-error`}>
           {text}

--- a/packages/gestalt/src/FormHelperText.js
+++ b/packages/gestalt/src/FormHelperText.js
@@ -7,7 +7,7 @@ import Text from './Text.js';
 export default function FormHelperText({ text }: {| text: string |}): Node {
   return (
     <Box marginTop={2}>
-      <Text color="gray" size="sm">
+      <Text color="gray" size="100">
         {text}
       </Text>
     </Box>

--- a/packages/gestalt/src/FormLabel.js
+++ b/packages/gestalt/src/FormLabel.js
@@ -14,7 +14,7 @@ export default function FormLabel({ id, label, labelDisplay }: Props): Node {
   return (
     <InternalLabel _labelDisplay={labelDisplay} htmlFor={id}>
       <div className={styles.formLabel}>
-        <Text size="sm">{label}</Text>
+        <Text size="100">{label}</Text>
       </div>
     </InternalLabel>
   );

--- a/packages/gestalt/src/Heading.flowtest.js
+++ b/packages/gestalt/src/Heading.flowtest.js
@@ -3,7 +3,7 @@ import Heading from './Heading.js';
 
 const Valid = <Heading size="400">Heading</Heading>;
 
-const ValidccessibilityLevel1 = (
+const ValidAccessibilityLevel1 = (
   <Heading size="400" accessibilityLevel={1}>
     Heading
   </Heading>

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -84,7 +84,7 @@ function Header({
 |}) {
   return (
     <Box justifyContent={align} padding={8}>
-      <Heading size="md" accessibilityLevel={1} align={align}>
+      <Heading size="500" accessibilityLevel={1} align={align}>
         {heading}
       </Heading>
       {subHeading && (

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -72,7 +72,7 @@ export default function ModuleExpandableItem({
                 <Box column={6} marginStart={6}>
                   <Flex direction="column" gap={2}>
                     {summary.map((item, i) => (
-                      <Text key={i} size="md" lineClamp={1}>
+                      <Text key={i} size="200" lineClamp={1}>
                         {item}
                       </Text>
                     ))}

--- a/packages/gestalt/src/OptionItem.js
+++ b/packages/gestalt/src/OptionItem.js
@@ -109,7 +109,7 @@ const OptionItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = f
           )}
         </Flex>
         {option.subtext && (
-          <Text size="md" color="gray">
+          <Text size="200" color="gray">
             {option.subtext}
           </Text>
         )}

--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -48,7 +48,7 @@ export default function PageHeader({
       <Flex flex="grow" justifyContent="center" maxWidth="100%">
         <Flex alignItems="center" flex="grow" justifyContent="between" maxWidth={maxWidth}>
           <Box marginEnd={4} minWidth={0} marginTop={2} marginBottom={2}>
-            <Heading size="md" lineClamp={1} accessibilityLevel={1}>
+            <Heading size="500" lineClamp={1} accessibilityLevel={1}>
               {title}
             </Heading>
             {subtext && (

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -160,12 +160,12 @@ const RadioButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
       {label && (
         <Label htmlFor={id}>
           <Box paddingX={1}>
-            <Text color={disabled ? 'gray' : undefined} size={size === 'sm' ? 'md' : 'lg'}>
+            <Text color={disabled ? 'gray' : undefined} size={size === 'sm' ? '200' : '300'}>
               {label}
             </Text>
             {subtext && (
               <Box paddingY={1}>
-                <Text color="gray" size={size === 'sm' ? 'md' : 'lg'}>
+                <Text color="gray" size={size === 'sm' ? '200' : '300'}>
                   <Box display="visuallyHidden">:</Box> {subtext}
                 </Text>
               </Box>

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -59,7 +59,7 @@ function SegmentedControlItem({
       style={{ width }}
     >
       {typeof item === 'string' ? (
-        <Text color="darkGray" align="center" size="md" weight="bold">
+        <Text color="darkGray" align="center" size="200" weight="bold">
           {item}
         </Text>
       ) : (

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -87,7 +87,7 @@ Internal components <Header> and <DismissButton>
 function Header({ heading }: {| heading: string |}) {
   return (
     <Box display="flex" justifyContent="start" padding={8}>
-      <Heading size="md" accessibilityLevel={1}>
+      <Heading size="500" accessibilityLevel={1}>
         {heading}
       </Heading>
     </Box>

--- a/packages/gestalt/src/Status.js
+++ b/packages/gestalt/src/Status.js
@@ -67,12 +67,12 @@ export default function Status({ accessibilityLabel, subtext, title, type }: Pro
     <Flex direction="column">
       <Flex alignItems="center" gap={2}>
         <Icon accessibilityLabel={accessibilityLabel ?? ''} color={color} icon={icon} size={16} />
-        {title && <Text size="md">{title}</Text>}
+        {title && <Text size="200">{title}</Text>}
       </Flex>
 
       {subtext && title && (
         <Box marginStart={6}>
-          <Text color="gray" size="md">
+          <Text color="gray" size="200">
             {subtext}
           </Text>
         </Box>

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -66,7 +66,7 @@ function Count({ count }: {| count: number |}) {
           __style: { padding: '0 0 1px 1px' },
         }}
       >
-        <Text align="center" color="white" size="sm" weight="bold">
+        <Text align="center" color="white" size="100" weight="bold">
           {displayCount}
         </Text>
       </Box>

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -97,7 +97,7 @@ export default function Tag(props: Props): Node {
           )}
         </Box>
         <div className={typographyStyles.truncate} title={text}>
-          <Text color={fgColor} inline size="md">
+          <Text color={fgColor} inline size="200">
             {text}
           </Text>
         </div>

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -145,7 +145,7 @@ export default function Tooltip({
               role="tooltip"
               tabIndex={0}
             >
-              <Text color="white" size="sm">
+              <Text color="white" size="100">
                 {text}
               </Text>
               {Boolean(link) && <Box marginTop={1}>{link}</Box>}

--- a/packages/gestalt/src/Tooltip.jsdom.test.js
+++ b/packages/gestalt/src/Tooltip.jsdom.test.js
@@ -21,7 +21,7 @@ test('Tooltip renders the link when hovered', () => {
     <Tooltip
       link={
         <Link href="https://pinterest.com" target="blank">
-          <Text color="white" size="sm" weight="bold">
+          <Text color="white" size="100" weight="bold">
             Learn more
           </Text>
         </Link>

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -134,7 +134,7 @@ function VideoControls({
         </Box>
       )}
       <Box width={50} padding={2}>
-        <Text align="end" color="white" overflow="normal" size="sm">
+        <Text align="end" color="white" overflow="normal" size="100">
           {timeToString(currentTime)}
         </Text>
       </Box>
@@ -149,7 +149,7 @@ function VideoControls({
         />
       </Box>
       <Box width={50} padding={2}>
-        <Text align="end" color="white" overflow="normal" size="sm">
+        <Text align="end" color="white" overflow="normal" size="100">
           {timeToString(duration)}
         </Text>
       </Box>

--- a/packages/gestalt/src/__snapshots__/Datapoint.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Datapoint.test.js.snap
@@ -36,7 +36,7 @@ exports[`Datapoint renders 1`] = `
         className="FlexItem"
       >
         <div
-          className="Heading fontSize400 darkGray alignStart breakWord"
+          className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
         >
           1M
         </div>
@@ -116,7 +116,7 @@ exports[`Datapoint renders an accessibility label 1`] = `
         className="FlexItem"
       >
         <div
-          className="Heading fontSize400 darkGray alignStart breakWord"
+          className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
         >
           1M
         </div>


### PR DESCRIPTION
### Summary

#### What changed?

For any instances of Heading or Text inside our components, switch out size values as follows:

| Size | Text | TextArea | px |
|------|------|----------|----|
| 100  | sm   |     --     | 12 |
| 200  | md   |    --      | 14 |
| 300  | lg   |     --     | 16 |
| 400  |   --   | sm       | 20 |
| 500  |   --   | md       | 28 |
| 600  |  --    | lg       | 36 |

#### Why?

In order to deprecate our old values, we need to convert any current instances over. Also helps us eliminate the use of accessibilityLevel="none" on Heading (which will be deprecated in a future ticket)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3889)

### Checklist

- [X] Updated unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
