### PR TITLE
Masonry: remove boolean flexible prop (Breaking change)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -111,6 +111,12 @@
       "globals": {
         "page": true,
         "browser": true
+      },
+      "rules": {
+        "jest/expect-expect": [
+          "error",
+          { "assertFunctionNames": ["expect", "runInlineTest"] }
+        ]
       }
     },
     {

--- a/docs/pages/masonry.js
+++ b/docs/pages/masonry.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Component, type Node } from 'react';
+import { Component, type Node, type ElementProps } from 'react';
 import { Box, Masonry, Image, Label, Text } from 'gestalt';
 import GeneratedPropTable from '../components/GeneratedPropTable.js';
 import PageHeader from '../components/PageHeader.js';
@@ -11,9 +11,8 @@ import QualityChecklist from '../components/QualityChecklist.js';
 import AccessibilitySection from '../components/AccessibilitySection.js';
 
 type Props = {|
-  flexible?: boolean,
   id?: string,
-  layout?: 'uniformRow',
+  layout?: $ElementType<ElementProps<typeof Masonry>, 'layout'>,
 |};
 
 type Pin = {|
@@ -158,7 +157,6 @@ class ExampleMasonry extends Component<Props, State> {
             <Masonry
               columnWidth={170}
               comp={GridComponent}
-              flexible={this.props.flexible}
               gutterWidth={5}
               items={this.state.pins}
               layout={this.props.layout}
@@ -201,15 +199,15 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       />
       <Card
         description={`
-    When the \`flexible\` property is set to true, the item width will shrink/grow to fill the container. This is great for responsive designs.
+    When layout is set to \`flexible\`, the item width will shrink/grow to fill the container. This is great for responsive designs.
 
     ~~~jsx
-    <Masonry flexible comp={Item} items={items} minCols={1} />
+    <Masonry layout="flexible" comp={Item} items={items} minCols={1} />
     ~~~
     `}
         name="Flexible item width"
       >
-        <ExampleMasonry flexible id="flexible-width" />
+        <ExampleMasonry layout="flexible" id="flexible-width" />
       </Card>
       <Card
         description={`

--- a/packages/gestalt-codemods/59.0.0/masonry-update-flexible-prop.js
+++ b/packages/gestalt-codemods/59.0.0/masonry-update-flexible-prop.js
@@ -1,0 +1,106 @@
+/*
+ * Converts
+ *  <Masonry flexible /> to <Masonry layout="flexible" />
+ */
+
+// Run
+// yarn codemod --parser=flow -t=packages/gestalt-codemods/59.0.0/masonry-update-flexible-prop.js relative/path/to/your/code
+
+const replaceOrRemoveFlexibleProp = (flexibleProp) => {
+  if (!flexibleProp.value || flexibleProp?.value.expression.raw === 'true') {
+    return 'replaceFlexibleProp';
+  }
+  if (flexibleProp?.value.expression.raw === 'false') {
+    return 'removeFlexibleProp';
+  }
+  return null;
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const src = j(file.source);
+  let localIdentifierName;
+  let fileHasModifications = false;
+
+  src.find(j.ImportDeclaration).forEach((path) => {
+    const decl = path.node;
+    if (decl.source.value !== 'gestalt') {
+      return null;
+    }
+
+    localIdentifierName = decl.specifiers
+      .filter((node) => node.imported.name === 'Masonry')
+      .map((node) => node.local.name);
+    return null;
+  });
+
+  if (!localIdentifierName) {
+    return null;
+  }
+
+  const transform = src
+    .find(j.JSXElement)
+    .forEach((jsxElement) => {
+      const { node } = jsxElement;
+
+      if (!localIdentifierName.includes(node.openingElement.name.name)) {
+        return null;
+      }
+      const attrs = node.openingElement.attributes;
+
+      if (attrs.some((attr) => attr.type === 'JSXSpreadAttribute')) {
+        throw new Error(
+          `Remove Dynamic properties on Masonry and rerun codemod. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+
+      const flexibleProp = attrs.find((attr) => attr?.name?.name && attr.name.name === 'flexible');
+
+      if (!flexibleProp) {
+        return null;
+      }
+
+      const transformType = replaceOrRemoveFlexibleProp(flexibleProp);
+
+      if (!transformType) {
+        throw new Error(
+          `Inspect Masonry component manually to evaluate if 'flexible' is set dynamically. Location: ${file.path} @line: ${node.loc.start.line}`,
+        );
+      }
+
+      // Remove flexible prop
+      node.openingElement.attributes = [
+        ...attrs
+          .map((attr) => {
+            if (attr?.name?.name && attr.name.name === 'flexible') {
+              return null;
+            }
+            return attr;
+          })
+          .filter(Boolean),
+      ];
+
+      // Add layout prop as required
+      if (transformType === 'replaceFlexibleProp') {
+        const layoutProp = attrs.find((attr) => attr?.name?.name && attr.name.name === 'layout');
+
+        if (!layoutProp) {
+          node.openingElement.attributes = [
+            ...node.openingElement.attributes,
+            j.jsxAttribute(j.jsxIdentifier('layout'), j.literal('flexible')),
+          ];
+        } else if (!['flexible', 'serverRenderedFlexible'].includes(layoutProp?.value?.value)) {
+          throw new Error(
+            `Invalid prop combination related to "flexible" on Masonry, please update manually. Location: ${file.path} @line: ${node.loc.start.line}`,
+          );
+        }
+      }
+
+      fileHasModifications = true;
+
+      return null;
+    })
+    .toSource();
+
+  return fileHasModifications ? transform : null;
+}

--- a/packages/gestalt-codemods/59.0.0/masonry-update-flexible-prop.test.js
+++ b/packages/gestalt-codemods/59.0.0/masonry-update-flexible-prop.test.js
@@ -1,0 +1,114 @@
+import { runInlineTest } from 'jscodeshift/dist/testUtils.js';
+import masonryUpdateFlexibleProp from './masonry-update-flexible-prop.js';
+
+describe('masonry-update-flexible-prop', () => {
+  it('transforms correctly', () => {
+    runInlineTest(
+      masonryUpdateFlexibleProp,
+      { quote: 'single' },
+      {
+        source: `
+    // @flow strict
+    import { Masonry } from 'gestalt';
+    export default function TestMasonry() {
+      return <>
+        <Masonry flexible={true} />
+        <Masonry flexible={false} />
+        <Masonry flexible />
+        <Masonry flexible layout="flexible" />
+        <Masonry />
+      </>
+    }
+      `,
+      },
+      `
+    // @flow strict
+    import { Masonry } from 'gestalt';
+    export default function TestMasonry() {
+      return <>
+        <Masonry layout="flexible" />
+        <Masonry />
+        <Masonry layout="flexible" />
+        <Masonry layout="flexible" />
+        <Masonry />
+      </>;
+    }
+    `,
+    );
+  });
+
+  it('throws an error when spread is used on Masonry', () => {
+    expect(() => {
+      runInlineTest(
+        masonryUpdateFlexibleProp,
+        { quote: 'single' },
+        {
+          path: 'test.js',
+          source: `
+      // @flow strict
+      import { Masonry } from 'gestalt';
+      export default function TestMasonry() {
+        return <>
+          <Masonry {...otherProps} />
+        </>
+      }
+        `,
+        },
+      );
+    }).toThrow(
+      new Error(
+        `Remove Dynamic properties on Masonry and rerun codemod. Location: test.js @line: 6`,
+      ),
+    );
+  });
+
+  it('throws an error when the flexible prop contains a dynamic value', () => {
+    expect(() => {
+      runInlineTest(
+        masonryUpdateFlexibleProp,
+        { quote: 'single' },
+        {
+          path: 'test.js',
+          source: `
+      // @flow strict
+      import { Masonry } from 'gestalt';
+      export default function TestMasonry() {
+        return <>
+          <Masonry flexible={dynamicValue} />
+        </>
+      }
+        `,
+        },
+      );
+    }).toThrow(
+      new Error(
+        `Inspect Masonry component manually to evaluate if 'flexible' is set dynamically. Location: test.js @line: 6`,
+      ),
+    );
+  });
+
+  it('throws an error when the flexible prop is set and layout is set to a non flexible layout', () => {
+    expect(() => {
+      runInlineTest(
+        masonryUpdateFlexibleProp,
+        { quote: 'single' },
+        {
+          path: 'test.js',
+          source: `
+      // @flow strict
+      import { Masonry } from 'gestalt';
+      export default function TestMasonry() {
+        return <>
+          <Masonry flexible layout="basicCentered" />
+        </>
+      }
+        `,
+        },
+      );
+    }).toThrow(
+      new Error(
+        `Invalid prop combination related to "flexible" on Masonry, please update manually. Location: test.js @line: 6`,
+      ),
+    );
+  });
+});

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -43,10 +43,6 @@ type Props<T> = {|
     isMeasuring: boolean,
   |}>,
   /**
-   * Item width will grow to fill column space and shrink to fit if below min columns.
-   */
-  flexible?: boolean,
-  /**
    * The amount of vertical and horizontal space between each item, specified in pixels.
    */
   gutterWidth?: number,
@@ -439,7 +435,6 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     const {
       columnWidth,
       comp: Component,
-      flexible,
       gutterWidth: gutter,
       items,
       layout,
@@ -450,10 +445,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
 
     let getPositions;
 
-    if (
-      (flexible || layout === 'flexible' || layout === 'serverRenderedFlexible') &&
-      width !== null
-    ) {
+    if ((layout === 'flexible' || layout === 'serverRenderedFlexible') && width !== null) {
       getPositions = fullWidthLayout({
         gutter,
         cache: measurementStore,
@@ -503,7 +495,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
               key={i}
               ref={(el) => {
                 // purposely not checking for layout === 'serverRenderedFlexible' here
-                if (el && !(flexible || layout === 'flexible')) {
+                if (el && layout !== 'flexible') {
                   // if we're hydrating from the server, we should only measure items on the initial render pass
                   // if we're not rendering a flexible layout.  "serverRenderedFlexible" is an exception because we assume
                   // that the caller has added the proper CSS to ensure the layout is correct during server render
@@ -517,7 +509,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                 transform: 'translateX(0px) translateY(0px)',
                 WebkitTransform: 'translateX(0px) translateY(0px)',
                 width:
-                  flexible || layout === 'flexible' || layout === 'serverRenderedFlexible'
+                  layout === 'flexible' || layout === 'serverRenderedFlexible'
                     ? undefined
                     : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
               }}


### PR DESCRIPTION
### Summary

#### What changed?

Removes the `flexible` boolean prop from Masonry.

#### Why?
Consistency: `layout="flexible"` and `flexible` props do the same thing, so it's confusing what prop to use when

### FAQ

<details>
  <summary>Why not use <code>packages/gestalt-codemods/generic-codemods/modifyPropValue.js</code> ?</summary>
  We need to throw when the `flexible` prop is set on a layout other than the default, `flexible` or `serverRenderedFlexible`.
</details>
