### PR TITLE
Docs: fix received 'true' for a non-boolean attribute 'wsz'

### DIFF
--- a/docs/pages/box.js
+++ b/docs/pages/box.js
@@ -194,7 +194,7 @@ function MenuButtonExample() {
         color="infoBase"
         height={firstBoxHeight}
         padding={2}
-        marginBottom={1}wsz
+        marginBottom={1}
       >
         <Text color="light" weight="bold">
           This uses a proper, Gestalt colored Box


### PR DESCRIPTION
### Summary

#### What changed?

Fix bug in one of the `Box` examples.

Error:
```
Warning: Received `true` for a non-boolean attribute `wsz`.

If you want to write it to the DOM, pass a string instead: wsz="true" or wsz={value.toString()}.
    at div
    at Box (webpack-internal:///../packages/gestalt/dist/gestalt.es.js:1575:3)
    at div
```

#### Caused by

#2187 /cc @EduhCosta

#### How can we prevent this?

By flow typing our doc examples and using Sandpack - #2221 