### PR TITLE
SelectList: Add option for hidden label

### DIFF
--- a/docs/pages/combobox.js
+++ b/docs/pages/combobox.js
@@ -96,7 +96,7 @@ function ComboBoxExample(props) {
         <MainSection.Subsection
           title="Labels"
           description={`
-      ComboBox requires both \`label\` and \`accessibilityClearButtonLabel\`. By default, the \`label\` is visible above TextField. However, if the form items are labelled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.
+      ComboBox requires both \`label\` and \`accessibilityClearButtonLabel\`. By default, the \`label\` is visible above TextField. However, if the form items are labeled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.
 
       In the example below, the "Discover this week's top searched trends across all categories" text is acting as a heading, so instead of repeating another label, we visually hide the label. When a user focuses on the ComboBox, a screen reader will announce "Choose a category to display top search trends, Select category".
       `}

--- a/docs/pages/fieldset.js
+++ b/docs/pages/fieldset.js
@@ -156,7 +156,7 @@ function RadioButtonExample() {
       <MainSection name="Variants">
         <MainSection.Subsection
           description={`
-      By default, the \`legend\` is visible above the items in the Fieldset. However, if the form items are labelled by content elsewhere on the page, or a more complex legend is needed, the \`legendDisplay\` prop can be used to visually hide the legend. In this case, it is still available to screen reader users, but will not appear visually on the screen.
+      By default, the \`legend\` is visible above the items in the Fieldset. However, if the form items are labeled by content elsewhere on the page, or a more complex legend is needed, the \`legendDisplay\` prop can be used to visually hide the legend. In this case, it is still available to screen reader users, but will not appear visually on the screen.
 
       In the example below, the "Company Account Goals" text is acting as a heading and a legend for the checkboxes, so instead of repeating another legend, we visually hide the Fieldset \`legend\`. When a user focuses on the first checkbox, a screen reader will announce "Sell more products, unchecked, checkbox, Choose up to 3 company account goals, group".
       `}

--- a/docs/pages/selectlist.js
+++ b/docs/pages/selectlist.js
@@ -1,6 +1,5 @@
 // @flow strict
 import { type Node } from 'react';
-import { Flex } from 'gestalt';
 import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';

--- a/docs/pages/selectlist.js
+++ b/docs/pages/selectlist.js
@@ -269,7 +269,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
           description={`
       SelectList comes with [Label](/label) built-in: just use the \`label\` prop. We strongly encourage always supplying a label. Be sure to provide a unique \`id\` so the Label is associated with the correct SelectList.
 
-      If SelectList is labelled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.`}
+      If SelectList is labeled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.`}
         >
           <MainSection.Card
             defaultCode={`

--- a/docs/pages/selectlist.js
+++ b/docs/pages/selectlist.js
@@ -275,7 +275,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
             defaultCode={`
 <Flex gap={6}>
   <SelectList
-    id="selectlistexampleHiddenLabel"
+    id="selectlistexampleA11yVisible"
     onChange={() => {}}
     options={[
       {label: 'Last 5 days', value: '5'},
@@ -290,7 +290,7 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
   <Flex gap={2} direction="column">
     <Text weight="bold" size="300">Date range</Text>
     <SelectList
-      id="selectlistexampleHiddenLabel"
+      id="selectlistexampleA11yHiddenLabel"
       onChange={() => {}}
       options={[
         {label: 'Last 5 days', value: '5'},

--- a/docs/pages/selectlist.js
+++ b/docs/pages/selectlist.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
+import { Flex } from 'gestalt';
 import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
 import MainSection from '../components/MainSection.js';
@@ -267,8 +268,47 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
         <MainSection.Subsection
           title="Labels"
           description={`
-      SelectList comes with [Label](/label) built-in: just use the \`label\` prop. We strongly encourage always supplying a label. Be sure to provide a unique \`id\` so the Label is associated with the correct SelectList.`}
-        />
+      SelectList comes with [Label](/label) built-in: just use the \`label\` prop. We strongly encourage always supplying a label. Be sure to provide a unique \`id\` so the Label is associated with the correct SelectList.
+
+      If SelectList is labelled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.`}
+        >
+          <MainSection.Card
+            defaultCode={`
+<Flex gap={6}>
+  <SelectList
+    id="selectlistexampleHiddenLabel"
+    onChange={() => {}}
+    options={[
+      {label: 'Last 5 days', value: '5'},
+      {label: 'Last week', value: '7'},
+      {label: 'Last 30 days', value: '30'},
+      {label: 'Last sixth months', value: '6m'},
+      {label: 'Last year', value: '365'},
+    ]}
+    label='Date range'
+    size='lg'
+  />
+  <Flex gap={2} direction="column">
+    <Text weight="bold" size="300">Date range</Text>
+    <SelectList
+      id="selectlistexampleHiddenLabel"
+      onChange={() => {}}
+      options={[
+        {label: 'Last 5 days', value: '5'},
+        {label: 'Last week', value: '7'},
+        {label: 'Last 30 days', value: '30'},
+        {label: 'Last sixth months', value: '6m'},
+        {label: 'Last year', value: '365'},
+      ]}
+      label='Date range'
+      labelDisplay="hidden"
+      size='lg'
+    />
+  </Flex>
+</Flex>
+`}
+          />
+        </MainSection.Subsection>
       </MainSection>
 
       <MainSection name="Variants">
@@ -312,6 +352,33 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
     size='md'
     label='Country'
   />`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Label visibility"
+          description={`In some cases, the label for a SelectList is represented in a different way visually, as demonstrated below. In these instances, you can set \`labelDisplay="hidden"\` to ensure SelectList is properly labeled for screen readers while using a different element to represent the label visually.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+            <Flex gap={2} direction="column">
+<Text weight="bold" size="300">Date range</Text>
+<SelectList
+  id="selectlistexampleHiddenLabel"
+  onChange={() => {}}
+  options={[
+    {label: 'Last 5 days', value: '5'},
+    {label: 'Last week', value: '7'},
+    {label: 'Last 30 days', value: '30'},
+    {label: 'Last sixth months', value: '6m'},
+    {label: 'Last year', value: '365'},
+  ]}
+  label='Date range'
+  labelDisplay="hidden"
+  size='lg'
+/>
+</Flex>
+`}
           />
         </MainSection.Subsection>
         <MainSection.Subsection

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -33,6 +33,10 @@ type Props = {|
    */
   label?: string,
   /**
+   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
+   */
+  labelDisplay?: 'visible' | 'hidden',
+  /**
    * Used to specify the name of the control.
    */
   name?: string,
@@ -71,6 +75,7 @@ export default function SelectList({
   helperText,
   id,
   label,
+  labelDisplay = 'visible',
   name,
   onChange,
   options,
@@ -107,7 +112,7 @@ export default function SelectList({
 
   return (
     <Box>
-      {label && <FormLabel id={id} label={label} />}
+      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} />}
       <Box
         color={disabled ? 'lightGray' : 'white'}
         display="flex"

--- a/packages/gestalt/src/SelectList.test.js
+++ b/packages/gestalt/src/SelectList.test.js
@@ -51,4 +51,17 @@ describe('SelectList', () => {
     const tree = create(<SelectList id="test" onChange={jest.fn()} options={options} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('SelectList with a hidden label', () => {
+    const tree = create(
+      <SelectList
+        label="testing"
+        labelDisplay="hidden"
+        id="test"
+        onChange={jest.fn()}
+        options={options}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
@@ -64,3 +64,82 @@ exports[`SelectList SelectList normal 1`] = `
   </div>
 </div>
 `;
+
+exports[`SelectList SelectList with a hidden label 1`] = `
+<div
+  className="box"
+>
+  <label
+    className="label visuallyHidden"
+    htmlFor="test"
+  >
+    <div
+      className="formLabel"
+    >
+      <div
+        className="Text fontSize100 darkGray alignStart breakWord fontWeightNormal"
+      >
+        testing
+      </div>
+    </div>
+  </label>
+  <div
+    className="box relative rounding4 whiteBg xsDisplayFlex"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="absolute bottom0 box itemsCenter right0 top0 xsDisplayFlex"
+      style={
+        Object {
+          "paddingRight": 14,
+          "paddingTop": 2,
+        }
+      }
+    >
+      <svg
+        aria-hidden={true}
+        aria-label=""
+        className="icon darkGray iconBlock"
+        height={12}
+        role="img"
+        viewBox="0 0 24 24"
+        width={12}
+      >
+        <path
+          d="test-file-stub"
+        />
+      </svg>
+    </div>
+    <select
+      aria-describedby={null}
+      aria-invalid="false"
+      className="select base enabled normal medium"
+      disabled={false}
+      id="test"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+    >
+      <option
+        value="value1"
+      >
+        option1
+      </option>
+      <option
+        value="value2"
+      >
+        option2
+      </option>
+      <option
+        value="value3"
+      >
+        option3
+      </option>
+    </select>
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Summary

#### What changed?

To help with accessibility, add the option to make the label of SelectList visually hidden

#### Why?

Sometime the thing that labels a SelectList is visually different from the default label style. This allows people to supply a label for screen readers, but make it visually hidden. 

<img width="485" alt="Screen Shot 2022-03-21 at 11 46 58 AM" src="https://user-images.githubusercontent.com/5125094/159342875-dce8f2fc-b0d8-48ed-963f-f363920a8fc4.png">

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)


### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
