### PR TITLE
Internal: add ability to use local Gestalt CSS & JS files

### DIFF
--- a/docs/components/App.js
+++ b/docs/components/App.js
@@ -5,12 +5,17 @@ import { useRouter } from 'next/router';
 import { AppContextProvider, AppContextConsumer } from './appContext.js';
 import { NavigationContextProvider } from './navigationContext.js';
 import AppLayout from './AppLayout.js';
+import { LocalFilesProvider } from './contexts/LocalFilesProvider.js';
 
 type Props = {|
   children?: Node,
+  files?: {|
+    css: string,
+    js: string,
+  |},
 |};
 
-export default function App({ children }: Props): Node {
+export default function App({ children, files }: Props): Node {
   const router = useRouter();
   const [isHomePage, setIsHomePage] = useState(router?.route === '/home');
 
@@ -59,9 +64,11 @@ export default function App({ children }: Props): Node {
           <ColorSchemeProvider colorScheme={colorScheme} id="gestalt-docs">
             <OnLinkNavigationProvider onNavigation={useOnNavigation}>
               <NavigationContextProvider>
-                <AppLayout isHomePage={isHomePage} colorScheme={colorScheme}>
-                  {children}
-                </AppLayout>
+                <LocalFilesProvider files={files}>
+                  <AppLayout isHomePage={isHomePage} colorScheme={colorScheme}>
+                    {children}
+                  </AppLayout>
+                </LocalFilesProvider>
               </NavigationContextProvider>
             </OnLinkNavigationProvider>
           </ColorSchemeProvider>

--- a/docs/components/SandpackExample.js
+++ b/docs/components/SandpackExample.js
@@ -6,7 +6,7 @@ import {
   SandpackCodeEditor,
   useSandpack,
 } from '@codesandbox/sandpack-react';
-import React, { type Node } from 'react';
+import React, { useEffect, type Node } from 'react';
 import { Box, Flex } from 'gestalt';
 import CopyCodeButton from './buttons/CopyCodeButton.js';
 import clipboardCopy from './clipboardCopy.js';
@@ -96,6 +96,31 @@ export default function SandpackExample({
   previewHeight?: number,
   showEditor?: boolean,
 |}): Node {
+  const [localFiles, setLocalFiles] = React.useState(false);
+  const [localCSS, setLocalCSS] = React.useState(null);
+  const [localJS, setLocalJS] = React.useState(null);
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || !document.location) {
+      return;
+    }
+    // Use local gestalt JS and CSS when `?localFiles=true` is in the URL
+    const params = new URL(document.location.toString()).searchParams;
+    setLocalFiles(params.get('localFiles') === 'true');
+  }, []);
+
+  useEffect(() => {
+    if (localFiles === false) {
+      return;
+    }
+    fetch('/api/localFiles')
+      .then((res) => res.json())
+      .then((data) => {
+        setLocalCSS(data.css);
+        setLocalJS(data.js);
+      });
+  }, [localFiles]);
+
   // Based on
   // https://github.com/codesandbox/sandpack/blob/53811bb4fdfb66ea95b9881ff18c93307f12ce0d/sandpack-react/src/presets/Sandpack.tsx#L67
   return (
@@ -108,6 +133,25 @@ export default function SandpackExample({
           body, html, #root { height: 100%; }`,
           hidden: true,
         },
+        ...(localFiles
+          ? {
+              // More info at https://twitter.com/CompuIves/status/1466464916441903116
+              // Example: https://codesandbox.io/s/custom-library-in-sandpack-gq12p?file=/src/App.js:407-672
+              '/node_modules/gestalt/package.json': {
+                code: JSON.stringify({
+                  name: 'gestalt',
+                  main: './dist/gestalt.js',
+                  style: 'dist/gestalt.css',
+                }),
+              },
+              '/node_modules/gestalt/dist/gestalt.js': {
+                code: localJS,
+              },
+              '/node_modules/gestalt/dist/gestalt.css': {
+                code: localCSS,
+              },
+            }
+          : {}),
         '/App.js': {
           code,
         },
@@ -115,7 +159,7 @@ export default function SandpackExample({
       theme="dark"
       customSetup={{
         dependencies: {
-          gestalt: 'latest',
+          ...(localFiles ? { classnames: 'latest' } : { gestalt: 'latest' }),
           react: '18.2.0',
           'react-dom': '18.2.0',
         },

--- a/docs/components/contexts/LocalFilesProvider.js
+++ b/docs/components/contexts/LocalFilesProvider.js
@@ -1,0 +1,36 @@
+// @flow strict
+import { type Context, type Element, type Node, useContext, createContext } from 'react';
+
+type LocalFilesContextType = {|
+  files: ?{|
+    css: string,
+    js: string,
+  |},
+|};
+
+type Props = {|
+  ...LocalFilesContextType,
+  children: Node,
+|};
+
+const LocalFilesContext: Context<LocalFilesContextType> = createContext<LocalFilesContextType>({
+  files: null,
+});
+
+const { Provider } = LocalFilesContext;
+
+function LocalFilesProvider({ children, files }: Props): Element<typeof Provider> {
+  const context = {
+    files,
+  };
+  return <Provider value={context}>{children}</Provider>;
+}
+
+function useLocalFiles(): LocalFilesContextType {
+  const { files } = useContext(LocalFilesContext);
+  return {
+    files,
+  };
+}
+
+export { LocalFilesProvider, useLocalFiles };

--- a/docs/pages/api/localFiles.js
+++ b/docs/pages/api/localFiles.js
@@ -1,0 +1,13 @@
+// @flow strict
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export default async function handler(req: NextRequest, res: NextResponse) {
+  const gestaltBuildDirectory = path.join(process.cwd(), '..', 'packages', 'gestalt', 'dist');
+  const [css, js] = await Promise.all([
+    fs.readFile(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8'),
+    fs.readFile(path.join(gestaltBuildDirectory, 'gestalt.js'), 'utf8'),
+  ]);
+
+  res.status(200).json({ css, js });
+}

--- a/docs/pages/development.js
+++ b/docs/pages/development.js
@@ -187,6 +187,21 @@ git remote -v
           </Text>
         </Flex>
       </Card>
+      <Card name="Use local Gestalt CSS &amp; JS">
+        <Flex alignItems="start" direction="column" gap={4}>
+          <Text>
+            By default we use the latest published version of Gestalt&apos;s CSS and JS for Sandpack
+            examples. If you want to use the local Gestalt CSS &amp; JS, append{' '}
+            <code>localFiles=true</code> to the URL:
+          </Text>
+          <Markdown
+            text="
+~~~bash
+http://localhost:8888/modal?localFiles=true
+~~~"
+          />
+        </Flex>
+      </Card>
       <Card name="Create a pull request">
         <Flex alignItems="start" direction="column" gap={4}>
           <ul>

--- a/flow-typed/npm/next_v10.x.x.js
+++ b/flow-typed/npm/next_v10.x.x.js
@@ -261,3 +261,11 @@ declare module "next/dynamic" {
     options: ?NextDynamicOptions
   ): Object;
 }
+
+// From TypeScript types
+// https://github.com/vercel/next.js/blob/dce8c0ce9d2af48ae29489dab7d052ff79acd357/packages/next/shared/lib/utils.ts#L238
+declare class NextRequest extends http$IncomingMessage { }
+declare class NextResponse extends http$ServerResponse {
+  status: (statusCode: number) => NextResponse;
+  json: (json: any) => NextResponse;
+}


### PR DESCRIPTION
### Summary

#### What changed?

Follow up from #2221 - we add the ability to use local Gestalt JS & CSS files instead of the latest Gestalt.

#### Why?

When developing locally, you want to use the Gestalt version which has your local changes, not the latest Gestalt release.

### FAQ

**Why do we not always use the local files?**

This is significantly slower since we
1) load the local JS & CSS through a Next.js API route
2) have to send the local JS & CSS to CodeSandbox

So it's useful when coding locally but we shouldn't use it in other cases.

**How do I use the local Gestalt CSS & JS files?**

Add `localFiles=true` to your URL:
http://localhost:8888/modal?localFiles=true

**Why do you use Next.js page data and not /api routes?**

With page data, the file reads & request only happen once per page load. If we use `/api` routes, we would get files reads & a request for each example.
