### PR TITLE
Datepicker: fix controlled state [bug]

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -164,13 +164,16 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
   const innerRef = useRef(null);
   useImperativeHandle(ref, () => innerRef.current);
 
+  const [selected, setSelected] = useState<?Date>(dateValue);
   // We keep month in state to trigger a re-render when month changes since height will vary by where days fall
   // in the month and we need to keep the popover pointed at the input correctly
-  const [selected, setSelected] = useState<?Date>(dateValue);
   const [, setMonth] = useState<?number>();
   const [format, setFormat] = useState<?string>();
   const [updatedLocale, setUpdatedLocale] = useState<?string>();
   const [initRangeHighlight, setInitRangeHighlight] = useState<?Date>();
+
+  // TO DO: Ideally this component should be fully controlled using value + onChange, where selected/setSelected are unnecessary.
+  useEffect(() => setSelected(dateValue), [dateValue]);
 
   useEffect(() => {
     if (rangeSelector) {


### PR DESCRIPTION
### Summary

#### What changed?

Added useEffect to update date value if programatically changes.

#### Why?

To programmatically change the value prop used to supply [pre-selected dates to the datepicker](https://gestalt.netlify.app/datepicker#preselectedValue). The actual displayed value on the datepicker does not appear to change with the variable given to the value prop.

NOTE: This is a quick fix. Ideally, we would rewrite DatePicker to be fully controlled rather than have internal state. This fix works well, but the nicer/more elegant fix would require going to all DatePickers and implementing the logic from the onChange to control the Datepicker value.

This is a fix for the current component state, which we know we have to sit down and reevaluate.

Repro  https://codesandbox.io/s/datepicker-preselected-date-change-forked-djdm48

To validate changes in Docs, use this code


```
function DatePickerExample() {
  const handleChange = (value) => value;

  const [budgetType, setBudgetType] = React.useState("DAILY");
  const [endDate, setEndDate] = React.useState(new Date());

  React.useEffect(() => {
    const tomorrow = new Date(1955, 12, 4);
    if (budgetType === "LIFETIME") {
      setEndDate(tomorrow);
    } else {
      setEndDate(new Date());
    }
  }, [budgetType]);

  return (
    <Flex direction="column" gap={4}>
      <Flex direction="column">
        <RadioButton
          checked={budgetType === "DAILY"}
          id="dailyBudgetType"
          label="Daily"
          value="DAILY"
          onChange={() => setBudgetType("DAILY")}
        />
        <RadioButton
          checked={budgetType === "LIFETIME"}
          id="lifetimeBudgetType"
          label="Lifetime"
          value="LIFETIME"
          onChange={() => setBudgetType("LIFETIME")}
        />
      </Flex>
      <DatePicker
        id="example-preselected value"
        label="Alberto's birth date"
        onChange={({ value }) => handleChange(value)}
        value={endDate}
      />
      <Text>Default date is {endDate.toString()}</Text>
    </Flex>
  );
}

```