### PR TITLE
Docs: fix npm badges wrapping

### DIFF
--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -18,7 +18,7 @@ export default function Changelog({ changelog }: {| changelog: string |}): Node 
       <Box>
         <PageHeader name="What's New 🎉" showSourceLink={false} />
         <Flex alignItems="start" direction="column" gap={4}>
-          <Flex gap={4}>
+          <Flex gap={4} wrap>
             {npmPackages.map((packageName) => (
               <Link
                 key={packageName}


### PR DESCRIPTION
whoops — this PR allows the npm badges to wrap so they don't break mobile layouts:
<img width="451" alt="Screen Shot 2022-03-02 at 7 01 33 PM" src="https://user-images.githubusercontent.com/12059539/156488086-dc8701f1-add5-4dc0-96f5-1e881a51446b.png">

