### PR TITLE
Internal: Fix flaky flow issue on Text

### DIFF
--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -122,7 +122,15 @@ export default function Text({
 }: Props): Node {
   let colorClass = null;
   const colorName = semanticColors.includes(color) ? `${color}Text` : color;
-  if (allowedColors.includes(color)) {
+  if (
+    allowedColors.includes(color) &&
+    colorName !== 'dark' &&
+    colorName !== 'error' &&
+    colorName !== 'light' &&
+    colorName !== 'subtle' &&
+    colorName !== 'success' &&
+    colorName !== 'warning'
+  ) {
     colorClass = colors[colorName];
   }
 


### PR DESCRIPTION
### Summary

Fixes a flaky flow issue on `Text`.

### Why

To unblock other developers

### Background

Flow doesn't understand the following line:
```
const colorName = semanticColors.includes(color) ? `${color}Text` : color;
```
even though `warning` is included in `semanticColors`, so the colorName would always be `warningText`, it still thinks `colorName` can be `warning`, which is not the case.

<img width="723" alt="image" src="https://user-images.githubusercontent.com/127199/159377939-493b77e2-5bf0-41a5-bf49-d04f382e9f2c.png">

The fix is to manually remove `success` / `warning` / `subtle` / `light` / `error` / `dark` in the `if` check.

Ideally though, we should finish the migration and remove the literal colors
