### PR TITLE
ActivationCard: Use Text instead of Heading for UncompletedCard

### DIFF
--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -2,7 +2,6 @@
 import { Fragment, type Node } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
-import Heading from './Heading.js';
 import Icon from './Icon.js';
 import IconButton from './IconButton.js';
 import Button from './Button.js';
@@ -180,7 +179,9 @@ function UncompletedCard({
         </Box>
       </Box>
       <Box marginTop={6}>
-        <Heading size="400">{title}</Heading>
+        <Text size="400" weight="bold">
+          {title}
+        </Text>
       </Box>
       {message && (
         <Box flex="grow" direction="column" alignContent="start" marginTop={2}>

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
@@ -49,11 +49,11 @@ exports[`<ActivationCard /> Needs attention ActivationCard 1`] = `
   <div
     className="box marginTop6"
   >
-    <h3
-      className="Heading fontSize400 darkGray alignStart breakWord"
+    <div
+      className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
     >
       Tag is unhealthy
-    </h3>
+    </div>
   </div>
   <div
     className="box contentStart flexGrow marginTop2 xsDirectionColumn"
@@ -99,11 +99,11 @@ exports[`<ActivationCard /> Not started ActivationCard 1`] = `
   <div
     className="box marginTop6"
   >
-    <h3
-      className="Heading fontSize400 darkGray alignStart breakWord"
+    <div
+      className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
     >
       Claim your website
-    </h3>
+    </div>
   </div>
   <div
     className="box contentStart flexGrow marginTop2 xsDirectionColumn"
@@ -166,11 +166,11 @@ exports[`<ActivationCard /> Pending ActivationCard 1`] = `
   <div
     className="box marginTop6"
   >
-    <h3
-      className="Heading fontSize400 darkGray alignStart breakWord"
+    <div
+      className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
     >
       Claiming your website
-    </h3>
+    </div>
   </div>
   <div
     className="box contentStart flexGrow marginTop2 xsDirectionColumn"
@@ -294,11 +294,11 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
   <div
     className="box marginTop6"
   >
-    <h3
-      className="Heading fontSize400 darkGray alignStart breakWord"
+    <div
+      className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
     >
       Tag is unhealthy
-    </h3>
+    </div>
   </div>
   <div
     className="box contentStart flexGrow marginTop2 xsDirectionColumn"
@@ -445,11 +445,11 @@ exports[`<ActivationCard /> message + title + link 1`] = `
   <div
     className="box marginTop6"
   >
-    <h3
-      className="Heading fontSize400 darkGray alignStart breakWord"
+    <div
+      className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
     >
       Tag is unhealthy
-    </h3>
+    </div>
   </div>
   <div
     className="box contentStart flexGrow marginTop2 xsDirectionColumn"
@@ -547,11 +547,11 @@ exports[`<ActivationCard /> message + title 1`] = `
   <div
     className="box marginTop6"
   >
-    <h3
-      className="Heading fontSize400 darkGray alignStart breakWord"
+    <div
+      className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
     >
       Tag is unhealthy
-    </h3>
+    </div>
   </div>
   <div
     className="box contentStart flexGrow marginTop2 xsDirectionColumn"


### PR DESCRIPTION
### Summary

#### What changed?

Follow up from #1980 - I only changed it for `CompletedCard`, not `UncompletedCard`

#### Why?

See #1980

