### PR TITLE
Docs: minor tweaks to Design Tokens page

### DIFF
--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -35,10 +35,18 @@ export function ColorBox({ token }: BaseProps): Node {
 }
 
 export function SpacingBox({ token }: BaseProps): Node {
-  return <Box color="eggplant" width={`${token.value}`} height={`${token.value}`} />;
+  const absoluteDimension = token.value.replace(/^-/, '');
+  return <Box color="eggplant" width={absoluteDimension} height={absoluteDimension} />;
 }
 
 export function TextColorBox({ token }: BaseProps): Node {
+  let backgroundColor;
+  if (token.name.includes('inverse') || token.name.includes('light')) {
+    backgroundColor = 'darkGray';
+  } else if (token.name.includes('dark')) {
+    backgroundColor = 'white';
+  }
+
   return (
     <Box
       dangerouslySetInlineStyle={{
@@ -50,7 +58,7 @@ export function TextColorBox({ token }: BaseProps): Node {
       alignItems="center"
       justifyContent="between"
       paddingX={2}
-      color={token.name.includes('inverse') ? 'darkGray' : undefined}
+      color={backgroundColor}
     >
       Gestalt
     </Box>


### PR DESCRIPTION
A few small tweaks for issues I just noticed:
- Add spacing examples for negative spacing
- 


Other fixes needed in future PRs:
- A persistent white background behind the "won't change in dark mode" dark colors:
<img width="978" alt="Screen Shot 2022-06-16 at 4 42 15 PM" src="https://user-images.githubusercontent.com/12059539/174171615-6a097ca3-9c4d-4765-af6b-a3c1db1a08b9.png">
- More explicit callout that this isn't broken UI, but a feature that only works in dark mode:
<img width="981" alt="Screen Shot 2022-06-16 at 4 43 12 PM" src="https://user-images.githubusercontent.com/12059539/174171470-cf7d98a2-55c9-4a26-89ab-807b83edab6c.png">
- Ditto here, but that it only works in light mode
<img width="989" alt="Screen Shot 2022-06-16 at 4 43 06 PM" src="https://user-images.githubusercontent.com/12059539/174171533-580f30c8-c5ce-44e6-86cd-4f545cf6ea69.png">
 