### PR TITLE
Masonry: Fix internal only flow issues

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -518,9 +518,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
         .filter((item) => item && !measurementStore.has(item))
         .slice(0, minCols);
 
-      // $FlowFixMe[incompatible-call]
       const positions = getPositions(itemsToRender);
-      // $FlowFixMe[incompatible-call]
       const measuringPositions = getPositions(itemsToMeasure);
       // Math.max() === -Infinity when there are no positions
       const height = positions.length

--- a/packages/gestalt/src/defaultLayout.js
+++ b/packages/gestalt/src/defaultLayout.js
@@ -42,8 +42,7 @@ const defaultLayout =
     minCols?: number,
     rawItemCount: number,
     width?: ?number,
-    // $FlowFixMe[unclear-type]
-  |}): ((items: $ReadOnlyArray<*>) => $ReadOnlyArray<Position>) =>
+  |}): ((items: $ReadOnlyArray<T>) => $ReadOnlyArray<Position>) =>
   (items): $ReadOnlyArray<Position> => {
     if (width == null) {
       return items.map(() => offscreen(columnWidth));

--- a/packages/gestalt/src/fullWidthLayout.js
+++ b/packages/gestalt/src/fullWidthLayout.js
@@ -25,19 +25,9 @@ const fullWidthLayout = <T>({
   minCols?: number,
   idealColumnWidth?: number,
   width?: ?number,
-|}):
-  | ((items: $ReadOnlyArray<string>) => $ReadOnlyArray<Position>)
-  | ((
-      // eslint-disable-next-line flowtype/no-mutable-array
-      items: Array<T>,
-    ) => $ReadOnlyArray<{|
-      height: number,
-      left: number,
-      top: number,
-      width: number,
-    |}>) => {
+|}): ((items: $ReadOnlyArray<T>) => $ReadOnlyArray<Position>) => {
   if (width == null) {
-    return (items: $ReadOnlyArray<string>): $ReadOnlyArray<Position> =>
+    return (items) =>
       items.map(() => ({
         top: Infinity,
         left: Infinity,
@@ -53,8 +43,7 @@ const fullWidthLayout = <T>({
   const columnCount = Math.max(Math.floor((width - colguess * gutter) / idealColumnWidth), minCols);
   const columnWidth = Math.floor(width / columnCount);
 
-  // eslint-disable-next-line flowtype/no-mutable-array
-  return (items: Array<T>) => {
+  return (items: $ReadOnlyArray<T>) => {
     // the total height of each column
     const heights = new Array(columnCount).fill(0);
 


### PR DESCRIPTION
Fixes 3 flow fixme's and 2 ESLint disables related to `Position` in `Masonry`. These changes are internal only