### PR TITLE
Internal: add eslint-plugin-validate-jsx-nesting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,6 @@
   },
   "rules": {
     "eslint-comments/no-unused-disable": "error",
-    "validate-jsx-nesting/no-invalid-jsx-nesting": "error",
     "flowtype/no-mutable-array": "error",
     "flowtype/require-exact-type": ["error", "always"],
     "flowtype/require-valid-file-annotation": [
@@ -80,7 +79,8 @@
     "react/require-default-props": "off",
     "react/sort-comp": "off",
     "react/state-in-constructor": ["error", "never"],
-    "react/static-property-placement": ["error", "static public field"]
+    "react/static-property-placement": ["error", "static public field"],
+    "validate-jsx-nesting/no-invalid-jsx-nesting": "error"
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,8 @@
     "jsx-a11y",
     "react",
     "react-hooks",
-    "testing-library"
+    "testing-library",
+    "validate-jsx-nesting"
   ],
   "settings": {
     "next": {
@@ -31,6 +32,7 @@
   },
   "rules": {
     "eslint-comments/no-unused-disable": "error",
+    "validate-jsx-nesting/no-invalid-jsx-nesting": "error",
     "flowtype/no-mutable-array": "error",
     "flowtype/require-exact-type": ["error", "always"],
     "flowtype/require-valid-file-annotation": [

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-testing-library": "^5.3.0",
+    "eslint-plugin-validate-jsx-nesting": "^0.1.0",
     "flow-bin": "^0.183.0",
     "flow-remove-types": "^2.183.0",
     "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7313,6 +7313,13 @@ eslint-plugin-testing-library@^5.3.0:
   dependencies:
     "@typescript-eslint/utils" "^5.13.0"
 
+eslint-plugin-validate-jsx-nesting@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-validate-jsx-nesting/-/eslint-plugin-validate-jsx-nesting-0.1.0.tgz#a7678264abdfb0d58dfed790ba3a57a2f5d1d4a8"
+  integrity sha512-cEFjl8bFBpWNP4hVyy3oRGKAyNH0WqxAVjjrfkvhD4ciqCrSvkDuYZqGZ7PkZb5XE76asHPxyuW2f9N2I1cSsg==
+  dependencies:
+    validate-html-nesting "^1.0.2"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
@@ -17321,6 +17328,11 @@ v8-to-istanbul@^9.0.0:
     "@jridgewell/trace-mapping" "^0.3.7"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
+
+validate-html-nesting@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/validate-html-nesting/-/validate-html-nesting-1.0.2.tgz#a9b602f5fc2deb7eab7fe3ba30e804dcdb2aaa2b"
+  integrity sha512-0eUJ1TJ8Pr5+/4E004blNnR5wqlnVYn5vJ7u0avl29kuU6KS2HTngJ0WpdyEEqeArHoizLu0iUA5zyJt/jB1RA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
This PR adds a new lint rule from [this package](https://github.com/MananTank/eslint-plugin-validate-jsx-nesting), checking to make sure we don't have invalid nested JSX (e.g. `<p>` within `<p>`). We don't have any errors currently, so this is more about preventing future errors.

![Screen Shot 2022-08-02 at 5 43 35 PM](https://user-images.githubusercontent.com/12059539/182500515-32663f14-489c-4331-8b3a-f10af2327583.png)