### PR TITLE
Image: update importance prop to fetchpriority

### DIFF
--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -32,10 +32,10 @@ type Props = {|
    */
   fit?: 'contain' | 'cover' | 'none',
   /**
-   * Priority hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded (only available via Chrome Origin Trial). \`"high"\`: the developer considers the resource to be high priority. \`"low"\`: the developer considers the resource to be low priority. \`auto\` the developer does not indicate a preference.
+   * Priority hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded. \`"high"\`: the developer considers the resource to be high priority. \`"low"\`: the developer considers the resource to be low priority. \`auto\` the developer does not indicate a preference.
    * Note that this feature is currently experimental; please see the [attribute spec](https://wicg.github.io/priority-hints/) for more details.
    */
-  importance?: 'high' | 'low' | 'auto',
+  fetchpriority?: 'high' | 'low' | 'auto',
   /**
    * Controls if loading the image should be deferred when it's off-screen. \`"lazy"\` defers the load until the image or iframe reaches a distance threshold from the viewport. \`"eager"\` loads the resource immediately. \`"auto"\` uses the default behavior, which is to eagerly load the resource. See the [Lazy example](https://gestalt.pinterest.systems/image#Lazy) for more details.
    */
@@ -81,14 +81,10 @@ export default class Image extends PureComponent<Props> {
   static defaultProps: {|
     color: string,
     fit?: 'contain' | 'cover' | 'none',
-    importance?: 'high' | 'low' | 'auto',
-    loading?: 'eager' | 'lazy' | 'auto',
   |} = {
     // eslint-disable-next-line react/default-props-match-prop-types
     color: 'transparent',
     fit: 'none',
-    importance: 'auto',
-    loading: 'auto',
   };
 
   componentDidMount() {
@@ -133,7 +129,7 @@ export default class Image extends PureComponent<Props> {
       crossOrigin,
       elementTiming,
       fit,
-      importance,
+      fetchpriority,
       loading,
       naturalHeight,
       naturalWidth,
@@ -178,7 +174,7 @@ export default class Image extends PureComponent<Props> {
           className={styles.img}
           crossOrigin={crossOrigin}
           elementtiming={elementTiming}
-          importance={importance}
+          fetchpriority={fetchpriority}
           loading={loading}
           onError={this.handleError}
           onLoad={this.handleLoad}

--- a/packages/gestalt/src/Image.test.js
+++ b/packages/gestalt/src/Image.test.js
@@ -64,3 +64,9 @@ test('Image with crossorigin specified matches snapshot', () => {
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Image with fetchpriority specified matches snapshot', () => {
+  const component = renderer.create(<Image alt="foo" fetchpriority="high" src="foo.png" />);
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -126,8 +126,6 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
-        loading="auto"
         onError={[Function]}
         onLoad={[Function]}
         src="http://pinterest.com/img/strave.png"
@@ -208,8 +206,6 @@ exports[`Avatar renders the correct size - lg 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
-        loading="auto"
         onError={[Function]}
         onLoad={[Function]}
         src="http://pinterest.com/img/strave.png"
@@ -253,8 +249,6 @@ exports[`Avatar renders the correct size - md 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
-        loading="auto"
         onError={[Function]}
         onLoad={[Function]}
         src="http://pinterest.com/img/strave.png"
@@ -298,8 +292,6 @@ exports[`Avatar renders the correct size - sm 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
-        loading="auto"
         onError={[Function]}
         onLoad={[Function]}
         src="http://pinterest.com/img/strave.png"
@@ -343,8 +335,6 @@ exports[`Avatar renders the correct size - xl 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
-        loading="auto"
         onError={[Function]}
         onLoad={[Function]}
         src="http://pinterest.com/img/strave.png"
@@ -388,8 +378,6 @@ exports[`Avatar renders the correct size - xs 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
-        loading="auto"
         onError={[Function]}
         onLoad={[Function]}
         src="http://pinterest.com/img/strave.png"
@@ -433,8 +421,6 @@ exports[`Avatar renders the correct src 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
-        loading="auto"
         onError={[Function]}
         onLoad={[Function]}
         src="http://pinterest.com/img/strave.png"

--- a/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
@@ -36,8 +36,6 @@ exports[`AvatarGroup renders AvatarGroup button with addCollaborators button 1`]
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
-                      loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
                   </div>
@@ -138,8 +136,6 @@ exports[`AvatarGroup renders AvatarGroup link with addCollaborators button 1`] =
                       <img
                         alt="Keerthi"
                         class="img"
-                        importance="auto"
-                        loading="auto"
                         src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                       />
                     </div>
@@ -235,8 +231,6 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
-                      loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
                   </div>
@@ -274,8 +268,6 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
-                      loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
                   </div>
@@ -444,8 +436,6 @@ exports[`AvatarGroup renders fit display-only AvatarGroup with image 1`] = `
                       <img
                         alt="Keerthi"
                         class="img"
-                        importance="auto"
-                        loading="auto"
                         src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                       />
                     </div>
@@ -501,8 +491,6 @@ exports[`AvatarGroup renders md display-only AvatarGroup with image 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
-                      loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
                   </div>
@@ -557,8 +545,6 @@ exports[`AvatarGroup renders sm display-only AvatarGroup with image 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
-                      loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
                   </div>
@@ -613,8 +599,6 @@ exports[`AvatarGroup renders xs display-only AvatarGroup with image 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
-                      loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
                   </div>

--- a/packages/gestalt/src/__snapshots__/AvatarPair.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarPair.test.js.snap
@@ -59,8 +59,6 @@ exports[`AvatarPair Renders only the first 2 collobarators when multiple are pas
           <img
             alt="Keerthi"
             className="img"
-            importance="auto"
-            loading="auto"
             onError={[Function]}
             onLoad={[Function]}
             src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
@@ -114,8 +112,6 @@ exports[`AvatarPair Renders only the first 2 collobarators when multiple are pas
           <img
             alt="Shanice"
             className="img"
-            importance="auto"
-            loading="auto"
             onError={[Function]}
             onLoad={[Function]}
             src="https://i.ibb.co/7tGKGvb/shanice.jpg"
@@ -189,8 +185,6 @@ exports[`AvatarPair Renders renders 2 collaborators 1`] = `
           <img
             alt="Keerthi"
             className="img"
-            importance="auto"
-            loading="auto"
             onError={[Function]}
             onLoad={[Function]}
             src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
@@ -244,8 +238,6 @@ exports[`AvatarPair Renders renders 2 collaborators 1`] = `
           <img
             alt="Shanice"
             className="img"
-            importance="auto"
-            loading="auto"
             onError={[Function]}
             onLoad={[Function]}
             src="https://i.ibb.co/7tGKGvb/shanice.jpg"
@@ -319,8 +311,6 @@ exports[`AvatarPair Renders renders the avatar with text when no image is provid
           <img
             alt="Keerthi"
             className="img"
-            importance="auto"
-            loading="auto"
             onError={[Function]}
             onLoad={[Function]}
             src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -392,8 +392,6 @@ exports[`Checkbox with an image 1`] = `
           <img
             alt=""
             className="img"
-            importance="auto"
-            loading="auto"
             onError={[Function]}
             onLoad={[Function]}
             src="https://i.ibb.co/FY2MKr5/stock6.jpg"

--- a/packages/gestalt/src/__snapshots__/Image.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Image.test.js.snap
@@ -13,8 +13,6 @@ exports[`Image matches snapshot 1`] = `
   <img
     alt="foo"
     className="img"
-    importance="auto"
-    loading="auto"
     onError={[Function]}
     onLoad={[Function]}
     src="foo.png"
@@ -36,8 +34,27 @@ exports[`Image with crossorigin specified matches snapshot 1`] = `
     alt="foo"
     className="img"
     crossOrigin="anonymous"
-    importance="auto"
-    loading="auto"
+    onError={[Function]}
+    onLoad={[Function]}
+    src="foo.png"
+  />
+</div>
+`;
+
+exports[`Image with fetchpriority specified matches snapshot 1`] = `
+<div
+  className="box relative"
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "paddingBottom": "NaN%",
+    }
+  }
+>
+  <img
+    alt="foo"
+    className="img"
+    fetchpriority="high"
     onError={[Function]}
     onLoad={[Function]}
     src="foo.png"
@@ -141,8 +158,6 @@ exports[`Image with overlay matches snapshot 1`] = `
   <img
     alt="foo"
     className="img"
-    importance="auto"
-    loading="auto"
     onError={[Function]}
     onLoad={[Function]}
     src="foo.png"

--- a/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
@@ -269,8 +269,6 @@ exports[`RadioButton with image 1`] = `
         <img
           alt=""
           className="img"
-          importance="auto"
-          loading="auto"
           onError={[Function]}
           onLoad={[Function]}
           src="https://i.ibb.co/FY2MKr5/stock6.jpg"


### PR DESCRIPTION
### Summary
Updating importance prop to fetchpriority.

#### What changed?
[Priority-hints](https://wicg.github.io/priority-hints/) is going to ship in the next version of chrome. Since the origin-trial, they've updated the name to fetchpriority.

I've also removed the default 'auto' for fetchpriority and loading. React correctly handles if the prop is undefined and does not set it. The browser will default to 'auto' if the attribute is not set.

#### Why?

Once priority-hints ships we want to start running experiments with it.

### Breaking Changes

Run the following codemod to locate Image components with `importance` prop and rename it to `fetchpriority`.

`yarn codemod modifyProp ~/path/to/your/code --component=Image  --previousProp=importance --nextProp=fetchpriority`


### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
