### PR TITLE
Docs: convert accessibility page to Sandpack & fix useReducedMotion example

### DIFF
--- a/docs/examples/accessibility/useFocusVisibleExample.js
+++ b/docs/examples/accessibility/useFocusVisibleExample.js
@@ -1,0 +1,45 @@
+// @flow strict
+import { useState, type Node } from 'react';
+import { Box, Flex, Text, useFocusVisible } from 'gestalt';
+
+export default function UseFocusVisibleExample(): Node {
+  const { isFocusVisible } = useFocusVisible();
+  const [focusedButton1, setFocusedButton1] = useState(false);
+  const [focusedButton2, setFocusedButton2] = useState(false);
+
+  return (
+    <Box padding={4} height="100%">
+      <Flex alignItems="center" direction="column" gap={12}>
+        <Flex direction="column" alignItems="center" gap={4}>
+          <Text>Using useFocusVisible(): Focus ring is only visible when using keyboard</Text>
+          <button
+            type="button"
+            onBlur={() => setFocusedButton1(false)}
+            onFocus={() => setFocusedButton1(true)}
+            style={{
+              outline: 'none',
+              boxShadow:
+                isFocusVisible && focusedButton1 ? '0 0 0 4px rgba(0, 132, 255, 0.5)' : null,
+            }}
+          >
+            <Text color="dark">Button 1</Text>
+          </button>
+        </Flex>
+        <Flex alignItems="center" direction="column" gap={4}>
+          <Text>Not using useFocusVisible(): Focus ring is always visible</Text>
+          <button
+            type="button"
+            onBlur={() => setFocusedButton2(false)}
+            onFocus={() => setFocusedButton2(true)}
+            style={{
+              outline: 'none',
+              boxShadow: focusedButton2 ? '0 0 0 4px rgba(0, 132, 255, 0.5)' : null,
+            }}
+          >
+            <Text color="dark">Button 2</Text>
+          </button>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/accessibility/useReducedMotionExample.js
+++ b/docs/examples/accessibility/useReducedMotionExample.js
@@ -1,0 +1,40 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Text, useReducedMotion } from 'gestalt';
+
+export default function UseReducedMotionExample(): Node {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <Box padding={4}>
+      <style
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: `
+                @keyframes vibrate {
+                  0% {
+                    transform: translate(0);
+                  }
+                  33% {
+                    transform: translate(-2px, -2px);
+                  }
+                  66% {
+                    transform: translate(2px, -2px);
+                  }
+                  100% {
+                    transform: translate(0);
+                  }
+                }
+              `,
+        }}
+      />
+      <div style={shouldReduceMotion ? {} : { animation: 'vibrate 0.3s linear infinite both' }}>
+        <Box color="errorBase" display="inlineBlock" padding={4}>
+          <Text color="inverse">
+            {shouldReduceMotion ? 'Reduced motion enabled' : 'Reduced motion not activated'}
+          </Text>
+        </Box>
+      </div>
+    </Box>
+  );
+}

--- a/docs/pages/foundations/accessibility.js
+++ b/docs/pages/foundations/accessibility.js
@@ -3,6 +3,9 @@ import { type Node } from 'react';
 import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import useFocusVisibleExample from '../../examples/accessibility/useFocusVisibleExample.js';
+import useReducedMotionExample from '../../examples/accessibility/useReducedMotionExample.js';
 
 export default function AccessibilityGuidelinesPage(): Node {
   return (
@@ -109,43 +112,14 @@ export default function AccessibilityGuidelinesPage(): Node {
             <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible">:focus-visible CSS pseudo-class</a></li>
           </ul>
         `}
-            defaultCode={`
-function Example() {
-  const { isFocusVisible } = useFocusVisible();
-  const [ focusedButton1, setFocusedButton1 ] = React.useState(false);
-  const [ focusedButton2, setFocusedButton2 ] = React.useState(false);
-
-  return (
-    <Flex alignItems="center" direction="column" gap={12}>
-      <Flex direction="column" alignItems="center" gap={4}>
-        <Text>Using useFocusVisible(): Focus ring is only visible when using keyboard</Text>
-        <button
-          onBlur={() => setFocusedButton1(false)}
-          onFocus={() => setFocusedButton1(true)}
-          style={{
-            outline: 'none',
-            boxShadow: isFocusVisible && focusedButton1 ? "0 0 0 4px rgba(0, 132, 255, 0.5)" : null
-          }}
-        >
-          <Text color="dark">Button 1</Text>
-        </button>
-      </Flex>
-      <Flex alignItems="center" direction="column" gap={4}>
-        <Text>Not using useFocusVisible(): Focus ring is always visible</Text>
-        <button
-          onBlur={() => setFocusedButton2(false)}
-          onFocus={() => setFocusedButton2(true)}
-          style={{
-            outline: 'none',
-            boxShadow: focusedButton2 ? "0 0 0 4px rgba(0, 132, 255, 0.5)" : null
-          }}
-        >
-          <Text color="dark">Button 2</Text>
-        </button>
-      </Flex>
-    </Flex>
-  );
-}`}
+            sandpackExample={
+              <SandpackExample
+                code={useFocusVisibleExample}
+                name="useFocusVisible example"
+                previewHeight={200}
+                showEditor={false}
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
@@ -161,42 +135,14 @@ function Example() {
             <li><a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C39.html">WCAG C39: Using the CSS reduce-motion query to prevent motion</a></li>
           </ul>
         `}
-            defaultCode={`
-        function Example() {
-          const shouldReduceMotion = useReducedMotion();
-
-          return (
-            <React.Fragment>
-              <style dangerouslySetInnerHTML={{__html: \`
-                @keyframes vibrate {
-                  0% {
-                    transform: translate(0);
-                  }
-                  33% {
-                    transform: translate(-2px, -2px);
-                  }
-                  66% {
-                    transform: translate(2px, -2px);
-                  }
-                  100% {
-                    transform: translate(0);
-                  }
-                }
-              \`}} />
-              <div
-                style={
-                  shouldReduceMotion
-                    ? {}
-                    : { animation: 'vibrate 0.3s linear infinite both' }
-                }
-              >
-                <Box color="red" display="inlineBlock" padding={4}>
-                  <Text color="inverse">{shouldReduceMotion ? 'Reduced motion enabled' : 'Reduced motion not activated'}</Text>
-                </Box>
-              </div>
-            </React.Fragment>
-          );
-        }`}
+            sandpackExample={
+              <SandpackExample
+                code={useReducedMotionExample}
+                name="useReducedMotion example"
+                previewHeight={200}
+                showEditor={false}
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>


### PR DESCRIPTION
# Summary

## What changed?

* Converts https://gestalt.pinterest.systems/foundations/accessibility examples to use Sandpack.

## Why?

More context in #2221 

Issues found in this diff:
* Lint error: Missing an explicit type attribute for button `eslintreact/button-has-type`
* Broken example: We were still using `color="red"` on `<Box />` which resulted in a broken `useReducedMotion` example.

### Before
![Screen Shot 2022-08-03 at 5 55 48 PM](https://user-images.githubusercontent.com/127199/182655544-53906c8a-55cf-481d-925f-aaba9d611bbf.png)

### After 
![Screen Shot 2022-08-03 at 6 01 20 PM](https://user-images.githubusercontent.com/127199/182655556-facd452b-83a3-4aaf-ad3b-1f55ba1689f8.png)

