### PR TITLE
ESlint plugin: Remove excludeTests & excludePaths

### DIFF
--- a/packages/eslint-plugin-gestalt/src/prefer-box-no-disallowed.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-no-disallowed.js
@@ -34,22 +34,7 @@ const rule: ESLintRule = {
       url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-box-no-disallowed',
     },
     fixable: 'code',
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          excludeTests: {
-            type: 'boolean',
-          },
-          excludePaths: {
-            type: 'array',
-            items: { type: 'string' },
-            uniqueItems: true,
-          },
-        },
-        additionalProperties: false,
-      },
-    ],
+    schema: [],
     messages: {
       disallowedLonelyRef: `Use <Box ref={ref}></Box> or other Gestalt components that support ref.`,
       disallowed: `Use <Box></Box>.`,
@@ -88,21 +73,8 @@ const rule: ESLintRule = {
         ...ignoreEslintPluginJsxA11yConflictingAttributes,
       ];
 
-      const { excludeTests, excludePaths } = context?.options?.[0] ?? {}; // Access options from Eslint configuration
-
-      const isTest = excludeTests && context.getFilename().endsWith('.test.js');
-
-      const isExcludedPath =
-        excludePaths?.length !== 0 &&
-        excludePaths?.some((path) => {
-          const pathRegex = new RegExp(`${path}`, 'g');
-          return pathRegex.test(context.getFilename());
-        });
-
       // First, exit if div should stay unmodified
       if (
-        isTest ||
-        isExcludedPath ||
         !isTag({ elementNode: node.openingElement, tagName: 'div' }) ||
         hasSpreadAttributes({ elementNode: node.openingElement }) ||
         hasAttributes({

--- a/packages/eslint-plugin-gestalt/src/prefer-heading.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-heading.js
@@ -37,22 +37,7 @@ const rule: ESLintRule = {
       url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-link',
     },
     fixable: 'code',
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          excludeTests: {
-            type: 'boolean',
-          },
-          excludePaths: {
-            type: 'array',
-            items: { type: 'string' },
-            uniqueItems: true,
-          },
-        },
-        additionalProperties: false,
-      },
-    ],
+    schema: [],
     messages: {
       fixMessageHeading: MESSAGES.fixMessageHeading,
       suggestionMessageA11yLevelNone: MESSAGES.suggestionMessageA11yLevelNone,
@@ -79,21 +64,8 @@ const rule: ESLintRule = {
     const jSXElementFnc = (node) => {
       const headingDisallowedAttributes = ['className'];
 
-      const { excludeTests, excludePaths } = context?.options?.[0] ?? {}; // Access options from Eslint configuration
-
-      const isTest = excludeTests && context.getFilename().endsWith('.test.js');
-
-      const isExcludedPath =
-        excludePaths?.length !== 0 &&
-        excludePaths?.some((path) => {
-          const pathRegex = new RegExp(`${path}`, 'g');
-          return pathRegex.test(context.getFilename());
-        });
-
       // First, exit if anchor tag should stay unmodified
       if (
-        isTest ||
-        isExcludedPath ||
         !isTag({ elementNode: node.openingElement, tagName: headingTags }) ||
         hasSpreadAttributes({ elementNode: node.openingElement }) ||
         hasAttributes({

--- a/packages/eslint-plugin-gestalt/src/prefer-link.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-link.js
@@ -39,22 +39,7 @@ const rule: ESLintRule = {
       url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-link',
     },
     fixable: 'code',
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          excludeTests: {
-            type: 'boolean',
-          },
-          excludePaths: {
-            type: 'array',
-            items: { type: 'string' },
-            uniqueItems: true,
-          },
-        },
-        additionalProperties: false,
-      },
-    ],
+    schema: [],
     messages: {
       fixMessageLink: MESSAGES.fixMessageLink,
       suggestionMessageTapArea: MESSAGES.suggestionMessageTapArea,
@@ -91,21 +76,8 @@ const rule: ESLintRule = {
         'target',
       ];
 
-      const { excludeTests, excludePaths } = context?.options?.[0] ?? {}; // Access options from Eslint configuration
-
-      const isTest = excludeTests && context.getFilename().endsWith('.test.js');
-
-      const isExcludedPath =
-        excludePaths?.length !== 0 &&
-        excludePaths?.some((path) => {
-          const pathRegex = new RegExp(`${path}`, 'g');
-          return pathRegex.test(context.getFilename());
-        });
-
       // First, exit if anchor tag should stay unmodified
       if (
-        isTest ||
-        isExcludedPath ||
         !isTag({ elementNode: node.openingElement, tagName: 'a' }) ||
         hasSpreadAttributes({ elementNode: node.openingElement }) ||
         hasAttributes({


### PR DESCRIPTION
## Summary

### What changed?

Remove `excludeTests` and `excludePaths` from ESLint rules

### Why?

* It's an anti-pattern to make those part of the rules themselves. Instead, we can use [ESLint overrides](https://eslint.org/docs/user-guide/configuring/configuration-files#how-do-overrides-work) and specify specific paths.
* `excludeTests` currently only uses a `test.js` files, however jest tests can also end in `jest.js` and mocha tests in `mocha.js` or `spec.js` ([example](https://github.com/mochajs/mocha-examples/blob/master/packages/babel/test/index.spec.js))

### Before / After

**Before `.eslintrc.js`**

```js
module.exports = {
  plugins: ['gestalt'],
  rules: {
    'gestalt/prefer-box-no-disallowed': [
      'error',
      {
        excludeTests: true,
      },
    ],
  },
};
```

**After `.eslintrc.js`**

```js
// @flow
module.exports = {
  plugins: ['gestalt'],
  rules: {
    'gestalt/prefer-box-no-disallowed': 'error',
  },
  overrides: [
    {
      files: ['**/*.test.js'],
      rules: {
        'gestalt/prefer-box-no-disallowed': 'off',
      },
    },
  ],
};
```

### Links
* Related Pinboard diff: 