### PR TITLE
Table: fix sortable header cell args bug

### DIFF
--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -88,9 +88,9 @@ export default function TableSortableHeaderCell({
       <Box display="inlineBlock">
         <TapArea
           fullWidth={false}
-          onTap={({ event, dangerouslyDisableOnNavigation }) => {
+          onTap={(...args) => {
             setFocused(false);
-            onSortChange({ event, dangerouslyDisableOnNavigation });
+            onSortChange(...args);
           }}
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}


### PR DESCRIPTION
The previous version of this change was too specific, potentially yielding this error if the event had no args:
```
TypeError: Cannot destructure property 'event' of 'undefined' as it is undefined.
```
This PR makes the handler adapt to whatever args it's given.