### PR TITLE
SideNavigation, Docs: add hasActiveChild prop in SideNavigation.Group and SideNavigation.NestedGroup, implemented hasActiveChild in Gestalt docs

### DIFF
--- a/docs/docs-components/useGetSideNavItems.js
+++ b/docs/docs-components/useGetSideNavItems.js
@@ -10,7 +10,7 @@ function convertNamesForURL(name) {
 }
 
 const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): Node => {
-  const router = useRouter();
+  const { pathname } = useRouter();
   const { setIsSidebarOpen } = useNavigationContext();
 
   let nestingLevel = 0;
@@ -25,7 +25,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
               )}`;
               return (
                 <SideNavigation.TopItem
-                  active={router.pathname === href ? 'page' : undefined}
+                  active={pathname === href ? 'page' : undefined}
                   label={pageInfo}
                   onClick={() => setIsSidebarOpen?.(false)}
                   key={`${pageInfo}--${i}`}
@@ -41,7 +41,13 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
     }
     if (nestingLevel === 1) {
       return (
-        <SideNavigation.Group key={`${navItem.sectionName}`} label={navItem.sectionName}>
+        <SideNavigation.Group
+          key={`${navItem.sectionName}`}
+          label={navItem.sectionName}
+          hasActiveChild={pathname.includes(
+            `/${navItem.sectionName.toLocaleLowerCase().replace(' ', '_')}/`,
+          )}
+        >
           {navItem.pages.map((nestedPage, i) => {
             if (typeof nestedPage === 'string') {
               const href = `/${convertNamesForURL(previousSectionName)}/${convertNamesForURL(
@@ -49,7 +55,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
               )}/${convertNamesForURL(nestedPage)}`;
               return (
                 <SideNavigation.NestedItem
-                  active={router.pathname === href ? 'page' : undefined}
+                  active={pathname === href ? 'page' : undefined}
                   label={nestedPage}
                   onClick={() => setIsSidebarOpen?.(false)}
                   key={`${nestedPage}--${i}`}
@@ -65,7 +71,13 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
       );
     }
     return (
-      <SideNavigation.NestedGroup key={`${navItem.sectionName}`} label={navItem.sectionName}>
+      <SideNavigation.NestedGroup
+        key={`${navItem.sectionName}`}
+        label={navItem.sectionName}
+        hasActiveChild={pathname.includes(
+          `/${navItem.sectionName.toLocaleLowerCase().replace(' ', '_')}/`,
+        )}
+      >
         {navItem.pages.map((nestedPage, i) => {
           if (typeof nestedPage === 'string') {
             const href = `/${convertNamesForURL(previousSectionName)}/${convertNamesForURL(
@@ -73,7 +85,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
             )}/${convertNamesForURL(nestedPage)}`;
             return (
               <SideNavigation.NestedItem
-                active={router.pathname === href ? 'page' : undefined}
+                active={pathname === href ? 'page' : undefined}
                 label={nestedPage}
                 onClick={() => setIsSidebarOpen?.(false)}
                 key={`${nestedPage}--${i}`}

--- a/packages/gestalt/src/SideNavigationGroup.js
+++ b/packages/gestalt/src/SideNavigationGroup.js
@@ -38,6 +38,10 @@ export type Props = {|
    */
   display?: Display,
   /**
+   * When supplied, the  group will render expanded to show an active item  child.See the [Accessibility](https://gestalt.pinterest.systems/SideNavigation#Accessibility) guidelines to learn more.
+   */
+  hasActiveChild?: boolean,
+  /**
    * When supplied, will display Icon. See the [Icon](https://gestalt.pinterest.systems/SideNavigation#Icon) variant to learn more.
    */
   icon?: IconType,
@@ -55,10 +59,11 @@ export type Props = {|
  * Use [SideNavigation.Group](https://gestalt.pinterest.systems/sidenavigation#SideNavigation.Group) to hold SideNavigation.NestedItem and SideNavigation.NestedGroup at the top level of SideNavigation. It supports badges, icons, counters, and notifications.
  */
 export default function SideNavigationGroup({
-  children,
   badge,
+  children,
   counter,
   display = 'expandable',
+  hasActiveChild = false,
   icon,
   notificationAccessibilityLabel,
   label,
@@ -70,7 +75,7 @@ export default function SideNavigationGroup({
 
   const [hovered, setHovered] = useState(false);
 
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(hasActiveChild);
 
   const itemId = useId();
 

--- a/packages/gestalt/src/SideNavigationGroup.js
+++ b/packages/gestalt/src/SideNavigationGroup.js
@@ -100,6 +100,7 @@ export default function SideNavigationGroup({
         badge={badge}
         counter={counter}
         display={display}
+        hasActiveChild={hasActiveChild}
         icon={icon}
         label={label}
         notificationAccessibilityLabel={notificationAccessibilityLabel}

--- a/packages/gestalt/src/SideNavigationNestedGroup.js
+++ b/packages/gestalt/src/SideNavigationNestedGroup.js
@@ -12,6 +12,10 @@ type Props = {|
    */
   display?: 'expandable' | 'static',
   /**
+   * When supplied, the  group will render expanded to show an active item  child.See the [Accessibility](https://gestalt.pinterest.systems/SideNavigation#Accessibility) guidelines to learn more.
+   */
+  hasActiveChild?: boolean,
+  /**
    * Label for the group. See [nested directory](#Nested-directory) variant for more information.
    */
   label: string,
@@ -23,10 +27,11 @@ type Props = {|
 export default function SideNavigationNestedGroup({
   children,
   display = 'expandable',
+  hasActiveChild,
   label,
 }: Props): Node {
   return (
-    <SideNavigationGroup label={label} display={display}>
+    <SideNavigationGroup label={label} display={display} hasActiveChild={hasActiveChild}>
       {children}
     </SideNavigationGroup>
   );

--- a/packages/gestalt/src/contexts/SideNavigationProvider.js
+++ b/packages/gestalt/src/contexts/SideNavigationProvider.js
@@ -18,6 +18,8 @@ type SideNavigationContextType = {|
   setSelectedItemId: (string) => void,
   selectedMobileChildren: Node | null,
   setSelectedMobileChildren: (Node | null) => void,
+  hideActiveChildren: boolean | null,
+  setHideActiveChildren: (boolean | null) => void,
   dismissButton?: {|
     accessibilityLabel?: string,
     onDismiss: () => void,
@@ -36,6 +38,8 @@ const SideNavigationContext: Context<SideNavigationContextType> =
     setSelectedItemId: () => {},
     selectedMobileChildren: null,
     setSelectedMobileChildren: () => {},
+    hideActiveChildren: false,
+    setHideActiveChildren: () => {},
   });
 
 const { Provider } = SideNavigationContext;
@@ -43,12 +47,15 @@ const { Provider } = SideNavigationContext;
 function SideNavigationProvider({ children, dismissButton }: Props): Element<typeof Provider> {
   const [selectedItemId, setSelectedItemId] = useState('');
   const [selectedMobileChildren, setSelectedMobileChildren] = useState(null);
+  const [hideActiveChildren, setHideActiveChildren] = useState(false);
 
   const sideNavigationContext = {
     selectedItemId,
     setSelectedItemId,
     selectedMobileChildren,
     setSelectedMobileChildren,
+    hideActiveChildren,
+    setHideActiveChildren,
     dismissButton,
   };
 
@@ -61,6 +68,8 @@ function useSideNavigation(): SideNavigationContextType {
     setSelectedItemId,
     selectedMobileChildren,
     setSelectedMobileChildren,
+    hideActiveChildren,
+    setHideActiveChildren,
     dismissButton,
   } = useContext(SideNavigationContext);
   return {
@@ -68,6 +77,8 @@ function useSideNavigation(): SideNavigationContextType {
     setSelectedItemId,
     selectedMobileChildren,
     setSelectedMobileChildren,
+    hideActiveChildren,
+    setHideActiveChildren,
     dismissButton,
   };
 }


### PR DESCRIPTION
### Summary

#### What changed?

SideNavigation, Docs: add hasActiveChild prop SideNavigation.Group and SideNavigation.NestedGroup, implemented hasActiveChild in Gestalt docs

#### Why?

To externally control the expanded state of SideNavigation.Group and SideNavigation.NestedGroup and show nested active items on first render. (Original suggestion by @ayeshakmaz )

I implemented hasActiveChild to externally control  the  expand/collapse of groups. The issue to manage 
 it internally is that the children & grand children can only communicate with their parent when rendered, and the initial state is collapsed. Therefore, the information is not available on first render. I tried communicating the children state to the parent via context which didn't work because context was not updated because the children are not rendered yet when groups are collapsed. Immediate children can communicate with parent but not grandchildren.