### PR TITLE
Docs: Update navigation and badge colors

### DIFF
--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -218,7 +218,7 @@ export default function PropTable({
                                   <code>{name}</code>
                                 )}
                               </Text>
-                              {required && <Badge text="Required" />}
+                              {required && <Badge text="Required" type="warning" />}
                             </Flex>
                           </Box>
                         </Td>

--- a/docs/components/Toc.js
+++ b/docs/components/Toc.js
@@ -166,7 +166,7 @@ export default function Toc({ cards }: Props): Node {
         return (
           <Flex key={anchor.id}>
             {/* INDICATOR */}
-            <Box color={isActive ? 'pine' : 'lightGray'} width={1} flex="none" />
+            <Box color={isActive ? 'successBase' : 'secondary'} width={1} flex="none" />
 
             <Link
               hoverStyle={isActive ? 'none' : 'underline'}
@@ -175,12 +175,12 @@ export default function Toc({ cards }: Props): Node {
             >
               <Box padding={2}>
                 {anchor.getElementsByTagName('h2').length > 0 ? (
-                  <Text color={isActive ? 'pine' : 'darkGray'} weight="bold">
+                  <Text color={isActive ? 'success' : 'default'} weight="bold">
                     {anchor.innerText}
                   </Text>
                 ) : (
                   <Box paddingX={3}>
-                    <Text size="200" color={isActive ? 'pine' : 'darkGray'} weight="bold">
+                    <Text size="200" color={isActive ? 'success' : 'default'} weight="bold">
                       {anchor.innerText}
                     </Text>
                   </Box>


### PR DESCRIPTION
### Summary

#### What changed?

Now that we have updated Text colors that work in dark mode, I updated the TOC green to use the new color, and updated the required badges to use "warning"

#### Why?

With recently color updates that better support dark mode, this enhances our docs in dark mode

#### Before
<img width="1105" alt="Screen Shot 2022-03-15 at 1 31 43 AM" src="https://user-images.githubusercontent.com/10593890/158282927-239880b1-a9ce-4400-b6ef-230d80a1ead4.png">
<img width="1091" alt="Screen Shot 2022-03-15 at 1 32 08 AM" src="https://user-images.githubusercontent.com/10593890/158282955-99439a9f-56a9-48dd-9273-c7a3d3886b2c.png">

#### After
<img width="1067" alt="Screen Shot 2022-03-15 at 1 30 48 AM" src="https://user-images.githubusercontent.com/10593890/158282881-ffbc5a0b-0ff9-4ebb-95ac-f85707f1fc4a.png">
<img width="1088" alt="Screen Shot 2022-03-15 at 1 31 23 AM" src="https://user-images.githubusercontent.com/10593890/158282900-9ef2e83b-b4ef-4c0b-96ae-6ce8e7409a20.png">

#### Before
<img width="218" alt="Screen Shot 2022-03-15 at 1 39 49 AM" src="https://user-images.githubusercontent.com/10593890/158283727-1f6b9ce5-a9f4-4c2b-82c9-b1e0d3610519.png">

#### After
<img width="280" alt="Screen Shot 2022-03-15 at 1 41 04 AM" src="https://user-images.githubusercontent.com/10593890/158283756-61a073ea-cfab-46b0-a212-be6001ad7353.png">

