### PR TITLE
Internal: Bump peer dependencies to support React 18

### DIFF
--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -18,8 +18,8 @@
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",
-    "react": "^16.13.1 || 17.x",
-    "react-dom": "^16.13.1 || 17.x"
+    "react": "^16.13.1 || ^17.0 || ^18.0",
+    "react-dom": "^16.13.1 || ^17.0 || ^18.0"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -17,8 +17,8 @@
     "gestalt-design-tokens": ">0.0.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || 17.x",
-    "react-dom": "^16.13.1 || 17.x"
+    "react": "^16.13.1 || ^17.0 || ^18.0",
+    "react-dom": "^16.13.1 || ^17.0 || ^18.0"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",


### PR DESCRIPTION
### Summary
Updates the react/react-dom peer dependencies for gestalt and gestalt-datepicker  to support 18.x.  We currently aren't leveraging any React 18 specific APIs so this change is safe.  In the future, if we start using some of the React 18 APIs, we'll need to think about backwards compatibility or dropping support for older versions of React.  

Note: this does not update the React version for docs.  
