### PR TITLE
Internal: replace flow-lint suppressions with FlowFixMe

### DIFF
--- a/docs/components/Combination.js
+++ b/docs/components/Combination.js
@@ -4,21 +4,6 @@ import { Box, Label, Text } from 'gestalt';
 import Checkerboard from './Checkerboard.js';
 import Card from './Card.js';
 
-type Props = {
-  children: (Object, number) => Node, // flowlint-line unclear-type:off
-  description?: string,
-  hasCheckerboard?: boolean,
-  heading?: boolean,
-  id?: string,
-  layout?: '2column' | '4column' | '12column',
-  name?: string,
-  showHeading?: boolean,
-  showValues?: boolean,
-  stacked?: boolean,
-  labelPrefix?: string,
-  ...
-};
-
 const flatMap = (arr, fn) => arr.map(fn).reduce((a, b) => a.concat(b));
 const combinations = (variationsByField) => {
   const fieldNames = Object.keys(variationsByField);
@@ -87,20 +72,37 @@ function layoutReducer(layout) {
   }
 }
 
+type Props = {
+  // $FlowFixMe[unclear-type]
+  children: (Object, number) => Node,
+  description?: string,
+  hasCheckerboard?: boolean,
+  heading?: boolean,
+  id?: string,
+  labelPrefix?: string,
+  layout?: '2column' | '4column' | '12column',
+  name?: string,
+  showHeading?: boolean,
+  showValues?: boolean,
+  stacked?: boolean,
+  ...
+};
+
 export default function Combination({
-  name = 'Combinations',
+  children,
   description = '',
-  layout = '2column',
   hasCheckerboard = true,
   id,
+  labelPrefix,
+  layout = '2column',
+  name = 'Combinations',
   showHeading,
   showValues = true,
   stacked = false,
-  labelPrefix,
-  children,
   ...props
 }: Props): Node {
   const { column, mdColumn, lgColumn } = layoutReducer(layout);
+
   return (
     <Card name={name} description={description} id={id} stacked={stacked} showHeading={showHeading}>
       <Box display="flex" wrap>

--- a/docs/components/GeneratedPropTable.js
+++ b/docs/components/GeneratedPropTable.js
@@ -47,19 +47,22 @@ function getHref(description?: string): {|
   };
 }
 
+type Props = {|
+  // $FlowFixMe[unclear-type]
+  Component?: ComponentType<any>,
+  excludeProps?: $ReadOnlyArray<string>,
+  generatedDocGen: DocGen,
+  id?: string,
+  name?: string,
+|};
+
 export default function GeneratedPropTable({
   Component,
+  excludeProps = [],
+  generatedDocGen,
   id,
   name,
-  generatedDocGen,
-  excludeProps = [],
-}: {|
-  Component?: ComponentType<any>, // flowlint-line unclear-type:off
-  name?: string,
-  id?: string,
-  generatedDocGen: DocGen,
-  excludeProps?: $ReadOnlyArray<string>,
-|}): Node {
+}: Props): Node {
   // Using Object.keys because of https://github.com/facebook/flow/issues/2174
   const props = Object.keys(generatedDocGen.props)
     .map((key: string) => {

--- a/docs/components/PropTable.js
+++ b/docs/components/PropTable.js
@@ -6,22 +6,6 @@ import { useAppContext } from './appContext.js';
 import { capitalizeFirstLetter } from './utils.js';
 import Markdown from './Markdown.js';
 
-type Props = {|
-  props: Array<{|
-    defaultValue?: boolean | string | number | null,
-    description?: string | Array<string>,
-    href?: string,
-    name: string,
-    required?: boolean,
-    responsive?: boolean,
-    nullable?: boolean,
-    type: string,
-  |}>,
-  Component?: ComponentType<any>, // flowlint-line unclear-type:off
-  name?: string,
-  id?: string,
-|};
-
 const unifyQuotes = (input) => input?.replace(/'/g, '"');
 
 function Description(lines: Array<string>): Node {
@@ -97,11 +81,28 @@ const transformDefaultValue = (input) => {
 
 const sortBy = (list, fn) => list.sort((a, b) => fn(a).localeCompare(fn(b)));
 
+type Props = {|
+  // $FlowFixMe[unclear-type]
+  Component?: ComponentType<any>,
+  id?: string,
+  name?: string,
+  props: Array<{|
+    defaultValue?: boolean | string | number | null,
+    description?: string | Array<string>,
+    href?: string,
+    name: string,
+    nullable?: boolean,
+    required?: boolean,
+    responsive?: boolean,
+    type: string,
+  |}>,
+|};
+
 export default function PropTable({
-  props: properties,
-  name: proptableName,
-  id = '',
   Component,
+  id = '',
+  name: proptableName,
+  props: properties,
 }: Props): Node {
   const { propTableVariant, setPropTableVariant } = useAppContext();
   const propsId = `${id}Props`;

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -8,30 +8,46 @@ import styles from './DatePicker.css';
 import dateFormat from './dateFormat.js';
 
 // LocaleData type from https://github.com/date-fns/date-fns/blob/81ab18785146405ca2ae28710cdfbb13a294ec50/src/locale/af/index.js.flow
-// flowlint unclear-type:off
 type LocaleData = {|
   code?: string,
+  // $FlowFixMe[unclear-type]
   formatDistance?: (...args: $ReadOnlyArray<any>) => any,
+  // $FlowFixMe[unclear-type]
   formatRelative?: (...args: $ReadOnlyArray<any>) => any,
   localize?: {|
+    // $FlowFixMe[unclear-type]
     ordinalNumber: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     era: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     quarter: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     month: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     day: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     dayPeriod: (...args: $ReadOnlyArray<any>) => any,
   |},
   formatLong?: {|
+    // $FlowFixMe[unclear-type]
     date: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     time: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     dateTime: (...args: $ReadOnlyArray<any>) => any,
   |},
   match?: {|
+    // $FlowFixMe[unclear-type]
     ordinalNumber: (...args: $ReadOnlyArray<string>) => any,
+    // $FlowFixMe[unclear-type]
     era: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     quarter: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     month: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     day: (...args: $ReadOnlyArray<any>) => any,
+    // $FlowFixMe[unclear-type]
     dayPeriod: (...args: $ReadOnlyArray<any>) => any,
   |},
   options?: {|
@@ -39,7 +55,6 @@ type LocaleData = {|
     firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   |},
 |};
-// flowlint unclear-type:error
 
 type Props = {|
   /**


### PR DESCRIPTION
This PR cleans up the way we suppress Flow errors to use `// $FlowFixMe` everywhere, as well as some other random cleanup