### PR TITLE
Docs: group sidebar toggles

### DIFF
--- a/docs/components/buttons/SidebarCategorizationButton.js
+++ b/docs/components/buttons/SidebarCategorizationButton.js
@@ -22,7 +22,7 @@ export default function SidebarCategorizationButton({ onClick, sidebarOrganisedB
           checked={sidebarOrganisedBy === 'categorized'}
           id="sortCategory"
           label="Category"
-          name="sidebarSortCategory"
+          name="sidebarSort"
           onChange={onSelect}
           value="categorized"
           size="sm"
@@ -31,7 +31,7 @@ export default function SidebarCategorizationButton({ onClick, sidebarOrganisedB
           checked={sidebarOrganisedBy === 'alphabetical'}
           id="sortAlphabetical"
           label="Alphabetical"
-          name="sidebarSortAlphabetical"
+          name="sidebarSort"
           onChange={onSelect}
           value="alphabetical"
           size="sm"


### PR DESCRIPTION
### Summary

#### What changed?

Group sidebar radio button toggles.
Revert of a change done in https://github.com/pinterest/gestalt/pull/2185 /cc @AlbertCarreras 

#### Why?

Radio buttons which belong together should have the same `name`:

> [Defining a radio group](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#defining_a_radio_group)
> A radio group is defined by giving each of radio buttons in the group the same [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-name).

### Issue

**Repro**
1) Tab to the category radio button
![image](https://user-images.githubusercontent.com/127199/182105830-72c1c8dc-de23-4cb9-82f4-5a2b4741562a.png)
2) Hit the right or left arrow key

**Expected**
Toggle between `Category` and `Alphabetical`
