### PR TITLE
IconButton: add type prop

### DIFF
--- a/docs/pages/iconbutton.js
+++ b/docs/pages/iconbutton.js
@@ -10,9 +10,9 @@ import Page from '../components/Page.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
-    <Page title="IconButton">
+    <Page title={generatedDocGen?.displayName}>
       <PageHeader
-        name="IconButton"
+        name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
         defaultCode={`
 function SectionsIconButtonDropdownExample() {
@@ -141,13 +141,6 @@ function SectionsIconButtonDropdownExample() {
               'Forward the ref to the underlying button or anchor element. See the [ref](#Ref) variant to learn more.',
           },
           {
-            name: 'tabIndex',
-            type: `-1 | 0`,
-            defaultValue: 0,
-            description:
-              'Removes IconButton from sequential keyboard navigation to improve accessibility. See the [Accessibility](#Keyboard-interaction) guidelines for details on proper usage.',
-          },
-          {
             name: 'role',
             type: `'button' | 'link'`,
             defaultValue: 'button',
@@ -162,6 +155,13 @@ function SectionsIconButtonDropdownExample() {
               'The maximum height and width of IconButton. See the [size](#Size) variant to learn more.',
           },
           {
+            name: 'tabIndex',
+            type: `-1 | 0`,
+            defaultValue: 0,
+            description:
+              'Removes IconButton from sequential keyboard navigation to improve accessibility. See the [Accessibility](#Keyboard-interaction) guidelines for details on proper usage.',
+          },
+          {
             name: 'tooltip',
             type: `{| text: string, accessibilityLabel?: string, inline?: boolean, idealDirection?: 'up' | 'right' | 'down' | 'left', zIndex?: Indexable, |}`,
             description: `Adds a [Tooltip](/tooltip) on hover/focus of the IconButton. See the [With Tooltip](#With-Tooltip) variant to learn more.`,
@@ -170,15 +170,9 @@ function SectionsIconButtonDropdownExample() {
       />
       <PropTable
         Component={IconButton}
-        name="Additional role = button"
+        name='Additional role="button"'
         id="role_button"
         props={[
-          {
-            name: 'role',
-            type: 'button',
-            description:
-              'Sets button interaction in the component. See the [role](#Role) variant to learn more.',
-          },
           {
             name: 'accessibilityControls',
             type: 'string',
@@ -198,25 +192,31 @@ function SectionsIconButtonDropdownExample() {
               'Indicates that a component controls the appearance of interactive popup elements, such as menu or dialog. See the [Accessibility](#ARIA-attributes) guidelines for details on proper usage.',
           },
           {
+            name: 'role',
+            type: 'button',
+            description:
+              'Sets button interaction in the component. See the [role](#Role) variant to learn more.',
+          },
+          {
             name: 'selected',
             type: 'boolean',
             description:
               'Toggles between binary states: on/off, selected/unselected, open/closed. See the [selected](#Selected-state) variant to learn more.',
           },
+          {
+            name: 'type',
+            type: `'submit' | 'button'`,
+            required: false,
+            defaultValue: 'button',
+            description: 'Use "submit" if IconButton is used within or associated with a form.',
+          },
         ]}
       />
       <PropTable
         Component={IconButton}
-        name="Additional role = link"
+        name='Additional role="link"'
         id="role_link"
         props={[
-          {
-            name: 'role',
-            type: 'link',
-            required: true,
-            description:
-              'Sets link interaction in the component. See the [role](#Role) variant and [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
-          },
           {
             name: 'href',
             type: 'string',
@@ -228,6 +228,13 @@ function SectionsIconButtonDropdownExample() {
             type: `'none' | 'nofollow'`,
             description:
               'Specifies the relationship between the current document and the linked document. See the [role](#Role) variant to learn more.',
+          },
+          {
+            name: 'role',
+            type: 'link',
+            required: true,
+            description:
+              'Sets link interaction in the component. See the [role](#Role) variant and [OnLinkNavigationProvider](/onlinknavigationprovider) to learn more about link navigation.',
           },
           {
             name: 'target',

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -6,29 +6,19 @@ import InternalLink from './InternalLink.js';
 import Pog from './Pog.js';
 import Tooltip from './Tooltip.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import { type Indexable } from './zIndex.js';
 import styles from './IconButton.css';
 import touchableStyles from './Touchable.css';
-import useTapFeedback from './useTapFeedback.js';
 import useFocusVisible from './useFocusVisible.js';
-import { type Indexable } from './zIndex.js';
+import useTapFeedback from './useTapFeedback.js';
 
-type TooltipType = {|
-  text: string,
+type TooltipProps = {|
   accessibilityLabel?: string,
   inline?: boolean,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
+  text: string,
   zIndex?: Indexable,
 |};
-
-function TooltipComponent({
-  children,
-  tooltipProps,
-}: {|
-  children: Node,
-  tooltipProps: TooltipType,
-|}): Node {
-  return tooltipProps.text ? <Tooltip {...tooltipProps}>{children}</Tooltip> : children;
-}
 
 type BaseIconButton = {|
   accessibilityLabel: string,
@@ -53,7 +43,7 @@ type BaseIconButton = {|
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   padding?: 1 | 2 | 3 | 4 | 5,
   tabIndex?: -1 | 0,
-  tooltip?: TooltipType,
+  tooltip?: TooltipProps,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
@@ -64,6 +54,7 @@ type IconButtonType = {|
   accessibilityHaspopup?: boolean,
   role?: 'button',
   selected?: boolean,
+  type?: 'submit' | 'button',
 |};
 
 type LinkIconButtonType = {|
@@ -181,96 +172,97 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
     setHovered(false);
   };
 
-  const createLinkIconButton = (href, rel, target) => (
-    <InternalLink
-      accessibilityLabel={accessibilityLabel}
-      disabled={disabled}
-      href={href}
-      onClick={handleLinkClick}
-      onBlur={handleOnBlur}
-      onFocus={handleOnFocus}
-      onMouseDown={handleOnMouseDown}
-      onMouseUp={handleOnMouseUp}
-      onMouseEnter={handleOnMouseEnter}
-      onMouseLeave={handleOnMouseLeave}
-      ref={innerRef}
-      rel={rel}
-      tabIndex={tabIndex}
-      target={target}
-      wrappedComponent="iconButton"
-    >
-      {renderPogComponent()}
-    </InternalLink>
-  );
-
-  const createIconButton = (
-    accessibilityControls,
-    accessibilityExpanded,
-    accessibilityHaspopup,
-    selected,
-  ) => (
-    <button
-      aria-controls={accessibilityControls}
-      aria-expanded={accessibilityExpanded}
-      aria-haspopup={accessibilityHaspopup}
-      aria-label={accessibilityLabel}
-      className={classnames(styles.parentButton)}
-      disabled={disabled}
-      onBlur={() => {
-        handleBlur();
-        handleOnBlur();
-      }}
-      onClick={handleClick}
-      onFocus={handleOnFocus}
-      onMouseDown={() => {
-        handleMouseDown();
-        handleOnMouseDown();
-      }}
-      onMouseEnter={handleOnMouseEnter}
-      onMouseLeave={handleOnMouseLeave}
-      onMouseUp={() => {
-        handleMouseUp();
-        handleOnMouseUp();
-      }}
-      onTouchCancel={handleTouchCancel}
-      onTouchEnd={handleTouchEnd}
-      onTouchMove={handleTouchMove}
-      onTouchStart={handleTouchStart}
-      ref={innerRef}
-      tabIndex={disabled ? null : tabIndex}
-      type="button"
-    >
-      <div
-        className={classnames(styles.button, touchableStyles.tapTransition, {
-          [styles.disabled]: disabled,
-          [styles.enabled]: !disabled,
-          [touchableStyles.tapCompress]: props.role !== 'link' && !disabled && isTapping,
-        })}
-        style={compressStyle || undefined}
-      >
-        {renderPogComponent(selected)}
-      </div>
-    </button>
-  );
-
-  let buttonComponentToRender = null;
+  let buttonComponent = null;
 
   if (props.role === 'link') {
     const { href, rel, target } = props;
-    buttonComponentToRender = createLinkIconButton(href, rel, target);
+    buttonComponent = (
+      <InternalLink
+        accessibilityLabel={accessibilityLabel}
+        disabled={disabled}
+        href={href}
+        onClick={handleLinkClick}
+        onBlur={handleOnBlur}
+        onFocus={handleOnFocus}
+        onMouseDown={handleOnMouseDown}
+        onMouseUp={handleOnMouseUp}
+        onMouseEnter={handleOnMouseEnter}
+        onMouseLeave={handleOnMouseLeave}
+        ref={innerRef}
+        rel={rel}
+        tabIndex={tabIndex}
+        target={target}
+        wrappedComponent="iconButton"
+      >
+        {renderPogComponent()}
+      </InternalLink>
+    );
   } else {
-    const { accessibilityControls, accessibilityExpanded, accessibilityHaspopup, selected } = props;
-    buttonComponentToRender = createIconButton(
+    const {
       accessibilityControls,
       accessibilityExpanded,
       accessibilityHaspopup,
       selected,
+      type,
+    } = props;
+    buttonComponent = (
+      <button
+        aria-controls={accessibilityControls}
+        aria-expanded={accessibilityExpanded}
+        aria-haspopup={accessibilityHaspopup}
+        aria-label={accessibilityLabel}
+        className={classnames(styles.parentButton)}
+        disabled={disabled}
+        onBlur={() => {
+          handleBlur();
+          handleOnBlur();
+        }}
+        onClick={handleClick}
+        onFocus={handleOnFocus}
+        onMouseDown={() => {
+          handleMouseDown();
+          handleOnMouseDown();
+        }}
+        onMouseEnter={handleOnMouseEnter}
+        onMouseLeave={handleOnMouseLeave}
+        onMouseUp={() => {
+          handleMouseUp();
+          handleOnMouseUp();
+        }}
+        onTouchCancel={handleTouchCancel}
+        onTouchEnd={handleTouchEnd}
+        onTouchMove={handleTouchMove}
+        onTouchStart={handleTouchStart}
+        ref={innerRef}
+        tabIndex={disabled ? null : tabIndex}
+        // react/button-has-type is very particular about this verbose syntax
+        type={type === 'submit' ? 'submit' : 'button'}
+      >
+        <div
+          className={classnames(styles.button, touchableStyles.tapTransition, {
+            [styles.disabled]: disabled,
+            [styles.enabled]: !disabled,
+            [touchableStyles.tapCompress]: props.role !== 'link' && !disabled && isTapping,
+          })}
+          style={compressStyle || undefined}
+        >
+          {renderPogComponent(selected)}
+        </div>
+      </button>
     );
   }
-  return tooltip ? (
-    <TooltipComponent tooltipProps={tooltip}>{buttonComponentToRender}</TooltipComponent>
+  return tooltip?.text ? (
+    <Tooltip
+      accessibilityLabel={tooltip.accessibilityLabel}
+      inline={tooltip.inline}
+      idealDirection={tooltip.idealDirection}
+      text={tooltip.text}
+      zIndex={tooltip.zIndex}
+    >
+      {buttonComponent}
+    </Tooltip>
   ) : (
-    buttonComponentToRender
+    buttonComponent
   );
 });
 


### PR DESCRIPTION
In some situations, particularly UIs with space constraints, it can make sense to use icon buttons for form submission. To enable this, this PR adds a `type` prop to IconButton (similar to Button's `type` prop).