### PR TITLE
Toast: revert `text` type change

### DIFF
--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node } from 'react';
+import { type Element, type Node } from 'react';
 import Box from './Box.js';
 import Flex from './Flex.js';
 import Mask from './Mask.js';
@@ -20,7 +20,8 @@ type Props = {|
   /**
    * Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Do not specify a Text color within this property, as the color is automatically determined based on the `variant`.
    */
-  text: string | Node,
+  // $FlowFixMe[unclear-type]
+  text: string | Element<*>,
   /**
    * An optional thumbnail image to displayed next to the text.
    */


### PR DESCRIPTION
The `text` type change from https://github.com/pinterest/gestalt/pull/1961 had unintended downstream effects in Pinboard's toast wrapper component, so this PR reverts that change.
![Screen Shot 2022-03-04 at 10 33 16 AM](https://user-images.githubusercontent.com/12059539/156821696-30411d28-2861-4f60-8e93-ab1964edbf25.png)

