### PR TITLE
Docs: Show code for top example and Do's

### DIFF
--- a/docs/components/ExampleCode.js
+++ b/docs/components/ExampleCode.js
@@ -51,7 +51,7 @@ export default function ExampleCode({
   }
 
   useEffect(() => {
-    const height = codeExampleRef?.current?.clientHeight;
+    const height = codeExampleRef?.current?.clientHeight ?? 0;
 
     // Save the height so we know how far to animate to
     setMaxHeight(`${height}px`);
@@ -112,11 +112,11 @@ export default function ExampleCode({
               onFocus={() => {
                 setExpanded(true);
               }}
-              aria-hidden={!expanded}
             >
               <div
                 className={!expanded ? 'LiveEditor__textarea__notExpanded' : undefined}
                 ref={codeExampleRef}
+                aria-hidden={!expanded}
               >
                 {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
                 {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}

--- a/docs/components/ExampleCode.js
+++ b/docs/components/ExampleCode.js
@@ -116,7 +116,6 @@ export default function ExampleCode({
               <div
                 className={!expanded ? 'LiveEditor__textarea__notExpanded' : undefined}
                 ref={codeExampleRef}
-                aria-hidden={!expanded}
               >
                 {/* We can not pass in an id for LiveEditor which links to the underlying text area */}
                 {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}

--- a/docs/components/MainSectionCard.js
+++ b/docs/components/MainSectionCard.js
@@ -8,6 +8,8 @@ import ExampleCode from './ExampleCode.js';
 import theme from './atomDark.js';
 import Markdown from './Markdown.js';
 import { capitalizeFirstLetter } from './utils.js';
+import OpenSandboxButton from './buttons/OpenSandboxButton.js';
+import handleCodeSandbox from './handleCodeSandbox.js';
 
 type Props = {|
   cardSize?: 'sm' | 'md' | 'lg',
@@ -58,6 +60,7 @@ function MainSectionCard({
   // Only show code if it's a md or lg card and it's not a Do/Don't
   const shouldShowCode = showCode && cardSize !== 'sm' && type === 'info';
   const showTitleAndDescriptionAboveExample = cardSize === 'lg' && type === 'info';
+
   const cardShadeColor = shaded && !shadeColor ? 'secondary' : shadeColor;
 
   const PreviewCard = useCallback(
@@ -88,10 +91,17 @@ function MainSectionCard({
       }}
     >
       {(title || type !== 'info') && (
-        <Box paddingY={1}>
+        <Box paddingY={1} display="flex" justifyContent="between">
           <Text weight="bold" color={TYPE_TO_COLOR[type]}>
             {cardTitle || capitalizeFirstLetter(type)}
           </Text>
+          {type === 'do' && code && (
+            <OpenSandboxButton
+              onClick={() => {
+                handleCodeSandbox({ code, title: cardTitle || '' });
+              }}
+            />
+          )}
         </Box>
       )}
       {description && (
@@ -123,6 +133,7 @@ function MainSectionCard({
           </Box>
         </LiveProvider>
       )}
+
       {iframeContent && code && (
         <LiveProvider code={code} scope={scope} theme={theme}>
           {shouldShowCode && <ExampleCode readOnly code={code} name={cardTitle || ''} />}

--- a/docs/components/MainSectionCard.js
+++ b/docs/components/MainSectionCard.js
@@ -16,6 +16,7 @@ type Props = {|
   children?: Node,
   defaultCode?: string,
   description?: string,
+  hideCodePreview?: boolean,
   iframeContent?: string,
   shadeColor?: 'tertiary' | 'darkWash' | 'lightWash' | 'default',
   shaded?: boolean,
@@ -46,6 +47,7 @@ function MainSectionCard({
   defaultCode,
   description,
   iframeContent,
+  hideCodePreview = false,
   shaded = false,
   shadeColor,
   showCode = true,
@@ -124,7 +126,9 @@ function MainSectionCard({
             <LivePreview style={{ display: 'contents' }} />
           </PreviewCard>
           {/* If it uses an iframe, show the original code (below), instead of the iframe code */}
-          {shouldShowCode && !iframeContent && <ExampleCode code={code} name={cardTitle || ''} />}
+          {shouldShowCode && !iframeContent && (
+            <ExampleCode hideCodePreview={hideCodePreview} code={code} name={cardTitle || ''} />
+          )}
 
           <Box paddingX={2}>
             <Text color="error">

--- a/docs/components/PageHeader.js
+++ b/docs/components/PageHeader.js
@@ -106,6 +106,7 @@ export default function PageHeader({
                 defaultCode={defaultCode}
                 shaded={shadedCodeExample}
                 showCode={showCode}
+                hideCodePreview
               />
             )}
           </Flex>

--- a/docs/components/PageHeader.js
+++ b/docs/components/PageHeader.js
@@ -22,6 +22,7 @@ type Props = {|
   description?: string,
   fileName?: string, // only use if name !== file name
   folderName?: string, // only use if name !== file name and the link should point to a directory
+  showCode?: boolean,
   name: string,
   shadedCodeExample?: boolean,
   slimBanner?: Element<typeof SlimBanner> | null,
@@ -34,6 +35,7 @@ export default function PageHeader({
   description = '',
   fileName,
   folderName,
+  showCode = true,
   name,
   shadedCodeExample,
   slimBanner = null,
@@ -101,9 +103,9 @@ export default function PageHeader({
             {defaultCode && (
               <MainSection.Card
                 cardSize="lg"
-                showCode={false}
                 defaultCode={defaultCode}
                 shaded={shadedCodeExample}
+                showCode={showCode}
               />
             )}
           </Flex>

--- a/docs/components/PageHeaderQualitySummary.js
+++ b/docs/components/PageHeaderQualitySummary.js
@@ -33,7 +33,7 @@ export default function PageHeaderQualitySumary({ name }: Props): Node {
       <Flex wrap>
         {['figma', 'responsive', 'iOS', 'android', 'accessible'].map((item, index) => (
           <Flex key={`summary-${index}`}>
-            <Box paddingX={4}>
+            <Box paddingX={4} marginBottom={2}>
               <Flex gap={2}>
                 <Text size="200" weight="bold">
                   {`${

--- a/docs/components/QualityChecklist.js
+++ b/docs/components/QualityChecklist.js
@@ -35,7 +35,7 @@ export default function QualityChecklist({ component }: Props): Node {
           <Box display="visuallyHidden">
             <Table.Header>
               <Table.Row>
-                {['Quality item', 'Status', 'Status descripyion'].map((header) => (
+                {['Quality item', 'Status', 'Status description'].map((header) => (
                   <Table.HeaderCell key={header.replace(' ', '_')}>
                     <Text weight="bold">{header}</Text>
                   </Table.HeaderCell>

--- a/docs/pages/activationcard.js
+++ b/docs/pages/activationcard.js
@@ -16,7 +16,27 @@ export default function ActivationCardPage({
 |}): Node {
   return (
     <Page title="ActivationCard">
-      <PageHeader name="ActivationCard" description={generatedDocGen?.description} />
+      <PageHeader
+        name="ActivationCard"
+        description={generatedDocGen?.description}
+        defaultCode={`
+<ActivationCard
+  dismissButton={{
+    accessibilityLabel: 'Dismiss card',
+    onDismiss: ()=>{},
+  }}
+  link={{
+    href: "https://pinterest.com",
+    label:"Learn more",
+    accessibilityLabel: "Learn more: website claim status"
+  }}
+  message="We will notify you via email as soon as your site has been successfully claimed."
+  status="pending"
+  statusMessage="Pending"
+  title="Claim your website"
+/>
+  `}
+      />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/avatargroup.js
+++ b/docs/pages/avatargroup.js
@@ -18,24 +18,24 @@ export default function AvatarGroupPage({ generatedDocGen }: {| generatedDocGen:
         name="AvatarGroup"
         description={generatedDocGen?.description}
         defaultCode={`
-  <Box width={300} height={125}>
-    <AvatarGroup size="fit" accessibilityLabel="Collaborators: Keerthi, Alberto, Shanice."
-      collaborators={[
+<Box width={300} height={125}>
+  <AvatarGroup size="fit" accessibilityLabel="Collaborators: Keerthi, Alberto, Shanice."
+    collaborators={[
+      {
+        name: 'Keerthi',
+        src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
+      },
+      {
+        name: 'Alberto',
+        src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
+      },
         {
-          name: 'Keerthi',
-          src: 'https://i.ibb.co/ZfCZrY8/keerthi.jpg',
-        },
-        {
-          name: 'Alberto',
-          src: 'https://i.ibb.co/NsK2w5y/Alberto.jpg',
-        },
-          {
-          name: 'Shanice',
-          src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
-        },
-      ]}
-    />
-  </Box>
+        name: 'Shanice',
+        src: 'https://i.ibb.co/7tGKGvb/shanice.jpg',
+      },
+    ]}
+  />
+</Box>
   `}
       />
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/badge.js
+++ b/docs/pages/badge.js
@@ -16,7 +16,7 @@ export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGe
         name="Badge"
         description={generatedDocGen?.description}
         defaultCode={`
-      <Text>Update your pronouns in your profile settings <Badge text="New" /></Text>
+<Text>Update your pronouns in your profile settings <Badge text="New" /></Text>
     `}
       />
 

--- a/docs/pages/button.js
+++ b/docs/pages/button.js
@@ -17,9 +17,9 @@ export default function ButtonPage({ generatedDocGen }: {| generatedDocGen: DocG
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
         defaultCode={`
-      <Flex>
-        <Button color='red' size='lg' text='Save' />
-      </Flex>
+<Flex>
+  <Button color='red' size='lg' text='Save' />
+</Flex>
     `}
       />
       <PropTable

--- a/docs/pages/callout.js
+++ b/docs/pages/callout.js
@@ -16,28 +16,28 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         name="Callout"
         description={generatedDocGen?.description}
         defaultCode={`
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss this banner',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Info"
-      message="Apply to the Verified Merchant Program"
-      primaryAction={{
-        accessibilityLabel: "Get started: Verified Merchant Program",
-        href: "https://pinterest.com",
-        label: "Get started",
-        target: "blank",
-      }}
-      secondaryAction={{
-        accessibilityLabel: "Learn more: Verified Merchant Program",
-        href: "https://pinterest.com",
-        label: "Learn more",
-        target: "blank",
-      }}
-      title="Your business account was created!"
-      type="info"
-    />
+<Callout
+  dismissButton={{
+    accessibilityLabel: 'Dismiss this banner',
+    onDismiss: () => {},
+  }}
+  iconAccessibilityLabel="Info"
+  message="Apply to the Verified Merchant Program"
+  primaryAction={{
+    accessibilityLabel: "Get started: Verified Merchant Program",
+    href: "https://pinterest.com",
+    label: "Get started",
+    target: "blank",
+  }}
+  secondaryAction={{
+    accessibilityLabel: "Learn more: Verified Merchant Program",
+    href: "https://pinterest.com",
+    label: "Learn more",
+    target: "blank",
+  }}
+  title="Your business account was created!"
+  type="info"
+/>
     `}
       />
 

--- a/docs/pages/datepicker.js
+++ b/docs/pages/datepicker.js
@@ -87,17 +87,17 @@ export default function DatePickerPage({ generatedDocGen }: {| generatedDocGen: 
         name="DatePicker"
         description={generatedDocGen?.description}
         defaultCode={`
-      function DatePickerExample() {
-        const handleChange = (value) => value;
+function DatePickerExample() {
+  const handleChange = (value) => value;
 
-        return (
-          <DatePicker
-            id="example-page-header"
-            label="Select a date"
-            onChange={({ value }) => handleChange(value)}
-          />
-        )
-      }
+  return (
+    <DatePicker
+      id="example-page-header"
+      label="Select a date"
+      onChange={({ value }) => handleChange(value)}
+    />
+  )
+}
     `}
       />
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/dropdown.js
+++ b/docs/pages/dropdown.js
@@ -22,63 +22,64 @@ export default function DropdownPage({
         description={generatedDocGen.Dropdown?.description}
         badge="pilot"
         defaultCode={`
-      function IntroMenuButtonDropdownExample() {
-        const [open, setOpen] = React.useState(false);
-        const [selected, setSelected] = React.useState(null);
-        const anchorRef = React.useRef(null);
-        const onSelect = ({ item }) => setSelected(item);
+function IntroMenuButtonDropdownExample() {
+  const [open, setOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState(null);
+  const anchorRef = React.useRef(null);
+  const onSelect = ({ item }) => setSelected(item);
 
-        return (
-          <Flex justifyContent="center">
-            <Button
-              accessibilityControls="demo-dropdown-example"
-              accessibilityExpanded={open}
-              accessibilityHaspopup
-              iconEnd="arrow-down"
-              onClick={() => setOpen((prevVal) => !prevVal)}
-              ref={anchorRef}
-              selected={open}
-              size="lg"
-              text="Menu"
-            />
-            {open && (
-              <Dropdown anchor={anchorRef.current} id="demo-dropdown-example" onDismiss={() => setOpen(false)}>
-                <Dropdown.Item
-                  onSelect={onSelect}
-                  option={{ value: "item 1", label: "Item 1" }}
-                  selected={selected}
-                />
-                <Dropdown.Item
-                  onSelect={onSelect}
-                  option={{ value: "item 2", label: "Item 2 with a really long, detailed, complex name" }}
-                  selected={selected}
-                />
-                <Dropdown.Link
-                  href="https://pinterest.com"
-                  isExternal
-                  option={{ value: "item 3", label: "Item 3 with a really long, detailed, complex name" }}
-                />
-                <Dropdown.Item
-                  badge={{ text: 'New' }}
-                  onSelect={onSelect}
-                  option={{ value: "item 4", label: "Item 4" }}
-                  selected={selected}
-                />
-                <Dropdown.Link
-                  badge={{ text: 'New' }}
-                  href="https://pinterest.com"
-                  isExternal
-                  option={{ value: "item 5", label: "Item 5 with a really long, detailed name" }}
-                />
-                <Dropdown.Link
-                  href="/combobox"
-                  option={{ value: "item 6", label: "Item 6 navigates internally" }}
-                />
-              </Dropdown>
-            )}
-          </Flex>
-        );
-      }`}
+  return (
+    <Flex justifyContent="center">
+      <Button
+        accessibilityControls="demo-dropdown-example"
+        accessibilityExpanded={open}
+        accessibilityHaspopup
+        iconEnd="arrow-down"
+        onClick={() => setOpen((prevVal) => !prevVal)}
+        ref={anchorRef}
+        selected={open}
+        size="lg"
+        text="Menu"
+      />
+      {open && (
+        <Dropdown anchor={anchorRef.current} id="demo-dropdown-example" onDismiss={() => setOpen(false)}>
+          <Dropdown.Item
+            onSelect={onSelect}
+            option={{ value: "item 1", label: "Item 1" }}
+            selected={selected}
+          />
+          <Dropdown.Item
+            onSelect={onSelect}
+            option={{ value: "item 2", label: "Item 2 with a really long, detailed, complex name" }}
+            selected={selected}
+          />
+          <Dropdown.Link
+            href="https://pinterest.com"
+            isExternal
+            option={{ value: "item 3", label: "Item 3 with a really long, detailed, complex name" }}
+          />
+          <Dropdown.Item
+            badge={{ text: 'New' }}
+            onSelect={onSelect}
+            option={{ value: "item 4", label: "Item 4" }}
+            selected={selected}
+          />
+          <Dropdown.Link
+            badge={{ text: 'New' }}
+            href="https://pinterest.com"
+            isExternal
+            option={{ value: "item 5", label: "Item 5 with a really long, detailed name" }}
+          />
+          <Dropdown.Link
+            href="/combobox"
+            option={{ value: "item 6", label: "Item 6 navigates internally" }}
+          />
+        </Dropdown>
+      )}
+    </Flex>
+  );
+}
+      `}
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen.Dropdown} />

--- a/docs/pages/fieldset.js
+++ b/docs/pages/fieldset.js
@@ -17,49 +17,49 @@ export default function FieldsetPage({ generatedDocGen }: {| generatedDocGen: Do
         badge="pilot"
         description={generatedDocGen?.description}
         defaultCode={`
-      function RadioButtonExample() {
-        const [favorite, setFavorite] = React.useState(undefined);
+function RadioButtonExample() {
+  const [favorite, setFavorite] = React.useState(undefined);
 
-        return (
-          <Fieldset legend="What is your favorite pet?">
-            <Flex direction="column" gap={2}>
-              <RadioButton
-                checked={favorite === 'dogs'}
-                id="favoriteDog"
-                label="Dogs"
-                name="favorite"
-                onChange={() => setFavorite( 'dogs' )}
-                value="dogs"
-              />
-              <RadioButton
-                checked={favorite === 'cats'}
-                id="favoriteCat"
-                label="Cats"
-                name="favorite"
-                onChange={() => setFavorite( 'cats' )}
-                value="cats"
-              />
-              <RadioButton
-                checked={favorite === 'plants'}
-                id="favoritePlants"
-                label="Plants"
-                name="favorite"
-                onChange={() => setFavorite( 'plants' )}
-                value="plants"
-              />
-              <RadioButton
-                checked={favorite === 'peeves'}
-                id="favoritePeeves"
-                label="Peeves"
-                name="favorite"
-                onChange={() => setFavorite( 'peeves' )}
-                value="peeves"
-              />
-            </Flex>
-          </Fieldset>
+  return (
+    <Fieldset legend="What is your favorite pet?">
+      <Flex direction="column" gap={2}>
+        <RadioButton
+          checked={favorite === 'dogs'}
+          id="favoriteDog"
+          label="Dogs"
+          name="favorite"
+          onChange={() => setFavorite( 'dogs' )}
+          value="dogs"
+        />
+        <RadioButton
+          checked={favorite === 'cats'}
+          id="favoriteCat"
+          label="Cats"
+          name="favorite"
+          onChange={() => setFavorite( 'cats' )}
+          value="cats"
+        />
+        <RadioButton
+          checked={favorite === 'plants'}
+          id="favoritePlants"
+          label="Plants"
+          name="favorite"
+          onChange={() => setFavorite( 'plants' )}
+          value="plants"
+        />
+        <RadioButton
+          checked={favorite === 'peeves'}
+          id="favoritePeeves"
+          label="Peeves"
+          name="favorite"
+          onChange={() => setFavorite( 'peeves' )}
+          value="peeves"
+        />
+      </Flex>
+    </Fieldset>
 
-        );
-      }
+  );
+}
 `}
       />
 

--- a/docs/pages/link.js
+++ b/docs/pages/link.js
@@ -12,7 +12,16 @@ import AccessibilitySection from '../components/AccessibilitySection.js';
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        defaultCode={`
+<Text inline>
+  Find tips and best practices on the
+  <Link href="https://business.pinterest.com/" inline> Pinterest Business Site </Link>
+</Text>
+        `}
+      />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} excludeProps={['disabled']} />
 

--- a/docs/pages/modal.js
+++ b/docs/pages/modal.js
@@ -16,12 +16,13 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
         name="Modal"
         description={generatedDocGen?.description}
         defaultCode={`
-<iframe src="https://codesandbox.io/embed/trusting-wu-c8514?fontsize=14&hidenavigation=1&theme=light&view=preview"
-style={{width: '100%', height:'500px', border:'0', borderRadius: '4px', overflow:'hidden'}}
-title="Modal Main Example"
-sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-></iframe>
-    `}
+          <iframe src="https://codesandbox.io/embed/trusting-wu-c8514?fontsize=14&hidenavigation=1&theme=light&view=preview"
+          style={{width: '100%', height:'500px', border:'0', borderRadius: '4px', overflow:'hidden'}}
+          title="Modal Main Example"
+          sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+          ></iframe>
+        `}
+        showCode={false}
       />
       <GeneratedPropTable
         generatedDocGen={generatedDocGen}

--- a/docs/pages/pog.js
+++ b/docs/pages/pog.js
@@ -16,10 +16,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         name="Pog"
         description={generatedDocGen?.description}
         defaultCode={`
-<Pog
-  icon="heart"
-  iconColor="red"
-/>
+<Pog icon="heart" iconColor="red"/>
 `}
       />
 

--- a/docs/pages/pulsar.js
+++ b/docs/pages/pulsar.js
@@ -16,24 +16,24 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         name="Pulsar"
         description={generatedDocGen?.description}
         defaultCode={`
-  function PulsarExample() {
-    const [isPulsing, setIsPulsing] = React.useState(true);
+function PulsarExample() {
+  const [isPulsing, setIsPulsing] = React.useState(true);
 
-    const text = isPulsing ? 'Click to pause' : 'Click to show';
+  const text = isPulsing ? 'Click to pause' : 'Click to show';
 
-    return (
-      <Box display="flex" direction="column">
-        <Box marginBottom={4}>
-          <Button
-            text={text}
-            onClick={() => setIsPulsing(!isPulsing)}
-            size="md"
-          />
-        </Box>
-        <Pulsar paused={!isPulsing} />
+  return (
+    <Box display="flex" direction="column">
+      <Box marginBottom={4}>
+        <Button
+          text={text}
+          onClick={() => setIsPulsing(!isPulsing)}
+          size="md"
+        />
       </Box>
-    );
-  }
+      <Pulsar paused={!isPulsing} />
+    </Box>
+  );
+}
 `}
       />
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/radiogroup.js
+++ b/docs/pages/radiogroup.js
@@ -19,46 +19,46 @@ export default function DocsPage({
         name={generatedDocGen.RadioGroup.displayName}
         description={generatedDocGen.RadioGroup?.description}
         defaultCode={`
-      function RadioButtonExample() {
-        const [favorite, setFavorite] = React.useState();
+function RadioButtonExample() {
+  const [favorite, setFavorite] = React.useState();
 
-        return (
-          <RadioGroup legend="Gender" id="header-example">
-            <RadioGroup.RadioButton
-              checked={favorite === 'Female'}
-              id="genderFemale"
-              label="Female"
-              name="gender-pref"
-              onChange={() => setFavorite('Female')}
-              value="Female"
-            />
-            <RadioGroup.RadioButton
-              checked={favorite === 'Male'}
-              id="genderMale"
-              label="Male"
-              name="gender-pref"
-              onChange={() => setFavorite('Male')}
-              value="Male"
-            />
-            <RadioGroup.RadioButton
-              checked={favorite === 'Non-binary'}
-              id="genderNon-binary"
-              label="Non-binary"
-              name="gender-pref"
-              onChange={() => setFavorite('Non-binary')}
-              value="Non-binary"
-            />
-            <RadioGroup.RadioButton
-              checked={favorite === 'Prefer not to state'}
-              id="genderPrefer not to state"
-              label="Prefer not to state"
-              name="gender-pref"
-              onChange={() => setFavorite('Prefer not to state')}
-              value="Prefer not to state"
-            />
-          </RadioGroup>
-        );
-      }
+  return (
+    <RadioGroup legend="Gender" id="header-example">
+      <RadioGroup.RadioButton
+        checked={favorite === 'Female'}
+        id="genderFemale"
+        label="Female"
+        name="gender-pref"
+        onChange={() => setFavorite('Female')}
+        value="Female"
+      />
+      <RadioGroup.RadioButton
+        checked={favorite === 'Male'}
+        id="genderMale"
+        label="Male"
+        name="gender-pref"
+        onChange={() => setFavorite('Male')}
+        value="Male"
+      />
+      <RadioGroup.RadioButton
+        checked={favorite === 'Non-binary'}
+        id="genderNon-binary"
+        label="Non-binary"
+        name="gender-pref"
+        onChange={() => setFavorite('Non-binary')}
+        value="Non-binary"
+      />
+      <RadioGroup.RadioButton
+        checked={favorite === 'Prefer not to state'}
+        id="genderPrefer not to state"
+        label="Prefer not to state"
+        name="gender-pref"
+        onChange={() => setFavorite('Prefer not to state')}
+        value="Prefer not to state"
+      />
+    </RadioGroup>
+  );
+}
       `}
       />
 

--- a/docs/pages/selectlist.js
+++ b/docs/pages/selectlist.js
@@ -16,20 +16,20 @@ export default function SelectListPage({ generatedDocGen }: {| generatedDocGen: 
         name="SelectList"
         description={generatedDocGen?.description}
         defaultCode={`
-      <SelectList
-        id="selectlistexample1"
-        onChange={() => {}}
-        options={[
-          {label:'Algeria', value: 'algeria'},
-          {label:'Belgium', value: 'belgium'},
-          {label:'Canada', value: 'canada'},
-          {label:'Denmark', value: 'denmark'},
-          {label:'Egypt', value: 'egypt'},
-          {label:'France', value: 'france'},
-        ]}
-        size='lg'
-        label='Country'
-      />
+<SelectList
+  id="selectlistexample1"
+  onChange={() => {}}
+  options={[
+    {label:'Algeria', value: 'algeria'},
+    {label:'Belgium', value: 'belgium'},
+    {label:'Canada', value: 'canada'},
+    {label:'Denmark', value: 'denmark'},
+    {label:'Egypt', value: 'egypt'},
+    {label:'France', value: 'france'},
+  ]}
+  size='lg'
+  label='Country'
+/>
     `}
       />
 

--- a/docs/pages/sheet.js
+++ b/docs/pages/sheet.js
@@ -23,6 +23,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
     ></iframe>
 `}
+        showCode={false}
       />
       <PropTable
         props={[

--- a/docs/pages/switch.js
+++ b/docs/pages/switch.js
@@ -15,24 +15,24 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         name="Switch"
         description={generatedDocGen?.description}
         defaultCode={`
-      function SwitchExample() {
-        const [switched, setSwitched] = React.useState(false);
+function SwitchExample() {
+  const [switched, setSwitched] = React.useState(false);
 
-        return (
-          <Box display="flex" alignItems="center">
-            <Box paddingX={2}>
-              <Label htmlFor="introExample">
-                <Text>Airplane mode</Text>
-              </Label>
-            </Box>
-            <Switch
-              onChange={() => setSwitched(!switched)}
-              id="introExample"
-              switched={switched}
-            />
-          </Box>
-        );
-      }
+  return (
+    <Box display="flex" alignItems="center">
+      <Box paddingX={2}>
+        <Label htmlFor="introExample">
+          <Text>Airplane mode</Text>
+        </Label>
+      </Box>
+      <Switch
+        onChange={() => setSwitched(!switched)}
+        id="introExample"
+        switched={switched}
+      />
+    </Box>
+  );
+}
       `}
       />
 

--- a/docs/pages/tabs.js
+++ b/docs/pages/tabs.js
@@ -17,22 +17,22 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         name="Tabs"
         description={generatedDocGen?.description}
         defaultCode={`
-    function DefaultExample() {
-      const [activeIndex, setActiveIndex] = React.useState(0);
+function DefaultExample() {
+  const [activeIndex, setActiveIndex] = React.useState(0);
 
-      return (
-        <Tabs
-          activeTabIndex={activeIndex}
-          onChange={({ activeTabIndex }) => { setActiveIndex(activeTabIndex); }}
-          tabs={[
-            { href: "#", text: "Explore", indicator: "dot" },
-            { href: "#", text: "Shop" },
-            { href: "#", text: "Profiles" },
-          ]}
-          wrap
-        />
-      );
-    }
+  return (
+    <Tabs
+      activeTabIndex={activeIndex}
+      onChange={({ activeTabIndex }) => { setActiveIndex(activeTabIndex); }}
+      tabs={[
+        { href: "#", text: "Explore", indicator: "dot" },
+        { href: "#", text: "Shop" },
+        { href: "#", text: "Profiles" },
+      ]}
+      wrap
+    />
+  );
+}
     `}
       />
 

--- a/docs/pages/textarea.js
+++ b/docs/pages/textarea.js
@@ -16,21 +16,21 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
         defaultCode={`
-      function Example(props) {
-        const [value, setValue] = React.useState('')
-        return (
-          <Box width="100%">
-            <TextArea
-              id="headerExample"
-              onChange={({value}) => setValue(value)}
-              placeholder="Write something about yourself..."
-              label="About me"
-              value={value}
-            />
-          </Box>
-        );
-      }
-          `}
+function Example(props) {
+  const [value, setValue] = React.useState('')
+  return (
+    <Box width="100%">
+      <TextArea
+        id="headerExample"
+        onChange={({value}) => setValue(value)}
+        placeholder="Write something about yourself..."
+        label="About me"
+        value={value}
+      />
+    </Box>
+  );
+}
+        `}
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/toast.js
+++ b/docs/pages/toast.js
@@ -39,7 +39,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     />
   }
 />
-              `}
+        `}
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/tooltip.js
+++ b/docs/pages/tooltip.js
@@ -30,36 +30,36 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           />
         }
         defaultCode={`
-      <Flex>
-        <Tooltip text="Align left" accessibilityLabel="">
-          <IconButton
-            accessibilityLabel="Align left"
-            bgColor="white"
-            icon="text-align-left"
-            iconColor="darkGray"
-            size="lg"
-          />
-        </Tooltip>
-        <Tooltip text="Align center" accessibilityLabel="">
-          <IconButton
-            accessibilityLabel="Align center"
-            bgColor="white"
-            icon="text-align-center"
-            iconColor="darkGray"
-            size="lg"
-          />
-        </Tooltip>
-        <Tooltip text="Align right" accessibilityLabel="">
-          <IconButton
-            accessibilityLabel="Align right"
-            bgColor="white"
-            icon="text-align-right"
-            iconColor="darkGray"
-            size="lg"
-          />
-        </Tooltip>
-      </Flex>
-    `}
+<Flex>
+  <Tooltip text="Align left" accessibilityLabel="">
+    <IconButton
+      accessibilityLabel="Align left"
+      bgColor="white"
+      icon="text-align-left"
+      iconColor="darkGray"
+      size="lg"
+    />
+  </Tooltip>
+  <Tooltip text="Align center" accessibilityLabel="">
+    <IconButton
+      accessibilityLabel="Align center"
+      bgColor="white"
+      icon="text-align-center"
+      iconColor="darkGray"
+      size="lg"
+    />
+  </Tooltip>
+  <Tooltip text="Align right" accessibilityLabel="">
+    <IconButton
+      accessibilityLabel="Align right"
+      bgColor="white"
+      icon="text-align-right"
+      iconColor="darkGray"
+      size="lg"
+    />
+  </Tooltip>
+</Flex>
+        `}
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/upsell.js
+++ b/docs/pages/upsell.js
@@ -20,29 +20,29 @@ export default function DocsPage({
         name={generatedDocGen?.Upsell?.displayName}
         description={generatedDocGen?.Upsell?.description}
         defaultCode={`
-      <Upsell
-        dismissButton={{
-          accessibilityLabel: 'Dismiss banner',
-          onDismiss: () => {},
-        }}
-        imageData={{
-          component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
-        }}
-        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-        primaryAction={{
-          accessibilityLabel: "Send ads invite",
-          href: 'https://pinterest.com',
-          label: 'Send invite',
-          target: 'blank',
-        }}
-        secondaryAction={{
-          accessibilityLabel: 'Learn more: Verified Merchant Program',
-          href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
-          label: 'Learn more',
-          target: 'blank',
-        }}
-        title="Give $30, get $60 in ads credit"
-      />;
+<Upsell
+  dismissButton={{
+    accessibilityLabel: 'Dismiss banner',
+    onDismiss: () => {},
+  }}
+  imageData={{
+    component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
+  }}
+  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+  primaryAction={{
+    accessibilityLabel: "Send ads invite",
+    href: 'https://pinterest.com',
+    label: 'Send invite',
+    target: 'blank',
+  }}
+  secondaryAction={{
+    accessibilityLabel: 'Learn more: Verified Merchant Program',
+    href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
+    label: 'Learn more',
+    target: 'blank',
+  }}
+  title="Give $30, get $60 in ads credit"
+/>;
     `}
       />
 


### PR DESCRIPTION
### Summary

#### What changed?

Added the ability to see the code for our top-most header examples on component pages
Also added a way to see the code for Best Practice Do's

#### Why?

Make it easier to see the code behind our examples and learn what to do for best practices

Header Before:
![Screen Shot 2022-07-05 at 2 44 12 PM](https://user-images.githubusercontent.com/5125094/177421905-c570a0e3-3041-4522-9378-d6301b7dbf29.png)


Header After:
![Screen Shot 2022-07-05 at 2 42 05 PM](https://user-images.githubusercontent.com/5125094/177421483-0a74ffda-1840-4349-bee5-20177a13acf1.png)

Best Practices Before:
![Screen Shot 2022-07-05 at 2 47 22 PM](https://user-images.githubusercontent.com/5125094/177422329-8555560e-506f-4925-b536-2cf90318b86c.png)

Best Practices After:
![Screen Shot 2022-07-05 at 2 47 15 PM](https://user-images.githubusercontent.com/5125094/177422327-3f2a8537-5d63-4575-8845-2e7daf828faa.png)


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4579) and [Jira](https://jira.pinadmin.com/browse/GESTALT-4580)


### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
