### PR TITLE
Docs: adding slimBanner prop into Docs' PageHeader to display information related to the component. 

### DIFF
--- a/docs/components/PageHeader.js
+++ b/docs/components/PageHeader.js
@@ -1,20 +1,9 @@
 // @flow strict
-import { type Node } from 'react';
-import { Badge, Box, Flex, Heading, Text, Tooltip } from 'gestalt';
+import { type Node, type Element } from 'react';
+import { Badge, Box, Flex, Heading, Text, Tooltip, SlimBanner } from 'gestalt';
 import Markdown from './Markdown.js';
 import MainSection from './MainSection.js';
 import trackButtonClick from './buttons/trackButtonClick.js';
-
-type Props = {|
-  badge?: 'pilot' | 'deprecated',
-  defaultCode?: string,
-  description?: string,
-  fileName?: string, // only use if name !== file name
-  folderName?: string, // only use if name !== file name and the link should point to a directory
-  name: string,
-  shadedCodeExample?: boolean,
-  showSourceLink?: boolean,
-|};
 
 const buildSourceLinkPath = (componentName) => {
   const packageName = componentName === 'DatePicker' ? 'gestalt-datepicker' : 'gestalt';
@@ -26,6 +15,18 @@ const buildSourceLinkUrl = (componentName) =>
     '/',
   );
 
+type Props = {|
+  badge?: 'pilot' | 'deprecated',
+  defaultCode?: string,
+  description?: string,
+  fileName?: string, // only use if name !== file name
+  folderName?: string, // only use if name !== file name and the link should point to a directory
+  name: string,
+  shadedCodeExample?: boolean,
+  showSourceLink?: boolean,
+  slimBanner?: Element<typeof SlimBanner> | null,
+|};
+
 export default function PageHeader({
   badge,
   defaultCode,
@@ -35,6 +36,7 @@ export default function PageHeader({
   name,
   shadedCodeExample,
   showSourceLink = true,
+  slimBanner = null,
 }: Props): Node {
   const sourcePathName = folderName ?? fileName ?? name;
   let sourceLink = buildSourceLinkUrl(sourcePathName);
@@ -42,6 +44,17 @@ export default function PageHeader({
     // Strip the file extension if linking to a folder
     sourceLink = sourceLink.replace(/\.js$/, '');
   }
+
+  const badgeMap = {
+    pilot: {
+      text: 'Pilot',
+      tooltipText: `This is the initial version of ${name}, and additional (non-breaking) functionality is planned for the future. Any feedback is greatly appreciated!`,
+    },
+    deprecated: {
+      text: 'Deprecated',
+      tooltipText: `This component is deprecated and will be removed soons`,
+    },
+  };
 
   return (
     <Box
@@ -52,49 +65,42 @@ export default function PageHeader({
         },
       }}
     >
-      <Box marginBottom={2}>
-        <Flex alignItems="baseline" direction="row" gap={2} justifyContent="between" wrap>
-          <Heading>
-            {name}{' '}
-            {badge === 'pilot' ? (
-              <Tooltip
-                inline
-                text={`This is the initial version of ${name}, and additional (non-breaking) functionality is planned for the future. Any feedback is greatly appreciated!`}
+      <Flex direction="column" gap={defaultCode ? 8 : 0}>
+        <Flex direction="column" gap={2}>
+          <Flex alignItems="baseline" direction="row" gap={2} justifyContent="between" wrap>
+            <Heading>
+              {name}{' '}
+              {badge ? (
+                <Tooltip inline text={badgeMap[badge].tooltipText}>
+                  <Badge text={badgeMap[badge].text} position="top" />
+                </Tooltip>
+              ) : null}
+            </Heading>
+
+            {showSourceLink && (
+              <a
+                href={sourceLink}
+                onClick={() => trackButtonClick('View source on GitHub', sourcePathName)}
+                target="blank"
               >
-                <Badge text="Pilot" position="top" />
-              </Tooltip>
-            ) : null}
-            {badge === 'deprecated' ? (
-              <Tooltip inline text="This component is deprecated and will be removed soon.">
-                <Badge text="Deprecated" position="top" />
-              </Tooltip>
-            ) : null}
-          </Heading>
+                <Text underline>View source on GitHub</Text>
+              </a>
+            )}
+          </Flex>
 
-          {showSourceLink && (
-            <a
-              href={sourceLink}
-              onClick={() => trackButtonClick('View source on GitHub', sourcePathName)}
-              target="blank"
-            >
-              <Text underline>View source on GitHub</Text>
-            </a>
-          )}
+          {description && <Markdown text={description} />}
+          {slimBanner}
         </Flex>
-      </Box>
 
-      {description && <Markdown text={description} />}
-
-      {defaultCode && (
-        <Box marginTop={8}>
+        {defaultCode && (
           <MainSection.Card
             cardSize="lg"
             showCode={false}
             defaultCode={defaultCode}
             shaded={shadedCodeExample}
           />
-        </Box>
-      )}
+        )}
+      </Flex>
     </Box>
   );
 }

--- a/docs/pages/radiobutton.js
+++ b/docs/pages/radiobutton.js
@@ -1,6 +1,5 @@
 // @flow strict
 import { type Node } from 'react';
-
 import { SlimBanner } from 'gestalt';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Page from '../components/Page.js';
@@ -13,17 +12,19 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <PageHeader
         name="RadioButton"
         description="Use [RadioButtons](https://gestalt.pinterest.systems/radiobutton) when you have a few options that a user can choose from. Never use radio buttons if the user can select more than one option from a list."
-      />
-      <SlimBanner
-        type="error"
-        iconAccessibilityLabel="Info"
-        message="The standalone RadioButton is soon to be deprecated, use RadioGroup and RadioGroup.RadioButton instead."
-        helperLink={{
-          text: 'View RadioGroup',
-          accessibilityLabel: 'View RadioGroup Docs',
-          href: '/radiogroup',
-          onClick: () => {},
-        }}
+        slimBanner={
+          <SlimBanner
+            type="error"
+            iconAccessibilityLabel="Info"
+            message="The standalone RadioButton is soon to be deprecated, use RadioGroup and RadioGroup.RadioButton instead."
+            helperLink={{
+              text: 'View RadioGroup',
+              accessibilityLabel: 'View RadioGroup Docs',
+              href: '/radiogroup',
+              onClick: () => {},
+            }}
+          />
+        }
       />
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
     </Page>

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
+import { SlimBanner } from 'gestalt';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import Page from '../components/Page.js';
 import PageHeader from '../components/PageHeader.js';
@@ -12,6 +13,19 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <PageHeader
         name="Tooltip"
         description={generatedDocGen?.description}
+        slimBanner={
+          <SlimBanner
+            type="info"
+            iconAccessibilityLabel="Info"
+            message="Planning to use Tooltip with IconButton? Instead, use"
+            helperLink={{
+              text: "IconButton's built-in tooltip.",
+              accessibilityLabel: 'View IconButton Docs, with Tooltip section',
+              href: '/iconbutton#With-Tooltip',
+              onClick: () => {},
+            }}
+          />
+        }
         defaultCode={`
       <Flex>
         <Tooltip text="Align left" accessibilityLabel="">

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -58,8 +58,8 @@ type Props = {|
 |};
 
 /**
- *  Use [RadioButtons](https://gestalt.pinterest.systems/radiobutton) when you have a few options that a user can choose from. Never use radio buttons if the user can select more than one option from a list. Note: The standalone RadioButton is soon to be deprecated, use RadioGroup and RadioGroup.RadioButton instead.
- *
+ *  Use [RadioButtons](https://gestalt.pinterest.systems/radiobutton) when you have a few options that a user can choose from. Never use radio buttons if the user can select more than one option from a list.
+ * **NOTE** The standalone RadioButton is soon to be deprecated, use [RadioGroup](https://gestalt.pinterest.systems/radiogroup) and RadioGroup.RadioButton instead.**NOTE**
  * ![RadioButton light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/RadioButton%20%230.png)
  * ![RadioButton dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/RadioButton-dark%20%230.png)
  *

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -77,7 +77,7 @@ type Props = {|
 /**
  * [Tooltip](https://gestalt.pinterest.systems/tooltip) is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/iconbutton). It’s displayed continuously as long as the user hovers over or focuses on the element.
  *
- * **Planning to use Tooltip with IconButton? Use [IconButton's built-in tooltip](https://gestalt.pinterest.systems/iconbutton#With-Tooltip) instead.**
+ * **NOTE** Planning to use Tooltip with IconButton? Use [IconButton's built-in tooltip](https://gestalt.pinterest.systems/iconbutton#With-Tooltip) instead. **NOTE**
  *
  * ![Tooltip light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Tooltip%20%230.png)
  * ![Tooltip dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/cypress/integration/visual-test/__image_snapshots__/Tooltip-dark%20%230.png)

--- a/scripts/generateMetadata.js
+++ b/scripts/generateMetadata.js
@@ -35,9 +35,9 @@ async function docgen(filePath) {
         // Remove the first markdown link from the description so we don't link to the page itself
         .replace(/\[(.*?)\][[(].*?[\])]/, '$1')
         // Remove images from the description
-        .replace(/!\[(.*?)\][[(].*?[\])]/g, '');
+        .replace(/!\[(.*?)\][[(].*?[\])]/g, '')
+        .replace(/(\*\*NOTE\*\*)[\S\s]+(\*\*NOTE\*\*)/, ''); // Remove NOTES for the Docs but keep them for VSCode description
     }
-
     return parsed;
   } catch {
     return null;
@@ -73,6 +73,7 @@ const getFilesFromDirectory = (directoryPath) => {
   const parsedDataArray = await Promise.all(
     files.map(async (file) => {
       const parsedFile = await docgen(path.join(root, file));
+
       return parsedFile ? { [getComponentNameFromFile(file)]: parsedFile } : null;
     }),
   );


### PR DESCRIPTION
### Summary

#### What changed?

Docs: adding slimBanner prop into Docs' PageHeader to display information related to the component. 


##BEFORE
![Screen Shot 2022-05-19 at 5 32 15 PM](https://user-images.githubusercontent.com/10593890/169408159-a45fb980-e43a-4579-90ca-aa14c132d3e7.png)

##AFTER
![Screen Shot 2022-05-19 at 5 29 36 PM](https://user-images.githubusercontent.com/10593890/169407802-ac3f805e-3529-4362-a026-5bba9ca0bff0.png)


#### Why?

New comms pattern re components

