### PR TITLE
Icon: Add brandPrimary color option

### DIFF
--- a/docs/pages/icon.js
+++ b/docs/pages/icon.js
@@ -139,7 +139,7 @@ If an icon has a visible label that describes what the icon represents, \`access
         <MainSection.Subsection
           title="Colors"
           description={`
-        Icons can be created using the following color options. See the [design tokens](/design_tokens#Text-color) for more info.
+        Icons can be created using the following color options. \`brand\` should only be used to represent the Pinterest logo, as it is not accessible. See the [design tokens](/design_tokens#Text-color) for more info.
 
         ⚠️ Please note: the previous options ("blue" , "darkGray" , "eggplant" , "gray" , "green" , "lightGray" , "maroon" , "midnight" , "navy" , "olive" , "orange" , "orchid" , "pine" , "purple" , "red" , "watermelon" and "white") are still valid, but will be deprecated soon. Avoid using them in any new implementations.`}
         >
@@ -152,6 +152,7 @@ If an icon has a visible label that describes what the icon represents, \`access
               'warning',
               'inverse',
               'shopping',
+              'brand',
               'light',
               'dark',
             ]}

--- a/docs/pages/icon.js
+++ b/docs/pages/icon.js
@@ -139,7 +139,7 @@ If an icon has a visible label that describes what the icon represents, \`access
         <MainSection.Subsection
           title="Colors"
           description={`
-        Icons can be created using the following color options. \`brand\` should only be used to represent the Pinterest logo, as it is not accessible. See the [design tokens](/design_tokens#Text-color) for more info.
+        Icons can be created using the following color options. \`brandPrimary\` should only be used to represent the Pinterest logo, as it is not accessible. See the [design tokens](/design_tokens#Text-color) for more info.
 
         ⚠️ Please note: the previous options ("blue" , "darkGray" , "eggplant" , "gray" , "green" , "lightGray" , "maroon" , "midnight" , "navy" , "olive" , "orange" , "orchid" , "pine" , "purple" , "red" , "watermelon" and "white") are still valid, but will be deprecated soon. Avoid using them in any new implementations.`}
         >
@@ -152,7 +152,7 @@ If an icon has a visible label that describes what the icon represents, \`access
               'warning',
               'inverse',
               'shopping',
-              'brand',
+              'brandPrimary',
               'light',
               'dark',
             ]}

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -86,8 +86,10 @@
           "comment": "Icon color to use for shopping surfaces"
         },
         "brand": {
-          "value": "{color.red.pushpin.450.value}",
-          "comment": "Icon color to use solely for representing the Pinterest brand"
+          "primary": {
+            "value": "{color.red.pushpin.450.value}",
+            "comment": "Icon color to use solely for representing the Pinterest brand"
+          }
         },
         "light": {
           "value": "{color.white.mochimalist.0.value}",

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -85,6 +85,10 @@
           "darkValue": "{color.blue.skycicle.300.value}",
           "comment": "Icon color to use for shopping surfaces"
         },
+        "brand": {
+          "value": "{color.red.pushpin.450.value}",
+          "comment": "Icon color to use solely for representing the Pinterest brand"
+        },
         "light": {
           "value": "{color.white.mochimalist.0.value}",
           "comment": "Icon color that will always remain light"

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -210,6 +210,10 @@
   color: var(--color-text-icon-shopping);
 }
 
+.brandIcon {
+  color: var(--color-text-icon-brand);
+}
+
 .lightIcon {
   color: var(--color-text-icon-light);
 }

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -210,8 +210,8 @@
   color: var(--color-text-icon-shopping);
 }
 
-.brandIcon {
-  color: var(--color-text-icon-brand);
+.brandPrimaryIcon {
+  color: var(--color-text-icon-brand-primary);
 }
 
 .lightIcon {

--- a/packages/gestalt/src/Colors.css.flow
+++ b/packages/gestalt/src/Colors.css.flow
@@ -5,6 +5,7 @@ declare module.exports: {|
   +'blue': string,
   +'blueBg': string,
   +'brand': string,
+  +'brandPrimaryIcon': string,
   +'darkGray': string,
   +'darkGrayBg': string,
   +'darkIcon': string,

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -13,6 +13,7 @@ const semanticColors = [
   'warning',
   'inverse',
   'shopping',
+  'brand',
   'light',
   'dark',
 ];
@@ -42,6 +43,7 @@ export type IconColor =
   | 'warning'
   | 'inverse'
   | 'shopping'
+  | 'brand'
   | 'light'
   | 'dark';
 
@@ -133,7 +135,8 @@ export default function Icon({
     colorName !== 'light' &&
     colorName !== 'subtle' &&
     colorName !== 'success' &&
-    colorName !== 'warning'
+    colorName !== 'warning' &&
+    colorName !== 'brand'
   ) {
     colorClass = colors[colorName];
   }

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -13,7 +13,7 @@ const semanticColors = [
   'warning',
   'inverse',
   'shopping',
-  'brand',
+  'brandPrimary',
   'light',
   'dark',
 ];
@@ -43,7 +43,7 @@ export type IconColor =
   | 'warning'
   | 'inverse'
   | 'shopping'
-  | 'brand'
+  | 'brandPrimary'
   | 'light'
   | 'dark';
 
@@ -136,7 +136,7 @@ export default function Icon({
     colorName !== 'subtle' &&
     colorName !== 'success' &&
     colorName !== 'warning' &&
-    colorName !== 'brand'
+    colorName !== 'brandPrimary'
   ) {
     colorClass = colors[colorName];
   }


### PR DESCRIPTION
### Summary

#### What changed?

We often use Icon to represent the Pinterest logo. In these cases, the color option should be set to 'brandPrimary'

#### Why?

Avoid using 'error' to represent the brand color, avoid confusion around color usage

<img width="778" alt="Screen Shot 2022-04-21 at 5 42 57 PM" src="https://user-images.githubusercontent.com/5125094/164574643-b47329e5-9a6e-49fd-8053-d0e038785f43.png">


