### PR TITLE
Datapoint: add prop to set z-index on integrated tooltip

### DIFF
--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -1,12 +1,13 @@
 // @flow strict
 import { type Node } from 'react';
+import Badge from './Badge.js';
 import DatapointTrend from './DatapointTrend.js';
 import Flex from './Flex.js';
 import Icon from './Icon.js';
 import TapArea from './TapArea.js';
 import Text from './Text.js';
 import Tooltip from './Tooltip.js';
-import Badge from './Badge.js';
+import { type Indexable } from './zIndex.js';
 
 type TrendObject = {|
   accessibilityLabel: string,
@@ -20,6 +21,10 @@ type BadgeObject = {|
 
 type Props = {|
   /**
+   * Adds a badge to the title. Currently a beta feature, expect changes.
+   */
+  badge?: BadgeObject,
+  /**
    * Used to set the size of the datapoint. See the [size](https://gestalt.pinterest.systems#Size) variant to learn more.
    */
   size?: 'md' | 'lg',
@@ -32,9 +37,9 @@ type Props = {|
    */
   tooltipText?: string,
   /**
-   * Adds a badge to the title. Currently a beta feature, expect changes.
+   * Specifying the z-index of the tooltip may be necessary if other elements with higher z-indices overlap the tooltip. See [ZIndex Classes](https://gestalt.pinterest.systems/zindex_classes) to learn more.
    */
-  badge?: BadgeObject,
+  tooltipZIndex?: Indexable,
   /**
    * Object detailing the trend value (change in time - e.g., +30%), and accessibilityLabel to describe the trend's icon (e.g., "Trending up").  See the [trend](https://gestalt.pinterest.systems#Trend) variant to learn more.
    */
@@ -61,6 +66,7 @@ export default function Datapoint({
   size = 'md',
   title,
   tooltipText,
+  tooltipZIndex,
   trend,
   trendSentiment = 'auto',
   value,
@@ -70,7 +76,12 @@ export default function Datapoint({
       <Flex gap={1} alignItems="center" minHeight={24}>
         <Text size="200">{title}</Text>
         {tooltipText && (
-          <Tooltip accessibilityLabel="" text={tooltipText} idealDirection="up">
+          <Tooltip
+            accessibilityLabel=""
+            idealDirection="up"
+            text={tooltipText}
+            zIndex={tooltipZIndex}
+          >
             {/* Interactive elements require an a11yLabel on them or their children.
             That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */}
             <TapArea accessibilityLabel={tooltipText} rounding="circle" tapStyle="none">


### PR DESCRIPTION
[context from Slack](https://pinterest.slack.com/archives/C13KLG5P0/p1652206272829709)

<img width="562" alt="Screen Shot 2022-05-11 at 5 31 16 PM" src="https://user-images.githubusercontent.com/12059539/167968882-917a14c7-c0b9-4439-9b13-62f0d7bdea43.png">

It should be no surprise that the same issues that caused us to add `zIndex` to Tooltip mean that we'll need to be able to set that prop where we integrate tooltip into other components, like Datapoint. This PR adds a prop to Datapoint to do just that. (We'll likely need to do the same for IconButton and any other places we integrate Tooltip into other components)