### PR TITLE
Table.Header: add 'display' prop

### DIFF
--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -59,21 +59,16 @@ function Td({
   shrink?: boolean,
   color?: 'default' | 'subtle',
 |}) {
-  let tdStyle = {
-    verticalAlign: 'top',
-    padding: 0,
-  };
-
-  if (border) {
-    tdStyle = { ...tdStyle, borderBottom: '1px solid #ddd' };
-  }
-
-  if (shrink) {
-    tdStyle = { ...tdStyle, width: '1px' };
-  }
-
   return (
-    <td style={tdStyle} colSpan={colspan}>
+    <td
+      style={{
+        borderBottom: border ? '1px solid #ddd' : null,
+        padding: 0,
+        verticalAlign: 'top',
+        width: shrink ? '1px' : null,
+      }}
+      colSpan={colspan}
+    >
       <Box paddingX={2} marginTop={2} marginBottom={border ? 2 : 0}>
         <Text overflow="normal" color={color}>
           {children}

--- a/docs/components/QualityChecklist.js
+++ b/docs/components/QualityChecklist.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Box, Text, Table, SlimBanner } from 'gestalt';
+import { Text, Table, SlimBanner } from 'gestalt';
 import COMPONENT_DATA from './COMPONENT_DATA.js';
 import MainSection from './MainSection.js';
 import StatusData from './StatusData.js';
@@ -32,17 +32,15 @@ export default function QualityChecklist({ component }: Props): Node {
             <col style={{ width: '20%' }} />
             <col style={{ width: '60%' }} />
           </colgroup>
-          <Box display="visuallyHidden">
-            <Table.Header>
-              <Table.Row>
-                {['Quality item', 'Status', 'Status description'].map((header) => (
-                  <Table.HeaderCell key={header.replace(' ', '_')}>
-                    <Text weight="bold">{header}</Text>
-                  </Table.HeaderCell>
-                ))}
-              </Table.Row>
-            </Table.Header>
-          </Box>
+          <Table.Header display="visuallyHidden">
+            <Table.Row>
+              {['Quality item', 'Status', 'Status description'].map((header) => (
+                <Table.HeaderCell key={header.replace(' ', '_')}>
+                  <Text weight="bold">{header}</Text>
+                </Table.HeaderCell>
+              ))}
+            </Table.Row>
+          </Table.Header>
           <Table.Body>
             {['figma', 'responsive', 'iOS', 'android'].map((item, index) => {
               const componentStatus = componentData?.status?.[item] ?? 'notAvailable';

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import cx from 'classnames';
+import boxStyles from './Box.css';
 import styles from './Table.css';
 
 type Props = {|
@@ -8,6 +9,10 @@ type Props = {|
    * Must be an instance of Table.Row. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
    */
   children: Node,
+  /**
+   * Display `visuallyHidden` ensures the component is visually hidden but still is read by screen readers.
+   */
+  display?: 'tableHeaderGroup' | 'visuallyHidden',
   /**
    * If true, the table header will be sticky and the table body will be scrollable. See the [sticky Header](https://gestalt.pinterest.systems/table#Sticky-header) and the [sticky header and columns](https://gestalt.pinterest.systems/table#Sticky-header-and-sticky-columns) variants for details.
    */
@@ -17,8 +22,16 @@ type Props = {|
 /**
  * Use [Table.Header](https://gestalt.pinterest.systems/table#Table.Header) to group the header content in Table.
  */
-export default function TableHeader({ sticky = false, children }: Props): Node {
-  const cs = cx(styles.thead, sticky && styles.sticky);
+export default function TableHeader({
+  children,
+  display = 'tableHeaderGroup',
+  sticky = false,
+}: Props): Node {
+  const cs = cx(
+    display === 'visuallyHidden' && boxStyles.visuallyHidden,
+    styles.thead,
+    sticky && styles.sticky,
+  );
   return <thead className={cs}>{children}</thead>;
 }
 


### PR DESCRIPTION
### Summary

#### What changed?

* Add `display` prop to `Table.Header`
* Fix hydration issues on every page which used the `QualityChecklist` component
* Fix `Warning: Expected server HTML to contain a matching <table> in <div>.`

#### Why?

The `QualityChecklist` component renders a `<div />` as a direct descendant of `<thead />` which is not allowed:
<img width="754" alt="Screen Shot 2022-07-25 at 1 25 57 PM" src="https://user-images.githubusercontent.com/127199/180770476-dacee324-39f6-4506-8030-5d167dd50fa4.png">

It results in the follow hydration error:
<img width="969" alt="Screen Shot 2022-07-25 at 7 16 47 AM" src="https://user-images.githubusercontent.com/127199/180770807-5a77c834-08ed-4e7b-9e55-132d68edf3c7.png">

#### Repro steps

* Clone the repro
* Go to `/modal` (or any other page with a `QualityChecklist` component
* Reload the page

#### Notes

* Bug was introduced in #2114 /cc @AlbertCarreras 
* Instead we could wrap `<Text />` in `<Box display="visuallyHidden" />` but that results in unnecessary space and an extra border
