### PR TITLE
ActivationCard: Use Text instead of Heading

### DIFF
--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -120,7 +120,9 @@ function CompletedCard({ dismissButton, message, status, statusMessage, title }:
         )}
         <Box>
           <Box>
-            <Heading size="400">{title}</Heading>
+            <Text size="400" weight="bold">
+              {title}
+            </Text>
           </Box>
           {message && (
             <Box flex="grow" direction="column" alignContent="start" marginTop={2}>

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
@@ -225,11 +225,11 @@ exports[`<ActivationCard /> complete ActivationCard 1`] = `
       <div
         className="box"
       >
-        <h3
-          className="Heading fontSize400 darkGray alignStart breakWord"
+        <div
+          className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
         >
           Nice work
-        </h3>
+        </div>
       </div>
       <div
         className="box contentStart flexGrow marginTop2 xsDirectionColumn"


### PR DESCRIPTION
### Summary

#### What changed?

Uses `Text` instead of `Heading` when rendering `ActivationCard`

#### Why?

* Using `Heading` results in an implicit accessibilityLevel to be set inside the `ActivationCard` component. That causes pinboard a11y tests to fail since we don't aren't able to override it from the outside.
* It doesn't make sense to use `Heading` since this is not describing a specific section on the page. It would make more sense to have `Heading` before the `ActivationCard` component.

#### Notes

* No visual differences

### Before

![Screen Shot 2022-03-10 at 4 50 46 AM](https://user-images.githubusercontent.com/127199/157666332-b562191e-060e-4f7b-ba4a-ca97d1f45da5.png)

### After

![Screen Shot 2022-03-10 at 4 51 17 AM](https://user-images.githubusercontent.com/127199/157666321-1520a2ca-bcee-4716-9800-76cb0ebee432.png)
