### PR TITLE
I18nProvider: provide default strings, downgrade throwing errors to console

### DIFF
--- a/packages/gestalt/src/contexts/I18nProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/I18nProvider.jsdom.test.js
@@ -7,9 +7,8 @@ import I18nProvider, { useI18nContext } from './I18nProvider.js';
 describe('useI18nContext', () => {
   it('returns provided string values for a supported component', () => {
     function TestComponent() {
-      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
-        'TextField',
-      );
+      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
+        useI18nContext('TextField');
 
       return <div>{[accessibilityHidePasswordLabel, accessibilityShowPasswordLabel]}</div>;
     }
@@ -47,9 +46,8 @@ describe('useI18nContext', () => {
 
   it('provides defaults for partial missing translations for supported component', () => {
     function TestComponent() {
-      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
-        'TextField',
-      );
+      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
+        useI18nContext('TextField');
 
       return <div>{[accessibilityHidePasswordLabel, accessibilityShowPasswordLabel]}</div>;
     }

--- a/packages/gestalt/src/contexts/I18nProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/I18nProvider.jsdom.test.js
@@ -7,8 +7,9 @@ import I18nProvider, { useI18nContext } from './I18nProvider.js';
 describe('useI18nContext', () => {
   it('returns provided string values for a supported component', () => {
     function TestComponent() {
-      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
-        useI18nContext('TextField');
+      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
+        'TextField',
+      );
 
       return <div>{[accessibilityHidePasswordLabel, accessibilityShowPasswordLabel]}</div>;
     }
@@ -44,40 +45,30 @@ describe('useI18nContext', () => {
     }).toThrow();
   });
 
-  it('throws on missing translations for supported component', () => {
+  it('provides defaults for partial missing translations for supported component', () => {
     function TestComponent() {
-      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
-        useI18nContext('TextField');
-
-      return <div>{[accessibilityHidePasswordLabel, accessibilityShowPasswordLabel]}</div>;
-    }
-
-    expect(() => {
-      render(<TestComponent />);
-    }).toThrow();
-  });
-
-  it('throws on partial missing translations for supported component', () => {
-    function TestComponent() {
-      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
-        useI18nContext('TextField');
-
-      return <div>{[accessibilityHidePasswordLabel, accessibilityShowPasswordLabel]}</div>;
-    }
-
-    expect(() => {
-      render(
-        <I18nProvider
-          value={{
-            // $FlowExpectedError[prop-missing]
-            TextField: {
-              accessibilityHidePasswordLabel: 'Hide password',
-            },
-          }}
-        >
-          <TestComponent />
-        </I18nProvider>,
+      const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } = useI18nContext(
+        'TextField',
       );
-    }).toThrow();
+
+      return <div>{[accessibilityHidePasswordLabel, accessibilityShowPasswordLabel]}</div>;
+    }
+
+    render(
+      <I18nProvider
+        value={{
+          // $FlowExpectedError[prop-missing]
+          TextField: {
+            accessibilityHidePasswordLabel: 'Hide password',
+          },
+        }}
+      >
+        <TestComponent />
+      </I18nProvider>,
+    );
+
+    // This is a bit roundabout — we don't really care that these strings are in the document, but that they were returned from the Hook correctly
+    expect(screen.getByText(/Hide password/)).toBeInTheDocument();
+    expect(screen.getByText(/Show password/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
While the previous approach worked fine in the product, I was unable to successfully mock the implemented provider (with translations) unless included in the `render`/`shallow` call in each component using TextField, or whose children use TextField. That's impractical for now and unreasonable for the future (every component with a string in I18nProvider would have to have such a mock), so I'm backing off throwing errors for missing translations for now. We can perhaps revisit in the future but it's not worth blocking our merge/bump pipeline for this.

Also, after discussions with @jennyscript, I warmed to the idea of providing default English strings within Gestalt. This replicates the behavior of Pinboard's i18n function, so it's not actually different from behavior on non-Gestalt components.