### PR TITLE
Avatar: Add data test id for testing

### DIFF
--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -73,6 +73,7 @@ export default function Avatar(props: Props): Node {
       height={height}
       position="relative"
       rounding="circle"
+      data-test-id="gestalt-avatar-svg"
     >
       {src && isImageLoaded ? (
         <Mask rounding="circle" wash>

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Avatar renders an outline 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "boxShadow": "0 0 0 1px #fff",
@@ -51,6 +52,7 @@ exports[`Avatar renders an outline 1`] = `
 exports[`Avatar renders multi-byte character initial 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": "",
@@ -98,6 +100,7 @@ exports[`Avatar renders multi-byte character initial 1`] = `
 exports[`Avatar renders the checkmark on verified default 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": 48,
@@ -180,6 +183,7 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
 exports[`Avatar renders the correct size - lg 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": 64,
@@ -225,6 +229,7 @@ exports[`Avatar renders the correct size - lg 1`] = `
 exports[`Avatar renders the correct size - md 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": 48,
@@ -270,6 +275,7 @@ exports[`Avatar renders the correct size - md 1`] = `
 exports[`Avatar renders the correct size - sm 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": 32,
@@ -315,6 +321,7 @@ exports[`Avatar renders the correct size - sm 1`] = `
 exports[`Avatar renders the correct size - xl 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": 24,
@@ -360,6 +367,7 @@ exports[`Avatar renders the correct size - xl 1`] = `
 exports[`Avatar renders the correct size - xs 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": 24,
@@ -405,6 +413,7 @@ exports[`Avatar renders the correct size - xs 1`] = `
 exports[`Avatar renders the correct src 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": "",
@@ -450,6 +459,7 @@ exports[`Avatar renders the correct src 1`] = `
 exports[`Avatar renders the verified icon 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": "",
@@ -534,6 +544,7 @@ exports[`Avatar renders the verified icon 1`] = `
 exports[`Avatar renders with an empty name shows default icon 1`] = `
 <div
   className="box circle relative"
+  data-test-id="gestalt-avatar-svg"
   style={
     Object {
       "height": "",

--- a/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
@@ -24,6 +24,7 @@ exports[`AvatarGroup renders AvatarGroup button with addCollaborators button 1`]
             >
               <div
                 class="box circle relative"
+                data-test-id="gestalt-avatar-svg"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -126,6 +127,7 @@ exports[`AvatarGroup renders AvatarGroup link with addCollaborators button 1`] =
               >
                 <div
                   class="box circle relative"
+                  data-test-id="gestalt-avatar-svg"
                   style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
                 >
                   <div
@@ -223,6 +225,7 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
             >
               <div
                 class="box circle relative"
+                data-test-id="gestalt-avatar-svg"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -262,6 +265,7 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
             >
               <div
                 class="box circle relative"
+                data-test-id="gestalt-avatar-svg"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -359,6 +363,7 @@ exports[`AvatarGroup renders display-only AvatarGroup without image 1`] = `
             >
               <div
                 class="box circle relative"
+                data-test-id="gestalt-avatar-svg"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -432,6 +437,7 @@ exports[`AvatarGroup renders fit display-only AvatarGroup with image 1`] = `
               >
                 <div
                   class="box circle relative"
+                  data-test-id="gestalt-avatar-svg"
                   style="box-shadow: 0 0 0 1px #fff; width: 100%;"
                 >
                   <div
@@ -489,6 +495,7 @@ exports[`AvatarGroup renders md display-only AvatarGroup with image 1`] = `
             >
               <div
                 class="box circle relative"
+                data-test-id="gestalt-avatar-svg"
                 style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
               >
                 <div
@@ -545,6 +552,7 @@ exports[`AvatarGroup renders sm display-only AvatarGroup with image 1`] = `
             >
               <div
                 class="box circle relative"
+                data-test-id="gestalt-avatar-svg"
                 style="box-shadow: 0 0 0 1px #fff; width: 32px; height: 32px;"
               >
                 <div
@@ -601,6 +609,7 @@ exports[`AvatarGroup renders xs display-only AvatarGroup with image 1`] = `
             >
               <div
                 class="box circle relative"
+                data-test-id="gestalt-avatar-svg"
                 style="box-shadow: 0 0 0 1px #fff; width: 24px; height: 24px;"
               >
                 <div

--- a/packages/gestalt/src/__snapshots__/AvatarPair.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarPair.test.js.snap
@@ -30,6 +30,7 @@ exports[`AvatarPair Renders only the first 2 collobarators when multiple are pas
   >
     <div
       className="box circle relative"
+      data-test-id="gestalt-avatar-svg"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",
@@ -85,6 +86,7 @@ exports[`AvatarPair Renders only the first 2 collobarators when multiple are pas
   >
     <div
       className="box circle relative"
+      data-test-id="gestalt-avatar-svg"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",
@@ -160,6 +162,7 @@ exports[`AvatarPair Renders renders 2 collaborators 1`] = `
   >
     <div
       className="box circle relative"
+      data-test-id="gestalt-avatar-svg"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",
@@ -215,6 +218,7 @@ exports[`AvatarPair Renders renders 2 collaborators 1`] = `
   >
     <div
       className="box circle relative"
+      data-test-id="gestalt-avatar-svg"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",
@@ -290,6 +294,7 @@ exports[`AvatarPair Renders renders the avatar with text when no image is provid
   >
     <div
       className="box circle relative"
+      data-test-id="gestalt-avatar-svg"
       style={
         Object {
           "boxShadow": "0 0 0 1px #fff",


### PR DESCRIPTION
### Summary

#### What changed?

Add a default data test id to allow exclusion of Avatars from contrast checker 

#### Why?

Because we rely on SVG for avatar initials, the aXe contrast checker complains about a lack of content to determine if it is text or not when checking for contrast. Adding this id allows us to exclude Avatars from this check.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4197)

![Screen Shot 2022-05-03 at 3 10 51 PM](https://user-images.githubusercontent.com/5125094/166574538-f473b2b4-eb6e-42ae-92ce-996cd55356eb.png)

### Checklist

- [x] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
