### PR TITLE
Table: Ensure tables are keyboard accessible

### DIFF
--- a/cypress/integration/accessibility_Table_spec.js
+++ b/cypress/integration/accessibility_Table_spec.js
@@ -12,11 +12,6 @@ describe('Table Accessibility check', () => {
           id: 'color-contrast',
           enabled: false,
         },
-        {
-          // Disabled to avoid confusion for sticky header and column examples
-          id: 'scrollable-region-focusable',
-          enabled: false,
-        },
       ],
     });
     cy.checkA11y();

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -1643,7 +1643,7 @@ function Example() {
         <MainSection.Card
           cardSize="lg"
           defaultCode={`
-<Box width="50%" overflow="auto">
+<Box width="50%">
   <Table accessibilityLabel="Sticky Column" maxHeight={200} stickyColumns={1}>
 
     <Table.Header>
@@ -1746,7 +1746,7 @@ function Example() {
         <MainSection.Card
           cardSize="lg"
           defaultCode={`
-<Box width="60%" overflow="auto">
+<Box width="60%">
   <Table accessibilityLabel="Multiple sticky columns" maxHeight={200} stickyColumns={3} borderStyle="none">
 
     <Table.Header>
@@ -1881,7 +1881,7 @@ function Example() {
         <MainSection.Card
           cardSize="lg"
           defaultCode={`
-<Box width="60%" overflow="auto">
+<Box width="60%">
   <Table accessibilityLabel="Sticky header and sticky columns" maxHeight={200} stickyColumns={3} borderStyle="none">
 
     <Table.Header sticky>
@@ -2236,7 +2236,7 @@ function Example() {
       };
 
       return(
-      <Box width="60%" overflow="auto">
+      <Box width="60%">
         <Table accessibilityLabel="Table Row Expandable with Sticky Columns" stickyColumns={3}>
 
           <Table.Header>
@@ -2503,7 +2503,7 @@ function Example() {
       }
 
       return (
-        <Box width="70%" overflow="auto">
+        <Box width="70%">
           <Table accessibilityLabel="Sortable header cells with sticky columns" stickyColumns={2}>
             <Table.Header>
               <Table.Row>

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -85,6 +85,7 @@ export default function Table({
       {...(borderStyle === 'sm' ? { borderStyle: 'sm', rounding: 1 } : {})}
       maxHeight={maxHeight}
       ref={tableRef}
+      tabIndex="0"
     >
       <table className={classNames}>
         <Box

--- a/packages/gestalt/src/__snapshots__/Table.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Table.test.js.snap
@@ -8,6 +8,7 @@ exports[`renders correctly 1`] = `
       "maxHeight": undefined,
     }
   }
+  tabIndex="0"
 >
   <table
     className="table"
@@ -40,6 +41,7 @@ exports[`renders correctly with border 1`] = `
       "maxHeight": undefined,
     }
   }
+  tabIndex="0"
 >
   <table
     className="table"
@@ -72,6 +74,7 @@ exports[`renders correctly with maxHeight 1`] = `
       "maxHeight": 100,
     }
   }
+  tabIndex="0"
 >
   <table
     className="table"
@@ -104,6 +107,7 @@ exports[`renders correctly with stickyColumns 1`] = `
       "maxHeight": undefined,
     }
   }
+  tabIndex="0"
 >
   <table
     className="table"


### PR DESCRIPTION
### Summary

#### What changed?

Add tabindex="0" to tables to ensure they are keyboard accessible and get focus 

#### Why?

In order to ensure keyboard accessibility and focus states of the table, the tabindex of 0 allows keyboard users to reach the table and anything inside while triggering a focus ring

More details: https://dev.to/lukekyl/3-steps-to-make-html-tables-web-accessible-3jjf

Before:

<img width="670" alt="Screen Shot 2022-02-17 at 11 19 13 AM" src="https://user-images.githubusercontent.com/5125094/154524089-4aaac588-a27b-4fa9-bdcc-6ea3298b88e6.png">

After

<img width="668" alt="Screen Shot 2022-02-17 at 11 19 18 AM" src="https://user-images.githubusercontent.com/5125094/154524093-0cfb9b64-2827-403b-ac6d-d0cb1063b7b9.png">


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3531)

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
