### PR TITLE
NumberField, TextField: update docs on usage

### DIFF
--- a/docs/pages/numberfield.js
+++ b/docs/pages/numberfield.js
@@ -8,9 +8,9 @@ import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function NumberFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
-    <Page title="NumberField">
+    <Page title={generatedDocGen?.displayName}>
       <PageHeader
-        name="NumberField"
+        name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
         defaultCode={`
 function Example(props) {
@@ -20,9 +20,11 @@ function Example(props) {
     <Box width={500}>
       <NumberField
         id="header-example"
-        label="ZIP Code"
-        onChange={({ value }) => setValue(value)}
-        placeholder="Please enter your ZIP Code"
+        label="Number of widgets"
+        onChange={({ value }) => {
+          setValue(value);
+        }}
+        placeholder="Please enter the number of widgets"
         value={value}
       />
     </Box>
@@ -48,7 +50,7 @@ function Example(props) {
             type="don't"
             title="When not to use"
             description={`
-          - When accepting telephone numbers. Use [TextField](/textfield) with \`type="tel"\` instead.
+          - When accepting telephone numbers, or numerical data that could contain leading 0's (e.g. ZIP codes). Use [TextField](/textfield) with \`type="tel"\` instead.
           - Situations where text needs to be entered. Use [TextField](/textfield) or [TextArea](/textarea) instead.`}
           />
         </MainSection.Subsection>
@@ -70,7 +72,9 @@ function Example(props) {
         helperText="Code was texted to you"
         id="best-practices-do-helper-text"
         label="Confirmation code"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         value={value}
       />
     </Box>
@@ -91,7 +95,9 @@ function Example(props) {
       <NumberField
         id="best-practices-dont-placeholder"
         label=""
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         placeholder="Code was texted to you"
         value={value}
       />
@@ -116,7 +122,9 @@ function Example(props) {
       <NumberField
         id="best-practices-do-label"
         label="Your age"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         value={value}
       />
     </Box>
@@ -138,7 +146,9 @@ function Example(props) {
         <NumberField
           id="best-practice-dont-label"
           label=""
-          onChange={({ value }) => setValue(value)}
+          onChange={({ value }) => {
+            setValue(value);
+          }}
           value={value}
         />
       </Box>
@@ -164,13 +174,17 @@ function Example(props) {
       <NumberField
         id="best-practices-do-related-first"
         label="First value"
-        onChange={({ value }) => setFirstValue(value)}
+        onChange={({ value }) => {
+          setFirstValue(value);
+        }}
         value={firstValue}
       />
       <NumberField
         id="best-practices-do-related-second"
         label="Second value"
-        onChange={({ value }) => setSecondValue(value)}
+        onChange={({ value }) => {
+          setSecondValue(value);
+        }}
         value={secondValue}
       />
     </Flex>
@@ -185,21 +199,25 @@ function Example(props) {
             defaultCode={`
 function Example(props) {
   const [ageValue, setAgeValue] = React.useState();
-  const [zipCodeValue, setZipCodeValue] = React.useState();
+  const [petsValue, setPetsValue] = React.useState();
 
   return (
     <Flex gap={4}>
       <NumberField
         id="best-practices-dont-related-age"
         label="Age"
-        onChange={({ value }) => setAgeValue(value)}
+        onChange={({ value }) => {
+          setAgeValue(value);
+        }}
         value={ageValue}
       />
       <NumberField
-        id="best-practices-dont-related-zip-code"
-        label="ZIP Code"
-        onChange={({ value }) => setZipCodeValue(value)}
-        value={zipCodeValue}
+        id="best-practices-dont-related-pets"
+        label="Number of pets"
+        onChange={({ value }) => {
+          setPetsValue(value);
+        }}
+        value={petsValue}
       />
     </Flex>
   );
@@ -224,7 +242,9 @@ function Example(props) {
         helperText="Minimum is $5"
         id="best-practices-do-error-message"
         label="Monthly ad spend"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         value={value}
       />
     </Box>
@@ -247,7 +267,9 @@ function Example(props) {
         helperText="Minimum is $5"
         id="best-practices-dont-error-message"
         label="Monthy ad spend"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         value={value}
       />
     </Box>
@@ -264,7 +286,7 @@ function Example(props) {
             description="Consider all text fields as required, unless explicitly noted as optional."
             defaultCode={`
 function Example(props) {
-  const [name, setName] = React.useState({
+  const [values, setValues] = React.useState({
     first: undefined,
     second: undefined,
     third: undefined,
@@ -275,20 +297,26 @@ function Example(props) {
       <NumberField
         id="best-practices-do-required-first"
         label="First number"
-        onChange={({ value }) => setName((name) => ({ ...name, first: value }))}
-        value={name.first}
+        onChange={({ value }) => {
+          setValues((prevValues) => ({ ...prevValues, first: value }));
+        }}
+        value={values.first}
       />
       <NumberField
         id="best-practices-do-required-second"
         label="Second number"
-        onChange={({ value }) => setName((name) => ({ ...name, second: value }))}
-        value={name.second}
+        onChange={({ value }) => {
+          setValues((prevValues) => ({ ...prevValues, second: value }));
+        }}
+        value={values.second}
       />
       <NumberField
         id="best-practices-do-required-third"
         label="Third number (optional)"
-        onChange={({ value }) => setName((name) => ({ ...name, third: value }))}
-        value={name.third}
+        onChange={({ value }) => {
+          setValues((prevValues) => ({ ...prevValues, third: value }));
+        }}
+        value={values.third}
       />
     </Flex>
   );
@@ -301,7 +329,7 @@ function Example(props) {
             description="Mark fields as required."
             defaultCode={`
 function Example(props) {
-  const [name, setName] = React.useState({
+  const [values, setValues] = React.useState({
     first: undefined,
     second: undefined,
     third: undefined,
@@ -313,21 +341,27 @@ function Example(props) {
         helperText="* This field is required."
         id="best-practices-dont-required-first"
         label="First number"
-        onChange={({ value }) => setName((name) => ({ ...name, first: value }))}
-        value={name.first}
+        onChange={({ value }) => {
+          setValues((prevValues) => ({ ...prevValues, first: value }));
+        }}
+        value={values.first}
       />
       <NumberField
         helperText="* This field is required."
         id="best-practices-dont-required-second"
         label="Second number"
-        onChange={({ value }) => setName((name) => ({ ...name, second: value }))}
-        value={name.second}
+        onChange={({ value }) => {
+          setValues((prevValues) => ({ ...prevValues, second: value }));
+        }}
+        value={values.second}
       />
       <NumberField
         id="best-practices-dont-required-third"
         label="Third number"
-        onChange={({ value }) => setName((name) => ({ ...name, third: value }))}
-        value={name.third}
+        onChange={({ value }) => {
+          setValues((prevValues) => ({ ...prevValues, third: value }));
+        }}
+        value={values.third}
       />
     </Flex>
   );
@@ -405,7 +439,9 @@ function Example(props) {
       disabled
       id="variant-disabled"
       label="Disabled"
-      onChange={({ value }) => setValue(value)}
+      onChange={({ value }) => {
+        setValue(value);
+      }}
       placeholder="This input is disabled"
       value={value}
     />
@@ -430,7 +466,9 @@ function Example(props) {
         id="variant-helperText"
         helperText="Round up to the nearest whole number"
         label="Average value"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         value={value}
       />
     </Box>
@@ -455,7 +493,9 @@ function Example(props) {
     <NumberField
       id="variant-errorMessage"
       errorMessage={value === null || value === undefined ? "You must enter a number" : null}
-      onChange={({ value }) => setValue(value)}
+      onChange={({ value }) => {
+        setValue(value);
+      }}
       label="With an error message"
       value={value}
     />
@@ -563,7 +603,7 @@ function Example(props) {
         <MainSection.Subsection
           description={`
       **[TextField](/textfield)**
-      For text input, use TextField. (For telephone numbers, use \`<TextField type="tel" />\`.)
+      For text input, telephone numbers, or numerical input with possible leading 0's (e.g. ZIP codes), use TextField. (For telephone numbers, use \`<TextField type="tel" />\`.)
     `}
         />
       </MainSection>

--- a/docs/pages/textfield.js
+++ b/docs/pages/textfield.js
@@ -8,9 +8,9 @@ import docgen, { type DocGen } from '../components/docgen.js';
 
 export default function TextFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
-    <Page title="TextField">
+    <Page title={generatedDocGen?.displayName}>
       <PageHeader
-        name="TextField"
+        name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
         defaultCode={`
 function Example(props) {
@@ -22,7 +22,9 @@ function Example(props) {
         autoComplete="username"
         id="header-example"
         label="Username"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         placeholder="Please enter your username"
         type="text"
         value={value}
@@ -72,7 +74,9 @@ function Example(props) {
         helperText="Password should be at least 20 characters in length"
         id="best-practices-do-helper-text"
         label="New password"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="password"
         value={value}
       />
@@ -95,7 +99,9 @@ function Example(props) {
         autoComplete="new-password"
         id="best-practices-dont-placeholder"
         label=""
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         placeholder="Password should be at least 20 characters in length"
         type="password"
         value={value}
@@ -122,7 +128,9 @@ function Example(props) {
         autoComplete="username"
         id="best-practices-do-label"
         label="Username"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="text"
         value={value}
       />
@@ -146,7 +154,9 @@ function Example(props) {
           autoComplete="username"
           id="best-practices-dont-label"
           label=""
-          onChange={({ value }) => setValue(value)}
+          onChange={({ value }) => {
+            setValue(value);
+          }}
           type="username"
           value={value}
         />
@@ -173,14 +183,18 @@ function Example(props) {
       <TextField
         id="best-practices-do-related-city"
         label="City"
-        onChange={({ value }) => setCityValue(value)}
+        onChange={({ value }) => {
+          setCityValue(value);
+        }}
         type="text"
         value={cityValue}
       />
       <TextField
         id="best-practices-do-related-state"
         label="State"
-        onChange={({ value }) => setStateValue(value)}
+        onChange={({ value }) => {
+          setStateValue(value);
+        }}
         type="text"
         value={stateValue}
       />
@@ -204,15 +218,18 @@ function Example(props) {
         autoComplete="new-password"
         id="best-practices-dont-related-password"
         label="Password"
-        onChange={({ value }) => setPasswordValue(value)}
+        onChange={({ value }) => {
+          setPasswordValue(value);
+        }}
         type="password"
         value={passwordValue}
       />
       <TextField
         id="best-practices-dont-related-zip-code"
         label="ZIP Code"
-        onChange={({ value }) => setZipCodeValue(value)}
-        type="number"
+        onChange={({ value }) => {
+          setZipCodeValue(value);
+        }}
         value={zipCodeValue}
       />
     </Flex>
@@ -238,7 +255,9 @@ function Example(props) {
         errorMessage="Password is too short! You need 20+ characters"
         id="best-practices-do-error-message"
         label="Password"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="password"
         value={value}
       />
@@ -262,7 +281,9 @@ function Example(props) {
         errorMessage="There is an error"
         id="best-practices-dont-error-message"
         label="Password"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="password"
         value={value}
       />
@@ -291,21 +312,27 @@ function Example(props) {
       <TextField
         id="best-practices-do-required-firstName"
         label="First name"
-        onChange={({ value }) => setName((name) => ({ ...name, first: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, first: value }));
+        }}
         type="text"
         value={name.first}
       />
       <TextField
         id="best-practices-do-required-middleName"
         label="Middle name (optional)"
-        onChange={({ value }) => setName((name) => ({ ...name, middle: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, middle: value }));
+        }}
         type="text"
         value={name.middle}
       />
       <TextField
         id="best-practices-do-required-lastName"
         label="Last name"
-        onChange={({ value }) => setName((name) => ({ ...name, last: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, last: value }));
+        }}
         type="text"
         value={name.last}
       />
@@ -332,14 +359,18 @@ function Example(props) {
         helperText="* This field is required."
         id="best-practices-dont-required-firstName"
         label="First name"
-        onChange={({ value }) => setName((name) => ({ ...name, first: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, first: value }));
+        }}
         type="text"
         value={name.first}
       />
       <TextField
         id="best-practices-dont-required-middleName"
         label="Middle name"
-        onChange={({ value }) => setName((name) => ({ ...name, middle: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, middle: value }));
+        }}
         type="text"
         value={name.middle}
       />
@@ -347,7 +378,9 @@ function Example(props) {
         helperText="* This field is required."
         id="best-practices-dont-required-lastName"
         label="Last name"
-        onChange={({ value }) => setName((name) => ({ ...name, last: value }))}
+        onChange={({ value }) => {
+          setName((nameFields) => ({ ...nameFields, last: value }));
+        }}
         type="text"
         value={name.last}
       />
@@ -427,7 +460,9 @@ function Example(props) {
       disabled
       id="variants-disabled"
       label="Disabled"
-      onChange={({ value }) => setValue(value)}
+      onChange={({ value }) => {
+        setValue(value);
+      }}
       placeholder="Name"
       value={value}
     />
@@ -455,7 +490,9 @@ function Example(props) {
         helperText="Password should be at least 20 characters long"
         id="variants-helper-text"
         label="Password"
-        onChange={({ value }) => setValue(value)}
+        onChange={({ value }) => {
+          setValue(value);
+        }}
         type="password"
         value={value}
       />
@@ -484,7 +521,9 @@ function Example(props) {
       errorMessage={!value ? "This field can't be blank!" : null}
       id="variants-error-message"
       label="With an error message"
-      onChange={({ value }) => setValue(value)}
+      onChange={({ value }) => {
+        setValue(value);
+      }}
       value={value}
     />
   );
@@ -586,15 +625,21 @@ function TextFieldPopoverExample() {
         id="variants-refs"
         label="Focus the TextField to show the Popover"
         onChange={() => {}}
-        onBlur={() => setOpen(false)}
-        onFocus={() => setOpen(true)}
+        onBlur={() => {
+          setOpen(false);
+        }}
+        onFocus={() => {
+          setOpen(true);
+        }}
         ref={anchorRef}
       />
       {open && (
         <Popover
           anchor={anchorRef.current}
           idealDirection="down"
-          onDismiss={() => setOpen(false)}
+          onDismiss={() => {
+            setOpen(false);
+          }}
           shouldFocus={false}
           size="md"
         >
@@ -618,7 +663,7 @@ function TextFieldPopoverExample() {
       When users need to enter long amounts of text, use TextArea to ensure the full content will be shown.
 
       **[NumberField](/numberfield)**
-      For numerical input, use NumberField. (For telephone numbers, use \`<TextField type="tel" />\`.)
+      For numerical input, use NumberField. Exceptions: for telephone numbers, use \`<TextField type="tel" />\`. And for numerical input with possible leading 0's (e.g. ZIP codes), use \`<TextField type="text" />\`.
 
       **[SearchField](/searchfield)**
       If the input is used for searching content, use SearchField.


### PR DESCRIPTION
As caught in [this issue](https://github.com/pinterest/gestalt/issues/1830), the way we handle parsing in NumberField doesn't support leading 0's, which are necessary for things like ZIP codes. This PR updates the docs for NumberField and TextField to make it more clear which should be used in a given situation.