### PR TITLE
Docs: adjustments to Sandpack code containers

### DIFF
--- a/docs/docs-components/SandpackExample.js
+++ b/docs/docs-components/SandpackExample.js
@@ -14,6 +14,8 @@ import ShowHideEditorButton from './buttons/ShowHideEditorButton.js';
 import OpenInCodeSandboxButton from './buttons/OpenInCodeSandboxButton.js';
 import { useLocalFiles } from './contexts/LocalFilesProvider.js';
 
+const MIN_HEIGHT = 350;
+
 async function copyCode({ code }: {| code: ?string |}) {
   try {
     await clipboardCopy(code ?? '');
@@ -41,7 +43,7 @@ function SandpackContainer({
 
   const CARD_SIZE_NAME_TO_PIXEL = {
     sm: 236,
-    md: 362,
+    md: MIN_HEIGHT,
   };
 
   const height =
@@ -57,9 +59,9 @@ function SandpackContainer({
             <SandpackCodeEditor
               wrapContent
               style={{
-                height,
+                height: height > MIN_HEIGHT ? height : MIN_HEIGHT,
                 flex: layout === 'column' ? 'none' : null,
-                order: layout === 'column' ? 1 : null,
+                order: 1,
               }}
             />
           )}

--- a/docs/pages/foundations/accessibility.js
+++ b/docs/pages/foundations/accessibility.js
@@ -116,8 +116,7 @@ export default function AccessibilityGuidelinesPage(): Node {
               <SandpackExample
                 code={useFocusVisibleExample}
                 name="useFocusVisible example"
-                previewHeight={200}
-                showEditor={false}
+                previewHeight={250}
               />
             }
           />
@@ -139,8 +138,7 @@ export default function AccessibilityGuidelinesPage(): Node {
               <SandpackExample
                 code={useReducedMotionExample}
                 name="useReducedMotion example"
-                previewHeight={200}
-                showEditor={false}
+                previewHeight={250}
               />
             }
           />

--- a/docs/pages/web/modal.js
+++ b/docs/pages/web/modal.js
@@ -98,25 +98,16 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
             cardSize="lg"
             type="don't"
             description="Use Modal for content that should have a dedicated surface, like login flows. Think about the core areas of your product that could appear in navigation. If a dedicated URL would be beneficial, use a full page instead. If the user interaction is an optional sub-task, consider using a [Sheet](/web/sheet)."
-            defaultCode={`
-
-`}
           />
           <MainSection.Card
             cardSize="lg"
             type="don't"
             description="Use Modal for long and complex tasks. Don’t keep the user in a Modal that takes multiple steps to exit. If multiple tasks are required, take the user to a separate page instead."
-            defaultCode={`
-
-`}
           />
           <MainSection.Card
             cardSize="lg"
             type="don't"
             description="Add additional task-based Modals to the Pinner product. While these are currently used in some Pinner surfaces for editing, consider using a full page, Sheet, Flyout or inline editing for a better user experience."
-            defaultCode={`
-
-`}
           />
         </MainSection.Subsection>
       </MainSection>
@@ -178,11 +169,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample
-                code={createBoardExample}
-                name="Create board example"
-                showEditor={false}
-              />
+              <SandpackExample code={createBoardExample} name="Create board example" />
             }
           />
         </MainSection.Subsection>
@@ -193,11 +180,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample
-                code={limitActionsExample}
-                name="Subheading example"
-                showEditor={false}
-              />
+              <SandpackExample code={limitActionsExample} name="Subheading example" />
             }
           />
         </MainSection.Subsection>
@@ -209,7 +192,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample code={sizesExample} name="Sizes example" showEditor={false} />
+              <SandpackExample code={sizesExample} name="Sizes example" layout="column" />
             }
           />
         </MainSection.Subsection>
@@ -220,11 +203,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample
-                code={preventCloseExample}
-                name="Prevent close example"
-                showEditor={false}
-              />
+              <SandpackExample code={preventCloseExample} name="Prevent close example" />
             }
           />
         </MainSection.Subsection>

--- a/docs/pages/web/pageheader.js
+++ b/docs/pages/web/pageheader.js
@@ -93,6 +93,7 @@ export default function PageHeaderPage({ generatedDocGen }: {| generatedDocGen: 
                 layout="column"
                 name="PageHeader one primary action example"
                 showEditor={false}
+                hideControls
               />
             }
           />
@@ -121,6 +122,7 @@ Plan for most PageHeaders to be full width. A \`maxWidth\` should only be suppli
                 layout="column"
                 name="PageHeader max width example"
                 showEditor={false}
+                hideControls
               />
             }
           />
@@ -149,6 +151,7 @@ Plan for most PageHeaders to be full width. A \`maxWidth\` should only be suppli
                 name="PageHeader include image example"
                 previewHeight={80}
                 showEditor={false}
+                hideControls
               />
             }
           />
@@ -178,6 +181,7 @@ Keep additional help buttons and links to a minimum, choosing one source of help
                 name="PageHeader do not overload example"
                 previewHeight={85}
                 showEditor={false}
+                hideControls
               />
             }
           />
@@ -200,7 +204,6 @@ Be brief with text in all components to account for languages with longer words.
               layout="column"
               name="PageHeader localization example"
               previewHeight={85}
-              showEditor={false}
             />
           }
         />
@@ -218,7 +221,6 @@ Be brief with text in all components to account for languages with longer words.
                 layout="column"
                 name="PageHeader title example"
                 previewHeight={80}
-                showEditor={false}
               />
             }
           />
@@ -245,7 +247,6 @@ Resize your window to observe how the PageHeaders below adapt to smaller screen 
                 layout="column"
                 name="Primary action example"
                 previewHeight={260}
-                showEditor={false}
               />
             }
           />
@@ -270,7 +271,6 @@ Resize your window to observe how the PageHeaders below adapt to smaller screen 
                 layout="column"
                 name="Secondary actions example"
                 previewHeight={170}
-                showEditor={false}
               />
             }
           />
@@ -287,7 +287,6 @@ Resize your window to observe how the PageHeaders below adapt to smaller screen 
                 layout="column"
                 name="Complimentary items example"
                 previewHeight={85}
-                showEditor={false}
               />
             }
           />
@@ -304,7 +303,6 @@ Resize your window to observe how the PageHeaders below adapt to smaller screen 
                 layout="column"
                 name="PageHeader subtext example"
                 previewHeight={85}
-                showEditor={false}
               />
             }
           />
@@ -322,7 +320,6 @@ PageHeader also supports a bottom border to show the division between PageHeader
                 code={centerAlignedExample}
                 layout="column"
                 name="PageHeader max width & border example"
-                showEditor={false}
               />
             }
           />

--- a/docs/pages/web/sheet.js
+++ b/docs/pages/web/sheet.js
@@ -135,7 +135,12 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
             type="do"
             description="Use Sheet for sub-tasks within a large workflow that are optional, like creating a new audience list while creating a campaign."
             sandpackExample={
-              <SandpackExample code={defaultExample} name="Sub task example" showEditor={false} />
+              <SandpackExample
+                code={defaultExample}
+                name="Sub task example"
+                showEditor={false}
+                layout="column"
+              />
             }
           />
 
@@ -148,6 +153,7 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
                 code={quickEditsExample}
                 name="Sub task example"
                 showEditor={false}
+                hideControls
               />
             }
           />
@@ -155,9 +161,6 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
             cardSize="lg"
             type="do"
             description="Use the same size Sheet on a product surface. For example, if filling out a form requires multiple Sheets to be opened to complete different subtasks, then all Sheets in that form should be the same width. When in doubt, pick the widest size needed for the entire flow."
-            defaultCode={`
-
-`}
           />
         </MainSection.Subsection>
         <MainSection.Subsection>
@@ -165,25 +168,16 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
             cardSize="lg"
             type="don't"
             description="Use Sheet for required tasks or main tasks, like logging in. Put those tasks within the content of the page instead."
-            defaultCode={`
-
-`}
           />
           <MainSection.Card
             cardSize="lg"
             type="don't"
             description="Use Sheet if edits or sub-tasks require more than two steps. Bring users to a full page experience or consider using [Modules](/web/module) to section out content."
-            defaultCode={`
-
-`}
           />
           <MainSection.Card
             cardSize="lg"
             type="don't"
             description="Use Sheet to confirm actions or display alerts. Use a [Modal](/web/modal) or [Toast](/web/toast) instead."
-            defaultCode={`
-
-`}
           />
         </MainSection.Subsection>
       </MainSection>
@@ -198,11 +192,7 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample
-                code={defaultExample}
-                name="Accessibility example"
-                showEditor={false}
-              />
+              <SandpackExample code={defaultExample} name="Accessibility example" layout="column" />
             }
           />
         </MainSection.Subsection>
@@ -225,7 +215,7 @@ When Sheet opens, focus should be placed on the first interactive element within
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample code={defaultExample} name="Heading example" showEditor={false} />
+              <SandpackExample code={defaultExample} name="Heading example" layout="column" />
             }
           />
         </MainSection.Subsection>
@@ -236,11 +226,7 @@ When Sheet opens, focus should be placed on the first interactive element within
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample
-                code={subheadingExample}
-                name="Subhading example"
-                showEditor={false}
-              />
+              <SandpackExample code={subheadingExample} name="Subhading example" layout="column" />
             }
           />
         </MainSection.Subsection>
@@ -251,7 +237,7 @@ When Sheet opens, focus should be placed on the first interactive element within
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample code={footerExample} name="Footer example" showEditor={false} />
+              <SandpackExample code={footerExample} name="Footer example" layout="column" />
             }
           />
         </MainSection.Subsection>
@@ -267,7 +253,7 @@ Sheet comes in 3 sizes: small (\`sm\`), medium (\`md\`), and large (\`lg\`).
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample code={sizesExample} name="Sizes example" showEditor={false} />
+              <SandpackExample code={sizesExample} name="Sizes example" layout="column" />
             }
           />
         </MainSection.Subsection>
@@ -282,7 +268,7 @@ Sheet comes in 3 sizes: small (\`sm\`), medium (\`md\`), and large (\`lg\`).
               <SandpackExample
                 code={preventClosingExample}
                 name="Prevent closing example"
-                showEditor={false}
+                layout="column"
               />
             }
           />
@@ -309,11 +295,7 @@ Sheet comes in 3 sizes: small (\`sm\`), medium (\`md\`), and large (\`lg\`).
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample
-                code={animationExample}
-                name="Animation example"
-                showEditor={false}
-              />
+              <SandpackExample code={animationExample} name="Animation example" layout="column" />
             }
           />
         </MainSection.Subsection>

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -210,13 +210,7 @@ export default function SideNavigationPage({
         >
           <MainSection.Card
             sandpackExample={
-              <SandpackExample
-                code={activeItemExample}
-                name="Active item example"
-                showEditor={false}
-                layout="column"
-                previewHeight={330}
-              />
+              <SandpackExample code={activeItemExample} name="Active item example" />
             }
           />
         </MainSection.Subsection>
@@ -230,13 +224,7 @@ export default function SideNavigationPage({
       >
         <MainSection.Card
           sandpackExample={
-            <SandpackExample
-              code={localizationExample}
-              name="Localization example"
-              showEditor={false}
-              layout="column"
-              previewHeight={263}
-            />
+            <SandpackExample code={localizationExample} name="Localization example" />
           }
         />
       </MainSection>
@@ -306,13 +294,7 @@ export default function SideNavigationPage({
         >
           <MainSection.Card
             sandpackExample={
-              <SandpackExample
-                code={sectionsExample}
-                name="Sections example"
-                showEditor={false}
-                layout="column"
-                previewHeight={470}
-              />
+              <SandpackExample code={sectionsExample} name="Sections example" previewHeight={470} />
             }
           />
         </MainSection.Subsection>
@@ -322,13 +304,7 @@ export default function SideNavigationPage({
         >
           <MainSection.Card
             sandpackExample={
-              <SandpackExample
-                code={headerExample}
-                name="Header example"
-                showEditor={false}
-                layout="column"
-                previewHeight={380}
-              />
+              <SandpackExample code={headerExample} name="Header example" previewHeight={380} />
             }
           />
         </MainSection.Subsection>
@@ -337,15 +313,6 @@ export default function SideNavigationPage({
           description="Footers allow for filters, additional external links or other UI controls to be included at the bottom of the navigation."
         >
           <MainSection.Card
-            // sandpackExample={
-            //   <SandpackExample
-            //     code={footerExample}
-            //     name="Footer example"
-            //     showEditor={false}
-            //
-            //     layout="column"
-            //   />
-            // }
             defaultCode={`
 <Box width="100%" height="100%">
   <Box height="100%" width={280} overflow="scroll">
@@ -407,15 +374,7 @@ export default function SideNavigationPage({
           description="A badge can be added to a menu label with information that may be useful to a person, such as whether a page is new or is a beta or deprecated feature. Only supported in SideNavigation.TopItem and SideNavigation.Group."
         >
           <MainSection.Card
-            sandpackExample={
-              <SandpackExample
-                code={badgeExample}
-                name="Badge example"
-                showEditor={false}
-                layout="column"
-                previewHeight={330}
-              />
-            }
+            sandpackExample={<SandpackExample code={badgeExample} name="Badge example" />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -423,15 +382,7 @@ export default function SideNavigationPage({
           description="A border can be added to the end edge of the navigation on dense surfaces with tight spacing where it helps to visually separate the nav from other content."
         >
           <MainSection.Card
-            sandpackExample={
-              <SandpackExample
-                code={borderExample}
-                name="Border example"
-                showEditor={false}
-                layout="column"
-                previewHeight={330}
-              />
-            }
+            sandpackExample={<SandpackExample code={borderExample} name="Border example" />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -441,26 +392,12 @@ export default function SideNavigationPage({
         >
           <MainSection.Card
             title="Gestalt icon"
-            sandpackExample={
-              <SandpackExample
-                code={iconsExample}
-                name="Icons example"
-                showEditor={false}
-                layout="column"
-                previewHeight={252}
-              />
-            }
+            sandpackExample={<SandpackExample code={iconsExample} name="Icons example" />}
           />
           <MainSection.Card
             title="Custom icon"
             sandpackExample={
-              <SandpackExample
-                code={customIconsExample}
-                name="Custom icon example"
-                showEditor={false}
-                layout="column"
-                previewHeight={252}
-              />
+              <SandpackExample code={customIconsExample} name="Custom icon example" />
             }
           />
         </MainSection.Subsection>
@@ -470,13 +407,7 @@ export default function SideNavigationPage({
         >
           <MainSection.Card
             sandpackExample={
-              <SandpackExample
-                code={notificationsExample}
-                name="Notifications example"
-                showEditor={false}
-                layout="column"
-                previewHeight={252}
-              />
+              <SandpackExample code={notificationsExample} name="Notifications example" />
             }
           />
         </MainSection.Subsection>
@@ -485,15 +416,7 @@ export default function SideNavigationPage({
           description="Counters can be included as indicators of the number of items on a page or section. Only include counters if it’s information that’s useful to the user to know before clicking on a menu item. Only supported in SideNavigation.TopItem and SideNavigation.Group."
         >
           <MainSection.Card
-            sandpackExample={
-              <SandpackExample
-                code={counterExample}
-                name="Counters example"
-                showEditor={false}
-                previewHeight={140}
-                layout="column"
-              />
-            }
+            sandpackExample={<SandpackExample code={counterExample} name="Counters example" />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -502,12 +425,7 @@ export default function SideNavigationPage({
         >
           <MainSection.Card
             sandpackExample={
-              <SandpackExample
-                code={nestedExample}
-                name="Nested directory example"
-                showEditor={false}
-                layout="column"
-              />
+              <SandpackExample code={nestedExample} name="Nested directory example" />
             }
           />
         </MainSection.Subsection>
@@ -516,13 +434,7 @@ export default function SideNavigationPage({
       <MainSection name="Mobile">
         <MainSection.Card
           sandpackExample={
-            <SandpackExample
-              code={mobileExample}
-              name="Mobile example"
-              showEditor={false}
-              layout="column"
-              previewHeight={500}
-            />
+            <SandpackExample code={mobileExample} name="Mobile example" previewHeight={500} />
           }
         />
       </MainSection>


### PR DESCRIPTION
### Summary

#### What changed?

Docs: adjustments to Sandpack code containers

Set default props for Sandpack containers

Variants and all examples except Best practices are open in SideNavigation, PageHeader, Sheet, and Modal