### PR TITLE
Internal: Add Pinterest metadata tag to connect Gestalt Pinterest account w/ Gestalt site

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -26,6 +26,7 @@ class GestaltDocument extends Document {
     return (
       <Html lang="en" dir={dir}>
         <Head>
+          <meta name="p:domain_verify" content="752e3976762ef39258186e60a40bbe5a" />
           {/* eslint-disable-next-line @next/next/no-sync-scripts */}
           <script
             type="text/javascript"


### PR DESCRIPTION
## What
Adding the Pinterest HTML tag to the 

## Why

Adding Pinterest HTML tag to connect the Gestalt Pinterest account  on Pinterest to the https://gestalt.pinterest.systems/ so we can officially claim it.
https://user-images.githubusercontent.com/50343812/171476588-5a994f80-9e90-4b22-9050-c46e15b2051c.png