### PR TITLE
Table: update sortable header cell behavior

### DIFF
--- a/docs/components/COMPONENT_DATA.js
+++ b/docs/components/COMPONENT_DATA.js
@@ -972,11 +972,11 @@ const GENERAL_COMPONENT_LIST: ListItemType = [
     category: 'Data',
     status: {
       accessible: {
-        summary: 'ready',
-        a11yVisual: 'ready',
-        a11yScreenreader: 'ready',
-        a11yNavigation: 'ready',
-        a11yComprehension: 'ready',
+        summary: 'partial',
+        a11yVisual: 'partial',
+        a11yScreenreader: 'partial',
+        a11yNavigation: 'partial',
+        a11yComprehension: 'partial',
       },
       badge: null,
       android: 'notAvailable',

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -20,67 +20,41 @@ export default function TablePage({
         name={generatedDocGen.Table?.displayName}
         description={generatedDocGen.Table?.description}
         defaultCode={`
-<Table accessibilityLabel="Basic Table">
-  <Table.Header>
-    <Table.Row>
-      <Table.HeaderCell>
-        <Text weight="bold">Name</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">House</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">Birthday</Text>
-      </Table.HeaderCell>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Luna Lovegood</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Ravenclaw</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>June 25, 1993</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Draco Malfoy</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Slytherin</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>December 3, 1992</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Hermione Granger</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Gryffindor</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>September 19, 1979</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Neville Longbottom</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Gryffindor</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>July 30, 1980</Text>
-      </Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table>
+        function SortableHeaderExample() {
+          const [sortOrder, setSortOrder] = React.useState("desc");
+          const [sortCol, setSortCol] = React.useState("keywords");
+
+          const onSortChange = (col) => {
+            if (sortCol === col) {
+              setSortCol("keywords");
+            } else {
+              setSortCol(col);
+            }
+          };
+
+          return (
+            <Table accessibilityLabel="Sortable header cells">
+              <Table.Header>
+                <Table.Row>
+                  <Table.SortableHeaderCell
+                    onSortChange={() => onSortChange("keywords")}
+                    sortOrder={sortOrder}
+                    status={sortCol === "keywords" ? "active" : "inactive"}
+                  >
+                    <Text weight="bold">Keywords</Text>
+                  </Table.SortableHeaderCell>
+                  <Table.SortableHeaderCell
+                    onSortChange={() => onSortChange("weekly")}
+                    sortOrder={sortOrder}
+                    status={sortCol === "weekly" ? "active" : "inactive"}
+                  >
+                    <Text weight="bold">Weekly Change</Text>
+                  </Table.SortableHeaderCell>
+                </Table.Row>
+              </Table.Header>
+            </Table>
+          );
+        }
 `}
       />
 

--- a/docs/pages/table.js
+++ b/docs/pages/table.js
@@ -20,41 +20,67 @@ export default function TablePage({
         name={generatedDocGen.Table?.displayName}
         description={generatedDocGen.Table?.description}
         defaultCode={`
-        function SortableHeaderExample() {
-          const [sortOrder, setSortOrder] = React.useState("desc");
-          const [sortCol, setSortCol] = React.useState("keywords");
-
-          const onSortChange = (col) => {
-            if (sortCol === col) {
-              setSortCol("keywords");
-            } else {
-              setSortCol(col);
-            }
-          };
-
-          return (
-            <Table accessibilityLabel="Sortable header cells">
-              <Table.Header>
-                <Table.Row>
-                  <Table.SortableHeaderCell
-                    onSortChange={() => onSortChange("keywords")}
-                    sortOrder={sortOrder}
-                    status={sortCol === "keywords" ? "active" : "inactive"}
-                  >
-                    <Text weight="bold">Keywords</Text>
-                  </Table.SortableHeaderCell>
-                  <Table.SortableHeaderCell
-                    onSortChange={() => onSortChange("weekly")}
-                    sortOrder={sortOrder}
-                    status={sortCol === "weekly" ? "active" : "inactive"}
-                  >
-                    <Text weight="bold">Weekly Change</Text>
-                  </Table.SortableHeaderCell>
-                </Table.Row>
-              </Table.Header>
-            </Table>
-          );
-        }
+<Table accessibilityLabel="Basic Table">
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>
+        <Text weight="bold">Name</Text>
+      </Table.HeaderCell>
+      <Table.HeaderCell>
+        <Text weight="bold">House</Text>
+      </Table.HeaderCell>
+      <Table.HeaderCell>
+        <Text weight="bold">Birthday</Text>
+      </Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row>
+      <Table.Cell>
+        <Text>Luna Lovegood</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>Ravenclaw</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>June 25, 1993</Text>
+      </Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>
+        <Text>Draco Malfoy</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>Slytherin</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>December 3, 1992</Text>
+      </Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>
+        <Text>Hermione Granger</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>Gryffindor</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>September 19, 1979</Text>
+      </Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>
+        <Text>Neville Longbottom</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>Gryffindor</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>July 30, 1980</Text>
+      </Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table>
 `}
       />
 

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -88,7 +88,10 @@ export default function TableSortableHeaderCell({
       <Box display="inlineBlock">
         <TapArea
           fullWidth={false}
-          onTap={onSortChange}
+          onTap={({ event, dangerouslyDisableOnNavigation }) => {
+            setFocused(false);
+            onSortChange({ event, dangerouslyDisableOnNavigation });
+          }}
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
           onFocus={() => setFocused(true)}


### PR DESCRIPTION
Current behavior isn't great when de-selecting a sortable header, with the arrow icon lingering due to the header cell having focus after being clicked:
https://user-images.githubusercontent.com/12059539/176942403-ead225fa-e627-4aad-81d3-5c8f5a539792.mov

This PR doesn't adjust the actual focus of the cell, but removes the focus UI state just after click.