### PR TITLE
Docs: Cleanup layout and shaded color examples

### DIFF
--- a/docs/components/CombinationNew.js
+++ b/docs/components/CombinationNew.js
@@ -5,7 +5,6 @@ import MainSectionCard from './MainSectionCard.js';
 
 type Props = {
   children: (props: { [key: string]: any, ... }, index?: number) => Node, // flowlint-line unclear-type:off
-  shaded?: boolean,
   hideTitle?: boolean,
   ...
 };
@@ -48,23 +47,29 @@ const toReactAttribute = (key, value) => {
   }
 };
 
-export default function CombinationNew({ children, hideTitle, shaded, ...props }: Props): Node {
+export default function CombinationNew({ children, hideTitle, ...props }: Props): Node {
   const CardArray = combinations(props).map((combination, i) => {
     const combinationTitles = Object.keys(combination).map((key) =>
       toReactAttribute(key, combination[key]),
     );
-    const shadeCard =
-      shaded ||
-      combinationTitles.some(
-        (title) =>
-          title.toLowerCase().includes('color') &&
-          (title.includes('white') || title.includes('inverse') || title.includes('light')),
-      );
+
+    let cardShadeColor;
+
+    if (combinationTitles.some((title) => title.includes('white') || title.includes('inverse'))) {
+      cardShadeColor = 'tertiary';
+    }
+    if (combinationTitles.some((title) => title.includes('"light"'))) {
+      cardShadeColor = 'darkWash';
+    }
+    if (combinationTitles.some((title) => title.includes('"dark"'))) {
+      cardShadeColor = 'lightWash';
+    }
+
     return (
       <MainSectionCard
         key={i}
         cardSize="sm"
-        shaded={shadeCard}
+        shadeColor={cardShadeColor}
         title={hideTitle ? undefined : combinationTitles}
       >
         {children(combination, i)}

--- a/docs/components/MainSectionCard.js
+++ b/docs/components/MainSectionCard.js
@@ -15,6 +15,7 @@ type Props = {|
   defaultCode?: string,
   description?: string,
   iframeContent?: string,
+  shadeColor?: 'tertiary' | 'darkWash' | 'lightWash' | 'default',
   shaded?: boolean,
   showCode?: boolean,
   title?: string | Array<string>,
@@ -44,6 +45,7 @@ function MainSectionCard({
   description,
   iframeContent,
   shaded = false,
+  shadeColor,
   showCode = true,
   title,
   type = 'info',
@@ -56,13 +58,14 @@ function MainSectionCard({
   // Only show code if it's a md or lg card and it's not a Do/Don't
   const shouldShowCode = showCode && cardSize !== 'sm' && type === 'info';
   const showTitleAndDescriptionAboveExample = cardSize === 'lg' && type === 'info';
+  const cardShadeColor = shaded && !shadeColor ? 'secondary' : shadeColor;
 
   const PreviewCard = useCallback(
     ({ children: cardChildren }: PreviewCardProps) => (
       <Box
         alignItems="center"
         borderStyle="sm"
-        color={shaded ? 'tertiary' : 'default'}
+        color={cardShadeColor}
         display="flex"
         height={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
         justifyContent="center"
@@ -73,7 +76,7 @@ function MainSectionCard({
         {cardChildren}
       </Box>
     ),
-    [cardSize, shaded],
+    [cardSize, cardShadeColor],
   );
 
   const TitleAndDescription = (

--- a/docs/pages/datapoint.js
+++ b/docs/pages/datapoint.js
@@ -66,6 +66,8 @@ export default function DatapointPage({ generatedDocGen }: {| generatedDocGen: D
 <Datapoint size="lg" title="Saves" value="10,392" trend={{value: -12.193, accessibilityLabel: "Trending down"}} />
 `}
           />
+        </MainSection.Subsection>
+        <MainSection.Subsection columns={2}>
           <MainSection.Card
             // This example should also display a localized trend value, but given trend accepts only a number,
             // the value cannot be localized. Once the API is changed, we should add a localized trend to this example.
@@ -85,6 +87,8 @@ export default function DatapointPage({ generatedDocGen }: {| generatedDocGen: D
 
 `}
           />
+        </MainSection.Subsection>
+        <MainSection.Subsection columns={2}>
           <MainSection.Card
             cardSize="md"
             type="do"

--- a/docs/pages/numberfield.js
+++ b/docs/pages/numberfield.js
@@ -522,7 +522,7 @@ function Example(props) {
   const [value2, setValue2] = React.useState();
 
   return (
-    <Flex direction="column" gap={2}>
+    <Flex direction="column" gap={2} width="80%">
       <NumberField
         id="minMaxStepExampleNumberField1"
         label="Stepping in intervals of 5"

--- a/docs/pages/status.js
+++ b/docs/pages/status.js
@@ -61,6 +61,8 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
 <Icon icon="workflow-status-problem" size="24" accessibilityLabel="This item has an error" />
 `}
           />
+        </MainSection.Subsection>
+        <MainSection.Subsection columns={2}>
           <MainSection.Card
             cardSize="md"
             type="do"
@@ -84,6 +86,8 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
 
 `}
           />
+        </MainSection.Subsection>
+        <MainSection.Subsection columns={2}>
           <MainSection.Card
             cardSize="md"
             type="do"


### PR DESCRIPTION
### Summary

#### What changed?

Small cleanups to adjust layout for Best Practices and shade colors for combination color examples

#### Why?

Try to provide an ideal background color when showcasing color example of a component using CombinationNew

