### PR TITLE
Box: add elevation accent color option

### DIFF
--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -445,6 +445,7 @@ function Example() {
               'inverse',
               'brand',
               'education',
+              'elevationAccent',
               'transparent',
               'transparentDarkGray',
               'lightWash',

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -172,7 +172,7 @@ type Props = {
     | 'selected'
     | 'inverse'
     | 'brand'
-    | 'education',
+    | 'education'
     | 'elevationAccent',
   /**
    * See the [column layout](https://gestalt.pinterest.systems/box#Column-layout) variant for more info.

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -26,7 +26,7 @@ import { type As } from './boxTypes.js';
 # PropTypes
 
 Box's type definition is exhaustive. With the exception of `dangerouslySetInlineStyle`, values
-shouldn't be ambigious. That means that we have to type out things like boints, but that's also
+shouldn't be ambiguous. That means that we have to type out things like boints, but that's also
 where Box's magic lies. Also, by putting in extra effort around type definitions here, we can skip
 extra runtime typechecks in the transformers for performance.
 
@@ -173,6 +173,7 @@ type Props = {
     | 'inverse'
     | 'brand'
     | 'education',
+    | 'elevationAccent',
   /**
    * See the [column layout](https://gestalt.pinterest.systems/box#Column-layout) variant for more info.
    *

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -114,6 +114,10 @@
   background-color: var(--color-background-education);
 }
 
+.elevationAccent {
+  background-color: var(--color-background-elevation-accent);
+}
+
 /** PRIMARY COLORS **/
 
 /* red */

--- a/packages/gestalt/src/Colors.css.flow
+++ b/packages/gestalt/src/Colors.css.flow
@@ -11,6 +11,7 @@ declare module.exports: {|
   +'education': string,
   +'eggplant': string,
   +'eggplantBg': string,
+  +'elevationAccent': string,
   +'errorBase': string,
   +'errorWeak': string,
   +'gray': string,

--- a/packages/gestalt/src/boxTransforms.js
+++ b/packages/gestalt/src/boxTransforms.js
@@ -179,6 +179,7 @@ const color: Functor<Color> = mapping({
   inverse: colors.inverse,
   brand: colors.brand,
   education: colors.education,
+  elevationAccent: colors.elevationAccent,
   // default: transparent
 });
 const fit: Functor<boolean> = toggle(layout.fit);


### PR DESCRIPTION
### Summary

#### What changed?

Add elevationAccent as a color option on Box

#### Why?
Now that we've added elevation options, we need to make that option available on Box as a background color (just the background elevation accent token)

Dark mode is coming soon

### Links


### Checklist

- [X] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
