### PR TITLE
Eslint: Allow iconEnd buttons to be any color or size

### DIFF
--- a/docs/pages/eslint_plugin.js
+++ b/docs/pages/eslint_plugin.js
@@ -83,15 +83,12 @@ With AUTOFIX!
       </MainSection>
       <MainSection
         name="Gestalt restrictions"
-        description="The following Eslint rules restrict the usage of Gestalt component props to enforce design consistency and code safety anf best practices."
+        description="The following Eslint rules restrict the usage of Gestalt component props to enforce design consistency, code safety and best practices."
       >
         <MainSection.Subsection
           title="gestalt/button-icon-restrictions"
           description={`
-        Require specific props when using an icon with Button. Gestalt recommends in adding icons to Buttons. Buttons using \`iconEnd\` must use:
-        * icon &quot;arrow-down&quot;
-        * color &quot;white&quot;
-        * size &quot;lg&quot;
+        Require a specific icon when using an icon with Button. Buttons using \`iconEnd\` must use icon &quot;arrow-down&quot;
       `}
         />
         <MainSection.Subsection

--- a/packages/eslint-plugin-gestalt/README.md
+++ b/packages/eslint-plugin-gestalt/README.md
@@ -42,15 +42,11 @@ Then configure the rules you want to use under the rules section.
 
 ### gestalt/button-icon-restrictions
 
-Require specific props when using an icon with Button. Gestalt is more permissive than PDS recommends in adding icons to Buttons. Buttons using iconEnd must use:
-
-- icon "arrow-down"
-- color "white"
-- size "lg"
+Require a specific value when using an icon with Button. Gestalt is more permissive than we recommend internally for adding icons to Buttons, so Buttons using iconEnd must use icon "arrow-down".
 
 ### gestalt/no-box-marginleft-marginright
 
-Disallow marginLeft/marginRight on Box. In order to have consistent usage of marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd
+Disallow marginLeft/marginRight on Box. In order to have consistent usage of marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd.
 
 ### gestalt/no-box-dangerous-style-duplicates
 

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-no-color.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-no-color.js
@@ -1,5 +1,0 @@
-import { Button } from 'gestalt';
-
-export default function TestElement() {
-  return <Button iconEnd="arrow-down" size="lg" text="Menu" />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-no-size.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-no-size.js
@@ -1,5 +1,0 @@
-import { Button } from 'gestalt';
-
-export default function TestElement() {
-  return <Button color="white" iconEnd="arrow-down" text="Menu" />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-renamed.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-renamed.js
@@ -1,5 +1,5 @@
 import { Button as GestaltButton } from 'gestalt';
 
 export default function TestElement() {
-  return <GestaltButton iconEnd="arrow-down" size="lg" text="Menu" />;
+  return <GestaltButton iconEnd="arrow-up" size="lg" text="Menu" />;
 }

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-wrong-color.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-wrong-color.js
@@ -1,5 +1,0 @@
-import { Button } from 'gestalt';
-
-export default function TestElement() {
-  return <Button color="red" iconEnd="arrow-down" size="lg" text="Menu" />;
-}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-wrong-size.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-wrong-size.js
@@ -1,5 +1,0 @@
-import { Button } from 'gestalt';
-
-export default function TestElement() {
-  return <Button color="white" iconEnd="arrow-down" size="md" text="Menu" />;
-}

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
@@ -4,8 +4,6 @@
  * Gestalt is more permissive than PDS recommends in adding icons to Buttons.
  * Buttons using iconEnd must use:
  * - icon "arrow-down"
- * - color "white"
- * - size "lg"
  */
 
 // @flow strict
@@ -73,18 +71,9 @@ const rule: ESLintRule = {
           return;
         }
 
-        const colorAttribute = getAttribute(node, 'color');
-        const isCorrectColor = getValue(colorAttribute) === 'white';
-
-        const sizeAttribute = getAttribute(node, 'size');
-        const isCorrectSize = getValue(sizeAttribute) === 'lg';
-
         // Not using correct props
-        if (!isCorrectColor || !isCorrectIcon || !isCorrectSize) {
-          context.report(
-            node,
-            'Buttons using iconEnd must use "arrow-down", color "white", and size "lg"',
-          );
+        if (!isCorrectIcon) {
+          context.report(node, 'Buttons using iconEnd must use "arrow-down"');
         }
       },
     };

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.test.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.test.js
@@ -11,15 +11,6 @@ const validWithSize = readFileSync(
   path.resolve(__dirname, './__fixtures__/button-icon-restrictions/valid/valid-size.js'),
   'utf-8',
 );
-
-const invalidMissingColor = readFileSync(
-  path.resolve(__dirname, './__fixtures__/button-icon-restrictions/invalid/invalid-no-color.js'),
-  'utf-8',
-);
-const invalidWrongColor = readFileSync(
-  path.resolve(__dirname, './__fixtures__/button-icon-restrictions/invalid/invalid-wrong-color.js'),
-  'utf-8',
-);
 const invalidRenamed = readFileSync(
   path.resolve(__dirname, './__fixtures__/button-icon-restrictions/invalid/invalid-renamed.js'),
   'utf-8',
@@ -28,25 +19,13 @@ const invalidWrongIcon = readFileSync(
   path.resolve(__dirname, './__fixtures__/button-icon-restrictions/invalid/invalid-wrong-icon.js'),
   'utf-8',
 );
-const invalidWrongSize = readFileSync(
-  path.resolve(__dirname, './__fixtures__/button-icon-restrictions/invalid/invalid-wrong-size.js'),
-  'utf-8',
-);
-const invalidWithoutSize = readFileSync(
-  path.resolve(__dirname, './__fixtures__/button-icon-restrictions/invalid/invalid-no-size.js'),
-  'utf-8',
-);
 
 const errorMessage = 'Buttons using iconEnd must use "arrow-down", color "white", and size "lg"';
 
 ruleTester.run('button-icon-restrictions', rule, {
   valid: [validWithSize].map((code) => ({ code })),
-  invalid: [
-    invalidMissingColor,
-    invalidWrongColor,
-    invalidRenamed,
-    invalidWrongIcon,
-    invalidWrongSize,
-    invalidWithoutSize,
-  ].map((code) => ({ code, errors: [{ message: errorMessage }] })),
+  invalid: [invalidRenamed, invalidWrongIcon].map((code) => ({
+    code,
+    errors: [{ message: errorMessage }],
+  })),
 });

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.test.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.test.js
@@ -20,7 +20,7 @@ const invalidWrongIcon = readFileSync(
   'utf-8',
 );
 
-const errorMessage = 'Buttons using iconEnd must use "arrow-down", color "white", and size "lg"';
+const errorMessage = 'Buttons using iconEnd must use "arrow-down"';
 
 ruleTester.run('button-icon-restrictions', rule, {
   valid: [validWithSize].map((code) => ({ code })),


### PR DESCRIPTION
### Summary

#### What changed?

Update our guidance to allow any color or size for Buttons with iconEnd="arrow-down"

#### Why?

We no longer have restrictions on the color or size when arrow-down is used
