### PR TITLE
InternalTextFieldIconButton: create component from InternalTextField

### DIFF
--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -14,12 +14,13 @@ import {
   type Node,
 } from 'react';
 import Box from './Box.js';
+import ComboBoxItem from './ComboBoxItem.js';
 import Layer from './Layer.js';
 import Popover from './Popover.js';
-import Text from './Text.js';
 import InternalTextField from './InternalTextField.js';
+import InternalTextFieldIconButton from './InternalTextFieldIconButton.js';
 import Tag from './Tag.js';
-import ComboBoxItem from './ComboBoxItem.js';
+import Text from './Text.js';
 import { ESCAPE, TAB, ENTER, UP_ARROW, DOWN_ARROW } from './keyCodes.js';
 import handleContainerScrolling, {
   KEYS,
@@ -27,6 +28,7 @@ import handleContainerScrolling, {
 } from './utils/keyboardNavigation.js';
 
 type Size = 'md' | 'lg';
+
 type OptionType = {|
   label: string,
   subtext?: string,
@@ -200,9 +202,6 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
 
   const isControlledInput = !(controlledInputValue === null || controlledInputValue === undefined);
   const isNotControlled = !isControlledInput && !tags;
-
-  const textfieldIconButton =
-    controlledInputValue || textfieldInput || (tags && tags.length > 0) ? 'clear' : 'expand';
 
   // ==== TAGS: Force disable state in Tags if ComboBox is disabled as well ====
 
@@ -412,7 +411,6 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
         role="combobox"
       >
         <InternalTextField
-          accessibilityClearButtonLabel={accessibilityClearButtonLabel}
           // add accessibilityControls once the option list element exists
           accessibilityControls={showOptionsList && innerRef.current ? id : undefined}
           // add accessibilityActiveDescendant once the option list element exists
@@ -426,16 +424,32 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
           errorMessage={errorMessage}
           hasError={!!errorMessage}
           helperText={helperText}
+          iconButton={
+            controlledInputValue || textfieldInput || (tags && tags.length > 0) ? (
+              <InternalTextFieldIconButton
+                accessibilityClearButtonLabel={accessibilityClearButtonLabel}
+                hoverStyle="default"
+                icon="cancel"
+                onClick={handleOnClickIconButtonClear}
+                pogPadding={size === 'lg' ? 2 : 1}
+                tapStyle="compress"
+              />
+            ) : (
+              <InternalTextFieldIconButton
+                accessibilityHidden
+                hoverStyle="none"
+                icon="arrow-down"
+                onClick={handleSetShowOptionsList}
+                pogPadding={size === 'lg' ? 2 : 1}
+                tapStyle="none"
+              />
+            )
+          }
           id={`combobox-${id}`}
           label={label}
           labelDisplay={labelDisplay}
           onBlur={handleOnBlur}
           onChange={handleOnChange}
-          onClickIconButton={
-            textfieldIconButton === 'clear'
-              ? handleOnClickIconButtonClear
-              : handleSetShowOptionsList
-          }
           onClick={handleSetShowOptionsList}
           onFocus={handleOnFocus}
           onKeyDown={handleOnKeyDown}
@@ -443,7 +457,6 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
           ref={innerRef}
           size={size}
           tags={selectedTags}
-          textfieldIconButton={textfieldIconButton}
           type="text"
           value={controlledInputValue ?? textfieldInput}
         />

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -2,17 +2,15 @@
 import { useImperativeHandle, useRef, forwardRef, type Element, type Node, useState } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
-import TapArea from './TapArea.js';
-import Icon from './Icon.js';
-import focusStyles from './Focus.css';
-import formElement from './FormElement.css';
 import FormErrorMessage from './FormErrorMessage.js';
 import FormHelperText from './FormHelperText.js';
 import FormLabel from './FormLabel.js';
+import InternalTextFieldIconButton from './InternalTextFieldIconButton.js';
 import Tag from './Tag.js';
+import focusStyles from './Focus.css';
+import formElement from './FormElement.css';
 import layout from './Layout.css';
 import styles from './InternalTextField.css';
-import { TAB, SPACE, ENTER } from './keyCodes.js';
 import typography from './Typography.css';
 
 type Props = {|
@@ -23,7 +21,6 @@ type Props = {|
     value: string,
   |}) => void,
   // OPTIONAL
-  accessibilityClearButtonLabel?: string,
   accessibilityControls?: string,
   accessibilityActiveDescendant?: string,
   autoComplete?: 'current-password' | 'new-password' | 'on' | 'off' | 'username' | 'email',
@@ -31,6 +28,7 @@ type Props = {|
   errorMessage?: Node,
   hasError?: boolean,
   helperText?: string,
+  iconButton?: Element<typeof InternalTextFieldIconButton>,
   label?: string,
   labelDisplay?: 'visible' | 'hidden',
   max?: number,
@@ -40,7 +38,6 @@ type Props = {|
     event: SyntheticFocusEvent<HTMLInputElement>,
     value: string,
   |}) => void,
-  onClickIconButton?: () => void,
   onClick?: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
     value: string,
@@ -57,7 +54,6 @@ type Props = {|
   size?: 'md' | 'lg',
   step?: number,
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
-  textfieldIconButton?: 'clear' | 'expand',
   type?: 'date' | 'email' | 'number' | 'password' | 'tel' | 'text' | 'url',
   value?: string,
 |};
@@ -69,13 +65,13 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
   {
     accessibilityControls,
     accessibilityActiveDescendant,
-    accessibilityClearButtonLabel,
     autoComplete,
     disabled = false,
     errorMessage,
     hasError = false,
     helperText,
     id,
+    iconButton,
     label,
     labelDisplay,
     max,
@@ -83,7 +79,6 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
     name,
     onBlur,
     onChange,
-    onClickIconButton,
     onClick,
     onFocus,
     onKeyDown,
@@ -91,26 +86,21 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
     size = 'md',
     step,
     tags,
-    textfieldIconButton,
     type = 'text',
     value,
   }: Props,
   ref,
 ): Node {
   // ==== REFS ====
-
   const innerRef = useRef(null);
   // When using both forwardRef and innerRefs, useimperativehandle() allows to externally set focus via the ref prop: textfieldRef.current.focus()
   // $FlowFixMe[incompatible-call]
   useImperativeHandle(ref, () => innerRef.current);
 
   // ==== STATE ====
-
   const [focused, setFocused] = useState(false);
-  const [focusedButton, setFocusedButton] = useState(false);
 
   // ==== HANDLERS ====
-
   const handleBlur = (event: SyntheticFocusEvent<HTMLInputElement>) => {
     setFocused(false);
     onBlur?.({ event, value: event.currentTarget.value });
@@ -130,10 +120,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
   const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) =>
     onKeyDown?.({ event, value: event.currentTarget.value });
 
-  const handleOnClickIconButton = () => onClickIconButton?.();
-
   // ==== STYLING ====
-
   const hasErrorMessage = Boolean(errorMessage);
 
   const styledClasses = classnames(
@@ -144,7 +131,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
     {
       [layout.medium]: !tags && size === 'md',
       [layout.large]: tags || size === 'lg',
-      [styles.actionButton]: textfieldIconButton,
+      [styles.actionButton]: iconButton,
     },
     tags
       ? {
@@ -188,6 +175,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
   return (
     <span>
       {label ? <FormLabel id={id} label={label} labelDisplay={labelDisplay} /> : null}
+
       <Box position="relative">
         {tags ? (
           <div className={styledClasses} {...(tags ? { ref: innerRef } : {})}>
@@ -210,54 +198,12 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<
         ) : (
           inputElement
         )}
-        {textfieldIconButton && !disabled ? (
-          // styles.actionButtonContainernis required for RTL positioning
-          <div className={classnames(styles.actionButtonContainer)}>
-            <Box
-              aria-hidden={textfieldIconButton === 'expand'}
-              alignItems="center"
-              display="flex"
-              height="100%"
-              marginEnd={2}
-              rounding="circle"
-            >
-              <TapArea
-                accessibilityLabel={
-                  textfieldIconButton === 'clear' ? accessibilityClearButtonLabel : undefined
-                }
-                onBlur={() => setFocusedButton(false)}
-                onFocus={() => setFocusedButton(true)}
-                onKeyDown={({ event }) => {
-                  if ([ENTER, SPACE].includes(event.keyCode)) handleOnClickIconButton();
-                  if (event.keyCode !== TAB) event.preventDefault();
-                }}
-                onMouseEnter={() => setFocusedButton(true)}
-                onMouseLeave={() => setFocusedButton(false)}
-                onTap={handleOnClickIconButton}
-                rounding="circle"
-                tabIndex={textfieldIconButton === 'clear' ? 0 : -1}
-                tapStyle={textfieldIconButton === 'clear' ? 'compress' : 'none'}
-              >
-                <Box
-                  color={
-                    focusedButton && textfieldIconButton === 'clear' ? 'lightGray' : 'transparent'
-                  }
-                  padding={size === 'lg' ? 2 : 1}
-                  rounding="circle"
-                >
-                  <Icon
-                    accessibilityLabel=""
-                    size={12}
-                    icon={textfieldIconButton === 'clear' ? 'cancel' : 'arrow-down'}
-                    color="darkGray"
-                  />
-                </Box>
-              </TapArea>
-            </Box>
-          </div>
-        ) : null}
+
+        {!disabled && iconButton}
       </Box>
+
       {helperText && !errorMessage ? <FormHelperText text={helperText} /> : null}
+
       {hasErrorMessage ? <FormErrorMessage id={id} text={errorMessage} /> : null}
     </span>
   );

--- a/packages/gestalt/src/InternalTextFieldIconButton.js
+++ b/packages/gestalt/src/InternalTextFieldIconButton.js
@@ -1,0 +1,69 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import classnames from 'classnames';
+import Box from './Box.js';
+import Pog from './Pog.js';
+import TapArea from './TapArea.js';
+import styles from './InternalTextField.css';
+import { TAB, SPACE, ENTER } from './keyCodes.js';
+
+type Props = {|
+  accessibilityClearButtonLabel?: string,
+  accessibilityHidden?: boolean,
+  hoverStyle: 'default' | 'none',
+  icon: 'arrow-down' | 'cancel' | 'eye' | 'eye-hide',
+  onClick: () => void,
+  pogPadding: 1 | 2,
+  tapStyle: $ElementType<React$ElementConfig<typeof TapArea>, 'tapStyle'>,
+|};
+
+export default function InternalTextFieldIconButton({
+  accessibilityClearButtonLabel,
+  accessibilityHidden,
+  hoverStyle,
+  icon,
+  onClick,
+  pogPadding,
+  tapStyle,
+}: Props): Node {
+  const [focused, setFocused] = useState(false);
+
+  return (
+    // styles.actionButtonContainer is required for RTL positioning
+    <div className={classnames(styles.actionButtonContainer)}>
+      <Box
+        aria-hidden={accessibilityHidden}
+        alignItems="center"
+        display="flex"
+        height="100%"
+        marginEnd={2}
+        rounding="circle"
+      >
+        <TapArea
+          accessibilityLabel={accessibilityClearButtonLabel}
+          onBlur={() => setFocused(false)}
+          onFocus={() => setFocused(true)}
+          onKeyDown={({ event }) => {
+            if ([ENTER, SPACE].includes(event.keyCode)) onClick();
+            if (event.keyCode !== TAB) event.preventDefault();
+          }}
+          onMouseEnter={() => setFocused(true)}
+          onMouseLeave={() => setFocused(false)}
+          onTap={onClick}
+          rounding="circle"
+          tabIndex={accessibilityHidden ? -1 : 0}
+          tapStyle={tapStyle}
+        >
+          <Pog
+            accessibilityLabel=""
+            bgColor={focused && hoverStyle === 'default' ? 'lightGray' : 'transparent'}
+            icon={icon}
+            iconColor="darkGray"
+            padding={pogPadding}
+            size="xs"
+          />
+        </TapArea>
+      </Box>
+    </div>
+  );
+}

--- a/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
@@ -53,7 +53,8 @@ exports[`ComboBox Controlled ComboBox renders basic controlled components 1`] = 
                 tabindex="-1"
               >
                 <div
-                  class="box circle paddingX1 paddingY1"
+                  class="pog transparent"
+                  style="height: 20px; width: 20px;"
                 >
                   <svg
                     aria-hidden="true"
@@ -575,7 +576,6 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
             class="actionButtonContainer"
           >
             <div
-              aria-hidden="false"
               class="box circle itemsCenter marginEnd2 xsDisplayFlex"
               style="height: 100%;"
             >
@@ -587,7 +587,8 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                 tabindex="0"
               >
                 <div
-                  class="box circle paddingX1 paddingY1"
+                  class="pog transparent"
+                  style="height: 20px; width: 20px;"
                 >
                   <svg
                     aria-hidden="true"
@@ -666,7 +667,8 @@ exports[`ComboBox Uncontrolled ComboBox renders default 1`] = `
                 tabindex="-1"
               >
                 <div
-                  class="box circle paddingX1 paddingY1"
+                  class="pog transparent"
+                  style="height: 20px; width: 20px;"
                 >
                   <svg
                     aria-hidden="true"


### PR DESCRIPTION
In preparation for future work using the icon button available on InternalTextField, this PR extracts that markup to a standalone component. This alters the API of InternalTextField a bit, and moves some ComboBox-specific logic back into ComboBox.