### PR TITLE
DeviceTypeProvider: Rollback to use `phone` to identify mobile devices

### DIFF
--- a/docs/examples/sidenavigation/mobileExample.js
+++ b/docs/examples/sidenavigation/mobileExample.js
@@ -6,7 +6,7 @@ export default function Example(): Node {
   const [showNav, setShowNav] = React.useState(false);
 
   return showNav ? (
-    <DeviceTypeProvider deviceType="mobile">
+    <DeviceTypeProvider deviceType="phone">
       <Box
         display="flex"
         alignItems="center"

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -23,7 +23,7 @@ function Providers({ children, isMobile }: {| children: Node, isMobile: boolean 
 
   return (
     <DocsDeviceTypeProvider isMobile={isMobileDevice}>
-      <DeviceTypeProvider deviceType={isMobileDevice ? 'mobile' : 'desktop'}>
+      <DeviceTypeProvider deviceType={isMobileDevice ? 'phone' : 'desktop'}>
         <DocsExperimentProvider>
           <DocsI18nProvider>{children}</DocsI18nProvider>
         </DocsExperimentProvider>

--- a/packages/gestalt/src/SideNavigation.js
+++ b/packages/gestalt/src/SideNavigation.js
@@ -78,7 +78,7 @@ export default function SideNavigation({
   const navigationChildren = useGetChildrenToArray({ children, filterLevel: 'main' });
 
   const deviceType = useDeviceType();
-  const isMobile = deviceType === 'mobile';
+  const isMobile = deviceType === 'phone';
 
   if (isMobile) {
     return (

--- a/packages/gestalt/src/SideNavigationGroup.js
+++ b/packages/gestalt/src/SideNavigationGroup.js
@@ -80,7 +80,7 @@ export default function SideNavigationGroup({
 
   const deviceType = useDeviceType();
 
-  const isMobile = deviceType === 'mobile';
+  const isMobile = deviceType === 'phone';
 
   const itemColor = hovered ? 'secondary' : undefined;
 

--- a/packages/gestalt/src/SideNavigationGroupContent.js
+++ b/packages/gestalt/src/SideNavigationGroupContent.js
@@ -47,7 +47,7 @@ export default function SideNavigationGroupContent({
 |}): Node {
   const deviceType = useDeviceType();
 
-  const isMobile = deviceType === 'mobile';
+  const isMobile = deviceType === 'phone';
 
   return (
     <Box

--- a/packages/gestalt/src/SideNavigationTopItem.js
+++ b/packages/gestalt/src/SideNavigationTopItem.js
@@ -84,7 +84,7 @@ export default function SideNavigationTopItem({
 
   const deviceType = useDeviceType();
 
-  const isMobile = deviceType === 'mobile';
+  const isMobile = deviceType === 'phone';
 
   const isTopLevel = nestedLevel === 0;
 

--- a/packages/gestalt/src/contexts/DeviceTypeProvider.js
+++ b/packages/gestalt/src/contexts/DeviceTypeProvider.js
@@ -3,7 +3,7 @@ import { type Context, type Node, createContext, useContext } from 'react';
 
 const defaultDeviceType = 'desktop';
 
-type DeviceType = 'desktop' | 'mobile' | 'tablet';
+type DeviceType = 'desktop' | 'phone' | 'tablet';
 
 const DeviceTypeContext: Context<DeviceType> = createContext<DeviceType>(defaultDeviceType);
 


### PR DESCRIPTION
### Summary

The type changing of `DeviceTypes` type would be a major change and was marked as a minor one. When the bumping happening the modification freezing the bumping and made a sensible diff.

#### What changed?

The word `phone` is used to identify mobile devices.

#### Why?

Create a big complexity to bumping a minor version of gestalt on pinboard.
