### PR TITLE
Docs: convert multiple "foundation" page examples to Sandpack

### DIFF
--- a/docs/docs-components/SandpackExample.js
+++ b/docs/docs-components/SandpackExample.js
@@ -14,8 +14,8 @@ import ShowHideEditorButton from './buttons/ShowHideEditorButton.js';
 import OpenInCodeSandboxButton from './buttons/OpenInCodeSandboxButton.js';
 import { useLocalFiles } from './contexts/LocalFilesProvider.js';
 
-const MIN_HEIGHT = 350;
-const MAX_WIDTH = 390;
+const MIN_EDITOR_HEIGHT = 350;
+const MAX_EDITOR_MOBILE_WIDTH = 390;
 
 async function copyCode({ code }: {| code: ?string |}) {
   try {
@@ -27,34 +27,20 @@ async function copyCode({ code }: {| code: ?string |}) {
 }
 
 function SandpackContainer({
-  name,
   layout,
-  previewHeight = 'md',
-  showEditor,
-  hideControls,
-  mobileView,
+  name,
+  previewHeight,
+  hideControls = false,
+  hideEditor = false,
 }: {|
+  layout: 'row' | 'column' | 'mobileRow',
   name: string,
-  layout: 'row' | 'column',
-  previewHeight?: 'sm' | 'md' | number,
-  showEditor: boolean,
+  previewHeight?: number,
   hideControls?: boolean,
-  mobileView?: boolean,
+  hideEditor?: boolean,
 |}) {
-  const [editorShown, setEditorShown] = React.useState(showEditor);
+  const [editorShown, setEditorShown] = React.useState(!hideEditor);
   const { sandpack } = useSandpack();
-
-  const CARD_SIZE_NAME_TO_PIXEL = {
-    sm: 236,
-    md: MIN_HEIGHT,
-  };
-
-  const height =
-    previewHeight !== 'sm' && previewHeight !== 'md'
-      ? previewHeight
-      : CARD_SIZE_NAME_TO_PIXEL[previewHeight];
-
-  const maxWidth = mobileView ? MAX_WIDTH : undefined;
 
   return (
     <React.Fragment>
@@ -62,8 +48,8 @@ function SandpackContainer({
         <SandpackLayout>
           <SandpackPreview
             style={{
-              maxWidth,
-              height,
+              maxWidth: layout === 'mobileRow' ? MAX_EDITOR_MOBILE_WIDTH : undefined,
+              height: previewHeight,
             }}
             showRefreshButton={false}
             showOpenInCodeSandbox={false}
@@ -72,9 +58,9 @@ function SandpackContainer({
             <SandpackCodeEditor
               wrapContent
               style={{
-                height: height > MIN_HEIGHT ? height : MIN_HEIGHT,
+                height:
+                  (previewHeight ?? 0) > MIN_EDITOR_HEIGHT ? previewHeight : MIN_EDITOR_HEIGHT,
                 flex: layout === 'column' ? 'none' : null,
-                order: 1,
               }}
             />
           )}
@@ -85,31 +71,33 @@ function SandpackContainer({
         display={hideControls ? undefined : 'none'}
         height={hideControls ? 24 : undefined}
       />
-      <Box marginTop={2} display={hideControls ? 'none' : undefined}>
-        <Flex
-          justifyContent="end"
-          alignItems="center"
-          gap={{
-            row: 2,
-            column: 0,
-          }}
-        >
-          <OpenInCodeSandboxButton />
-
-          <CopyCodeButton
-            onClick={() => {
-              const code = sandpack?.files?.['/App.js']?.code;
-              copyCode({ code });
+      {!hideControls && (
+        <Box marginTop={2}>
+          <Flex
+            justifyContent="end"
+            alignItems="center"
+            gap={{
+              row: 2,
+              column: 0,
             }}
-          />
+          >
+            <OpenInCodeSandboxButton />
 
-          <ShowHideEditorButton
-            expanded={editorShown}
-            name={name}
-            onClick={() => setEditorShown(!editorShown)}
-          />
-        </Flex>
-      </Box>
+            <CopyCodeButton
+              onClick={() => {
+                const code = sandpack?.files?.['/App.js']?.code;
+                copyCode({ code });
+              }}
+            />
+
+            <ShowHideEditorButton
+              expanded={editorShown}
+              name={name}
+              onClick={() => setEditorShown(!editorShown)}
+            />
+          </Flex>
+        </Box>
+      )}
     </React.Fragment>
   );
 }
@@ -119,17 +107,15 @@ export default function SandpackExample({
   layout = 'row',
   name,
   previewHeight,
-  showEditor = true,
-  hideControls = false,
-  mobileView = false,
+  hideControls,
+  hideEditor,
 }: {|
   code: ?string | (() => Node),
-  layout?: 'row' | 'column',
+  layout?: 'row' | 'column' | 'mobileRow',
   name: string,
-  previewHeight?: 'sm' | 'md' | number,
-  showEditor?: boolean,
+  previewHeight?: number,
   hideControls?: boolean,
-  mobileView?: boolean,
+  hideEditor?: boolean,
 |}): Node {
   const { files } = useLocalFiles();
 
@@ -181,12 +167,11 @@ export default function SandpackExample({
       }}
     >
       <SandpackContainer
-        name={name}
-        showEditor={showEditor}
-        previewHeight={previewHeight}
         layout={layout}
+        name={name}
+        previewHeight={previewHeight}
         hideControls={hideControls}
-        mobileView={mobileView}
+        hideEditor={hideEditor}
       />
     </SandpackProvider>
   );

--- a/docs/examples/colors/alternativeColorTextExample.js
+++ b/docs/examples/colors/alternativeColorTextExample.js
@@ -1,0 +1,28 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Icon, Text } from 'gestalt';
+
+export default function AlternativeColorTextExample(): Node {
+  return (
+    <Flex
+      gap={{
+        row: 1,
+        column: 0,
+      }}
+      alignItems="center"
+      justifyContent="center"
+      height="100%"
+    >
+      <Icon icon="eye" accessibilityLabel="views" />
+      <Text weight="bold">
+        <Box
+          dangerouslySetInlineStyle={{
+            __style: { color: 'darkmagenta' },
+          }}
+        >
+          views
+        </Box>
+      </Text>
+    </Flex>
+  );
+}

--- a/docs/examples/colors/alternativeColorTokensExample.js
+++ b/docs/examples/colors/alternativeColorTokensExample.js
@@ -1,0 +1,80 @@
+// @flow strict
+import { type Node } from 'react';
+import {
+  Box,
+  Button,
+  ColorSchemeProvider,
+  Flex,
+  IconButton,
+  SearchField,
+  TapArea,
+  Text,
+} from 'gestalt';
+
+export default function AlternativeColorTokensExample(): Node {
+  return (
+    <Flex height="100%" justifyContent="center" alignItems="center">
+      <ColorSchemeProvider colorScheme="dark" id="dark-example-dont">
+        <Box color="default" padding={10} height="100%">
+          <Flex
+            direction="column"
+            gap={{
+              row: 0,
+              column: 8,
+            }}
+            alignItems="center"
+            height="100%"
+          >
+            <Flex
+              gap={{
+                row: 4,
+                column: 0,
+              }}
+            >
+              <IconButton icon="speech" accessibilityLabel="Comment" />
+              <IconButton icon="share" iconColor="darkGray" accessibilityLabel="Share" />
+            </Flex>
+            <Flex
+              gap={{
+                row: 4,
+                column: 0,
+              }}
+            >
+              <Button color="red" text="Primary" />
+              <Box color="warningWeak" rounding="pill" padding={3}>
+                <TapArea>
+                  <Text weight="bold" color="light">
+                    Secondary
+                  </Text>
+                </TapArea>
+              </Box>
+              <Button color="blue" text="Shop" />
+            </Flex>
+            <Flex
+              gap={{
+                row: 4,
+                column: 0,
+              }}
+            >
+              <SearchField
+                accessibilityLabel="Search you Pins"
+                id="color-dont-search"
+                placeholder="Search your Pins"
+                onChange={() => {}}
+              />
+            </Flex>
+            <Flex
+              gap={{
+                row: 8,
+                column: 0,
+              }}
+            >
+              <Text>Default text</Text>
+              <Text color="subtle">Subtle text</Text>
+            </Flex>
+          </Flex>
+        </Box>
+      </ColorSchemeProvider>
+    </Flex>
+  );
+}

--- a/docs/examples/colors/alternativeColorsExample.js
+++ b/docs/examples/colors/alternativeColorsExample.js
@@ -1,0 +1,36 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Icon, Flex, Text } from 'gestalt';
+
+export default function AlternativeColorsExample(): Node {
+  return (
+    <Flex
+      gap={{
+        row: 2,
+        column: 0,
+      }}
+      alignItems="center"
+      justifyContent="center"
+      height="100%"
+    >
+      <Box
+        dangerouslySetInlineStyle={{
+          __style: { backgroundColor: 'gold' },
+        }}
+        rounding="pill"
+        padding={3}
+      >
+        <Text weight="bold">Button</Text>
+      </Box>
+      <Box
+        dangerouslySetInlineStyle={{
+          __style: { backgroundColor: 'green' },
+        }}
+        rounding="circle"
+        padding={3}
+      >
+        <Icon icon="add" color="inverse" accessibilityLabel="Create" />
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/colors/appropriateColorTokensExample.js
+++ b/docs/examples/colors/appropriateColorTokensExample.js
@@ -1,0 +1,60 @@
+// @flow strict
+import { type Node } from 'react';
+import { Button, IconButton, Flex, SearchField, Text } from 'gestalt';
+
+export default function AppropriateColorTokensExample(): Node {
+  return (
+    <Flex
+      direction="column"
+      gap={{
+        row: 0,
+        column: 8,
+      }}
+      alignItems="center"
+      justifyContent="center"
+      height="100%"
+    >
+      <Flex
+        gap={{
+          row: 4,
+          column: 0,
+        }}
+      >
+        <IconButton icon="speech" accessibilityLabel="Comment" />
+        <IconButton icon="share" iconColor="darkGray" accessibilityLabel="Share" />
+      </Flex>
+      <Flex
+        gap={{
+          row: 4,
+          column: 0,
+        }}
+      >
+        <Button color="red" text="Primary" />
+        <Button color="gray" text="Secondary" />
+        <Button color="blue" text="Shop" />
+      </Flex>
+      <Flex
+        gap={{
+          row: 4,
+          column: 0,
+        }}
+      >
+        <SearchField
+          accessibilityLabel="Search you Pins"
+          id="color-do-search"
+          placeholder="Search your Pins"
+          onChange={() => {}}
+        />
+      </Flex>
+      <Flex
+        gap={{
+          row: 8,
+          column: 0,
+        }}
+      >
+        <Text>Default text</Text>
+        <Text color="subtle">Subtle text</Text>
+      </Flex>
+    </Flex>
+  );
+}

--- a/docs/examples/colors/communicateStatusExample.js
+++ b/docs/examples/colors/communicateStatusExample.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { type Node } from 'react';
+import { Badge, Flex } from 'gestalt';
+
+export default function CommunicateStatusExample(): Node {
+  return (
+    <Flex
+      direction="column"
+      gap={{
+        row: 0,
+        column: 3,
+      }}
+      justifyContent="center"
+      alignItems="center"
+      height="100%"
+    >
+      <Badge type="info" text="Info" />
+      <Badge type="success" text="Success" />
+      <Badge type="warning" text="Warning" />
+      <Badge type="error" text="Error" />
+      <Badge type="neutral" text="Neutral" />
+    </Flex>
+  );
+}

--- a/docs/examples/colors/distinctionExample.js
+++ b/docs/examples/colors/distinctionExample.js
@@ -1,0 +1,22 @@
+// @flow strict
+import { type Node } from 'react';
+import { Button, Flex, IconButton } from 'gestalt';
+
+export default function DistinctionExample(): Node {
+  return (
+    <Flex
+      gap={{
+        row: 4,
+        column: 0,
+      }}
+      justifyContent="center"
+      alignItems="center"
+      height="100%"
+    >
+      <IconButton icon="speech" iconColor="darkGray" accessibilityLabel="Comment" />
+      <Button color="gray" text="Visit" />
+      <Button color="red" text="Save" />
+      <IconButton icon="share" iconColor="darkGray" accessibilityLabel="Share" />
+    </Flex>
+  );
+}

--- a/docs/examples/colors/establishedExample.js
+++ b/docs/examples/colors/establishedExample.js
@@ -1,0 +1,11 @@
+// @flow strict
+import { type Node } from 'react';
+import { Flex, Status } from 'gestalt';
+
+export default function EstablishedExample(): Node {
+  return (
+    <Flex alignItems="center" justifyContent="center" height="100%">
+      <Status type="ok" title="Campaign complete" />
+    </Flex>
+  );
+}

--- a/docs/examples/colors/extendedColorsExample.js
+++ b/docs/examples/colors/extendedColorsExample.js
@@ -1,0 +1,18 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Image } from 'gestalt';
+
+export default function ExtendedColorsExample(): Node {
+  return (
+    <Flex height="100%" alignItems="center" justifyContent="center">
+      <Box width={200} height={305}>
+        <Image
+          naturalWidth={200}
+          naturalHeight={350}
+          src="https://i.ibb.co/7yLs8qG/Brand.png"
+          alt="An example of brand colors used in the Pinterest app."
+        />
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/colors/invalidElevationExample.js
+++ b/docs/examples/colors/invalidElevationExample.js
@@ -1,0 +1,19 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Image } from 'gestalt';
+
+export default function InvalidElevationExample(): Node {
+  return (
+    <Flex height="100%" alignItems="center" justifyContent="center">
+      <Box width={200} height={305}>
+        <Image
+          fit="contain"
+          naturalWidth={200}
+          naturalHeight={350}
+          src="https://i.ibb.co/FqM70HS/screen-sample-02.png"
+          alt="Example showing an incorrect mobile dark mode on the Pinterest app."
+        />
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/colors/repurposeExample.js
+++ b/docs/examples/colors/repurposeExample.js
@@ -1,0 +1,31 @@
+// @flow strict
+import { type Node } from 'react';
+import { Badge, Flex, Label, Switch, Text } from 'gestalt';
+
+export default function RepurposeExample(): Node {
+  return (
+    <Flex justifyContent="center" alignItems="center" height="100%">
+      <Flex
+        direction="column"
+        gap={{
+          row: 0,
+          column: 2,
+        }}
+      >
+        <Flex
+          gap={{
+            row: 2,
+            column: 0,
+          }}
+        >
+          <Label htmlFor="dont-01">
+            <Text weight="bold"> Search privacy</Text>
+          </Label>
+          <Badge type="error" text="New" />
+        </Flex>
+        <Text color="subtle">Hide your profile from search engines</Text>
+      </Flex>
+      <Switch id="dont-01" onChange={() => {}} />
+    </Flex>
+  );
+}

--- a/docs/examples/colors/soleIndicatorExample.js
+++ b/docs/examples/colors/soleIndicatorExample.js
@@ -1,0 +1,40 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Label, SelectList, Text } from 'gestalt';
+
+export default function SoleIndicatorExample(): Node {
+  return (
+    <Flex
+      direction="column"
+      gap={{
+        row: 0,
+        column: 2,
+      }}
+      justifyContent="center"
+      alignItems="center"
+      height="100%"
+    >
+      <Label htmlFor="solo-color">
+        <Text>Audience 1</Text>
+      </Label>
+      <Flex
+        alignItems="center"
+        gap={{
+          row: 2,
+          column: 0,
+        }}
+      >
+        <Box rounding="circle" color="infoBase" width={12} height={12} />
+        <SelectList
+          id="solo-color"
+          onChange={() => {}}
+          options={[
+            { label: 'Your total audience', value: '5' },
+            { label: 'Active in the last week', value: '7' },
+            { label: 'Active in the last month', value: '30' },
+          ]}
+        />
+      </Flex>
+    </Flex>
+  );
+}

--- a/docs/examples/colors/validElevationExample.js
+++ b/docs/examples/colors/validElevationExample.js
@@ -1,0 +1,19 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Image } from 'gestalt';
+
+export default function ValidElevationExample(): Node {
+  return (
+    <Flex height="100%" alignItems="center" justifyContent="center">
+      <Box width={200} height={305}>
+        <Image
+          fit="contain"
+          naturalWidth={200}
+          naturalHeight={350}
+          src="https://i.ibb.co/5rQQnDR/screen-sample-01.png"
+          alt="Example showing mobile dark mode on the Pinterest app."
+        />
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/layouts/layoutsExample.js
+++ b/docs/examples/layouts/layoutsExample.js
@@ -1,0 +1,83 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Button, Flex, Heading, SelectList, TextField } from 'gestalt';
+
+export default function LayoutsExample(): Node {
+  return (
+    <Box padding={4}>
+      <Flex
+        direction="column"
+        gap={{
+          row: 0,
+          column: 6,
+        }}
+        maxWidth={800}
+        width="100%"
+        wrap
+      >
+        <Heading size="400" accessibilityLevel={2}>
+          Form Title
+        </Heading>
+
+        <TextField
+          label="TextField 1"
+          id="textfield1"
+          onChange={() => {}}
+          placeholder="Placeholder"
+        />
+
+        <Flex gap={3} wrap>
+          <Flex.Item flex="grow" minWidth={250}>
+            <TextField
+              label="TextField 2"
+              id="textfield2"
+              onChange={() => {}}
+              placeholder="Placeholder"
+            />
+          </Flex.Item>
+          <Flex.Item flex="grow" minWidth={250}>
+            <TextField
+              label="TextField 3"
+              id="textfield3"
+              onChange={() => {}}
+              placeholder="Placeholder"
+            />
+          </Flex.Item>
+        </Flex>
+
+        <SelectList
+          label="SelectList"
+          id="selectlist"
+          options={[
+            {
+              value: 'belgium',
+              label: 'Belgium',
+            },
+            {
+              value: 'france',
+              label: 'France',
+            },
+            {
+              value: 'usa',
+              label: 'USA',
+            },
+          ]}
+          placeholder="Placeholder"
+          onChange={() => {}}
+        />
+
+        <Flex
+          gap={{
+            row: 2,
+            column: 0,
+          }}
+          justifyContent="end"
+          wrap
+        >
+          <Button text="Cancel" size="lg" />
+          <Button text="Submit" color="red" size="lg" type="submit" />
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/screenSizes/screenSizesAndroid.js
+++ b/docs/examples/screenSizes/screenSizesAndroid.js
@@ -1,0 +1,48 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Table, Text } from 'gestalt';
+
+export default function ScreenSizesIos(): Node {
+  return (
+    <Box width="100%" padding={8}>
+      <Table accessibilityLabel="Android Screen Sizes">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text weight="bold">Device</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Size (dp)</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Small phone</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>320 x 480</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Phone</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>360 x 640</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Tablet</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>800 x 1280</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/screenSizes/screenSizesIos.js
+++ b/docs/examples/screenSizes/screenSizesIos.js
@@ -1,0 +1,48 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Table, Text } from 'gestalt';
+
+export default function ScreenSizesIos(): Node {
+  return (
+    <Box padding={8} width="100%">
+      <Table accessibilityLabel="iOS Screen Sizes">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text weight="bold">Device</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Size (pt)</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Small phone</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>320 x 568</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Phone</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>360 x 780</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Tablet</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>768 x 1024</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/screenSizes/screenSizesWeb.js
+++ b/docs/examples/screenSizes/screenSizesWeb.js
@@ -1,0 +1,72 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Table, Text } from 'gestalt';
+
+export default function ScreenSizesWeb(): Node {
+  return (
+    <Box padding={8} width="100%">
+      <Table accessibilityLabel="Web Screen Sizes">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text weight="bold">Device</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Size (px)</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Small phone</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>320 x 568</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Phone</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>360 x 780</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Tablet</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>768 x 1024</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Desktop Breakpoints (min-width)</Text>
+              <Box paddingY={2} maxWidth={500}>
+                <Text italic>
+                  Components in Gestalt adjust to browser size at these breakpoints. When designing,
+                  please make sure your designs take these breakpoints into consideration.
+                </Text>
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Flex
+                direction="column"
+                gap={{
+                  row: 0,
+                  column: 2,
+                }}
+              >
+                <Text>sm: 576px</Text>
+                <Text>md: 768px</Text>
+                <Text>lg: 1312px</Text>
+              </Flex>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/pages/foundations/color/examples.js
+++ b/docs/pages/foundations/color/examples.js
@@ -8,6 +8,20 @@ import A11Y from '../../../graphics/home-page/accessibility.svg';
 import ColorEase from '../../../graphics/color-examples/colorEase.svg';
 import Consistency from '../../../graphics/color-examples/consistency.svg';
 
+import alternativeColors from '../../../examples/colors/alternativeColorsExample.js';
+import alternativeColorTextExample from '../../../examples/colors/alternativeColorTextExample.js';
+import alternativeColorTokensExample from '../../../examples/colors/alternativeColorTokensExample.js';
+import appropriateColorTokensExample from '../../../examples/colors/appropriateColorTokensExample.js';
+import communicateStatusExample from '../../../examples/colors/communicateStatusExample.js';
+import distinctionExample from '../../../examples/colors/distinctionExample.js';
+import establishedExample from '../../../examples/colors/establishedExample.js';
+import extendedColors from '../../../examples/colors/extendedColorsExample.js';
+import invalidElevationExample from '../../../examples/colors/invalidElevationExample.js';
+import repurposeExample from '../../../examples/colors/repurposeExample.js';
+import SandpackExample from '../../../docs-components/SandpackExample.js';
+import soleIndicatorExample from '../../../examples/colors/soleIndicatorExample.js';
+import validElevationExample from '../../../examples/colors/validElevationExample.js';
+
 type PrincipleCardProps = {|
   color: string,
   image?: Node,
@@ -133,50 +147,28 @@ export default function ColorExamplesPage(): Node {
             cardSize="md"
             type="do"
             description="Use colors to support creating distinction between elements, such as define primary and secondary actions. See [color usage](/foundations/color/usage) for reference and appropriate tokens."
-            defaultCode={`
-            <Flex gap={{ row: 4, column: 0 }}>
-              <IconButton
-                icon="speech"
-                iconColor="darkGray"
-                accessibilityLabel="Comment"
+            sandpackExample={
+              <SandpackExample
+                code={distinctionExample}
+                name="Color distinction example"
+                hideEditor
+                previewHeight={286}
               />
-              <Button
-                color="gray"
-                text="Visit"
-              />
-              <Button
-                color="red"
-                text="Save"
-              />
-              <IconButton
-                icon="share"
-                iconColor="darkGray"
-                accessibilityLabel="Share"
-              />
-            </Flex>
-`}
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Use color as a sole indicator of information. Color-only changes do not work well for those who may be color blind or have low vision; always supply an icon or text label for context."
-            defaultCode={`
-            <Flex direction="column" gap={{ column: 2, row: 0 }}>
-              <Label htmlFor={"solo-color"}><Text>Audience 1</Text></Label>
-              <Flex alignItems="center" gap={{ row: 2, column: 0 }}>
-                <Box rounding="circle" color="infoBase" width={12} height={12}/>
-                <SelectList
-                  id={"solo-color"}
-                  onChange={() => {}}
-                  options={[
-                    {label: 'Your total audience', value: '5'},
-                    {label: 'Active in the last week', value: '7'},
-                    {label: 'Active in the last month', value: '30'},
-                  ]}
-                />
-              </Flex>
-            </Flex>
-`}
+            sandpackExample={
+              <SandpackExample
+                code={soleIndicatorExample}
+                name="Sole indicator example"
+                hideEditor
+                hideControls
+                previewHeight={286}
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -184,37 +176,28 @@ export default function ColorExamplesPage(): Node {
             cardSize="md"
             type="do"
             description="Use colors purposefully as it can convey meaning in multiple ways. Our extended color palette is used for communicating status or enhancing illustrations when needed. See [color usage](/foundations/color/usage) for reference."
-            defaultCode={`
-            <Flex direction="column" gap={{ column: 3, row: 0 }}>
-              <Badge type="info" text="Info"/>
-              <Badge type="success" text="Success" />
-              <Badge type="warning" text="Warning"/>
-              <Badge type="error" text="Error" />
-              <Badge type="neutral" text="Neutral" />
-            </Flex>
-`}
+            sandpackExample={
+              <SandpackExample
+                code={communicateStatusExample}
+                name="Communicate status example"
+                hideEditor
+                previewHeight={286}
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Repurpose colors. Using colors for their intended meaning supports good comprehension and avoids usability and accessibility issues."
-            defaultCode={`
-            <Flex>
-              <Flex direction="column" gap={{ column: 2, row: 0 }}>
-                <Flex gap={{ column: 0, row: 2 }}>
-                  <Label htmlFor="dont-01">
-                    <Text weight="bold"> Search privacy</Text>
-                  </Label>
-                  <Badge inline type="error" text="New"/>
-                </Flex>
-                <Text color="subtle">Hide your profile from search engines</Text>
-              </Flex>
-              <Switch
-                id={"dont-01"}
-                onChange={() => {}}
+            sandpackExample={
+              <SandpackExample
+                code={repurposeExample}
+                name="Repurpose colors example"
+                hideEditor
+                hideControls
+                previewHeight={286}
               />
-            </Flex>
-`}
+            }
           />
         </MainSection.Subsection>
 
@@ -223,45 +206,28 @@ export default function ColorExamplesPage(): Node {
             cardSize="md"
             type="do"
             description="Use extended colors to emphasize brand moments and reinforce Pinterest's style when appropriate to a specific use case without breaking an actual product UI pattern (e.g., onboarding, marketing announcements). Please reach out to the [Core Brand](https://brand.pinterest.com/) team for guidance."
-            defaultCode={`
-            <Box width={200} height={305}>
-              <Image
-                naturalWidth={"200"}
-                naturalHeight={"350"}
-                src="https://i.ibb.co/7yLs8qG/Brand.png"
-                alt="An example of brand colors used in the Pinterest app."
+            sandpackExample={
+              <SandpackExample
+                code={extendedColors}
+                name="Extended colors example"
+                hideEditor
+                previewHeight={400}
               />
-            </Box>
-`}
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Apply alternative colors modifying Gestalt components or UI patterns as it can create inconsistency and cognitive issues."
-            defaultCode={`
-            <Flex gap={{ column: 0, row: 2 }}>
-              <Box
-                dangerouslySetInlineStyle={{
-                  __style: {backgroundColor: 'gold'}
-                }}
-                rounding="pill"
-                padding={3}
-              >
-                  <Text weight="bold">
-                    Button
-                  </Text>
-              </Box>
-              <Box
-                dangerouslySetInlineStyle={{
-                  __style: {backgroundColor: 'green'}
-                }}
-                rounding="circle"
-                padding={3}
-              >
-                <Icon icon="add" color="inverse" accessibilityLabel="Create"/>
-              </Box>
-            </Flex>
-`}
+            sandpackExample={
+              <SandpackExample
+                code={alternativeColors}
+                name="Alternative colors example"
+                hideEditor
+                hideControls
+                previewHeight={400}
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -269,29 +235,28 @@ export default function ColorExamplesPage(): Node {
             cardSize="md"
             type="do"
             description="Use the established [typography](/foundations/color/usage#Typography-color) and [iconography](/foundations/color/usage#Iconography-color) color tokens so users can quickly scan and identify sentiment."
-            defaultCode={`
-            <Status
-              type="ok"
-              title="Campaign complete"
-            />
-`}
+            sandpackExample={
+              <SandpackExample
+                code={establishedExample}
+                name="Established colors example"
+                hideEditor
+                previewHeight={286}
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Apply alternative colors to text and icons. Always refer to [color usage](/foundations/color/usage) for the appropriate color pattern. "
-            defaultCode={`
-            <Flex gap={{ row: 1, column: 0 }} alignItems="center">
-              <Icon icon="eye" accessibilityLabel="views"/>
-              <Text weight="bold">
-                <Box dangerouslySetInlineStyle={{
-                  __style: {color: 'darkmagenta'}
-                }}>
-                  views
-                </Box>
-              </Text>
-            </Flex>
-`}
+            sandpackExample={
+              <SandpackExample
+                code={alternativeColorTextExample}
+                name="Alternative color text example"
+                hideEditor
+                hideControls
+                previewHeight={286}
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -299,72 +264,29 @@ export default function ColorExamplesPage(): Node {
             cardSize="md"
             type="do"
             description="Use the appropriate [color tokens](/foundations/design_tokens) to switch between themes (light and dark mode). It ensures consistency and avoids accessibility issues."
-            defaultCode={`
-            <Flex direction="column" gap={{ column: 8, row: 0 }} alignItems="center">
-              <Flex gap={{ column: 0, row: 4 }}>
-                <IconButton icon="speech" accessibilityLabel="Comment" />
-                <IconButton icon="share" iconColor="darkGray" accessibilityLabel="Share"/>
-              </Flex>
-              <Flex gap={{ column: 0, row: 4 }}>
-                <Button color="red" text="Primary" />
-                <Button color="gray" text="Secondary" />
-                <Button color="blue" text="Shop" />
-              </Flex>
-              <Flex gap={{ column: 0, row: 4 }}>
-                <SearchField
-                  accessibilityLabel={'Search you Pins'}
-                  id={'color-do-search'}
-                  placeholder="Search your Pins"
-                  onChange={() => {}}
-                />
-              </Flex>
-              <Flex gap={{ column: 0, row: 8 }}>
-                <Text>Default text</Text>
-                <Text color="subtle">Subtle text</Text>
-              </Flex>
-            </Flex>
-`}
+            sandpackExample={
+              <SandpackExample
+                code={appropriateColorTokensExample}
+                name="Appropriate color tokens example"
+                hideEditor
+                previewHeight={400}
+              />
+            }
           />
 
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Apply alternative colors not specified in our color tokens when switching between themes. If a new color value is needed for a specific use case, [let the Gestalt team know](https://gestalt.pinterest.systems/get_started/how_to_work_with_us#Meetings-and-events) and we will evaluate."
-            defaultCode={`
-            <ColorSchemeProvider colorScheme="dark" id="dark-example-dont">
-              <Box color="default" padding={10}>
-                <Flex direction="column" gap={{ column: 8, row: 0 }} alignItems="center">
-                  <Flex gap={{ column: 0, row: 4 }}>
-                    <IconButton icon="speech" accessibilityLabel="Comment"/>
-                    <IconButton icon="share" iconColor="darkGray" accessibilityLabel="Share" />
-                  </Flex>
-                  <Flex gap={{ column: 0, row: 4 }}>
-                    <Button color="red" text="Primary" />
-                      <Box color="warningWeak" rounding="pill" padding={3}>
-                        <TapArea color="white">
-                          <Text weight="bold" color="light">
-                            Secondary
-                          </Text>
-                        </TapArea>
-                      </Box>
-                    <Button color="blue" text="Shop" />
-                  </Flex>
-                  <Flex gap={{ column: 0, row: 4 }}>
-                    <SearchField
-                      accessibilityLabel={'Search you Pins'}
-                      id={'color-dont-search'}
-                      placeholder="Search your Pins"
-                      onChange={() => {}}
-                    />
-                  </Flex>
-                  <Flex gap={{ column: 0, row: 8 }}>
-                    <Text>Default text</Text>
-                    <Text color="subtle">Subtle text</Text>
-                  </Flex>
-                </Flex>
-              </Box>
-            </ColorSchemeProvider>
-`}
+            sandpackExample={
+              <SandpackExample
+                code={alternativeColorTokensExample}
+                name="Alternative color tokens example"
+                hideEditor
+                hideControls
+                previewHeight={400}
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -372,33 +294,28 @@ export default function ColorExamplesPage(): Node {
             cardSize="md"
             type="do"
             description="Use designated elevation color values and styles on light and dark mode themes. See [elevation guidelines](/foundations/elevation) for guidance."
-            defaultCode={`
-            <Box width={200} height={305}>
-              <Image
-                fit="contain"
-                naturalWidth={"200"}
-                naturalHeight={"350"}
-                src="https://i.ibb.co/5rQQnDR/screen-sample-01.png"
-                alt="Example showing mobile dark mode on the Pinterest app."
+            sandpackExample={
+              <SandpackExample
+                code={validElevationExample}
+                name="Valid elevation example"
+                hideEditor
+                previewHeight={400}
               />
-            </Box>
-`}
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Apply colors and styles not available in our elevation tokens to elevate surfaces as it can create inconsistency, and eye strain. If a different color value is needed for a specific elevation use case, [let the Gestalt team know](https://gestalt.pinterest.systems/get_started/how_to_work_with_us#Meetings-and-events) and we will assist."
-            defaultCode={`
-            <Box width={200} height={305}>
-              <Image
-                fit="contain"
-                naturalWidth={"200"}
-                naturalHeight={"350"}
-                src="https://i.ibb.co/FqM70HS/screen-sample-02.png"
-                alt="Example showing an incorrect mobile dark mode on the Pinterest app."
+            sandpackExample={
+              <SandpackExample
+                code={invalidElevationExample}
+                name="Invalid elevation example"
+                hideEditor
+                hideControls
+                previewHeight={400}
               />
-            </Box>
-`}
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/foundations/layouts.js
+++ b/docs/pages/foundations/layouts.js
@@ -3,6 +3,8 @@ import { type Node } from 'react';
 import PageHeader from '../../docs-components/PageHeader.js';
 import Page from '../../docs-components/Page.js';
 import MainSection from '../../docs-components/MainSection.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import LayoutsExample from '../../examples/layouts/layoutsExample.js';
 
 export default function DocsPage(): Node {
   return (
@@ -19,79 +21,9 @@ export default function DocsPage(): Node {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Flex
-  direction="column"
-  gap={{ column: 6, row: 0 }}
-  maxWidth={800}
-  width="100%"
-  wrap
->
-  <Heading size="400" accessibilityLevel={2}>
-    Form Title
-  </Heading>
-
-  <TextField
-    label="TextField 1"
-    id="textfield1"
-    onChange={() => {}}
-    placeholder="Placeholder"
-  />
-
-  <Box
-    // Using Box instead of Flex + 'gap' for proper vertical spacing when text fields wrap
-    display="flex"
-    marginStart={-3}
-    marginEnd={-3}
-    marginBottom={-3}
-    marginTop={-3}
-    wrap
-  >
-    <Box flex="grow" minWidth={250} paddingX={3} paddingY={3}>
-      <TextField
-        label="TextField 2"
-        id="textfield2"
-        onChange={() => {}}
-        placeholder="Placeholder"
-      />
-    </Box>
-    <Box flex="grow" minWidth={250} paddingX={3} paddingY={3}>
-      <TextField
-        label="TextField 3"
-        id="textfield3"
-        onChange={() => {}}
-        placeholder="Placeholder"
-      />
-    </Box>
-  </Box>
-
-  <SelectList
-    label="SelectList"
-    id="selectlist"
-    options={[
-      {
-        value: 'belgium',
-        label: 'Belgium',
-      },
-      {
-        value: 'france',
-        label: 'France',
-      },
-      {
-        value: 'usa',
-        label: 'USA',
-      },
-    ]}
-    placeholder="Placeholder"
-    onChange={() => {}}
-  />
-
-  <Flex gap={{ row: 2, column: 0 }} justifyContent="end" wrap>
-    <Button text="Cancel" size="lg" />
-    <Button text="Submit" color="red" size="lg" type="submit" />
-  </Flex>
-</Flex>
-`}
+            sandpackExample={
+              <SandpackExample code={LayoutsExample} name="Layout example" previewHeight={400} />
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/foundations/screen_sizes.js
+++ b/docs/pages/foundations/screen_sizes.js
@@ -3,6 +3,9 @@ import { type Node } from 'react';
 import MainSection from '../../docs-components/MainSection.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import Page from '../../docs-components/Page.js';
+import screenSizesWeb from '../../examples/screenSizes/screenSizesWeb.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import screenSizesIos from '../../examples/screenSizes/screenSizesIos.js';
 
 export default function DocsPage(): Node {
   return (
@@ -15,160 +18,43 @@ export default function DocsPage(): Node {
       <MainSection name="Web (px)">
         <MainSection.Card
           cardSize="lg"
-          showCode={false}
-          defaultCode={`
-      <Box width={'100%'}>
-        <Table>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Text weight="bold">Device</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Size (px)</Text>
-              </Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Small phone</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>320 x 568</Text>
-              </Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Phone</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>360 x 780</Text>
-              </Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Tablet</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>768 x 1024</Text>
-              </Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Desktop Breakpoints (min-width)</Text>
-                <Box paddingY={2} maxWidth={500}>
-                  <Text italic>Components in Gestalt adjust to browser size at these breakpoints. When designing, please make sure your designs take these breakpoints into consideration.</Text>
-                </Box>
-              </Table.Cell>
-              <Table.Cell>
-                <Flex direction="column" gap={{ column: 2, row: 0 }}>
-                  <Text>sm: 576px</Text>
-                  <Text>md: 768px</Text>
-                  <Text>lg: 1312px</Text>
-                </Flex>
-              </Table.Cell>
-            </Table.Row>
-          </Table.Body>
-        </Table>
-      </Box>
-      `}
+          sandpackExample={
+            <SandpackExample
+              code={screenSizesWeb}
+              name="Web screen sizes"
+              previewHeight={350}
+              hideControls
+              hideEditor
+            />
+          }
         />
       </MainSection>
       <MainSection name="iOS (pt)">
         <MainSection.Card
           cardSize="lg"
-          showCode={false}
-          defaultCode={`
-      <Box width={'100%'}>
-        <Table>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Text weight="bold">Device</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Size (pt)</Text>
-              </Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Small phone</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>320 x 568</Text>
-              </Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Phone</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>360 x 780</Text>
-              </Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Tablet</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>768 x 1024</Text>
-              </Table.Cell>
-            </Table.Row>
-          </Table.Body>
-        </Table>
-      </Box>
-      `}
+          sandpackExample={
+            <SandpackExample
+              code={screenSizesIos}
+              name="iOS screen sizes"
+              previewHeight={250}
+              hideControls
+              hideEditor
+            />
+          }
         />
       </MainSection>
       <MainSection name="Android (dp)">
         <MainSection.Card
           cardSize="lg"
-          showCode={false}
-          defaultCode={`
-      <Box width={'100%'}>
-        <Table>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Text weight="bold">Device</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Size (dp)</Text>
-              </Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Small phone</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>320 x 480</Text>
-              </Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Phone</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>360 x 640</Text>
-              </Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>
-                <Text>Tablet</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>800 x 1280</Text>
-              </Table.Cell>
-            </Table.Row>
-          </Table.Body>
-        </Table>
-      </Box>
-      `}
+          sandpackExample={
+            <SandpackExample
+              code={screenSizesIos}
+              name="Android screen sizes"
+              previewHeight={250}
+              hideControls
+              hideEditor
+            />
+          }
         />
       </MainSection>
     </Page>

--- a/docs/pages/web/modal.js
+++ b/docs/pages/web/modal.js
@@ -21,7 +21,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
   return (
     <Page title="Modal">
       <PageHeader name="Modal" description={generatedDocGen?.description}>
-        <SandpackExample code={defaultExample} name="Modal Main Example" showEditor={false} />
+        <SandpackExample code={defaultExample} name="Modal Main Example" hideEditor />
       </PageHeader>
       <GeneratedPropTable
         generatedDocGen={generatedDocGen}
@@ -60,11 +60,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
             type="do"
             description="Use Modal when a response is required from the user. Clearly communicate what response is expected and make the action simple and straight forward, such as clicking a button to confirm. The most common responses will be related to confirming or canceling."
             sandpackExample={
-              <SandpackExample
-                code={userResponseExample}
-                name="User response example"
-                showEditor={false}
-              />
+              <SandpackExample code={userResponseExample} name="User response example" hideEditor />
             }
           />
 
@@ -73,11 +69,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
             type="do"
             description="Limit the number of actions in a Modal. A primary and secondary action should be used for Modals. The rarely used tertiary actions are often destructive, such as “Delete”."
             sandpackExample={
-              <SandpackExample
-                code={limitActionsExample}
-                name="Limit actions example"
-                showEditor={false}
-              />
+              <SandpackExample code={limitActionsExample} name="Limit actions example" hideEditor />
             }
           />
           <MainSection.Card
@@ -85,11 +77,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
             type="do"
             description="In the few cases where Modals are being used within the Pinner product, aim to prevent the content from needing to scroll at a reasonable screen size."
             sandpackExample={
-              <SandpackExample
-                code={createBoardExample}
-                name="Create board example"
-                showEditor={false}
-              />
+              <SandpackExample code={createBoardExample} name="Create board example" hideEditor />
             }
           />
         </MainSection.Subsection>

--- a/docs/pages/web/pageheader.js
+++ b/docs/pages/web/pageheader.js
@@ -37,7 +37,7 @@ export default function PageHeaderPage({ generatedDocGen }: {| generatedDocGen: 
           name="PageHeader Example"
           layout="column"
           previewHeight={85}
-          showEditor={false}
+          hideEditor
         />
       </DocsPageHeader>
 
@@ -79,7 +79,7 @@ export default function PageHeaderPage({ generatedDocGen }: {| generatedDocGen: 
                 layout="column"
                 name="PageHeader one primary action example"
                 previewHeight={80}
-                showEditor={false}
+                hideEditor
               />
             }
           />
@@ -92,8 +92,9 @@ export default function PageHeaderPage({ generatedDocGen }: {| generatedDocGen: 
                 code={multiplePrimaryActionsExample}
                 layout="column"
                 name="PageHeader one primary action example"
-                showEditor={false}
+                hideEditor
                 hideControls
+                previewHeight={320}
               />
             }
           />
@@ -108,7 +109,8 @@ Plan for most PageHeaders to be full width. A \`maxWidth\` should only be suppli
                 code={centerAlignedExample}
                 layout="column"
                 name="PageHeader center aligned example"
-                showEditor={false}
+                hideEditor
+                previewHeight={420}
               />
             }
           />
@@ -121,8 +123,9 @@ Plan for most PageHeaders to be full width. A \`maxWidth\` should only be suppli
                 code={maxWidthExample}
                 layout="column"
                 name="PageHeader max width example"
-                showEditor={false}
+                hideEditor
                 hideControls
+                previewHeight={420}
               />
             }
           />
@@ -136,7 +139,7 @@ Plan for most PageHeaders to be full width. A \`maxWidth\` should only be suppli
                 layout="column"
                 name="PageHeader include image example"
                 previewHeight={80}
-                showEditor={false}
+                hideEditor
               />
             }
           />
@@ -150,7 +153,7 @@ Plan for most PageHeaders to be full width. A \`maxWidth\` should only be suppli
                 layout="column"
                 name="PageHeader include image example"
                 previewHeight={80}
-                showEditor={false}
+                hideEditor
                 hideControls
               />
             }
@@ -165,7 +168,8 @@ Keep additional help buttons and links to a minimum, choosing one source of help
                 code={minimumButtonsExample}
                 layout="column"
                 name="PageHeader minimum buttons example"
-                showEditor={false}
+                hideEditor
+                previewHeight={200}
               />
             }
           />
@@ -178,8 +182,9 @@ Keep additional help buttons and links to a minimum, choosing one source of help
                 code={dontOverloadExample}
                 layout="column"
                 name="PageHeader do not overload example"
-                showEditor={false}
+                hideEditor
                 hideControls
+                previewHeight={200}
               />
             }
           />
@@ -195,13 +200,18 @@ PageHeader has built-in components that require accessibility labels.
 - [IconButton](/iconbutton) requires \`accessibilityLabel\`,  \`accessibilityControls\`, and  \`accessibilityExpanded\` via \`helperIconButton\`
 - [Link](/link) requires \`accessibilityLabel\` via \`helperLink\`
 
-Follow the accessibility guidelines for any other Gestat component passed to \`primaryaction\`, \`secondaryAction\` or \`items\`.
+Follow the accessibility guidelines for any other Gestalt component passed to \`primaryaction\`, \`secondaryAction\` or \`items\`.
 `}
         >
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample code={defaultExample} name="Accessibility example" layout="column" />
+              <SandpackExample
+                code={defaultExample}
+                name="Accessibility example"
+                layout="column"
+                previewHeight={85}
+              />
             }
           />
         </MainSection.Subsection>
@@ -237,7 +247,7 @@ Be brief with text in all components to account for languages with longer words.
                 code={titleExample}
                 layout="column"
                 name="PageHeader title example"
-                previewHeight={80}
+                previewHeight={200}
               />
             }
           />
@@ -337,6 +347,7 @@ PageHeader also supports a bottom border to show the division between PageHeader
                 code={centerAlignedExample}
                 layout="column"
                 name="PageHeader max width & border example"
+                previewHeight={420}
               />
             }
           />
@@ -356,7 +367,7 @@ PageHeader doesn't depend on DeviceTypeProvider to display a mobile view; instea
               <SandpackExample
                 code={responsiveExample}
                 name="PageHeader max width & border example"
-                mobileView
+                layout="mobileRow"
               />
             }
           />

--- a/docs/pages/web/sheet.js
+++ b/docs/pages/web/sheet.js
@@ -20,7 +20,7 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
   return (
     <Page title={generatedDocGen?.displayName}>
       <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
-        <SandpackExample code={defaultExample} name="Sheet Main Example" showEditor={false} />
+        <SandpackExample code={defaultExample} name="Sheet Main Example" hideEditor />
       </PageHeader>
       <PropTable
         props={[
@@ -138,7 +138,7 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
               <SandpackExample
                 code={defaultExample}
                 name="Sub task example"
-                showEditor={false}
+                hideEditor
                 layout="column"
               />
             }
@@ -152,7 +152,7 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
               <SandpackExample
                 code={quickEditsExample}
                 name="Sub task example"
-                showEditor={false}
+                hideEditor
                 hideControls
               />
             }

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -52,7 +52,7 @@ export default function SideNavigationPage({
         <SandpackExample
           code={mainExample}
           name="SideNavigation Main Example"
-          showEditor={false}
+          hideEditor
           previewHeight={208}
         />
       </PageHeader>
@@ -92,7 +92,7 @@ export default function SideNavigationPage({
               <SandpackExample
                 code={correctLengthExample}
                 name="Correct length example"
-                showEditor={false}
+                hideEditor
                 previewHeight={230}
               />
             }
@@ -105,7 +105,7 @@ export default function SideNavigationPage({
               <SandpackExample
                 code={incorrectLengthExample}
                 name="Incorrect length example"
-                showEditor={false}
+                hideEditor
                 previewHeight={230}
                 hideControls
               />
@@ -121,7 +121,7 @@ export default function SideNavigationPage({
               <SandpackExample
                 code={correctGroupingExample}
                 name="Correct grouping example"
-                showEditor={false}
+                hideEditor
                 previewHeight={286}
               />
             }
@@ -134,7 +134,7 @@ export default function SideNavigationPage({
               <SandpackExample
                 code={incorrectGroupingExample}
                 name="Incorrect grouping example"
-                showEditor={false}
+                hideEditor
                 previewHeight={286}
                 hideControls
               />
@@ -150,7 +150,7 @@ export default function SideNavigationPage({
               <SandpackExample
                 code={correctIconExample}
                 name="Correct icon example"
-                showEditor={false}
+                hideEditor
                 previewHeight={164}
               />
             }
@@ -163,7 +163,7 @@ export default function SideNavigationPage({
               <SandpackExample
                 code={incorrectIconExample}
                 name="Incorrect icon example"
-                showEditor={false}
+                hideEditor
                 previewHeight={164}
                 hideControls
               />
@@ -179,7 +179,7 @@ export default function SideNavigationPage({
               <SandpackExample
                 code={correctHeadingExample}
                 name="Correct heading example"
-                showEditor={false}
+                hideEditor
                 layout="column"
                 previewHeight={230}
               />
@@ -193,7 +193,7 @@ export default function SideNavigationPage({
               <SandpackExample
                 code={incorrectHeadingExample}
                 name="Incorrect heading example"
-                showEditor={false}
+                hideEditor
                 layout="column"
                 previewHeight={210}
                 hideControls


### PR DESCRIPTION
### Summary

#### What changed?

* Converts multiple "foundation" page examples to Sandpack
* Convert `hideControls` prop to `showControls` => makes it consistent with the `showEditor` prop on `SandpackExample`
* Remove t-shirt sizes `sm` and `md` from `SandpackExample`

#### Why?

For more context see #2221 

Flow issues found in this diff:

```
* Cannot create `Table` element because property `accessibilityLabel` is missing in  props [1] but exists in  `Props` [2].Flow(prop-missing)
* Cannot create `Badge` element because property `inline` is missing in  `Props` [1] but exists in  props [2].Flow(prop-missing)
* Cannot create `Image` element because  string [1] is incompatible with  number [2] in property `naturalWidth`.
* Cannot create `TapArea` element because: Either property `color` is missing in  `TapAreaType` [1] but exists in  props [2]. Or property `color` is missing in  `LinkTapAreaType` [3] but exists in  props [2].Flow(incompatible-type)
```
