### PR TITLE
Tooling: fix in generic codemods to handle nested children components

### DIFF
--- a/packages/gestalt-codemods/README.md
+++ b/packages/gestalt-codemods/README.md
@@ -55,7 +55,12 @@ Finally, it can come handy the jscodeshift API
 
 ## jscodeshift Limitations
 
-When using the find() method in the Collection object, the resulting Collection doesn't return unique nodepaths when matching complex objects that are nested within each other. Therefore, in a <Box color='red'> containing <Box color='red'>, the matching results won't be a Collection of 2 nodepaths but a Collection of 3. If the child Box, also contains another <Box color='red'>, the Collection won't be 3 nodepaths but 6 nodepaths. Related to this issue, the remove() method in nested-result Collections throws errors while replaceWith() can be used instead.
+When using the find() method in the Collection object, the method traverses each node and its children recursively. This affects the resulting Collections. If we chain two find methods, the second find method will traverse all nodePaths returned in the first method including their children.
+At a practical level, this affects in different ways. In a <Box color='red'> nesting another <Box color='red'>, the matching results won't be a Collection of 2 nodePaths but a Collection of 3 (parent, child 1, and repeated child 1). If the child Box, also contains another <Box color='red'>, the Collection won't be 3 nodePaths but 6 nodePaths (parent, child 1, child 2, repeated child 1, repeated child 2, and repeated child 2). Also, considering the case <Box color='red'> nesting <Flex color='red'>, if we first look for Box components and we chain the resulting collection with a find method to look for attributes color='red', the final Collection will include both Box and its nested Flex as when looking into Box for color='red', it also traverses its children, finding and returning the Flex component.
+
+To prevent this, most finds are complemented with a filter that matches the JSX element name to the component and subcomponent name, to exclude those children.
+
+Related to this issue, the remove() method in nested-result Collections throws errors while replaceWith() can be used instead.
 
 ## Run a codemod
 

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/detectManualReplacement/componentProp.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/detectManualReplacement/componentProp.input.js
@@ -1,10 +1,11 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box color="red">
-      <Box color="red">
+      <Box color="blue">
         <Box />
+        <Flex color="red"/>
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/detectManualReplacement/componentPropValue.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/detectManualReplacement/componentPropValue.input.js
@@ -1,11 +1,12 @@
-import { Box } from 'gestalt';
+import { Dropdown, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
-    <Box color="red">
-      <Box color="red">
-        <Box color="red"/>
-      </Box>
-    </Box>
+    <Dropdown.Item color="red">
+      <Dropdown.Item color="blue">
+        <Dropdown.Item color="red"/>
+        <Flex color="red"/>
+      </Dropdown.Item>
+    </Dropdown.Item>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/deprecateProp.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/deprecateProp.input.js
@@ -1,10 +1,10 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400} height="100%">
       <Box height="100%"/>
-      <Box height="100%"/>
+      <Flex width={400} height="100%"/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/deprecateProp.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/deprecateProp.output.js
@@ -1,10 +1,10 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400} >
       <Box  />
-      <Box  />
+      <Flex width={400} height="100%"/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/renameProp.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/renameProp.input.js
@@ -1,9 +1,10 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width="100%" height={200}>
       <Box/>
+      <Flex width="100%" height={200}/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/renameProp.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/renameProp.output.js
@@ -1,9 +1,10 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width="100%" renameHeight={200}>
       <Box/>
+      <Flex width="100%" height={200}/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/renamePropAlias.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/renamePropAlias.input.js
@@ -1,9 +1,10 @@
-import { Box as RenamedBox } from 'gestalt';
+import { Box as RenamedBox, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <RenamedBox height={200}>
       <RenamedBox/>
+      <Flex height={200} />
     </RenamedBox>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/renamePropAlias.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/renamePropAlias.output.js
@@ -1,9 +1,10 @@
-import { Box as RenamedBox } from 'gestalt';
+import { Box as RenamedBox, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <RenamedBox renameHeight={200}>
       <RenamedBox/>
+      <Flex height={200} />
     </RenamedBox>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/subcomponentProp.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/subcomponentProp.input.js
@@ -1,9 +1,10 @@
-import { Dropdown, Box } from 'gestalt';
+import { Dropdown, Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Dropdown.Item height={200}>
       <Box/>
+      <Flex height={200}/>
     </Dropdown.Item>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/subcomponentProp.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyProp/subcomponentProp.output.js
@@ -1,9 +1,10 @@
-import { Dropdown, Box } from 'gestalt';
+import { Dropdown, Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Dropdown.Item renameHeight={200}>
       <Box/>
+      <Flex height={200}/>
     </Dropdown.Item>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/addPropValueString.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/addPropValueString.input.js
@@ -1,10 +1,11 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400}>
       <Box>
         <Box/>
+        <Flex />
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/addPropValueString.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/addPropValueString.output.js
@@ -1,10 +1,11 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400} variant="error">
       <Box variant="error">
         <Box variant="error" />
+        <Flex />
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueBoolean.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueBoolean.input.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
@@ -6,6 +6,7 @@ export default function TestComp() {
       <Box fit={false}/>
       <Box width={400} fit={false}>
         <Box fit={false}/>
+        <Flex width={400} fit={false}/>
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueBoolean.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueBoolean.output.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
@@ -6,6 +6,7 @@ export default function TestComp() {
       <Box  />
       <Box width={400} >
         <Box  />
+        <Flex width={400} fit={false}/>
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueNumber.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueNumber.input.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
@@ -6,6 +6,7 @@ export default function TestComp() {
       <Box color="red"/>
       <Box width={400} color="red">
         <Box color="red"/>
+        <Flex width={400} color="red" />
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueNumber.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueNumber.output.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
@@ -6,6 +6,7 @@ export default function TestComp() {
       <Box color="red"/>
       <Box  color="red">
         <Box color="red"/>
+        <Flex width={400} color="red" />
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueString.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueString.input.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
@@ -6,6 +6,7 @@ export default function TestComp() {
       <Box color="red"/>
       <Box width={400} color="red">
         <Box color="red"/>
+        <Flex width={400} color="red" />
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueString.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueString.output.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
@@ -6,6 +6,7 @@ export default function TestComp() {
       <Box  />
       <Box width={400} >
         <Box  />
+        <Flex width={400} color="red" />
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueTrueBoolean.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueTrueBoolean.input.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
@@ -6,6 +6,7 @@ export default function TestComp() {
       <Box fit/>
       <Box width={400} fit>
         <Box fit/>
+        <Flex width={400} fit />
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueTrueBoolean.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/deprecatePropValueTrueBoolean.output.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
@@ -6,6 +6,7 @@ export default function TestComp() {
       <Box  />
       <Box width={400} >
         <Box  />
+        <Flex width={400} fit />
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/errorSpreadProp.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/errorSpreadProp.input.js
@@ -1,4 +1,4 @@
-import { Box } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   const props = {}
@@ -6,6 +6,7 @@ export default function TestComp() {
     <Box {...props} width={400}>
       <Box {...props} >
         <Box/>
+        <Flex {...props} width={400}/>
       </Box>
     </Box>
   );

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueBoolean.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueBoolean.input.js
@@ -1,11 +1,11 @@
-import { Box, Button } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400} fit={false}>
       <Box fit={false}/>
       <Box fit={false}/>
-      <Button/>
+      <Flex width={400} fit={false}/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueBoolean.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueBoolean.output.js
@@ -1,11 +1,11 @@
-import { Box, Button } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400} left>
       <Box left/>
       <Box left/>
-      <Button/>
+      <Flex width={400} fit={false}/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueNumber.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueNumber.input.js
@@ -1,11 +1,11 @@
-import { Box, Button } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width="100%" color="red">
       <Box color="red" width="100%"/>
       <Box width="100%"/>
-      <Button/>
+      <Flex width="100%" color="red"/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueNumber.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueNumber.output.js
@@ -1,11 +1,11 @@
-import { Box, Button } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box height={40} color="red">
       <Box color="red" height={40}/>
       <Box height={40}/>
-      <Button/>
+      <Flex width="100%" color="red"/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueString.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueString.output.js
@@ -1,11 +1,11 @@
-import { Box, Button } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400} variant="error">
       <Box variant="error"/>
       <Box variant="error"/>
-      <Button/>
+      <Flex width={400} color="red"/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueStringAlias.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueStringAlias.input.js
@@ -1,9 +1,10 @@
-import { Box as RenamedBox } from 'gestalt';
+import { Box as RenamedBox, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <RenamedBox width={400} color="red">
       <RenamedBox color="red"/>
+      <Flex width={400} color="red"/>
     </RenamedBox>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueStringAlias.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueStringAlias.output.js
@@ -1,9 +1,10 @@
-import { Box as RenamedBox } from 'gestalt';
+import { Box as RenamedBox, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <RenamedBox width={400} variant="error">
       <RenamedBox variant="error"/>
+      <Flex width={400} color="red"/>
     </RenamedBox>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueStringValue.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueStringValue.input.js
@@ -2,10 +2,10 @@ import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
-    <Box width={400} color="red">
+    <Box height="100%" color="red">
       <Box color="red"/>
       <Box color="red"/>
-      <Flex width={400} color="red"/>
+      <Flex height="100%" color="red"/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueStringValue.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueStringValue.output.js
@@ -2,10 +2,10 @@ import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
-    <Box width={400} color="red">
+    <Box height="200%" color="red">
       <Box color="red"/>
       <Box color="red"/>
-      <Flex width={400} color="red"/>
+      <Flex height="100%" color="red"/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueTrueBoolean.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueTrueBoolean.input.js
@@ -1,11 +1,11 @@
-import { Box, Button } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400} fit>
       <Box fit/>
       <Box fit/>
-      <Button/>
+      <Flex width={400} fit/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueTrueBoolean.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/renamePropValueTrueBoolean.output.js
@@ -1,11 +1,11 @@
-import { Box, Button } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Box width={400} left={false}>
       <Box left={false}/>
       <Box left={false}/>
-      <Button/>
+      <Flex width={400} fit/>
     </Box>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/subcomponentPropValue.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/subcomponentPropValue.input.js
@@ -1,9 +1,10 @@
-import { Dropdown } from 'gestalt';
+import { Dropdown, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Dropdown.Item width={400} color="red">
       <Dropdown.Item color="red"/>
+      <Flex width={400} color="red"/>
     </Dropdown.Item>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/subcomponentPropValue.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/modifyPropValue/subcomponentPropValue.output.js
@@ -1,9 +1,10 @@
-import { Dropdown } from 'gestalt';
+import { Dropdown, Flex } from 'gestalt';
 
 export default function TestComp() {
   return (
     <Dropdown.Item width={400} variant="error">
       <Dropdown.Item variant="error"/>
+      <Flex width={400} color="red"/>
     </Dropdown.Item>
   );
 }

--- a/packages/gestalt-codemods/generic-codemods/__tests__/detectManualReplacement.test.js
+++ b/packages/gestalt-codemods/generic-codemods/__tests__/detectManualReplacement.test.js
@@ -93,7 +93,8 @@ describe('detectManualReplacement: component + prop + value', () => {
           transformName: 'detectManualReplacement',
           moduleOptions: {
             quote: 'single',
-            component: 'Box',
+            component: 'Dropdown',
+            subcomponent: 'Item',
             prop: 'color',
             value: 'red',
           },
@@ -103,7 +104,7 @@ describe('detectManualReplacement: component + prop + value', () => {
         new Error(
           buildManualAttentionErrorMessage({
             test,
-            lines: [5, 6, 7, 6, 7, 7],
+            lines: [5, 7, 7, 7],
           }),
         ),
       );

--- a/packages/gestalt-codemods/generic-codemods/__tests__/modifyPropValue.test.js
+++ b/packages/gestalt-codemods/generic-codemods/__tests__/modifyPropValue.test.js
@@ -85,6 +85,24 @@ describe('modifyPropValue: rename omitted boolean', () => {
   });
 });
 
+describe('modifyPropValue: rename value string', () => {
+  ['modifyPropValue/renamePropValueStringValue'].forEach((test) => {
+    defineTest(
+      __dirname,
+      'modifyPropValue',
+      {
+        quote: 'single',
+        component: 'Box',
+        previousProp: 'height',
+        previousValue: '100%',
+        nextValue: '200%',
+      },
+      test,
+      {},
+    );
+  });
+});
+
 describe('modifyPropValue: remove string', () => {
   ['modifyPropValue/deprecatePropValueString'].forEach((test) => {
     defineTest(

--- a/packages/gestalt-codemods/generic-codemods/detectManualReplacement.js
+++ b/packages/gestalt-codemods/generic-codemods/detectManualReplacement.js
@@ -83,7 +83,12 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
     throwErrorMessageWithNodesData({ fileInfo, jSXCollection: matchedJSXCollection });
   }
 
-  throwErrorIfSpreadProps({ fileInfo, j, jSXCollection: matchedJSXCollection });
+  throwErrorIfSpreadProps({
+    fileInfo,
+    j,
+    jSXCollection: matchedJSXCollection,
+    componentName: targetLocalName,
+  });
 
   if (prop) {
     const jSXWithMatchingAttributesCollection = filterJSXByAttribute({

--- a/packages/gestalt-codemods/generic-codemods/detectManualReplacement.js
+++ b/packages/gestalt-codemods/generic-codemods/detectManualReplacement.js
@@ -88,12 +88,15 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
     j,
     jSXCollection: matchedJSXCollection,
     componentName: targetLocalName,
+    subcomponentName: subcomponent,
   });
 
   if (prop) {
     const jSXWithMatchingAttributesCollection = filterJSXByAttribute({
       j,
       jSXCollection: matchedJSXCollection,
+      componentName: targetLocalName,
+      subcomponentName: subcomponent,
       prop,
       value,
     });

--- a/packages/gestalt-codemods/generic-codemods/flowtypes.js
+++ b/packages/gestalt-codemods/generic-codemods/flowtypes.js
@@ -18,6 +18,7 @@ export type ImportSpecifierType = {|
 
 // TODO: Delete after removing deprecatedUtils.js
 export type NodePathType = {|
+  parentPath: { parentPath: GenericObjectType },
   value: {|
     type: string,
     specifiers: Array<ImportSpecifierType>,

--- a/packages/gestalt-codemods/generic-codemods/modifyProp.js
+++ b/packages/gestalt-codemods/generic-codemods/modifyProp.js
@@ -18,12 +18,13 @@
  * yarn codemod modifyProp ~/path/to/your/code --component=<value> --previousProp=<value> --nextProp=<value>
  *
  *
- * If all options passed, previous prop is replaced with next prop value
- * In the absence of nextProp, the codemod removes the prop
+ * If all options passed, previous prop is replaced with next prop value (REPLACE)
+ * In the absence of nextProp, the codemod removes the prop (REMOVE)
  *
  *
- * RENAME E.g. yarn codemod modifyProp ~/code/pinboard/webapp --component=Box --previousProp=size --nextProp=renamedSize
- * RENAME E.g. yarn codemod modifyProp ~/code/pinboard/webapp --component=Dropdown --subcomponent=Item --previousProp=size --nextProp=renamedSize
+ * REPLACE E.g. yarn codemod modifyProp ~/code/pinboard/webapp --component=Box --previousProp=size --nextProp=renamedSize
+ * REPLACE E.g. yarn codemod modifyProp ~/code/pinboard/webapp --component=Dropdown --subcomponent=Item --previousProp=size --nextProp=renamedSize
+ *
  * REMOVE E.g. yarn codemod modifyProp ~/code/pinboard/webapp --component=Box --previousProp=size
  */
 
@@ -82,22 +83,30 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
     j,
     jSXCollection: matchedJSXCollection,
     componentName: targetLocalName,
+    subcomponentName: subcomponent,
   });
 
   if (previousProp) {
     const jSXWithMatchingAttributesCollection = filterJSXByAttribute({
       j,
       jSXCollection: matchedJSXCollection,
+      componentName: targetLocalName,
+      subcomponentName: subcomponent,
       prop: previousProp,
     });
 
     if (jSXWithMatchingAttributesCollection.size() === 0) return null;
 
     let replaceWithModifiedCloneCallback;
+
     if (!nextProp) {
-      replaceWithModifiedCloneCallback = buildReplaceWithModifiedAttributes({ j });
+      replaceWithModifiedCloneCallback = buildReplaceWithModifiedAttributes({ j, previousProp });
     } else {
-      replaceWithModifiedCloneCallback = buildReplaceWithModifiedAttributes({ j, nextProp });
+      replaceWithModifiedCloneCallback = buildReplaceWithModifiedAttributes({
+        j,
+        previousProp,
+        nextProp,
+      });
     }
     jSXWithMatchingAttributesCollection.replaceWith(replaceWithModifiedCloneCallback);
   }

--- a/packages/gestalt-codemods/generic-codemods/modifyProp.js
+++ b/packages/gestalt-codemods/generic-codemods/modifyProp.js
@@ -77,7 +77,12 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
     subcomponent,
   });
 
-  throwErrorIfSpreadProps({ fileInfo, j, jSXCollection: matchedJSXCollection });
+  throwErrorIfSpreadProps({
+    fileInfo,
+    j,
+    jSXCollection: matchedJSXCollection,
+    componentName: targetLocalName,
+  });
 
   if (previousProp) {
     const jSXWithMatchingAttributesCollection = filterJSXByAttribute({

--- a/packages/gestalt-codemods/generic-codemods/modifyPropValue.js
+++ b/packages/gestalt-codemods/generic-codemods/modifyPropValue.js
@@ -93,7 +93,12 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
     subcomponent,
   });
 
-  throwErrorIfSpreadProps({ fileInfo, j, jSXCollection: matchedJSXCollection });
+  throwErrorIfSpreadProps({
+    fileInfo,
+    j,
+    jSXCollection: matchedJSXCollection,
+    componentName: targetLocalName,
+  });
 
   if (previousProp && !isNullOrUndefined(previousValue)) {
     const jSXWithMatchingAttributesCollection = filterJSXByAttribute({

--- a/packages/gestalt-codemods/generic-codemods/modifyPropValue.js
+++ b/packages/gestalt-codemods/generic-codemods/modifyPropValue.js
@@ -27,14 +27,16 @@
  * --nextValue=string|number|boolean
  *
  *
- * If all options passed, prop+value combination are replaced with new prop+value combination
- * In the absence of nextProp, the codemod only replaces the prop value
- * In the absence of nextValue, the codemod only replaces the prop name for that prop+value combination
- * In the absence of nextProp+nextValue, the codemod removes the prop with that particular value
- * In the absence of previousProp+previousValue, the codemod adds a new prop with value
+ * If all options passed, prop+value combination are replaced with new prop+value combination (REPLACE)
+ * In the absence of nextProp, the codemod only replaces the prop value (REPLACE)
+ * In the absence of nextValue, the codemod only replaces the prop name for that prop+value combination (REPLACE)
+ * In the absence of previousProp+previousValue, the codemod adds a new prop with value (ADD)
+ * In the absence of nextProp+nextValue, the codemod removes the prop with that particular value (REMOVE)
  *
  *
- * RENAME E.g. yarn codemod modifyPropValue ~/code/pinboard/webapp --component=Box --previousProp=color --nextProp=variant --previousValue=400 --nextValue=error
+ * REPLACE E.g. yarn codemod modifyPropValue ~/code/pinboard/webapp --component=Box --previousProp=color --nextProp=variant --previousValue=400 --nextValue=error
+ * REPLACE E.g. yarn codemod modifyPropValue ~/code/pinboard/webapp --component=Box --previousProp=color --previousValue=400 --nextValue=error
+ * REPLACE E.g. yarn codemod modifyPropValue ~/code/pinboard/webapp --component=Box --previousProp=color --nextProp=variant --previousValue=400
  *
  * ADD E.g. yarn codemod modifyPropValue ~/code/pinboard/webapp --component=Box --nextProp=variant --nextValue=error
  *
@@ -98,12 +100,16 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
     j,
     jSXCollection: matchedJSXCollection,
     componentName: targetLocalName,
+    subcomponentName: subcomponent,
   });
 
+  // We need to identify previousProp & previousValue in order to RENAME or DEPRECATE
   if (previousProp && !isNullOrUndefined(previousValue)) {
     const jSXWithMatchingAttributesCollection = filterJSXByAttribute({
       j,
       jSXCollection: matchedJSXCollection,
+      componentName: targetLocalName,
+      subcomponentName: subcomponent,
       prop: previousProp,
       value: previousValue,
     });
@@ -112,11 +118,15 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
 
     let replaceWithModifiedCloneCallback;
 
+    // In the absence of nextProp & nextValue, we REMOVE prop and values
     if (!nextProp && isNullOrUndefined(nextValue)) {
-      replaceWithModifiedCloneCallback = buildReplaceWithModifiedAttributes({ j });
+      replaceWithModifiedCloneCallback = buildReplaceWithModifiedAttributes({ j, previousProp });
     } else {
+      // In the absence of just nextProp, we change the value.
+      // In the absence of just nextValue, we rename the prop if both prop and value match.
       replaceWithModifiedCloneCallback = buildReplaceWithModifiedAttributes({
         j,
+        previousProp,
         nextProp,
         nextValue,
       });
@@ -124,6 +134,7 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
     jSXWithMatchingAttributesCollection.replaceWith(replaceWithModifiedCloneCallback);
   }
 
+  // In the absence of previousProp & previousValue, we ADD prop and values
   if (isNullOrUndefined(previousProp) && isNullOrUndefined(previousValue)) {
     for (let idx = matchedJSXCollection.size() - 1; idx >= 0; idx -= 1) {
       matchedJSXCollection.at(idx).replaceWith((node) => {

--- a/packages/gestalt-codemods/generic-codemods/utils.js
+++ b/packages/gestalt-codemods/generic-codemods/utils.js
@@ -79,7 +79,7 @@ const getLocalImportedName = ({
   importSpecifierCollection,
 }: {
   importSpecifierCollection: Collection,
-}): ?string => importSpecifierCollection.get(0).node.local?.name;
+}): string => importSpecifierCollection.get(0).node.local?.name;
 
 /**
  * filterJSXByTargetLocalName: Returns a collection containing the Gestalt JSX component matching the targetLocalName value
@@ -223,13 +223,16 @@ const throwErrorIfSpreadProps = ({
   fileInfo,
   j,
   jSXCollection,
+  componentName,
 }: {
   fileInfo: FileType,
   j: JSCodeShift,
   jSXCollection: Collection,
+  componentName: string,
 }): void => {
-  const spreadPropsCollection = jSXCollection.find(j.JSXSpreadAttribute);
-
+  const spreadPropsCollection = jSXCollection
+    .find(j.JSXSpreadAttribute)
+    .filter((nodepath) => nodepath.parentPath.parentPath.value.name.name === componentName);
   if (spreadPropsCollection.size() > 0) {
     throw new Error(
       `Remove dynamic properties and rerun codemod.\n${spreadPropsCollection


### PR DESCRIPTION
Tooling: fix to generic codemods to handle nested children components

Fix to handle jscodeshit limitation:

When using the find() method in the Collection object, the method traverses each node and its children recursively. This affects the resulting Collections. If we chain two find methods, the second find method will traverse all nodePaths returned in the first method including their children.
At a practical level, this affects in different ways. In a `<Box color='red'>` nesting another `<Box color='red'>`, the matching results won't be a Collection of 2 nodepaths but a Collection of 3 (parent, child 1, and repeated child 1). If the child Box, also contains another `<Box color='red'>`, the Collection won't be 3 nodepaths but 6 nodepaths (parent, child 1, child 2, repeated child 1, repeated child 2, and repeated child 2). Also, considering the case `<Box color='red'>` nesting `<Flex color='red'>`, if we first look for Box components and we chain the resulting collection with a find method to look for attributes color='red', the final Collection will include both Box and its nested Flex as when looking into Box for color='red', it also traverse its children, finding and returning the Flex component.

To prevent this, most finds are complemented with a filter that matches the JSX element name to the component and subcomponent name, to exclude those children.


### Checklist

- [ X ] Added unit and Flow Tests
