### PR TITLE
TextField & TextArea: Added labelDisplay prop

### DIFF
--- a/docs/pages/searchfield.js
+++ b/docs/pages/searchfield.js
@@ -216,6 +216,36 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
   }
 `}
           />
+          <MainSection.Card
+            description={`
+            SearchField comes with [Label](/label) built-in: just use the \`label\` prop. We strongly encourage always supplying a label. Be sure to provide a unique \`id\` so the Label is associated with the correct SearchField.
+
+            If SearchField is labeled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.`}
+            defaultCode={`
+<Flex gap={6}>
+<SearchField
+  accessibilityLabel=""
+  accessibilityClearButtonLabel="Clear search field"
+  id="searchfieldexampleA11yVisible"
+  onChange={() => {}}
+  label='Search messages'
+  size='md'
+/>
+<Flex gap={2} direction="column">
+  <Text weight="bold" size="300">Search messages</Text>
+  <SearchField
+    accessibilityLabel=""
+    accessibilityClearButtonLabel="Clear search field"
+    id="searchfieldexampleA11yHiddenLabel"
+    onChange={() => {}}
+    label='Search messages'
+    labelDisplay="hidden"
+    size='md'
+  />
+</Flex>
+</Flex>
+`}
+          />
         </MainSection.Subsection>
       </MainSection>
 
@@ -292,6 +322,36 @@ function SearchFieldExample() {
           value={value}
         />
         </Flex.Item>
+    </Flex>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="Label visibility"
+          description={`In some cases, the label for a SearchField is represented in a different way visually, as demonstrated below. In these instances, you can set \`labelDisplay="hidden"\` to ensure SearchField is properly labeled for screen readers while using a different element to represent the label visually.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function SearchFieldExample() {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <Flex gap={2} direction="column" width="100%">
+      <Text weight="bold" size="300">Search Messages</Text>
+      <SearchField
+      accessibilityLabel=""
+      accessibilityClearButtonLabel="Clear search field"
+      id="searchfieldexampleHiddenLabel"
+      onChange={({value}) => setValue(value)}
+      label='Search Messages'
+      labelDisplay="hidden"
+      placeholder="Search by name"
+      value={value}
+      />
     </Flex>
   );
 }

--- a/docs/pages/searchfield.js
+++ b/docs/pages/searchfield.js
@@ -15,7 +15,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
         defaultCode={`
   function SearchFieldExample() {
     const [value, setValue] = React.useState('');
-
     return (
       <Flex gap={4} alignItems="center" flex="grow">
         <Icon
@@ -24,7 +23,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
           size={20}
           accessibilityLabel="Pinterest"
         />
-
         <Flex.Item flex="grow">
           <SearchField
             accessibilityLabel="Search all of Pinterest"
@@ -35,13 +33,11 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             value={value}
           />
         </Flex.Item>
-
         <IconButton
           accessibilityLabel="Notifications"
           icon="speech-ellipsis"
           size="md"
         />
-
         <IconButton accessibilityLabel="Profile" icon="person" size="md" />
       </Flex>
     );
@@ -174,7 +170,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
           title="Labels"
           description={`
       SearchField should ideally have a visible label above the input using the \`label\` prop. However, if need be, \`accessibilityLabel\` can be used to provide screen readers with context about the SearchField.
-
       Be sure to also specify (and localize) a string for the \`accessibilityClearButtonLabel\`.
       `}
         >
@@ -183,7 +178,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             defaultCode={`
   function SearchFieldExample() {
     const [value, setValue] = React.useState('');
-
     return (
       <Flex alignItems="center" flex="grow" gap={4}>
         <Icon
@@ -192,7 +186,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
           icon="pinterest"
           size={20}
         />
-
         <Flex.Item flex="grow">
           <SearchField
             accessibilityLabel="Search all of Pinterest"
@@ -203,47 +196,15 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             value={value}
           />
         </Flex.Item>
-
         <IconButton
           accessibilityLabel="Notifications"
           icon="speech-ellipsis"
           size="md"
         />
-
         <IconButton accessibilityLabel="Profile" icon="person" size="md" />
       </Flex>
     );
   }
-`}
-          />
-          <MainSection.Card
-            description={`
-            SearchField comes with [Label](/label) built-in: just use the \`label\` prop. We strongly encourage always supplying a label. Be sure to provide a unique \`id\` so the Label is associated with the correct SearchField.
-
-            If SearchField is labeled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.`}
-            defaultCode={`
-<Flex gap={6}>
-<SearchField
-  accessibilityLabel=""
-  accessibilityClearButtonLabel="Clear search field"
-  id="searchfieldexampleA11yVisible"
-  onChange={() => {}}
-  label='Search messages'
-  size='md'
-/>
-<Flex gap={2} direction="column">
-  <Text weight="bold" size="300">Search messages</Text>
-  <SearchField
-    accessibilityLabel=""
-    accessibilityClearButtonLabel="Clear search field"
-    id="searchfieldexampleA11yHiddenLabel"
-    onChange={() => {}}
-    label='Search messages'
-    labelDisplay="hidden"
-    size='md'
-  />
-</Flex>
-</Flex>
 `}
           />
         </MainSection.Subsection>
@@ -253,7 +214,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
         <MainSection.Subsection
           description={`
       Be sure to localize the \`accessibilityLabel\`, \`accessibilityClearButtonLabel\`, \`errorMessage\`, \`label\` and \`placeholder\` prop values. Also localize \`value\` for those cases when it can be translated.
-
       Note that localization can lengthen text by 20 to 30 percent.
       `}
         >
@@ -262,7 +222,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             defaultCode={`
   function SearchFieldExample() {
     const [value, setValue] = React.useState('');
-
     return (
       <Flex alignItems="center" flex="grow" gap={4}>
         <Icon
@@ -271,7 +230,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
           icon="pinterest"
           size={20}
         />
-
         <Flex.Item flex="grow">
           <SearchField
             accessibilityLabel="सभी Pinterest खोजें"
@@ -282,13 +240,11 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             value={value}
           />
         </Flex.Item>
-
         <IconButton
           accessibilityLabel="सूचनाएं"
           icon="speech-ellipsis"
           size="md"
         />
-
         <IconButton accessibilityLabel="प्रोफ़ाइल" icon="person" size="md" />
       </Flex>
     );
@@ -308,7 +264,6 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
             defaultCode={`
 function SearchFieldExample() {
   const [value, setValue] = React.useState('');
-
   return (
     <Flex alignItems="center" flex="grow">
       <Flex.Item flex="grow">
@@ -330,36 +285,6 @@ function SearchFieldExample() {
         </MainSection.Subsection>
 
         <MainSection.Subsection
-          title="Label visibility"
-          description={`In some cases, the label for a SearchField is represented in a different way visually, as demonstrated below. In these instances, you can set \`labelDisplay="hidden"\` to ensure SearchField is properly labeled for screen readers while using a different element to represent the label visually.`}
-        >
-          <MainSection.Card
-            cardSize="lg"
-            defaultCode={`
-function SearchFieldExample() {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Flex gap={2} direction="column" width="100%">
-      <Text weight="bold" size="300">Search Messages</Text>
-      <SearchField
-      accessibilityLabel=""
-      accessibilityClearButtonLabel="Clear search field"
-      id="searchfieldexampleHiddenLabel"
-      onChange={({value}) => setValue(value)}
-      label='Search Messages'
-      labelDisplay="hidden"
-      placeholder="Search by name"
-      value={value}
-      />
-    </Flex>
-  );
-}
-`}
-          />
-        </MainSection.Subsection>
-
-        <MainSection.Subsection
           title="Sizes"
           description={`There are 2 sizes available: \`md\` (default) and \`lg\`.`}
         >
@@ -369,7 +294,6 @@ function SearchFieldExample() {
 function SearchFieldExample() {
   const [value, setValue] = React.useState('');
   const [lgValue, setLgValue] = React.useState('');
-
   return (
     <Flex alignItems="center" gap={12}>
       <Flex direction="column" flex="grow" gap={4}>
@@ -384,7 +308,6 @@ function SearchFieldExample() {
           value={value}
         />
       </Flex>
-
       <Flex direction="column" flex="grow" gap={4}>
         <Text>Large (lg)</Text>
         <SearchField
@@ -414,7 +337,6 @@ function SearchFieldExample() {
             defaultCode={`
 function SearchFieldExample() {
   const [value, setValue] = React.useState('pepper#$%');
-
   return (
     <Flex alignItems="center" flex="grow">
       <Flex.Item flex="grow">
@@ -442,10 +364,8 @@ function SearchFieldExample() {
           description={`
 **[ComboBox](/combobox)**
 ComboBox allows users to filter a list when selecting an option. Choose ComboBox when the user is selecting from a finite list of options.
-
 **[TextField](/textfield)**
 TextField provides an affordance to input small to medium length text. Unless the text is used to search for or filter through content, choose TextField for shorter text input.
-
 **[TextArea](/textarea)**
 TextArea allows for multiline text input, suitable for longer length text. Unless the text is used to search for or filter through content, choose TextArea for longer text input.
       `}

--- a/docs/pages/searchfield.js
+++ b/docs/pages/searchfield.js
@@ -15,6 +15,7 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
         defaultCode={`
   function SearchFieldExample() {
     const [value, setValue] = React.useState('');
+
     return (
       <Flex gap={4} alignItems="center" flex="grow">
         <Icon
@@ -170,6 +171,7 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
           title="Labels"
           description={`
       SearchField should ideally have a visible label above the input using the \`label\` prop. However, if need be, \`accessibilityLabel\` can be used to provide screen readers with context about the SearchField.
+
       Be sure to also specify (and localize) a string for the \`accessibilityClearButtonLabel\`.
       `}
         >
@@ -214,6 +216,7 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
         <MainSection.Subsection
           description={`
       Be sure to localize the \`accessibilityLabel\`, \`accessibilityClearButtonLabel\`, \`errorMessage\`, \`label\` and \`placeholder\` prop values. Also localize \`value\` for those cases when it can be translated.
+
       Note that localization can lengthen text by 20 to 30 percent.
       `}
         >

--- a/docs/pages/textarea.js
+++ b/docs/pages/textarea.js
@@ -105,6 +105,27 @@ function Example(props) {
           />
         </MainSection.Subsection>
         <MainSection.Subsection
+          title="Label visibility"
+          description={`In some cases, the label for a TextArea is represented in a different way visually, as demonstrated below. In these instances, you can set \`labelDisplay="hidden"\` to ensure TextArea is properly labeled for screen readers while using a different element to represent the label visually.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+          <Flex gap={2} direction="column" width="100%">
+<Text weight="bold" size="300">About me</Text>
+<TextArea
+id="textareaexampleHiddenLabel"
+placeholder="Write something about yourself..."
+onChange={() => {}}
+label='About me'
+labelDisplay="hidden"
+size='lg'
+/>
+</Flex>
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
           title="Read-only"
           description={`
       \`TextArea\` can be in read-only mode in order to present information to the user without allowing them to edit the content. Typically this variation is used to show content or information that the user does not have permission or access to edit.

--- a/docs/pages/textarea.js
+++ b/docs/pages/textarea.js
@@ -111,16 +111,16 @@ function Example(props) {
           <MainSection.Card
             cardSize="lg"
             defaultCode={`
-          <Flex gap={2} direction="column" width="100%">
-<Text weight="bold" size="300">About me</Text>
-<TextArea
-id="textareaexampleHiddenLabel"
-placeholder="Write something about yourself..."
-onChange={() => {}}
-label='About me'
-labelDisplay="hidden"
-size='lg'
-/>
+<Flex gap={2} direction="column" width="100%">
+  <Text weight="bold" size="300">About me</Text>
+  <TextArea
+    id="textareaexampleHiddenLabel"
+    placeholder="Write something about yourself..."
+    onChange={() => {}}
+    label='About me'
+    labelDisplay="hidden"
+    size='lg'
+  />
 </Flex>
 `}
           />

--- a/docs/pages/textfield.js
+++ b/docs/pages/textfield.js
@@ -399,8 +399,34 @@ function Example(props) {
         />
         <MainSection.Subsection
           title="Labels"
-          description="Ensure the labels are precise and concise. Labels should only describe the text field they are associated with, and they must be visible."
-        />
+          description={`
+      TextField comes with [Label](/label) built-in: just use the \`label\` prop. We strongly encourage always supplying a label. Be sure to provide a unique \`id\` so the Label is associated with the correct TextField.
+
+      If TextField is labeled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.`}
+        >
+          <MainSection.Card
+            defaultCode={`
+<Flex gap={6}>
+  <TextField
+    id="textfieldexampleA11yVisible"
+    onChange={() => {}}
+    label='First name'
+    size='lg'
+  />
+  <Flex gap={2} direction="column">
+    <Text weight="bold" size="300">First name</Text>
+    <TextField
+      id="textfieldexampleA11yHiddenLabel"
+      onChange={() => {}}
+      label='First name'
+      labelDisplay="hidden"
+      size='lg'
+    />
+  </Flex>
+</Flex>
+`}
+          />
+        </MainSection.Subsection>
         <MainSection.Subsection
           title="Validation"
           description={`
@@ -472,6 +498,26 @@ function Example(props) {
     </Box>
   );
 }
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Label visibility"
+          description={`In some cases, the label for a TextField is represented in a different way visually, as demonstrated below. In these instances, you can set \`labelDisplay="hidden"\` to ensure TextField is properly labeled for screen readers while using a different element to represent the label visually.`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+          <Flex gap={2} direction="column">
+<Text weight="bold" size="300">First name</Text>
+<TextField
+id="textfieldexampleHiddenLabel"
+onChange={() => {}}
+label='First name'
+labelDisplay="hidden"
+size='lg'
+/>
+</Flex>
 `}
           />
         </MainSection.Subsection>

--- a/docs/pages/textfield.js
+++ b/docs/pages/textfield.js
@@ -508,15 +508,15 @@ function Example(props) {
           <MainSection.Card
             cardSize="lg"
             defaultCode={`
-          <Flex gap={2} direction="column">
-<Text weight="bold" size="300">First name</Text>
-<TextField
-id="textfieldexampleHiddenLabel"
-onChange={() => {}}
-label='First name'
-labelDisplay="hidden"
-size='lg'
-/>
+<Flex gap={2} direction="column">
+  <Text weight="bold" size="300">First name</Text>
+  <TextField
+    id="textfieldexampleHiddenLabel"
+    onChange={() => {}}
+    label='First name'
+    labelDisplay="hidden"
+    size='lg'
+  />
 </Flex>
 `}
           />

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -38,10 +38,6 @@ type Props = {|
    */
   label?: string,
   /**
-   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
-   */
-  labelDisplay?: 'visible' | 'hidden',
-  /**
    *
    */
   onBlur?: AbstractEventHandler<SyntheticEvent<HTMLInputElement>>,
@@ -101,7 +97,6 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
     autoComplete,
     id,
     label,
-    labelDisplay,
     onBlur,
     onChange,
     onFocus,
@@ -178,7 +173,7 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
 
   return (
     <span>
-      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} />}
+      {label && <FormLabel id={id} label={label} />}
       <Box
         alignItems="center"
         display="flex"

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -38,6 +38,10 @@ type Props = {|
    */
   label?: string,
   /**
+   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
+   */
+  labelDisplay?: 'visible' | 'hidden',
+  /**
    *
    */
   onBlur?: AbstractEventHandler<SyntheticEvent<HTMLInputElement>>,
@@ -97,6 +101,7 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
     autoComplete,
     id,
     label,
+    labelDisplay,
     onBlur,
     onChange,
     onFocus,
@@ -173,7 +178,7 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
 
   return (
     <span>
-      {label && <FormLabel id={id} label={label} />}
+      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} />}
       <Box
         alignItems="center"
         display="flex"

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -39,7 +39,7 @@ type Props = {|
    */
   label?: string,
   /**
-   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
+   * Whether the label should be visible or not. If `hidden`, the label is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
    */
   labelDisplay?: 'visible' | 'hidden',
   /**

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -39,6 +39,10 @@ type Props = {|
    */
   label?: string,
   /**
+   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
+   */
+  labelDisplay?: 'visible' | 'hidden',
+  /**
    * A unique name for the input.
    */
   name?: string,
@@ -114,6 +118,7 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
     helperText,
     id,
     label,
+    labelDisplay,
     name,
     onBlur,
     onChange,
@@ -194,7 +199,7 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
 
   return (
     <span>
-      {label && <FormLabel id={id} label={label} />}
+      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} />}
       {tags ? (
         <div className={classes} style={tagsWrapperStyle}>
           {tags.map((tag, tagIndex) => (

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -39,7 +39,7 @@ type Props = {|
    */
   label?: string,
   /**
-   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
+   * Whether the label should be visible or not. If `hidden`, the label is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
    */
   labelDisplay?: 'visible' | 'hidden',
   /**

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -39,6 +39,10 @@ type Props = {|
    */
   label?: string,
   /**
+   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
+   */
+  labelDisplay?: 'visible' | 'hidden',
+  /**
    * A unique name for the input.
    */
   name?: string,
@@ -119,6 +123,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     helperText,
     id,
     label,
+    labelDisplay = 'visible',
     name,
     onBlur,
     onChange,
@@ -197,6 +202,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
       iconButton={iconButton}
       id={id}
       label={label}
+      labelDisplay={labelDisplay}
       name={name}
       onBlur={onBlur}
       onChange={onChange}


### PR DESCRIPTION
In order to make the `label` prop required, we need to provide a `labelDisplay` drop for toggling visibility. This work includes adding the prop to each component and providing documentation updates to each component.