### PR TITLE
Docs: Revamp What's New page into our blog

### DIFF
--- a/docs/components/PageHeader.js
+++ b/docs/components/PageHeader.js
@@ -52,13 +52,14 @@ export default function PageHeader({
     },
     deprecated: {
       text: 'Deprecated',
-      tooltipText: `This component is deprecated and will be removed soons`,
+      tooltipText: `This component is deprecated and will be removed soon`,
+      type: 'error',
     },
   };
 
   return (
     <Box
-      marginBottom={defaultCode ? 0 : 12}
+      marginBottom={defaultCode ? 0 : 2}
       dangerouslySetInlineStyle={{
         __style: {
           paddingBottom: '1px',
@@ -72,7 +73,11 @@ export default function PageHeader({
               {name}{' '}
               {badge ? (
                 <Tooltip inline text={badgeMap[badge].tooltipText}>
-                  <Badge text={badgeMap[badge].text} position="top" />
+                  <Badge
+                    text={badgeMap[badge].text}
+                    position="top"
+                    type={badgeMap[badge].type || 'info'}
+                  />
                 </Tooltip>
               ) : null}
             </Heading>

--- a/docs/pages/BlogPosts.json
+++ b/docs/pages/BlogPosts.json
@@ -9,7 +9,7 @@
           "audience": ["Engineering", "Design"],
           "imageSrc": "https://slack-imgs.com/?c=1&o1=wi1200.he674.si.ro&url=https%3A%2F%2Fi.pinimg.com%2Foriginals%2Fa6%2F10%2F67%2Fa61067eea24034113e7e3cfe96823dbe.png",
           "imageAltText": "Full color palette for data viz",
-          "content": "The team is super excited to share that we shipped [data visualization tokens](/data_visualization_tokens) to Gestalt this week! This is due to the incredible work of @mengqiuhu and @tsimpson with their proposed color palette. We’re hoping to build upon this work to develop dataviz components and guidelines in future sprints, so stay tuned!"
+          "content": "The team is super excited to share that we shipped [data visualization tokens](/data_visualization_colors) to Gestalt this week! This is due to the incredible work of @mengqiuhu and @tsimpson with their proposed color palette. We’re hoping to build upon this work to develop dataviz components and guidelines in future sprints, so stay tuned!"
         },
         {
           "title": "New RadioButton Component",

--- a/docs/pages/BlogPosts.json
+++ b/docs/pages/BlogPosts.json
@@ -1,0 +1,32 @@
+{
+  "year": "2022",
+  "digests": [
+    {
+      "week": "5/26",
+      "posts": [
+        {
+          "title": "Data visualization tokens added to Gestalt",
+          "audience": ["Engineering", "Design"],
+          "imageSrc": "https://slack-imgs.com/?c=1&o1=wi1200.he674.si.ro&url=https%3A%2F%2Fi.pinimg.com%2Foriginals%2Fa6%2F10%2F67%2Fa61067eea24034113e7e3cfe96823dbe.png",
+          "imageAltText": "Full color palette for data viz",
+          "content": "The team is super excited to share that we shipped [data visualization tokens](/data_visualization_tokens) to Gestalt this week! This is due to the incredible work of @mengqiuhu and @tsimpson with their proposed color palette. We’re hoping to build upon this work to develop dataviz components and guidelines in future sprints, so stay tuned!"
+        },
+        {
+          "title": "New RadioButton Component",
+          "audience": ["Engineering"],
+          "imageSrc": "https://slack-imgs.com/?c=1&o1=wi1200.he674.si.ro&url=https%3A%2F%2Fi.pinimg.com%2Foriginals%2Fa7%2F68%2F23%2Fa7682371976aaa31d270d0dc36ee04be.png",
+          "imageAltText": "RadioGroup depiction",
+          "content": "We recently shipped a new [RadioGroup component](/radiogroup) which will make building forms easier and faster. The big change is that this component allows you to create a group of radio buttons as opposed to having to create each one independently. This may not have a ton of impact on your day-to-day, but we’re sharing it with you so that you remind your XFN buddies in case they aren’t aware. On that note, we’ve also deprecated our [RadioButton component](/radiobutton) in favor of RadioGroup."
+        },
+
+        {
+          "title": "Gestalt Open Forum — Iconography workshop!",
+          "audience": ["Design"],
+          "imageSrc": "https://slack-imgs.com/?c=1&o1=wi1200.he674.si.ro&url=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F3b%2F27%2F0c%2F3b270c8baf1cfd8a023e57ded5b03473.png",
+          "imageAltText": "",
+          "content": "We know you care a lot about icons, and it’s a hot topic and priority for Gestalt! So we’re planning an icon “workshop” that will happen during our next Gestalt Open Forum meeting (June 16th), facilitated by @sandreae. Please join us and help us evolve our iconography guidelines — we need your input!"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/pages/radiobutton.js
+++ b/docs/pages/radiobutton.js
@@ -11,6 +11,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     <Page title="RadioButton">
       <PageHeader
         name="RadioButton"
+        badge="deprecated"
         description="Use [RadioButtons](https://gestalt.pinterest.systems/radiobutton) when you have a few options that a user can choose from. Never use radio buttons if the user can select more than one option from a list."
         slimBanner={
           <SlimBanner

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -42,7 +42,7 @@ function PostLayout({ imageSrc, imageAltText, title, audience, content }: PostPr
         </Box>
       )}
       <Flex direction="column" gap={2} maxWidth="600px">
-        <Flex direction="column" gap={2}>
+        <Flex direction="column" gap={1}>
           <Heading size="400">{title}</Heading>
           <Flex gap={2}>
             {audience.includes('Design') && <Badge type="info" text="Design" />}
@@ -62,7 +62,8 @@ export default function Blog(): Node {
       <PageHeader
         name="What's New"
         description={`
-    Follow along to learn about documentation updates, new components, events, and more! Have questions? Feel free to reach out to #gestalt-design in Slack. To get the full play-by-play for each version, view the [changelog in GitHub](https://github.com/pinterest/gestalt/blob/master/CHANGELOG.md).
+    Follow along to learn about documentation updates, new components, events, and more!
+    To get the full details for each version, view the [changelog in GitHub](https://github.com/pinterest/gestalt/blob/master/CHANGELOG.md).
     `}
         showSourceLink={false}
       />

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -5,7 +5,6 @@ import Markdown from '../components/Markdown.js';
 import PageHeader from '../components/PageHeader.js';
 import Page from '../components/Page.js';
 import MainSection from '../components/MainSection.js';
-
 // $FlowExpectedError[untyped-import]
 import blogPosts from './BlogPosts.json';
 
@@ -17,12 +16,20 @@ type PostProps = {|
   content: string,
 |};
 function PostLayout({ imageSrc, imageAltText, title, audience, content }: PostProps): Node {
+  const POST_WIDTH = '600px';
   return (
-    <Flex direction="column" gap={3}>
+    <Flex direction="column" gap={4}>
+      <Flex direction="column" gap={1}>
+        <Heading size="400">{title}</Heading>
+        <Flex gap={2}>
+          {audience.includes('Design') && <Badge type="info" text="Design" />}
+          {audience.includes('Engineering') && <Badge type="success" text="Engineering" />}
+        </Flex>
+      </Flex>
       {imageSrc && (
         <Box
           height="252px"
-          maxWidth="420px"
+          maxWidth={POST_WIDTH}
           display="none"
           mdDisplay="block"
           marginBottom={4}
@@ -41,14 +48,7 @@ function PostLayout({ imageSrc, imageAltText, title, audience, content }: PostPr
           </Mask>
         </Box>
       )}
-      <Flex direction="column" gap={2} maxWidth="600px">
-        <Flex direction="column" gap={1}>
-          <Heading size="400">{title}</Heading>
-          <Flex gap={2}>
-            {audience.includes('Design') && <Badge type="info" text="Design" />}
-            {audience.includes('Engineering') && <Badge type="success" text="Engineering" />}
-          </Flex>
-        </Flex>
+      <Flex maxWidth={POST_WIDTH}>
         <Markdown text={content} />
       </Flex>
     </Flex>

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -10,8 +10,8 @@ import MainSection from '../components/MainSection.js';
 import blogPosts from './BlogPosts.json';
 
 type PostProps = {|
-  imageSrc: string,
-  imageAltText: string,
+  imageSrc?: string,
+  imageAltText?: string,
   title: string,
   audience: Array<string>,
   content: string,
@@ -33,7 +33,7 @@ function PostLayout({ imageSrc, imageAltText, title, audience, content }: PostPr
           <Mask rounding={2} height="250px">
             <Image
               src={imageSrc}
-              alt={imageAltText}
+              alt={imageAltText || ''}
               naturalHeight={674}
               naturalWidth={1200}
               fit="cover"

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -1,62 +1,115 @@
 // @flow strict
-import { type Node } from 'react';
-import { Box, Flex, Link, Text } from 'gestalt';
+import { type Node, useState } from 'react';
+import { Badge, Box, Flex, Heading, Image, Mask, RadioGroup } from 'gestalt';
 import Markdown from '../components/Markdown.js';
 import PageHeader from '../components/PageHeader.js';
 import Page from '../components/Page.js';
+import MainSection from '../components/MainSection.js';
 
-const npmPackages = [
-  'gestalt',
-  'gestalt-datepicker',
-  'gestalt-design-tokens',
-  'eslint-plugin-gestalt',
-];
+// $FlowExpectedError[untyped-import]
+import blogPosts from './BlogPosts.json';
 
-export default function Changelog({ changelog }: {| changelog: string |}): Node {
+type PostProps = {|
+  imageSrc: string,
+  imageAltText: string,
+  title: string,
+  audience: Array<string>,
+  content: string,
+|};
+function PostLayout({ imageSrc, imageAltText, title, audience, content }: PostProps): Node {
   return (
-    <Page title="Changelog">
-      <Box>
-        <PageHeader name="What's new 🎉" showSourceLink={false} />
-        <Flex alignItems="start" direction="column" gap={4}>
-          <Flex gap={4} wrap>
-            {npmPackages.map((packageName) => (
-              <Link
-                key={packageName}
-                inline
-                target="blank"
-                href={`https://npmjs.org/package/${packageName}`}
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={`https://img.shields.io/npm/v/${packageName}.svg?label=${packageName}`}
-                  alt={`${packageName} NPM package version badge`}
-                />
-              </Link>
-            ))}
+    <Flex direction="column" gap={3}>
+      {imageSrc && (
+        <Box
+          height="252px"
+          maxWidth="420px"
+          display="none"
+          mdDisplay="block"
+          marginBottom={4}
+          lgMarginBottom={0}
+          borderStyle="sm"
+          rounding={2}
+        >
+          <Mask rounding={2} height="250px">
+            <Image
+              src={imageSrc}
+              alt={imageAltText}
+              naturalHeight={674}
+              naturalWidth={1200}
+              fit="cover"
+            />
+          </Mask>
+        </Box>
+      )}
+      <Flex direction="column" gap={2} maxWidth="600px">
+        <Flex direction="column" gap={2}>
+          <Heading size="400">{title}</Heading>
+          <Flex gap={2}>
+            {audience.includes('Design') && <Badge type="info" text="Design" />}
+            {audience.includes('Engineering') && <Badge type="success" text="Engineering" />}
           </Flex>
-          <Text>
-            Gestalt is a set of React UI components that enforces Pinterest’s design language. We
-            use it to streamline communication between designers and developers by enforcing a bunch
-            of fundamental UI components. This common set of components helps raise the bar for UX
-            &amp; accessibility across Pinterest.
-          </Text>
-          <Text>
-            Find information below on all new and updated components by version number, as well as
-            available codemods to help upgrade between versions.
-          </Text>
         </Flex>
-
-        <Markdown text={changelog} type="changelog" />
-      </Box>
-    </Page>
+        <Markdown text={content} />
+      </Flex>
+    </Flex>
   );
 }
 
-export async function getServerSideProps(): Promise<{| props: {| changelog: string |} |}> {
-  const result = await fetch(
-    'https://raw.githubusercontent.com/pinterest/gestalt/master/CHANGELOG.md',
+export default function Blog(): Node {
+  const [filter, setFilter] = useState('All');
+  return (
+    <Page title="What's New Blog">
+      <PageHeader
+        name="What's New"
+        description={`
+    Follow along to learn about documentation updates, new components, events, and more! Have questions? Feel free to reach out to #gestalt-design in Slack. To get the full play-by-play for each version, view the [changelog in GitHub](https://github.com/pinterest/gestalt/blob/master/CHANGELOG.md).
+    `}
+        showSourceLink={false}
+      />
+      <RadioGroup id="filter" legend="Filter posts by" direction="row">
+        <RadioGroup.RadioButton
+          size="sm"
+          id="all"
+          value="All"
+          label="All"
+          checked={filter === 'All'}
+          onChange={() => {
+            setFilter('All');
+          }}
+        />
+        <RadioGroup.RadioButton
+          id="design"
+          value="Design"
+          label="Design updates"
+          checked={filter === 'Design'}
+          onChange={() => {
+            setFilter('Design');
+          }}
+          size="sm"
+        />
+        <RadioGroup.RadioButton
+          id="eng"
+          value="Engineering"
+          label="Engineering updates"
+          checked={filter === 'Engineering'}
+          onChange={() => {
+            setFilter('Engineering');
+          }}
+          size="sm"
+        />
+      </RadioGroup>
+      {blogPosts.digests.map((digest, idx) => (
+        <MainSection key={`digest-${idx}`} name={`Week of ${digest.week}`}>
+          <Flex direction="column" gap={12}>
+            {digest.posts.map(
+              (post, index) =>
+                (filter === 'All' || post.audience.includes(filter)) && (
+                  <PostLayout key={`post-${index}`} {...post} />
+                ),
+            )}
+          </Flex>
+        </MainSection>
+      ))}
+    </Page>
   );
-  return {
-    props: { changelog: await result.text() },
-  };
 }


### PR DESCRIPTION
### Summary

#### What changed?

Update the What's New page to become a blog page for recent updates

#### Why?

Have a single source of truth to host weekly digests of updates, allowing designers and engineers to find information easily and predictably.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4376)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
