### PR TITLE
ComboBox: Fix spacing with Tags

### DIFF
--- a/packages/gestalt/src/InternalTextField.css
+++ b/packages/gestalt/src/InternalTextField.css
@@ -15,7 +15,7 @@
   composes: Text from "./Text.css";
   composes: fontSize300 from "./Typography.css";
   margin-bottom: var(--space-100);
-  padding: var(--space-100) var(--space-200);
+  padding: var(--space-100) var(--space-0);
 }
 
 .unstyledTextField {


### PR DESCRIPTION


### Summary

#### What changed?

Remove unnecessary spacing from "spacer" div

#### Why?

Align spacing with Textarea and TextField so forms look consistent

