### PR TITLE
Masonry: remove deprecated layouts

### DIFF
--- a/docs/pages/masonry.js
+++ b/docs/pages/masonry.js
@@ -244,18 +244,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   const generatedDocGen = await docgen({ componentName: 'Masonry' });
 
-  generatedDocGen.props.layout = {
-    ...generatedDocGen.props.layout,
-    defaultValue: {
-      value: 'MasonryDefaultLayout',
-      computed: false,
-    },
-    flowType: {
-      name: 'string',
-      raw: 'MasonryDefaultLayout | MasonryUniformRowLayout',
-    },
-  };
-
   generatedDocGen.props.loadItems = {
     ...generatedDocGen.props.loadItems,
     defaultValue: null,

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -8,25 +8,13 @@ import throttle, { type ThrottleReturn } from './throttle.js';
 import { type Cache } from './Cache.js';
 import MeasurementStore from './MeasurementStore.js';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './scrollUtils.js';
-import { DefaultLayoutSymbol, UniformRowLayoutSymbol } from './legacyLayoutSymbols.js';
 import defaultLayout from './defaultLayout.js';
 import uniformRowLayout from './uniformRowLayout.js';
 import fullWidthLayout from './fullWidthLayout.js';
-import LegacyMasonryLayout from './layouts/MasonryLayout.js';
-import LegacyUniformRowLayout from './layouts/UniformRowLayout.js';
 
 type Position = {| top: number, left: number, width: number, height: number |};
 
-type Layout =
-  | typeof DefaultLayoutSymbol
-  | typeof UniformRowLayoutSymbol
-  | LegacyMasonryLayout
-  | LegacyUniformRowLayout
-  | 'basic'
-  | 'basicCentered'
-  | 'flexible'
-  | 'serverRenderedFlexible'
-  | 'uniformRow';
+type Layout = 'basic' | 'basicCentered' | 'flexible' | 'serverRenderedFlexible' | 'uniformRow';
 
 type Props<T> = {|
   /**
@@ -55,7 +43,11 @@ type Props<T> = {|
    */
   items: $ReadOnlyArray<T>,
   /**
-   * MasonryUniformRowLayout will make it so that each row is as tall as the tallest item in that row.
+   * `basic`: Left aligned masonry layout.
+   * `basicCentered`: Center aligned masonry layout.
+   * `flexible`: Item width grows to fill column space and shrinks to fit if below min columns.
+   * `serverRenderedFlexible`: Item width grows to fill column space and shrinks to fit if below min columns. Main differerence with `flexible` is that we do not store the initial measurement. More context in [#2084](https://github.com/pinterest/gestalt/pull/2084)
+   * `uniformRow`: Items are laid out in a single row, with all items having the same height.
    */
   layout?: Layout,
   /**
@@ -461,11 +453,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
         idealColumnWidth: columnWidth,
         width,
       });
-    } else if (
-      layout === UniformRowLayoutSymbol ||
-      layout instanceof LegacyUniformRowLayout ||
-      layout === 'uniformRow'
-    ) {
+    } else if (layout === 'uniformRow') {
       getPositions = uniformRowLayout({
         cache: measurementStore,
         columnWidth,

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -34,8 +34,6 @@ import Letterbox from './Letterbox.js';
 import Link from './Link.js';
 import Mask from './Mask.js';
 import Masonry from './Masonry.js';
-import MasonryDefaultLayout from './layouts/MasonryLayout.js';
-import MasonryUniformRowLayout from './layouts/UniformRowLayout.js';
 import Modal from './Modal.js';
 import Module from './Module.js';
 import NumberField from './NumberField.js';
@@ -109,8 +107,6 @@ export {
   Link,
   Mask,
   Masonry,
-  MasonryDefaultLayout,
-  MasonryUniformRowLayout,
   Modal,
   Module,
   NumberField,

--- a/packages/gestalt/src/layouts/MasonryLayout.js
+++ b/packages/gestalt/src/layouts/MasonryLayout.js
@@ -1,2 +1,0 @@
-// @flow strict
-export default class MasonryLayout {}

--- a/packages/gestalt/src/layouts/UniformRowLayout.js
+++ b/packages/gestalt/src/layouts/UniformRowLayout.js
@@ -1,2 +1,0 @@
-// @flow strict
-export default class UniformRowLayout {}

--- a/packages/gestalt/src/legacyLayoutSymbols.js
+++ b/packages/gestalt/src/legacyLayoutSymbols.js
@@ -1,3 +1,0 @@
-// @flow strict
-export const DefaultLayoutSymbol: symbol = Symbol('default');
-export const UniformRowLayoutSymbol: symbol = Symbol('uniformRow');


### PR DESCRIPTION
### Summary

#### What changed?

1 way to specify masonry layouts: string enums

#### Why?

Masonry has 3 different ways to specify layouts:

1. As a string enum: `'basic' | 'basicCentered' | 'flexible' | 'serverRenderedFlexible' | 'uniformRow'`
2. As a class: `LegacyMasonryLayout | LegacyUniformRowLayout`
3. As a symbol: `typeof DefaultLayoutSymbol | typeof UniformRowLayoutSymbol`

These 3 different ways are confusing and we should stick to 1

#### Context

In https://github.com/pinterest/gestalt/pull/782 we introduced the option to specify masonry layouts as strings but never completed the conversion:

> Because extra exports are annoying and we already split on what to use, I'd like to update to one true system: strings.

### Related diffs

- https://phabricator.pinadmin.com/D906449 - Replaces all deprecated layouts in pinboard/webapp
- #2175 - Replaces `flexible` prop with `layout="flexible"`
