### PR TITLE
Design Tokens: Update android output files

### DIFF
--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -73,6 +73,11 @@ StyleDictionary.registerFormat({
 });
 
 StyleDictionary.registerFormat({
+  name: 'androidColorDark',
+  formatter: darkFormatWrapper(`android/colors`),
+});
+
+StyleDictionary.registerFormat({
   name: 'cssDarkJson',
   formatter: darkFormatWrapper(`json/flat`),
 });

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -90,6 +90,11 @@
           }
         },
         {
+          "destination": "colors-dark.xml",
+          "format": "androidColorDark",
+          "filter": "customDarkColorFilter"
+        },
+        {
           "destination": "space.xml",
           "format": "android/resources",
           "resourceType": "dimen",

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -91,8 +91,7 @@
         },
         {
           "destination": "colors-dark.xml",
-          "format": "androidColorDark",
-          "filter": "customDarkColorFilter"
+          "format": "androidColorDark"
         },
         {
           "destination": "space.xml",


### PR DESCRIPTION
### Summary

#### What changed?

Add an output for Android to support dark-mode colors 

#### Why?

Ensure there's a single file that has every color and the value it should use in dark mode

### Checklist

- [x] Checked stakeholder feedback (e.g. Gestalt designers)
