### PR TITLE
Toast: fix for darkMode

### DIFF
--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -1,12 +1,12 @@
 // @flow strict
 import { type Element, type Node } from 'react';
 import Box from './Box.js';
+import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import Flex from './Flex.js';
 import Mask from './Mask.js';
 import Text from './Text.js';
 import styles from './Toast.css';
 import useResponsiveMinWidth from './useResponsiveMinWidth.js';
-import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 
 const TOAST_MAX_WIDTH_PX = 500;
 const TOAST_WIDTH_PX = 330;
@@ -59,7 +59,7 @@ export default function Toast({
   const responsiveMinWidth = useResponsiveMinWidth();
   const isMobileWidth = responsiveMinWidth === 'xs';
 
-  let containerColor = isDarkMode ? 'white' : 'darkGray';
+  let containerColor = 'darkGray';
   let textColor = isDarkMode ? 'dark' : 'light';
   let textElement = text;
 

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -1,12 +1,12 @@
 // @flow strict
 import { type Element, type Node } from 'react';
 import Box from './Box.js';
-import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import Flex from './Flex.js';
 import Mask from './Mask.js';
 import Text from './Text.js';
 import styles from './Toast.css';
 import useResponsiveMinWidth from './useResponsiveMinWidth.js';
+import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 
 const TOAST_MAX_WIDTH_PX = 500;
 const TOAST_WIDTH_PX = 330;


### PR DESCRIPTION
### Summary
Toast was not working in darMode. The color white was redering as black if darkMode is set.

#### What changed?
changed default color to darkGray. And the Box Component takes care of it during darkMode.


