### PR TITLE
Docs: sidebar border should reach bottom

### DIFF
--- a/docs/components/AppLayout.js
+++ b/docs/components/AppLayout.js
@@ -51,7 +51,7 @@ export default function AppLayout({ children, colorScheme, isHomePage }: Props):
               mdDisplay="block"
               position="fixed"
               overflow="auto"
-              maxHeight="calc(100% - 100px)"
+              maxHeight="calc(100% - 75px)"
               minWidth={MIN_NAV_WIDTH_PX}
               marginTop={2}
             >


### PR DESCRIPTION
## Summary

### What changed?

The sidebar border should reach the bottom of the page.

#### Before
![Screen Shot 2022-08-01 at 11 22 13 AM](https://user-images.githubusercontent.com/127199/182117636-5b2ff087-83e5-4e59-8389-c8d47f44ff03.png)

#### After
![Screen Shot 2022-08-01 at 11 22 00 AM](https://user-images.githubusercontent.com/127199/182117648-01125666-3d8f-4dfe-983e-548676505db8.png)

