### PR TITLE
Docs: Tooltip / IconButton usage guidance

### DIFF
--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -63,7 +63,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             type="don't"
             title="When not to use"
             description={`
-          - Using a separate Tooltip instance with IconButton. Use [IconButton's built-in tooltip](/iconbutton#With-Tooltip) instead.
+          - Using a separate Tooltip instance with IconButton. Use [IconButton's built-in tooltip](https://gestalt.pinterest.systems/iconbutton#With-Tooltip) instead.
           - Displaying information that is critical to the understanding of an element/feature. Use inline text instead.
           - Offering context at the surface-level scope. Consider a [Callout](/callout) instead.
         `}

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -63,6 +63,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             type="don't"
             title="When not to use"
             description={`
+          - Using a separate Tooltip instance with IconButton. Use [IconButton's built-in tooltip](/iconbutton#With-Tooltip) instead.
           - Displaying information that is critical to the understanding of an element/feature. Use inline text instead.
           - Offering context at the surface-level scope. Consider a [Callout](/callout) instead.
         `}

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -77,7 +77,7 @@ type Props = {|
 /**
  * [Tooltip](https://gestalt.pinterest.systems/tooltip) is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/iconbutton). It’s displayed continuously as long as the user hovers over or focuses on the element.
  *
- * **Planning to use Tooltip with IconButton? Use [IconButton's built-in tooltip](/iconbutton#With-Tooltip) instead.**
+ * **Planning to use Tooltip with IconButton? Use [IconButton's built-in tooltip](https://gestalt.pinterest.systems/iconbutton#With-Tooltip) instead.**
  *
  * ![Tooltip light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Tooltip%20%230.png)
  * ![Tooltip dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Tooltip-dark%20%230.png)

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -77,6 +77,8 @@ type Props = {|
 /**
  * [Tooltip](https://gestalt.pinterest.systems/tooltip) is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/iconbutton). It’s displayed continuously as long as the user hovers over or focuses on the element.
  *
+ * **Planning to use Tooltip with IconButton? Use [IconButton's built-in tooltip](/iconbutton#With-Tooltip) instead.**
+ *
  * ![Tooltip light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Tooltip%20%230.png)
  * ![Tooltip dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Tooltip-dark%20%230.png)
  */


### PR DESCRIPTION
Added a note at the top of the Tooltip doc and added a bullet point in the Don't's Best Practices section.