### PR TITLE
Docs: fix web repository link

### DIFF
--- a/docs/components/ResourcesFooter.js
+++ b/docs/components/ResourcesFooter.js
@@ -48,7 +48,7 @@ const slackChannels = [
   },
 ];
 const engResources = [
-  { title: 'Web repository', url: 'https://github.com/pinterest/gestalt/pull/2162' },
+  { title: 'Web repository', url: 'https://github.com/pinterest/gestalt' },
   { title: 'Code sandbox', url: 'https://codesandbox.io/s/gestalt-cnwugg?file=/yourCode.js' },
 ];
 


### PR DESCRIPTION
### Summary

#### What changed?

Fix the `Web repository` link

#### Why?

Previously this link went to a specific PR instead of the main Gestalt repository

### Related PR

https://github.com/pinterest/gestalt/pull/2163