### PR TITLE
Masonry: Fix hydration for server rendered flexible grids

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -499,38 +499,35 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
           role="list"
           style={{ height: 0, width: '100%' }}
         >
-          {items
-            // this is here to filter out falsy values
-            .filter((item) => item)
-            .map((item, i) => (
-              <div // keep this in sync with renderMasonryComponent
-                className="static"
-                data-grid-item
-                key={i}
-                ref={(el) => {
-                  // purposely not checking for layout === 'serverRenderedFlexible' here
-                  if (el && !(flexible || layout === 'flexible')) {
-                    // if we're hydrating from the server, we should only measure items on the initial render pass
-                    // if we're not rendering a flexible layout.  "serverRenderedFlexible" is an exception because we assume
-                    // that the caller has added the proper CSS to ensure the layout is correct during server render
-                    measurementStore.set(item, el.clientHeight);
-                  }
-                }}
-                role="listitem"
-                style={{
-                  top: 0,
-                  left: 0,
-                  transform: 'translateX(0px) translateY(0px)',
-                  WebkitTransform: 'translateX(0px) translateY(0px)',
-                  width:
-                    flexible || layout === 'flexible' || layout === 'serverRenderedFlexible'
-                      ? undefined
-                      : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
-                }}
-              >
-                <Component data={item} itemIdx={i} isMeasuring={false} />
-              </div>
-            ))}
+          {items.filter(Boolean).map((item, i) => (
+            <div // keep this in sync with renderMasonryComponent
+              className="static"
+              data-grid-item
+              key={i}
+              ref={(el) => {
+                // purposely not checking for layout === 'serverRenderedFlexible' here
+                if (el && !(flexible || layout === 'flexible')) {
+                  // if we're hydrating from the server, we should only measure items on the initial render pass
+                  // if we're not rendering a flexible layout.  "serverRenderedFlexible" is an exception because we assume
+                  // that the caller has added the proper CSS to ensure the layout is correct during server render
+                  measurementStore.set(item, el.clientHeight);
+                }
+              }}
+              role="listitem"
+              style={{
+                top: 0,
+                left: 0,
+                transform: 'translateX(0px) translateY(0px)',
+                WebkitTransform: 'translateX(0px) translateY(0px)',
+                width:
+                  flexible || layout === 'flexible' || layout === 'serverRenderedFlexible'
+                    ? undefined
+                    : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
+              }}
+            >
+              <Component data={item} itemIdx={i} isMeasuring={false} />
+            </div>
+          ))}
         </div>
       );
     } else if (width == null) {


### PR DESCRIPTION
### Summary
This PR fixes an issue where we are unable to hydrate a server-rendered flexible grid.

#### Why?
At the moment, when `Masonry` hydrates from a server render it attaches a callbackRef to each of the items being rendered so it can measure each element's heights.  It does this so that in the next pass, it can properly infer the layout from these measurements.

For _flexible_ grids, we don't store the element heights during this initial pass because the assumption is that the height will be incorrect since the server does not have enough information to properly layout a flexible grid.  What this ends up causing is that all the grid items are _removed_ during the second render pass because we don't have any measurements to lay out the grid.  

What this ends up looking like from a user perspective:

https://user-images.githubusercontent.com/6487551/165243071-eaaaeb4a-5411-4e28-8e21-a473fdc93d06.mov

Notice how the grid appears to be unmounted/remounted.  We can confirm this happens during hydration if we take a look at the profiler
<img width="932" alt="image" src="https://user-images.githubusercontent.com/6487551/165242154-1159dfea-d28a-4cc3-8907-e3f962feb28a.png">

#### What changed?
In order to fix this, I'm introducing a new layout option called `serverRenderedFlexible`.  The only difference between `flexible` and `serverRenderedFlexible` is this line [here](https://github.com/pinterest/gestalt/compare/master...liuyenwei:fix-hydration-for-server-render-flexible?expand=1#diff-950854f5c35fa3a72ab2c5e83b94a2ccc6c06241197219fc988ec943a368a9e4R509) where we skip storing the initial measurement for `flexible`.  

**Why did I add a new layout?**
I originally considered just removing the flexible check altogether and go with the assumption that if someone is server rendering a flexible grid, they have also taken the steps to add CSS styles to correctly layout the flexible grid.  This didn't feel great to me because it would result in a very broken experience if someone ever tried to server render a flexible grid without additional CSS.  Furthermore, adding the new layout here seemed like a much safer approach of introducing this fix (which is generally what I lean towards for Masonry changes).

I think the larger problem here is that `Masonry` has no context into the styles that get added in Pinboard for server rendering and so it's left making these isolated assumptions.  This is something I think we should revisit (having Masonry handle injecting the server rendered CSS) which would make changes like this much easier.  

### Links

- [Jira](https://jira.pinadmin.com/browse/BUG-139772)

### Checklist
Validated the fix locally.  Notice in the video how the grid no longer flashes

https://user-images.githubusercontent.com/6487551/165244859-1e48099b-0983-4c0e-bc36-8d075cab6823.mov

Also verified via the profiler
<img width="985" alt="image" src="https://user-images.githubusercontent.com/6487551/165245043-04ec5015-dfdb-4fad-88ab-38017711a29d.png">
