### PR TITLE
Callout: Update text to be readable in dark mode

### DIFF
--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -157,7 +157,7 @@ function CalloutAction({
 /**
  * [Callout](https://gestalt.pinterest.systems/callout) is a banner displaying short messages with helpful information for a task on the page, or something that requires the user’s attention.
  *
- * ⚠️ Please note: Callout is not currently supported in dark mode.
+ * ⚠️ Please note: Callout is not currently optimized for dark mode.
  *
  * ![Callout light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Callout%20%230.png)
  *
@@ -226,12 +226,15 @@ export default function Callout({
                     size="400"
                     weight="bold"
                     align={responsiveMinWidth === 'xs' ? 'center' : undefined}
+                    color="dark"
                   >
                     {title}
                   </Text>
                 </Box>
               )}
-              <Text align={responsiveMinWidth === 'xs' ? 'center' : undefined}>{message}</Text>
+              <Text align={responsiveMinWidth === 'xs' ? 'center' : undefined} color="dark">
+                {message}
+              </Text>
             </Box>
           </Box>
         </Box>

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -49,7 +49,7 @@ exports[`<Callout /> Error Callout 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="Text fontSize300 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 darkText alignStart breakWord fontWeightNormal"
           >
             Insert a clever error callout message here
           </div>
@@ -109,7 +109,7 @@ exports[`<Callout /> Info Callout 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="Text fontSize300 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 darkText alignStart breakWord fontWeightNormal"
           >
             Insert a clever info callout message here
           </div>
@@ -169,7 +169,7 @@ exports[`<Callout /> Warning Callout 1`] = `
           className="box itemsCenter marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex"
         >
           <div
-            className="Text fontSize300 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 darkText alignStart breakWord fontWeightNormal"
           >
             Insert a clever warning callout message here
           </div>
@@ -232,13 +232,13 @@ exports[`<Callout /> message + title + primaryAction + dismissButton 1`] = `
             className="box marginBottom2"
           >
             <div
-              className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
+              className="Text fontSize400 darkText alignStart breakWord fontWeightBold"
             >
               A Title
             </div>
           </div>
           <div
-            className="Text fontSize300 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 darkText alignStart breakWord fontWeightNormal"
           >
             Insert a clever info callout message here
           </div>
@@ -385,13 +385,13 @@ exports[`<Callout /> message + title + primaryAction + secondaryAction 1`] = `
             className="box marginBottom2"
           >
             <div
-              className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
+              className="Text fontSize400 darkText alignStart breakWord fontWeightBold"
             >
               A Title
             </div>
           </div>
           <div
-            className="Text fontSize300 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 darkText alignStart breakWord fontWeightNormal"
           >
             Insert a clever info callout message here
           </div>
@@ -520,13 +520,13 @@ exports[`<Callout /> message + title + primaryAction with href 1`] = `
             className="box marginBottom2"
           >
             <div
-              className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
+              className="Text fontSize400 darkText alignStart breakWord fontWeightBold"
             >
               A Title
             </div>
           </div>
           <div
-            className="Text fontSize300 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 darkText alignStart breakWord fontWeightNormal"
           >
             Insert a clever info callout message here
           </div>
@@ -624,13 +624,13 @@ exports[`<Callout /> message + title + primaryAction without href 1`] = `
             className="box marginBottom2"
           >
             <div
-              className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
+              className="Text fontSize400 darkText alignStart breakWord fontWeightBold"
             >
               A Title
             </div>
           </div>
           <div
-            className="Text fontSize300 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 darkText alignStart breakWord fontWeightNormal"
           >
             Insert a clever info callout message here
           </div>
@@ -726,13 +726,13 @@ exports[`<Callout /> message + title 1`] = `
             className="box marginBottom2"
           >
             <div
-              className="Text fontSize400 darkGray alignStart breakWord fontWeightBold"
+              className="Text fontSize400 darkText alignStart breakWord fontWeightBold"
             >
               A Title
             </div>
           </div>
           <div
-            className="Text fontSize300 darkGray alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 darkText alignStart breakWord fontWeightNormal"
           >
             Insert a clever info callout message here
           </div>


### PR DESCRIPTION
### Summary

#### What changed?

Use our new Text color for Callout to avoid the font color changing in dark mode

#### Why?

Previously the title and message of Callout were unreadable in dark mode. This updates the text color used to be one that does not change in dark mode, making the text readable

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
