### PR TITLE
Docs: Update ComboBox tag variant example

### DIFF
--- a/docs/pages/combobox.js
+++ b/docs/pages/combobox.js
@@ -530,7 +530,7 @@ function ComboBoxExample(props) {
 function ComboBoxExample(props) {
   const ref = React.useRef();
   const [selected, setSelected] = React.useState([]);
-  const [defaultOption, setDefaultOption] = React.useState('');
+  const [searchTerm, setSearchTerm] = React.useState('');
 
   const PRONOUNS = [
     'ey / em',
@@ -546,36 +546,33 @@ function ComboBoxExample(props) {
 
   const options = PRONOUNS.map((pronoun, index) => ({ label: pronoun, value: 'value'+index }));
 
-  const [unselectedOptions, setUnselectedOptions] = React.useState(options.filter((pronoun) => !selected.includes(pronoun.value)));
-  const [suggestedOptions, setSuggestedOptions] = React.useState(unselectedOptions);
+  const [suggestedOptions, setSuggestedOptions] = React.useState(options.filter((pronoun) => !selected.includes(pronoun.value)));
 
   const handleOnSelect = ({ item: { label } }) => {
     if (!selected.includes(label) && selected.length < 2) {
       const newSelected = [...selected, label];
       setSelected(newSelected);
       setSuggestedOptions(options.filter((pronoun) => !newSelected.includes(pronoun.label)));
-      setDefaultOption('');
+      setSearchTerm('');
     }
   };
 
   const handleOnChange = ({ value }) => {
-    setDefaultOption(value);
-    if (value) {
-      setDefaultOption(value);
-      const filteredOptions = unselectedOptions.filter((item) =>
+    setSearchTerm(value);
+
+    const suggested = value
+      ? suggestedOptions.filter((item) =>
         item.label.toLowerCase().includes(value.toLowerCase()),
-      );
-      setSuggestedOptions(filteredOptions);
-    } else {
-      setSuggestedOptions(unselectedOptions);
-    }
+      )
+      : options.filter((option) => !selected.includes(option.value))
+
+    setSuggestedOptions(suggested);
   };
 
-  const handleOnBlur = () => setDefaultOption("");
+  const handleOnBlur = () => setSearchTerm("");
 
   const handleClear = () => {
     setSelected([]);
-    setUnselectedOptions(options);
     setSuggestedOptions(options);
   };
 
@@ -589,7 +586,6 @@ function ComboBoxExample(props) {
     if (keyCode === 8 /* Backspace */ && selectionEnd === 0) {
       const newSelected = [...selected.slice(0, -1)];
       setSelected(newSelected);
-      setUnselectedOptions(options.filter((pronoun) => !newSelected.includes(pronoun.label)));
       setSuggestedOptions(options.filter((pronoun) => !newSelected.includes(pronoun.label)));
     }
   };
@@ -597,7 +593,6 @@ function ComboBoxExample(props) {
   const handleRemoveTag = (removedValue) => {
     const newSelected = selected.filter((tagValue) => tagValue !== removedValue);
     setSelected(newSelected);
-    setUnselectedOptions(options.filter((pronoun) => !newSelected.includes(pronoun.label)));
     setSuggestedOptions(options.filter((pronoun) => !newSelected.includes(pronoun.label)));
   };
 
@@ -615,7 +610,7 @@ function ComboBoxExample(props) {
       accessibilityClearButtonLabel="Clear the current value"
       label="Pronouns"
       id="tags"
-      inputValue={defaultOption}
+      inputValue={searchTerm}
       noResultText="No results for your selection"
       options={suggestedOptions}
       ref={ref}


### PR DESCRIPTION
The example of the ComboBox tag variant contains some duplicate state that makes the example somewhat confusing.

This change simplifies the state in this example and renames `defaultOption` to `searchTerm` to clarify how this value is used

Thanks for creating a PR! Please follow this template and delete items/sections that are not relevant to your changes, including these instructions.

Please also make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `ComponentName: Description`

### Summary

#### What changed?

From a high level, what are the changes this PR introduces? (No need to recount line-by-line, we can see that.)

#### Why?

What is the purpose of this PR? Please include the context around these changes for Future Us. In addition to _what_ is changing, we need to know _why_ these changes are needed. Imagine someone is looking at these changes a year from now and needs to know why they were made.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
