### PR TITLE
DatePicker: Add note about installing as a separate package

### DIFF
--- a/docs/pages/installation.js
+++ b/docs/pages/installation.js
@@ -20,7 +20,16 @@ npm i gestalt --save
 or
 ~~~jsx
 yarn add gestalt
-~~~"
+~~~
+To install the DatePicker package:
+~~~jsx
+npm i gestalt-datepicker --save
+~~~
+or
+~~~jsx
+yarn add gestalt-datepicker
+~~~
+"
           />
         </Flex>
       </Card>

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -133,6 +133,7 @@ type Props = {|
  */
 /**
  * [DatePicker](https://gestalt.pinterest.systems/datepicker) is used when the user has to select a date or date range.
+ * DatePicker is distributed in its own package and must be installed separately.
  *
  * ![DatePicker closed light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/DatePicker-closed%20%230.png)
  * ![DatePicker open light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/DatePicker-open%20%230.png)


### PR DESCRIPTION
### Summary
Adds a note to the documentation page for `DatePicker` that this component is installed from a separate package
Update the `Installation` page of the documentation for installation of the DatePicker package

<img width="1928" alt="Screen Shot 2022-05-18 at 2 30 07 PM" src="https://user-images.githubusercontent.com/10646092/169160086-6303ff4d-9e57-41a7-b5f1-9e9a3b336c47.png">
<img width="1378" alt="Screen Shot 2022-05-18 at 2 29 31 PM" src="https://user-images.githubusercontent.com/10646092/169160089-d76f5528-8413-427e-9c56-a3168ee85359.png">


#### What changed?

Updated documentation to note that installation of datepicker is separate from the installation of the main gestalt package

#### Why?
It is not immediately clear from the documentation that DatePicker is in a separate package and must be installed separately. This information is noted in the README.md of the repo and appear on the github homepage

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
