### PR TITLE
Internal: add note about Jira on bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template-for-jira.md
+++ b/.github/ISSUE_TEMPLATE/bug-template-for-jira.md
@@ -6,6 +6,11 @@ labels: bug, to be migrated
 assignees: ''
 ---
 
+**PINTEREST EMPLOYEES, [PLEASE FILE BUGS IN JIRA INSTEAD](https://jira.pinadmin.com/secure/CreateIssue!default.jspa)!**
+**Project: BUG**
+**Type: Bug**
+**Component: Gestalt**
+
 Platform: (desktop web | mobile web)
 
 Steps to reproduce:


### PR DESCRIPTION
Updating bug template to guide Pinployees to use Jira instead