### PR TITLE
Docs: Fix /_error renders on collage page

### DIFF
--- a/docs/pages/collage.js
+++ b/docs/pages/collage.js
@@ -141,7 +141,7 @@ export default function CollagePage({ generatedDocGen }: {| generatedDocGen: Doc
           const image = images[index] || {};
           return (
             <Mask wash width={width} height={height}>
-              {image ? (
+              {image?.src ? (
                 <Image
                   alt="collage image"
                   color={image.color}
@@ -343,7 +343,7 @@ export default function CollagePage({ generatedDocGen }: {| generatedDocGen: Doc
           const image = images[index] || {};
           return (
             <Mask wash width={width} height={height}>
-              {image ? (
+              {image?.src ? (
                 <Image
                   alt="collage image"
                   color={image.color}


### PR DESCRIPTION
### Summary

#### What changed?

Fix an issue where the collage page was making requests to `/undefined`

#### Why?

It results in multiple calls to `GestaltApp.getInitialProps` which render the `/_error` page

#### Root cause

#1662 /cc @dangerismycat
In that PR we fall back to `{}` for `image`, however that is truthy while before it was `undefined` which is falsy

```js
const image = images[index];
// Works as expected
if (image) {
```

```js
// Fails
const image = images[index] || {};
if (image) {
```