### PR TITLE
Icon: Add info color option

### DIFF
--- a/docs/pages/icon.js
+++ b/docs/pages/icon.js
@@ -148,6 +148,7 @@ If an icon has a visible label that describes what the icon represents, \`access
               'success',
               'error',
               'warning',
+              'info',
               'inverse',
               'shopping',
               'brandPrimary',

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -75,6 +75,11 @@
           "darkValue": "{color.yellow.caramellow.400.value}",
           "comment": "Icon color to indicate a warning or caution"
         },
+        "info": {
+          "value": "{color.blue.skycicle.500.value}",
+          "darkValue": "{color.blue.skycicle.300.value}",
+          "comment": "Icon color to use for information"
+        },
         "inverse": {
           "value": "{color.white.mochimalist.0.value}",
           "darkValue": "{color.black.cosmicore.900.value}",

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -210,6 +210,10 @@
   color: var(--color-text-icon-shopping);
 }
 
+.infoIcon {
+  color: var(--color-text-icon-info);
+}
+
 .brandPrimaryIcon {
   color: var(--color-text-icon-brand-primary);
 }

--- a/packages/gestalt/src/Colors.css.flow
+++ b/packages/gestalt/src/Colors.css.flow
@@ -29,6 +29,7 @@ declare module.exports: {|
   +'green': string,
   +'greenBg': string,
   +'infoBase': string,
+  +'infoIcon': string,
   +'infoWeak': string,
   +'inverse': string,
   +'inverseIcon': string,

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -11,6 +11,7 @@ export type IconColor =
   | 'success'
   | 'error'
   | 'warning'
+  | 'info'
   | 'inverse'
   | 'shopping'
   | 'brandPrimary'

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -50,6 +50,7 @@ exports[`Video with callbacks 1`] = `
   --color-text-icon-success: #005f3e;
   --color-text-icon-error: #cc0000;
   --color-text-icon-warning: #bd5b00;
+  --color-text-icon-info: #0074e8;
   --color-text-icon-inverse: #ffffff;
   --color-text-icon-shopping: #0074e8;
   --color-background-default: #ffffff;
@@ -159,6 +160,7 @@ exports[`Video with children 1`] = `
   --color-text-icon-success: #005f3e;
   --color-text-icon-error: #cc0000;
   --color-text-icon-warning: #bd5b00;
+  --color-text-icon-info: #0074e8;
   --color-text-icon-inverse: #ffffff;
   --color-text-icon-shopping: #0074e8;
   --color-background-default: #ffffff;
@@ -485,6 +487,7 @@ exports[`Video with crossOrigin 1`] = `
   --color-text-icon-success: #005f3e;
   --color-text-icon-error: #cc0000;
   --color-text-icon-warning: #bd5b00;
+  --color-text-icon-info: #0074e8;
   --color-text-icon-inverse: #ffffff;
   --color-text-icon-shopping: #0074e8;
   --color-background-default: #ffffff;
@@ -595,6 +598,7 @@ exports[`Video with media attributes 1`] = `
   --color-text-icon-success: #005f3e;
   --color-text-icon-error: #cc0000;
   --color-text-icon-warning: #bd5b00;
+  --color-text-icon-info: #0074e8;
   --color-text-icon-inverse: #ffffff;
   --color-text-icon-shopping: #0074e8;
   --color-background-default: #ffffff;
@@ -705,6 +709,7 @@ exports[`Video with multiple sources 1`] = `
   --color-text-icon-success: #005f3e;
   --color-text-icon-error: #cc0000;
   --color-text-icon-warning: #bd5b00;
+  --color-text-icon-info: #0074e8;
   --color-text-icon-inverse: #ffffff;
   --color-text-icon-shopping: #0074e8;
   --color-background-default: #ffffff;
@@ -821,6 +826,7 @@ exports[`Video with objectFit 1`] = `
   --color-text-icon-success: #005f3e;
   --color-text-icon-error: #cc0000;
   --color-text-icon-warning: #bd5b00;
+  --color-text-icon-info: #0074e8;
   --color-text-icon-inverse: #ffffff;
   --color-text-icon-shopping: #0074e8;
   --color-background-default: #ffffff;
@@ -935,6 +941,7 @@ exports[`Video with source 1`] = `
   --color-text-icon-success: #005f3e;
   --color-text-icon-error: #cc0000;
   --color-text-icon-warning: #bd5b00;
+  --color-text-icon-info: #0074e8;
   --color-text-icon-inverse: #ffffff;
   --color-text-icon-shopping: #0074e8;
   --color-background-default: #ffffff;

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
@@ -59,6 +59,7 @@ describe('ColorSchemeProvider', () => {
         --color-text-icon-success: #005f3e;
         --color-text-icon-error: #cc0000;
         --color-text-icon-warning: #bd5b00;
+        --color-text-icon-info: #0074e8;
         --color-text-icon-inverse: #ffffff;
         --color-text-icon-shopping: #0074e8;
         --color-background-default: #ffffff;
@@ -129,6 +130,7 @@ describe('ColorSchemeProvider', () => {
         --color-text-icon-success: #005f3e;
         --color-text-icon-error: #cc0000;
         --color-text-icon-warning: #bd5b00;
+        --color-text-icon-info: #0074e8;
         --color-text-icon-inverse: #ffffff;
         --color-text-icon-shopping: #0074e8;
         --color-background-default: #ffffff;
@@ -199,6 +201,7 @@ describe('ColorSchemeProvider', () => {
         --color-text-icon-success: #39d377;
         --color-text-icon-error: #eb4242;
         --color-text-icon-warning: #e18d00;
+        --color-text-icon-info: #75bfff;
         --color-text-icon-inverse: #111111;
         --color-text-icon-shopping: #75bfff;
         --color-background-default: #111111;
@@ -270,6 +273,7 @@ describe('ColorSchemeProvider', () => {
         --color-text-icon-success: #39d377;
         --color-text-icon-error: #eb4242;
         --color-text-icon-warning: #e18d00;
+        --color-text-icon-info: #75bfff;
         --color-text-icon-inverse: #111111;
         --color-text-icon-shopping: #75bfff;
         --color-background-default: #111111;
@@ -341,6 +345,7 @@ describe('ColorSchemeProvider', () => {
         --color-text-icon-success: #005f3e;
         --color-text-icon-error: #cc0000;
         --color-text-icon-warning: #bd5b00;
+        --color-text-icon-info: #0074e8;
         --color-text-icon-inverse: #ffffff;
         --color-text-icon-shopping: #0074e8;
         --color-background-default: #ffffff;


### PR DESCRIPTION
### Summary

#### What changed?

Add option to create info icons (used in Callout, Banner etc.) to avoid contamination with Shopping option

#### Why?

Create separation so we can make updates to either in the future

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
