### PR TITLE
DatePicker: add `name` prop

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -88,6 +88,10 @@ type Props = {|
    */
   minDate?: Date,
   /**
+   * A unique name for the input.
+   */
+  name?: string,
+  /**
    * Required for date range selection. Pass the complimentary range date picker ref object to DatePicker to autofocus on the unselected date range field. See the [date range picker example](https://gestalt.pinterest.systems/datepicker#rangePicker) to learn more.
    */
   nextRef?: {| current: ?HTMLInputElement |},
@@ -151,6 +155,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
     localeData,
     maxDate,
     minDate,
+    name,
     nextRef,
     onChange,
     placeholder,
@@ -220,7 +225,7 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
       )}
       <ReactDatePicker
         calendarClassName={classnames(styles['react-datepicker'])}
-        customInput={<DatePickerTextField id={id} />}
+        customInput={<DatePickerTextField name={name} id={id} />}
         dateFormat={format}
         dayClassName={() => classnames(styles['react-datepicker__days'])}
         disabled={disabled}

--- a/packages/gestalt-datepicker/src/DatePickerTextField.js
+++ b/packages/gestalt-datepicker/src/DatePickerTextField.js
@@ -10,6 +10,7 @@ import styles from './DatePicker.css';
 type InjectedProps = {|
   disabled?: boolean,
   id: string,
+  name?: string,
   onBlur?: (event: SyntheticFocusEvent<HTMLInputElement>) => void,
   onChange?: (event: SyntheticInputEvent<HTMLInputElement>) => void,
   onClick?: () => void,
@@ -31,6 +32,7 @@ function DatePickerTextField(props: Props) {
     disabled,
     forwardedRef,
     id,
+    name,
     onChange,
     onClick,
     onBlur,
@@ -57,6 +59,7 @@ function DatePickerTextField(props: Props) {
                 onClick();
               }
             }}
+            name={name}
             onChange={(data) => onChange && onChange(data.event)}
             onKeyDown={(data) => onKeyDown && onKeyDown(data.event)}
             placeholder={placeholder}

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -134,7 +134,6 @@ function Sheet(props: SheetProps): Node {
   const [showBottomShadow, setShowBottomShadow] = useState<boolean>(false);
   const { animationState: animationStateFromHook, onAnimationEnd: onAnimationEndFromHook } =
     useAnimation();
-  const containerRef = useRef<?HTMLDivElement>(null);
   const contentRef = useRef<?HTMLElement>(null);
 
   // Handle onDismiss triggering from ESC keyup event
@@ -187,7 +186,7 @@ function Sheet(props: SheetProps): Node {
   return (
     <StopScrollBehavior>
       <TrapFocusBehavior>
-        <div className={sheetStyles.container} ref={containerRef}>
+        <div className={sheetStyles.container}>
           <Backdrop
             animationState={animationStateFromHook}
             closeOnOutsideClick={closeOnOutsideClick}


### PR DESCRIPTION
### Summary

#### What changed?

Adding `name` prop which gets passed to the internal TextField component used by DatePicker.

#### Why?

To keep consistent pattern across form fields and enable the consistent use of form-related API such as [formData](https://developer.mozilla.org/en-US/docs/Web/API/FormData)

