### PR TITLE
Popover: remove unused caret stroke style

### DIFF
--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -5,7 +5,6 @@ import Caret from './Caret.js';
 import styles from './Contents.css';
 import borders from './Borders.css';
 import colors from './Colors.css';
-import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import { useScrollBoundaryContainer } from './contexts/ScrollBoundaryContainer.js';
 import {
   type CaretOffset,
@@ -50,12 +49,8 @@ type OwnProps = {|
 type HookProps = {|
   scrollBoundaryContainerRef: ?HTMLElement,
 |};
-type ColorSchemeProps = {|
-  colorGray100: string,
-  isDarkMode: boolean,
-|};
 
-type Props = {| ...OwnProps, ...ColorSchemeProps, ...HookProps |};
+type Props = {| ...OwnProps, ...HookProps |};
 
 type State = {|
   popoverOffset: {|
@@ -207,24 +202,12 @@ class Contents extends Component<Props, State> {
   };
 
   render(): Node {
-    const {
-      bgColor,
-      border,
-      caret,
-      children,
-      colorGray100,
-      id,
-      isDarkMode,
-      role,
-      rounding,
-      width,
-    } = this.props;
+    const { bgColor, border, caret, children, id, role, rounding, width } = this.props;
     const { caretOffset, popoverOffset, popoverDir } = this.state;
 
     // Needed to prevent UI thrashing
     const visibility = popoverDir === null ? 'hidden' : 'visible';
     const background = bgColor === 'white' ? `${bgColor}BgElevated` : `${bgColor}Bg`;
-    const stroke = bgColor === 'white' && !isDarkMode ? colorGray100 : null;
     const bgColorElevated = bgColor === 'white' ? 'whiteElevated' : bgColor;
     const isCaretVertical = ['down', 'up'].includes(popoverDir);
 
@@ -232,7 +215,7 @@ class Contents extends Component<Props, State> {
       <div
         className={styles.container}
         // popoverOffset positions the Popover component
-        style={{ stroke, visibility, ...popoverOffset }}
+        style={{ visibility, ...popoverOffset }}
       >
         <div
           className={classnames(
@@ -282,15 +265,7 @@ class Contents extends Component<Props, State> {
 }
 
 export default function WrappedContents(props: OwnProps): Node {
-  const { colorGray100, name: colorSchemeName } = useColorScheme();
   const { scrollBoundaryContainerRef = null } = useScrollBoundaryContainer();
 
-  return (
-    <Contents
-      {...props}
-      colorGray100={colorGray100}
-      isDarkMode={colorSchemeName === 'darkMode'}
-      scrollBoundaryContainerRef={scrollBoundaryContainerRef}
-    />
-  );
+  return <Contents {...props} scrollBoundaryContainerRef={scrollBoundaryContainerRef} />;
 }

--- a/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
@@ -7,7 +7,6 @@ exports[`Controller renders 1`] = `
     style={
       Object {
         "left": -10,
-        "stroke": null,
         "top": 4,
         "visibility": "visible",
       }

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -9,7 +9,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
     <div>
       <div
         class="container"
-        style="stroke: #efefef; visibility: visible; top: 8px; left: -10px;"
+        style="visibility: visible; top: 8px; left: -10px;"
       >
         <div
           class="rounding4 contents maxDimensions minDimensions"

--- a/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
@@ -9,7 +9,6 @@ exports[`Popover renders 1`] = `
     style={
       Object {
         "left": -10,
-        "stroke": "#efefef",
         "top": 8,
         "visibility": "visible",
       }
@@ -39,7 +38,6 @@ exports[`Popover renders as blue 1`] = `
     style={
       Object {
         "left": -10,
-        "stroke": null,
         "top": 8,
         "visibility": "visible",
       }
@@ -69,7 +67,6 @@ exports[`Popover renders as error 1`] = `
     style={
       Object {
         "left": -10,
-        "stroke": null,
         "top": 8,
         "visibility": "visible",
       }


### PR DESCRIPTION
### Summary

#### What changed?

Remove caret stroke style as it's not needed anymore (PRs that introduced code https://github.com/pinterest/gestalt/pull/1017, https://github.com/pinterest/gestalt/pull/1081)

#### Why?

The previous stroke color logic was overriding strokes in SVGs contained within Popover as seeing here which was causing bugs in Dropdown containing avatars without image.


![Screen Shot 2022-04-06 at 11 41 43](https://user-images.githubusercontent.com/10593890/162096463-180ad8a7-b310-4d0c-9e33-ba78153251d5.png)
![Screen Shot 2022-04-06 at 2 47 54 PM](https://user-images.githubusercontent.com/10593890/162096465-35eae942-9f3d-4337-a662-1ca2d9aae1d5.png)


## BEFORE

![Screen Shot 2022-04-06 at 8 30 27 PM](https://user-images.githubusercontent.com/10593890/162096769-34a768bf-aef4-4d74-a864-dc34b6b4981b.png)
![Screen Shot 2022-04-06 at 8 43 05 PM](https://user-images.githubusercontent.com/10593890/162097769-9ee30143-fb7c-4c83-a295-a48f67ddb3d0.png)

## AFTER
![Screen Shot 2022-04-06 at 8 29 40 PM](https://user-images.githubusercontent.com/10593890/162096693-e123a76d-edec-443c-9afb-76935f16a663.png)
![Screen Shot 2022-04-06 at 8 43 17 PM](https://user-images.githubusercontent.com/10593890/162097781-0f64e28d-8c09-4c0f-a85e-190c5d9ec311.png)

