### PR TITLE
Link: remove `role` and `accessibilitySelected` props

### DIFF
--- a/docs/pages/link.js
+++ b/docs/pages/link.js
@@ -464,47 +464,6 @@ When possible, limit one external Link per paragraph, as adding more than two ic
 
 For external Links that aren't in a paragraph or text context, consider [Button](https://gestalt.netlify.app/button#Role) or [IconButton](https://gestalt.netlify.app/iconbutton#Role) with \`role="link"\`.`}
         />
-
-        <MainSection.Subsection
-          title="Accessible tab Link"
-          description={`Use \`accessibilitySelected\` and \`role="tab"\` when using Link as a tab. However, don't use Link to create custom tabs, use [Tabs](/tabs) instead.`}
-        >
-          <MainSection.Card
-            cardSize="lg"
-            defaultCode={`
-function TabExample() {
-  const [activeIndex, setActiveIndex] = React.useState(0);
-  return (
-    <Box display="flex" alignItems="center" role="tablist">
-      {['Boards', 'Pins'].map((text, index) => (
-        <Box
-          color={index === activeIndex ? 'darkGray' : undefined}
-          display="inlineBlock"
-          key={text}
-          rounding="pill"
-        >
-          <Link
-            accessibilitySelected={index === activeIndex}
-            underline="none"
-            href="https://pinterest.com"
-            onClick={({ event }) => {
-              event.preventDefault();
-              setActiveIndex(index);
-            }}
-            rounding="pill"
-            role="tab"
-          >
-            <Box padding={3} rounding="pill">
-              <Text color={index === activeIndex ? 'inverse' : 'default'}>{text}</Text>
-            </Box>
-          </Link>
-        </Box>
-      ))}
-    </Box>
-  );
-}`}
-          />
-        </MainSection.Subsection>
       </MainSection>
 
       <MainSection

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -68,10 +68,6 @@ type Props = {|
    */
   accessibilityLabel?: string,
   /**
-   * Use `accessibilitySelected` and `role` when using it as a tab. See the [Accessibility guidelines](https://gestalt.pinterest.systems/link#Accessible-tab-Link) for more information.
-   */
-  accessibilitySelected?: boolean,
-  /**
    * Link is a wrapper around components (or children), most commonly text, so that they become hyperlinks. See the [Text and Link variant](https://gestalt.pinterest.systems/link#Link-and-Text) to learn more.
    */
   children?: Node,
@@ -115,10 +111,6 @@ type Props = {|
    */
   rel?: 'none' | 'nofollow',
   /**
-   * When supplied, Link acts a tab. See the [Accessible Tab Link](https://gestalt.pinterest.systems/link#Accessible-Tab-Link) for more information.
-   */
-  role?: 'tab',
-  /**
    * Sets a border radius for Link. Select a rounding option that aligns with its children.
    */
   rounding?: Rounding,
@@ -154,7 +146,6 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
 >(function Link(
   {
     accessibilityLabel,
-    accessibilitySelected,
     children,
     externalLinkIcon = 'none',
     href,
@@ -164,7 +155,6 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     onClick,
     onFocus,
     rel = 'none',
-    role,
     rounding = 0,
     underline = 'auto',
     tapStyle = 'none',
@@ -232,7 +222,6 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
   return (
     <a
       aria-label={accessibilityLabel}
-      aria-selected={accessibilitySelected}
       className={className}
       href={href}
       id={id}
@@ -276,7 +265,6 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
         ...(rel === 'nofollow' ? ['nofollow'] : []),
       ].join(' ')}
       {...(compressStyle && tapStyle === 'compress' ? { style: compressStyle } : {})}
-      role={role}
       target={target ? `_${target}` : null}
     >
       {children}

--- a/packages/gestalt/src/Link.test.js
+++ b/packages/gestalt/src/Link.test.js
@@ -106,14 +106,3 @@ it('with custom rounding, and tapStyle', () =>
       )
       .toJSON(),
   ).toMatchSnapshot());
-
-it('with accessibilitySelected and role', () =>
-  expect(
-    renderer
-      .create(
-        <Link href="https://example.com" accessibilitySelected role="tab">
-          Link
-        </Link>,
-      )
-      .toJSON(),
-  ).toMatchSnapshot());

--- a/packages/gestalt/src/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.js.snap
@@ -207,29 +207,6 @@ exports[`target self 1`] = `
 </a>
 `;
 
-exports[`with accessibilitySelected and role 1`] = `
-<a
-  aria-selected={true}
-  className="link hideOutline tapTransition rounding0 block noUnderline hoverUnderline accessibilityOutline"
-  href="https://example.com"
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onKeyPress={[Function]}
-  onMouseDown={[Function]}
-  onMouseUp={[Function]}
-  onTouchCancel={[Function]}
-  onTouchEnd={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
-  rel=""
-  role="tab"
-  target={null}
->
-  Link
-</a>
-`;
-
 exports[`with custom rounding, and tapStyle 1`] = `
 <a
   className="link hideOutline tapTransition pill block noUnderline hoverUnderline accessibilityOutline"


### PR DESCRIPTION
### Summary

#### What changed?

Link: remove `role` and `accessibilitySelected` props

#### Why?

Both `role` and `accessibilitySelected` props were deprecated and unused

## Breaking change

Run codemod to detect instances of prop usage

`yarn codemod detectManualReplacement  ~/path/to/your/code --component=Link --prop=role`
`yarn codemod detectManualReplacement  ~/path/to/your/code --component=Link --prop= accessibilitySelected `
