### PR TITLE
Design Tokens: Add cross-linking to various pages

### DIFF
--- a/docs/components/ColorPalette.js
+++ b/docs/components/ColorPalette.js
@@ -15,7 +15,9 @@ function ColorPalette({ name, tokenId }: Props): Node {
   const colorId = `${tokenId}-${name.toLowerCase()}`;
   return (
     <Box marginTop={8} marginBottom={8}>
-      <Text weight="bold">{name}</Text>
+      <Text weight="bold">
+        {name} ({tokenId})
+      </Text>
       <Box marginTop={2}>
         {tokenNumbers.map((number) => {
           const textColor = number > 400 ? 'light' : 'dark';

--- a/docs/components/TokenExample.js
+++ b/docs/components/TokenExample.js
@@ -35,8 +35,27 @@ export function ColorBox({ token }: BaseProps): Node {
 }
 
 export function SpacingBox({ token }: BaseProps): Node {
-  const absoluteDimension = token.value.replace(/^-/, '');
-  return <Box color="eggplant" width={absoluteDimension} height={absoluteDimension} />;
+  if (token.value.includes('-')) {
+    const absoluteDimension = token.value.replace(/^-/, '');
+    const marginLeftDimension = `calc(64px + ${token.value})`;
+    return (
+      <Box
+        dangerouslySetInlineStyle={{ __style: { marginLeft: marginLeftDimension } }}
+        borderStyle="lg"
+        width={absoluteDimension}
+        height={absoluteDimension}
+      />
+    );
+  }
+
+  return (
+    <Box
+      dangerouslySetInlineStyle={{ __style: { marginLeft: '64px' } }}
+      color="brand"
+      width={token.value}
+      height={token.value}
+    />
+  );
 }
 
 export function TextColorBox({ token }: BaseProps): Node {

--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -443,6 +443,8 @@ function Example() {
           title="Colors"
           description={`
           The following values can be used to change the background color of Box. Be sure to use the value that semantically matches your use case. For full details on how to use our colors, visit our [Color usage page](/color_usage).
+          
+          Colors should be used semantically whenever possible (i.e. using "errorBase" for error scenarios). If a color is needed for a branded moment in product, Box color can be set using our [color palette design tokens](/color_palette), but it is [considered a hack](/how_to_hack_around_gestalt#Box's-dangerouslySetInlineStyle) and should be avoided.
 
           _⚠️ Note that the previous options ('red', 'white', 'lightGray', 'gray', 'darkGray', 'green', 'pine', 'olive', 'blue', 'navy', 'midnight', 'purple', 'orchid', 'eggplant', 'maroon', 'watermelon', 'orange') are still valid but will be deprecated soon._
         `}

--- a/docs/pages/color_palette.js
+++ b/docs/pages/color_palette.js
@@ -171,6 +171,17 @@ export default function ColorPage(): Node {
           </Flex>
         </MainSection.Subsection>
       </MainSection>
+      <MainSection
+        name="Colors in code"
+        description={`
+       All colors in this palette are available through [design tokens](/https://uxdesign.cc/design-tokens-cheatsheet-927fc1404099) and follow the naming pattern of \`color-{common_name}-{pinterest_name}-{number}\`. For example:
+
+       - JavaScript  \`$color-pink-flaminglow-400\`
+       - CSS  \`var(--color-pink-flaminglow-400)\`
+
+       Using colors that are not available through our [semantic design tokens](/design_tokens) and components directly is considered an anti-pattern and should be avoided whenever possible. If it's absolutely necessary, a [hack on Box](/how_to_hack_around_gestalt#Box's-dangerouslySetInlineStyle) can be used.
+      `}
+      />
     </Page>
   );
 }

--- a/docs/pages/data_visualization_colors.js
+++ b/docs/pages/data_visualization_colors.js
@@ -48,7 +48,7 @@ export default function ColorPage(): Node {
     <Page title="Data visualization color palette">
       <PageHeader
         name="Data visualization color palette"
-        description={`The data visualization color palette is used to represent discrete categories of data. This palette utilizes the Gestalt color palette and is optimized for accessibility in data visualizations. The palette is comprised of a 12-color categorical palette and semantic colors.  `}
+        description={`The data visualization color palette is used to represent discrete categories of data. This palette utilizes the Gestalt color palette and is optimized for accessibility in data visualizations. The palette is comprised of a 12-color categorical palette, along with a few semantic colors. It can be implemented through our [design tokens](/design_tokens#Data-visualization). `}
         showSourceLink={false}
       />
       <MainSection

--- a/docs/pages/data_visualization_guidelines.js
+++ b/docs/pages/data_visualization_guidelines.js
@@ -34,7 +34,11 @@ function PaletteGenerator({ count }: ColorCardProps): Node {
 export default function ColorPage(): Node {
   return (
     <Page title="Data visualization guidelines">
-      <PageHeader name="Data visualization guidelines" showSourceLink={false} />
+      <PageHeader
+        name="Data visualization guidelines"
+        showSourceLink={false}
+        description="Details about approved color pairings, accessibility guidelines, and pairings to avoid. The [data visualization palette](/data_visualization_colors) can be implemented through our [design tokens](/design_tokens#Data-visualization)."
+      />
       <MainSection
         name="Primary color"
         description="We use `$color-data-visualization-primary` as the main color for data visualization, which is used for showing total value or whenever only 1 color is needed in a visualization."

--- a/docs/pages/design_tokens.js
+++ b/docs/pages/design_tokens.js
@@ -18,15 +18,60 @@ export type Token = {|
 |};
 
 const tokenCategories = [
-  { name: 'Spacing', category: 'spacing', id: 'space' },
-  { name: 'Background color', category: 'background-color', id: 'background' },
-  { name: 'Text color', category: 'text-color', id: 'color-text' },
-  { name: 'Font size', category: 'font-size', id: 'font-size' },
-  { name: 'Font weight', category: 'font-weight', id: 'font-weight' },
-  { name: 'Font family', category: 'font-family', id: 'font-family' },
-  { name: 'Border color', category: 'color-border', id: 'color-border' },
-  { name: 'Elevation', category: 'elevation', id: 'elevation' },
-  { name: 'Data visualization', category: 'data-visualization', id: 'data-visualization' },
+  {
+    name: 'Spacing',
+    category: 'spacing',
+    id: 'space',
+    infoPage: { name: 'Box', id: 'box#Responsive-padding' },
+  },
+  {
+    name: 'Background color',
+    category: 'background-color',
+    id: 'background',
+    infoPage: { name: 'Box', id: 'box#Colors' },
+  },
+  {
+    name: 'Text color',
+    category: 'text-color',
+    id: 'color-text',
+    infoPage: { name: 'Text', id: 'text#Colors' },
+  },
+  {
+    name: 'Font size',
+    category: 'font-size',
+    id: 'font-size',
+    infoPage: { name: 'Text', id: 'text#Sizes' },
+  },
+  {
+    name: 'Font weight',
+    category: 'font-weight',
+    id: 'font-weight',
+    infoPage: { name: 'Text', id: 'text#Styles' },
+  },
+  {
+    name: 'Font family',
+    category: 'font-family',
+    id: 'font-family',
+    infoPage: { name: 'Typography', id: 'typography' },
+  },
+  {
+    name: 'Border color',
+    category: 'color-border',
+    id: 'color-border',
+    infoPage: { name: 'Box', id: 'box#Borders' },
+  },
+  {
+    name: 'Elevation',
+    category: 'elevation',
+    id: 'elevation',
+    infoPage: { name: 'Box', id: 'box#Elevation' },
+  },
+  {
+    name: 'Data visualization',
+    category: 'data-visualization',
+    id: 'data-visualization',
+    infoPage: { name: 'Data Visualization Guidelines', id: 'data_visualization_colors' },
+  },
 ];
 
 const darkValueCategories = [
@@ -77,7 +122,11 @@ export default function DesignTokensPage(): Node {
         {tokenCategories.map((category) => {
           const tokensToUse = category.name === 'Data visualization' ? sortedDataTokens : tokens;
           return (
-            <MainSection.Subsection key={`table${category.name}`} title={category.name}>
+            <MainSection.Subsection
+              key={`table${category.name}`}
+              title={category.name}
+              description={`Visit the [${category?.infoPage?.name} page](/${category?.infoPage?.id}) for guidelines and implementation details.`}
+            >
               <Table accessibilityLabel={`${category.name} Values`}>
                 {tableHeaders(category.name)}
                 <Table.Body>

--- a/docs/pages/how_to_hack_around_gestalt.js
+++ b/docs/pages/how_to_hack_around_gestalt.js
@@ -73,7 +73,7 @@ Custom components can also be made from scratch, using native DOM elements and C
 - Doesn't support pseudo-classes, pseudo-elements, or animations
 - Overridden styles will not respond to dark mode or RTL
 
-**Alternative:** When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
+**Alternative:** When possible, stick to the styles available on Gestalt components natively. If you need to use a custom style, try to use the corresponding [design token](/design_tokens) instead of a hard-coded value. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
 `}
         >
           <MainSection.Card
@@ -82,7 +82,7 @@ Custom components can also be made from scratch, using native DOM elements and C
 <Box
   dangerouslySetInlineStyle={{
     __style: {
-      backgroundColor: 'rebeccapurple',
+      backgroundColor: 'var(--color-pink-flaminglow-400)',
     },
   }}
   height={100}


### PR DESCRIPTION
### Summary

#### What changed?

Add multiple links across tokens and color guideline pages to try and add context wherever needed. Also updated "hackign Box" example to use a design token.

#### Why?

As folks start implementing Data Viz colors and design tokens, we want to ensure the best practices and information are easily consumable.

