### PR TITLE
Eslint plugin: Avoid "workflow-status-[..]" on Icon

### DIFF
--- a/docs/pages/eslint_plugin.js
+++ b/docs/pages/eslint_plugin.js
@@ -135,6 +135,10 @@ With AUTOFIX!
       `}
         />
         <MainSection.Subsection
+          title="gestalt/no-workflow-status-icon"
+          description="Prevent the usage of 'workflow-status-[...]' icons on `Icon` component where the values of props matches with the [Status](/status) component usage."
+        />
+        <MainSection.Subsection
           title="gestalt/prefer-flex"
           description={`Prevent \`Box\` usages in those cases where they can be replaced with \`Flex\`.
 

--- a/docs/pages/eslint_plugin.js
+++ b/docs/pages/eslint_plugin.js
@@ -136,7 +136,7 @@ With AUTOFIX!
         />
         <MainSection.Subsection
           title="gestalt/no-workflow-status-icon"
-          description="Prevent the usage of 'workflow-status-[...]' icons on `Icon` component where the values of props matches with the [Status](/status) component usage."
+          description="Prevent the usage of 'workflow-status-[...]' icons on Icon component when the style matches one of the [Status](/status) types."
         />
         <MainSection.Subsection
           title="gestalt/prefer-flex"

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/invalid/default-size.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/invalid/default-size.js
@@ -1,0 +1,7 @@
+import { Icon } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Icon icon="workflow-status-problem" color="error" />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/invalid/match-properties.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/invalid/match-properties.js
@@ -1,0 +1,7 @@
+import { Icon } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Icon icon="workflow-status-problem" color="error" size={16} />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/invalid/renamed-icon.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/invalid/renamed-icon.js
@@ -1,0 +1,7 @@
+import { Icon as RenamedIcon } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <RenamedIcon icon="workflow-status-problem" color="error" />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/valid/no-match-color.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/valid/no-match-color.js
@@ -1,0 +1,7 @@
+import { Icon } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Icon icon="workflow-status-problem" color="dark" />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/valid/no-match-icon.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/valid/no-match-icon.js
@@ -1,0 +1,7 @@
+import { Icon } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Icon icon="visit" color="dark" />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/valid/no-match-size.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/valid/no-match-size.js
@@ -1,0 +1,7 @@
+import { Icon } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Icon icon="workflow-status-problem" color="error" size={24} />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/valid/renamed-icon.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/no-workflow-status-icon/valid/renamed-icon.js
@@ -1,0 +1,7 @@
+import { Icon as RenamedIcon } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <RenamedIcon icon="workflow-status-problem" color="error" size={24} />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/index.js
+++ b/packages/eslint-plugin-gestalt/src/index.js
@@ -8,6 +8,7 @@ import noBoxMarginleftMarginright from './no-box-marginleft-marginright.js';
 import noMediumFormfields from './no-medium-formfields.js';
 import noRoleLinkComponents from './no-role-link-components.js';
 import noSpreadProps from './no-spread-props.js';
+import noWorkflowStatusIcon from './no-workflow-status-icon.js';
 import preferBoxInlineStyle from './prefer-box-inline-style.js';
 import preferBoxNoClassname from './prefer-box-no-disallowed.js';
 import preferBoxAsTag from './prefer-box-as-tag.js';
@@ -25,6 +26,7 @@ module.exports = {
     'no-medium-formfields': noMediumFormfields,
     'no-role-link-components': noRoleLinkComponents,
     'no-spread-props': noSpreadProps,
+    'no-workflow-status-icon': noWorkflowStatusIcon,
     'prefer-box-inline-style': preferBoxInlineStyle,
     'prefer-box-no-disallowed': preferBoxNoClassname,
     'prefer-box-as-tag': preferBoxAsTag,

--- a/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
+++ b/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
@@ -5,7 +5,12 @@
 
 // @flow strict
 import { type ESLintRule } from './helpers/eslintFlowTypes.js';
-import { hasImport, isGestaltComponent, hasAttributes } from './helpers/eslintASTHelpers.js';
+import {
+  hasImport,
+  isGestaltComponent,
+  hasAttributes,
+  getLocalComponentImportName,
+} from './helpers/eslintASTHelpers.js';
 
 const disallowedMatch = [
   { icon: 'workflow-status-in-progress', color: 'success' },
@@ -21,8 +26,7 @@ const rule: ESLintRule = {
   meta: {
     type: 'suggestion',
     docs: {
-      description:
-        'Prevent the use of the Icon where should be replaceable for the `Status` component.',
+      description: 'Prevent the use of Icon that can be replaced with Status.',
       category: 'Gestalt restrictions',
       recommended: true,
       url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-workflow-status-icon',
@@ -40,6 +44,7 @@ const rule: ESLintRule = {
 
   create(context) {
     let gestaltImportNode;
+    let componentName = 'Icon';
 
     const matchValues = (node) => {
       const props = {};
@@ -66,6 +71,7 @@ const rule: ESLintRule = {
 
       if (!isGestaltImportNode) return;
 
+      componentName = node?.specifiers?.find(item => item?.imported?.name === 'Icon')?.local?.name || 'Icon';
       gestaltImportNode = node;
     };
 
@@ -84,8 +90,8 @@ const rule: ESLintRule = {
 
       const isMatchProps = hasAttributes({
         elementNode: node,
-        tagName: 'Icon',
-        attributes: ['icon', 'color', 'size'],
+        tagName: componentName,
+        attributes: ['icon', 'color'],
       });
 
       // exit if not have correct props

--- a/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
+++ b/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview Error on use a <Icon icon="workflow-status-[...]" size={16} />, and suggest use
+ * <Status /> component rather than <Icon />
+ */
+
+// @flow strict
+import { type ESLintRule } from './helpers/eslintFlowTypes.js';
+import { hasImport, isGestaltComponent, hasAttributes } from './helpers/eslintASTHelpers.js';
+
+const disallowedMatch = [
+  { icon: 'workflow-status-in-progress', color: 'success' },
+  { icon: 'workflow-status-ok', color: 'success' },
+  { icon: 'workflow-status-problem', color: 'error' },
+  { icon: 'workflow-status-warning', color: 'warning' },
+];
+
+export const errorMessage =
+  'Icons where `workflow-status-[...]` and matching color should be replaced for the Status Component. https://gestalt.pinterest.systems/status';
+
+const rule: ESLintRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prevent the use of the Icon where should be replaceable for the `Status` component.',
+      category: 'Gestalt restrictions',
+      recommended: true,
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltno-workflow-status-icon',
+    },
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      disallowed: errorMessage,
+    },
+  },
+
+  create(context) {
+    let gestaltImportNode;
+
+    const matchValues = (node) => {
+      const props = {};
+      node.attributes.forEach(({ name, value }) => {
+        props[name?.name] = value?.value || value?.expression?.value;
+      });
+
+      const isDisallowedMatch = disallowedMatch.some(
+        ({ icon, color }) =>
+          icon === props?.icon &&
+          color === props?.color &&
+          (props?.size === 16 || props?.size === undefined),
+      );
+
+      if (!isDisallowedMatch) return null;
+
+      return node;
+    };
+
+    const importDeclarationFnc = (node) => {
+      if (!node) return;
+
+      const isGestaltImportNode = hasImport({ importNode: node, path: 'gestalt' });
+
+      if (!isGestaltImportNode) return;
+
+      gestaltImportNode = node;
+    };
+
+    const jSXOpeningElementFnc = (node) => {
+      // exit if Gestalt is not imported
+      if (!gestaltImportNode) return null;
+
+      const isIcon = isGestaltComponent({
+        elementNode: node,
+        gestaltImportNode,
+        componentName: 'Icon',
+      });
+
+      // exit if not Icon component
+      if (!isIcon) return null;
+
+      const isMatchProps = hasAttributes({
+        elementNode: node,
+        tagName: 'Icon',
+        attributes: ['icon', 'color', 'size'],
+      });
+
+      // exit if not have correct props
+      if (!isMatchProps) return null;
+
+      const isMatchAttributesValues = matchValues(node);
+
+      // exit if not have correct props and values
+      if (!isMatchAttributesValues) return null;
+
+      return context.report({
+        node,
+        messageId: 'disallowed',
+      });
+    };
+
+    return {
+      ImportDeclaration: importDeclarationFnc,
+      JSXOpeningElement: jSXOpeningElementFnc,
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
+++ b/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
@@ -5,12 +5,7 @@
 
 // @flow strict
 import { type ESLintRule } from './helpers/eslintFlowTypes.js';
-import {
-  hasImport,
-  isGestaltComponent,
-  hasAttributes,
-  getLocalComponentImportName,
-} from './helpers/eslintASTHelpers.js';
+import { hasImport, isGestaltComponent, hasAttributes } from './helpers/eslintASTHelpers.js';
 
 const disallowedMatch = [
   { icon: 'workflow-status-in-progress', color: 'success' },
@@ -71,7 +66,8 @@ const rule: ESLintRule = {
 
       if (!isGestaltImportNode) return;
 
-      componentName = node?.specifiers?.find(item => item?.imported?.name === 'Icon')?.local?.name || 'Icon';
+      componentName =
+        node?.specifiers?.find((item) => item?.imported?.name === 'Icon')?.local?.name || 'Icon';
       gestaltImportNode = node;
     };
 

--- a/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.test.js
@@ -23,6 +23,11 @@ const noMatchSize = readFileSync(
   'utf-8',
 );
 
+const renamedIcon = readFileSync(
+  path.resolve(__dirname, './__fixtures__/no-workflow-status-icon/valid/renamed-icon.js'),
+  'utf-8',
+);
+
 /** Invalid cases */
 const invalidDefaultSize = readFileSync(
   path.resolve(__dirname, './__fixtures__/no-workflow-status-icon/invalid/default-size.js'),
@@ -34,10 +39,16 @@ const invalidMatchProperties = readFileSync(
   'utf-8',
 );
 
+const invalidRenamedIcon = readFileSync(
+  path.resolve(__dirname, './__fixtures__/no-workflow-status-icon/invalid/renamed-icon.js'),
+  'utf-8',
+);
+
 ruleTester.run('no-workflow-status-icon', rule, {
-  valid: [noMatchColor, noMatchIcon, noMatchSize],
+  valid: [noMatchColor, noMatchIcon, noMatchSize, renamedIcon],
   invalid: [
     [invalidDefaultSize, defaultOutputMessage],
     [invalidMatchProperties, defaultOutputMessage],
+    [invalidRenamedIcon, defaultOutputMessage],
   ].map(([code, errorMessage]) => ({ code, errors: [{ message: errorMessage }] })),
 });

--- a/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.test.js
+++ b/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.test.js
@@ -1,0 +1,43 @@
+// @flow strict
+import { RuleTester } from 'eslint';
+import { readFileSync } from 'fs';
+import path from 'path';
+import rule, { errorMessage as defaultOutputMessage } from './no-workflow-status-icon.js';
+import { parserOptions } from './helpers/testHelpers.js';
+
+const ruleTester = new RuleTester({ parserOptions });
+
+/** Valid cases */
+const noMatchColor = readFileSync(
+  path.resolve(__dirname, './__fixtures__/no-workflow-status-icon/valid/no-match-color.js'),
+  'utf-8',
+);
+
+const noMatchIcon = readFileSync(
+  path.resolve(__dirname, './__fixtures__/no-workflow-status-icon/valid/no-match-icon.js'),
+  'utf-8',
+);
+
+const noMatchSize = readFileSync(
+  path.resolve(__dirname, './__fixtures__/no-workflow-status-icon/valid/no-match-size.js'),
+  'utf-8',
+);
+
+/** Invalid cases */
+const invalidDefaultSize = readFileSync(
+  path.resolve(__dirname, './__fixtures__/no-workflow-status-icon/invalid/default-size.js'),
+  'utf-8',
+);
+
+const invalidMatchProperties = readFileSync(
+  path.resolve(__dirname, './__fixtures__/no-workflow-status-icon/invalid/match-properties.js'),
+  'utf-8',
+);
+
+ruleTester.run('no-workflow-status-icon', rule, {
+  valid: [noMatchColor, noMatchIcon, noMatchSize],
+  invalid: [
+    [invalidDefaultSize, defaultOutputMessage],
+    [invalidMatchProperties, defaultOutputMessage],
+  ].map(([code, errorMessage]) => ({ code, errors: [{ message: errorMessage }] })),
+});


### PR DESCRIPTION
### Summary

#### What changed?

Add a new rule to avoid the following cases on Icon component:

| Implementations disallowed by rule |
| - |
| \<Icon icon="workflow-status-warning" color="warning" /\> |
| \<Icon icon="workflow-status-warning" color="warning"  size={16} /\> |
| \<Icon icon="workflow-status-problem" color="error" /> |
| \<Icon icon="workflow-status-problem" color="error"  size={16} /\> |
| \<Icon icon="workflow-status-ok" color="success" /\> |
| \<Icon icon="workflow-status-ok" color="success"  size={16} \> |
| \<Icon icon="workflow-status-in-progress" color="success" /\> |
| \<Icon icon="workflow-status-in-progress" color="success"  size={16} /\> |

#### Why?

The current good practice is use the [Status Component](https://gestalt.pinterest.systems/status) rather than the previous one list. Like the table bellow:

| Current prop | + color | Status equivalent |
| - | - | - |
| workflow-status-warning | warning | \<Status type="warning" /\> |
| workflow-status-problem | error | \<Status type="problem" /\> |
| workflow-status-ok | success | \<Status type="ok" /\> |
| workflow-status-in-progress | success | \<Status type="inProgress" /\> |

_Keep attention on the size of component, the `Status` component only must be used when the size of Icon is `default` or `16`, the other sizes you are allowed to use the Icon component freely._

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4267)

### Checklist

- [x] Added unit and Flow Tests
- [x] Checked stakeholder feedback (e.g. @AlbertCarreras )
