### PR TITLE
DeviceTypeProvider: add new component

### DIFF
--- a/cypress/integration/accessibility_DeviceTypeProvider_spec.js
+++ b/cypress/integration/accessibility_DeviceTypeProvider_spec.js
@@ -1,0 +1,11 @@
+describe('DeviceTypeProvider Accessibility check', () => {
+  beforeEach(() => {
+    cy.visit('/devicetypeprovider');
+    cy.injectAxe();
+  });
+
+  it('Tests accessibility on the DeviceTypeProvider page', () => {
+    cy.configureAxe();
+    cy.checkA11y();
+  });
+});

--- a/docs/pages/devicetypeprovider.js
+++ b/docs/pages/devicetypeprovider.js
@@ -1,0 +1,32 @@
+// @flow strict
+import type { Node } from 'react';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+// To be used when this page is made live
+// import MainSection from '../components/MainSection.js';
+import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
+import docgen, { type DocGen } from '../components/docgen.js';
+
+// TODO: @rjames
+// - Add usage examples to this docs page
+// - Add reference to this docs page in docs/components/sidebarIndex.js
+
+export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+  return (
+    <Page title="DeviceTypeProvider">
+      <PageHeader name="DeviceTypeProvider" description={generatedDocGen?.description} />
+
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
+    </Page>
+  );
+}
+
+export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  return {
+    props: {
+      generatedDocGen: await docgen({
+        componentName: 'DeviceTypeProvider',
+      }),
+    },
+  };
+}

--- a/packages/gestalt/src/contexts/DeviceTypeProvider.js
+++ b/packages/gestalt/src/contexts/DeviceTypeProvider.js
@@ -1,0 +1,31 @@
+// @flow strict
+import { type Context, type Node, createContext, useContext } from 'react';
+
+const defaultDeviceType = 'desktop';
+
+type DeviceType = 'desktop' | 'phone' | 'tablet';
+
+const DeviceTypeContext: Context<DeviceType> = createContext<DeviceType>(defaultDeviceType);
+
+type Props = {|
+  /**
+   *
+   */
+  children: Node,
+  /**
+   * The device type as determined by logic within your app. This will be used within certain Gestalt components to render device-specific UI.
+   */
+  deviceType: DeviceType,
+|};
+
+/**
+ * *ALPHA - DO NOT USE YET - MAY HAVE BREAKING CHANGES IN THE NEAR FUTURE*
+ * [DeviceTypeProvider](https://gestalt.pinterest.systems/devicetypeprovider) is an optional [React Context provider](https://reactjs.org/docs/context.html#contextprovider) to enable device-specific UI for Gestalt components that support it.
+ */
+export default function DeviceTypeProvider({ children, deviceType }: Props): Node {
+  return <DeviceTypeContext.Provider value={deviceType}>{children}</DeviceTypeContext.Provider>;
+}
+
+export function useDeviceType(): DeviceType {
+  return useContext(DeviceTypeContext) ?? defaultDeviceType;
+}

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -18,6 +18,7 @@ import Column from './Column.js';
 import ComboBox from './ComboBox.js';
 import Container from './Container.js';
 import Datapoint from './Datapoint.js';
+import DeviceTypeProvider from './contexts/DeviceTypeProvider.js';
 import Divider from './Divider.js';
 import Dropdown from './Dropdown.js';
 import Fieldset from './Fieldset.js';
@@ -88,6 +89,7 @@ export {
   CompositeZIndex,
   Container,
   Datapoint,
+  DeviceTypeProvider,
   Divider,
   Dropdown,
   Fieldset,


### PR DESCRIPTION
### Summary

#### What changed?

This PR introduces a new component, DeviceTypeProvider. The associated docs page is skeletal for now, as this component is an alpha that may change. The docs page can be navigated to directly but has not yet been added to the sidebar index, so it is somewhat hidden for now. I will flesh out the rest of the docs page before this component officially launches.

#### Why?

We'd like to start offering device-specific UI for certain components, e.g. migrating Pinboard's MobileModal into Gestalt and rendering that UI for mobile devices. Using the same `'desktop' | 'mobile' | 'tablet'` device types as Pinboard, this context provider is the first step in this project, making device type available within components. Future work will add logic within components to use this device type.

I'm imagining this will be used something like
```js
// App.js

return (
  <DeviceTypeProvider value={useDeviceType()}>
    {children}
  </DeviceTypeProvider>
);
```
```js
// Gestalt Modal.js

const deviceType = useDeviceType();

return deviceType === 'mobile' ? <MobileModal /> : <Modal />;
```

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3477)

### Checklist

- [ ] ~Added unit and Flow Tests~ Don't seem necessary for a context this simple
- [x] Added documentation + accessibility tests
