### PR TITLE
TextField: Add experimental show/hide password button

### DIFF
--- a/docs/components/App.js
+++ b/docs/components/App.js
@@ -2,9 +2,11 @@
 import { useEffect, type Node } from 'react';
 import { ColorSchemeProvider, OnLinkNavigationProvider } from 'gestalt';
 import { useRouter } from 'next/router';
+import DocsExperimentProvider from './contexts/DocsExperimentProvider.js';
 import { AppContextProvider, AppContextConsumer } from './appContext.js';
 import { NavigationContextProvider } from './navigationContext.js';
 import AppLayout from './AppLayout.js';
+import DocsI18nProvider from './contexts/DocsI18nProvider.js';
 
 type Props = {|
   children?: Node,
@@ -55,7 +57,11 @@ export default function App({ children }: Props): Node {
           <ColorSchemeProvider colorScheme={colorScheme} id="gestalt-docs">
             <OnLinkNavigationProvider onNavigation={useOnNavigation}>
               <NavigationContextProvider>
-                <AppLayout>{children}</AppLayout>
+                <DocsExperimentProvider>
+                  <DocsI18nProvider>
+                    <AppLayout>{children}</AppLayout>
+                  </DocsI18nProvider>
+                </DocsExperimentProvider>
               </NavigationContextProvider>
             </OnLinkNavigationProvider>
           </ColorSchemeProvider>

--- a/docs/components/App.js
+++ b/docs/components/App.js
@@ -2,11 +2,9 @@
 import { useEffect, type Node } from 'react';
 import { ColorSchemeProvider, OnLinkNavigationProvider } from 'gestalt';
 import { useRouter } from 'next/router';
-import DocsExperimentProvider from './contexts/DocsExperimentProvider.js';
 import { AppContextProvider, AppContextConsumer } from './appContext.js';
 import { NavigationContextProvider } from './navigationContext.js';
 import AppLayout from './AppLayout.js';
-import DocsI18nProvider from './contexts/DocsI18nProvider.js';
 
 type Props = {|
   children?: Node,
@@ -50,6 +48,7 @@ export default function App({ children }: Props): Node {
     };
   }, [router.events]);
 
+  // NOTE: there are other Providers added in pages/_app.js
   return (
     <AppContextProvider>
       <AppContextConsumer>
@@ -57,11 +56,7 @@ export default function App({ children }: Props): Node {
           <ColorSchemeProvider colorScheme={colorScheme} id="gestalt-docs">
             <OnLinkNavigationProvider onNavigation={useOnNavigation}>
               <NavigationContextProvider>
-                <DocsExperimentProvider>
-                  <DocsI18nProvider>
-                    <AppLayout>{children}</AppLayout>
-                  </DocsI18nProvider>
-                </DocsExperimentProvider>
+                <AppLayout>{children}</AppLayout>
               </NavigationContextProvider>
             </OnLinkNavigationProvider>
           </ColorSchemeProvider>

--- a/docs/components/contexts/DocsExperimentProvider.js
+++ b/docs/components/contexts/DocsExperimentProvider.js
@@ -1,0 +1,39 @@
+// @flow strict
+import { type Node } from 'react';
+import { ExperimentProvider } from 'gestalt';
+
+/**
+ * To implement experimental behavior in the docs:
+ * - Add your experiment name here
+ * - Unless you want the experimental behavior live on the docs for everyone, REMOVE YOUR EXPERIMENT HERE before merging your PR!
+ * */
+
+const enabledExperiments = [];
+
+function buildExperimentsObj(experiments: $ReadOnlyArray<string>) {
+  return experiments.reduce(
+    (
+      acc: {|
+        [string]: {|
+          anyEnabled: boolean,
+          group: string,
+        |},
+      |},
+      cur: string,
+    ) => ({
+      ...acc,
+      [cur]: { anyEnabled: true, group: 'enabled' },
+    }),
+    {},
+  );
+}
+
+type Props = {| children: Node |};
+
+export default function DocsExperimentProvider({ children }: Props): Node {
+  return (
+    <ExperimentProvider value={buildExperimentsObj(enabledExperiments)}>
+      {children}
+    </ExperimentProvider>
+  );
+}

--- a/docs/components/contexts/DocsI18nProvider.js
+++ b/docs/components/contexts/DocsI18nProvider.js
@@ -1,0 +1,16 @@
+// @flow strict
+import { type Node } from 'react';
+import { I18nProvider } from 'gestalt';
+
+const translations = {
+  TextField: {
+    accessibilityHidePasswordLabel: 'Hide password',
+    accessibilityShowPasswordLabel: 'Show password',
+  },
+};
+
+type Props = {| children: Node |};
+
+export default function DocsI18nProvider({ children }: Props): Node {
+  return <I18nProvider value={translations}>{children}</I18nProvider>;
+}

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -9,6 +9,17 @@ import { CookiesProvider } from 'react-cookie';
 import { useRouter } from 'next/router';
 import { Box } from 'gestalt';
 import App from '../components/App.js';
+import DocsExperimentProvider from '../components/contexts/DocsExperimentProvider.js';
+import DocsI18nProvider from '../components/contexts/DocsI18nProvider.js';
+
+// Adding providers here instead of components/App.js as they're needed by visual tests as well
+function Providers({ children }: {| children: Node |}): Node {
+  return (
+    <DocsExperimentProvider>
+      <DocsI18nProvider>{children}</DocsI18nProvider>
+    </DocsExperimentProvider>
+  );
+}
 
 // This default export is required in a new `pages/_app.js` file.
 function GestaltApp(
@@ -20,9 +31,11 @@ function GestaltApp(
   // Hide navigation / sidebar for visual tests
   if (router.pathname.startsWith('/visual-test/')) {
     return (
-      <Box data-test-id="visual-test" display="inlineBlock">
-        <Component {...pageProps} />
-      </Box>
+      <Providers>
+        <Box data-test-id="visual-test" display="inlineBlock">
+          <Component {...pageProps} />
+        </Box>
+      </Providers>
     );
   }
 
@@ -30,9 +43,11 @@ function GestaltApp(
 
   return (
     <CookiesProvider cookies={cookies}>
-      <App>
-        <Component {...pageProps} />
-      </App>
+      <Providers>
+        <App>
+          <Component {...pageProps} />
+        </App>
+      </Providers>
     </CookiesProvider>
   );
 }

--- a/docs/pages/textfield.js
+++ b/docs/pages/textfield.js
@@ -6,7 +6,7 @@ import Page from '../components/Page.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 
-export default function TextFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
@@ -485,6 +485,8 @@ function Example(props) {
   return (
     <Box padding={2} color="white">
       <TextField
+        accessibilityHidePasswordLabel="Hide password"
+        accessibilityShowPasswordLabel="Show password"
         autoComplete="new-password"
         helperText="Password should be at least 20 characters long"
         id="variants-helper-text"

--- a/docs/pages/textfield.js
+++ b/docs/pages/textfield.js
@@ -6,7 +6,7 @@ import Page from '../components/Page.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 
-export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
+export default function TextFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
@@ -22,9 +22,7 @@ function Example(props) {
         autoComplete="username"
         id="header-example"
         label="Username"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
+        onChange={({ value }) => setValue(value)}
         placeholder="Please enter your username"
         type="text"
         value={value}
@@ -74,9 +72,7 @@ function Example(props) {
         helperText="Password should be at least 20 characters in length"
         id="best-practices-do-helper-text"
         label="New password"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
+        onChange={({ value }) => setValue(value)}
         type="password"
         value={value}
       />
@@ -99,9 +95,7 @@ function Example(props) {
         autoComplete="new-password"
         id="best-practices-dont-placeholder"
         label=""
-        onChange={({ value }) => {
-          setValue(value);
-        }}
+        onChange={({ value }) => setValue(value)}
         placeholder="Password should be at least 20 characters in length"
         type="password"
         value={value}
@@ -128,9 +122,7 @@ function Example(props) {
         autoComplete="username"
         id="best-practices-do-label"
         label="Username"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
+        onChange={({ value }) => setValue(value)}
         type="text"
         value={value}
       />
@@ -154,9 +146,7 @@ function Example(props) {
           autoComplete="username"
           id="best-practices-dont-label"
           label=""
-          onChange={({ value }) => {
-            setValue(value);
-          }}
+          onChange={({ value }) => setValue(value)}
           type="username"
           value={value}
         />
@@ -183,18 +173,14 @@ function Example(props) {
       <TextField
         id="best-practices-do-related-city"
         label="City"
-        onChange={({ value }) => {
-          setCityValue(value);
-        }}
+        onChange={({ value }) => setCityValue(value)}
         type="text"
         value={cityValue}
       />
       <TextField
         id="best-practices-do-related-state"
         label="State"
-        onChange={({ value }) => {
-          setStateValue(value);
-        }}
+        onChange={({ value }) => setStateValue(value)}
         type="text"
         value={stateValue}
       />
@@ -218,18 +204,15 @@ function Example(props) {
         autoComplete="new-password"
         id="best-practices-dont-related-password"
         label="Password"
-        onChange={({ value }) => {
-          setPasswordValue(value);
-        }}
+        onChange={({ value }) => setPasswordValue(value)}
         type="password"
         value={passwordValue}
       />
       <TextField
         id="best-practices-dont-related-zip-code"
         label="ZIP Code"
-        onChange={({ value }) => {
-          setZipCodeValue(value);
-        }}
+        onChange={({ value }) => setZipCodeValue(value)}
+        type="number"
         value={zipCodeValue}
       />
     </Flex>
@@ -255,9 +238,7 @@ function Example(props) {
         errorMessage="Password is too short! You need 20+ characters"
         id="best-practices-do-error-message"
         label="Password"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
+        onChange={({ value }) => setValue(value)}
         type="password"
         value={value}
       />
@@ -281,9 +262,7 @@ function Example(props) {
         errorMessage="There is an error"
         id="best-practices-dont-error-message"
         label="Password"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
+        onChange={({ value }) => setValue(value)}
         type="password"
         value={value}
       />
@@ -312,27 +291,21 @@ function Example(props) {
       <TextField
         id="best-practices-do-required-firstName"
         label="First name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, first: value }));
-        }}
+        onChange={({ value }) => setName((name) => ({ ...name, first: value }))}
         type="text"
         value={name.first}
       />
       <TextField
         id="best-practices-do-required-middleName"
         label="Middle name (optional)"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, middle: value }));
-        }}
+        onChange={({ value }) => setName((name) => ({ ...name, middle: value }))}
         type="text"
         value={name.middle}
       />
       <TextField
         id="best-practices-do-required-lastName"
         label="Last name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, last: value }));
-        }}
+        onChange={({ value }) => setName((name) => ({ ...name, last: value }))}
         type="text"
         value={name.last}
       />
@@ -359,18 +332,14 @@ function Example(props) {
         helperText="* This field is required."
         id="best-practices-dont-required-firstName"
         label="First name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, first: value }));
-        }}
+        onChange={({ value }) => setName((name) => ({ ...name, first: value }))}
         type="text"
         value={name.first}
       />
       <TextField
         id="best-practices-dont-required-middleName"
         label="Middle name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, middle: value }));
-        }}
+        onChange={({ value }) => setName((name) => ({ ...name, middle: value }))}
         type="text"
         value={name.middle}
       />
@@ -378,9 +347,7 @@ function Example(props) {
         helperText="* This field is required."
         id="best-practices-dont-required-lastName"
         label="Last name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, last: value }));
-        }}
+        onChange={({ value }) => setName((name) => ({ ...name, last: value }))}
         type="text"
         value={name.last}
       />
@@ -459,9 +426,7 @@ function Example(props) {
       disabled
       id="variants-disabled"
       label="Disabled"
-      onChange={({ value }) => {
-        setValue(value);
-      }}
+      onChange={({ value }) => setValue(value)}
       placeholder="Name"
       value={value}
     />
@@ -485,15 +450,11 @@ function Example(props) {
   return (
     <Box padding={2} color="white">
       <TextField
-        accessibilityHidePasswordLabel="Hide password"
-        accessibilityShowPasswordLabel="Show password"
         autoComplete="new-password"
         helperText="Password should be at least 20 characters long"
         id="variants-helper-text"
         label="Password"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
+        onChange={({ value }) => setValue(value)}
         type="password"
         value={value}
       />
@@ -522,9 +483,7 @@ function Example(props) {
       errorMessage={!value ? "This field can't be blank!" : null}
       id="variants-error-message"
       label="With an error message"
-      onChange={({ value }) => {
-        setValue(value);
-      }}
+      onChange={({ value }) => setValue(value)}
       value={value}
     />
   );
@@ -626,21 +585,15 @@ function TextFieldPopoverExample() {
         id="variants-refs"
         label="Focus the TextField to show the Popover"
         onChange={() => {}}
-        onBlur={() => {
-          setOpen(false);
-        }}
-        onFocus={() => {
-          setOpen(true);
-        }}
+        onBlur={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
         ref={anchorRef}
       />
       {open && (
         <Popover
           anchor={anchorRef.current}
           idealDirection="down"
-          onDismiss={() => {
-            setOpen(false);
-          }}
+          onDismiss={() => setOpen(false)}
           shouldFocus={false}
           size="md"
         >
@@ -664,7 +617,7 @@ function TextFieldPopoverExample() {
       When users need to enter long amounts of text, use TextArea to ensure the full content will be shown.
 
       **[NumberField](/numberfield)**
-      For numerical input, use NumberField. Exceptions: for telephone numbers, use \`<TextField type="tel" />\`. And for numerical input with possible leading 0's (e.g. ZIP codes), use \`<TextField type="text" />\`.
+      For numerical input, use NumberField. (For telephone numbers, use \`<TextField type="tel" />\`.)
 
       **[SearchField](/searchfield)**
       If the input is used for searching content, use SearchField.

--- a/docs/pages/textfield.js
+++ b/docs/pages/textfield.js
@@ -22,7 +22,9 @@ function Example(props) {
         autoComplete="username"
         id="header-example"
         label="Username"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         placeholder="Please enter your username"
         type="text"
         value={value}
@@ -72,7 +74,9 @@ function Example(props) {
         helperText="Password should be at least 20 characters in length"
         id="best-practices-do-helper-text"
         label="New password"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="password"
         value={value}
       />
@@ -95,7 +99,9 @@ function Example(props) {
         autoComplete="new-password"
         id="best-practices-dont-placeholder"
         label=""
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         placeholder="Password should be at least 20 characters in length"
         type="password"
         value={value}
@@ -122,7 +128,9 @@ function Example(props) {
         autoComplete="username"
         id="best-practices-do-label"
         label="Username"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="text"
         value={value}
       />
@@ -146,7 +154,9 @@ function Example(props) {
           autoComplete="username"
           id="best-practices-dont-label"
           label=""
-          onChange={({ value }) => setValue(value)}
+          onChange={({ value }) => {
+            setValue(value);
+          }}
           type="username"
           value={value}
         />
@@ -173,14 +183,18 @@ function Example(props) {
       <TextField
         id="best-practices-do-related-city"
         label="City"
-        onChange={({ value }) => setCityValue(value)}
+        onChange={({ value }) => {
+          setCityValue(value);
+        }}
         type="text"
         value={cityValue}
       />
       <TextField
         id="best-practices-do-related-state"
         label="State"
-        onChange={({ value }) => setStateValue(value)}
+        onChange={({ value }) => {
+          setStateValue(value);
+        }}
         type="text"
         value={stateValue}
       />
@@ -204,15 +218,18 @@ function Example(props) {
         autoComplete="new-password"
         id="best-practices-dont-related-password"
         label="Password"
-        onChange={({ value }) => setPasswordValue(value)}
+        onChange={({ value }) => {
+          setPasswordValue(value);
+        }}
         type="password"
         value={passwordValue}
       />
       <TextField
         id="best-practices-dont-related-zip-code"
         label="ZIP Code"
-        onChange={({ value }) => setZipCodeValue(value)}
-        type="number"
+        onChange={({ value }) => {
+          setZipCodeValue(value);
+        }}
         value={zipCodeValue}
       />
     </Flex>
@@ -238,7 +255,9 @@ function Example(props) {
         errorMessage="Password is too short! You need 20+ characters"
         id="best-practices-do-error-message"
         label="Password"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="password"
         value={value}
       />
@@ -262,7 +281,9 @@ function Example(props) {
         errorMessage="There is an error"
         id="best-practices-dont-error-message"
         label="Password"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="password"
         value={value}
       />
@@ -291,21 +312,27 @@ function Example(props) {
       <TextField
         id="best-practices-do-required-firstName"
         label="First name"
-        onChange={({ value }) => setName((name) => ({ ...name, first: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, first: value }));
+        }}
         type="text"
         value={name.first}
       />
       <TextField
         id="best-practices-do-required-middleName"
         label="Middle name (optional)"
-        onChange={({ value }) => setName((name) => ({ ...name, middle: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, middle: value }));
+        }}
         type="text"
         value={name.middle}
       />
       <TextField
         id="best-practices-do-required-lastName"
         label="Last name"
-        onChange={({ value }) => setName((name) => ({ ...name, last: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, last: value }));
+        }}
         type="text"
         value={name.last}
       />
@@ -332,14 +359,18 @@ function Example(props) {
         helperText="* This field is required."
         id="best-practices-dont-required-firstName"
         label="First name"
-        onChange={({ value }) => setName((name) => ({ ...name, first: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, first: value }));
+        }}
         type="text"
         value={name.first}
       />
       <TextField
         id="best-practices-dont-required-middleName"
         label="Middle name"
-        onChange={({ value }) => setName((name) => ({ ...name, middle: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, middle: value }));
+        }}
         type="text"
         value={name.middle}
       />
@@ -347,7 +378,9 @@ function Example(props) {
         helperText="* This field is required."
         id="best-practices-dont-required-lastName"
         label="Last name"
-        onChange={({ value }) => setName((name) => ({ ...name, last: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, last: value }));
+        }}
         type="text"
         value={name.last}
       />
@@ -426,7 +459,9 @@ function Example(props) {
       disabled
       id="variants-disabled"
       label="Disabled"
-      onChange={({ value }) => setValue(value)}
+      onChange={({ value }) => {
+        setValue(value);
+      }}
       placeholder="Name"
       value={value}
     />
@@ -454,7 +489,9 @@ function Example(props) {
         helperText="Password should be at least 20 characters long"
         id="variants-helper-text"
         label="Password"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="password"
         value={value}
       />
@@ -483,7 +520,9 @@ function Example(props) {
       errorMessage={!value ? "This field can't be blank!" : null}
       id="variants-error-message"
       label="With an error message"
-      onChange={({ value }) => setValue(value)}
+      onChange={({ value }) => {
+        setValue(value);
+      }}
       value={value}
     />
   );
@@ -585,15 +624,21 @@ function TextFieldPopoverExample() {
         id="variants-refs"
         label="Focus the TextField to show the Popover"
         onChange={() => {}}
-        onBlur={() => setOpen(false)}
-        onFocus={() => setOpen(true)}
+        onBlur={() => {
+          setOpen(false);
+        }}
+        onFocus={() => {
+          setOpen(true);
+        }}
         ref={anchorRef}
       />
       {open && (
         <Popover
           anchor={anchorRef.current}
           idealDirection="down"
-          onDismiss={() => setOpen(false)}
+          onDismiss={() => {
+            setOpen(false);
+          }}
           shouldFocus={false}
           size="md"
         >
@@ -617,7 +662,7 @@ function TextFieldPopoverExample() {
       When users need to enter long amounts of text, use TextArea to ensure the full content will be shown.
 
       **[NumberField](/numberfield)**
-      For numerical input, use NumberField. (For telephone numbers, use \`<TextField type="tel" />\`.)
+      For numerical input, use NumberField. Exceptions: for telephone numbers, use \`<TextField type="tel" />\`. And for numerical input with possible leading 0's (e.g. ZIP codes), use \`<TextField type="text" />\`.
 
       **[SearchField](/searchfield)**
       If the input is used for searching content, use SearchField.

--- a/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
+++ b/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
@@ -1,7 +1,19 @@
 // @flow strict-local
 import { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nProvider } from 'gestalt';
 import DatePicker from './DatePicker.js';
+
+const translations = {
+  TextField: {
+    accessibilityHidePasswordLabel: 'Hide password',
+    accessibilityShowPasswordLabel: 'Show password',
+  },
+};
+
+function renderComp(comp) {
+  return render(<I18nProvider value={translations}>{comp}</I18nProvider>);
+}
 
 describe('DatePicker', () => {
   const mockOnChange = jest.fn();
@@ -17,7 +29,7 @@ describe('DatePicker', () => {
   });
 
   it('displays TextField with given initial date', () => {
-    render(<DatePicker id="fake_id" onChange={() => {}} value={initialDate} />);
+    renderComp(<DatePicker id="fake_id" onChange={() => {}} value={initialDate} />);
     // We only check for selected value upon rendering,
     // because onChange logic is outside DatePicker
     // So initial date value does not change upon firing click event
@@ -27,7 +39,7 @@ describe('DatePicker', () => {
   it('passes clicked date to onChange prop', () => {
     const newDate = new Date(2018, 11, 13);
 
-    render(
+    renderComp(
       <DatePicker
         id="fake_id"
         onChange={mockOnChange}
@@ -54,7 +66,7 @@ describe('DatePicker', () => {
       return <DatePicker id="fake_id" onChange={(e) => setDate(e.value)} value={date} />;
     }
 
-    render(<DatePickerWrap />);
+    renderComp(<DatePickerWrap />);
 
     fireEvent.focus(screen.getByDisplayValue('12/14/2018'));
 
@@ -85,7 +97,7 @@ describe('DatePicker', () => {
       return <DatePicker id="fake_id" onChange={(e) => setDate(e.value)} value={date} />;
     }
 
-    render(<DatePickerWrap />);
+    renderComp(<DatePickerWrap />);
 
     fireEvent.focus(screen.getByDisplayValue('12/14/2018'));
 

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -427,7 +427,7 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
           iconButton={
             controlledInputValue || textfieldInput || (tags && tags.length > 0) ? (
               <InternalTextFieldIconButton
-                accessibilityClearButtonLabel={accessibilityClearButtonLabel}
+                accessibilityLabel={accessibilityClearButtonLabel}
                 hoverStyle="default"
                 icon="cancel"
                 onClick={handleOnClickIconButtonClear}

--- a/packages/gestalt/src/InternalTextFieldIconButton.js
+++ b/packages/gestalt/src/InternalTextFieldIconButton.js
@@ -16,6 +16,7 @@ type Props = {|
   icon: 'arrow-down' | 'cancel' | 'eye' | 'eye-hide',
   onClick: () => void,
   pogPadding?: 1 | 2,
+  role?: 'switch',
   tapStyle?: $ElementType<React$ElementConfig<typeof TapArea>, 'tapStyle'>,
   tooltipText?: string,
 |};
@@ -28,6 +29,7 @@ export default function InternalTextFieldIconButton({
   icon,
   onClick,
   pogPadding = 1,
+  role,
   tapStyle,
   tooltipText,
 }: Props): Node {
@@ -56,7 +58,7 @@ export default function InternalTextFieldIconButton({
           onMouseEnter={() => setFocused(true)}
           onMouseLeave={() => setFocused(false)}
           onTap={onClick}
-          role="switch"
+          role={role}
           rounding="circle"
           tabIndex={accessibilityHidden ? -1 : 0}
           tapStyle={tapStyle}

--- a/packages/gestalt/src/InternalTextFieldIconButton.js
+++ b/packages/gestalt/src/InternalTextFieldIconButton.js
@@ -4,31 +4,36 @@ import classnames from 'classnames';
 import Box from './Box.js';
 import Pog from './Pog.js';
 import TapArea from './TapArea.js';
+import Tooltip from './Tooltip.js';
 import styles from './InternalTextField.css';
 import { TAB, SPACE, ENTER } from './keyCodes.js';
 
 type Props = {|
-  accessibilityLabel?: string,
   accessibilityHidden?: boolean,
+  accessibilityLabel?: string,
+  accessibilityPressed?: boolean,
   hoverStyle?: 'default' | 'none',
   icon: 'arrow-down' | 'cancel' | 'eye' | 'eye-hide',
   onClick: () => void,
   pogPadding?: 1 | 2,
   tapStyle?: $ElementType<React$ElementConfig<typeof TapArea>, 'tapStyle'>,
+  tooltipText?: string,
 |};
 
 export default function InternalTextFieldIconButton({
-  accessibilityLabel,
   accessibilityHidden,
+  accessibilityLabel,
+  accessibilityPressed,
   hoverStyle = 'default',
   icon,
   onClick,
   pogPadding = 1,
   tapStyle,
+  tooltipText,
 }: Props): Node {
   const [focused, setFocused] = useState(false);
 
-  return (
+  const iconButton = (
     // styles.actionButtonContainer is required for RTL positioning
     <div className={classnames(styles.actionButtonContainer)}>
       <Box
@@ -41,6 +46,7 @@ export default function InternalTextFieldIconButton({
       >
         <TapArea
           accessibilityLabel={accessibilityLabel}
+          accessibilityPressed={accessibilityPressed}
           onBlur={() => setFocused(false)}
           onFocus={() => setFocused(true)}
           onKeyDown={({ event }) => {
@@ -50,6 +56,7 @@ export default function InternalTextFieldIconButton({
           onMouseEnter={() => setFocused(true)}
           onMouseLeave={() => setFocused(false)}
           onTap={onClick}
+          role="switch"
           rounding="circle"
           tabIndex={accessibilityHidden ? -1 : 0}
           tapStyle={tapStyle}
@@ -65,5 +72,13 @@ export default function InternalTextFieldIconButton({
         </TapArea>
       </Box>
     </div>
+  );
+
+  return tooltipText ? (
+    <Tooltip inline text={tooltipText}>
+      {iconButton}
+    </Tooltip>
+  ) : (
+    iconButton
   );
 }

--- a/packages/gestalt/src/InternalTextFieldIconButton.js
+++ b/packages/gestalt/src/InternalTextFieldIconButton.js
@@ -9,9 +9,9 @@ import styles from './InternalTextField.css';
 import { TAB, SPACE, ENTER } from './keyCodes.js';
 
 type Props = {|
+  accessibilityChecked?: boolean,
   accessibilityHidden?: boolean,
   accessibilityLabel?: string,
-  accessibilityPressed?: boolean,
   hoverStyle?: 'default' | 'none',
   icon: 'arrow-down' | 'cancel' | 'eye' | 'eye-hide',
   onClick: () => void,
@@ -22,9 +22,9 @@ type Props = {|
 |};
 
 export default function InternalTextFieldIconButton({
+  accessibilityChecked,
   accessibilityHidden,
   accessibilityLabel,
-  accessibilityPressed,
   hoverStyle = 'default',
   icon,
   onClick,
@@ -47,8 +47,8 @@ export default function InternalTextFieldIconButton({
         rounding="circle"
       >
         <TapArea
+          accessibilityChecked={accessibilityChecked}
           accessibilityLabel={accessibilityLabel}
-          accessibilityPressed={accessibilityPressed}
           onBlur={() => setFocused(false)}
           onFocus={() => setFocused(true)}
           onKeyDown={({ event }) => {

--- a/packages/gestalt/src/InternalTextFieldIconButton.js
+++ b/packages/gestalt/src/InternalTextFieldIconButton.js
@@ -8,22 +8,22 @@ import styles from './InternalTextField.css';
 import { TAB, SPACE, ENTER } from './keyCodes.js';
 
 type Props = {|
-  accessibilityClearButtonLabel?: string,
+  accessibilityLabel?: string,
   accessibilityHidden?: boolean,
-  hoverStyle: 'default' | 'none',
+  hoverStyle?: 'default' | 'none',
   icon: 'arrow-down' | 'cancel' | 'eye' | 'eye-hide',
   onClick: () => void,
-  pogPadding: 1 | 2,
-  tapStyle: $ElementType<React$ElementConfig<typeof TapArea>, 'tapStyle'>,
+  pogPadding?: 1 | 2,
+  tapStyle?: $ElementType<React$ElementConfig<typeof TapArea>, 'tapStyle'>,
 |};
 
 export default function InternalTextFieldIconButton({
-  accessibilityClearButtonLabel,
+  accessibilityLabel,
   accessibilityHidden,
-  hoverStyle,
+  hoverStyle = 'default',
   icon,
   onClick,
-  pogPadding,
+  pogPadding = 1,
   tapStyle,
 }: Props): Node {
   const [focused, setFocused] = useState(false);
@@ -40,7 +40,7 @@ export default function InternalTextFieldIconButton({
         rounding="circle"
       >
         <TapArea
-          accessibilityLabel={accessibilityClearButtonLabel}
+          accessibilityLabel={accessibilityLabel}
           onBlur={() => setFocused(false)}
           onFocus={() => setFocused(true)}
           onKeyDown={({ event }) => {

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -45,16 +45,19 @@ type BaseTapArea = {|
   onMouseEnter?: MouseEventHandler,
   onMouseLeave?: MouseEventHandler,
   onTap?: OnTapType,
-  tabIndex?: -1 | 0,
+  role?: 'button' | 'link' | 'switch',
   rounding?: Rounding,
+  tabIndex?: -1 | 0,
   tapStyle?: 'none' | 'compress',
 |};
+
 type TapAreaType = {|
   ...BaseTapArea,
   accessibilityControls?: string,
   accessibilityExpanded?: boolean,
   accessibilityHaspopup?: boolean,
-  role?: 'button',
+  accessibilityPressed?: boolean,
+  role?: 'button' | 'switch',
 |};
 
 type LinkTapAreaType = {|
@@ -225,13 +228,20 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
     );
   }
 
-  const { accessibilityControls, accessibilityExpanded, accessibilityHaspopup } = props;
+  const {
+    accessibilityControls,
+    accessibilityExpanded,
+    accessibilityHaspopup,
+    accessibilityPressed,
+    role,
+  } = props;
   return (
     <div
       aria-controls={accessibilityControls}
       aria-disabled={disabled}
       aria-expanded={accessibilityExpanded}
       aria-haspopup={accessibilityHaspopup}
+      aria-pressed={accessibilityPressed}
       aria-label={accessibilityLabel}
       className={buttonRoleClasses}
       onClick={handleClick}
@@ -257,7 +267,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
       onTouchCancel={handleTouchCancel}
       onTouchEnd={handleTouchEnd}
       ref={innerRef}
-      role="button"
+      role={role ?? 'button'}
       {...(tapStyle === 'compress' && compressStyle && !disabled ? { style: compressStyle } : {})}
       tabIndex={disabled ? null : tabIndex}
     >

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -53,10 +53,10 @@ type BaseTapArea = {|
 
 type TapAreaType = {|
   ...BaseTapArea,
+  accessibilityChecked?: boolean,
   accessibilityControls?: string,
   accessibilityExpanded?: boolean,
   accessibilityHaspopup?: boolean,
-  accessibilityPressed?: boolean,
   role?: 'button' | 'switch',
 |};
 
@@ -232,17 +232,16 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
     accessibilityControls,
     accessibilityExpanded,
     accessibilityHaspopup,
-    accessibilityPressed,
+    accessibilityChecked,
     role,
   } = props;
   return (
     <div
-      aria-checked={role === 'switch' ? accessibilityPressed : undefined}
+      aria-checked={role === 'switch' ? accessibilityChecked : undefined}
       aria-controls={accessibilityControls}
       aria-disabled={disabled}
       aria-expanded={accessibilityExpanded}
       aria-haspopup={accessibilityHaspopup}
-      aria-pressed={accessibilityPressed}
       aria-label={accessibilityLabel}
       className={buttonRoleClasses}
       onClick={handleClick}

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -237,6 +237,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
   } = props;
   return (
     <div
+      aria-checked={role === 'switch' ? accessibilityPressed : undefined}
       aria-controls={accessibilityControls}
       aria-disabled={disabled}
       aria-expanded={accessibilityExpanded}

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -133,9 +133,8 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const isCurrentlyPasswordType = type === 'password';
 
   const inShowPasswordExp = useExperimentContext('my_exp_name');
-  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
-    'TextField',
-  );
+  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
+    useI18nContext('TextField');
 
   const iconButton =
     inShowPasswordExp && isPasswordField ? (

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -142,9 +142,8 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     'mweb_unauth_show_password_button',
   );
   const inShowPasswordExp = inWebShowPasswordExp || inMwebShowPasswordExp;
-  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
-    'TextField',
-  );
+  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
+    useI18nContext('TextField');
 
   const iconButton =
     inShowPasswordExp && isPasswordField ? (

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -1,9 +1,20 @@
 // @flow strict
-import { forwardRef, type Element, type Node } from 'react';
-import Tag from './Tag.js';
+import { forwardRef, type Element, type Node, useState } from 'react';
 import InternalTextField from './InternalTextField.js';
+import InternalTextFieldIconButton from './InternalTextFieldIconButton.js';
+import Tag from './Tag.js';
+
+type Type = 'date' | 'email' | 'password' | 'tel' | 'text' | 'url';
 
 type Props = {|
+  /**
+   * Label for the "Hide password" button. Required when `type="password"`. Be sure to localize the label.
+   */
+  accessibilityHidePasswordLabel?: string,
+  /**
+   * Label for the "Show password" button. Required when `type="password"`. Be sure to localize the label.
+   */
+  accessibilityShowPasswordLabel?: string,
   /**
    * Indicate if autocomplete should be available on the input, and the type of autocomplete.
    */
@@ -79,7 +90,7 @@ type Props = {|
   /**
    * The type of input. For non-telephone numerical input, please use [NumberField](https://gestalt.pinterest.systems/numberfield).
    */
-  type?: 'date' | 'email' | 'password' | 'tel' | 'text' | 'url',
+  type?: Type,
   /**
    * md: 40px, lg: 48px
    */
@@ -102,6 +113,8 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   HTMLInputElement,
 >(function TextField(
   {
+    accessibilityHidePasswordLabel,
+    accessibilityShowPasswordLabel,
     autoComplete,
     disabled = false,
     errorMessage,
@@ -117,11 +130,31 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     placeholder,
     size = 'md',
     tags,
-    type = 'text',
+    type: typeProp = 'text',
     value,
   }: Props,
   ref,
 ): Node {
+  const [type, setType] = useState<Type>(typeProp);
+
+  const isPasswordField = typeProp === 'password';
+  const isCurrentlyPasswordType = type === 'password';
+
+  // TODO:
+  // - Wrap this in experiment
+  // - Tooltip?
+  const iconButton = isPasswordField ? (
+    <InternalTextFieldIconButton
+      accessibilityLabel={
+        isCurrentlyPasswordType ? accessibilityShowPasswordLabel : accessibilityHidePasswordLabel
+      }
+      icon={isCurrentlyPasswordType ? 'eye' : 'eye-hide'}
+      onClick={() => {
+        setType(isCurrentlyPasswordType ? 'text' : 'password');
+      }}
+    />
+  ) : undefined;
+
   return (
     <InternalTextField
       autoComplete={autoComplete}
@@ -129,6 +162,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
       errorMessage={errorMessage}
       hasError={hasError}
       helperText={helperText}
+      iconButton={iconButton}
       id={id}
       label={label}
       name={name}

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -3,6 +3,7 @@ import { forwardRef, type Element, type Node, useState } from 'react';
 import InternalTextField from './InternalTextField.js';
 import InternalTextFieldIconButton from './InternalTextFieldIconButton.js';
 import Tag from './Tag.js';
+import { useExperimentContext } from './contexts/ExperimentProvider.js';
 
 type Type = 'date' | 'email' | 'password' | 'tel' | 'text' | 'url';
 
@@ -140,20 +141,23 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const isPasswordField = typeProp === 'password';
   const isCurrentlyPasswordType = type === 'password';
 
+  const inShowPasswordExp = useExperimentContext('my_exp_name');
+
   // TODO:
-  // - Wrap this in experiment
   // - Tooltip?
-  const iconButton = isPasswordField ? (
-    <InternalTextFieldIconButton
-      accessibilityLabel={
-        isCurrentlyPasswordType ? accessibilityShowPasswordLabel : accessibilityHidePasswordLabel
-      }
-      icon={isCurrentlyPasswordType ? 'eye' : 'eye-hide'}
-      onClick={() => {
-        setType(isCurrentlyPasswordType ? 'text' : 'password');
-      }}
-    />
-  ) : undefined;
+  // - I18nContext?
+  const iconButton =
+    inShowPasswordExp && isPasswordField ? (
+      <InternalTextFieldIconButton
+        accessibilityLabel={
+          isCurrentlyPasswordType ? accessibilityShowPasswordLabel : accessibilityHidePasswordLabel
+        }
+        icon={isCurrentlyPasswordType ? 'eye' : 'eye-hide'}
+        onClick={() => {
+          setType(isCurrentlyPasswordType ? 'text' : 'password');
+        }}
+      />
+    ) : undefined;
 
   return (
     <InternalTextField

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -139,9 +139,8 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     'mweb_unauth_show_password_button',
   );
   const inShowPasswordExp = inWebShowPasswordExp || inMwebShowPasswordExp;
-  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
-    'TextField',
-  );
+  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
+    useI18nContext('TextField');
 
   const iconButton =
     inShowPasswordExp && isPasswordField ? (

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -4,18 +4,11 @@ import InternalTextField from './InternalTextField.js';
 import InternalTextFieldIconButton from './InternalTextFieldIconButton.js';
 import Tag from './Tag.js';
 import { useExperimentContext } from './contexts/ExperimentProvider.js';
+import { useI18nContext } from './contexts/I18nProvider.js';
 
 type Type = 'date' | 'email' | 'password' | 'tel' | 'text' | 'url';
 
 type Props = {|
-  /**
-   * Label for the "Hide password" button. Required when `type="password"`. Be sure to localize the label.
-   */
-  accessibilityHidePasswordLabel?: string,
-  /**
-   * Label for the "Show password" button. Required when `type="password"`. Be sure to localize the label.
-   */
-  accessibilityShowPasswordLabel?: string,
   /**
    * Indicate if autocomplete should be available on the input, and the type of autocomplete.
    */
@@ -114,8 +107,6 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   HTMLInputElement,
 >(function TextField(
   {
-    accessibilityHidePasswordLabel,
-    accessibilityShowPasswordLabel,
     autoComplete,
     disabled = false,
     errorMessage,
@@ -142,14 +133,17 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const isCurrentlyPasswordType = type === 'password';
 
   const inShowPasswordExp = useExperimentContext('my_exp_name');
+  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
+    'TextField',
+  );
 
-  // TODO:
-  // - I18nContext?
   const iconButton =
     inShowPasswordExp && isPasswordField ? (
       <InternalTextFieldIconButton
         accessibilityLabel={
-          isCurrentlyPasswordType ? accessibilityShowPasswordLabel : accessibilityHidePasswordLabel
+          isCurrentlyPasswordType
+            ? accessibilityShowPasswordLabel ?? ''
+            : accessibilityHidePasswordLabel ?? ''
         }
         accessibilityPressed={!isCurrentlyPasswordType}
         icon={isCurrentlyPasswordType ? 'eye' : 'eye-hide'}
@@ -157,7 +151,9 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
           setType(isCurrentlyPasswordType ? 'text' : 'password');
         }}
         tooltipText={
-          isCurrentlyPasswordType ? accessibilityShowPasswordLabel : accessibilityHidePasswordLabel
+          isCurrentlyPasswordType
+            ? accessibilityShowPasswordLabel ?? ''
+            : accessibilityHidePasswordLabel ?? ''
         }
       />
     ) : undefined;

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -144,7 +144,6 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const inShowPasswordExp = useExperimentContext('my_exp_name');
 
   // TODO:
-  // - Tooltip?
   // - I18nContext?
   const iconButton =
     inShowPasswordExp && isPasswordField ? (
@@ -152,10 +151,14 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
         accessibilityLabel={
           isCurrentlyPasswordType ? accessibilityShowPasswordLabel : accessibilityHidePasswordLabel
         }
+        accessibilityPressed={!isCurrentlyPasswordType}
         icon={isCurrentlyPasswordType ? 'eye' : 'eye-hide'}
         onClick={() => {
           setType(isCurrentlyPasswordType ? 'text' : 'password');
         }}
+        tooltipText={
+          isCurrentlyPasswordType ? accessibilityShowPasswordLabel : accessibilityHidePasswordLabel
+        }
       />
     ) : undefined;
 

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -132,9 +132,16 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const isPasswordField = typeProp === 'password';
   const isCurrentlyPasswordType = type === 'password';
 
-  const inShowPasswordExp = useExperimentContext('my_exp_name');
-  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
-    useI18nContext('TextField');
+  const { anyEnabled: inWebShowPasswordExp } = useExperimentContext(
+    'web_unauth_show_password_button',
+  );
+  const { anyEnabled: inMwebShowPasswordExp } = useExperimentContext(
+    'mweb_unauth_show_password_button',
+  );
+  const inShowPasswordExp = inWebShowPasswordExp || inMwebShowPasswordExp;
+  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
+    'TextField',
+  );
 
   const iconButton =
     inShowPasswordExp && isPasswordField ? (

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -145,12 +145,12 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const iconButton =
     inShowPasswordExp && isPasswordField ? (
       <InternalTextFieldIconButton
+        accessibilityChecked={!isCurrentlyPasswordType}
         accessibilityLabel={
           isCurrentlyPasswordType
             ? accessibilityShowPasswordLabel ?? ''
             : accessibilityHidePasswordLabel ?? ''
         }
-        accessibilityPressed={!isCurrentlyPasswordType}
         icon={isCurrentlyPasswordType ? 'eye' : 'eye-hide'}
         onClick={() => {
           setType(isCurrentlyPasswordType ? 'text' : 'password');

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -127,6 +127,9 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   }: Props,
   ref,
 ): Node {
+  /**
+   * Yes, this is initializing a state variable with a prop value and then disregarding the prop value — often a code smell, I know. This is necessary to internalize the effective input type (password vs text) and not force the user to handle responding to clicks on the button
+   */
   const [type, setType] = useState<Type>(typeProp);
 
   const isPasswordField = typeProp === 'password';
@@ -139,8 +142,9 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     'mweb_unauth_show_password_button',
   );
   const inShowPasswordExp = inWebShowPasswordExp || inMwebShowPasswordExp;
-  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
-    useI18nContext('TextField');
+  const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
+    'TextField',
+  );
 
   const iconButton =
     inShowPasswordExp && isPasswordField ? (

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -156,6 +156,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
         onClick={() => {
           setType(isCurrentlyPasswordType ? 'text' : 'password');
         }}
+        role="switch"
         tooltipText={
           isCurrentlyPasswordType
             ? accessibilityShowPasswordLabel ?? ''

--- a/packages/gestalt/src/TextField.jsdom.test.js
+++ b/packages/gestalt/src/TextField.jsdom.test.js
@@ -3,6 +3,8 @@ import { createRef } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import TextField from './TextField.js';
 
+jest.mock('./contexts/I18nProvider.js');
+
 describe('TextField', () => {
   it('renders error message on errorMessage prop change', () => {
     const { getByText, rerender } = render(

--- a/packages/gestalt/src/TextField.test.js
+++ b/packages/gestalt/src/TextField.test.js
@@ -3,6 +3,8 @@ import { create } from 'react-test-renderer';
 import Tag from './Tag.js';
 import TextField from './TextField.js';
 
+jest.mock('./contexts/I18nProvider.js');
+
 describe('TextField', () => {
   it('Renders an FormErrorMessage if an error message is passed in', () => {
     const component = create(

--- a/packages/gestalt/src/Upsell.jsdom.test.js
+++ b/packages/gestalt/src/Upsell.jsdom.test.js
@@ -2,6 +2,8 @@
 import { render } from '@testing-library/react';
 import Upsell from './Upsell.js';
 
+jest.mock('./contexts/I18nProvider.js');
+
 test('Upsell handles onDismiss callback', () => {
   const mockOnDismiss = jest.fn();
   const { getByLabelText } = render(

--- a/packages/gestalt/src/Upsell.test.js
+++ b/packages/gestalt/src/Upsell.test.js
@@ -4,6 +4,8 @@ import Icon from './Icon.js';
 import TextField from './TextField.js';
 import Upsell from './Upsell.js';
 
+jest.mock('./contexts/I18nProvider.js');
+
 describe('<Upsell />', () => {
   test('Basic Upsell', () => {
     const tree = create(<Upsell message="Insert a clever upsell message here" />).toJSON();

--- a/packages/gestalt/src/UpsellForm.test.js
+++ b/packages/gestalt/src/UpsellForm.test.js
@@ -3,6 +3,8 @@ import { create } from 'react-test-renderer';
 import TextField from './TextField.js';
 import UpsellForm from './UpsellForm.js';
 
+jest.mock('./contexts/I18nProvider.js');
+
 describe('UpsellForm', () => {
   it('renders', () => {
     const tree = create(

--- a/packages/gestalt/src/contexts/ExperimentProvider.js
+++ b/packages/gestalt/src/contexts/ExperimentProvider.js
@@ -20,5 +20,5 @@ export default ExperimentProvider;
 
 export function useExperimentContext(experimentName: string): Experiment {
   const experiments = useContext(ExperimentContext) ?? {};
-  return experiments[experimentName];
+  return experiments[experimentName] ?? {};
 }

--- a/packages/gestalt/src/contexts/I18nProvider.js
+++ b/packages/gestalt/src/contexts/I18nProvider.js
@@ -58,9 +58,11 @@ export function useI18nContext<C: ValidComponent>(
   );
   const missingAndNullTranslations = [...nullTranslations, ...missingTranslations];
   if (missingAndNullTranslations.length > 0) {
-    const multipleMissing = missingTranslations.length > 1;
+    const multipleMissing = missingAndNullTranslations.length > 1;
     throw new Error(
-      `${componentName} prop${multipleMissing ? 's' : ''} ${missingTranslations.join(', ')} ${
+      `${componentName} prop${multipleMissing ? 's' : ''} ${missingAndNullTranslations.join(
+        ', ',
+      )} ${
         multipleMissing ? 'are' : 'is'
       } missing translations — please add translations to I18nProvider`,
     );

--- a/packages/gestalt/src/contexts/I18nProvider.js
+++ b/packages/gestalt/src/contexts/I18nProvider.js
@@ -6,9 +6,10 @@ import { type Context, createContext, useContext } from 'react';
  * - Create a type for the component's translations (these types need to be flat, *not* nested)
  * - Add component translation type to I18nContextType keyed by component name
  * - Add component translation object to initialContext using `null` for all values
+ * - Add default translations to the mock file (./__mocks__/I18nProvider.js) and docs/components/contexts/DocsExperimentProvider.js
  */
 
-type I18nContextType = {|
+export type I18nContextType = {|
   TextField: {|
     accessibilityHidePasswordLabel: ?string,
     accessibilityShowPasswordLabel: ?string,

--- a/packages/gestalt/src/contexts/__mocks__/I18nProvider.js
+++ b/packages/gestalt/src/contexts/__mocks__/I18nProvider.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { createContext, type Context, useContext } from 'react';
+// eslint-disable-next-line import/no-relative-parent-imports
+import { type I18nContextType } from '../I18nProvider.js';
+
+const translations: I18nContextType = {
+  TextField: {
+    accessibilityHidePasswordLabel: 'Hide password',
+    accessibilityShowPasswordLabel: 'Show password',
+  },
+};
+
+const MockContext: Context<I18nContextType> = createContext<I18nContextType>(translations);
+const I18nProvider = MockContext.Provider;
+export default I18nProvider;
+
+type ValidComponent = $Keys<I18nContextType>;
+
+export function useI18nContext<C: ValidComponent>(
+  componentName: C,
+): $ElementType<I18nContextType, C> {
+  const propsTranslations = useContext(MockContext);
+  return propsTranslations[componentName];
+}


### PR DESCRIPTION
Currently TextField doesn't give users any way of viewing what they've typed so far when `type="password"`. This is a frustrating UX and is likely leading to failed logins. This PR adds an experimental "show/hide password" button to solve this problem.
<img width="377" alt="Screen Shot 2022-03-17 at 5 32 06 PM" src="https://user-images.githubusercontent.com/12059539/160717777-bfac9640-5782-4d62-8d6c-8575701defee.png">
<img width="374" alt="Screen Shot 2022-03-17 at 5 32 12 PM" src="https://user-images.githubusercontent.com/12059539/160717781-f5131a4e-0926-4eed-8820-1df6e2a2d010.png">

