### PR TITLE
[Text/Heading] Standardization of `size` props 

### DIFF
--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-lg.input.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-lg.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Heading } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Heading size="lg" />
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-lg.output.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-lg.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Heading } from 'gestalt';
+
+export default function TestComponent() {
+  return <Heading size="300" />;
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-md.input.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-md.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Heading } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Heading size="md" />
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-md.output.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-md.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Heading } from 'gestalt';
+
+export default function TestComponent() {
+  return <Heading size="200" />;
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-numbers-to-string.input.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-numbers-to-string.input.js
@@ -1,0 +1,16 @@
+// @flow strict
+import { Fragment } from 'react';
+import { Heading } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Fragment>
+      <Heading size={100} />
+      <Heading size={200} />
+      <Heading size={300} />
+      <Heading size={400} />
+      <Heading size={500} />
+      <Heading size={600} />
+    </Fragment>
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-numbers-to-string.output.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-numbers-to-string.output.js
@@ -1,0 +1,16 @@
+// @flow strict
+import { Fragment } from 'react';
+import { Heading } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Fragment>
+      <Heading size="100" />
+      <Heading size="200" />
+      <Heading size="300" />
+      <Heading size="400" />
+      <Heading size="500" />
+      <Heading size="600" />
+    </Fragment>
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-sm.input.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-sm.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Heading } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Heading size="sm" />
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-sm.output.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/heading-sm.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Heading } from 'gestalt';
+
+export default function TestComponent() {
+  return <Heading size="100" />;
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/text-lg.input.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/text-lg.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Text } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Text size="lg" />
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/text-lg.output.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/text-lg.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Text } from 'gestalt';
+
+export default function TestComponent() {
+  return <Text size="300" />;
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/text-md.input.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/text-md.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Text } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Text size="md" />
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/text-md.output.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/text-md.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Text } from 'gestalt';
+
+export default function TestComponent() {
+  return <Text size="200" />;
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/text-numbers-to-string.input.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/text-numbers-to-string.input.js
@@ -1,0 +1,16 @@
+// @flow strict
+import { Fragment } from 'react';
+import { Text } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Fragment>
+      <Text size={100} />
+      <Text size={200} />
+      <Text size={300} />
+      <Text size={400} />
+      <Text size={500} />
+      <Text size={600} />
+    </Fragment>
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/text-numbers-to-string.output.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/text-numbers-to-string.output.js
@@ -1,0 +1,16 @@
+// @flow strict
+import { Fragment } from 'react';
+import { Text } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Fragment>
+      <Text size="100" />
+      <Text size="200" />
+      <Text size="300" />
+      <Text size="400" />
+      <Text size="500" />
+      <Text size="600" />
+    </Fragment>
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/text-sm.input.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/text-sm.input.js
@@ -1,0 +1,8 @@
+// @flow strict
+import { Text } from 'gestalt';
+
+export default function TestComponent() {
+  return (
+    <Text size="sm" />
+  );
+}

--- a/packages/gestalt-codemods/47.0.0/__testfixtures__/text-sm.output.js
+++ b/packages/gestalt-codemods/47.0.0/__testfixtures__/text-sm.output.js
@@ -1,0 +1,6 @@
+// @flow strict
+import { Text } from 'gestalt';
+
+export default function TestComponent() {
+  return <Text size="100" />;
+}

--- a/packages/gestalt-codemods/47.0.0/__tests__/future-typo-changes.test.js
+++ b/packages/gestalt-codemods/47.0.0/__tests__/future-typo-changes.test.js
@@ -1,0 +1,22 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../future-typo-changes', () =>
+  Object.assign(jest.requireActual('../future-typo-changes'), {
+    parser: 'flow',
+  }),
+);
+
+describe('future-typo-changes', () => {
+  [
+    'text-sm',
+    'heading-sm',
+    'text-md',
+    'heading-md',
+    'text-lg',
+    'heading-lg',
+    'text-numbers-to-string',
+    'heading-numbers-to-string',
+  ].forEach((test) => {
+    defineTest(__dirname, 'future-typo-changes', { quote: 'single' }, test);
+  });
+});

--- a/packages/gestalt-codemods/47.0.0/future-typo-changes.js
+++ b/packages/gestalt-codemods/47.0.0/future-typo-changes.js
@@ -1,0 +1,105 @@
+/**
+ * Convert Heading and Text Sterling components to use new size values using codemod
+ */
+
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/47.0.0/future-typo-changes.js relative/path/to/your/code
+
+export default function transformer({ source }, { jscodeshift }) {
+  const researchReference = ['Heading', 'Text'];
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  // Verify the imports on file
+  const src = jscodeshift(source);
+  src.find(jscodeshift.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+
+    // Not Gestalt, bail
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    // Not to research, bail
+    localIdentifierName = decl.specifiers
+      .filter((node) => researchReference.includes(node.imported.name))
+      .map((node) => node.local.name);
+
+    return null;
+  });
+
+  // No elements imported, bail
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(jscodeshift.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+
+      // No elements to refact, bail
+      const name = node.openingElement.name.name;
+      if (!researchReference.includes(name)) {
+        return null;
+      }
+
+      const attrs = node.openingElement.attributes;
+      if (attrs.length === 0) {
+        return null;
+      }
+
+      const newAttrs = attrs
+        .map((attr) => {
+          const propName = attr?.name?.name;
+
+          // Not size prop, bail
+          if (propName !== 'size') {
+            return attr;
+          }
+
+          let propValue = null;
+          if (attr?.value?.type !== 'Literal') {
+            propValue = attr?.value?.expression?.value;
+          } else {
+            propValue = attr?.value?.value;
+          }
+          
+          const propValueVariableName = attr?.value?.expression?.name;
+
+          // If explicitly set to false or undefined the prop isn't actually doing anything and can be removed
+          if (propValue === false || propValue === null || propValueVariableName === 'undefined') {
+            return null;
+          }
+
+          const reValued = { ...attr };
+
+          if (typeof propValue === 'number') {
+            reValued.value = jscodeshift.stringLiteral(propValue.toString());
+          }
+
+          if (propValue === 'sm') {
+            reValued.value = jscodeshift.stringLiteral("100");
+          }
+
+          if (propValue === 'md') {
+            reValued.value = jscodeshift.stringLiteral("200");
+          }
+
+          if (propValue === 'lg') {
+            reValued.value = jscodeshift.stringLiteral("300");
+          }
+
+          // reValued.value.expression.value = propValue?.toString();
+          return reValued;
+        })
+        .filter(Boolean);
+
+      fileHasModifications = true;
+      node.openingElement.attributes = newAttrs;
+
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt-codemods/47.0.0/future-typo-changes.js
+++ b/packages/gestalt-codemods/47.0.0/future-typo-changes.js
@@ -38,7 +38,7 @@ export default function transformer({ source }, { jscodeshift }) {
       const { node } = jsxElement;
 
       // No elements to refact, bail
-      const name = node.openingElement.name.name;
+      const { name } = node.openingElement.name;
       if (!researchReference.includes(name)) {
         return null;
       }
@@ -63,7 +63,7 @@ export default function transformer({ source }, { jscodeshift }) {
           } else {
             propValue = attr?.value?.value;
           }
-          
+
           const propValueVariableName = attr?.value?.expression?.name;
 
           // If explicitly set to false or undefined the prop isn't actually doing anything and can be removed
@@ -78,18 +78,17 @@ export default function transformer({ source }, { jscodeshift }) {
           }
 
           if (propValue === 'sm') {
-            reValued.value = jscodeshift.stringLiteral("100");
+            reValued.value = jscodeshift.stringLiteral('100');
           }
 
           if (propValue === 'md') {
-            reValued.value = jscodeshift.stringLiteral("200");
+            reValued.value = jscodeshift.stringLiteral('200');
           }
 
           if (propValue === 'lg') {
-            reValued.value = jscodeshift.stringLiteral("300");
+            reValued.value = jscodeshift.stringLiteral('300');
           }
 
-          // reValued.value.expression.value = propValue?.toString();
           return reValued;
         })
         .filter(Boolean);


### PR DESCRIPTION
### Summary

#### What changed?

The sizes props to Text and Heading should be replaced to a new pattern. So this PR create a new Codemod to identify and replace de old notations to the new ones, on the `Text` and `Heading` components;

#### Why?

As soon as possible the values `sm`, `md` and `lg` of prop `size` will be deprecated from these components. And the new pattern require the sizes as a `string` and not a `number`;

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3888)

### Checklist

- [x] Added unit and Flow Tests
