### PR TITLE
PageHeader: Make onClick for helperLink optional

### DIFF
--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -61,7 +61,7 @@ type Props = {|
     text: string,
     accessibilityLabel: string,
     href: string,
-    onClick: ({|
+    onClick?: ({|
       event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
       dangerouslyDisableOnNavigation: () => void,
     |}) => void,

--- a/packages/gestalt/src/PageHeaderComponents.js
+++ b/packages/gestalt/src/PageHeaderComponents.js
@@ -108,7 +108,7 @@ export function PageHeaderSubtext({
     text: string,
     accessibilityLabel: string,
     href: string,
-    onClick: ({|
+    onClick?: ({|
       event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
       dangerouslyDisableOnNavigation: () => void,
     |}) => void,


### PR DESCRIPTION

### Summary

#### What changed?

the onClick prop of the helperLink prop was unnecessarily required (it's not required on Link), so this switches it to be optional

#### Why?

Avoid unnecessarily strict flow types if onClick is not needed for the link

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
