### PR TITLE
ExperimentProvider: create new Context

### DIFF
--- a/packages/gestalt/src/contexts/ExperimentProvider.js
+++ b/packages/gestalt/src/contexts/ExperimentProvider.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { type Context, createContext, useContext } from 'react';
+
+type Experiment = {|
+  anyEnabled: boolean,
+  group: string,
+|};
+
+type ExperimentContextType = {|
+  [experimentName: string]: Experiment,
+|};
+
+const ExperimentContext: Context<ExperimentContextType> = createContext<ExperimentContextType>({});
+
+/**
+ * *ALPHA - DO NOT USE YET - MAY HAVE BREAKING CHANGES IN THE NEAR FUTURE*
+ */
+const ExperimentProvider = ExperimentContext.Provider;
+export default ExperimentProvider;
+
+export function useExperimentContext(experimentName: string): Experiment {
+  const experiments = useContext(ExperimentContext) ?? {};
+  return experiments[experimentName];
+}

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -21,6 +21,7 @@ import Datapoint from './Datapoint.js';
 import DeviceTypeProvider from './contexts/DeviceTypeProvider.js';
 import Divider from './Divider.js';
 import Dropdown from './Dropdown.js';
+import ExperimentProvider from './contexts/ExperimentProvider.js';
 import Fieldset from './Fieldset.js';
 import Flex from './Flex.js';
 import Heading from './Heading.js';
@@ -92,6 +93,7 @@ export {
   DeviceTypeProvider,
   Divider,
   Dropdown,
+  ExperimentProvider,
   Fieldset,
   FixedZIndex,
   Flex,


### PR DESCRIPTION
[plan for experimentation in Gestalt](https://paper.dropbox.com/doc/Experimentation-in-Gestalt--BddgXa8eh85dBvzWzoUx3ki0Ag-SG2FCNEsklOe5lJ7gznTa)

tl;dr of that ⬆️ doc: we need a better way of running experiments on Gestalt components. Undocumented props (`_expProp`) aren't great.

This PR creates a new ExperimentProvider which I'll implement in Pinboard and start playing around with. Similar to DeviceTypeProvider, this is an alpha and the API may change considerably in the near future, so I'm leaving it undocumented for now. I'll add documentation when our story around experimentation in Gestalt components is a bit more solidified.