### PR TITLE
Icon: add back to sidebar index

### DIFF
--- a/docs/components/sidebarIndex.js
+++ b/docs/components/sidebarIndex.js
@@ -51,6 +51,7 @@ const sidebarIndex: Array<sidebarIndexType> = [
       'Column',
       'Container',
       'Flex',
+      'Icon',
       'Layer',
       'Letterbox',
       'Mask',


### PR DESCRIPTION
it looks like Icon was unintentionally removed as part of #2008 😬 