### PR TITLE
Docs: fix heading scroll position

### DIFF
--- a/docs/components/Card.js
+++ b/docs/components/Card.js
@@ -52,7 +52,7 @@ export default function Card({
         <Box
           dangerouslySetInlineStyle={{
             __style: {
-              scrollMarginTop: 60,
+              scrollMarginTop: 90,
             },
           }}
           id={slugifiedId}


### PR DESCRIPTION
The height of the top nav increase but we never updated the scroll margin top for the heading.

To repo, go to https://gestalt.pinterest.systems/buttongroup#Props

# Before

![Screen Shot 2022-07-29 at 8 23 22 AM](https://user-images.githubusercontent.com/127199/181696643-e09dcd57-8bd4-4587-a24b-2d43a7083157.png)

# After

![Screen Shot 2022-07-29 at 8 23 31 AM](https://user-images.githubusercontent.com/127199/181696655-56e73583-0890-4af1-9f91-b7273f6b50b0.png)

