### PR TITLE
Heading: Removing justify value prop

### DIFF
--- a/docs/pages/web/heading.js
+++ b/docs/pages/web/heading.js
@@ -395,8 +395,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
   <Divider />
   <Heading align="center" size="400">Center-aligned heading</Heading>
   <Divider />
-  <Heading align="justify" size="400">Justify-aligned heading</Heading>
-  <Divider />
   <Heading align="forceLeft" size="400">Forced-left-aligned heading</Heading>
   <Divider />
   <Heading align="forceRight" size="400">Forced-right-aligned heading</Heading>

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -31,7 +31,7 @@ type Props = {|
   /**
    * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text. See [Alignment example](https://gestalt.pinterest.systems/heading#Alignment) for more details.
    */
-  align?: 'start' | 'end' | 'center' | 'justify' | 'forceLeft' | 'forceRight',
+  align?: 'start' | 'end' | 'center' | 'forceLeft' | 'forceRight',
   /**
    *
    */


### PR DESCRIPTION
### Summary

Removing unused prop `justify` of `Heading` component;

The following codemod help you to do the follow table replacement.

To modifyPropValue, please, use

```bash
yarn codemod modifyPropValue ~/path/to/your/code
  --component=Heading
  --previousProp=align
  --previousValue=justify
```

To detect manual changes use

```bash
 yarn codemod detectManualReplacement ~/path/to/your/code
 --component=Heading
 --prop=align
 --value=justify
 ```

#### What changed?

The value was removed of main file and code;

#### Why?

The value is not used and the design suggest your delete;

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4508)

### Checklist

- [x] Added documentation + accessibility tests
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
