### PR TITLE
Heading: Deprecate old color options, add new semantic colors

### DIFF
--- a/docs/pages/heading.js
+++ b/docs/pages/heading.js
@@ -19,7 +19,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         description="These font sizes follow those available through our [Design Tokens](/design_tokens#Font-size). If your text does not need to be a [semantic heading (H1-H6)](/https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements), use [Text](/text) instead."
         defaultCode={`
 <Flex gap={4} direction="column">
-  <Heading size="lg">Heading size 100</Heading>
+  <Heading size="100">Heading size 100</Heading>
   <span lang="ja">
     <Heading size="100">こんにちは</Heading>
   </span>
@@ -58,29 +58,47 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         name="Example: Colors"
         defaultCode={`
 <Box>
-  <Box margin={-1}>
     <Box color="gray" padding={1}>
-      <Heading color="white" size="500">
-        White
+      <Heading color="inverse" size="500">
+        Inverse
       </Heading>
     </Box>
-  </Box>
 
   <Heading size="500">
-    Dark gray (default)
+    Default
   </Heading>
 
-  <Heading color="gray" size="500">
-    Gray
+  <Heading color="subtle" size="500">
+    Subtle
   </Heading>
 
-  <Heading color="blue" size="500">
-    Blue
+  <Heading color="success" size="500">
+    Success
   </Heading>
 
-  <Heading color="red" size="500">
-    Red
+  <Heading color="error" size="500">
+    Error
   </Heading>
+
+  <Heading color="warning" size="500">
+    Warning
+  </Heading>
+
+  <Heading color="shopping" size="500">
+    Shopping
+  </Heading>
+
+  <Box color="primary" padding={1}>
+    <Heading color="light" size="500">
+      Light
+    </Heading>
+  </Box>
+
+  <Box color="infoWeak" padding={1}>
+    <Heading color="dark" size="500">
+      Dark
+    </Heading>
+  </Box>
 </Box>
 `}
       />

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import colors from './Colors.css';
 import styles from './Heading.css';
 import typography from './Typography.css';
-import { literalColors } from './textTypes.js';
+import { semanticColors } from './textTypes.js';
 
 function isNotNullish(val): boolean {
   return val !== null && val !== undefined;
@@ -56,23 +56,15 @@ type Props = {|
    * The color of the text. See [Colors example](https://gestalt.pinterest.systems#colors) for more details.
    */
   color?:
-    | 'blue'
-    | 'darkGray'
-    | 'eggplant'
-    | 'gray'
-    | 'green'
-    | 'lightGray'
-    | 'maroon'
-    | 'midnight'
-    | 'navy'
-    | 'olive'
-    | 'orange'
-    | 'orchid'
-    | 'pine'
-    | 'purple'
-    | 'red'
-    | 'watermelon'
-    | 'white',
+    | 'default'
+    | 'subtle'
+    | 'success'
+    | 'error'
+    | 'warning'
+    | 'shopping'
+    | 'inverse'
+    | 'light'
+    | 'dark',
   /**
    * A unique identifier for the element.
    */
@@ -103,7 +95,7 @@ export default function Heading({
   accessibilityLevel,
   align = 'start',
   children,
-  color = 'darkGray',
+  color = 'default',
   lineClamp,
   id,
   overflow = 'breakWord',
@@ -112,7 +104,7 @@ export default function Heading({
   const cs = cx(
     styles.Heading,
     typography[`fontSize${SIZE_SCALE[size]}`],
-    color && literalColors.includes(color) && colors[color],
+    color && semanticColors.includes(color) && colors[`${color}Text`],
     align === 'center' && typography.alignCenter,
     align === 'justify' && typography.alignJustify,
     align === 'start' && typography.alignStart,

--- a/packages/gestalt/src/__snapshots__/Heading.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Heading.test.js.snap
@@ -2,25 +2,25 @@
 
 exports[`Deprecated Heading large 1`] = `
 <h1
-  className="Heading fontSize600 darkGray alignStart breakWord"
+  className="Heading fontSize600 defaultText alignStart breakWord"
 />
 `;
 
 exports[`Heading default overflow 1`] = `
 <h3
-  className="Heading fontSize400 darkGray alignStart breakWord"
+  className="Heading fontSize400 defaultText alignStart breakWord"
 />
 `;
 
 exports[`Heading large 1`] = `
 <h1
-  className="Heading fontSize600 darkGray alignStart breakWord"
+  className="Heading fontSize600 defaultText alignStart breakWord"
 />
 `;
 
 exports[`Heading lineClamp adds a title when the children are text only 1`] = `
 <h1
-  className="Heading fontSize600 darkGray alignStart breakWord lineClamp"
+  className="Heading fontSize600 defaultText alignStart breakWord lineClamp"
   style={
     Object {
       "WebkitLineClamp": 1,
@@ -34,7 +34,7 @@ exports[`Heading lineClamp adds a title when the children are text only 1`] = `
 
 exports[`Heading lineClamp does not add a title when the children are objects 1`] = `
 <h1
-  className="Heading fontSize600 darkGray alignStart breakWord lineClamp"
+  className="Heading fontSize600 defaultText alignStart breakWord lineClamp"
 >
   <div>
     Breakup reading:
@@ -45,25 +45,25 @@ exports[`Heading lineClamp does not add a title when the children are objects 1`
 
 exports[`Heading overflow normal 1`] = `
 <h3
-  className="Heading fontSize400 darkGray alignStart"
+  className="Heading fontSize400 defaultText alignStart"
 />
 `;
 
 exports[`Heading small with id 1`] = `
 <h3
-  className="Heading fontSize400 darkGray alignStart breakWord"
+  className="Heading fontSize400 defaultText alignStart breakWord"
   id="account-basics"
 />
 `;
 
 exports[`Heading small with level 3 1`] = `
 <h3
-  className="Heading fontSize400 darkGray alignStart breakWord"
+  className="Heading fontSize400 defaultText alignStart breakWord"
 />
 `;
 
 exports[`Heading small with level none 1`] = `
 <div
-  className="Heading fontSize400 darkGray alignStart breakWord"
+  className="Heading fontSize400 defaultText alignStart breakWord"
 />
 `;

--- a/packages/gestalt/src/__snapshots__/PageHeader.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/PageHeader.test.js.snap
@@ -58,7 +58,7 @@ exports[`PageHeader renders 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize400 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -73,7 +73,7 @@ exports[`PageHeader renders 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize500 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -179,7 +179,7 @@ exports[`PageHeader renders primary action 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize400 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -194,7 +194,7 @@ exports[`PageHeader renders primary action 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize500 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -402,7 +402,7 @@ exports[`PageHeader renders secondary action 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize400 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -417,7 +417,7 @@ exports[`PageHeader renders secondary action 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize500 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -656,7 +656,7 @@ exports[`PageHeader renders subtext 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize400 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -671,7 +671,7 @@ exports[`PageHeader renders subtext 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize500 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -791,7 +791,7 @@ exports[`PageHeader renders within a max width 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize400 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -806,7 +806,7 @@ exports[`PageHeader renders within a max width 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 darkGray alignStart breakWord lineClamp"
+                          className="Heading fontSize500 defaultText alignStart breakWord lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -35,7 +35,7 @@ exports[`Sheet should render all props with nodes 1`] = `
                   class="box paddingX8 paddingY8 xsDisplayFlex"
                 >
                   <h1
-                    class="Heading fontSize500 darkGray alignStart breakWord"
+                    class="Heading fontSize500 defaultText alignStart breakWord"
                   >
                     Sheet title
                   </h1>
@@ -134,7 +134,7 @@ exports[`Sheet should render all props with render props 1`] = `
                   class="box paddingX8 paddingY8 xsDisplayFlex"
                 >
                   <h1
-                    class="Heading fontSize500 darkGray alignStart breakWord"
+                    class="Heading fontSize500 defaultText alignStart breakWord"
                   >
                     Sheet title
                   </h1>

--- a/packages/gestalt/src/textTypes.js
+++ b/packages/gestalt/src/textTypes.js
@@ -18,45 +18,4 @@ export const semanticColors = [
   'dark',
 ];
 
-export const literalColors = [
-  'blue',
-  'darkGray',
-  'eggplant',
-  'gray',
-  'green',
-  'lightGray',
-  'maroon',
-  'midnight',
-  'navy',
-  'olive',
-  'orange',
-  'orchid',
-  'pine',
-  'purple',
-  'red',
-  'watermelon',
-  'white',
-];
-
-export const allowedColors: $ReadOnlyArray<string> = [...semanticColors, ...literalColors];
-
-export type Color =
-  | 'blue'
-  | 'darkGray'
-  | 'eggplant'
-  | 'gray'
-  | 'green'
-  | 'lightGray'
-  | 'maroon'
-  | 'midnight'
-  | 'navy'
-  | 'olive'
-  | 'orange'
-  | 'orchid'
-  | 'pine'
-  | 'purple'
-  | 'red'
-  | 'watermelon'
-  | 'white';
-
 export type FontWeight = 'bold' | 'normal';


### PR DESCRIPTION
### Summary

#### What changed?

Remove old colors from Heading, switch to new semantic colors.

#### Why?

Align with design tokens and avoid arbitrary color usage

To make any conversions using our codemods, run 
`yarn codemod modifyPropValue [path-to-files] --component=Heading --previousProp=color --previousValue=[value to replace] --nextValue=[new value]`

Typically, conversions are as follows:

| Old | New |
|---|--|
|red| error|
|darkGray| default|
|white | inverse|
|gray | subtle|
|blue/navy/etc. | shopping, if shopping related|
| white on dark backgrounds | light |
| darkGray on light backgrounds | dark |

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4063)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [x] Updated unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
