### PR TITLE
Docs: Typo fixes and link shortening

### DIFF
--- a/docs/pages/about_us.js
+++ b/docs/pages/about_us.js
@@ -66,7 +66,7 @@ From space to space, across any journey, Pinterest's elements should keep their 
       <MainSection name="Connect with Gestalt">
         <MainSection.Subsection
           description={`
-[Meet the Gestalt team](https://docs.google.com/presentation/d/16LgONudktdWFDlT9X0aKEKZ0SJcOEh53BGmZN_BoGWY/edit?usp=sharing). We are designers, engineers, producers, writers, and so much more! We love to show our work, debate, and challenge each other, but ultimately we trust and empower each other to create great work, and we're always open to feedback.
+[Meet the Gestalt team](http://pinch.pinadmin.com/gestaltOnboarding). We are designers, engineers, producers, writers, and so much more! We love to show our work, debate, and challenge each other, but ultimately we trust and empower each other to create great work, and we're always open to feedback.
 
 You can connect with us through our slack channels, weekly meetings, and events. Visit [How to work with us](/how_to_work_with_us) for support and collaboration details.
 `}

--- a/docs/pages/accessibility.js
+++ b/docs/pages/accessibility.js
@@ -207,7 +207,7 @@ function Example() {
         **[Web Accessibility Wiki](https://w.pinadmin.com/display/WT/Accessibility)**
         Learn more about or web accessibility efforts, best practices, and [Web Accessibility Integration Tests](https://w.pinadmin.com/display/WT/Web+Accessibility+Integration+Tests).
 
-        **[Product Accessibility Working Group](https://paper.dropbox.com/doc/Product-Accessibility-Working-Group--BO3YB5RlBqMR_dd4mPlH47TQAg-3yV0JaSZlrnj5escjkAex)**
+        **[Product Accessibility Working Group](http://pinch.pinadmin.com/productAccessibilityWorkingGroup)**
         Details about the accessibility working group, including success metrics and project statuses.
 
         **[Accessible Design](https://docs.google.com/presentation/d/1b-L0tuzaMTIf1xX7j86g46QfDW3_C0Ep_Ca4TEmXPz8/edit#slide=id.gcf38b911e3_0_750)**

--- a/docs/pages/how_to_work_with_us.js
+++ b/docs/pages/how_to_work_with_us.js
@@ -45,7 +45,7 @@ We love to see more iteration from the product designer asking for the component
         />
       </MainSection>
 
-      <MainSection name="Contribuiting to Gestalt">
+      <MainSection name="Contributing to Gestalt">
         <MainSection.Subsection
           title="Making a design contribution"
           description={`


### PR DESCRIPTION
Pinched some links and fixed a typo in the How to work with us page