### PR TITLE
Internal: remove deprecated Prettier option

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,7 +5,6 @@
       "files": "*.js",
       "options": {
         "arrowParens": "always",
-        "jsxBracketSameLine": false,
         "printWidth": 100,
         "quoteProps": "preserve",
         "tabWidth": 2,


### PR DESCRIPTION
Prettier has been complaining about this since the most recent upgrade:
```
[warn] jsxBracketSameLine is deprecated.
```
This PR removes that option from our `.prettierrc.json`.