### PR TITLE
Flex: use autogenerated props/description

### DIFF
--- a/docs/pages/flex.js
+++ b/docs/pages/flex.js
@@ -1,151 +1,33 @@
 // @flow strict
 import { type Node } from 'react';
-import { Box, Flex } from 'gestalt';
-import PropTable from '../components/PropTable.js';
-import PageHeader from '../components/PageHeader.js';
-import MainSection from '../components/MainSection.js';
+import { Box } from 'gestalt';
 import CombinationNew from '../components/CombinationNew.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
+import MainSection from '../components/MainSection.js';
 import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
+import { multipledocgen, type DocGen } from '../components/docgen.js';
 
-export default function ModulePage(): Node {
+export default function DocsPage({
+  generatedDocGen,
+}: {|
+  generatedDocGen: {| [string]: DocGen |},
+|}): Node {
   return (
     <Page title="Flex">
-      <PageHeader
-        name="Flex"
-        description={`
-      Flex is a layout component with a very limited subset of the props available to [Box](/box) and a few special props of its own.
+      <PageHeader name="Flex" description={generatedDocGen?.Flex?.description} />
 
-      Use this component for flex layouts, especially when even spacing between elements is desired (see the 'gap' property!).
-    `}
-      />
-      <PropTable
-        Component={Flex}
-        props={[
-          {
-            name: 'children',
-            type: 'React.Node',
-          },
-          {
-            name: 'alignContent',
-            type: `"start" | "end" | "center" | "between" | "around" | "evenly" | "stretch"`,
-            defaultValue: 'stretch',
-            description:
-              "Aligns the flex container's lines within when there is extra space in the cross axis, similar to how justify-content aligns individual items within the main axis.",
-          },
-          {
-            name: 'alignItems',
-            type: `"start" | "end" | "center" | "baseline" | "stretch"`,
-            defaultValue: 'start',
-            description:
-              'Defines the default behaviour for how flex items are laid out along the cross axis on the current line. Think of it as the justify-content version for the cross axis (perpendicular to the main axis).',
-            href: 'layout',
-          },
-          {
-            name: 'alignSelf',
-            type: `"auto" | "start" | "end" | "center" | "baseline" | "stretch"`,
-            defaultValue: 'stretch',
-            description:
-              'Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items.',
-          },
-          {
-            name: 'direction',
-            type: `"row" | "column"`,
-            defaultValue: 'row',
-            description:
-              'Establishes the main axis, thus defining the direction flex items are placed in the flex container.',
-          },
-          {
-            name: 'flex',
-            type: '"grow" | "shrink" | "none"',
-            defaultValue: 'shrink',
-            description: `Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size the Flex relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows the Flex to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves the Flex's size based on child content regardless of its container's size.`,
-          },
-          {
-            name: 'gap',
-            type: '0 .. 12',
-            defaultValue: 0,
-            description: 'Defines spacing between each child along the main axis.',
-          },
-          {
-            name: 'height',
-            type: `number | string`,
-            description: `Use numbers for pixels: height={100} and strings for percentages: height="100%"`,
-          },
-          {
-            name: 'justifyContent',
-            type: `"start" | "end" | "center" | "between" | "around" | "evenly"`,
-            defaultValue: 'center',
-            description:
-              'Defines the alignment along the main axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.',
-            href: 'layout',
-          },
-          {
-            name: 'maxHeight',
-            type: `number | string`,
-          },
-          {
-            name: 'maxWidth',
-            type: `number | string`,
-            description: `Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%"`,
-          },
-          {
-            name: 'minHeight',
-            type: `number | string`,
-            description: `Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%"`,
-          },
-          {
-            name: 'minWidth',
-            type: `number | string`,
-            description: `Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%"`,
-          },
-          {
-            name: 'width',
-            type: `number | string`,
-            description: `Use numbers for pixels: width={100} and strings for percentages: width="100%"`,
-          },
-          {
-            name: 'wrap',
-            type: 'boolean',
-            defaultValue: false,
-            description: `By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.`,
-          },
-        ]}
-      />
-      <MainSection name="Subcomponents" />
-      <PropTable
-        name="Flex.Item"
-        id="Flex.Item"
-        Component={Flex?.Item}
-        props={[
-          {
-            name: 'children',
-            type: 'React.Node',
-          },
-          {
-            name: 'alignSelf',
-            type: `"auto" | "start" | "end" | "center" | "baseline" | "stretch"`,
-            defaultValue: 'stretch',
-            description:
-              'Allows the default alignment (or the one specified by `align-items`) to be overridden for individual flex items.',
-          },
-          {
-            name: 'flex',
-            type: '"grow" | "shrink" | "none"',
-            defaultValue: 'shrink',
-            description: `Defines how a flex item will be sized. \`"grow"\`, equivalent to \`"flex: 1 1 auto"\`, will size the Flex.Item relative to its parent, growing and shrinking based on available space. \`"shrink"\`, equivalent to \`"flex: 0 1 auto"\` (the browser default), allows the Flex.Item to shrink if compressed but not grow if given extra space. Finally, \`"none"\`, equivalent to \`"flex: 0 0 auto"\`, preserves the Flex.Item's size based on child content regardless of its container's size.`,
-          },
-          {
-            name: 'flexBasis',
-            type: `number | string`,
-            description: `Defines the initial main size of the flex item. Use numbers for pixels: \`flexBasis={100}\` and strings for other units: \`flexBasis="100vh"\`.`,
-          },
-          {
-            name: 'minWidth',
-            type: `number | string`,
-            description: `Use numbers for pixels: \`minWidth={100}\` and strings for percentages: \`minWidth="100%"\`. Can be used to fix overflowing children; see [the example](#FlexItem-minWidth) to learn more.`,
-          },
-        ]}
-      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen.Flex} />
+
+      <MainSection name="Subcomponents">
+        <MainSection.Subsection
+          title={generatedDocGen?.FlexItem?.displayName}
+          description={generatedDocGen?.FlexItem?.description}
+        >
+          <GeneratedPropTable generatedDocGen={generatedDocGen.FlexItem} />
+        </MainSection.Subsection>
+      </MainSection>
+
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Flex Layout"
@@ -173,6 +55,7 @@ export default function ModulePage(): Node {
             )}
           </CombinationNew>
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Menu"
           description={`
@@ -192,6 +75,7 @@ export default function ModulePage(): Node {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Applying flex properties to children"
           description={`
@@ -213,6 +97,7 @@ export default function ModulePage(): Node {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Initial item width using flexBasis"
           description={`
@@ -238,6 +123,7 @@ export default function ModulePage(): Node {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Overflowing children and minWidth"
           description={`
@@ -267,4 +153,14 @@ export default function ModulePage(): Node {
       </MainSection>
     </Page>
   );
+}
+
+export async function getServerSideProps(): Promise<{|
+  props: {| generatedDocGen: {| [string]: DocGen |} |},
+|}> {
+  const docgen = await multipledocgen({ componentName: ['Flex', 'FlexItem'] });
+
+  return {
+    props: { generatedDocGen: docgen },
+  };
 }

--- a/docs/pages/flex.js
+++ b/docs/pages/flex.js
@@ -24,7 +24,11 @@ export default function DocsPage({
           title={generatedDocGen?.FlexItem?.displayName}
           description={generatedDocGen?.FlexItem?.description}
         >
-          <GeneratedPropTable generatedDocGen={generatedDocGen.FlexItem} />
+          <GeneratedPropTable
+            generatedDocGen={generatedDocGen.FlexItem}
+            id="Flex.Item"
+            name="Flex.Item"
+          />
         </MainSection.Subsection>
       </MainSection>
 

--- a/docs/pages/module.js
+++ b/docs/pages/module.js
@@ -1,13 +1,13 @@
 // @flow strict
 import { type Node } from 'react';
 import { Module } from 'gestalt';
-import PageHeader from '../components/PageHeader.js';
+import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import MainSection from '../components/MainSection.js';
 import Page from '../components/Page.js';
+import PageHeader from '../components/PageHeader.js';
 import { multipledocgen, type DocGen } from '../components/docgen.js';
-import GeneratedPropTable from '../components/GeneratedPropTable.js';
 
-export default function ModulePage({
+export default function DocsPage({
   generatedDocGen,
 }: {|
   generatedDocGen: {| [string]: DocGen |},
@@ -15,7 +15,9 @@ export default function ModulePage({
   return (
     <Page title="Module">
       <PageHeader name="Module" description={generatedDocGen.Module?.description} />
+
       <GeneratedPropTable generatedDocGen={generatedDocGen.Module} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -41,13 +43,15 @@ export default function ModulePage({
           />
         </MainSection.Subsection>
       </MainSection>
-      <MainSection name="Subcomponents" />
-      <GeneratedPropTable
-        Component={Module.Expandable}
-        name="Module.Expandable"
-        id="Module.Expandable"
-        generatedDocGen={generatedDocGen.ModuleExpandable}
-      />
+
+      <MainSection name="Subcomponents">
+        <GeneratedPropTable
+          Component={Module.Expandable}
+          name="Module.Expandable"
+          id="Module.Expandable"
+          generatedDocGen={generatedDocGen.ModuleExpandable}
+        />
+      </MainSection>
 
       <MainSection name="Variants">
         <MainSection.Subsection
@@ -73,6 +77,7 @@ function ModuleExample() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Static - Icon"
           description={`
@@ -101,6 +106,7 @@ function ModuleExample() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Static - IconButton"
           description={`
@@ -154,6 +160,7 @@ function ModuleExample() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Static - Badge"
           description={`Badge text can be provided, which will be displayed after the \`title\`. Note that if no title text is provided, the badge will not be displayed.`}
@@ -177,6 +184,7 @@ function ModuleExample() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Static - Error"
           description={`When using \`type\` as \`"error"\`, be sure to provide an \`iconAccessibilityLabel\`.`}
@@ -213,6 +221,7 @@ function ModuleExample() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Expandable"
           description={`Modules can also allow for expanding and collapsing content. The \`title\` is required and always present. The collapsed state shows optional \`summary\` content, while the expanded state shows any content desired.`}
@@ -240,6 +249,7 @@ function ModuleExample1() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Expandable - Group"
           description="Multiple expandable items can be stacked together into a Module group. However, only one Module will be expanded at any time."
@@ -277,6 +287,7 @@ function ModuleExample2() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="ExpExpandable - Icon, Badge and IconButton"
           description={`
@@ -346,6 +357,7 @@ function ModuleExample3() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Expandable - Error"
           description={`When using \`type\` as \`"error"\`, be sure to provide an \`iconAccessibilityLabel\`.`}
@@ -388,6 +400,7 @@ function ModuleExample4() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection title="Example with external control">
           <MainSection.Card
             cardSize="lg"

--- a/packages/gestalt/src/Flex.js
+++ b/packages/gestalt/src/Flex.js
@@ -4,34 +4,73 @@ import FlexItem from './FlexItem.js';
 import styles from './Flex.css';
 import wrapWithComponent from './utils/wrapWithComponent.js';
 import { buildStyles } from './boxTransforms.js';
-import {
-  type AlignContent,
-  type AlignItems,
-  type AlignSelf,
-  type Dimension,
-  type Direction,
-  type Flex as FlexType,
-  type Gap,
-  type JustifyContent,
-  type Overflow,
-} from './boxTypes.js';
+
+type Dimension = number | string;
 
 type Props = {|
-  alignContent?: AlignContent,
-  alignItems?: AlignItems,
-  alignSelf?: AlignSelf,
+  /**
+   * Aligns the flex container's lines within when there is extra space in the cross axis, similar to how `justify-content` aligns individual items within the main axis.
+   */
+  alignContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch',
+  /**
+   * Defines the default behaviour for how flex items are laid out along the cross axis on the current line. Think of it as the `justify-content` version for the cross axis (perpendicular to the main axis).
+   */
+  alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch',
+  /**
+   * Allows the default alignment (or the one specified by `align-items`) to be overridden for individual flex items.
+   */
+  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch',
+  /**
+   *
+   */
   children?: Node,
-  direction?: Direction,
-  flex?: FlexType,
-  gap?: Gap,
+  /**
+   * Establishes the main axis, thus defining the direction flex items are placed in the flex container.
+   */
+  direction?: 'row' | 'column',
+  /**
+   * Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size Flex relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows Flex to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves Flex's size based on child content regardless of its container's size.
+   */
+  flex?: 'grow' | 'shrink' | 'none',
+  /**
+   * Defines spacing between each child along the main axis.
+   */
+  gap?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,
+  /**
+   * Use numbers for pixels: `height={100}` and strings for percentages: `height="100%"`.
+   */
   height?: Dimension,
-  justifyContent?: JustifyContent,
+  /**
+   * Defines the alignment along the main axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.
+   */
+  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly',
+  /**
+   * Use numbers for pixels: `maxHeight={100}` and strings for percentages: `maxHeight="100%"`.
+   */
   maxHeight?: Dimension,
+  /**
+   * Use numbers for pixels: `maxWidth={100}` and strings for percentages: `maxWidth="100%"`.
+   */
   maxWidth?: Dimension,
+  /**
+   * Use numbers for pixels: `minHeight={100}` and strings for percentages: `minHeight="100%"`.
+   */
   minHeight?: Dimension,
+  /**
+   * Use numbers for pixels: `minWidth={100}` and strings for percentages: `minWidth="100%"`.
+   */
   minWidth?: Dimension,
-  overflow?: Overflow,
+  /**
+   * Defines how to handle content that extends beyond the Flex container.
+   */
+  overflow?: 'visible' | 'hidden' | 'scroll' | 'scrollX' | 'scrollY' | 'auto',
+  /**
+   * Use numbers for pixels: `width={100}` and strings for percentages: `width="100%"`.
+   */
   width?: Dimension,
+  /**
+   * By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.
+   */
   wrap?: boolean,
 |};
 
@@ -54,7 +93,9 @@ const allowedProps = [
 ];
 
 /**
- * https://gestalt.pinterest.systems/flex
+ * [Flex](https://gestalt.pinterest.systems/flex) is a layout component with a very limited subset of the props available to [Box](https://gestalt.pinterest.systems/box) and a special prop of its own.
+
+ * Use this component for flexbox layouts, especially when even spacing between elements is desired (see the `gap` prop!).
  */
 export default function Flex({
   alignItems,

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -2,20 +2,36 @@
 import { type Node } from 'react';
 import { buildStyles } from './boxTransforms.js';
 import styles from './Flex.css';
-import { type AlignSelf, type Dimension, type Flex } from './boxTypes.js';
+
+type Dimension = number | string;
 
 export type Props = {|
-  alignSelf?: AlignSelf,
+  /**
+   * Allows the default alignment (or the one specified by `align-items`) to be overridden for the individual flex item.
+   */
+  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch',
+  /**
+   *
+   */
   children?: Node,
-  flex?: Flex,
+  /**
+   * Defines how the flex item will be sized. `"grow"`, equivalent to `"flex: 1 1 auto"`, will size Flex.Item relative to its parent, growing and shrinking based on available space. `"shrink"`, equivalent to `"flex: 0 1 auto"` (the browser default), allows Flex.Item to shrink if compressed but not grow if given extra space. Finally, `"none"`, equivalent to `"flex: 0 0 auto"`, preserves Flex.Item's size based on child content regardless of its container's size.
+   */
+  flex?: 'grow' | 'shrink' | 'none',
+  /**
+   * Defines the initial main size of the flex item. Use numbers for pixels: `flexBasis={100}` and strings for other units: `flexBasis="100vh"`.
+   */
   flexBasis?: string | number,
+  /**
+   * Use numbers for pixels: `minWidth={100}` and strings for percentages: `minWidth="100%"`. Can be used to fix overflowing children; see [the example](https://gestalt.pinterest.systems/flex#FlexItem-minWidth) to learn more.
+   */
   minWidth?: Dimension,
 |};
 
 const allowedProps = ['alignSelf', 'children', 'flex', 'flexBasis', 'minWidth'];
 
 /**
- * https://gestalt.pinterest.systems/flex
+ * Use [Flex.Item](https://gestalt.pinterest.systems/flex) within a Flex container for more precise control over the child element. Flex children that are not explicitly wrapped in Flex.Item will be wrapped in the the component automatically to apply `gap` spacing.
  */
 export default function FlexItem(props: Props): Node {
   const { passthroughProps, propsStyles } = buildStyles<Props>({


### PR DESCRIPTION
Of note: this also makes use of the component name and description for the sub-component. I'll update the rest of our sub-component-havin' components unless people hate this for some reason.