### PR TITLE
Development: updated info re updating Cypress snapshots tests

### DIFF
--- a/cypress/integration/visual-test/ActivationCard-dark_spec.js
+++ b/cypress/integration/visual-test/ActivationCard-dark_spec.js
@@ -3,7 +3,7 @@ describe('ActivationCard dark mode visual regression check', () => {
     cy.visit('/visual-test/ActivationCard-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'ActivationCard-dark',
     });

--- a/cypress/integration/visual-test/ActivationCard_spec.js
+++ b/cypress/integration/visual-test/ActivationCard_spec.js
@@ -3,7 +3,7 @@ describe('ActivationCard visual regression check', () => {
     cy.visit('/visual-test/ActivationCard');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'ActivationCard',
     });

--- a/cypress/integration/visual-test/Avatar-dark_spec.js
+++ b/cypress/integration/visual-test/Avatar-dark_spec.js
@@ -3,7 +3,7 @@ describe('Avatar dark mode visual regression check', () => {
     cy.visit('/visual-test/Avatar-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Avatar-dark',
     });

--- a/cypress/integration/visual-test/AvatarGroup-dark_spec.js
+++ b/cypress/integration/visual-test/AvatarGroup-dark_spec.js
@@ -3,7 +3,7 @@ describe('AvatarGroup dark mode visual regression check', () => {
     cy.visit('/visual-test/AvatarGroup-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'AvatarGroup-dark',
     });

--- a/cypress/integration/visual-test/AvatarGroup_spec.js
+++ b/cypress/integration/visual-test/AvatarGroup_spec.js
@@ -3,7 +3,7 @@ describe('AvatarGroup visual regression check', () => {
     cy.visit('/visual-test/AvatarGroup');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'AvatarGroup',
     });

--- a/cypress/integration/visual-test/Avatar_spec.js
+++ b/cypress/integration/visual-test/Avatar_spec.js
@@ -3,7 +3,7 @@ describe('Avatar visual regression check', () => {
     cy.visit('/visual-test/Avatar');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Avatar',
     });

--- a/cypress/integration/visual-test/Badge-dark_spec.js
+++ b/cypress/integration/visual-test/Badge-dark_spec.js
@@ -3,7 +3,7 @@ describe('Badge dark mode visual regression check', () => {
     cy.visit('/visual-test/Badge-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Badge-dark',
     });

--- a/cypress/integration/visual-test/Badge_spec.js
+++ b/cypress/integration/visual-test/Badge_spec.js
@@ -3,7 +3,7 @@ describe('Badge visual regression check', () => {
     cy.visit('/visual-test/Badge');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Badge',
     });

--- a/cypress/integration/visual-test/Button-dark_spec.js
+++ b/cypress/integration/visual-test/Button-dark_spec.js
@@ -3,7 +3,7 @@ describe('Button dark mode visual regression check', () => {
     cy.visit('/visual-test/Button-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Button-dark',
     });

--- a/cypress/integration/visual-test/Button_spec.js
+++ b/cypress/integration/visual-test/Button_spec.js
@@ -3,7 +3,7 @@ describe('Button visual regression check', () => {
     cy.visit('/visual-test/Button');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Button',
     });

--- a/cypress/integration/visual-test/Callout-dark_spec.js
+++ b/cypress/integration/visual-test/Callout-dark_spec.js
@@ -3,7 +3,7 @@ describe('Callout dark mode visual regression check', () => {
     cy.visit('/visual-test/Callout-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Callout-dark',
     });

--- a/cypress/integration/visual-test/Callout_spec.js
+++ b/cypress/integration/visual-test/Callout_spec.js
@@ -3,7 +3,7 @@ describe('Callout visual regression check', () => {
     cy.visit('/visual-test/Callout');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Callout',
     });

--- a/cypress/integration/visual-test/Checkbox-dark_spec.js
+++ b/cypress/integration/visual-test/Checkbox-dark_spec.js
@@ -3,7 +3,7 @@ describe('Checkbox dark mode visual regression check', () => {
     cy.visit('/visual-test/Checkbox-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Checkbox-dark',
     });

--- a/cypress/integration/visual-test/Checkbox_spec.js
+++ b/cypress/integration/visual-test/Checkbox_spec.js
@@ -3,7 +3,7 @@ describe('Checkbox visual regression check', () => {
     cy.visit('/visual-test/Checkbox');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Checkbox',
     });

--- a/cypress/integration/visual-test/ComboBox-closed-dark_spec.js
+++ b/cypress/integration/visual-test/ComboBox-closed-dark_spec.js
@@ -3,7 +3,7 @@ describe('ComboBox visual regression check', () => {
     cy.visit('/visual-test/ComboBox-closed-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'ComboBox-closed-dark',
     });

--- a/cypress/integration/visual-test/ComboBox-closed_spec.js
+++ b/cypress/integration/visual-test/ComboBox-closed_spec.js
@@ -3,7 +3,7 @@ describe('ComboBox visual regression check', () => {
     cy.visit('/visual-test/ComboBox-closed');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'ComboBox-closed',
     });

--- a/cypress/integration/visual-test/ComboBox-open-dark_spec.js
+++ b/cypress/integration/visual-test/ComboBox-open-dark_spec.js
@@ -3,7 +3,7 @@ describe('ComboBox visual regression check', () => {
     cy.visit('/visual-test/ComboBox-open-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').find('label').click();
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'ComboBox-open-dark',

--- a/cypress/integration/visual-test/ComboBox-open_spec.js
+++ b/cypress/integration/visual-test/ComboBox-open_spec.js
@@ -3,7 +3,7 @@ describe('ComboBox visual regression check', () => {
     cy.visit('/visual-test/ComboBox-open');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').find('label').first().click();
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'ComboBox-open',

--- a/cypress/integration/visual-test/Datapoint-dark_spec.js
+++ b/cypress/integration/visual-test/Datapoint-dark_spec.js
@@ -3,7 +3,7 @@ describe('Datapoint dark mode visual regression check', () => {
     cy.visit('/visual-test/Datapoint-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Datapoint-dark',
     });

--- a/cypress/integration/visual-test/Datapoint_spec.js
+++ b/cypress/integration/visual-test/Datapoint_spec.js
@@ -3,7 +3,7 @@ describe('Datapoint visual regression check', () => {
     cy.visit('/visual-test/Datapoint');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Datapoint',
     });

--- a/cypress/integration/visual-test/DatePicker-closed-dark_spec.js
+++ b/cypress/integration/visual-test/DatePicker-closed-dark_spec.js
@@ -3,7 +3,7 @@ describe('DatePicker visual regression check', () => {
     cy.visit('/visual-test/DatePicker-closed-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'DatePicker-closed-dark',
     });

--- a/cypress/integration/visual-test/DatePicker-closed_spec.js
+++ b/cypress/integration/visual-test/DatePicker-closed_spec.js
@@ -3,7 +3,7 @@ describe('DatePicker visual regression check', () => {
     cy.visit('/visual-test/DatePicker-closed');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'DatePicker-closed',
     });

--- a/cypress/integration/visual-test/DatePicker-open-dark_spec.js
+++ b/cypress/integration/visual-test/DatePicker-open-dark_spec.js
@@ -3,7 +3,7 @@ describe('DatePicker visual regression check', () => {
     cy.visit('/visual-test/DatePicker-open-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').find('label').first().click();
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'DatePicker-open-dark',

--- a/cypress/integration/visual-test/DatePicker-open_spec.js
+++ b/cypress/integration/visual-test/DatePicker-open_spec.js
@@ -3,7 +3,7 @@ describe('DatePicker visual regression check', () => {
     cy.visit('/visual-test/DatePicker-open');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').find('label').first().click();
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'DatePicker-open',

--- a/cypress/integration/visual-test/Divider-dark_spec.js
+++ b/cypress/integration/visual-test/Divider-dark_spec.js
@@ -3,7 +3,7 @@ describe('Divider dark mode visual regression check', () => {
     cy.visit('/visual-test/Divider-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Divider-dark',
     });

--- a/cypress/integration/visual-test/Divider.js
+++ b/cypress/integration/visual-test/Divider.js
@@ -3,7 +3,7 @@ describe('Divider visual regression check', () => {
     cy.visit('/visual-test/Divider');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Divider',
     });

--- a/cypress/integration/visual-test/Dropdown-open-dark_spec.js
+++ b/cypress/integration/visual-test/Dropdown-open-dark_spec.js
@@ -3,7 +3,7 @@ describe('Dropdown visual regression check', () => {
     cy.visit('/visual-test/Dropdown-open-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').find('button').click();
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Dropdown-open-dark',

--- a/cypress/integration/visual-test/Dropdown-open_spec.js
+++ b/cypress/integration/visual-test/Dropdown-open_spec.js
@@ -3,7 +3,7 @@ describe('Dropdown visual regression check', () => {
     cy.visit('/visual-test/Dropdown-open');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').find('button').click();
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Dropdown-open',

--- a/cypress/integration/visual-test/Heading-dark_spec.js
+++ b/cypress/integration/visual-test/Heading-dark_spec.js
@@ -3,7 +3,7 @@ describe('Heading dark mode visual regression check', () => {
     cy.visit('/visual-test/Heading-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Heading-dark',
     });

--- a/cypress/integration/visual-test/Heading_spec.js
+++ b/cypress/integration/visual-test/Heading_spec.js
@@ -3,7 +3,7 @@ describe('Heading visual regression check', () => {
     cy.visit('/visual-test/Heading');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Heading',
     });

--- a/cypress/integration/visual-test/Icon-list-dark_spec.js
+++ b/cypress/integration/visual-test/Icon-list-dark_spec.js
@@ -3,7 +3,7 @@ describe('Button dark mode visual regression check', () => {
     cy.visit('/visual-test/Icon-list-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Icon-list-dark',
     });

--- a/cypress/integration/visual-test/Icon-list_spec.js
+++ b/cypress/integration/visual-test/Icon-list_spec.js
@@ -3,7 +3,7 @@ describe('Button visual regression check', () => {
     cy.visit('/visual-test/Icon-list');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Icon-list',
     });

--- a/cypress/integration/visual-test/IconButton-dark_spec.js
+++ b/cypress/integration/visual-test/IconButton-dark_spec.js
@@ -3,7 +3,7 @@ describe('Button dark mode visual regression check', () => {
     cy.visit('/visual-test/IconButton-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'IconButton-dark',
     });

--- a/cypress/integration/visual-test/IconButton_spec.js
+++ b/cypress/integration/visual-test/IconButton_spec.js
@@ -3,7 +3,7 @@ describe('Button visual regression check', () => {
     cy.visit('/visual-test/IconButton');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'IconButton',
     });

--- a/cypress/integration/visual-test/Tag-dark_spec.js
+++ b/cypress/integration/visual-test/Tag-dark_spec.js
@@ -3,7 +3,7 @@ describe('Tag visual dark mode regression check', () => {
     cy.visit('/visual-test/Tag-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Tag-dark',
     });

--- a/cypress/integration/visual-test/Tag_spec.js
+++ b/cypress/integration/visual-test/Tag_spec.js
@@ -3,7 +3,7 @@ describe('Tag visual regression check', () => {
     cy.visit('/visual-test/Tag');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Tag',
     });

--- a/cypress/integration/visual-test/Text-dark_spec.js
+++ b/cypress/integration/visual-test/Text-dark_spec.js
@@ -3,7 +3,7 @@ describe('Text dark mode visual regression check', () => {
     cy.visit('/visual-test/Text-dark');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Text-dark',
     });

--- a/cypress/integration/visual-test/Text_spec.js
+++ b/cypress/integration/visual-test/Text_spec.js
@@ -3,7 +3,7 @@ describe('Text visual regression check', () => {
     cy.visit('/visual-test/Text');
   });
 
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'Text',
     });

--- a/docs/pages/development.js
+++ b/docs/pages/development.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Flex, Heading, Link, Text } from 'gestalt';
+import { Box, Image, Flex, Heading, Link, Text } from 'gestalt';
 import Card from '../components/Card.js';
 import Markdown from '../components/Markdown.js';
 import PageHeader from '../components/PageHeader.js';
@@ -242,6 +242,63 @@ yarn jest -u
 yarn cypress open
 ~~~"
                   />
+                </li>
+                <li>
+                  <Text>
+                    Run{' '}
+                    <Link href="https://github.com/meinaart/cypress-plugin-snapshots" inline>
+                      <Text weight="bold">Cypress snapshot tests</Text>
+                    </Link>
+                    . If any component changes are expected to visually modify your component, you
+                    must update the snapshot tests. In order to run the tests, you must start the
+                    documentation server in one terminal and the Cypress testing interface in
+                    another.
+                  </Text>
+                  <Markdown
+                    text="
+~~~bash
+yarn start
+~~~"
+                  />
+                  <Markdown
+                    text="
+~~~bash
+yarn cypress open
+~~~"
+                  />
+                  <Flex direction="column">
+                    <Box as="figure" width={400}>
+                      <Image
+                        alt=""
+                        color="white"
+                        naturalHeight={262}
+                        naturalWidth={400}
+                        src="https://i.ibb.co/FY1pp4Y/Screen-Shot-2022-03-09-at-4-49-21-PM.png"
+                      />
+                      <Text size="100" align="center">
+                        <Box as="figcaption" marginTop={3}>
+                          {`Each failing snapshot test with display an error message. Click on
+                          "Compare Snapshot". It will open a separate interface displaying the
+                          expected and the received snapshots side by side for your comparison.`}
+                        </Box>
+                      </Text>
+                    </Box>
+                    <Box as="figure" width={400}>
+                      <Image
+                        alt=""
+                        color="white"
+                        naturalHeight={176}
+                        naturalWidth={400}
+                        src="https://i.ibb.co/7NyhPRD/Screen-Shot-2022-03-09-at-4-49-40-PM.png"
+                      />
+                      <Text size="100" align="center">
+                        <Box as="figcaption" marginTop={3}>
+                          {`On this new interface displaying the expected and the received snapshots,
+                          click on the "Update snapshot" button to reconcile the changes.`}
+                        </Box>
+                      </Text>
+                    </Box>
+                  </Flex>
                 </li>
                 <li>
                   <Text>Update CSS flow types.</Text>

--- a/docs/pages/development.js
+++ b/docs/pages/development.js
@@ -247,7 +247,7 @@ yarn cypress open
                   <Text>
                     Run{' '}
                     <Link href="https://github.com/meinaart/cypress-plugin-snapshots" inline>
-                      <Text weight="bold">Cypress snapshot tests</Text>
+                      <Text weight="bold">Cypress visual diff snapshot tests</Text>
                     </Link>
                     . If any component changes are expected to visually modify your component, you
                     must update the snapshot tests. In order to run the tests, you must start the
@@ -257,16 +257,18 @@ yarn cypress open
                   <Markdown
                     text="
 ~~~bash
+// Terminal tab #1
 yarn start
 ~~~"
                   />
                   <Markdown
                     text="
 ~~~bash
+// Terminal tab #2
 yarn cypress open
 ~~~"
                   />
-                  <Flex direction="column">
+                  <Flex wrap justifyContent="center">
                     <Box as="figure" width={400}>
                       <Image
                         alt=""
@@ -277,9 +279,9 @@ yarn cypress open
                       />
                       <Text size="100" align="center">
                         <Box as="figcaption" marginTop={3}>
-                          {`Each failing snapshot test with display an error message. Click on
-                          "Compare Snapshot". It will open a separate interface displaying the
-                          expected and the received snapshots side by side for your comparison.`}
+                          Each failing snapshot test will display an error message. Click on
+                          &quot;Compare Snapshot&quot;. It will open a separate interface displaying
+                          the expected and the received snapshots side by side for your comparison.
                         </Box>
                       </Text>
                     </Box>
@@ -293,8 +295,9 @@ yarn cypress open
                       />
                       <Text size="100" align="center">
                         <Box as="figcaption" marginTop={3}>
-                          {`On this new interface displaying the expected and the received snapshots,
-                          click on the "Update snapshot" button to reconcile the changes.`}
+                          On this new interface displaying the expected and the received snapshots,
+                          click on the &quot;Update snapshot&quot; button to reconcile the changes.
+                          Only update if the changes are expected, otherwise revisit the code.
                         </Box>
                       </Text>
                     </Box>

--- a/docs/pages/tooling.js
+++ b/docs/pages/tooling.js
@@ -146,7 +146,6 @@ Custom codemods can be found in this [directory](https://github.com/pinterest/ge
       </MainSection>
       <MainSection name="Visual Studio Code tooling">
         <MainSection.Subsection
-          badge="alpha"
           title="Props documentation on hover in Visual Studio Code"
           description="You can now see component and props documentation on hover in VSCode for certain Gestalt components. Quickly see what a component looks like, its sizes and other props documentation."
         >

--- a/docs/pages/tooling.js
+++ b/docs/pages/tooling.js
@@ -171,6 +171,7 @@ Custom codemods can be found in this [directory](https://github.com/pinterest/ge
           </Box>
         </MainSection.Subsection>
         <MainSection.Subsection
+          badge="alpha"
           title="Visual Studio Code extension for Gestalt"
           description="Access Gestalt component snippets and documentation right on your VSCode editor. Right at your fingertips!"
         >

--- a/docs/pages/visual-test/ActivationCard-dark.js
+++ b/docs/pages/visual-test/ActivationCard-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Flex, ActivationCard, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/ActivationCard.js
+++ b/docs/pages/visual-test/ActivationCard.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Flex, ActivationCard, Box } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box color="white" display="inlineBlock" padding={1}>
       <Flex direction="column" gap={2}>

--- a/docs/pages/visual-test/Avatar-dark.js
+++ b/docs/pages/visual-test/Avatar-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Avatar, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/Avatar.js
+++ b/docs/pages/visual-test/Avatar.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Avatar, Box } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box color="white" display="inlineBlock" padding={1}>
       <Avatar verified size="xl" name="Keerthi" src="https://i.ibb.co/ZfCZrY8/keerthi.jpg" />

--- a/docs/pages/visual-test/AvatarGroup-dark.js
+++ b/docs/pages/visual-test/AvatarGroup-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { AvatarGroup, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/AvatarGroup.js
+++ b/docs/pages/visual-test/AvatarGroup.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { AvatarGroup, Box } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box padding={1}>
       <AvatarGroup

--- a/docs/pages/visual-test/Badge-dark.js
+++ b/docs/pages/visual-test/Badge-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Badge, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/Badge.js
+++ b/docs/pages/visual-test/Badge.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Badge, Box } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box color="white" display="inlineBlock" padding={1}>
       <Badge text="Try it out!" />

--- a/docs/pages/visual-test/Button-dark.js
+++ b/docs/pages/visual-test/Button-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, Button, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/Button.js
+++ b/docs/pages/visual-test/Button.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, Button } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box padding={1}>
       <Button color="red" text="Save a Pin" />

--- a/docs/pages/visual-test/Callout-dark.js
+++ b/docs/pages/visual-test/Callout-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Flex, Callout, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/Callout.js
+++ b/docs/pages/visual-test/Callout.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Flex, Callout, Box } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box color="white" display="inlineBlock" padding={1}>
       <Flex direction="column" gap={2}>

--- a/docs/pages/visual-test/Checkbox-dark.js
+++ b/docs/pages/visual-test/Checkbox-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Flex, Checkbox, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/Checkbox.js
+++ b/docs/pages/visual-test/Checkbox.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Flex, Checkbox, Box } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box color="white" display="inlineBlock" padding={1}>
       <Flex direction="column" gap={2}>

--- a/docs/pages/visual-test/ComboBox-closed-dark.js
+++ b/docs/pages/visual-test/ComboBox-closed-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { ComboBox, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" padding={1} width={400}>

--- a/docs/pages/visual-test/ComboBox-closed.js
+++ b/docs/pages/visual-test/ComboBox-closed.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { ComboBox, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
       <Box color="white" padding={1} width={400}>

--- a/docs/pages/visual-test/ComboBox-open-dark.js
+++ b/docs/pages/visual-test/ComboBox-open-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { ComboBox, Box, ColorSchemeProvider, Flex } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" padding={4} width={300} height={200}>

--- a/docs/pages/visual-test/ComboBox-open.js
+++ b/docs/pages/visual-test/ComboBox-open.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { ComboBox, Box, Flex, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
       <Box color="white" padding={4} width={300} height={200}>

--- a/docs/pages/visual-test/Datapoint-dark.js
+++ b/docs/pages/visual-test/Datapoint-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Datapoint, Box, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/Datapoint.js
+++ b/docs/pages/visual-test/Datapoint.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Datapoint, Box } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box color="white" display="inlineBlock" padding={1}>
       <Datapoint

--- a/docs/pages/visual-test/DatePicker-closed-dark.js
+++ b/docs/pages/visual-test/DatePicker-closed-dark.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Box, ColorSchemeProvider } from 'gestalt';
 import GestaltDatePicker from 'gestalt-datepicker';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" padding={1} width={400}>

--- a/docs/pages/visual-test/DatePicker-closed.js
+++ b/docs/pages/visual-test/DatePicker-closed.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Box, ColorSchemeProvider } from 'gestalt';
 import GestaltDatePicker from 'gestalt-datepicker';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
       <Box color="white" padding={1} width={400}>

--- a/docs/pages/visual-test/DatePicker-open-dark.js
+++ b/docs/pages/visual-test/DatePicker-open-dark.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Box, ColorSchemeProvider } from 'gestalt';
 import GestaltDatePicker from 'gestalt-datepicker';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" padding={1} width={400} height={400}>

--- a/docs/pages/visual-test/DatePicker-open.js
+++ b/docs/pages/visual-test/DatePicker-open.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Box, ColorSchemeProvider } from 'gestalt';
 import GestaltDatePicker from 'gestalt-datepicker';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
       <Box color="white" padding={1} width={400} height={400}>

--- a/docs/pages/visual-test/Divider-dark.js
+++ b/docs/pages/visual-test/Divider-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Divider, Box, Flex, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" borderStyle="shadow" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/Divider.js
+++ b/docs/pages/visual-test/Divider.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Divider, Box, Flex } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box color="white" borderStyle="shadow" display="inlineBlock" padding={1}>
       <Flex direction="column" gap={2}>

--- a/docs/pages/visual-test/Dropdown-open-dark.js
+++ b/docs/pages/visual-test/Dropdown-open-dark.js
@@ -2,7 +2,7 @@
 import { useState, useRef, type Node } from 'react';
 import { IconButton, Dropdown, Box, ColorSchemeProvider, Flex } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
   return (

--- a/docs/pages/visual-test/Dropdown-open.js
+++ b/docs/pages/visual-test/Dropdown-open.js
@@ -2,7 +2,7 @@
 import { useState, useRef, type Node } from 'react';
 import { IconButton, Dropdown, Box, ColorSchemeProvider, Flex } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
 

--- a/docs/pages/visual-test/Heading-dark.js
+++ b/docs/pages/visual-test/Heading-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, ColorSchemeProvider, Heading } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock">

--- a/docs/pages/visual-test/Heading.js
+++ b/docs/pages/visual-test/Heading.js
@@ -2,7 +2,7 @@
 import { type Node, Fragment } from 'react';
 import { Box, Heading } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Fragment>
       <Box padding={1}>

--- a/docs/pages/visual-test/Icon-list-dark.js
+++ b/docs/pages/visual-test/Icon-list-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, Flex, Icon, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   const { icons } = Icon;
 
   return (

--- a/docs/pages/visual-test/Icon-list.js
+++ b/docs/pages/visual-test/Icon-list.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, Flex, Icon, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   const { icons } = Icon;
 
   return (

--- a/docs/pages/visual-test/IconButton-dark.js
+++ b/docs/pages/visual-test/IconButton-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, IconButton, ColorSchemeProvider } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock" padding={1}>

--- a/docs/pages/visual-test/IconButton.js
+++ b/docs/pages/visual-test/IconButton.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, IconButton } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Box padding={1}>
       <IconButton

--- a/docs/pages/visual-test/Tag-dark.js
+++ b/docs/pages/visual-test/Tag-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { ColorSchemeProvider, Flex, Tag } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Flex direction="column" gap={2}>

--- a/docs/pages/visual-test/Tag.js
+++ b/docs/pages/visual-test/Tag.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { ColorSchemeProvider, Flex, Tag } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
       <Flex direction="column" gap={2}>

--- a/docs/pages/visual-test/Text-dark.js
+++ b/docs/pages/visual-test/Text-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, ColorSchemeProvider, Text } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="white" display="inlineBlock">

--- a/docs/pages/visual-test/Text.js
+++ b/docs/pages/visual-test/Text.js
@@ -2,7 +2,7 @@
 import { type Node, Fragment } from 'react';
 import { Box, Text } from 'gestalt';
 
-export default function Screenshot(): Node {
+export default function Snapshot(): Node {
   return (
     <Fragment>
       <Box padding={1}>

--- a/scripts/templates/ComponentName-dark.js
+++ b/scripts/templates/ComponentName-dark.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { ComponentName, ColorSchemeProvider } from 'gestalt';
 
-export default function ComponentNameSpec(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <ComponentName />

--- a/scripts/templates/ComponentName-dark_spec.js
+++ b/scripts/templates/ComponentName-dark_spec.js
@@ -4,7 +4,7 @@ describe('ComponentName dark mode visual regression check', () => {
   });
 
   // eslint-disable-next-line jest/expect-expect
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'ComponentName-dark',
     });

--- a/scripts/templates/ComponentName-light.js
+++ b/scripts/templates/ComponentName-light.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { ComponentName, ColorSchemeProvider } from 'gestalt';
 
-export default function ComponentNameSpec(): Node {
+export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
       <ComponentName />

--- a/scripts/templates/ComponentName-light_spec.js
+++ b/scripts/templates/ComponentName-light_spec.js
@@ -4,7 +4,7 @@ describe('ComponentName light mode visual regression check', () => {
   });
 
   // eslint-disable-next-line jest/expect-expect
-  it('Compares screenshots', () => {
+  it('Compares snapshots', () => {
     cy.get('[data-test-id="visual-test"]').toMatchImageSnapshot({
       name: 'ComponentName-light',
     });


### PR DESCRIPTION
Development: updated info re updating Cypress snapshots tests [MAIN CHANGE](https://github.com/pinterest/gestalt/pull/1978#discussion_r822860106)

All other noisy changes are just renames of `screenshot` to `snapshot` references for consistency.