### PR TITLE
Datepicker: fix useEffect side effect

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -173,7 +173,9 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
   const [initRangeHighlight, setInitRangeHighlight] = useState<?Date>();
 
   // TO DO: Ideally this component should be fully controlled using value + onChange, where selected/setSelected are unnecessary.
-  useEffect(() => setSelected(dateValue), [dateValue]);
+  useEffect(() => {
+    setSelected(dateValue);
+  }, [dateValue]);
 
   useEffect(() => {
     if (rangeSelector) {


### PR DESCRIPTION
### Summary

#### What changed?

Datepicker: fix useEffect side effect (misusing cleanup side effect)

#### Why?

We’re passing useEffect a function that returns the setter call, which is a bit odd. The syntax for useEffect:
```
useEffect(() => {
  // do some stuff
  return () => {
    // clean up stuff
  };
}, [dependencies]);

```
[react Docs info
](https://user-images.githubusercontent.com/10593890/164085712-61419522-a1ed-44d1-b30f-897b9b4f2e49.png)

![Screen Shot 2022-04-19 at 4 02 24 PM](https://user-images.githubusercontent.com/10593890/164086273-1c76a106-1ce0-4ae7-820d-b4cc2f744cea.png)

So returning the setter is a bit odd, and it could potentially lead to subtle bugs in the future. Some curlies will prevent the return:

`useEffect(() => { setSelected(...); }, [...]);
`