### PR TITLE
Video: fix on Flow type

### DIFF
--- a/docs/pages/video.js
+++ b/docs/pages/video.js
@@ -4,7 +4,6 @@ import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
 import docgen, { type DocGen } from '../components/docgen.js';
-import deepCloneReplacingUndefined from '../utils/deepCloneReplacingUndefined.js';
 import MainSection from '../components/MainSection.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
@@ -366,7 +365,17 @@ function Example () {
 export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   const generatedDocGen = await docgen({ componentName: 'Video' });
 
+  generatedDocGen.props.ref = {
+    required: false,
+    defaultValue: null,
+    flowType: {
+      name: 'Ref',
+      raw: 'Ref<typeof Video>',
+    },
+    description: 'Ref on the Gestalt Video component.',
+  };
+
   return {
-    props: { generatedDocGen: deepCloneReplacingUndefined(generatedDocGen) },
+    props: { generatedDocGen },
   };
 }

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { PureComponent, type Node, type Ref } from 'react';
+import { PureComponent, type Node } from 'react';
 import classnames from 'classnames';
 import VideoControls from './VideoControls.js';
 import ColorSchemeProvider from './contexts/ColorSchemeProvider.js';
@@ -211,10 +211,6 @@ type Props = {|
    * Specifies how, if at all, the video should be pre-loaded when the page loads. See the [MDN Web Docs: preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-preload)
    */
   preload: 'auto' | 'metadata' | 'none',
-  /**
-   * Ref on the Gestalt Video component.
-   */
-  ref?: Ref<typeof Video>, // eslint-disable-line no-use-before-define
   /**
    * The URL of the video file to play. This can also be supplied as a list of video types to respective video source urls in fallback order for support on various browsers. See [multiple sources example](https://gestalt.pinterest.systems/video#Video-multiple-sources) for more details.
    */


### PR DESCRIPTION
### Summary

#### What changed?

Video: fix on Flow type

#### Why?

The Flowtype provided doesn't match the actual Flowtype for ref in Classes. Moving ref type signature to a manual definition.

