### PR TITLE
Box: Add new raised shadow options to borderStyle

### DIFF
--- a/docs/components/Header.js
+++ b/docs/components/Header.js
@@ -18,6 +18,7 @@ function Header() {
       paddingX={4}
       mdPaddingX={6}
       color="lightGray"
+      borderStyle="raisedTopShadow"
       display="flex"
       direction="row"
       alignItems="center"

--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -44,6 +44,24 @@ const ignoredProps = [
   'lgPaddingY',
 ];
 
+type ColorCardProps = {|
+  children: Node,
+|};
+function ColorSchemeLayout({ children }: ColorCardProps): Node {
+  return (
+    <Flex gap={4}>
+      {['light', 'dark'].map((scheme) => (
+        <ColorSchemeProvider key={scheme} colorScheme={scheme} id={scheme}>
+          <Box color="default" padding={4} display="flex" direction="column" alignItems="center">
+            {children}
+            <Text>{scheme === 'light' ? 'Light mode' : 'Dark mode'}</Text>
+          </Box>
+        </ColorSchemeProvider>
+      ))}
+    </Flex>
+  );
+}
+
 export default function BoxPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Box">
@@ -467,18 +485,9 @@ function Example() {
             <Box>
               <CombinationNew color={['elevationAccent', 'elevationFloating', 'elevationRaised']}>
                 {({ color }) => (
-                  <Flex gap={4} direction="row">
-                    <ColorSchemeProvider colorScheme="light" id="light">
-                      <Box color="default" padding={8}>
-                        <Box width={60} height={60} rounding="circle" color={color} />
-                      </Box>
-                    </ColorSchemeProvider>
-                    <ColorSchemeProvider colorScheme="dark" id="dark">
-                      <Box color="default" padding={8}>
-                        <Box width={60} height={60} rounding="circle" color={color} />
-                      </Box>
-                    </ColorSchemeProvider>
-                  </Flex>
+                  <ColorSchemeLayout>
+                    <Box width={60} height={60} rounding="circle" color={color} marginBottom={8} />
+                  </ColorSchemeLayout>
                 )}
               </CombinationNew>
             </Box>
@@ -486,18 +495,15 @@ function Example() {
             <Box>
               <CombinationNew borderStyle={['shadow', 'raisedTopShadow', 'raisedBottomShadow']}>
                 {({ borderStyle }) => (
-                  <Flex gap={4} direction="row">
-                    <ColorSchemeProvider colorScheme="light" id="light">
-                      <Box color="default" padding={8}>
-                        <Box width={60} height={60} rounding="circle" borderStyle={borderStyle} />
-                      </Box>
-                    </ColorSchemeProvider>
-                    <ColorSchemeProvider colorScheme="dark" id="dark">
-                      <Box color="default" padding={8}>
-                        <Box width={60} height={60} rounding="circle" borderStyle={borderStyle} />
-                      </Box>
-                    </ColorSchemeProvider>
-                  </Flex>
+                  <ColorSchemeLayout>
+                    <Box
+                      width={60}
+                      height={60}
+                      rounding="circle"
+                      borderStyle={borderStyle}
+                      marginBottom={8}
+                    />
+                  </ColorSchemeLayout>
                 )}
               </CombinationNew>
             </Box>

--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -404,10 +404,12 @@ function Example() {
 
       <MainSection name="Variants">
         <MainSection.Subsection
-          description={`Borders are controlled by the \`borderStyle\` property. Specifying a size ("sm" or "lg") enables a solid, light gray color in that width, while specifying "shadow" adds a box-shadow instead.`}
+          description={`Borders are controlled by the \`borderStyle\` property. Specifying a size ("sm" or "lg") enables a solid, light gray color in that width. Specifying "shadow" adds an even box-shadow around the entire container, while \`raisedTopShadow\` and \`raisedBottomShadow\` add shadows to indicate an elevated header or footer. See the [elevation foundations page](/elevation) for more details.`}
           title="Borders"
         >
-          <CombinationNew borderStyle={['sm', 'lg', 'shadow']}>
+          <CombinationNew
+            borderStyle={['sm', 'lg', 'shadow', 'raisedTopShadow', 'raisedBottomShadow']}
+          >
             {(props) => (
               <Box
                 width={60}

--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -1,6 +1,6 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Box } from 'gestalt';
+import { Box, ColorSchemeProvider, Flex, Text } from 'gestalt';
 import Page from '../components/Page.js';
 import CombinationNew from '../components/CombinationNew.js';
 import PageHeader from '../components/PageHeader.js';
@@ -460,11 +460,48 @@ function Example() {
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Elevation"
-          description="These colors can elevate elements within the UI. In light mode, `elevationAccent` can be used when shadows or borders are not an option. `elevationFloating` and `elevationRaised` are only applicable in dark mode. For full details, visit our [Elevation foundations page](/elevation)."
+          description="Colors and shadows can elevate elements within the UI. In light mode, `elevationAccent` can be used when shadows or borders are not an option. `elevationFloating` and `elevationRaised` are only applicable in dark mode, while `shadow` is only applicable in light mode. For full details, visit our [Elevation foundations page](/elevation)."
         >
-          <CombinationNew color={['elevationAccent', 'elevationFloating', 'elevationRaised']}>
-            {({ color }) => <Box width={60} height={60} rounding="circle" color={color} />}
-          </CombinationNew>
+          <Flex direction="column" gap={2}>
+            <Text size="400">Color</Text>
+            <Box>
+              <CombinationNew color={['elevationAccent', 'elevationFloating', 'elevationRaised']}>
+                {({ color }) => (
+                  <Flex gap={4} direction="row">
+                    <ColorSchemeProvider colorScheme="light" id="light">
+                      <Box color="default" padding={8}>
+                        <Box width={60} height={60} rounding="circle" color={color} />
+                      </Box>
+                    </ColorSchemeProvider>
+                    <ColorSchemeProvider colorScheme="dark" id="dark">
+                      <Box color="default" padding={8}>
+                        <Box width={60} height={60} rounding="circle" color={color} />
+                      </Box>
+                    </ColorSchemeProvider>
+                  </Flex>
+                )}
+              </CombinationNew>
+            </Box>
+            <Text size="400">Borders and Shadows</Text>
+            <Box>
+              <CombinationNew borderStyle={['shadow', 'raisedTopShadow', 'raisedBottomShadow']}>
+                {({ borderStyle }) => (
+                  <Flex gap={4} direction="row">
+                    <ColorSchemeProvider colorScheme="light" id="light">
+                      <Box color="default" padding={8}>
+                        <Box width={60} height={60} rounding="circle" borderStyle={borderStyle} />
+                      </Box>
+                    </ColorSchemeProvider>
+                    <ColorSchemeProvider colorScheme="dark" id="dark">
+                      <Box color="default" padding={8}>
+                        <Box width={60} height={60} rounding="circle" borderStyle={borderStyle} />
+                      </Box>
+                    </ColorSchemeProvider>
+                  </Flex>
+                )}
+              </CombinationNew>
+            </Box>
+          </Flex>
         </MainSection.Subsection>
 
         <MainSection.Subsection

--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -404,19 +404,19 @@ function Example() {
 
       <MainSection name="Variants">
         <MainSection.Subsection
-          description={`Borders are controlled by the \`borderStyle\` property. Specifying a size ("sm" or "lg") enables a solid, light gray color in that width. Specifying "shadow" adds an even box-shadow around the entire container, while \`raisedTopShadow\` and \`raisedBottomShadow\` add shadows to indicate an elevated header or footer. See the [elevation foundations page](/elevation) for more details.`}
+          description={`Borders are controlled by the \`borderStyle\` property. Specifying a size (\`sm\` or \`lg\`) enables a solid, light gray color in that width. Specifying \`shadow\` adds an even box-shadow around the entire container, while \`raisedTopShadow\` and \`raisedBottomShadow\` add shadows to indicate an elevated header or footer. See the [elevation foundations page](/elevation) for more details.`}
           title="Borders"
         >
           <CombinationNew
             borderStyle={['sm', 'lg', 'shadow', 'raisedTopShadow', 'raisedBottomShadow']}
           >
-            {(props) => (
+            {({ borderStyle }) => (
               <Box
                 width={60}
                 height={60}
                 rounding="circle"
                 color="white"
-                borderStyle={props.borderStyle} // eslint-disable-line react/prop-types
+                borderStyle={borderStyle}
               />
             )}
           </CombinationNew>

--- a/docs/pages/elevation.js
+++ b/docs/pages/elevation.js
@@ -9,7 +9,7 @@ type ColorCardProps = {|
   description: string,
   colorScheme: 'light' | 'dark',
   id: string,
-  borderStyle?: 'sm' | 'lg' | 'shadow',
+  borderStyle?: $ElementType<React$ElementConfig<typeof Box>, 'borderStyle'>,
   color?: 'default' | 'elevationAccent' | 'elevationFloating' | 'elevationRaised',
   dangerouslySetInlineStyle?: {|
     __style: { [key: string]: string | number | void },
@@ -104,9 +104,7 @@ export default function ColorUsagePage(): Node {
         <MainSection.Subsection
           title="Raised"
           description={`
-          Presents a drop shadow on the edge of a top or bottom component, allowing surfaces to move behind when scrolled. In dark mode, the raised border should be paired with the \`elevationRaised\` background color.
-
-          ⚠️ Note: Raised shadow options will be available automatically in Box soon.
+          Presents a drop shadow on the edge of a top or bottom component, allowing surfaces to move behind when scrolled. Available through the \`borderStyle\` prop in [Box](https://gestalt.pinterest.systems/box#Borders). In dark mode, the raised border should be paired with the \`elevationRaised\` background color.
           `}
         >
           <Flex direction="column" gap={8}>
@@ -120,9 +118,7 @@ export default function ColorUsagePage(): Node {
               <ColorCard
                 colorScheme="light"
                 id="elevation-raised-top-light"
-                dangerouslySetInlineStyle={{
-                  __style: { boxShadow: 'var(--elevation-raised-top)' },
-                }}
+                borderStyle="raisedTopShadow"
                 description="12% (#000000) opacity / Y: 2 / Blur: 8"
               />
 
@@ -130,11 +126,7 @@ export default function ColorUsagePage(): Node {
                 colorScheme="dark"
                 id="elevation-raised-top-dark"
                 color="elevationRaised"
-                dangerouslySetInlineStyle={{
-                  __style: {
-                    boxShadow: 'var(--elevation-raised-top)',
-                  },
-                }}
+                borderStyle="raisedTopShadow"
                 description="Top: Roboflow 600 / Y: 0.5 / Blur: 0"
               />
             </Flex>
@@ -148,20 +140,14 @@ export default function ColorUsagePage(): Node {
               <ColorCard
                 colorScheme="light"
                 id="elevation-raised-bottom-light"
-                dangerouslySetInlineStyle={{
-                  __style: { boxShadow: 'var(--elevation-raised-bottom)' },
-                }}
+                borderStyle="raisedBottomShadow"
                 description="12% (#000000) opacity / Y: -2 / Blur: 8"
               />
               <ColorCard
                 colorScheme="dark"
                 id="elevation-raised-bottom-dark"
                 color="elevationRaised"
-                dangerouslySetInlineStyle={{
-                  __style: {
-                    boxShadow: 'var(--elevation-raised-bottom)',
-                  },
-                }}
+                borderStyle="raisedBottomShadow"
                 description="Top: Roboflow 600 / Y: -0.5 / Blur: 0"
               />
             </Flex>

--- a/packages/gestalt/src/Borders.css
+++ b/packages/gestalt/src/Borders.css
@@ -123,3 +123,11 @@ html[dir="rtl"] .borderLeft {
 .shadow {
   box-shadow: var(--elevation-floating);
 }
+
+.raisedTop {
+  box-shadow: var(--elevation-raised-top);
+}
+
+.raisedBottom {
+  box-shadow: var(--elevation-raised-bottom);
+}

--- a/packages/gestalt/src/Borders.css.flow
+++ b/packages/gestalt/src/Borders.css.flow
@@ -15,6 +15,8 @@ declare module.exports: {|
   +'circle': string,
   +'noBorder': string,
   +'pill': string,
+  +'raisedBottom': string,
+  +'raisedTop': string,
   +'rounding0': string,
   +'rounding1': string,
   +'rounding2': string,

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -125,7 +125,7 @@ type Props = {
    * Specify a border style for the box. For sizes, "sm" is 1px and "lg" is 2px. Setting a size will always default the border style to solid and color to lightGray. See the [borders](https://gestalt.pinterest.systems/box#Borders) variant for more details.
    * Default: 'none'
    */
-  borderStyle?: 'sm' | 'lg' | 'shadow' | 'none',
+  borderStyle?: 'sm' | 'lg' | 'shadow' | 'raisedTopShadow' | 'raisedBottomShadow' | 'none',
   /**
    * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/box#Absolute-positioning) variant for more info.
    * Default: false

--- a/packages/gestalt/src/Box.test.js
+++ b/packages/gestalt/src/Box.test.js
@@ -95,6 +95,11 @@ test('Box has correct classes when borderStyle is shadow', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Box has correct classes when borderStyle is raisedTopShadow', () => {
+  const tree = create(<Box borderStyle="raisedTopShadow" />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Box has correct zIndex', () => {
   const zIndexStub = {
     index() {

--- a/packages/gestalt/src/__snapshots__/Box.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Box.test.js.snap
@@ -77,6 +77,12 @@ exports[`Box has correct classes when borderStyle is lg 1`] = `
 />
 `;
 
+exports[`Box has correct classes when borderStyle is raisedTopShadow 1`] = `
+<div
+  className="box raisedTop"
+/>
+`;
+
 exports[`Box has correct classes when borderStyle is shadow 1`] = `
 <div
   className="box shadow"

--- a/packages/gestalt/src/boxTransforms.js
+++ b/packages/gestalt/src/boxTransforms.js
@@ -137,6 +137,8 @@ const borderStyle: Functor<BorderStyle> = (value) => {
       sm: borders.sizeSm,
       lg: borders.sizeLg,
       shadow: borders.shadow,
+      raisedTopShadow: borders.raisedTop,
+      raisedBottomShadow: borders.raisedBottom,
       // default: none
     })(value),
     ...borderProps,
@@ -207,19 +209,17 @@ const left: Functor<boolean> = toggle(layout.left0);
 
 type MarginFunctorType = Functor<Margin>;
 
-const transformNumberOrPassthrough =
-  (selector: string): MarginFunctorType =>
-  (m) => {
-    if (typeof m === 'number') {
-      return bind(rangeWithZero(selector), whitespace)(m);
-    }
+const transformNumberOrPassthrough = (selector: string): MarginFunctorType => (m) => {
+  if (typeof m === 'number') {
+    return bind(rangeWithZero(selector), whitespace)(m);
+  }
 
-    if (m === 'auto') {
-      return fromClassName(whitespace[`${selector}Auto`]);
-    }
+  if (m === 'auto') {
+    return fromClassName(whitespace[`${selector}Auto`]);
+  }
 
-    return identity();
-  };
+  return identity();
+};
 
 const marginStart: MarginFunctorType = transformNumberOrPassthrough('marginStart');
 const marginEnd: MarginFunctorType = transformNumberOrPassthrough('marginEnd');

--- a/packages/gestalt/src/boxTransforms.js
+++ b/packages/gestalt/src/boxTransforms.js
@@ -139,7 +139,6 @@ const borderStyle: Functor<BorderStyle> = (value) => {
       shadow: borders.shadow,
       raisedTopShadow: borders.raisedTop,
       raisedBottomShadow: borders.raisedBottom,
-      // default: none
     })(value),
     ...borderProps,
   ]);

--- a/packages/gestalt/src/boxTransforms.js
+++ b/packages/gestalt/src/boxTransforms.js
@@ -209,17 +209,19 @@ const left: Functor<boolean> = toggle(layout.left0);
 
 type MarginFunctorType = Functor<Margin>;
 
-const transformNumberOrPassthrough = (selector: string): MarginFunctorType => (m) => {
-  if (typeof m === 'number') {
-    return bind(rangeWithZero(selector), whitespace)(m);
-  }
+const transformNumberOrPassthrough =
+  (selector: string): MarginFunctorType =>
+  (m) => {
+    if (typeof m === 'number') {
+      return bind(rangeWithZero(selector), whitespace)(m);
+    }
 
-  if (m === 'auto') {
-    return fromClassName(whitespace[`${selector}Auto`]);
-  }
+    if (m === 'auto') {
+      return fromClassName(whitespace[`${selector}Auto`]);
+    }
 
-  return identity();
-};
+    return identity();
+  };
 
 const marginStart: MarginFunctorType = transformNumberOrPassthrough('marginStart');
 const marginEnd: MarginFunctorType = transformNumberOrPassthrough('marginEnd');

--- a/packages/gestalt/src/boxTypes.js
+++ b/packages/gestalt/src/boxTypes.js
@@ -28,7 +28,13 @@ export type As =
   | 'section'
   | 'summary';
 export type Bottom = boolean;
-export type BorderStyle = 'sm' | 'lg' | 'shadow' | 'none';
+export type BorderStyle =
+  | 'sm'
+  | 'lg'
+  | 'shadow'
+  | 'raisedTopShadow'
+  | 'raisedBottomShadow'
+  | 'none';
 export type Color =
   | 'blue'
   | 'darkGray'


### PR DESCRIPTION
### Summary

#### What changed?

after adding 2 new ways to show elevated items, a raised top or raised bottom shadow, this PR adds those options to Box

#### Why?

We have a full shadow option in Box, and now this adds two new options to showcase raised headers or footers with a corresponding top or bottom box-shadow. We discussed as a group and found that leaving these on borderStyle for now is an ideal way to move forward, so that we prevent users trying to add both a solid pixel border and a shadow.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)


### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
