### PR TITLE
Toast: fix layout bug with long text + button text

### DIFF
--- a/packages/gestalt/src/Flex.js
+++ b/packages/gestalt/src/Flex.js
@@ -30,6 +30,7 @@ type Props = {|
   direction?: 'row' | 'column',
   /**
    * Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size Flex relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows Flex to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves Flex's size based on child content regardless of its container's size.
+   * Default: 'shrink'
    */
   flex?: 'grow' | 'shrink' | 'none',
   /**

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -16,6 +16,7 @@ export type Props = {|
   children?: Node,
   /**
    * Defines how the flex item will be sized. `"grow"`, equivalent to `"flex: 1 1 auto"`, will size Flex.Item relative to its parent, growing and shrinking based on available space. `"shrink"`, equivalent to `"flex: 0 1 auto"` (the browser default), allows Flex.Item to shrink if compressed but not grow if given extra space. Finally, `"none"`, equivalent to `"flex: 0 0 auto"`, preserves Flex.Item's size based on child content regardless of its container's size.
+   * Default: 'shrink'
    */
   flex?: 'grow' | 'shrink' | 'none',
   /**

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -23,12 +23,16 @@ export type Props = {|
    */
   flexBasis?: string | number,
   /**
+   * Use numbers for pixels: `maxWidth={100}` and strings for percentages: `maxWidth="100%"`.
+   */
+  maxWidth?: Dimension,
+  /**
    * Use numbers for pixels: `minWidth={100}` and strings for percentages: `minWidth="100%"`. Can be used to fix overflowing children; see [the example](https://gestalt.pinterest.systems/flex#FlexItem-minWidth) to learn more.
    */
   minWidth?: Dimension,
 |};
 
-const allowedProps = ['alignSelf', 'children', 'flex', 'flexBasis', 'minWidth'];
+const allowedProps = ['alignSelf', 'children', 'flex', 'flexBasis', 'maxWidth', 'minWidth'];
 
 /**
  * Use [Flex.Item](https://gestalt.pinterest.systems/flex) within a Flex container for more precise control over the child element. Flex children that are not explicitly wrapped in Flex.Item will be wrapped in the the component automatically to apply `gap` spacing.

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -9,7 +9,7 @@ import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 
 const TOAST_MAX_WIDTH_PX = 500;
 const TOAST_WIDTH_PX = 330;
-const TEXT_MAX_WIDTH_PX = 160;
+const TEXT_MAX_WIDTH_PX = 127;
 
 type Props = {|
   /**

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -7,6 +7,10 @@ import Text from './Text.js';
 import styles from './Toast.css';
 import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 
+const TOAST_MAX_WIDTH_PX = 500;
+const TOAST_WIDTH_PX = 360;
+const TEXT_MAX_WIDTH_PX = 200;
+
 type Props = {|
   /**
    * Add an optional button for user interaction. Generally not recommended given the ephemeral nature of Toasts.
@@ -69,8 +73,17 @@ export default function Toast({
     textColor = 'white';
   }
 
+  const hasImage = thumbnail != null;
+  const hasButton = button != null;
+
   return (
-    <Box marginBottom={3} maxWidth={360} paddingX={4} role="status" width="100vw">
+    <Box
+      marginBottom={3}
+      maxWidth={TOAST_MAX_WIDTH_PX}
+      paddingX={4}
+      role="status"
+      width={hasImage && hasButton != null ? undefined : TOAST_WIDTH_PX}
+    >
       <Box borderStyle="shadow" color={containerColor} fit padding={6} rounding="pill">
         <Flex alignItems="center" gap={4}>
           {thumbnail ? (
@@ -85,7 +98,10 @@ export default function Toast({
             </Flex.Item>
           ) : null}
 
-          <Flex.Item flex="grow">
+          <Flex.Item
+            flex="grow"
+            maxWidth={hasImage && hasButton != null ? TEXT_MAX_WIDTH_PX : undefined}
+          >
             <Text align={!thumbnail && !button ? 'center' : 'start'} color={textColor}>
               {textElement}
             </Text>

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Element, type Node } from 'react';
+import { type Node } from 'react';
 import Box from './Box.js';
 import Flex from './Flex.js';
 import Mask from './Mask.js';
@@ -8,8 +8,8 @@ import styles from './Toast.css';
 import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 
 const TOAST_MAX_WIDTH_PX = 500;
-const TOAST_WIDTH_PX = 360;
-const TEXT_MAX_WIDTH_PX = 200;
+const TOAST_WIDTH_PX = 330;
+const TEXT_MAX_WIDTH_PX = 160;
 
 type Props = {|
   /**
@@ -19,8 +19,7 @@ type Props = {|
   /**
    * Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Do not specify a Text color within this property, as the color is automatically determined based on the `variant`.
    */
-  // $FlowFixMe[unclear-type]
-  text: string | Element<*>,
+  text: string | Node,
   /**
    * An optional thumbnail image to displayed next to the text.
    */
@@ -80,9 +79,12 @@ export default function Toast({
     <Box
       marginBottom={3}
       maxWidth={TOAST_MAX_WIDTH_PX}
+      minWidth={TOAST_WIDTH_PX}
       paddingX={4}
       role="status"
-      width={hasImage && hasButton != null ? undefined : TOAST_WIDTH_PX}
+      // Button text and text can be long, so allow toast to expand
+      // to max width if button is present
+      width={hasButton ? undefined : TOAST_WIDTH_PX}
     >
       <Box borderStyle="shadow" color={containerColor} fit padding={6} rounding="pill">
         <Flex alignItems="center" gap={4}>
@@ -98,10 +100,7 @@ export default function Toast({
             </Flex.Item>
           ) : null}
 
-          <Flex.Item
-            flex="grow"
-            maxWidth={hasImage && hasButton != null ? TEXT_MAX_WIDTH_PX : undefined}
-          >
+          <Flex.Item flex="grow" maxWidth={hasImage && hasButton ? TEXT_MAX_WIDTH_PX : undefined}>
             <Text align={!thumbnail && !button ? 'center' : 'start'} color={textColor}>
               {textElement}
             </Text>

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -5,6 +5,7 @@ import Flex from './Flex.js';
 import Mask from './Mask.js';
 import Text from './Text.js';
 import styles from './Toast.css';
+import useResponsiveMinWidth from './useResponsiveMinWidth.js';
 import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 
 const TOAST_MAX_WIDTH_PX = 500;
@@ -50,6 +51,9 @@ export default function Toast({
   const isDarkMode = colorSchemeName === 'darkMode';
   const isErrorVariant = variant === 'error';
 
+  const responsiveMinWidth = useResponsiveMinWidth();
+  const isMobileWidth = responsiveMinWidth === 'xs';
+
   let containerColor = isDarkMode ? 'white' : 'darkGray';
   let textColor = isDarkMode ? 'darkGray' : 'white';
   let textElement = text;
@@ -78,7 +82,8 @@ export default function Toast({
   return (
     <Box
       marginBottom={3}
-      maxWidth={TOAST_MAX_WIDTH_PX}
+      // Ensure that maxWidth isn't greater than viewport width (for small screens)
+      maxWidth={`min(${TOAST_MAX_WIDTH_PX}px, 100vw)`}
       minWidth={TOAST_WIDTH_PX}
       paddingX={4}
       role="status"
@@ -106,7 +111,10 @@ export default function Toast({
             </Text>
           </Flex.Item>
 
-          {button ? <Flex.Item flex="none">{button}</Flex.Item> : null}
+          {button ? (
+            // Allow button text to wrap on mobile
+            <Flex.Item flex={isMobileWidth ? 'shrink' : 'none'}>{button}</Flex.Item>
+          ) : null}
         </Flex>
       </Box>
     </Box>

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -6,7 +6,7 @@ exports[`<Toast /> Error Toast 1`] = `
   role="status"
   style={
     Object {
-      "maxWidth": 500,
+      "maxWidth": "min(500px, 100vw)",
       "minWidth": 330,
       "width": 330,
     }
@@ -43,7 +43,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
   role="status"
   style={
     Object {
-      "maxWidth": 500,
+      "maxWidth": "min(500px, 100vw)",
       "minWidth": 330,
       "width": undefined,
     }
@@ -149,7 +149,7 @@ exports[`<Toast /> Text + Image 1`] = `
   role="status"
   style={
     Object {
-      "maxWidth": 500,
+      "maxWidth": "min(500px, 100vw)",
       "minWidth": 330,
       "width": 330,
     }
@@ -227,7 +227,7 @@ exports[`<Toast /> Text Only 1`] = `
   role="status"
   style={
     Object {
-      "maxWidth": 500,
+      "maxWidth": "min(500px, 100vw)",
       "minWidth": 330,
       "width": 330,
     }

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -6,8 +6,9 @@ exports[`<Toast /> Error Toast 1`] = `
   role="status"
   style={
     Object {
-      "maxWidth": 360,
-      "width": "100vw",
+      "maxWidth": 500,
+      "minWidth": 330,
+      "width": 330,
     }
   }
 >
@@ -19,6 +20,11 @@ exports[`<Toast /> Error Toast 1`] = `
     >
       <div
         className="FlexItem flexGrow"
+        style={
+          Object {
+            "maxWidth": undefined,
+          }
+        }
       >
         <div
           className="Text fontSize300 white alignCenter breakWord fontWeightNormal"
@@ -37,8 +43,9 @@ exports[`<Toast /> Text + Image + Button 1`] = `
   role="status"
   style={
     Object {
-      "maxWidth": 360,
-      "width": "100vw",
+      "maxWidth": 500,
+      "minWidth": 330,
+      "width": undefined,
     }
   }
 >
@@ -68,6 +75,11 @@ exports[`<Toast /> Text + Image + Button 1`] = `
       </div>
       <div
         className="FlexItem flexGrow"
+        style={
+          Object {
+            "maxWidth": 127,
+          }
+        }
       >
         <div
           className="Text fontSize300 white alignStart breakWord fontWeightNormal"
@@ -137,8 +149,9 @@ exports[`<Toast /> Text + Image 1`] = `
   role="status"
   style={
     Object {
-      "maxWidth": 360,
-      "width": "100vw",
+      "maxWidth": 500,
+      "minWidth": 330,
+      "width": 330,
     }
   }
 >
@@ -168,6 +181,11 @@ exports[`<Toast /> Text + Image 1`] = `
       </div>
       <div
         className="FlexItem flexGrow"
+        style={
+          Object {
+            "maxWidth": undefined,
+          }
+        }
       >
         <div
           className="Text fontSize300 white alignStart breakWord fontWeightNormal"
@@ -209,8 +227,9 @@ exports[`<Toast /> Text Only 1`] = `
   role="status"
   style={
     Object {
-      "maxWidth": 360,
-      "width": "100vw",
+      "maxWidth": 500,
+      "minWidth": 330,
+      "width": 330,
     }
   }
 >
@@ -222,6 +241,11 @@ exports[`<Toast /> Text Only 1`] = `
     >
       <div
         className="FlexItem flexGrow"
+        style={
+          Object {
+            "maxWidth": undefined,
+          }
+        }
       >
         <div
           className="Text fontSize300 white alignCenter breakWord fontWeightNormal"


### PR DESCRIPTION
This PR tweaks the layout of Toast to better accommodate long text + button text, which can lead to this visual bug:

_before_
<img width="960" alt="DE_locale" src="https://user-images.githubusercontent.com/12059539/156432331-5b33d386-818b-4ed4-86e1-3ac2bc112be7.PNG">

_after, desktop_
<img width="533" alt="Screen Shot 2022-03-02 at 4 25 33 PM" src="https://user-images.githubusercontent.com/12059539/156482472-aa91f556-c671-4628-ba62-13e230edcbe8.png">

_after, mobile_
<img width="458" alt="Screen Shot 2022-03-02 at 4 25 15 PM" src="https://user-images.githubusercontent.com/12059539/156482495-94bc66b4-cdcd-441d-8e1c-357444f4e2c2.png">
(Note: wrap the Toast in Layer to get the width of the viewport rather than the doc section container, reflecting real world usage)

This does have the side effect of slightly increasing Toast width when the button is present, even if not strictly required by the text length:
<img width="478" alt="Screen Shot 2022-03-02 at 4 25 45 PM" src="https://user-images.githubusercontent.com/12059539/156482514-e7ac91c6-2e7f-47d6-a015-725131412179.png">

Though these fixes aren't _ideal_, given the future messaging work, these are acceptable for now. The stress-test case (especially for mobile) doesn't look great, but it at least doesn't look buggy.

### Links

- [Jira](https://jira.pinadmin.com/browse/BUG-137320)