### PR TITLE
Docs: New top navigation

### DIFF
--- a/docs/components/DocSearch.js
+++ b/docs/components/DocSearch.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node, useEffect } from 'react';
-import { CompositeZIndex, Tooltip } from 'gestalt';
+import { Box, CompositeZIndex, Icon, Tooltip } from 'gestalt';
 
 function filterKeyboardEvent(event: KeyboardEvent) {
   const target = event.target || event.srcElement;
@@ -71,6 +71,9 @@ export default function DocSearch({ popoverZIndex }: {| popoverZIndex?: Composit
             placeholder="Search Gestalt"
             aria-label="Search Gestalt docs"
           />
+          <Box position="absolute" top left marginTop={3} marginStart={4}>
+            <Icon icon="search" accessibilityLabel="" size="16" color="default" />
+          </Box>
         </div>
       </form>
     </Tooltip>

--- a/docs/components/Header.js
+++ b/docs/components/Header.js
@@ -24,6 +24,8 @@ import { useNavigationContext } from './navigationContext.js';
 function Header() {
   const { isSidebarOpen, setIsSidebarOpen } = useNavigationContext();
   const [isSettingsDropdownOpen, setSettingsDropdownOpen] = useState(false);
+  const [isMobileSearchExpandedOpen, setMobileSearchExpanded] = useState(false);
+
   const [activeTab, setActiveTab] = useState(0);
 
   const anchorRef = useRef(null);
@@ -63,7 +65,11 @@ function Header() {
     >
       <Box marginStart={-2} marginEnd={2} display="flex" alignItems="center">
         {/* Small-screen menu button */}
-        <Box display="flex" mdDisplay="none" alignItems="center">
+        <Box
+          display={isMobileSearchExpandedOpen ? 'none' : 'flex'}
+          mdDisplay="none"
+          alignItems="center"
+        >
           <IconButton
             size="md"
             accessibilityLabel={`${isSidebarOpen ? 'Hide' : 'Show'} Menu`}
@@ -75,29 +81,33 @@ function Header() {
             }}
           />
         </Box>
-        {/* <Text> is out here to get proper underline styles on link */}
-        <Text color="default" weight="bold">
-          <Link
-            accessibilityLabel="Gestalt home"
-            href="/"
-            onClick={() => trackButtonClick('Gestalt logo')}
-          >
-            <Box paddingX={2}>
-              <Flex alignItems="center" gap={2}>
-                <GestaltLogo height={40} width={40} />
-                {/* slight tweak to vertically center to logo */}
-                <Box
-                  display="none"
-                  mdDisplay="block"
-                  dangerouslySetInlineStyle={{ __style: { marginBottom: '1px' } }}
-                >
-                  Gestalt Design System
-                </Box>
-              </Flex>
-            </Box>
-          </Link>
-        </Text>
-        <Box paddingX={2}>
+        <Box display={isMobileSearchExpandedOpen ? 'none' : 'flex'}>
+          {/* <Text> is out here to get proper underline styles on link */}
+          <Text color="default" weight="bold">
+            <Link
+              accessibilityLabel="Gestalt home"
+              href="/"
+              onClick={() => trackButtonClick('Gestalt logo')}
+            >
+              <Box paddingX={2}>
+                <Flex alignItems="center" gap={2}>
+                  <GestaltLogo height={40} width={40} />
+                  {/* slight tweak to vertically center to logo */}
+                  <Box
+                    display="none"
+                    mdDisplay="block"
+                    dangerouslySetInlineStyle={{ __style: { marginBottom: '1px' } }}
+                  >
+                    Gestalt Design System
+                  </Box>
+                </Flex>
+              </Box>
+            </Link>
+          </Text>
+        </Box>
+      </Box>
+      <Flex alignItems="center" justifyContent="end" flex="grow">
+        <Box paddingX={2} display={isMobileSearchExpandedOpen ? 'none' : 'flex'}>
           <IconButton
             accessibilityControls="site-settings-dropdown"
             accessibilityExpanded={isSettingsDropdownOpen}
@@ -152,33 +162,56 @@ function Header() {
             </Dropdown.Item>
           </Dropdown>
         )}
-      </Box>
 
-      {/* Spacer element */}
-      <Box display="none" mdDisplay="block" flex="grow">
-        <Flex justifyContent="center">
-          <Tabs
-            activeTabIndex={activeTab}
-            onChange={({ activeTabIndex }) => {
-              setActiveTab(activeTabIndex);
-            }}
-            tabs={[
-              { href: 'https://gestalt.pinterest.systems/about_us', text: 'Get started' },
-              { href: 'https://gestalt.pinterest.systems/component_overview', text: 'Components' },
-              { href: 'https://gestalt.pinterest.systems/accessibility', text: 'Foundations' },
-              { href: '#', text: 'Design patterns' },
-              { href: 'https://gestalt.pinterest.systems/roadmap', text: 'Roadmap' },
-            ]}
-            wrap
-          />
-        </Flex>
-      </Box>
-
-      <Box alignItems="center" display="flex" flex="shrink" marginStart={2} mdMarginStart={0}>
-        <Box paddingX={2}>
-          <DocSearch popoverZIndex={POPOVER_ZINDEX} />
+        <Box display="none" mdDisplay="block" flex="grow">
+          <Flex justifyContent="center">
+            <Tabs
+              activeTabIndex={activeTab}
+              onChange={({ activeTabIndex }) => {
+                setActiveTab(activeTabIndex);
+              }}
+              tabs={[
+                { href: '/about_us', text: 'Get started' },
+                {
+                  href: '/component_overview',
+                  text: 'Components',
+                },
+                { href: '/accessibility', text: 'Foundations' },
+                { href: '/roadmap', text: 'Roadmap' },
+              ]}
+              wrap
+            />
+          </Flex>
         </Box>
-      </Box>
+
+        <Box
+          alignItems="center"
+          display={isMobileSearchExpandedOpen ? 'flex' : 'none'}
+          mdDisplay="flex"
+          flex="shrink"
+          marginStart={2}
+          mdMarginStart={0}
+        >
+          <Box paddingX={2}>
+            <DocSearch popoverZIndex={POPOVER_ZINDEX} />
+          </Box>
+        </Box>
+        <Box display="block" mdDisplay="none" marginStart={2}>
+          <IconButton
+            accessibilityControls="site-settings-dropdown"
+            accessibilityExpanded={isSettingsDropdownOpen}
+            accessibilityHaspopup
+            accessibilityLabel="Search Gestalt"
+            icon={isMobileSearchExpandedOpen ? 'cancel' : 'search'}
+            iconColor="darkGray"
+            onClick={() => setMobileSearchExpanded((prevVal) => !prevVal)}
+            ref={anchorRef}
+            selected={isSettingsDropdownOpen}
+            size="sm"
+            tooltip={{ 'text': 'Search Gestalt', 'zIndex': POPOVER_ZINDEX }}
+          />
+        </Box>
+      </Flex>
     </Box>
   );
 }

--- a/docs/components/Header.js
+++ b/docs/components/Header.js
@@ -4,14 +4,15 @@ import {
   Box,
   CompositeZIndex,
   Dropdown,
-  Flex,
   FixedZIndex,
-  Label,
-  Switch,
-  Text,
+  Flex,
   IconButton,
-  Sticky,
+  Label,
   Link,
+  Sticky,
+  Switch,
+  Tabs,
+  Text,
 } from 'gestalt';
 
 import { useAppContext } from './appContext.js';
@@ -23,6 +24,7 @@ import { useNavigationContext } from './navigationContext.js';
 function Header() {
   const { isSidebarOpen, setIsSidebarOpen } = useNavigationContext();
   const [isSettingsDropdownOpen, setSettingsDropdownOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState(0);
 
   const anchorRef = useRef(null);
 
@@ -60,6 +62,19 @@ function Header() {
       role="banner"
     >
       <Box marginStart={-2} marginEnd={2} display="flex" alignItems="center">
+        {/* Small-screen menu button */}
+        <Box display="flex" mdDisplay="none" alignItems="center">
+          <IconButton
+            size="md"
+            accessibilityLabel={`${isSidebarOpen ? 'Hide' : 'Show'} Menu`}
+            iconColor="darkGray"
+            icon="menu"
+            onClick={() => {
+              window.scrollTo(0, 0);
+              setIsSidebarOpen(!isSidebarOpen);
+            }}
+          />
+        </Box>
         {/* <Text> is out here to get proper underline styles on link */}
         <Text color="default" weight="bold">
           <Link
@@ -140,25 +155,28 @@ function Header() {
       </Box>
 
       {/* Spacer element */}
-      <Box flex="grow" />
+      <Box display="none" mdDisplay="block" flex="grow">
+        <Flex justifyContent="center">
+          <Tabs
+            activeTabIndex={activeTab}
+            onChange={({ activeTabIndex }) => {
+              setActiveTab(activeTabIndex);
+            }}
+            tabs={[
+              { href: 'https://gestalt.pinterest.systems/about_us', text: 'Get started' },
+              { href: 'https://gestalt.pinterest.systems/component_overview', text: 'Components' },
+              { href: 'https://gestalt.pinterest.systems/accessibility', text: 'Foundations' },
+              { href: '#', text: 'Design patterns' },
+              { href: 'https://gestalt.pinterest.systems/roadmap', text: 'Roadmap' },
+            ]}
+            wrap
+          />
+        </Flex>
+      </Box>
 
       <Box alignItems="center" display="flex" flex="shrink" marginStart={2} mdMarginStart={0}>
         <Box paddingX={2}>
           <DocSearch popoverZIndex={POPOVER_ZINDEX} />
-        </Box>
-
-        {/* Small-screen menu button */}
-        <Box display="flex" mdDisplay="none" alignItems="center">
-          <IconButton
-            size="md"
-            accessibilityLabel={`${isSidebarOpen ? 'Hide' : 'Show'} Menu`}
-            iconColor="darkGray"
-            icon="menu"
-            onClick={() => {
-              window.scrollTo(0, 0);
-              setIsSidebarOpen(!isSidebarOpen);
-            }}
-          />
         </Box>
       </Box>
     </Box>

--- a/docs/components/Header.js
+++ b/docs/components/Header.js
@@ -192,7 +192,6 @@ function Header() {
                 { href: '/accessibility', text: 'Foundations' },
                 { href: '/roadmap', text: 'Roadmap' },
               ]}
-              wrap
             />
           </Flex>
         </Box>

--- a/docs/components/Header.js
+++ b/docs/components/Header.js
@@ -26,7 +26,7 @@ function Header() {
   const [isSettingsDropdownOpen, setSettingsDropdownOpen] = useState(false);
   const [isMobileSearchExpandedOpen, setMobileSearchExpanded] = useState(false);
 
-  const [activeTab, setActiveTab] = useState(0);
+  const [activeTab, setActiveTab] = useState(-1);
 
   const anchorRef = useRef(null);
 
@@ -51,6 +51,13 @@ function Header() {
     return setTextDirection(textDirection === 'rtl' ? 'ltr' : 'rtl');
   };
 
+  useEffect(() => {
+    const algoliaSearchInput = document.querySelector('#algolia-doc-search');
+    if (algoliaSearchInput && isMobileSearchExpandedOpen) {
+      algoliaSearchInput.focus();
+    }
+  }, [isMobileSearchExpandedOpen]);
+
   return (
     <Box
       paddingY={2}
@@ -63,7 +70,7 @@ function Header() {
       alignItems="center"
       role="banner"
     >
-      <Box marginStart={-2} marginEnd={2} display="flex" alignItems="center">
+      <Box marginStart={-2} display="flex" alignItems="center">
         {/* Small-screen menu button */}
         <Box
           display={isMobileSearchExpandedOpen ? 'none' : 'flex'}
@@ -90,15 +97,22 @@ function Header() {
               onClick={() => trackButtonClick('Gestalt logo')}
             >
               <Box paddingX={2}>
-                <Flex alignItems="center" gap={2}>
+                <Flex alignItems="center">
                   <GestaltLogo height={40} width={40} />
                   {/* slight tweak to vertically center to logo */}
                   <Box
                     display="none"
-                    mdDisplay="block"
-                    dangerouslySetInlineStyle={{ __style: { marginBottom: '1px' } }}
+                    lgDisplay="block"
+                    paddingX={1}
+                    dangerouslySetInlineStyle={{
+                      __style: {
+                        marginBottom: '1px',
+                        fontSize: '20px',
+                        color: 'var(--color-green-matchacado-700)',
+                      },
+                    }}
                   >
-                    Gestalt Design System
+                    Gestalt
                   </Box>
                 </Flex>
               </Box>
@@ -192,23 +206,27 @@ function Header() {
           marginStart={2}
           mdMarginStart={0}
         >
-          <Box paddingX={2}>
+          <Box flex="grow" paddingX={2}>
             <DocSearch popoverZIndex={POPOVER_ZINDEX} />
           </Box>
         </Box>
         <Box display="block" mdDisplay="none" marginStart={2}>
           <IconButton
             accessibilityControls="site-settings-dropdown"
-            accessibilityExpanded={isSettingsDropdownOpen}
+            accessibilityExpanded={isMobileSearchExpandedOpen}
             accessibilityHaspopup
             accessibilityLabel="Search Gestalt"
             icon={isMobileSearchExpandedOpen ? 'cancel' : 'search'}
             iconColor="darkGray"
-            onClick={() => setMobileSearchExpanded((prevVal) => !prevVal)}
+            onClick={() => {
+              setMobileSearchExpanded((prevVal) => !prevVal);
+            }}
             ref={anchorRef}
-            selected={isSettingsDropdownOpen}
             size="sm"
-            tooltip={{ 'text': 'Search Gestalt', 'zIndex': POPOVER_ZINDEX }}
+            tooltip={{
+              'text': isMobileSearchExpandedOpen ? 'Close search' : 'Search Gestalt',
+              'zIndex': POPOVER_ZINDEX,
+            }}
           />
         </Box>
       </Flex>

--- a/docs/components/Header.js
+++ b/docs/components/Header.js
@@ -62,7 +62,6 @@ function Header() {
     <Box
       paddingY={2}
       paddingX={4}
-      mdPaddingX={6}
       color="default"
       borderStyle="raisedTopShadow"
       display="flex"
@@ -201,7 +200,7 @@ function Header() {
         <Box
           alignItems="center"
           display={isMobileSearchExpandedOpen ? 'flex' : 'none'}
-          mdDisplay="flex"
+          lgDisplay="flex"
           flex="shrink"
           marginStart={2}
           mdMarginStart={0}
@@ -210,7 +209,7 @@ function Header() {
             <DocSearch popoverZIndex={POPOVER_ZINDEX} />
           </Box>
         </Box>
-        <Box display="block" mdDisplay="none" marginStart={2}>
+        <Box display="block" lgDisplay="none" marginStart={2}>
           <IconButton
             accessibilityControls="site-settings-dropdown"
             accessibilityExpanded={isMobileSearchExpandedOpen}

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -133,8 +133,8 @@ html[dir="rtl"] .Markdown ul + pre {
   box-sizing: border-box;
   display: inline-block;
   font-family: var(--font-family-default-latin);
-  height: 32px;
-  max-width: 200px;
+  height: 40px;
+  max-width: 250px;
   min-width: 100px;
   position: relative;
   visibility: visible;
@@ -166,7 +166,7 @@ html[dir="rtl"] .Markdown ul + pre {
   font-family: var(--font-family-default-latin);
   font-size: 16px;
   height: 100%;
-  padding: 0 32px 0 26px;
+  padding: 0 32px 0 40px;
   vertical-align: middle;
   white-space: normal;
   width: 100%;

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -134,7 +134,6 @@ html[dir="rtl"] .Markdown ul + pre {
   display: inline-block;
   font-family: var(--font-family-default-latin);
   height: 40px;
-  max-width: 250px;
   min-width: 100px;
   position: relative;
   visibility: visible;
@@ -311,6 +310,10 @@ html[dir="rtl"] .Markdown ul + pre {
 @media all and (min-width: 768px) {
   .algolia-autocomplete .ds-dropdown-menu {
     min-width: 500px;
+  }
+
+  .searchbox {
+    max-width: 250px;
   }
 }
 


### PR DESCRIPTION
### Summary

#### What changed?

Introduce new top level navigation for key pages

#### Why?

Add top level navigation on desktop web. mWeb implementation will be added in part 2
Also consolidates search at smaller screen widths

![Screen Shot 2022-07-11 at 1 02 40 PM](https://user-images.githubusercontent.com/5125094/178348578-4a83acff-bd95-492b-a142-4341a8bdf98f.png)


### Links

- [Figma](https://www.figma.com/file/emykswARRS1tQwpB7ThIPN/Gestalt-2022-Site?node-id=879%3A17764)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
