### PR TITLE
Text + Heading: Deprecate old size options

### DIFF
--- a/docs/components/IllustrationCard.js
+++ b/docs/components/IllustrationCard.js
@@ -40,7 +40,7 @@ function IllustrationCard({ image, description, isNew, title, color, href }: Pro
               justifyContent="start"
             >
               <Flex direction="row" alignItems="baseline" gap={2}>
-                <Heading accessibilityLevel={3} size="sm">
+                <Heading accessibilityLevel={3} size="400">
                   {title}
                 </Heading>
                 {isNew && <Badge text="New" />}

--- a/docs/pages/popover.js
+++ b/docs/pages/popover.js
@@ -1003,7 +1003,7 @@ function ScrollBoundaryContainerExample() {
     return (
       <React.Fragment>
           <Flex direction="column" gap={2}>
-            <Text size="sm">Board</Text>
+            <Text size="100">Board</Text>
             <Button
               accessibilityHaspopup={true}
               accessibilityExpanded={openPopover}

--- a/docs/pages/scrollboundarycontainer.js
+++ b/docs/pages/scrollboundarycontainer.js
@@ -452,7 +452,7 @@ function ScrollBoundaryContainerExample() {
                 >
                   <Heading
                     accessibilityLevel={2}
-                    size="sm"
+                    size="400"
                   >
                     Billing Address
                   </Heading>

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -715,7 +715,7 @@ function Example() {
       <Table.Row>
         <Table.Cell>
           <Text color="default">{name}</Text>
-          <Text color="subtle" size="sm" lineClamp={lineClamp}>{subtext}</Text>
+          <Text color="subtle" size="100" lineClamp={lineClamp}>{subtext}</Text>
         </Table.Cell>
         <Table.Cell>
           <Text align="end">{total}</Text>

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -18,16 +18,10 @@ const defaultHeadingLevels = {
   '400': 3,
   '500': 2,
   '600': 1,
-  'sm': 3,
-  'md': 2,
-  'lg': 1,
 };
 
 // Corresponds to the font-size design tokens
 const SIZE_SCALE = {
-  sm: 400,
-  md: 500,
-  lg: 600,
   '100': 100,
   '200': 200,
   '300': 300,
@@ -38,7 +32,7 @@ const SIZE_SCALE = {
 
 type AccessibilityLevel = 1 | 2 | 3 | 4 | 5 | 6 | 'none';
 type Overflow = 'normal' | 'breakWord';
-type Size = '100' | '200' | '300' | '400' | '500' | '600' | 'sm' | 'md' | 'lg';
+type Size = '100' | '200' | '300' | '400' | '500' | '600';
 
 type Props = {|
   /**

--- a/packages/gestalt/src/Heading.test.js
+++ b/packages/gestalt/src/Heading.test.js
@@ -7,11 +7,6 @@ test('Heading large', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Deprecated Heading large', () => {
-  const tree = create(<Heading size="lg" />).toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
 test('Heading small with level 3', () => {
   const tree = create(<Heading size="400" accessibilityLevel={3} />).toJSON();
   expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -12,9 +12,6 @@ function isNotNullish(val): boolean {
 }
 
 const SIZE_SCALE = {
-  sm: 100,
-  md: 200,
-  lg: 300,
   '100': 100,
   '200': 200,
   '300': 300,
@@ -24,7 +21,7 @@ const SIZE_SCALE = {
 };
 
 type Overflow = 'normal' | 'breakWord' | 'noWrap';
-type Size = '100' | '200' | '300' | '400' | '500' | '600' | 'sm' | 'md' | 'lg';
+type Size = '100' | '200' | '300' | '400' | '500' | '600';
 
 type Props = {|
   /**

--- a/packages/gestalt/src/Text.test.js
+++ b/packages/gestalt/src/Text.test.js
@@ -22,11 +22,6 @@ test('Text size 100 adds the smallest size class', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Deprecated Text size sm adds the small size class', () => {
-  const tree = create(<Text size="sm" />).toJSON();
-  expect(tree).toMatchSnapshot();
-});
-
 test('Text lineClamp should add a title when the children are text only', () => {
   const tree = create(
     <Text lineClamp={1}>Shall I compare thee to a summer&#39;s day - William Shakespeare</Text>,

--- a/packages/gestalt/src/__snapshots__/Heading.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Heading.test.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Deprecated Heading large 1`] = `
-<h1
-  className="Heading fontSize600 defaultText alignStart breakWord"
-/>
-`;
-
 exports[`Heading default overflow 1`] = `
 <h3
   className="Heading fontSize400 defaultText alignStart breakWord"

--- a/packages/gestalt/src/__snapshots__/Text.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Text.test.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Deprecated Text size sm adds the small size class 1`] = `
-<div
-  className="Text fontSize100 defaultText alignStart breakWord fontWeightNormal"
-/>
-`;
-
 exports[`Text error adds the error color class 1`] = `
 <div
   className="Text fontSize300 errorText alignStart breakWord fontWeightNormal"


### PR DESCRIPTION
### Summary

Remove deprecated sizes from Heading and Text (`sm`, `md` and `lg`).

#### Why?

Align with design tokens and avoid arbitrary size usage.

To make any conversions using our codemods, run
`yarn codemod modifyPropValue [path-to-files] --component=Heading --previousProp=size --previousValue=[value to replace] --nextValue=[new value]`
and
`yarn codemod modifyPropValue [path-to-files] --component=Text --previousProp=size --previousValue=[value to replace] --nextValue=[new value]`

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4162)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
