### PR TITLE
Video: handle HTMLMediaElement.play() Promise rejection and autoplay blocking, and API improvements

### DIFF
--- a/docs/pages/video.js
+++ b/docs/pages/video.js
@@ -1,46 +1,89 @@
 // @flow strict
 import { type Node } from 'react';
-import Example from '../components/Example.js';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
 import docgen, { type DocGen } from '../components/docgen.js';
 import deepCloneReplacingUndefined from '../utils/deepCloneReplacingUndefined.js';
+import MainSection from '../components/MainSection.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Video">
-      <PageHeader name="Video" description={generatedDocGen?.description} />
-
+      <PageHeader
+        name="Video"
+        description={generatedDocGen?.description}
+        defaultCode={`
+<Box width={300}>
+  <Video
+    accessibilityMaximizeLabel="Maximize"
+    accessibilityMinimizeLabel="Minimize"
+    accessibilityMuteLabel="Mute"
+    accessibilityPauseLabel="Pause"
+    accessibilityPlayLabel="Play"
+    accessibilityProgressBarLabel="Progress bar"
+    accessibilityUnmuteLabel="Unmute"
+    aspectRatio={540 / 960}
+    captions=""
+    src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+    controls
+  />
+</Box>
+`}
+      />
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
-      {/* <Example
-        id="basicExample"
-        name="Video media basics"
-        description={`
-    The source url you pass into \`Video\` will be used to download and play the video file. While it is
-    downloading the metadata, you may show a thumbnail image by using the \`poster\` prop.
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          title="Native video attributes"
+          description={`Video supports the native HTML video attributes such as \`src\`, \`poster\`, \`loop\`, \`muted\`, and more. Simply pass these through as props on the Video component.
+
+The source url you pass into Video will be used to download and play the video file. While it is downloading the metadata, you may show a thumbnail image by using the \`poster\` prop.
   `}
-        defaultCode={`
-<Video
-  aspectRatio={853 / 480}
-  captions=""
-  poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
-  src="https://media.w3.org/2010/05/bunny/movie.mp4"
-/>
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+<Box width={300}>
+  <Video
+    accessibilityMaximizeLabel="Maximize"
+    accessibilityMinimizeLabel="Minimize"
+    accessibilityMuteLabel="Mute"
+    accessibilityPauseLabel="Pause"
+    accessibilityPlayLabel="Play"
+    accessibilityProgressBarLabel="Progress bar"
+    accessibilityUnmuteLabel="Unmute"
+    aspectRatio={540 / 960}
+    captions=""
+    poster="https://i.pinimg.com/videos/thumbnails/originals/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4.0000000.jpg"
+    src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+    controls
+    muted
+  />
+</Box>
 `}
-      /> */}
-      <Example
-        name="Video multiple sources"
-        description={`
-    Not all browsers support the same video encoding types. If you have multiple video file sources, you can pass
-    them as a list to \`Video\` in the order you want the HTML video tag to use as fallbacks.
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Multiple video sources"
+          description={`Not all browsers support the same video encoding types. If you have multiple video file sources, you can pass them as a list to Video in the order you want the HTML video tag to use as fallbacks.
   `}
-        defaultCode={`
-<Video
-  aspectRatio={426 / 240}
-  captions=""
-  src={[
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+<Box width={300}>
+  <Video
+    accessibilityMaximizeLabel="Maximize"
+    accessibilityMinimizeLabel="Minimize"
+    accessibilityMuteLabel="Mute"
+    accessibilityPauseLabel="Pause"
+    accessibilityPlayLabel="Play"
+    accessibilityProgressBarLabel="Progress bar"
+    accessibilityUnmuteLabel="Unmute"
+    aspectRatio={426 / 240}
+    captions=""
+    src={[
     {
       type: "video/mp4",
       src: "https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
@@ -50,148 +93,25 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       src: "https://archive.org/download/ElephantsDream/ed_hd.ogv"
     },
   ]}
-/>
+    controls
+  />
+</Box>
 `}
-      />
-      <Example
-        id="nativeVideoAttributesExample"
-        name="Native video attributes"
-        description={`
-    \`Video\` supports the native HTML video attributes such as \`autoPlay\`, \`loop\`, \`muted\`, and more.
-    Simply pass these through as props on the \`Video\` component.
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Video controls"
+          description={`Video components can show a control bar to users in order to allow them access to certain features such as play/pause, timestamps, mute, and fullscreen. Pass in the \`controls\` prop to make them appear.
   `}
-        defaultCode={`
-<Video
-  aspectRatio={1920 / 1080}
-  captions=""
-  loop
-  src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
-/>
-`}
-      />
-      <Example
-        id="videoControlsExample"
-        name="Video controls"
-        description={`
-    \`Video\` components can show a control bar to users in order to allow them access to certain features
-    such as play/pause, timestamps, mute, and fullscreen. Pass in the \`controls\` prop to make them appear.
-  `}
-        defaultCode={`
-        function Example() {
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function Example () {
   const [playing, setPlaying] = React.useState(true);
 
-  return <Video
-    accessibilityMaximizeLabel="Maximize"
-    accessibilityMinimizeLabel="Minimize"
-    accessibilityMuteLabel="Mute"
-    accessibilityPauseLabel="Pause"
-    accessibilityPlayLabel="Play"
-    accessibilityProgressBarLabel="Progress bar"
-    accessibilityUnmuteLabel="Unmute"
-    aspectRatio={853 / 480}
-    captions=""
-    controls
-    onPlayError={() => { console.log('hi'); setPlaying(false) }}
-    onPlay={() => setPlaying(true)}
-    onPause={() => setPlaying(false)}
-    playing={playing}
-    src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
-  />
-}
-`}
-      />
-      {/* <Example
-        name="Video with children"
-        description={`
-    \`Video\` component can show components in the \`children\` prop on top of the html video element, while under the controls.
-    The children of \`Video\` are not same as the children of the html \`video\` element; they're "outside" the html \`video\` element.
-  `}
-        defaultCode={`
-<Video
-  accessibilityMaximizeLabel="Maximize"
-  accessibilityMinimizeLabel="Minimize"
-  accessibilityMuteLabel="Mute"
-  accessibilityPauseLabel="Pause"
-  accessibilityPlayLabel="Play"
-  accessibilityProgressBarLabel="Progress bar"
-  accessibilityUnmuteLabel="Unmute"
-  aspectRatio={853 / 480}
-  captions=""
-  controls
-  src="https://media.w3.org/2010/05/bunny/movie.mp4"
->
-  <Box width="100%" height="100%"
-    display="flex"
-    justifyContent="center"
-    alignItems="center"
-    dangerouslySetInlineStyle={{__style:{backgroundColor:'rgba(0, 0, 0, 0.3)'}}}>
-      <IconButton
-        accessibilityLabel="Love"
-        bgColor="white"
-        icon="trash-can"
-        size="lg" />
-  </Box>
-</Video>
-`}
-      /> */}
-      {/* <Example
-        id="videoUpdatesExample"
-        name="Video updates"
-        description={`
-    \`Video\` is robust enough to handle any updates, such as changing the source, volume, or speed.`}
-        defaultCode={`
-function Example() {
-  const [input, setInput] = React.useState("https://media.w3.org/2010/05/bunny/movie.mp4");
-  const [playbackRate, setPlaybackRate] = React.useState(1);
-  const [playing, setPlaying] = React.useState(false);
-  const [src, setSrc] = React.useState("https://media.w3.org/2010/05/bunny/movie.mp4");
-  const [volume, setVolume] = React.useState(1);
-
   return (
-    <Box>
-      <Box paddingY={2}>
-        <Box marginBottom={2}>
-          <Label htmlFor="video-source">
-            <Text>Video source URL</Text>
-          </Label>
-        </Box>
-        <Box display="flex" marginStart={-1} marginEnd={-1}>
-          <Box flex="grow" paddingX={1}>
-            <TextField
-              id="video-source"
-              onChange={({ value }) => setInput(value)}
-              value={input}
-            />
-          </Box>
-          <Box paddingX={1}>
-            <Button
-              text="Submit"
-              color="red"
-              onClick={() => setSrc(input)}
-            />
-          </Box>
-        </Box>
-      </Box>
-      <Box paddingY={2}>
-        <Button
-          text={volume === 0 ? "Unmute" : "Mute"}
-          onClick={() => setVolume(volume === 0 ? 1 : 0)}
-        />
-      </Box>
-      <Box display="flex" paddingY={2} marginStart={-1} marginEnd={-1}>
-        <Box paddingX={1} column={6}>
-          <Button
-            text="Playback x0.5"
-            onClick={() => setPlaybackRate(playbackRate / 2)}
-          />
-        </Box>
-        <Box paddingX={1} column={6}>
-          <Button
-            text="Playback x2"
-            onClick={() => setPlaybackRate(playbackRate * 2)}
-          />
-        </Box>
-      </Box>
+    <Box width={300}>
       <Video
         accessibilityMaximizeLabel="Maximize"
         accessibilityMinimizeLabel="Minimize"
@@ -200,22 +120,135 @@ function Example() {
         accessibilityPlayLabel="Play"
         accessibilityProgressBarLabel="Progress bar"
         accessibilityUnmuteLabel="Unmute"
-        aspectRatio={853 / 480}
+        aspectRatio={540 / 960}
         captions=""
         controls
+        onPlayError={() => setPlaying(false)}
         onPlay={() => setPlaying(true)}
         onPause={() => setPlaying(false)}
-        onVolumeChange={({ volume }) => setVolume(volume)}
-        playbackRate={playbackRate}
         playing={playing}
-        src={src}
-        volume={volume}
-      />
+        src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"  />
     </Box>
+  )
+}
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Video with children"
+          description={`Video component can show components in the \`children\` prop on top of the html video element, while under the controls.
+    The children of Video are not same as the children of the html video element; they're "outside" the html video element.
+  `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+<Box width={300}>
+  <Video
+    accessibilityMaximizeLabel="Maximize"
+    accessibilityMinimizeLabel="Minimize"
+    accessibilityMuteLabel="Mute"
+    accessibilityPauseLabel="Pause"
+    accessibilityPlayLabel="Play"
+    accessibilityProgressBarLabel="Progress bar"
+    accessibilityUnmuteLabel="Unmute"
+    aspectRatio={540 / 960}
+    captions=""
+    controls
+    src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+  >
+    <Box width="100%" height="100%"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      dangerouslySetInlineStyle={{__style:{backgroundColor:'rgba(0, 0, 0, 0.3)'}}}>
+        <IconButton
+          accessibilityLabel="Love"
+          bgColor="white"
+          icon="trash-can"
+          size="lg" />
+    </Box>
+  </Video>
+</Box>
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Video updates"
+          description="Video is robust enough to handle any updates, such as changing the source, volume, or speed."
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function Example() {
+  const [input, setInput] = React.useState("https://v.pinimg.com/videos/mc/expMp4/ce/b4/cc/ceb4cc8c4889a86432a65884c147021f_t1.mp4");
+  const [playbackRate, setPlaybackRate] = React.useState(1);
+  const [playing, setPlaying] = React.useState(false);
+  const [src, setSrc] = React.useState("https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4");
+  const [volume, setVolume] = React.useState(1);
+
+  return (
+    <Flex width="100%" gap={2} direction="column">
+      <Flex width="100%" gap={2} alignItems="center">
+        <Label htmlFor="video-source">
+          <Text>Video source URL</Text>
+        </Label>
+        <Flex.Item flex="grow">
+          <TextField
+            id="video-source"
+            onChange={({ value }) => setInput(value)}
+            value={input}
+          />
+        </Flex.Item>
+        <Button
+          text="Submit"
+          color="red"
+          onClick={() => setSrc(input)}
+        />
+      </Flex>
+      <Flex gap={2}>
+        <Button
+          text={volume === 0 ? "Unmute" : "Mute"}
+          onClick={() => setVolume(volume === 0 ? 1 : 0)}
+        />
+        <Button
+          text="Playback x0.5"
+          onClick={() => setPlaybackRate((value) => value >= 1 ? value / 2 : 0.5)}
+        />
+        <Button
+          text="Playback x2"
+          onClick={() => setPlaybackRate((value) => value < 8 ? value * 2 : 16)}
+        />
+      </Flex>
+      <Box width={300}>
+        <Video
+          accessibilityMaximizeLabel="Maximize"
+          accessibilityMinimizeLabel="Minimize"
+          accessibilityMuteLabel="Mute"
+          accessibilityPauseLabel="Pause"
+          accessibilityPlayLabel="Play"
+          accessibilityProgressBarLabel="Progress bar"
+          accessibilityUnmuteLabel="Unmute"
+          aspectRatio={540 / 960}
+          captions=""
+          controls
+          onPlay={() => setPlaying(true)}
+          onPause={() => setPlaying(false)}
+          onVolumeChange={({ volume }) => setVolume(volume)}
+          playbackRate={playbackRate}
+          playing={playing}
+          src={src}
+          loop
+          volume={volume}
+        />
+      </Box>
+    </Flex>
   );
 }
 `}
-      /> */}
+          />
+        </MainSection.Subsection>
+      </MainSection>
     </Page>
   );
 }

--- a/docs/pages/video.js
+++ b/docs/pages/video.js
@@ -14,7 +14,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
-      <Example
+      {/* <Example
         id="basicExample"
         name="Video media basics"
         description={`
@@ -29,7 +29,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   src="https://media.w3.org/2010/05/bunny/movie.mp4"
 />
 `}
-      />
+      /> */}
       <Example
         name="Video multiple sources"
         description={`
@@ -40,7 +40,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 <Video
   aspectRatio={426 / 240}
   captions=""
-  playing
   src={[
     {
       type: "video/mp4",
@@ -66,7 +65,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   aspectRatio={1920 / 1080}
   captions=""
   loop
-  playing
   src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
 />
 `}
@@ -79,25 +77,33 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     such as play/pause, timestamps, mute, and fullscreen. Pass in the \`controls\` prop to make them appear.
   `}
         defaultCode={`
-<Video
-  accessibilityMaximizeLabel="Maximize"
-  accessibilityMinimizeLabel="Minimize"
-  accessibilityMuteLabel="Mute"
-  accessibilityPauseLabel="Pause"
-  accessibilityPlayLabel="Play"
-  accessibilityProgressBarLabel="Progress bar"
-  accessibilityUnmuteLabel="Unmute"
-  aspectRatio={853 / 480}
-  captions=""
-  controls
-  src="https://media.w3.org/2010/05/bunny/movie.mp4"
-/>
+        function Example() {
+  const [playing, setPlaying] = React.useState(true);
+
+  return <Video
+    accessibilityMaximizeLabel="Maximize"
+    accessibilityMinimizeLabel="Minimize"
+    accessibilityMuteLabel="Mute"
+    accessibilityPauseLabel="Pause"
+    accessibilityPlayLabel="Play"
+    accessibilityProgressBarLabel="Progress bar"
+    accessibilityUnmuteLabel="Unmute"
+    aspectRatio={853 / 480}
+    captions=""
+    controls
+    onPlayError={() => { console.log('hi'); setPlaying(false) }}
+    onPlay={() => setPlaying(true)}
+    onPause={() => setPlaying(false)}
+    playing={playing}
+    src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+  />
+}
 `}
       />
-      <Example
+      {/* <Example
         name="Video with children"
         description={`
-    \`Video\` component can show components in the \`chilren\` prop on top of the html video element, while under the controls.
+    \`Video\` component can show components in the \`children\` prop on top of the html video element, while under the controls.
     The children of \`Video\` are not same as the children of the html \`video\` element; they're "outside" the html \`video\` element.
   `}
         defaultCode={`
@@ -112,7 +118,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   aspectRatio={853 / 480}
   captions=""
   controls
-  playing
   src="https://media.w3.org/2010/05/bunny/movie.mp4"
 >
   <Box width="100%" height="100%"
@@ -128,8 +133,8 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   </Box>
 </Video>
 `}
-      />
-      <Example
+      /> */}
+      {/* <Example
         id="videoUpdatesExample"
         name="Video updates"
         description={`
@@ -210,7 +215,7 @@ function Example() {
   );
 }
 `}
-      />
+      /> */}
     </Page>
   );
 }

--- a/docs/pages/video.js
+++ b/docs/pages/video.js
@@ -24,94 +24,36 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     accessibilityProgressBarLabel="Progress bar"
     accessibilityUnmuteLabel="Unmute"
     aspectRatio={540 / 960}
-    captions=""
-    src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
     controls
+    onPlayError={() => {}}
+    onPlay={() => {}}
+    src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
   />
 </Box>
 `}
       />
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
-      <MainSection name="Variants">
+      <MainSection name="Accessibility">
         <MainSection.Subsection
-          title="Native video attributes"
-          description={`Video supports the native HTML video attributes such as \`src\`, \`poster\`, \`loop\`, \`muted\`, and more. Simply pass these through as props on the Video component.
+          title="Captions"
+          description={`Warning: Captions aren't currently supported.
 
-The source url you pass into Video will be used to download and play the video file. While it is downloading the metadata, you may show a thumbnail image by using the \`poster\` prop.
-  `}
-        >
-          <MainSection.Card
-            cardSize="lg"
-            defaultCode={`
-<Box width={300}>
-  <Video
-    accessibilityMaximizeLabel="Maximize"
-    accessibilityMinimizeLabel="Minimize"
-    accessibilityMuteLabel="Mute"
-    accessibilityPauseLabel="Pause"
-    accessibilityPlayLabel="Play"
-    accessibilityProgressBarLabel="Progress bar"
-    accessibilityUnmuteLabel="Unmute"
-    aspectRatio={540 / 960}
-    captions=""
-    poster="https://i.pinimg.com/videos/thumbnails/originals/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4.0000000.jpg"
-    src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
-    controls
-    muted
-  />
-</Box>
-`}
-          />
-        </MainSection.Subsection>
-        <MainSection.Subsection
-          title="Multiple video sources"
-          description={`Not all browsers support the same video encoding types. If you have multiple video file sources, you can pass them as a list to Video in the order you want the HTML video tag to use as fallbacks.
-  `}
-        >
-          <MainSection.Card
-            cardSize="lg"
-            defaultCode={`
-<Box width={300}>
-  <Video
-    accessibilityMaximizeLabel="Maximize"
-    accessibilityMinimizeLabel="Minimize"
-    accessibilityMuteLabel="Mute"
-    accessibilityPauseLabel="Pause"
-    accessibilityPlayLabel="Play"
-    accessibilityProgressBarLabel="Progress bar"
-    accessibilityUnmuteLabel="Unmute"
-    aspectRatio={426 / 240}
-    captions=""
-    src={[
-    {
-      type: "video/mp4",
-      src: "https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
-    },
-    {
-      type: "video/ogg",
-      src: "https://archive.org/download/ElephantsDream/ed_hd.ogv"
-    },
-  ]}
-    controls
-  />
-</Box>
-`}
-          />
-        </MainSection.Subsection>
-        <MainSection.Subsection
-          title="Video controls"
-          description={`Video components can show a control bar to users in order to allow them access to certain features such as play/pause, timestamps, mute, and fullscreen. Pass in the \`controls\` prop to make them appear.
+Captions are intended for deaf and hard-of-hearing audiences. Captions are usually in the same language as the audio. Please, reade the [differences between captions and subtitles](https://web.archive.org/web/20160117160743/http://screenfont.ca/learn/).
+
+Read more about [adding captions to video](https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video#html5_and_video_captions).
+
+The following example uses an excerpt from the [Sintel open movie](https://www.sintel.org), created by the [Blender Foundation](https://www.blender.org/foundation/).
   `}
         >
           <MainSection.Card
             cardSize="lg"
             defaultCode={`
 function Example () {
-  const [playing, setPlaying] = React.useState(true);
+  const [playing, setPlaying] = React.useState(false);
 
   return (
-    <Box width={300}>
+    <Box width={1000}>
       <Video
         accessibilityMaximizeLabel="Maximize"
         accessibilityMinimizeLabel="Minimize"
@@ -120,14 +62,19 @@ function Example () {
         accessibilityPlayLabel="Play"
         accessibilityProgressBarLabel="Progress bar"
         accessibilityUnmuteLabel="Unmute"
-        aspectRatio={540 / 960}
-        captions=""
+        accessibilityHideCaptionsLabel="Hide captions"
+        accessibilityShowCaptionsLabel="Show captions"
+        aspectRatio={1024 / 435}
+        captions="https://iandevlin.github.io/mdn/video-player-with-captions/subtitles/vtt/sintel-en.vtt"
         controls
-        onPlayError={() => setPlaying(false)}
-        onPlay={() => setPlaying(true)}
-        onPause={() => setPlaying(false)}
+        onPlayError={({ error }) => error && setPlaying(false)}
+        onPlay={({ event }) => setPlaying(true)}
+        onControlsPlay={() => setPlaying(true)}
+        onControlsPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
         playing={playing}
-        src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"  />
+        loop
+        src="https://iandevlin.github.io/mdn/video-player-with-captions/video/sintel-short.mp4"  />
     </Box>
   )
 }
@@ -135,9 +82,131 @@ function Example () {
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          title="Video with children"
+          title="Labels"
+          description={`Video requires several accessibility labels for each video control: \`accessibilityMaximizeLabel\`, \`accessibilityMinimizeLabel\`, \`accessibilityMuteLabel\`, \`accessibilityPauseLabel\`, \`accessibilityPlayLabel\`, \`accessibilityProgressBarLabel\` and \`accessibilityUnmuteLabel\`.
+
+If the video contain captions, it also requires \`accessibilityHideCaptionsLabel\` and \`accessibilityShowCaptionsLabel\`.
+.
+`}
+        />
+      </MainSection>
+
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          title="Autoplay and error detection"
+          description={`Autoplay or automatically starting the playback of the video requires the \`autoplay\` prop. While autoplay of media serves a useful purpose, it should be used carefully and only when needed. In order to give users control over this, browsers often provide various forms of autoplay blocking.
+
+Autoplay blocking is not applied to video elements when the source media doesn't have an audio track or is muted.
+
+Gestalt Video provides a comprehensive API to handle gracefully autoplay blocking and prevent UI and/or client errors. The example below shows how to correctly handle autoplay error detection.
+
+If \`autoplay\` is set, use \`onPlay\` to detect when the video starts playing and display the pause control accordingly. In case \`autoplay\` gets blocked, \`onPlay\` would never get triggered and controls will still display the play control.
+
+\`onPlayError\` is another error-handling callback. In this case, \`onPlayError\` detects if the HTMLMediaElement.play() method fails. HTMLMediaElement.play() returns a Promise and \`onPlayError\` catches the error if the Promise is rejected. Display the pause control if any error is detected.
+
+If \`autoplay\` is set, don't set the initial \`playing\` state to true as both will attempt to autoplay the video. We recommend setting \`autoplay\`, using \`onPlay\` to detect when the video is played and setting \`playing\` to true. If the initial \`playing\` state is set to true, don't set \`autoplay\`. If both \`autoplay\` and the initial \`playing\` state are set to true, \`autoplay\` has preference.
+
+For more information about autoplay, check the [MDN Web Docs: video](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-autoplay), [MDN Web Docs: HTMLMediaElement.autoplay](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/autoplay), and the [MDN Web Docs: Autoplay guide for media and Web Audio APIs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/autoplay).
+  `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function Example () {
+  const [playing, setPlaying] = React.useState(false);
+
+  return (
+    <Box width={300}>
+      <Video
+        autoplay
+        accessibilityMaximizeLabel="Maximize"
+        accessibilityMinimizeLabel="Minimize"
+        accessibilityMuteLabel="Mute"
+        accessibilityPauseLabel="Pause"
+        accessibilityPlayLabel="Play"
+        accessibilityProgressBarLabel="Progress bar"
+        accessibilityUnmuteLabel="Unmute"
+        aspectRatio={540 / 960}
+        controls
+        onPlayError={({ error }) => error && setPlaying(false)}
+        onPlay={({ event }) => setPlaying(true)}
+        onControlsPlay={() => setPlaying(true)}
+        onControlsPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+        playing={playing}
+        loop
+        src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"  />
+    </Box>
+  )
+}`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Video controls"
+          description={`Video components can show a control bar to users in order to allow them access to certain features such as play/pause, timestamps, mute, and fullscreen. Pass in the \`controls\` prop to make them appear. The Video \`controls\` are custom; they aren't the [native video controls](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-controls).
+  `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function Example() {
+  const [showControls, setShowControls] = React.useState(false);
+
+  return (
+    <Flex alignItems="center" gap={2} direction="column">
+      <Flex alignItems="center" gap={2}>
+        <Box paddingX={2}>
+          <Label htmlFor="video">
+            <Text>Show built-in Video controls</Text>
+          </Label>
+        </Box>
+        <Switch
+          onChange={() => setShowControls((value) => !value)}
+          id="video"
+          switched={showControls}
+        />
+      </Flex>
+      <Box width={300}>
+        <Video
+          accessibilityMaximizeLabel="Maximize"
+          accessibilityMinimizeLabel="Minimize"
+          accessibilityMuteLabel="Mute"
+          accessibilityPauseLabel="Pause"
+          accessibilityPlayLabel="Play"
+          accessibilityProgressBarLabel="Progress bar"
+          accessibilityUnmuteLabel="Unmute"
+          aspectRatio={540 / 960}
+          controls={showControls}
+          onPlayError={() => {}}
+          onPlay={() => {}}
+          poster="https://i.pinimg.com/videos/thumbnails/originals/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4.0000000.jpg"
+          src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+        >
+          {!showControls ? (
+            <Box
+              width="100%"
+              height="100%"
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              dangerouslySetInlineStyle={{ __style: { backgroundColor: 'rgba(0, 0, 0, 0.3)' } }}
+            >
+              <IconButton accessibilityLabel="Love" bgColor="white" icon="play" size="lg" />
+            </Box>
+          ) : null}
+        </Video>
+      </Box>
+    </Flex>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="With children"
           description={`Video component can show components in the \`children\` prop on top of the html video element, while under the controls.
-    The children of Video are not same as the children of the html video element; they're "outside" the html video element.
+    The children of Video aren't same as the children of the html video element; they're "outside" the html video element.
   `}
         >
           <MainSection.Card
@@ -153,7 +222,6 @@ function Example () {
     accessibilityProgressBarLabel="Progress bar"
     accessibilityUnmuteLabel="Unmute"
     aspectRatio={540 / 960}
-    captions=""
     controls
     src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
   >
@@ -173,6 +241,7 @@ function Example () {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Video updates"
           description="Video is robust enough to handle any updates, such as changing the source, volume, or speed."
@@ -230,10 +299,9 @@ function Example() {
           accessibilityProgressBarLabel="Progress bar"
           accessibilityUnmuteLabel="Unmute"
           aspectRatio={540 / 960}
-          captions=""
           controls
-          onPlay={() => setPlaying(true)}
-          onPause={() => setPlaying(false)}
+          onControlsPlay={() => setPlaying(true)}
+          onControlsPause={() => setPlaying(false)}
           onVolumeChange={({ volume }) => setVolume(volume)}
           playbackRate={playbackRate}
           playing={playing}
@@ -244,6 +312,48 @@ function Example() {
       </Box>
     </Flex>
   );
+}
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Multiple video sources"
+          description={`Not all browsers support the same video encoding types. If you have multiple video file sources, you can pass them as a list to Video in the order you want the HTML video tag to use as fallbacks.
+  `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function Example () {
+  const [playing, setPlaying] = React.useState(false);
+
+  return (
+    <Box width={300}>
+      <Video
+        accessibilityMaximizeLabel="Maximize"
+        accessibilityMinimizeLabel="Minimize"
+        accessibilityMuteLabel="Mute"
+        accessibilityPauseLabel="Pause"
+        accessibilityPlayLabel="Play"
+        accessibilityProgressBarLabel="Progress bar"
+        accessibilityUnmuteLabel="Unmute"
+        aspectRatio={426 / 240}
+        controls
+        playing={playing}
+        onControlsPlay={() => setPlaying(true)}
+        src={[
+          {
+            type: "video/mp4",
+            src: "https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
+          },
+          {
+            type: "video/ogg",
+            src: "https://archive.org/download/ElephantsDream/ed_hd.ogv"
+          },
+        ]}
+      />
+    </Box>
+  )
 }
 `}
           />

--- a/docs/pages/visual-test/Video.js
+++ b/docs/pages/visual-test/Video.js
@@ -16,6 +16,8 @@ export default function Snapshot(): Node {
         accessibilityUnmuteLabel=""
         captions=""
         controls
+        onPlay={() => {}}
+        onPlayError={() => {}}
         poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
         src="https://media.w3.org/2010/05/bunny/movie.mp4"
       />

--- a/packages/gestalt/src/Video.flowtest.js
+++ b/packages/gestalt/src/Video.flowtest.js
@@ -13,6 +13,8 @@ const Valid = (
     aspectRatio={1}
     captions="https://media.w3.org/2010/05/sintel/captions.vtt"
     disableRemotePlayback
+    onPlay={() => {}}
+    onPlayError={() => {}}
     src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
   />
 );

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -110,7 +110,7 @@ type Props = {|
   /**
    * Callback triggered when an [play() method's Promise is rejected](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) during playing a video, such as [blocked automatic playback](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions). See [updates example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
    */
-  onPlayError?: () => void,
+  onPlayError?: ({| error: Error |}) => void,
   /**
    * Callback triggered when the video full screen status changes. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
    */
@@ -458,10 +458,8 @@ export default class Video extends PureComponent<Props, State> {
       if (!isPlaying) {
         try {
           await this.video.play();
-          console.log('playing');
-        } catch (err) {
-          this.props.onPlayError?.();
-          console.log('ERROR', err, this.props.src );
+        } catch (error) {
+          this.props.onPlayError?.({ error });
         }
       }
     }

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -108,6 +108,10 @@ type Props = {|
    */
   onError?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
+   * Callback triggered when an [play() method's Promise is rejected](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) during playing a video, such as [blocked automatic playback](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions). See [updates example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   */
+  onPlayError?: () => void,
+  /**
    * Callback triggered when the video full screen status changes. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
    */
   onFullscreenChange?: ({| event: Event, fullscreen: boolean |}) => void,
@@ -444,14 +448,22 @@ export default class Video extends PureComponent<Props, State> {
   };
 
   // Play the video
-  play: () => void = () => {
+  play: () => Promise<void> = async () => {
     if (this.video) {
       const isPlaying =
         this.video.currentTime > 0 &&
         !this.video.paused &&
         !this.video.ended &&
         this.video.readyState > 2;
-      if (!isPlaying) this.video.play();
+      if (!isPlaying) {
+        try {
+          await this.video.play();
+          console.log('playing');
+        } catch (err) {
+          this.props.onPlayError?.();
+          console.log('ERROR', err, this.props.src );
+        }
+      }
     }
   };
 

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { PureComponent, type Node } from 'react';
+import { PureComponent, type Node, type Ref } from 'react';
 import classnames from 'classnames';
 import VideoControls from './VideoControls.js';
 import ColorSchemeProvider from './contexts/ColorSchemeProvider.js';
@@ -20,41 +20,45 @@ type BackgroundColor = 'black' | 'transparent';
 
 type Props = {|
   /**
-   * Accessibility label for the button to hide captions if controls are shown. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Accessibility label for the button to hide captions if controls are shown.
    */
   accessibilityHideCaptionsLabel?: string,
   /**
-   * Accessibility label for the button to show captions if controls are shown. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
-   */
-  accessibilityShowCaptionsLabel?: string,
-  /**
-   * Accessibility label for the fullscreen maximize button if controls are shown. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Accessibility label for the fullscreen maximize button if controls are shown.
    */
   accessibilityMaximizeLabel: string,
   /**
-   * Accessibility label for the fullscreen minimize button if controls are shown. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Accessibility label for the fullscreen minimize button if controls are shown.
    */
   accessibilityMinimizeLabel: string,
   /**
-   * Accessibility label for the mute button if controls are shown. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Accessibility label for the mute button if controls are shown.
    */
   accessibilityMuteLabel: string,
   /**
-   * Accessibility label for the pause button if controls are shown. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Accessibility label for the pause button if controls are shown.
    */
   accessibilityPauseLabel: string,
   /**
-   * Accessibility label for the play button if controls are shown. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Accessibility label for the play button if controls are shown.
    */
   accessibilityPlayLabel: string,
   /**
-   * Accessibility label for progress bar. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Accessibility label for the video progress bar.
    */
   accessibilityProgressBarLabel: string,
   /**
-   * Accessibility label for the unmute button if controls are shown. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Accessibility label for the button to show captions if controls are shown. See the [accessibility section](https://gestalt.pinterest.systems/video#Captions) to learn more.
+   */
+  accessibilityShowCaptionsLabel?: string,
+  /**
+   * Accessibility label for the unmute button if controls are shown. See the [accessibility section](https://gestalt.pinterest.systems/video#Captions) to learn more.
    */
   accessibilityUnmuteLabel: string,
+  /**
+   * When set to autoplay, the video will automatically start playing. See the [autoplay and error detection variant](https://gestalt.pinterest.systems/video#Autoplay-and-error-detection) to learn more.
+   */
+  autoplay?: boolean,
   /**
    * Proportional relationship between width and height of the video, calculated as width / height.
    */
@@ -64,12 +68,11 @@ type Props = {|
    */
   backgroundColor: BackgroundColor,
   /**
-   * The URL of the captions track for the video (.vtt file).
+   * The URL of the captions track for the video (.vtt file). Warning: Captions aren't currently supported. See the [accessibility section](https://gestalt.pinterest.systems/video#Captions) to learn more.
    */
-  captions: string,
+  captions?: string,
   /**
-   * This \`children\` prop is not same as children inside the native html \`video\` element.
-   * Instead it serves to add overlays on top of the html video element, while still being under the video controls. See [children example](https://gestalt.pinterest.systems/video#video-with-children) for more details.
+   * This `children` prop is not same as children inside the native html `video` element. Instead, it serves to add overlays on top of the html video element, while still being under the video controls. See [children example](https://gestalt.pinterest.systems/video#video-with-children) for more details.
    */
   children?: Node,
   /**
@@ -77,7 +80,7 @@ type Props = {|
    */
   crossOrigin?: CrossOrigin,
   /**
-   * Show the video player controls. See [controls example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Show the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
    */
   controls?: boolean,
   /**
@@ -89,121 +92,135 @@ type Props = {|
    */
   loop?: boolean,
   /**
-   * Sets how the content of the replaced `<video>` element should be resized to fit its container.
+   * Sets how the content of the replaced video element should be resized to fit its container.
    */
   objectFit?: ObjectFit,
   /**
-   * Callback triggered when the metadata has loaded or changed, indicating a change in duration. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when playback is played via the video control interface.
+   */
+  onControlsPlay?: ({|
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
+  |}) => void,
+  /**
+   * Callback triggered when playback is paused via the video control interface.
+   */
+  onControlsPause?: ({|
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
+  |}) => void,
+  /**
+   * Callback triggered when the metadata has loaded or changed, indicating a change in duration. See the [MDN Web Docs: durationchange event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/durationchange_event).
    */
   onDurationChange?: ({|
     event: SyntheticEvent<HTMLVideoElement>,
     duration: number,
   |}) => void,
   /**
-   * Callback triggered when playback of the video completes. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when playback of the video completes. See the [MDN Web Docs: ended event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/ended_event).
    */
   onEnded?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when an error occurs. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when an error occurs. See the [MDN Web Docs: onerror](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/onerror).
    */
   onError?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
+
   /**
-   * Callback triggered when an [play() method's Promise is rejected](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) during playing a video, such as [blocked automatic playback](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions). See [updates example](https://gestalt.pinterest.systems/video#videoControlsExample) for more details.
+   * Callback triggered when playback is paused. See the [MDN Web Docs: pause event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause_event).
    */
-  onPlayError?: ({| error: Error |}) => void,
+  onPause?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
+
   /**
-   * Callback triggered when the video full screen status changes. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when `pause` is changed from "true" to "false" or `autoplay`. See the [MDN Web Docs: play event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play_event) and the [autoplay and error detection variant](https://gestalt.pinterest.systems/video#Autoplay-and-error-detection) to learn more.
+   */
+  onPlay: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
+  /**
+   * Callback triggered when a [play() method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play)'s Promise is [rejected](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions). See the [autoplay and error detection variant](https://gestalt.pinterest.systems/video#Autoplay-and-error-detection) to learn more.
+   */
+  onPlayError: ({| error: Error |}) => void,
+  /**
+   * Callback triggered when the video full-screen status changes. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
    */
   onFullscreenChange?: ({| event: Event, fullscreen: boolean |}) => void,
   /**
-   * Callback triggered when progress happens on downloading the media. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when progress happens on downloading the media. See the [MDN Web Docs: progress event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/progress_event).
    */
   onLoadedChange?: ({| event: SyntheticEvent<HTMLVideoElement>, loaded: number |}) => void,
   /**
-   * Callback triggered when the media has started to load. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when the media has started to load.
    */
   onLoadStart?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when playback of the media starts after having been paused. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
-   */
-  onPlay?: ({|
-    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
-  |}) => void,
-  /**
-   * Callback triggered when playback of the media is ready to start after having been paused. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered after playback is first started, and whenever it is restarted. See the [MDN Web Docs: playing event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playing_event).
    */
   onPlaying?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when mouse down event occurs on playhead. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when mousedown event occurs on the playhead via the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
    */
   onPlayheadDown?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
   /**
-   * Callback triggered when mouse up event occurs on playhead. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when mouseup event occurs on the playhead via the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
    */
   onPlayheadUp?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
   /**
-   * Callback triggered when playback is paused. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
-   */
-  onPause?: ({|
-    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
-  |}) => void,
-  /**
-   * Callback triggered when video is loaded and ready to play. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when enough data is available that the media can be played. See the [MDN Web Docs: canplay event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canplay_event).
    */
   onReady?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when a seek operation completes from the playhead. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when a seek operation completes from the playhead. See the [MDN Web Docs: seeked event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seeked_event).
    */
   onSeek?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when a seek operation begins. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when a seek operation begins. See the [MDN Web Docs: seeking event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seeking_event).
    */
   onSeeking?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when trying to fetch data but the data is unexpectedly not forthcoming. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when trying to fetch data but the data is unexpectedly not forthcoming. See the [MDN Web Docs: stalled event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/stalled_event).
    */
   onStalled?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when the time indicated by the element's currentTime attribute has changed. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when the time indicated by the element's currentTime attribute has changed. See the [MDN Web Docs: timeupdate event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/timeupdate_event).
    */
   onTimeChange?: ({| event: SyntheticEvent<HTMLVideoElement>, time: number |}) => void,
   /**
-   * Callback triggered when the audio volume changes. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when the audio volume changes via the video control interface. See the [video updates variant](https://gestalt.pinterest.systems/video#Video-updates) to learn more.
    */
   onVolumeChange?: ({|
     event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
     volume: number,
   |}) => void,
   /**
-   * Callback triggered when playback has stopped because of a temporary lack of data. See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Callback triggered when playback has stopped because of a temporary lack of data. See the [MDN Web Docs: waiting event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/waiting_event).
    */
   onWaiting?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Specifies the speed at which the video plays: 1 for normal.  See [updates example](https://gestalt.pinterest.systems/video#videoUpdatesExample) for more details.
+   * Specifies the speed at which the video plays: 1 for normal. See the [video updates variant](https://gestalt.pinterest.systems/video#Video-updates) to learn more.
    */
   playbackRate: number,
   /**
-   * Specifies whether the video should play or not.
+   * Specifies whether the video should play or not. See [autoplay and error detection variant](https://gestalt.pinterest.systems/video#Autoplay-and-error-detection) to learn more.
    */
   playing: boolean,
   /**
-   * Serves as a hint to the user agent that the video should to be displayed "inline" in the document by default, constrained to the element's playback area, instead of being displayed fullscreen or in an independent resizable window. This attribute is mainly relevant to iOS Safari browsers.
+   * Serves as a hint to the user agent that the video should to be displayed "inline" in the document by default, constrained to the element's playback area, instead of being displayed fullscreen or in an independent resizable window. This attribute is mainly relevant to iOS Safari browsers. See the [MDN Web Docs: playsinline](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-playsinline)
    */
   playsInline?: boolean,
   /**
-   * The image to show while the video is loading.
+   * The image to show while the video is loading. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
    */
   poster?: string,
   /**
-   * Specifies how, if at all, the video should be pre-loaded when the page loads.
+   * Specifies how, if at all, the video should be pre-loaded when the page loads. See the [MDN Web Docs: preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-preload)
    */
   preload: 'auto' | 'metadata' | 'none',
+  /**
+   * Ref on the Gestalt Video component.
+   */
+  ref?: Ref<typeof Video>, // eslint-disable-line no-use-before-define
   /**
    * The URL of the video file to play. This can also be supplied as a list of video types to respective video source urls in fallback order for support on various browsers. See [multiple sources example](https://gestalt.pinterest.systems/video#Video-multiple-sources) for more details.
    */
   src: Source,
   /**
-   * Specifies the volume of the video audio: 0 for muted, 1 for max. See [example](https://gestalt.pinterest.systems/video#nativeVideoAttributesExample) for more details.
+   * Specifies the volume of the video audio: 0 for muted, 1 for max. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
    */
   volume: number,
 |};
@@ -308,7 +325,7 @@ const isNewSource = (oldSource: Source, newSource: Source): boolean => {
 };
 
 /**
- * Like Image, [Video](https://gestalt.pinterest.systems/video) is used for media layout. This component is supercharged with lots of goodies to turn a regular video in a full blown viewing experience.
+ * [Video](https://gestalt.pinterest.systems/video) is used for media layout.
  *
  * ![Video light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Video%20%230.png)
  */
@@ -350,7 +367,7 @@ export default class Video extends PureComponent<Props, State> {
    */
 
   componentDidMount() {
-    const { captions, playbackRate, playing, volume } = this.props;
+    const { captions, playbackRate, volume, playing, autoplay } = this.props;
     // Set up event listeners to catch backdoors in fullscreen
     // changes such as using the ESC key to exit
     if (typeof document !== 'undefined') {
@@ -362,8 +379,8 @@ export default class Video extends PureComponent<Props, State> {
     this.setVolume(volume);
     // Set the initial playback rate
     this.setPlaybackRate(playbackRate);
-    // Simulate an autoplay effect if the component
-    if (playing) {
+
+    if (!autoplay && playing) {
       this.play();
     }
 
@@ -456,10 +473,9 @@ export default class Video extends PureComponent<Props, State> {
         !this.video.ended &&
         this.video.readyState > 2;
       if (!isPlaying) {
-        try {
-          await this.video.play();
-        } catch (error) {
-          this.props.onPlayError?.({ error });
+        const startPlayPromise = this.video.play();
+        if (startPlayPromise !== undefined) {
+          startPlayPromise.then().catch((error) => this.props.onPlayError?.({ error }));
         }
       }
     }
@@ -499,9 +515,25 @@ export default class Video extends PureComponent<Props, State> {
   handleCanPlay: (event: SyntheticEvent<HTMLVideoElement>) => void = (event) => {
     const { onReady } = this.props;
 
-    if (onReady) {
-      onReady({ event });
-    }
+    onReady?.({ event });
+  };
+
+  // Sent when playback of the media starts after having been paused.
+  handleControlsPlay: (
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
+  ) => void = (event) => {
+    const { onControlsPlay } = this.props;
+
+    onControlsPlay?.({ event });
+  };
+
+  // Sent when playback is paused.
+  handleControlsPause: (
+    event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
+  ) => void = (event) => {
+    const { onControlsPause } = this.props;
+
+    onControlsPause?.({ event });
   };
 
   // The metadata has loaded or changed, indicating a change in
@@ -511,18 +543,14 @@ export default class Video extends PureComponent<Props, State> {
     const duration = (this.video && this.video.duration) || 0;
     this.setState({ duration });
 
-    if (onDurationChange) {
-      onDurationChange({ event, duration });
-    }
+    onDurationChange?.({ event, duration });
   };
 
   // Sent when playback completes.
   handleEnded: (event: SyntheticEvent<HTMLVideoElement>) => void = (event) => {
     const { onEnded } = this.props;
 
-    if (onEnded) {
-      onEnded({ event });
-    }
+    onEnded?.({ event });
   };
 
   // Sent when an error occurs.
@@ -538,9 +566,7 @@ export default class Video extends PureComponent<Props, State> {
     const fullscreen = !!isFullscreen();
     this.setState({ fullscreen });
 
-    if (onFullscreenChange) {
-      onFullscreenChange({ event, fullscreen });
-    }
+    onFullscreenChange?.({ event, fullscreen });
   };
 
   // Sent when the video has started to load
@@ -550,15 +576,19 @@ export default class Video extends PureComponent<Props, State> {
     onLoadStart?.({ event });
   };
 
-  // Sent when playback of the media starts after having been paused.
-  handlePlay: (event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>) => void =
-    (event) => {
-      const { onPlay } = this.props;
+  // Sent when playback of the media is paused.
+  handlePause: (event: SyntheticEvent<HTMLVideoElement>) => void = (event) => {
+    const { onPause } = this.props;
 
-      if (onPlay) {
-        onPlay({ event });
-      }
-    };
+    onPause?.({ event });
+  };
+
+  // Sent when playback of the media is ready to start after having been paused.
+  handlePlay: (event: SyntheticEvent<HTMLVideoElement>) => void = (event) => {
+    const { onPlay } = this.props;
+
+    onPlay?.({ event });
+  };
 
   // Sent when playback of the media is ready to start after having been paused.
   handlePlaying: (event: SyntheticEvent<HTMLVideoElement>) => void = (event) => {
@@ -571,29 +601,15 @@ export default class Video extends PureComponent<Props, State> {
   handlePlayheadDown: (event: SyntheticMouseEvent<HTMLDivElement>) => void = (event) => {
     const { onPlayheadDown } = this.props;
 
-    if (onPlayheadDown) {
-      onPlayheadDown({ event });
-    }
+    onPlayheadDown?.({ event });
   };
 
   // Sent when mouse up event happens on playhead
   handlePlayheadUp: (event: SyntheticMouseEvent<HTMLDivElement>) => void = (event) => {
     const { onPlayheadUp } = this.props;
 
-    if (onPlayheadUp) {
-      onPlayheadUp({ event });
-    }
+    onPlayheadUp?.({ event });
   };
-
-  // Sent when playback is paused.
-  handlePause: (event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>) => void =
-    (event) => {
-      const { onPause } = this.props;
-
-      if (onPause) {
-        onPause({ event });
-      }
-    };
 
   // Sent periodically to inform interested parties of progress downloading the media
   handleProgress: (event: SyntheticEvent<HTMLVideoElement>) => void = (event) => {
@@ -601,18 +617,14 @@ export default class Video extends PureComponent<Props, State> {
     const { buffered } = this.video || {};
     const loaded = buffered && buffered.length > 0 ? buffered.end(buffered.length - 1) : 0;
 
-    if (onLoadedChange) {
-      onLoadedChange({ event, loaded });
-    }
+    onLoadedChange?.({ event, loaded });
   };
 
   // Sent when a seek operation completes.
   handleSeek: (event: SyntheticEvent<HTMLVideoElement>) => void = (event) => {
     const { onSeek } = this.props;
 
-    if (onSeek) {
-      onSeek({ event });
-    }
+    onSeek?.({ event });
   };
 
   // Sent when a seek operation beings.
@@ -635,9 +647,7 @@ export default class Video extends PureComponent<Props, State> {
     const currentTime = (this.video && this.video.currentTime) || 0;
     this.setState({ currentTime });
 
-    if (onTimeChange) {
-      onTimeChange({ event, time: currentTime });
-    }
+    onTimeChange?.({ event, time: currentTime });
   };
 
   // Sent when the audio volume changes
@@ -647,9 +657,7 @@ export default class Video extends PureComponent<Props, State> {
     const { onVolumeChange } = this.props;
     const muted = (this.video && this.video.muted) || false;
 
-    if (onVolumeChange) {
-      onVolumeChange({ event, volume: muted ? 1 : 0 });
-    }
+    onVolumeChange?.({ event, volume: muted ? 1 : 0 });
   };
 
   // Sent when playback has stopped because of a temporary lack of data.
@@ -662,6 +670,7 @@ export default class Video extends PureComponent<Props, State> {
   render(): Node {
     const {
       aspectRatio,
+      autoplay,
       backgroundColor,
       captions,
       children,
@@ -691,32 +700,34 @@ export default class Video extends PureComponent<Props, State> {
       >
         <ColorSchemeProvider id="Video" colorScheme="light">
           <video
-            autoPlay={playing}
+            autoPlay={autoplay}
+            className={styles.video}
+            {...((crossOrigin ? { crossOrigin } : { ...null }): {|
+              crossOrigin?: CrossOrigin,
+            |})}
+            disableRemotePlayback={disableRemotePlayback}
             loop={loop}
             muted={volume === 0}
-            playsInline={playsInline}
-            poster={poster}
-            preload={preload}
-            src={typeof src === 'string' ? src : undefined}
-            ref={this.setVideoRef}
-            className={styles.video}
-            disableRemotePlayback={disableRemotePlayback}
+            {...(objectFit ? { style: { objectFit } } : null)}
             onCanPlay={this.handleCanPlay}
             onDurationChange={this.handleDurationChange}
             onEnded={this.handleEnded}
             onError={this.handleError}
             onLoadStart={this.handleLoadStart}
+            onPlay={this.handlePlay}
+            onPause={this.handlePause}
             onPlaying={this.handlePlaying}
+            onProgress={this.handleProgress}
             onSeeked={this.handleSeek}
             onSeeking={this.handleSeeking}
             onStalled={this.handleStalled}
             onTimeUpdate={this.handleTimeUpdate}
-            onProgress={this.handleProgress}
             onWaiting={this.handleWaiting}
-            {...(objectFit ? { style: { objectFit } } : null)}
-            {...((crossOrigin ? { crossOrigin } : { ...null }): {|
-              crossOrigin?: CrossOrigin,
-            |})}
+            playsInline={playsInline}
+            poster={poster}
+            preload={preload}
+            src={typeof src === 'string' ? src : undefined}
+            ref={this.setVideoRef}
           >
             {Array.isArray(src) &&
               src.map((source) => <source key={source.src} src={source.src} type={source.type} />)}
@@ -744,10 +755,10 @@ export default class Video extends PureComponent<Props, State> {
               duration={duration}
               fullscreen={fullscreen}
               onCaptionsChange={this.toggleCaptions}
-              onPlay={this.handlePlay}
+              onPlay={this.handleControlsPlay}
               onPlayheadDown={this.handlePlayheadDown}
               onPlayheadUp={this.handlePlayheadUp}
-              onPause={this.handlePause}
+              onPause={this.handleControlsPause}
               onFullscreenChange={this.toggleFullscreen}
               onVolumeChange={this.handleVolumeChange}
               playing={playing}

--- a/packages/gestalt/src/Video.jsdom.test.js
+++ b/packages/gestalt/src/Video.jsdom.test.js
@@ -20,6 +20,8 @@ describe('Video loading', () => {
   it('Does not load when string src does not change', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: 'https://media.w3.org/2010/05/sintel/trailer_hd.mp4',
@@ -36,6 +38,8 @@ describe('Video loading', () => {
   it('Does not load when array src does not change', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: [
@@ -57,6 +61,8 @@ describe('Video loading', () => {
   it('Loads when string src changes to new string src', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: 'https://media.w3.org/2010/05/sintel/trailer_hd.mp4',
@@ -73,6 +79,8 @@ describe('Video loading', () => {
   it('Loads when string src changes to new array src', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: 'https://media.w3.org/2010/05/sintel/trailer_hd.mp4',
@@ -99,6 +107,8 @@ describe('Video loading', () => {
   it('Loads when array src changes to new string src', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: [
@@ -120,6 +130,8 @@ describe('Video loading', () => {
   it('Loads when array src changes to new array src', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: [
@@ -151,6 +163,8 @@ describe('Video loading', () => {
   it('Loads when array src changes to new length array src', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: [
@@ -186,6 +200,8 @@ describe('Video loading', () => {
   it('DisableRemotePlayback is set on <video />', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: [
@@ -205,6 +221,8 @@ describe('Video loading', () => {
   it('DisableRemotePlayback is not set on <video />', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       src: [
@@ -224,6 +242,8 @@ describe('Video loading', () => {
   it('Progress bar label is set', () => {
     const props = {
       ...A11Y_LABELS,
+      onPlay: () => {},
+      onPlayError: () => {},
       aspectRatio: 1,
       captions: 'https://media.w3.org/2010/05/sintel/captions.vtt',
       controls: true,

--- a/packages/gestalt/src/Video.test.js
+++ b/packages/gestalt/src/Video.test.js
@@ -18,6 +18,8 @@ test('Video with source', () => {
       {...A11Y_LABELS}
       aspectRatio={1}
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+      onPlay={() => {}}
+      onPlayError={() => {}}
       src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
     />,
   ).toJSON();
@@ -30,6 +32,8 @@ test('Video with multiple sources', () => {
       {...A11Y_LABELS}
       aspectRatio={1}
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
+      onPlay={() => {}}
+      onPlayError={() => {}}
       src={[
         {
           type: 'video/mp4',
@@ -53,6 +57,8 @@ test('Video with media attributes', () => {
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
       loop
       volume={0}
+      onPlay={() => {}}
+      onPlayError={() => {}}
       preload="metadata"
       src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
     />,
@@ -70,12 +76,14 @@ test('Video with callbacks', () => {
       onEnded={() => {}}
       onFullscreenChange={() => {}}
       onLoadedChange={() => {}}
-      onPause={() => {}}
-      onPlay={() => {}}
+      onControlsPause={() => {}}
+      onControlsPlay={() => {}}
       onReady={() => {}}
       onSeek={() => {}}
       onTimeChange={() => {}}
       onVolumeChange={() => {}}
+      onPlay={() => {}}
+      onPlayError={() => {}}
       src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
     />,
   ).toJSON();
@@ -90,6 +98,8 @@ test('Video with children', () => {
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
       src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
       controls
+      onPlay={() => {}}
+      onPlayError={() => {}}
     >
       <div>overlay</div>
     </Video>,
@@ -105,6 +115,8 @@ test('Video with crossOrigin', () => {
       aspectRatio={1}
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
       src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+      onPlay={() => {}}
+      onPlayError={() => {}}
     />,
   ).toJSON();
   expect(tree).toMatchSnapshot();
@@ -118,6 +130,8 @@ test('Video with objectFit', () => {
       aspectRatio={1}
       captions="https://media.w3.org/2010/05/sintel/captions.vtt"
       src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+      onPlay={() => {}}
+      onPlayError={() => {}}
     />,
   ).toJSON();
   expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -80,7 +80,6 @@ exports[`Video with callbacks 1`] = `
     className="__gestaltThemeVideo"
   >
     <video
-      autoPlay={false}
       className="video"
       disableRemotePlayback={false}
       muted={true}
@@ -89,6 +88,8 @@ exports[`Video with callbacks 1`] = `
       onEnded={[Function]}
       onError={[Function]}
       onLoadStart={[Function]}
+      onPause={[Function]}
+      onPlay={[Function]}
       onPlaying={[Function]}
       onProgress={[Function]}
       onSeeked={[Function]}
@@ -188,7 +189,6 @@ exports[`Video with children 1`] = `
     className="__gestaltThemeVideo"
   >
     <video
-      autoPlay={false}
       className="video"
       disableRemotePlayback={false}
       muted={true}
@@ -197,6 +197,8 @@ exports[`Video with children 1`] = `
       onEnded={[Function]}
       onError={[Function]}
       onLoadStart={[Function]}
+      onPause={[Function]}
+      onPlay={[Function]}
       onPlaying={[Function]}
       onProgress={[Function]}
       onSeeked={[Function]}
@@ -513,7 +515,6 @@ exports[`Video with crossOrigin 1`] = `
     className="__gestaltThemeVideo"
   >
     <video
-      autoPlay={false}
       className="video"
       crossOrigin="anonymous"
       disableRemotePlayback={false}
@@ -523,6 +524,8 @@ exports[`Video with crossOrigin 1`] = `
       onEnded={[Function]}
       onError={[Function]}
       onLoadStart={[Function]}
+      onPause={[Function]}
+      onPlay={[Function]}
       onPlaying={[Function]}
       onProgress={[Function]}
       onSeeked={[Function]}
@@ -622,7 +625,6 @@ exports[`Video with media attributes 1`] = `
     className="__gestaltThemeVideo"
   >
     <video
-      autoPlay={false}
       className="video"
       disableRemotePlayback={false}
       loop={true}
@@ -632,6 +634,8 @@ exports[`Video with media attributes 1`] = `
       onEnded={[Function]}
       onError={[Function]}
       onLoadStart={[Function]}
+      onPause={[Function]}
+      onPlay={[Function]}
       onPlaying={[Function]}
       onProgress={[Function]}
       onSeeked={[Function]}
@@ -731,7 +735,6 @@ exports[`Video with multiple sources 1`] = `
     className="__gestaltThemeVideo"
   >
     <video
-      autoPlay={false}
       className="video"
       disableRemotePlayback={false}
       muted={true}
@@ -740,6 +743,8 @@ exports[`Video with multiple sources 1`] = `
       onEnded={[Function]}
       onError={[Function]}
       onLoadStart={[Function]}
+      onPause={[Function]}
+      onPlay={[Function]}
       onPlaying={[Function]}
       onProgress={[Function]}
       onSeeked={[Function]}
@@ -846,7 +851,6 @@ exports[`Video with objectFit 1`] = `
     className="__gestaltThemeVideo"
   >
     <video
-      autoPlay={false}
       className="video"
       disableRemotePlayback={false}
       muted={true}
@@ -855,6 +859,8 @@ exports[`Video with objectFit 1`] = `
       onEnded={[Function]}
       onError={[Function]}
       onLoadStart={[Function]}
+      onPause={[Function]}
+      onPlay={[Function]}
       onPlaying={[Function]}
       onProgress={[Function]}
       onSeeked={[Function]}
@@ -959,7 +965,6 @@ exports[`Video with source 1`] = `
     className="__gestaltThemeVideo"
   >
     <video
-      autoPlay={false}
       className="video"
       disableRemotePlayback={false}
       muted={true}
@@ -968,6 +973,8 @@ exports[`Video with source 1`] = `
       onEnded={[Function]}
       onError={[Function]}
       onLoadStart={[Function]}
+      onPause={[Function]}
+      onPlay={[Function]}
       onPlaying={[Function]}
       onProgress={[Function]}
       onSeeked={[Function]}

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom/extend-expect.js';
+import 'regenerator-runtime/runtime';
 
 // Set up react testing library.
 import { configure } from '@testing-library/react';

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom/extend-expect.js';
+// Prevents `ReferenceError: regeneratorRuntime is not defined Babel 6` error due to using async/await syntax.
+// TODO: to be replaced with @babel/plugin-transform-runtime within babel.config.js
 import 'regenerator-runtime/runtime';
 
 // Set up react testing library.


### PR DESCRIPTION
### Summary

#### What changed?

**1. Handle HTMLMediaElement.play() Promise rejection and autoplay blocking**
Implemented try, catch statement around HTMLMediaElement.play() method within Gestalt's Video component to catch Promise rejection and consequent associated errors. Implemented `onPlayError` prop (callback) which gets called when HTMLMediaElement.play()'s Promise is rejected.

To learn more, see [HTMLMediaElement.play()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) and [exceptions](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions)

As a consequence of adding the first async/await in our components (within Video), I started getting the error  `ReferenceError: regeneratorRuntime is not defined Babel 6` while  running tests. To get it fixed, we are adding `import 'regenerator-runtime/runtime'` into setupJest.js

**2. API changes**
- adding `onPlayError` (required) & `onPlay` (required)  & `onPause` (optional)
- renaming `onPlay` to `onControlsPlay` (so that `onPlay` matches native `onPlay` event)
- renaming `onPause` to `onControlsPause` (so that  new `onPause` matches native `onPause` event)
- no longer required `captions` as they are unsupported atm.

**3. [Updated Docs](https://deploy-preview-2063--gestalt.netlify.app/video)** to improve API comprehension

#### Why?

In production we are seeing a huge amount of client errors that look like 
![Screen Shot 2022-04-11 at 7 19 15 PM](https://user-images.githubusercontent.com/10593890/162848560-55326e19-e0ad-4ea3-98bd-a31ee7d0c2e6.png)

The error started on 3/12/2022, though so far we can't pinpoint the change that triggered it as the data doesn't go further (max 30 days). But this probably started happening as soon as browser implemented this new restrictions. 
![Screen Shot 2022-04-11 at 7 31 42 PM](https://user-images.githubusercontent.com/10593890/162849674-cb5d3825-f148-4ff9-bdde-1ee91e559a22.png)

![Screen Shot 2022-04-11 at 7 21 55 PM](https://user-images.githubusercontent.com/10593890/162848826-39fe72d9-5663-4ca2-836b-7f0545533098.png)
Most browsers:
![Screen Shot 2022-04-11 at 7 25 03 PM](https://user-images.githubusercontent.com/10593890/162849111-c35e175b-41d4-4d7c-b769-10c686a5fe01.png)
![Screen Shot 2022-04-11 at 7 23 09 PM](https://user-images.githubusercontent.com/10593890/162848941-cbc0865e-eda3-40e7-b5ee-673ca890876f.png)

Firefox:
![Screen Shot 2022-04-11 at 7 24 11 PM](https://user-images.githubusercontent.com/10593890/162849029-0c8430a5-a898-43fe-a4a2-ea3e46436cde.png)

The origin is Gestalt > Video component
![Screen Shot 2022-04-11 at 7 27 17 PM](https://user-images.githubusercontent.com/10593890/162849287-a7491be3-3b0e-4a82-9328-50e7d5d9feb2.png)
Many cases come from CloseupVideo.js thought there are other sources of the error.
![Screen Shot 2022-04-11 at 7 29 28 PM](https://user-images.githubusercontent.com/10593890/162849631-c01682a1-ff88-4c4e-b2f4-d5da59a2c92c.png)

This error is well documented in MDN documentation, see [HTMLMediaElement.play()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) and [exceptions](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions)

![Screen Shot 2022-04-11 at 7 33 26 PM](https://user-images.githubusercontent.com/10593890/162849816-6046cb1d-1db0-4edb-907b-8c759cfc2bc9.png)

MDN recommends handling the Promise rejection with try,catch. [suggested code solution here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#example).

To repro issue, we can use this [Pin URL](https://www.pinterest.ca/pin/623185667197861916/) on Safari. This pin is rendered via  CloseupVideo.js. We'll observe that the video doesn't play (compared to Chrome or others); however, the controls show it's playing. See issue here:
![Kapture 2022-04-11 at 19 46 48](https://user-images.githubusercontent.com/10593890/162850973-da5b1721-82f4-4ac0-a0c8-2ce9dfa0c931.gif)

After implementing try,catch; however, in some cases we still observe the Video plays after the error is thrown (this has been reproed in the Gestalt Video docs, not in Pinterest production).

This required to continue the research because detecting the Promise rejection wasn't enough. After some more reading, we also read about the [autoplay](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/autoplay) property. Gestalt Video's `playing` prop is directly passed to `autoplay` while controlling the execution of play(). Therefore if `playing={true}` in Video, the internal video is set to `autoplay={true}` at the same time it executes `play()`. This is a double control of the autoplay behavior. 

In Safari, both logics cause `play()` to throw an error if `playing={true}`. both logics work well separately. If we internally remove `autoplay`, the video autoplays without errors. If we don't execute play() after mounting, the video also autoplays without errors.

According to [documentation](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide#autoplay_and_autoplay_blocking)
![Screen Shot 2022-04-15 at 2 40 23 PM](https://user-images.githubusercontent.com/10593890/163608579-2d02c562-c0b5-44e0-bcc0-7d41f58c2e09.png)

According to the [autoplay documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/autoplay#value)
![Screen Shot 2022-04-15 at 2 36 38 PM](https://user-images.githubusercontent.com/10593890/163608313-5b872657-b56b-4167-bd9e-7d43dc77fd28.png)
According to the [Autoplay guide for media and Web Audio APIs](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide#the_play_method)
![Screen Shot 2022-04-15 at 2 54 01 PM](https://user-images.githubusercontent.com/10593890/163615985-a3502fa7-126b-490b-838e-8165f79c65b8.png)

And a few [other consideration](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide#the_autoplay_attribute) about `autoplay`
![Screen Shot 2022-04-15 at 3 22 21 PM](https://user-images.githubusercontent.com/10593890/163623392-3fa8be2e-1855-46b8-89e6-30173812d648.png)

### Browser test 

To test use the following code (autoplay and volume on)

```
function Example () {
  const [playing, setPlaying] = React.useState(false);

  return (
    <Box width={300}>
      <Video
        autoplay
        accessibilityMaximizeLabel="Maximize"
        accessibilityMinimizeLabel="Minimize"
        accessibilityMuteLabel="Mute"
        accessibilityPauseLabel="Pause"
        accessibilityPlayLabel="Play"
        accessibilityProgressBarLabel="Progress bar"
        accessibilityUnmuteLabel="Unmute"
        aspectRatio={540 / 960}
        controls
        onPlayError={({ error }) => {
          console.log(error)
          error && setPlaying(false)}
        }
        onPlay={({ event }) => setPlaying(true)}
        onControlsPlay={() => setPlaying(true)}
        onControlsPause={() => setPlaying(false)}
        onEnded={() => setPlaying(false)}
        playing={playing}
        volume={1}
        loop
        src="https://iandevlin.github.io/mdn/video-player-with-captions/video/sintel-short.mp4"  />
    </Box>
  )
}
```

| Browser       | Tested | Forcing autoplay block works (autoplay + volume 1) | Any other errors with correct autoplay (autoplay + volume 0)
|---------------|--------|------------|------------|
| Mobile Safari  | Yes | Yes | No errors |
| Safari              | Yes | Yes | No errors |
| Chrome          | Yes | Yes | No errors |
| Firefox            | Yes | Yes | No errors |


### Checklist

- [ ] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
