### PR TITLE
Icon: Deprecate old literal colors

### DIFF
--- a/docs/components/Footer.js
+++ b/docs/components/Footer.js
@@ -10,7 +10,7 @@ export default function Footer(): Node {
         <Box column={12} mdColumn={3} padding={2}>
           <Flex alignItems="center" gap={2}>
             <Box aria-hidden>
-              <Icon icon="pinterest" color="red" size={24} accessibilityLabel="" />
+              <Icon icon="pinterest" color="brandPrimary" size={24} accessibilityLabel="" />
             </Box>
             <Text color="default" weight="bold">
               <Link

--- a/docs/pages/callout.js
+++ b/docs/pages/callout.js
@@ -95,7 +95,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             defaultCode={`
           <Flex direction="column" gap={4}>
             <Flex alignItems="center" justifyContent="start">
-              <Icon accessibilityLabel="" icon="pinterest" color="red" size={32}/>
+              <Icon accessibilityLabel="" icon="pinterest" color="error" size={32}/>
               <ButtonGroup>
                 <Button color="transparent" iconEnd="arrow-down" text="Business" />
                 <Button color="transparent" iconEnd="arrow-down" text="Create" />
@@ -157,7 +157,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             defaultCode={`
         <Flex direction="column" gap={4}>
           <Flex alignItems="center" justifyContent="start">
-            <Icon accessibilityLabel="" icon="pinterest" color="red" size={32}/>
+            <Icon accessibilityLabel="" icon="pinterest" color="error" size={32}/>
             <ButtonGroup>
               <Button color="transparent" iconEnd="arrow-down" text="Business" />
               <Button color="transparent" iconEnd="arrow-down" text="Create" />
@@ -172,7 +172,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             <Flex gap={2} direction="column">
               <Upsell
                 imageData={{
-                  component: <Icon icon="send" accessibilityLabel="Send" color="darkGray" size={32}/>
+                  component: <Icon icon="send" accessibilityLabel="Send" color="default" size={32}/>
                 }}
                 message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
                 primaryAction={{

--- a/docs/pages/checkbox.js
+++ b/docs/pages/checkbox.js
@@ -245,7 +245,7 @@ function Example() {
               onChange={({ checked }) => setChecked3(checked)}
             />
             <Tooltip text="A hardboiled egg that is then scrambled" idealDirection="up">
-              <Icon icon="info-circle" accessibilityLabel="" size={14} color="darkGray"/>
+              <Icon icon="info-circle" accessibilityLabel="" size={14} color="default"/>
             </Tooltip>
           </Flex>
         </Flex>

--- a/docs/pages/color_examples.js
+++ b/docs/pages/color_examples.js
@@ -246,7 +246,7 @@ export default function ColorExamplesPage(): Node {
                 rounding="circle"
                 padding={3}
               >
-                <Icon icon="add" color="white" accessibilityLabel="Create"/>
+                <Icon icon="add" color="inverse" accessibilityLabel="Create"/>
               </Box>
             </Flex>
 `}

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -447,7 +447,7 @@ function CustomContentDropdownExample() {
             isExternal
             option={{ value: "Get help", label: "Get help" }}
           >
-            <Icon accessibilityLabel="Ad" color="darkGray" icon="ad"/>
+            <Icon accessibilityLabel="Ad" color="default" icon="ad"/>
             <Text>Get help</Text>
           </Dropdown.Link>
           <Dropdown.Link

--- a/docs/pages/icon.js
+++ b/docs/pages/icon.js
@@ -16,7 +16,7 @@ export default function IconPage({ generatedDocGen }: {| generatedDocGen: DocGen
         description={generatedDocGen?.description}
         defaultCode={`
           <Flex gap={1}>
-              <Icon icon="pin" accessibilityLabel="Pin" color="darkGray" />
+              <Icon icon="pin" accessibilityLabel="Pin" color="default" />
             <Text align="center" color="default" weight="bold">
               Pinterest
             </Text>
@@ -54,7 +54,7 @@ export default function IconPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description="Use icons intentionally, ensuring the Icon choice is easily recognizable and makes sense in the context. "
             defaultCode={`
   <Flex gap={1}>
-    <Icon icon="eye" accessibilityLabel="Number of views" color="darkGray" />
+    <Icon icon="eye" accessibilityLabel="Number of views" color="default" />
     <Text weight="bold" size="300">4</Text>
   </Flex>`}
           />
@@ -64,7 +64,7 @@ export default function IconPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description="Repurpose icons. Using icons for their intended meaning supports good comprehension."
             defaultCode={`
   <Flex gap={2}>
-    <Icon icon="sound" accessibilityLabel="" color="darkGray" />
+    <Icon icon="sound" accessibilityLabel="" color="default" />
     <Text size="300" weight="bold">24 monthly views</Text>
   </Flex>`}
           />
@@ -76,7 +76,7 @@ export default function IconPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description="Pair text and icons when possible to provide better clarity."
             defaultCode={`
 <Flex gap={1}>
-  <Icon icon="tag" accessibilityLabel="" color="darkGray" />
+  <Icon icon="tag" accessibilityLabel="" color="default" />
   <Text size="300" weight="bold">
     Shopping spotlight
   </Text>
@@ -89,7 +89,7 @@ export default function IconPage({ generatedDocGen }: {| generatedDocGen: DocGen
             defaultCode={`
 <Tooltip text="Share pin" accessibilityLabel="">
   <TapArea>
-    <Icon icon="share" accessibilityLabel="Share Pin" color="darkGray" />
+    <Icon icon="share" accessibilityLabel="Share Pin" color="default" />
   </TapArea>
 </Tooltip>`}
           />
@@ -114,7 +114,7 @@ If an icon has a visible label that describes what the icon represents, \`access
             cardSize="md"
             defaultCode={`
 <Flex gap={1}>
-  <Icon icon="eye" accessibilityLabel="Number of views" color="darkGray" />
+  <Icon icon="eye" accessibilityLabel="Number of views" color="default" />
   <Text weight="bold" size="300">4</Text>
 </Flex>`}
           />
@@ -122,7 +122,7 @@ If an icon has a visible label that describes what the icon represents, \`access
             cardSize="md"
             defaultCode={`
 <Flex gap={1}>
-  <Icon icon="tag" accessibilityLabel="" color="darkGray" />
+  <Icon icon="tag" accessibilityLabel="" color="default" />
   <Text align="center" weight="bold">
     Shopping spotlight
   </Text>
@@ -139,9 +139,7 @@ If an icon has a visible label that describes what the icon represents, \`access
         <MainSection.Subsection
           title="Colors"
           description={`
-        Icons can be created using the following color options. \`brandPrimary\` should only be used to represent the Pinterest logo, as it is not accessible. See the [design tokens](/design_tokens#Text-color) for more info.
-
-        ⚠️ Please note: the previous options ("blue" , "darkGray" , "eggplant" , "gray" , "green" , "lightGray" , "maroon" , "midnight" , "navy" , "olive" , "orange" , "orchid" , "pine" , "purple" , "red" , "watermelon" and "white") are still valid, but will be deprecated soon. Avoid using them in any new implementations.`}
+        Icons can be created using the following color options. \`brandPrimary\` should only be used to represent the Pinterest logo, as it is not accessible. See the [design tokens](/design_tokens#Text-color) for more info.`}
         >
           <CombinationNew
             color={[

--- a/docs/pages/iconography_and_svgs.js
+++ b/docs/pages/iconography_and_svgs.js
@@ -13,7 +13,7 @@ function ClickableIcon({ iconName, onTap }: {| iconName: IconName, onTap: () => 
     <Tooltip text={iconName} accessibilityLabel="">
       <TapArea rounding="circle" tapStyle="compress" onTap={onTap}>
         <Box padding={2}>
-          <Icon color="darkGray" accessibilityLabel={iconName} icon={iconName} />
+          <Icon color="default" accessibilityLabel={iconName} icon={iconName} />
         </Box>
       </TapArea>
     </Tooltip>

--- a/docs/pages/link.js
+++ b/docs/pages/link.js
@@ -253,7 +253,7 @@ Use the "visit" icon to represent an external Link/domain in a text context. The
       <Link href="https://www.w3.org/WAI/standards-guidelines/" inline> WCAG accessibility resources</Link>
     </Text>
   </Text>
-  <Icon icon="link" accessibilityLabel="" color="darkGray" />
+  <Icon icon="link" accessibilityLabel="" color="default" />
 </Flex>
             `}
           />

--- a/docs/pages/onlinknavigationprovider.js
+++ b/docs/pages/onlinknavigationprovider.js
@@ -205,7 +205,7 @@ function OnNavigation() {
               onDismiss: () => {},
             }}
             imageData={{
-              component: <Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32}/>
+              component: <Icon icon="pinterest" accessibilityLabel="Pin" color="default" size={32}/>
             }}
           />
           <ActivationCard

--- a/docs/pages/scrollboundarycontainer.js
+++ b/docs/pages/scrollboundarycontainer.js
@@ -124,7 +124,7 @@ function ScrollBoundaryContainerExample() {
               <Icon
                 icon="info-circle"
                 accessibilityLabel="Information"
-                color="darkGray"
+                color="default"
               />
             </Tooltip>
           </Flex>
@@ -185,7 +185,7 @@ function ScrollBoundaryContainerExample() {
               <Icon
                 icon="info-circle"
                 accessibilityLabel="Information"
-                color="darkGray"
+                color="default"
               />
             </Tooltip>
           </Flex>
@@ -245,7 +245,7 @@ function ScrollBoundaryContainerExample() {
               <Icon
                 icon="info-circle"
                 accessibilityLabel="Information"
-                color="darkGray"
+                color="default"
               />
             </Tooltip>
           </Flex>

--- a/docs/pages/searchfield.js
+++ b/docs/pages/searchfield.js
@@ -20,7 +20,7 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
       <Flex gap={4} alignItems="center" flex="grow">
         <Icon
           icon="pinterest"
-          color="red"
+          color="brandPrimary"
           size={20}
           accessibilityLabel="Pinterest"
         />
@@ -188,7 +188,7 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
       <Flex alignItems="center" flex="grow" gap={4}>
         <Icon
           accessibilityLabel="Pinterest"
-          color="red"
+          color="brandPrimary"
           icon="pinterest"
           size={20}
         />
@@ -237,7 +237,7 @@ export default function SearchFieldPage({ generatedDocGen }: {| generatedDocGen:
       <Flex alignItems="center" flex="grow" gap={4}>
         <Icon
           accessibilityLabel="Pinterest"
-          color="red"
+          color="brandPrimary"
           icon="pinterest"
           size={20}
         />

--- a/docs/pages/segmentedcontrol.js
+++ b/docs/pages/segmentedcontrol.js
@@ -54,7 +54,7 @@ function SegmentedControlExample() {
     <Icon
       icon="pin"
       accessibilityLabel="Pin"
-      color="darkGray"
+      color="default"
     />,
   ];
 

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -663,7 +663,7 @@ function ScrollBoundaryContainerExample() {
               <Icon
                 icon="info-circle"
                 accessibilityLabel="Information"
-                color="darkGray"
+                color="default"
               />
             </Tooltip>
           </Flex>
@@ -723,7 +723,7 @@ function ScrollBoundaryContainerExample() {
               <Icon
                 icon="info-circle"
                 accessibilityLabel="Information"
-                color="darkGray"
+                color="default"
               />
             </Tooltip>
           </Flex>

--- a/docs/pages/upsell.js
+++ b/docs/pages/upsell.js
@@ -23,7 +23,7 @@ export default function DocsPage({
           onDismiss: () => {},
         }}
         imageData={{
-          component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
+          component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
         }}
         message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
         primaryAction={{
@@ -88,7 +88,7 @@ export default function DocsPage({
     onDismiss: () => {},
   }}
   imageData={{
-    component: <Icon accessibilityLabel="" color="darkGray" icon="pinterest" size={32} />,
+    component: <Icon accessibilityLabel="" color="default" icon="pinterest" size={32} />,
   }}
   message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
   primaryAction={{
@@ -110,7 +110,7 @@ export default function DocsPage({
             defaultCode={`
 <Box>
   <Box alignItems="center" display="flex" marginBottom={4}>
-    <Icon accessibilityLabel="" color="red" icon="pinterest" size={32} />
+    <Icon accessibilityLabel="" color="brandPrimary" icon="pinterest" size={32} />
     <ButtonGroup>
       <Button color="transparent" iconEnd="arrow-down" text="Business" />
       <Button color="transparent" iconEnd="arrow-down" text="Create" />
@@ -128,7 +128,7 @@ export default function DocsPage({
         onDismiss: () => {},
       }}
       imageData={{
-        component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
+        component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
       }}
       message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
       primaryAction={{
@@ -159,7 +159,7 @@ export default function DocsPage({
       onDismiss: () => {},
     }}
     imageData={{
-      component: <Icon icon="ads-stats" accessibilityLabel="" color="darkGray" size={32} />,
+      component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
     }}
     message="Install the Pinterest tag to track your website traffic, conversions and more."
     primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag now' }}
@@ -169,7 +169,7 @@ export default function DocsPage({
   <Text>Follow-up Upsell:</Text>
   <Upsell
     imageData={{
-      component: <Icon icon="send" accessibilityLabel="" color="darkGray" size={32} />,
+      component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
     }}
     message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
     primaryAction={{ label: 'Claim now', accessibilityLabel: "Claim ads credit" }}
@@ -192,7 +192,7 @@ export default function DocsPage({
     onDismiss: () => {},
   }}
   imageData={{
-    component: <Icon icon="workflow-status-warning" accessibilityLabel="Warning" color="darkGray" size={32} />,
+    component: <Icon icon="workflow-status-warning" accessibilityLabel="Warning" color="default" size={32} />,
   }}
   message="There was a problem connecting your account."
   primaryAction={{ label: 'Try again', accessibilityLabel: 'Try linking account again' }}
@@ -210,7 +210,7 @@ export default function DocsPage({
             defaultCode={`
 <Box>
   <Box alignItems="center" display="flex" marginBottom={4}>
-    <Icon accessibilityLabel="" color="red" icon="pinterest" size={32} />
+    <Icon accessibilityLabel="" color="brandPrimary" icon="pinterest" size={32} />
     <ButtonGroup>
       <Button color="transparent" iconEnd="arrow-down" text="Business" />
       <Button color="transparent" iconEnd="arrow-down" text="Create" />
@@ -225,7 +225,7 @@ export default function DocsPage({
     <Flex direction="column" gap={2}>
       <Upsell
         imageData={{
-          component: <Icon icon="send" accessibilityLabel="" color="darkGray" size={32} />,
+          component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
         }}
         message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
         primaryAction={{ label: 'Claim now', accessibilityLabel: 'Claim ads credit now' }}
@@ -237,7 +237,7 @@ export default function DocsPage({
           onDismiss: () => {},
         }}
         imageData={{
-          component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
+          component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
         }}
         message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
         primaryAction={{
@@ -268,7 +268,7 @@ export default function DocsPage({
       onDismiss: () => {},
     }}
     imageData={{
-      component: <Icon icon="ads-stats" accessibilityLabel="" color="darkGray" size={32} />,
+      component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
     }}
     message="Install the Pinterest tag to track your website traffic, conversions and more."
     primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
@@ -280,7 +280,7 @@ export default function DocsPage({
       onDismiss: () => {},
     }}
     imageData={{
-      component: <Icon icon="ads-stats" accessibilityLabel="" color="darkGray" size={32} />,
+      component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
     }}
     message="Install the Pinterest tag to track your website traffic, conversions and more."
     primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
@@ -314,7 +314,7 @@ export default function DocsPage({
     onDismiss: () => {},
   }}
   imageData={{
-    component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
+    component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
   }}
   message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
   primaryAction={{
@@ -340,7 +340,7 @@ export default function DocsPage({
             defaultCode={`
 <Upsell
   imageData={{
-    component: <Icon icon="send" accessibilityLabel="" color="darkGray" size={32} />,
+    component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
   }}
   message="Verfolgen Sie die Anzeigenkonvertierung - Umsatz, Traffic und mehr - mit dem Pinterest Tag"
   primaryAction={{
@@ -387,7 +387,7 @@ export default function DocsPage({
     onDismiss: () => {},
   }}
   imageData={{
-    component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
+    component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
   }}
   message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
   primaryAction={{
@@ -584,7 +584,7 @@ function FormExample(props) {
         onDismiss: ()=>{},
       }}
       imageData={{
-        component: <Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32}/>
+        component: <Icon icon="pinterest" accessibilityLabel="Pin" color="default" size={32}/>
       }}
       message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
       title="Give $30, get $60 in ads credit"

--- a/docs/pages/visual-test/Icon-list-dark.js
+++ b/docs/pages/visual-test/Icon-list-dark.js
@@ -11,7 +11,7 @@ export default function Snapshot(): Node {
         <Flex gap={1} wrap>
           {icons.map((name, index) => (
             <Box key={index} padding={2}>
-              <Icon color="darkGray" accessibilityLabel="" icon={name} />
+              <Icon color="default" accessibilityLabel="" icon={name} />
             </Box>
           ))}
         </Flex>

--- a/docs/pages/visual-test/Icon-list.js
+++ b/docs/pages/visual-test/Icon-list.js
@@ -11,7 +11,7 @@ export default function Snapshot(): Node {
         <Flex gap={1} wrap>
           {icons.map((name, index) => (
             <Box key={index} padding={2}>
-              <Icon color="darkGray" accessibilityLabel="" icon={name} />
+              <Icon color="default" accessibilityLabel="" icon={name} />
             </Box>
           ))}
         </Flex>

--- a/docs/pages/visual-test/Upsell-dark.js
+++ b/docs/pages/visual-test/Upsell-dark.js
@@ -12,7 +12,7 @@ export default function Snapshot(): Node {
             onDismiss: () => {},
           }}
           imageData={{
-            component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
+            component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
           }}
           message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
           primaryAction={{

--- a/docs/pages/visual-test/Upsell.js
+++ b/docs/pages/visual-test/Upsell.js
@@ -11,7 +11,7 @@ export default function Snapshot(): Node {
           onDismiss: () => {},
         }}
         imageData={{
-          component: <Icon icon="pinterest" accessibilityLabel="" color="darkGray" size={32} />,
+          component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
         }}
         message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
         primaryAction={{

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -233,7 +233,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
         maxDate={rangeSelector === 'end' ? maxDate : rangeEndDate || maxDate}
         minDate={rangeSelector === 'start' ? minDate : rangeStartDate || minDate}
         nextMonthButtonLabel={
-          <Icon accessibilityLabel="" color="darkGray" icon="arrow-forward" size={16} />
+          <Icon accessibilityLabel="" color="default" icon="arrow-forward" size={16} />
         }
         onChange={(value: Date, event: SyntheticInputEvent<HTMLInputElement>) => {
           setSelected(value);
@@ -249,7 +249,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
         )}
         popperPlacement={popperPlacement[idealDirection]}
         previousMonthButtonLabel={
-          <Icon accessibilityLabel="" color="darkGray" icon="arrow-back" size={16} />
+          <Icon accessibilityLabel="" color="default" icon="arrow-back" size={16} />
         }
         ref={(refElement) => {
           if (!innerRef || !refElement) {

--- a/packages/gestalt-datepicker/src/DatePickerTextField.js
+++ b/packages/gestalt-datepicker/src/DatePickerTextField.js
@@ -67,7 +67,7 @@ function DatePickerTextField(props: Props) {
         </Box>
         <div className={classnames(styles.calendarIcon)}>
           <Box position="relative" marginEnd={4}>
-            <Icon accessibilityLabel="" color="darkGray" icon="calendar" />
+            <Icon accessibilityLabel="" color="default" icon="calendar" />
           </Box>
         </div>
       </Box>

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -11,9 +11,9 @@ import styles from './ActivationCard.css';
 
 const STATUS_ICONS = {
   notStarted: undefined,
-  pending: { symbol: 'clock', color: 'gray' },
-  needsAttention: { symbol: 'workflow-status-problem', color: 'red' },
-  complete: { symbol: 'check-circle', color: 'green' },
+  pending: { symbol: 'clock', color: 'subtle' },
+  needsAttention: { symbol: 'workflow-status-problem', color: 'error' },
+  complete: { symbol: 'check-circle', color: 'success' },
 };
 
 type LinkData = {|

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -104,7 +104,7 @@ export default function Avatar(props: Props): Node {
           }}
         >
           <Box color="white" width="100%" height="100%" rounding="circle">
-            <Icon color="red" icon="check-circle" accessibilityLabel="" size="100%" />
+            <Icon color="brandPrimary" icon="check-circle" accessibilityLabel="" size="100%" />
           </Box>
         </Box>
       )}

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -24,12 +24,6 @@ const DEFAULT_TEXT_COLORS = {
   white: 'default',
 };
 
-const NEW_TO_OLD_COLOR_MAPPING = {
-  inverse: 'white',
-  default: 'darkGray',
-  subtle: 'gray',
-};
-
 const SIZE_NAME_TO_PIXEL = {
   sm: 10,
   md: 12,
@@ -231,12 +225,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         wrappedComponent="button"
       >
         {iconEnd ? (
-          <IconEnd
-            text={buttonText}
-            textColor={NEW_TO_OLD_COLOR_MAPPING[textColor]}
-            icon={iconEnd}
-            size={size}
-          />
+          <IconEnd text={buttonText} textColor={textColor} icon={iconEnd} size={size} />
         ) : (
           buttonText
         )}
@@ -267,12 +256,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
         type="submit"
       >
         {iconEnd ? (
-          <IconEnd
-            text={buttonText}
-            textColor={NEW_TO_OLD_COLOR_MAPPING[textColor]}
-            icon={iconEnd}
-            size={size}
-          />
+          <IconEnd text={buttonText} textColor={textColor} icon={iconEnd} size={size} />
         ) : (
           buttonText
         )}
@@ -305,12 +289,7 @@ const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = for
     >
       <div className={childrenDivClasses} style={compressStyle || undefined}>
         {iconEnd ? (
-          <IconEnd
-            text={buttonText}
-            textColor={NEW_TO_OLD_COLOR_MAPPING[textColor]}
-            icon={iconEnd}
-            size={size}
-          />
+          <IconEnd text={buttonText} textColor={textColor} icon={iconEnd} size={size} />
         ) : (
           buttonText
         )}

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -81,17 +81,17 @@ type Props = {|
 const CALLOUT_TYPE_ATTRIBUTES = {
   info: {
     icon: 'info-circle',
-    color: 'blue',
+    color: 'shopping',
     backgroundColor: '#EBF4FE',
   },
   warning: {
     icon: 'workflow-status-warning',
-    color: 'orange',
+    color: 'warning',
     backgroundColor: '#FDF5EC',
   },
   error: {
     icon: 'workflow-status-problem',
-    color: 'red',
+    color: 'error',
     backgroundColor: '#FDEBEE',
   },
 };

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -196,7 +196,7 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
               {(checked || indeterminate) && (
                 <Icon
                   accessibilityLabel=""
-                  color="white"
+                  color="inverse"
                   icon={indeterminate ? 'dash' : 'check'}
                   size={size === 'sm' ? 8 : 12}
                 />

--- a/packages/gestalt/src/ComboBoxItem.js
+++ b/packages/gestalt/src/ComboBoxItem.js
@@ -91,7 +91,7 @@ const ComboBoxItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> =
           )}
         >
           {isSelected ? (
-            <Icon accessibilityLabel="Selected item" color="darkGray" icon="check" size={12} />
+            <Icon accessibilityLabel="Selected item" color="default" icon="check" size={12} />
           ) : (
             <div style={{ width: '12px' }} />
           )}

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -74,7 +74,7 @@ export default function Datapoint({
             {/* Interactive elements require an a11yLabel on them or their children.
             That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */}
             <TapArea accessibilityLabel={tooltipText} rounding="circle" tapStyle="none">
-              <Icon accessibilityLabel="" size={16} icon="info-circle" color="gray" />
+              <Icon accessibilityLabel="" size={16} icon="info-circle" color="subtle" />
             </TapArea>
           </Tooltip>
         )}

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -91,13 +91,13 @@ const flipOnRtlIconNames = [
  */
 export default function Icon({
   accessibilityLabel,
-  color = 'gray',
+  color = 'subtle',
   dangerouslySetSvgPath,
   icon,
   inline = false,
   size = 16,
 }: Props): Node {
-  const colorClass = colors[`${color}Icon`];
+  const colorClass = colors[`${color}Icon`] && colors[`${color}Icon`];
 
   const cs = classnames(
     flipOnRtlIconNames.includes(icon) && styles.rtlSupport,

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -5,37 +5,7 @@ import styles from './Icon.css';
 import icons from './icons/index.js';
 import colors from './Colors.css';
 
-const semanticColors = [
-  'default',
-  'subtle',
-  'success',
-  'error',
-  'warning',
-  'inverse',
-  'shopping',
-  'brandPrimary',
-  'light',
-  'dark',
-];
-
 export type IconColor =
-  | 'blue'
-  | 'darkGray'
-  | 'eggplant'
-  | 'gray'
-  | 'green'
-  | 'lightGray'
-  | 'maroon'
-  | 'midnight'
-  | 'navy'
-  | 'olive'
-  | 'orange'
-  | 'orchid'
-  | 'pine'
-  | 'purple'
-  | 'red'
-  | 'watermelon'
-  | 'white'
   | 'default'
   | 'subtle'
   | 'success'
@@ -127,19 +97,7 @@ export default function Icon({
   inline = false,
   size = 16,
 }: Props): Node {
-  let colorClass = null;
-  const colorName = semanticColors.includes(color) ? `${color}Icon` : color;
-  if (
-    colorName !== 'dark' &&
-    colorName !== 'error' &&
-    colorName !== 'light' &&
-    colorName !== 'subtle' &&
-    colorName !== 'success' &&
-    colorName !== 'warning' &&
-    colorName !== 'brandPrimary'
-  ) {
-    colorClass = colors[colorName];
-  }
+  const colorClass = colors[`${color}Icon`];
 
   const cs = classnames(
     flipOnRtlIconNames.includes(icon) && styles.rtlSupport,

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -92,7 +92,7 @@ export default function ModuleExpandableItem({
                   accessibilityLabel={
                     isCollapsed ? accessibilityExpandLabel : accessibilityCollapseLabel
                   }
-                  color="darkGray"
+                  color="default"
                   icon={isCollapsed ? 'arrow-down' : 'arrow-up'}
                   size="12"
                 />

--- a/packages/gestalt/src/ModuleTitle.js
+++ b/packages/gestalt/src/ModuleTitle.js
@@ -29,8 +29,7 @@ export default function ModuleTitle(props: {|
   const decoration = ['icon', 'badge', 'iconButton'].find((prop) => !!props[prop]);
   const hasError = type === 'error';
   const hasIcon = hasError || decoration === 'icon';
-  const textColor = hasError ? 'error' : 'default';
-  const iconColor = hasError ? 'red' : 'darkGray';
+  const textAndIconColor = hasError ? 'error' : 'default';
 
   return (
     <Flex alignItems="center" gap={2}>
@@ -38,7 +37,7 @@ export default function ModuleTitle(props: {|
         <Flex.Item minWidth={0}>
           <Icon
             accessibilityLabel={iconAccessibilityLabel}
-            color={iconColor}
+            color={textAndIconColor}
             icon={hasError ? 'workflow-status-problem' : props.icon}
           />
         </Flex.Item>
@@ -46,7 +45,7 @@ export default function ModuleTitle(props: {|
 
       {title && (
         <Flex.Item minWidth={0}>
-          <Text color={textColor} lineClamp={1} weight="bold">
+          <Text color={textAndIconColor} lineClamp={1} weight="bold">
             {title}
           </Text>
         </Flex.Item>

--- a/packages/gestalt/src/OptionItem.js
+++ b/packages/gestalt/src/OptionItem.js
@@ -126,7 +126,7 @@ const OptionItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = f
         justifyContent="center"
       >
         {isSelectedItem && !isExternal ? (
-          <Icon accessibilityLabel="Selected item" color="darkGray" icon="check" size={12} />
+          <Icon accessibilityLabel="Selected item" color="default" icon="check" size={12} />
         ) : (
           <Box width={12} />
         )}
@@ -141,7 +141,7 @@ const OptionItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = f
           marginStart={2}
         >
           {/* TODO: this label needs to be translated */}
-          <Icon accessibilityLabel=", External" color="darkGray" icon="arrow-up-right" size={12} />
+          <Icon accessibilityLabel=", External" color="default" icon="arrow-up-right" size={12} />
         </Box>
       )}
     </Flex>

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -21,6 +21,13 @@ const SIZE_NAME_TO_ICON_SIZE_PIXEL = {
   xl: 24,
 };
 
+const OLD_TO_NEW_COLOR_MAP = {
+  'white': 'inverse',
+  'gray': 'subtle',
+  'darkGray': 'default',
+  'red': 'error',
+};
+
 const defaultIconButtonIconColors = {
   darkGray: 'white',
   gray: 'white',
@@ -132,7 +139,7 @@ export default function Pog({
     <div className={classes} style={inlineStyle}>
       <Icon
         accessibilityLabel={accessibilityLabel || ''}
-        color={color}
+        color={OLD_TO_NEW_COLOR_MAP[color]}
         dangerouslySetSvgPath={dangerouslySetSvgPath}
         icon={icon}
         size={iconSizeInPx}

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -230,7 +230,7 @@ const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
             >
               <Icon
                 accessibilityLabel={accessibilityClearButtonLabel || ''}
-                color={focused ? 'white' : 'darkGray'}
+                color={focused ? 'inverse' : 'default'}
                 icon="cancel"
                 size={clearIconSize}
               />

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -134,7 +134,7 @@ export default function SelectList({
           <Icon
             icon="arrow-down"
             size={12}
-            color={disabled ? 'gray' : 'darkGray'}
+            color={disabled ? 'subtle' : 'default'}
             accessibilityLabel=""
           />
         </Box>

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -107,7 +107,7 @@ export default function TableSortableHeaderCell({
                 icon={
                   status === 'active' && sortOrder === 'asc' ? 'sort-ascending' : 'sort-descending'
                 }
-                color={status === 'active' ? 'darkGray' : 'gray'}
+                color={status === 'active' ? 'default' : 'subtle'}
               />
             </Box>
           </Box>

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -12,12 +12,6 @@ import touchableStyles from './Touchable.css';
 import typographyStyles from './Typography.css';
 import styles from './Tag.css';
 
-const NEW_TO_OLD_COLOR_MAPPING = {
-  inverse: 'white',
-  default: 'darkGray',
-  subtle: 'gray',
-};
-
 type Props = {|
   text: string,
   errorMessage?: string,
@@ -96,7 +90,7 @@ export default function Tag(props: Props): Node {
           {errorMessage && (
             <Icon
               accessibilityLabel={errorMessage}
-              color={NEW_TO_OLD_COLOR_MAPPING[fgColor]}
+              color={fgColor}
               icon="workflow-status-problem"
               size={12}
             />
@@ -112,7 +106,7 @@ export default function Tag(props: Props): Node {
             <button className={removeIconClasses} onClick={onRemove} type="button">
               <Icon
                 accessibilityLabel={removeIconAccessibilityLabel}
-                color={NEW_TO_OLD_COLOR_MAPPING[fgColor]}
+                color={fgColor}
                 icon="cancel"
                 size={8}
               />

--- a/packages/gestalt/src/Upsell.test.js
+++ b/packages/gestalt/src/Upsell.test.js
@@ -83,7 +83,7 @@ describe('<Upsell />', () => {
         }}
         title="A Title"
         imageData={{
-          component: <Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32} />,
+          component: <Icon icon="pinterest" accessibilityLabel="Pin" color="default" size={32} />,
         }}
       />,
     ).toJSON();
@@ -100,7 +100,7 @@ describe('<Upsell />', () => {
         }}
         title="A Title"
         imageData={{
-          component: <Icon icon="pinterest" accessibilityLabel="Pin" color="darkGray" size={32} />,
+          component: <Icon icon="pinterest" accessibilityLabel="Pin" color="default" size={32} />,
         }}
       >
         <Upsell.Form

--- a/packages/gestalt/src/VideoControls.js
+++ b/packages/gestalt/src/VideoControls.js
@@ -111,7 +111,7 @@ function VideoControls({
         <TapArea onTap={handlePlayingChange} fullWidth={false}>
           <Icon
             accessibilityLabel={playing ? accessibilityPauseLabel : accessibilityPlayLabel}
-            color="white"
+            color="light"
             icon={playing ? 'pause' : 'play'}
             size={20}
           />
@@ -126,7 +126,7 @@ function VideoControls({
                   ? accessibilityHideCaptionsLabel
                   : accessibilityShowCaptionsLabel
               }
-              color="white"
+              color="light"
               icon={captionsButton === 'enabled' ? 'speech-ellipsis' : 'speech'}
               size={20}
             />
@@ -157,7 +157,7 @@ function VideoControls({
         <TapArea onTap={handleVolumeChange} fullWidth={false}>
           <Icon
             accessibilityLabel={muted ? accessibilityUnmuteLabel : accessibilityMuteLabel}
-            color="white"
+            color="light"
             icon={muted ? 'mute' : 'sound'}
             size={20}
           />
@@ -170,7 +170,7 @@ function VideoControls({
               accessibilityLabel={
                 fullscreen ? accessibilityMinimizeLabel : accessibilityMaximizeLabel
               }
-              color="white"
+              color="light"
               icon={fullscreen ? 'minimize' : 'maximize'}
               size={20}
             />

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
@@ -25,7 +25,7 @@ exports[`<ActivationCard /> Needs attention ActivationCard 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Needs attention"
-        className="icon red iconBlock"
+        className="icon errorIcon iconBlock"
         height={24}
         role="img"
         viewBox="0 0 24 24"
@@ -142,7 +142,7 @@ exports[`<ActivationCard /> Pending ActivationCard 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Pending"
-        className="icon gray iconBlock"
+        className="icon subtleIcon iconBlock"
         height={24}
         role="img"
         viewBox="0 0 24 24"
@@ -207,7 +207,7 @@ exports[`<ActivationCard /> complete ActivationCard 1`] = `
         <svg
           aria-hidden={null}
           aria-label="Complete"
-          className="icon green iconBlock"
+          className="icon successIcon iconBlock"
           height={40}
           role="img"
           viewBox="0 0 24 24"
@@ -270,7 +270,7 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Needs attention"
-        className="icon red iconBlock"
+        className="icon errorIcon iconBlock"
         height={24}
         role="img"
         viewBox="0 0 24 24"
@@ -379,7 +379,7 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon gray iconBlock"
+            className="icon subtleIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"
@@ -421,7 +421,7 @@ exports[`<ActivationCard /> message + title + link 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Needs attention"
-        className="icon red iconBlock"
+        className="icon errorIcon iconBlock"
         height={24}
         role="img"
         viewBox="0 0 24 24"
@@ -523,7 +523,7 @@ exports[`<ActivationCard /> message + title 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Needs attention"
-        className="icon red iconBlock"
+        className="icon errorIcon iconBlock"
         height={24}
         role="img"
         viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -162,7 +162,7 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
       <svg
         aria-hidden={true}
         aria-label=""
-        className="icon red iconBlock"
+        className="icon brandPrimaryIcon iconBlock"
         height="100%"
         role="img"
         viewBox="0 0 24 24"
@@ -516,7 +516,7 @@ exports[`Avatar renders the verified icon 1`] = `
       <svg
         aria-hidden={true}
         aria-label=""
-        className="icon red iconBlock"
+        className="icon brandPrimaryIcon iconBlock"
         height="100%"
         role="img"
         viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -26,7 +26,7 @@ exports[`<Callout /> Error Callout 1`] = `
         <svg
           aria-hidden={null}
           aria-label="error"
-          className="icon red iconBlock"
+          className="icon errorIcon iconBlock"
           height={32}
           role="img"
           viewBox="0 0 24 24"
@@ -86,7 +86,7 @@ exports[`<Callout /> Info Callout 1`] = `
         <svg
           aria-hidden={null}
           aria-label="info"
-          className="icon blue iconBlock"
+          className="icon shoppingIcon iconBlock"
           height={32}
           role="img"
           viewBox="0 0 24 24"
@@ -146,7 +146,7 @@ exports[`<Callout /> Warning Callout 1`] = `
         <svg
           aria-hidden={null}
           aria-label="warning"
-          className="icon orange iconBlock"
+          className="icon warningIcon iconBlock"
           height={32}
           role="img"
           viewBox="0 0 24 24"
@@ -206,7 +206,7 @@ exports[`<Callout /> message + title + primaryAction + dismissButton 1`] = `
         <svg
           aria-hidden={null}
           aria-label="info"
-          className="icon blue iconBlock"
+          className="icon shoppingIcon iconBlock"
           height={32}
           role="img"
           viewBox="0 0 24 24"
@@ -316,7 +316,7 @@ exports[`<Callout /> message + title + primaryAction + dismissButton 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"
@@ -359,7 +359,7 @@ exports[`<Callout /> message + title + primaryAction + secondaryAction 1`] = `
         <svg
           aria-hidden={null}
           aria-label="info"
-          className="icon blue iconBlock"
+          className="icon shoppingIcon iconBlock"
           height={32}
           role="img"
           viewBox="0 0 24 24"
@@ -494,7 +494,7 @@ exports[`<Callout /> message + title + primaryAction with href 1`] = `
         <svg
           aria-hidden={null}
           aria-label="info"
-          className="icon blue iconBlock"
+          className="icon shoppingIcon iconBlock"
           height={32}
           role="img"
           viewBox="0 0 24 24"
@@ -598,7 +598,7 @@ exports[`<Callout /> message + title + primaryAction without href 1`] = `
         <svg
           aria-hidden={null}
           aria-label="info"
-          className="icon blue iconBlock"
+          className="icon shoppingIcon iconBlock"
           height={32}
           role="img"
           viewBox="0 0 24 24"
@@ -700,7 +700,7 @@ exports[`<Callout /> message + title 1`] = `
         <svg
           aria-hidden={null}
           aria-label="info"
-          className="icon blue iconBlock"
+          className="icon shoppingIcon iconBlock"
           height={32}
           role="img"
           viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -83,7 +83,7 @@ exports[`Checkbox checked 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon white iconBlock"
+            className="icon inverseIcon iconBlock"
             height={12}
             role="img"
             viewBox="0 0 24 24"
@@ -147,7 +147,7 @@ exports[`Checkbox disabled & checked 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon white iconBlock"
+            className="icon inverseIcon iconBlock"
             height={8}
             role="img"
             viewBox="0 0 24 24"
@@ -261,7 +261,7 @@ exports[`Checkbox indeterminate 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon white iconBlock"
+            className="icon inverseIcon iconBlock"
             height={12}
             role="img"
             viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
@@ -59,7 +59,7 @@ exports[`ComboBox Controlled ComboBox renders basic controlled components 1`] = 
                   <svg
                     aria-hidden="true"
                     aria-label=""
-                    class="icon darkGray iconBlock"
+                    class="icon defaultIcon iconBlock"
                     height="12"
                     role="img"
                     viewBox="0 0 24 24"
@@ -146,7 +146,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -195,7 +195,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -244,7 +244,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -293,7 +293,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -342,7 +342,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -391,7 +391,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -440,7 +440,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -489,7 +489,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -538,7 +538,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     >
                       <svg
                         aria-label="Remove tag"
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="8"
                         role="img"
                         viewBox="0 0 24 24"
@@ -593,7 +593,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label=""
-                    class="icon darkGray iconBlock"
+                    class="icon defaultIcon iconBlock"
                     height="12"
                     role="img"
                     viewBox="0 0 24 24"
@@ -673,7 +673,7 @@ exports[`ComboBox Uncontrolled ComboBox renders default 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label=""
-                    class="icon darkGray iconBlock"
+                    class="icon defaultIcon iconBlock"
                     height="12"
                     role="img"
                     viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Datapoint.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Datapoint.test.js.snap
@@ -230,7 +230,7 @@ exports[`Datapoint renders a tooltip 1`] = `
               <svg
                 aria-hidden={true}
                 aria-label=""
-                className="icon gray iconBlock"
+                className="icon subtleIcon iconBlock"
                 height={16}
                 role="img"
                 viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -158,7 +158,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                       >
                         <svg
                           aria-label=", External"
-                          class="rtlSupport icon darkGray iconBlock"
+                          class="rtlSupport icon defaultIcon iconBlock"
                           height="12"
                           role="img"
                           viewBox="0 0 24 24"
@@ -293,7 +293,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                       >
                         <svg
                           aria-label=", External"
-                          class="rtlSupport icon darkGray iconBlock"
+                          class="rtlSupport icon defaultIcon iconBlock"
                           height="12"
                           role="img"
                           viewBox="0 0 24 24"
@@ -358,7 +358,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                       >
                         <svg
                           aria-label=", External"
-                          class="rtlSupport icon darkGray iconBlock"
+                          class="rtlSupport icon defaultIcon iconBlock"
                           height="12"
                           role="img"
                           viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Icon.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Icon.test.js.snap
@@ -4,7 +4,7 @@ exports[`Icon flipped if its in the flip on rtl list 1`] = `
 <svg
   aria-hidden={null}
   aria-label="send"
-  className="rtlSupport icon gray iconBlock"
+  className="rtlSupport icon subtleIcon iconBlock"
   height={16}
   role="img"
   viewBox="0 0 24 24"
@@ -20,7 +20,7 @@ exports[`Icon has correct aria-hidden property applied when accessibilityLabel i
 <svg
   aria-hidden={true}
   aria-label=""
-  className="icon gray iconBlock"
+  className="icon subtleIcon iconBlock"
   height={16}
   role="img"
   viewBox="0 0 24 24"
@@ -36,7 +36,7 @@ exports[`Icon renders 1`] = `
 <svg
   aria-hidden={null}
   aria-label="Add"
-  className="icon gray iconBlock"
+  className="icon subtleIcon iconBlock"
   height={16}
   role="img"
   viewBox="0 0 24 24"
@@ -52,7 +52,7 @@ exports[`Icon uses the dangerouslySetSvgPath prop when icon path is not specifie
 <svg
   aria-hidden={null}
   aria-label="Line"
-  className="icon gray iconBlock"
+  className="icon subtleIcon iconBlock"
   height={16}
   role="img"
   viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.test.js.snap
@@ -34,7 +34,7 @@ exports[`IconButton renders with disabled state 1`] = `
       <svg
         aria-hidden={true}
         aria-label=""
-        className="icon gray iconBlock"
+        className="icon subtleIcon iconBlock"
         height={18}
         role="img"
         viewBox="0 0 24 24"
@@ -82,7 +82,7 @@ exports[`IconButton renders with icon 1`] = `
       <svg
         aria-hidden={true}
         aria-label=""
-        className="icon gray iconBlock"
+        className="icon subtleIcon iconBlock"
         height={18}
         role="img"
         viewBox="0 0 24 24"
@@ -130,7 +130,7 @@ exports[`IconButton renders with svg 1`] = `
       <svg
         aria-hidden={true}
         aria-label=""
-        className="icon gray iconBlock"
+        className="icon subtleIcon iconBlock"
         height={18}
         role="img"
         viewBox="0 0 24 24"
@@ -189,7 +189,7 @@ exports[`IconButton renders with tooltip 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon gray iconBlock"
+            className="icon subtleIcon iconBlock"
             height={18}
             role="img"
             viewBox="0 0 24 24"
@@ -250,7 +250,7 @@ exports[`IconButton renders with tooltip and no accessibilityLabel 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon gray iconBlock"
+            className="icon subtleIcon iconBlock"
             height={18}
             role="img"
             viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/InternalLink.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/InternalLink.test.js.snap
@@ -158,7 +158,7 @@ exports[`renders IconButton 1`] = `
     <svg
       aria-hidden={true}
       aria-label=""
-      className="icon red iconBlock"
+      className="icon errorIcon iconBlock"
       height={18}
       role="img"
       viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Module.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Module.test.js.snap
@@ -140,7 +140,7 @@ exports[`Module renders an error correctly 1`] = `
           <svg
             aria-hidden={null}
             aria-label="there is an error"
-            className="icon red iconBlock"
+            className="icon errorIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"
@@ -260,7 +260,7 @@ exports[`Module renders an icon button correctly 1`] = `
                 <svg
                   aria-hidden={true}
                   aria-label=""
-                  className="icon darkGray iconBlock"
+                  className="icon defaultIcon iconBlock"
                   height={12}
                   role="img"
                   viewBox="0 0 24 24"
@@ -314,7 +314,7 @@ exports[`Module renders an icon correctly 1`] = `
           <svg
             aria-hidden={null}
             aria-label="locked"
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -100,7 +100,7 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="click to expand"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height="12"
                 role="img"
                 viewBox="0 0 24 24"
@@ -215,7 +215,7 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="click to expand"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height="12"
                 role="img"
                 viewBox="0 0 24 24"
@@ -288,7 +288,7 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
                     <svg
                       aria-hidden={true}
                       aria-label=""
-                      className="icon red iconBlock"
+                      className="icon errorIcon iconBlock"
                       height={16}
                       role="img"
                       viewBox="0 0 24 24"
@@ -352,7 +352,7 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="click to expand"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height="12"
                 role="img"
                 viewBox="0 0 24 24"
@@ -501,7 +501,7 @@ exports[`Module Expandable renders correctly with one item 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="click to expand"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height="12"
                 role="img"
                 viewBox="0 0 24 24"
@@ -597,7 +597,7 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="click to collapse"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height="12"
                 role="img"
                 viewBox="0 0 24 24"
@@ -717,7 +717,7 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="click to expand"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height="12"
                 role="img"
                 viewBox="0 0 24 24"
@@ -790,7 +790,7 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
                     <svg
                       aria-hidden={true}
                       aria-label=""
-                      className="icon red iconBlock"
+                      className="icon errorIcon iconBlock"
                       height={16}
                       role="img"
                       viewBox="0 0 24 24"
@@ -854,7 +854,7 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="click to expand"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height="12"
                 role="img"
                 viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandableItem.test.js.snap
@@ -300,7 +300,7 @@ exports[`ModuleExpandableItem renders correctly with error 1`] = `
                   <svg
                     aria-hidden={null}
                     aria-label="there is an error"
-                    className="icon red iconBlock"
+                    className="icon errorIcon iconBlock"
                     height={16}
                     role="img"
                     viewBox="0 0 24 24"
@@ -396,7 +396,7 @@ exports[`ModuleExpandableItem renders correctly with icon 1`] = `
                   <svg
                     aria-hidden={null}
                     aria-label="lock icon label"
-                    className="icon darkGray iconBlock"
+                    className="icon defaultIcon iconBlock"
                     height={16}
                     role="img"
                     viewBox="0 0 24 24"
@@ -541,7 +541,7 @@ exports[`ModuleExpandableItem renders correctly with icon button 1`] = `
                         <svg
                           aria-hidden={true}
                           aria-label=""
-                          className="icon darkGray iconBlock"
+                          className="icon defaultIcon iconBlock"
                           height={12}
                           role="img"
                           viewBox="0 0 24 24"
@@ -766,7 +766,7 @@ exports[`ModuleExpandableItem renders correctly with when expanded 1`] = `
             <svg
               aria-hidden={null}
               aria-label="click to collapse"
-              className="icon darkGray iconBlock"
+              className="icon defaultIcon iconBlock"
               height="12"
               role="img"
               viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/PageHeader.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/PageHeader.test.js.snap
@@ -321,7 +321,7 @@ exports[`PageHeader renders primary action 1`] = `
                       <svg
                         aria-hidden={true}
                         aria-label=""
-                        className="icon darkGray iconBlock"
+                        className="icon defaultIcon iconBlock"
                         height={20}
                         role="img"
                         viewBox="0 0 24 24"
@@ -575,7 +575,7 @@ exports[`PageHeader renders secondary action 1`] = `
                       <svg
                         aria-hidden={true}
                         aria-label=""
-                        className="icon darkGray iconBlock"
+                        className="icon defaultIcon iconBlock"
                         height={20}
                         role="img"
                         viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Pog.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Pog.test.js.snap
@@ -13,7 +13,7 @@ exports[`Pog active renders 1`] = `
   <svg
     aria-hidden={true}
     aria-label=""
-    className="icon gray iconBlock"
+    className="icon subtleIcon iconBlock"
     height={18}
     role="img"
     viewBox="0 0 24 24"
@@ -39,7 +39,7 @@ exports[`Pog focused renders 1`] = `
   <svg
     aria-hidden={true}
     aria-label=""
-    className="icon gray iconBlock"
+    className="icon subtleIcon iconBlock"
     height={18}
     role="img"
     viewBox="0 0 24 24"
@@ -65,7 +65,7 @@ exports[`Pog hovered renders 1`] = `
   <svg
     aria-hidden={true}
     aria-label=""
-    className="icon gray iconBlock"
+    className="icon subtleIcon iconBlock"
     height={18}
     role="img"
     viewBox="0 0 24 24"
@@ -91,7 +91,7 @@ exports[`Pog renders with accessibilityLabel 1`] = `
   <svg
     aria-hidden={null}
     aria-label="Following"
-    className="icon gray iconBlock"
+    className="icon subtleIcon iconBlock"
     height={18}
     role="img"
     viewBox="0 0 24 24"
@@ -117,7 +117,7 @@ exports[`Pog renders with icon 1`] = `
   <svg
     aria-hidden={true}
     aria-label=""
-    className="icon gray iconBlock"
+    className="icon subtleIcon iconBlock"
     height={18}
     role="img"
     viewBox="0 0 24 24"
@@ -143,7 +143,7 @@ exports[`Pog renders with size and custom padding 1`] = `
   <svg
     aria-hidden={true}
     aria-label=""
-    className="icon gray iconBlock"
+    className="icon subtleIcon iconBlock"
     height={24}
     role="img"
     viewBox="0 0 24 24"
@@ -169,7 +169,7 @@ exports[`Pog renders with size and default padding 1`] = `
   <svg
     aria-hidden={true}
     aria-label=""
-    className="icon gray iconBlock"
+    className="icon subtleIcon iconBlock"
     height={24}
     role="img"
     viewBox="0 0 24 24"
@@ -195,7 +195,7 @@ exports[`Pog renders with svg 1`] = `
   <svg
     aria-hidden={true}
     aria-label=""
-    className="icon gray iconBlock"
+    className="icon subtleIcon iconBlock"
     height={18}
     role="img"
     viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
@@ -24,7 +24,7 @@ exports[`SelectList SelectList normal 1`] = `
       <svg
         aria-hidden={true}
         aria-label=""
-        className="icon darkGray iconBlock"
+        className="icon defaultIcon iconBlock"
         height={12}
         role="img"
         viewBox="0 0 24 24"
@@ -103,7 +103,7 @@ exports[`SelectList SelectList with a hidden label 1`] = `
       <svg
         aria-hidden={true}
         aria-label=""
-        className="icon darkGray iconBlock"
+        className="icon defaultIcon iconBlock"
         height={12}
         role="img"
         viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -60,7 +60,7 @@ exports[`Sheet should render all props with nodes 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label=""
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="18"
                         role="img"
                         viewBox="0 0 24 24"
@@ -159,7 +159,7 @@ exports[`Sheet should render all props with render props 1`] = `
                       <svg
                         aria-hidden="true"
                         aria-label=""
-                        class="icon darkGray iconBlock"
+                        class="icon defaultIcon iconBlock"
                         height="18"
                         role="img"
                         viewBox="0 0 24 24"
@@ -249,7 +249,7 @@ exports[`Sheet should render animation in 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label=""
-                      class="icon darkGray iconBlock"
+                      class="icon defaultIcon iconBlock"
                       height="18"
                       role="img"
                       viewBox="0 0 24 24"
@@ -322,7 +322,7 @@ exports[`Sheet should render animation out 1`] = `
                     <svg
                       aria-hidden="true"
                       aria-label=""
-                      class="icon darkGray iconBlock"
+                      class="icon defaultIcon iconBlock"
                       height="18"
                       role="img"
                       viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Spinner.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Spinner.test.js.snap
@@ -12,7 +12,7 @@ exports[`Spinner renders when passed show 1`] = `
     <svg
       aria-hidden={null}
       aria-label="Test"
-      className="icon gray iconBlock"
+      className="icon subtleIcon iconBlock"
       height={40}
       role="img"
       viewBox="0 0 24 24"
@@ -36,7 +36,7 @@ exports[`Spinner renders with medium size 1`] = `
     <svg
       aria-hidden={null}
       aria-label="Test"
-      className="icon gray iconBlock"
+      className="icon subtleIcon iconBlock"
       height={40}
       role="img"
       viewBox="0 0 24 24"
@@ -60,7 +60,7 @@ exports[`Spinner renders with no delay 1`] = `
     <svg
       aria-hidden={null}
       aria-label="Test"
-      className="icon gray iconBlock"
+      className="icon subtleIcon iconBlock"
       height={40}
       role="img"
       viewBox="0 0 24 24"
@@ -84,7 +84,7 @@ exports[`Spinner renders with small size 1`] = `
     <svg
       aria-hidden={null}
       aria-label="Test"
-      className="icon gray iconBlock"
+      className="icon subtleIcon iconBlock"
       height={32}
       role="img"
       viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/TableRowExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableRowExpandable.test.js.snap
@@ -47,7 +47,7 @@ exports[`renders correctly 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={12}
             role="img"
             viewBox="0 0 24 24"
@@ -114,7 +114,7 @@ exports[`renders correctly with explicit hover 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={12}
             role="img"
             viewBox="0 0 24 24"
@@ -181,7 +181,7 @@ exports[`renders correctly without hover 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={12}
             role="img"
             viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -48,7 +48,7 @@ exports[`renders correctly when active 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"
@@ -113,7 +113,7 @@ exports[`renders correctly when inactive 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon gray iconBlock"
+            className="icon subtleIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Tag.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tag.test.js.snap
@@ -43,7 +43,7 @@ exports[`Tag clips long strings 1`] = `
         <svg
           aria-hidden={null}
           aria-label="Remove long example tag"
-          className="icon darkGray iconBlock"
+          className="icon defaultIcon iconBlock"
           height={8}
           role="img"
           viewBox="0 0 24 24"
@@ -102,7 +102,7 @@ exports[`Tag renders 1`] = `
         <svg
           aria-hidden={null}
           aria-label="Remove New tag"
-          className="icon darkGray iconBlock"
+          className="icon defaultIcon iconBlock"
           height={8}
           role="img"
           viewBox="0 0 24 24"
@@ -183,7 +183,7 @@ exports[`Tag renders a tag with an error state 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Something went wrong"
-        className="icon white iconBlock"
+        className="icon inverseIcon iconBlock"
         height={12}
         role="img"
         viewBox="0 0 24 24"
@@ -215,7 +215,7 @@ exports[`Tag renders a tag with an error state 1`] = `
         <svg
           aria-hidden={null}
           aria-label="Remove New tag"
-          className="icon white iconBlock"
+          className="icon inverseIcon iconBlock"
           height={8}
           role="img"
           viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
@@ -177,7 +177,7 @@ exports[`TextArea renders tags when supplied 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="Remove email tag"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height={8}
                 role="img"
                 viewBox="0 0 24 24"
@@ -237,7 +237,7 @@ exports[`TextArea renders tags when supplied 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="Remove email tag"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height={8}
                 role="img"
                 viewBox="0 0 24 24"
@@ -297,7 +297,7 @@ exports[`TextArea renders tags when supplied 1`] = `
               <svg
                 aria-hidden={null}
                 aria-label="Remove email tag"
-                className="icon darkGray iconBlock"
+                className="icon defaultIcon iconBlock"
                 height={8}
                 role="img"
                 viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -231,7 +231,7 @@ exports[`TextField TextField with tags 1`] = `
                 <svg
                   aria-hidden={null}
                   aria-label="Remove email tag"
-                  className="icon darkGray iconBlock"
+                  className="icon defaultIcon iconBlock"
                   height={8}
                   role="img"
                   viewBox="0 0 24 24"
@@ -291,7 +291,7 @@ exports[`TextField TextField with tags 1`] = `
                 <svg
                   aria-hidden={null}
                   aria-label="Remove email tag"
-                  className="icon darkGray iconBlock"
+                  className="icon defaultIcon iconBlock"
                   height={8}
                   role="img"
                   viewBox="0 0 24 24"
@@ -351,7 +351,7 @@ exports[`TextField TextField with tags 1`] = `
                 <svg
                   aria-hidden={null}
                   aria-label="Remove email tag"
-                  className="icon darkGray iconBlock"
+                  className="icon defaultIcon iconBlock"
                   height={8}
                   role="img"
                   viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -73,7 +73,7 @@ exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
           <svg
             aria-hidden={null}
             aria-label="Pin"
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={32}
             role="img"
             viewBox="0 0 24 24"
@@ -225,7 +225,7 @@ exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"
@@ -277,7 +277,7 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] 
           <svg
             aria-hidden={null}
             aria-label="Pin"
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={32}
             role="img"
             viewBox="0 0 24 24"
@@ -388,7 +388,7 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] 
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"
@@ -519,7 +519,7 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="icon darkGray iconBlock"
+            className="icon defaultIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -249,7 +249,7 @@ exports[`Video with children 1`] = `
           <svg
             aria-hidden={null}
             aria-label="Play"
-            className="icon white iconBlock"
+            className="icon lightIcon iconBlock"
             height={20}
             role="img"
             viewBox="0 0 24 24"
@@ -286,7 +286,7 @@ exports[`Video with children 1`] = `
           <svg
             aria-hidden={true}
             aria-label=""
-            className="rtlSupport icon white iconBlock"
+            className="rtlSupport icon lightIcon iconBlock"
             height={20}
             role="img"
             viewBox="0 0 24 24"
@@ -418,7 +418,7 @@ exports[`Video with children 1`] = `
           <svg
             aria-hidden={null}
             aria-label="Unmute"
-            className="icon white iconBlock"
+            className="icon lightIcon iconBlock"
             height={20}
             role="img"
             viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/VideoControls.test.js.snap
@@ -29,7 +29,7 @@ exports[`VideoControls for double digit minutes 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Play"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -161,7 +161,7 @@ exports[`VideoControls for double digit minutes 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -205,7 +205,7 @@ exports[`VideoControls for double digit seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Play"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -337,7 +337,7 @@ exports[`VideoControls for double digit seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -381,7 +381,7 @@ exports[`VideoControls for single digit minutes 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Play"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -513,7 +513,7 @@ exports[`VideoControls for single digit minutes 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -557,7 +557,7 @@ exports[`VideoControls for single digit seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Play"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -689,7 +689,7 @@ exports[`VideoControls for single digit seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -733,7 +733,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Play"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -865,7 +865,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon white iconBlock"
+        className="icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"


### PR DESCRIPTION
### Summary

#### What changed?

Deprecate old Icon colors in favor of our new semantic colors

#### Why?

In favor of our new semantic colors (error, subtle, inverse, etc.), we are deprecating the old colors to create consistency for the future using our design tokens. 

To make any conversions using our codemods, run 
`yarn codemod modifyPropValue [path-to-files] --component=Icon --previousProp=color --previousValue=[value to replace] --nextValue=[new value]`

Typically, conversions are as follows:

| Old | New |
|---|--|
|red| error|
|red| brandPrimary if used to present Brand|
|darkGray| default|
|white | inverse|
|gray | subtle|
|blue/navy/etc. | shopping|
| white on dark backgrounds | light |
| darkGray on light backgrounds | dark |

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4159)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
