### PR TITLE
Text: rework color class logic to appease Flow

### DIFF
--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -121,7 +121,6 @@ export default function Text({
   weight = 'normal',
 }: Props): Node {
   let colorClass = null;
-
   if (allowedColors.includes(color)) {
     colorClass = semanticColors.includes(color) ? typography[`${color}Text`] : colors[color];
   }

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -120,9 +120,12 @@ export default function Text({
   underline = false,
   weight = 'normal',
 }: Props): Node {
-  const colorClass =
-    allowedColors.includes(color) &&
-    (semanticColors.includes(color) ? typography[`${color}Text`] : colors[color]);
+  let colorClass = null;
+
+  if (allowedColors.includes(color)) {
+    colorClass = semanticColors.includes(color) ? typography[`${color}Text`] : colors[color];
+  }
+
   const cs = cx(
     styles.Text,
     typography[`fontSize${SIZE_SCALE[size]}`],


### PR DESCRIPTION
Flow is failing on CI due to recent `color` changes in Text, though I can't repro locally. This PR is an attempt to fix the Flow issue and also make the related logic a bit more readable.