### PR TITLE
Docs: update all internal links to new URL structure

### DIFF
--- a/docs/examples/sidenavigation/badgeExample.js
+++ b/docs/examples/sidenavigation/badgeExample.js
@@ -7,24 +7,24 @@ export default function Example(): Node {
     <SideNavigation accessibilityLabel="Badge example">
       <SideNavigation.Section label="Navigation">
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/pageheader"
+          href="https://gestalt.pinterest.systems/web/pageheader"
           label="PageHeader"
         />
-        <SideNavigation.TopItem href="https://gestalt.pinterest.systems/tabs" label="Tabs" />
+        <SideNavigation.TopItem href="https://gestalt.pinterest.systems/web/tabs" label="Tabs" />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/tooling"
+          href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
           label="SideNavigation"
           badge={{ text: 'New', type: 'info' }}
         />
       </SideNavigation.Section>
       <SideNavigation.Section label="Controls">
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/radiobutton"
+          href="https://gestalt.pinterest.systems/web/radiobutton"
           label="RadioButton"
           badge={{ text: 'Deprecated', type: 'warning' }}
         />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/radiogroup"
+          href="https://gestalt.pinterest.systems/web/radiogroup"
           label="RadioGroup"
         />
       </SideNavigation.Section>

--- a/docs/examples/sidenavigation/borderExample.js
+++ b/docs/examples/sidenavigation/borderExample.js
@@ -7,22 +7,22 @@ export default function Example(): Node {
     <SideNavigation accessibilityLabel="Border example" showBorder>
       <SideNavigation.Section label="Navigation">
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/pageheader"
+          href="https://gestalt.pinterest.systems/web/pageheader"
           label="PageHeader"
         />
-        <SideNavigation.TopItem href="https://gestalt.pinterest.systems/tabs" label="Tabs" />
+        <SideNavigation.TopItem href="https://gestalt.pinterest.systems/web/tabs" label="Tabs" />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/tooling"
+          href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
           label="SideNavigation"
         />
       </SideNavigation.Section>
       <SideNavigation.Section label="Controls">
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/radiobutton"
+          href="https://gestalt.pinterest.systems/web/radiobutton"
           label="RadioButton"
         />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/radiogroup"
+          href="https://gestalt.pinterest.systems/web/radiogroup"
           label="RadioGroup"
         />
       </SideNavigation.Section>

--- a/docs/examples/sidenavigation/headerExample.js
+++ b/docs/examples/sidenavigation/headerExample.js
@@ -37,24 +37,27 @@ export default function Example(): Node {
         <React.Fragment>
           <SideNavigation.Section label="Navigation">
             <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/pageheader"
+              href="https://gestalt.pinterest.systems/web/pageheader"
               label="PageHeader"
             />
-            <SideNavigation.TopItem href="https://gestalt.pinterest.systems/tabs" label="Tabs" />
             <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/tooling"
+              href="https://gestalt.pinterest.systems/web/tabs"
+              label="Tabs"
+            />
+            <SideNavigation.TopItem
+              href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
               label="SideNavigation"
               badge={{ text: 'New', type: 'info' }}
             />
           </SideNavigation.Section>
           <SideNavigation.Section label="Controls">
             <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/radiobutton"
+              href="https://gestalt.pinterest.systems/web/radiobutton"
               label="RadioButton"
               badge={{ text: 'Deprecated', type: 'warning' }}
             />
             <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/radiogroup"
+              href="https://gestalt.pinterest.systems/web/radiogroup"
               label="RadioGroup"
             />
           </SideNavigation.Section>
@@ -62,24 +65,24 @@ export default function Example(): Node {
       ) : (
         <React.Fragment>
           <SideNavigation.TopItem
-            href="https://gestalt.pinterest.systems/pageheader"
+            href="https://gestalt.pinterest.systems/web/pageheader"
             label="PageHeader"
           />
           <SideNavigation.TopItem
-            href="https://gestalt.pinterest.systems/radiobutton"
+            href="https://gestalt.pinterest.systems/web/radiobutton"
             label="RadioButton"
             badge={{ text: 'Deprecated', type: 'warning' }}
           />
           <SideNavigation.TopItem
-            href="https://gestalt.pinterest.systems/radiogroup"
+            href="https://gestalt.pinterest.systems/web/radiogroup"
             label="RadioGroup"
           />
           <SideNavigation.TopItem
-            href="https://gestalt.pinterest.systems/tooling"
+            href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
             label="SideNavigation"
             badge={{ text: 'New', type: 'info' }}
           />
-          <SideNavigation.TopItem href="https://gestalt.pinterest.systems/tabs" label="Tabs" />
+          <SideNavigation.TopItem href="https://gestalt.pinterest.systems/web/tabs" label="Tabs" />
         </React.Fragment>
       )}
     </SideNavigation>

--- a/docs/examples/sidenavigation/sectionsExample.js
+++ b/docs/examples/sidenavigation/sectionsExample.js
@@ -7,31 +7,37 @@ export default function Example(): Node {
     <SideNavigation accessibilityLabel="Sections example">
       <SideNavigation.Section label="Resources">
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/eslint_plugin"
+          href="https://gestalt.pinterest.systems/get_started/developers/eslint_plugin"
           label="Eslint plugin"
         />
-        <SideNavigation.TopItem href="https://gestalt.pinterest.systems/faq" label="FAQ" />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/how_to_hack_around_gestalt"
+          href="https://gestalt.pinterest.systems/get_started/faq"
+          label="FAQ"
+        />
+        <SideNavigation.TopItem
+          href="https://gestalt.pinterest.systems/get_started/developers/hacking_gestalt"
           label="How to hack around Gestalt"
         />
-        <SideNavigation.TopItem href="https://gestalt.pinterest.systems/tooling" label="Tooling" />
+        <SideNavigation.TopItem
+          href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
+          label="Tooling"
+        />
       </SideNavigation.Section>
       <SideNavigation.Section label="Foundations">
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/accessibility"
+          href="https://gestalt.pinterest.systems/foundations/accessibility"
           label="Accessibility"
         />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/elevation"
+          href="https://gestalt.pinterest.systems/foundations/elevation"
           label="Elevation"
         />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/typography"
+          href="https://gestalt.pinterest.systems/foundations/typography/guidelines"
           label="Typography"
         />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/color_palette"
+          href="https://gestalt.pinterest.systems/foundations/color/palette"
           label="Color palette"
         />
       </SideNavigation.Section>

--- a/docs/markdown/testing/develop.md
+++ b/docs/markdown/testing/develop.md
@@ -152,7 +152,7 @@ git push -f origin HEAD
 
 - Click on `Create Draft Pull Request` to create your PR. Once you are done committing changes to it, and all the CI tests have passed, click the "Ready for Review" button. (Keeping the PR as a draft until it is ready for review reduces the number of unneeded notifications for maintainers.) If you are a Pinterest employee, please let us know on Slack (#gestalt-web) that your PR is ready for review.
 
-- Ensure checks pass on your Pull Request - having the "Require Semver / Test (pull_request)" check fail is expected, because a Gestalt maintainer needs to add a correct semver label. Check out our [versioning guidelines](https://gestalt.pinterest.systems/development#versioning) for more info.
+- Ensure checks pass on your Pull Request - having the "Require Semver / Test (pull_request)" check fail is expected, because a Gestalt maintainer needs to add a correct semver label. Check out our [versioning guidelines](https://gestalt.pinterest.systems/web/development#versioning) for more info.
 
 - After a Gestalt maintainer adds a correct semver label and approves a Pull Request, the PR will be ready to merge. Coordinate with the reviewer to determine when the PR should be merged.
 
@@ -169,7 +169,7 @@ Our versioning guidelines follow those outlined at **[semver.org](https://semver
 - Patch: internal fixes, documentation changes, or package upgrades (anything that consumers of Gestalt don't need to worry about)
 - Minor: any new functionality or properties for a component, or net-new components
 - Major: any breaking change, whether it be in a specific component or the library itself (will most likely include a
-  [codemod](https://gestalt.pinterest.systems/development#codemods))
+  [codemod](https://gestalt.pinterest.systems/web/development#codemods))
 
 ### Codemods
 

--- a/docs/pages/foundations/color/examples.js
+++ b/docs/pages/foundations/color/examples.js
@@ -61,7 +61,7 @@ export default function ColorExamplesPage(): Node {
                   Having a limited range of colors supports consistency, making our product easier
                   to interact with. Keep in mind that continuous use of high-contrast and saturated
                   colors can create fatigue and eye strain. See our{' '}
-                  <Link inline href="https://gestalt.pinterest.systems/color_usage">
+                  <Link inline href="https://gestalt.pinterest.systems/foundations/color/usage">
                     <Text underline>color usage guidelines</Text>
                   </Link>{' '}
                   for more information about our color choices.
@@ -82,7 +82,7 @@ export default function ColorExamplesPage(): Node {
                   Any colors used should be consistent with the full{' '}
                   <Link
                     inline
-                    href="https://gestalt.pinterest.systems/color_palette#Extended-palette"
+                    href="https://gestalt.pinterest.systems/foundations/color/palette#Extended-palette"
                   >
                     <Text inline underline>
                       Pinterest color palette
@@ -102,7 +102,7 @@ export default function ColorExamplesPage(): Node {
                 <Text>
                   All color pairings must pass WCAG&apos;s AA color contrast standards. Using our
                   color tokens properly ensures our colors meet legibility standards. Check out our{' '}
-                  <Link inline href="https://gestalt.pinterest.systems/accessibility">
+                  <Link inline href="https://gestalt.pinterest.systems/foundations/accessibility">
                     <Text inline underline>
                       accessibility guidelines
                     </Text>

--- a/docs/pages/roadmap/BlogPosts.json
+++ b/docs/pages/roadmap/BlogPosts.json
@@ -42,14 +42,14 @@
           "audience": ["Design", "Engineering"],
           "imageSrc": "https://i.pinimg.com/originals/9e/cb/ea/9ecbeadb6a8c683b10c1c72cb7b0b591.png",
           "imageAltText": "A screenshot of the Gestalt SideNavigation component",
-          "content": "In some more exciting news, we shipped a pre-release of our fancy new [SideNavigation component](https://gestalt.pinterest.systems/sidenavigation). This component is still in alpha and not (quite) ready for production, but we wanted to give y'all a sneak peek ahead of time. We also created a [SideNavigation Figma component](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-web?node-id=17421%3A31236) that's ready to use today. Again, keep in mind that this component is currently in alpha."
+          "content": "In some more exciting news, we shipped a pre-release of our fancy new [SideNavigation component](https://gestalt.pinterest.systems/web/sidenavigation). This component is still in alpha and not (quite) ready for production, but we wanted to give y'all a sneak peek ahead of time. We also created a [SideNavigation Figma component](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-web?node-id=17421%3A31236) that's ready to use today. Again, keep in mind that this component is currently in alpha."
         },
         {
           "title": "Gestalt Iconography guidelines",
           "audience": ["Design", "Engineering"],
           "imageSrc": "https://i.pinimg.com/originals/57/08/98/570898bb6afdfe679262900b11c5d45c.png",
           "imageAltText": "A screenshot of Gestalt's Iconography guidelines",
-          "content": "The Gestalt team is working to up its icon game and our first big step is publishing an MVP our of [Iconography guidelines](https://gestalt.pinterest.systems/iconography). Keep in mind, this is our _first step_ towards greater clarity around using icons within Gestalt. So please send us your feedback and stay tuned for future updates."
+          "content": "The Gestalt team is working to up its icon game and our first big step is publishing an MVP our of [Iconography guidelines](https://gestalt.pinterest.systems/foundations/iconography/usage). Keep in mind, this is our _first step_ towards greater clarity around using icons within Gestalt. So please send us your feedback and stay tuned for future updates."
         },
         {
           "title": "Gestalt for iOS Figma library improvements",
@@ -63,7 +63,7 @@
           "audience": ["Design"],
           "imageSrc": "https://i.pinimg.com/originals/22/c9/ca/22c9ca872312b3d67e8e5bab00b26ce3.png",
           "imageAltText": "Screenshot of Gestalt Figma Web components",
-          "content": "Similar to the iOS library, we make enhancements to [Button](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-web?node-id=2508%3A17905) which should closer mimic the API of our [React Button](https://gestalt.pinterest.systems/button). We also made a near-complete overhaul to [Dropdown](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-web?node-id=4526%3A0) to again better mimic its [React counterpart](https://gestalt.pinterest.systems/dropdown). One note on Dropdown - we ran into so Figma limitations which prevented us from implementing text truncation in the Dropdown list components, so you'd need to manually truncate text until we can determine a solution. Lastly, we made updates to the Figma Web library's page strucure/organization to more closely resemble our documentation."
+          "content": "Similar to the iOS library, we make enhancements to [Button](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-web?node-id=2508%3A17905) which should closer mimic the API of our [React Button](https://gestalt.pinterest.systems/web/button). We also made a near-complete overhaul to [Dropdown](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-web?node-id=4526%3A0) to again better mimic its [React counterpart](https://gestalt.pinterest.systems/web/dropdown). One note on Dropdown - we ran into so Figma limitations which prevented us from implementing text truncation in the Dropdown list components, so you'd need to manually truncate text until we can determine a solution. Lastly, we made updates to the Figma Web library's page strucure/organization to more closely resemble our documentation."
         }
       ]
     },
@@ -129,7 +129,7 @@
           "audience": ["Design", "Engineering"],
           "imageSrc": "https://i.pinimg.com/originals/fe/40/a6/fe40a60cd15b7af081a5c98f01b6c694.png",
           "imageAltText": "",
-          "content": "In the spirit of consistent, accessible visuals across Pinterest, and better support for dark mode, we've officially deprecated the old, literal colors on Box in favor of our semantic, design-token-based options. This means watermelon is out and primary is in! Check out the [Box documentation](https://gestalt.pinterest.systems/box#Colors) to see all the options, and feel free to reach out if you think a color is missing."
+          "content": "In the spirit of consistent, accessible visuals across Pinterest, and better support for dark mode, we've officially deprecated the old, literal colors on Box in favor of our semantic, design-token-based options. This means watermelon is out and primary is in! Check out the [Box documentation](https://gestalt.pinterest.systems/web/box#Colors) to see all the options, and feel free to reach out if you think a color is missing."
         },
         {
           "title": "More ways to view code in our docs",
@@ -201,7 +201,7 @@
           "audience": ["Design"],
           "imageSrc": "https://i.pinimg.com/originals/a3/11/75/a31175baabf4be7d4cc0519034096f11.png",
           "imageAltText": "Iconography open forum next steps",
-          "content": "We wanted to thank everyone who participated in the iconography open forum session and give you a peak into what we'll be doing next. We're going to be using your feedback to publish a baseline set of iconography guidelines in our documentation which we plan to begin work on next sprint. We are also going to use your feedback to develop refinements to our [Iconography & SVGs page](https://gestalt.pinterest.systems/iconography_and_svgs). Once again, thank you so much for your support. We look forward to sharing updates _soon_."
+          "content": "We wanted to thank everyone who participated in the iconography open forum session and give you a peak into what we'll be doing next. We're going to be using your feedback to publish a baseline set of iconography guidelines in our documentation which we plan to begin work on next sprint. We are also going to use your feedback to develop refinements to our [Iconography & SVGs page](https://gestalt.pinterest.systems/foundations/iconography/library). Once again, thank you so much for your support. We look forward to sharing updates _soon_."
         },
         {
           "title": "Gestalt tutorials on Pinterest",
@@ -227,14 +227,14 @@
           "audience": ["Engineering", "Design"],
           "imageSrc": "https://i.pinimg.com/originals/68/b7/29/68b7290ff502f95904a959a0a5239372.png",
           "imageAltText": "Screenshot of Gestalt's data visualization guidelines",
-          "content": "We recently shipped our [data visualization color palette](https://gestalt.pinterest.systems/data_visualization_colors) which was our building block to deliver [data visualization guidelines](https://gestalt.pinterest.systems/data_visualization_guidelines). This is a major milestone for us and unlocks our ability to provide even more in this space later this year."
+          "content": "We recently shipped our [data visualization color palette](https://gestalt.pinterest.systems/data_visualization/colors) which was our building block to deliver [data visualization guidelines](https://gestalt.pinterest.systems/data_visualization/usage). This is a major milestone for us and unlocks our ability to provide even more in this space later this year."
         },
         {
           "title": "Design guidelines for Text and Heading components",
           "audience": ["Engineering", "Design"],
           "imageSrc": "https://i.pinimg.com/originals/51/b1/29/51b129c9260e824d1e87e328080dea2f.png",
           "imageAltText": "Screenshots of Gestalt's Text and Heading documentation",
-          "content": "We added [typography guidelines](https://gestalt.pinterest.systems/typography) a couple weeks ago and now we're coming in hot with design guidelines for [Text](https://gestalt.pinterest.systems/text) and [Heading](https://gestalt.pinterest.systems/heading). Our goal for these updates is to develop a strong foundation of typographic guidance that we can build upon in future releases."
+          "content": "We added [typography guidelines](https://gestalt.pinterest.systems/foundations/typography/guidelines) a couple weeks ago and now we're coming in hot with design guidelines for [Text](https://gestalt.pinterest.systems/web/text) and [Heading](https://gestalt.pinterest.systems/web/heading). Our goal for these updates is to develop a strong foundation of typographic guidance that we can build upon in future releases."
         },
         {
           "title": "Gestalt Learning released",
@@ -272,7 +272,7 @@
           "audience": ["Engineering", "Design"],
           "imageSrc": "https://i.pinimg.com/originals/ad/66/52/ad66524c172960e4fe2edaa67d150a58.png",
           "imageAltText": "Screenshot of typography guidelines",
-          "content": "To keep the momentum going on our release of guidelines in 2022, we just published the first iteration of our [Typography guidelines](https://gestalt.pinterest.systems/typography). This is intended to serve as the foundation for much more detail and updates in the future. We look forward to sharing many more typography-related updates in the near future."
+          "content": "To keep the momentum going on our release of guidelines in 2022, we just published the first iteration of our [Typography guidelines](https://gestalt.pinterest.systems/foundations/typography/guidelines). This is intended to serve as the foundation for much more detail and updates in the future. We look forward to sharing many more typography-related updates in the near future."
         },
         {
           "title": "Major updates to our Pin and Masonry Figma components",
@@ -286,7 +286,7 @@
           "audience": ["Engineering", "Design"],
           "imageSrc": "https://i.pinimg.com/originals/a7/38/95/a73895ed57aa346c8c5d52d10e41a9a5.png",
           "imageAltText": "Screenshot of updated What's new page",
-          "content": "In an effort to make our Gestalt docs _the_ single source of truth, it's now [the home for our weekly updates](https://gestalt.pinterest.systems/whats_new). We know it's hard to keep track of everything we ship, so we want to provide an easily accessible and digestible synopsis of all the new goodies our team cooks up.\n\nAnd for all you fans of our Changelog, never fear &mdash; it's not gone, it's just in a happier place now. You can view our [full changelog](https://github.com/pinterest/gestalt/blob/master/CHANGELOG.md) on Gestalt Web Github repo."
+          "content": "In an effort to make our Gestalt docs _the_ single source of truth, it's now [the home for our weekly updates](https://gestalt.pinterest.systems/roadmap/whats_new). We know it's hard to keep track of everything we ship, so we want to provide an easily accessible and digestible synopsis of all the new goodies our team cooks up.\n\nAnd for all you fans of our Changelog, never fear &mdash; it's not gone, it's just in a happier place now. You can view our [full changelog](https://github.com/pinterest/gestalt/blob/master/CHANGELOG.md) on Gestalt Web Github repo."
         },
         {
           "title": "Gestalt is on Pinterest!",

--- a/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
+++ b/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
@@ -15,7 +15,7 @@ const disallowedMatch = [
 ];
 
 export const errorMessage =
-  'Icons where `workflow-status-[...]` and matching color should be replaced for the Status Component. https://gestalt.pinterest.systems/status';
+  'Icons where `workflow-status-[...]` and matching color should be replaced for the Status Component. https://gestalt.pinterest.systems/web/status';
 
 const rule: ESLintRule = {
   meta: {

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -58,19 +58,19 @@ type LocaleData = {|
 
 type Props = {|
   /**
-   *  When disabled, DatePicker looks inactive and cannot be interacted with. See the [disabled example](https://gestalt.pinterest.systems/datepicker#disabled) to learn more.
+   *  When disabled, DatePicker looks inactive and cannot be interacted with. See the [disabled example](https://gestalt.pinterest.systems/web/datepicker#disabled) to learn more.
    */
   disabled?: boolean,
   /**
-   * Provide feedback when an error on selection occurs. See the [error message example](https://gestalt.pinterest.systems/datepicker#errorMessage) to learn more.
+   * Provide feedback when an error on selection occurs. See the [error message example](https://gestalt.pinterest.systems/web/datepicker#errorMessage) to learn more.
    */
   errorMessage?: string,
   /**
-   * Array of disabled dates. Datepicker can be interacted with except for the dates passed which look inactive and cannot be selected. See the [disabled dates example](https://gestalt.pinterest.systems/datepicker#exclude) to learn more.
+   * Array of disabled dates. Datepicker can be interacted with except for the dates passed which look inactive and cannot be selected. See the [disabled dates example](https://gestalt.pinterest.systems/web/datepicker#exclude) to learn more.
    */
   excludeDates?: $ReadOnlyArray<Date>,
   /**
-   * More information about how to complete the DatePicker field. See the [helper text example](https://gestalt.pinterest.systems/datepicker#helperText) to learn more.
+   * More information about how to complete the DatePicker field. See the [helper text example](https://gestalt.pinterest.systems/web/datepicker#helperText) to learn more.
    */
   helperText?: string,
   /**
@@ -78,12 +78,12 @@ type Props = {|
    */
   id: string,
   /**
-   * Preferred direction for the calendar popover to open. See the [ideal direction example](https://gestalt.pinterest.systems/datepicker#idealDirection) to learn more.
+   * Preferred direction for the calendar popover to open. See the [ideal direction example](https://gestalt.pinterest.systems/web/datepicker#idealDirection) to learn more.
    */
   idealDirection?: 'up' | 'right' | 'down' | 'left',
 
   /**
-   * Array of enabled dates. Datepicker can be interacted with only on the dates passed, all other dates look inactive and cannot be selected. See the [disabled dates example](https://gestalt.pinterest.systems/datepicker#include) to learn more.
+   * Array of enabled dates. Datepicker can be interacted with only on the dates passed, all other dates look inactive and cannot be selected. See the [disabled dates example](https://gestalt.pinterest.systems/web/datepicker#include) to learn more.
    */
   includeDates?: $ReadOnlyArray<Date>,
   /**
@@ -91,15 +91,15 @@ type Props = {|
    */
   label?: string,
   /**
-   * DatePicker accepts imported locales from the open source date utility library date-fns. See the [locales example](https://gestalt.pinterest.systems/datepicker#localeData) to learn more.
+   * DatePicker accepts imported locales from the open source date utility library date-fns. See the [locales example](https://gestalt.pinterest.systems/web/datepicker#localeData) to learn more.
    */
   localeData?: LocaleData,
   /**
-   * Disable dates outside a max date. See the [delimited selection period example](https://gestalt.pinterest.systems/datepicker#maxMinDates) to learn more.
+   * Disable dates outside a max date. See the [delimited selection period example](https://gestalt.pinterest.systems/web/datepicker#maxMinDates) to learn more.
    */
   maxDate?: Date,
   /**
-   * Disable dates outside a min date. See the [delimited selection period example](https://gestalt.pinterest.systems/datepicker#maxMinDates) to learn more.
+   * Disable dates outside a min date. See the [delimited selection period example](https://gestalt.pinterest.systems/web/datepicker#maxMinDates) to learn more.
    */
   minDate?: Date,
   /**
@@ -107,7 +107,7 @@ type Props = {|
    */
   name?: string,
   /**
-   * Required for date range selection. Pass the complimentary range date picker ref object to DatePicker to autofocus on the unselected date range field. See the [date range picker example](https://gestalt.pinterest.systems/datepicker#rangePicker) to learn more.
+   * Required for date range selection. Pass the complimentary range date picker ref object to DatePicker to autofocus on the unselected date range field. See the [date range picker example](https://gestalt.pinterest.systems/web/datepicker#rangePicker) to learn more.
    */
   nextRef?: {| current: ?HTMLInputElement |},
   /**
@@ -122,32 +122,32 @@ type Props = {|
    */
   placeholder?: string,
   /**
-   * Required for date range selection. End date on a date range selection. See the [date range picker example](https://gestalt.pinterest.systems/datepicker#rangePicker) to learn more.
+   * Required for date range selection. End date on a date range selection. See the [date range picker example](https://gestalt.pinterest.systems/web/datepicker#rangePicker) to learn more.
    */
   rangeEndDate?: Date,
   /**
-   * Required for date range selection. Defines the datepicker start/end role in a date range selection.See the [date range picker example](https://gestalt.pinterest.systems/datepicker#rangePicker) to learn more.
+   * Required for date range selection. Defines the datepicker start/end role in a date range selection.See the [date range picker example](https://gestalt.pinterest.systems/web/datepicker#rangePicker) to learn more.
    */
   rangeSelector?: 'start' | 'end',
   /**
-   * Required for date range selection. Start date on a date range selection. See the [date range picker example](https://gestalt.pinterest.systems/datepicker#rangePicker) to learn more.
+   * Required for date range selection. Start date on a date range selection. See the [date range picker example](https://gestalt.pinterest.systems/web/datepicker#rangePicker) to learn more.
    */
   rangeStartDate?: Date,
   /**
-   * Required for date range selection. Pass a ref object to DatePicker to autofocus on the unselected date range field. See the [date range picker example](https://gestalt.pinterest.systems/datepicker#rangePicker) to learn more.
+   * Required for date range selection. Pass a ref object to DatePicker to autofocus on the unselected date range field. See the [date range picker example](https://gestalt.pinterest.systems/web/datepicker#rangePicker) to learn more.
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
-   * Pre-selected date value. See the [preselected date example](https://gestalt.pinterest.systems/datepicker#preselectedValue) to learn more.
+   * Pre-selected date value. See the [preselected date example](https://gestalt.pinterest.systems/web/datepicker#preselectedValue) to learn more.
    */
   value?: Date,
 |};
 
 /**
- * Use [Datepicker](https://gestalt.pinterest.systems/datepicker) when the user has to select a date or date range.
+ * Use [Datepicker](https://gestalt.pinterest.systems/web/datepicker) when the user has to select a date or date range.
  */
 /**
- * [DatePicker](https://gestalt.pinterest.systems/datepicker) is used when the user has to select a date or date range.
+ * [DatePicker](https://gestalt.pinterest.systems/web/datepicker) is used when the user has to select a date or date range.
  * DatePicker is distributed in its own package and must be installed separately.
  *
  * ![DatePicker closed light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/DatePicker-closed.spec.mjs-snapshots/DatePicker-closed-chromium-darwin.png)

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -50,7 +50,7 @@ type Props = {|
    * - label: Text to render inside the button to convey the function and purpose of the button. The button text has a fixed size.
    * - accessibilityLabel: Supply a short, descriptive label for screen-readers to replace button texts that do not provide sufficient context about the button component behavior. Texts like `Click Here,` `Follow,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the button text.
    * - onClick: Callback fired when the button component is clicked (pressed and released) with a mouse or keyboard.
-   * ActivationCard can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
+   * ActivationCard can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
    */
   link?: LinkData,
   /**
@@ -212,7 +212,7 @@ function UncompletedCard({
 }
 
 /**
- * [ActivationCards](https://gestalt.pinterest.systems/activationcard) are used in groups to communicate a user’s stage in a series of steps toward an overall action.
+ * [ActivationCards](https://gestalt.pinterest.systems/web/activationcard) are used in groups to communicate a user’s stage in a series of steps toward an overall action.
  *
  * ![ActivationCard light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ActivationCard.spec.mjs-snapshots/ActivationCard-chromium-darwin.png)
  * ![ActivationCard dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ActivationCard-dark.spec.mjs-snapshots/ActivationCard-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -43,7 +43,7 @@ type Props = {|
 |};
 
 /**
- * [Avatar](https://gestalt.pinterest.systems/avatar) is used to represent a user. Every Avatar image has a subtle color wash.
+ * [Avatar](https://gestalt.pinterest.systems/web/avatar) is used to represent a user. Every Avatar image has a subtle color wash.
  *
  * ![Avatar light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Avatar.spec.mjs-snapshots/Avatar-chromium-darwin.png)
  * ![Avatar dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Avatar-dark.spec.mjs-snapshots/Avatar-dark-chromium-darwin.png)

--- a/packages/gestalt/src/AvatarGroup.js
+++ b/packages/gestalt/src/AvatarGroup.js
@@ -14,62 +14,62 @@ type Props = {|
   /**
    * Label for screen readers to announce AvatarGroup.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/avatargroup#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/avatargroup#Accessibility) for details on proper usage.
    */
   accessibilityLabel: string,
   /**
    * Specify the `id` of an associated element (or elements) whose contents or visibility are controlled by a component so that screen reader users can identify the relationship between elements. Optional with button-role component.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/avatargroup#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/avatargroup#Accessibility) for details on proper usage.
    */
   accessibilityControls?: string,
   /**
    * Indicate that a component hides or exposes collapsible components and expose whether they are currently expanded or collapsed. Optional with button-role component.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/avatargroup#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/avatargroup#Accessibility) for details on proper usage.
    */
   accessibilityExpanded?: boolean,
   /**
    * Indicate that a component controls the appearance of interactive popup elements, such as menu or dialog. Optional with button-role component.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/avatargroup#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/avatargroup#Accessibility) for details on proper usage.
    */
   accessibilityHaspopup?: boolean,
   /**
-   * When supplied, it appends an `add` [icon](https://gestalt.pinterest.systems/Icon) to the avatar pile as a call to action to the user. See [Best Practices](https://gestalt.pinterest.systems/avatargroup#Best-practices) for more info.
+   * When supplied, it appends an `add` [icon](https://gestalt.pinterest.systems/Icon) to the avatar pile as a call to action to the user. See [Best Practices](https://gestalt.pinterest.systems/web/avatargroup#Best-practices) for more info.
    */
   addCollaborators?: boolean,
   /**
-   * The user group data. See the [collaborators display](https://gestalt.pinterest.systems/avatargroup#Collaborators-display) variant to learn more.
+   * The user group data. See the [collaborators display](https://gestalt.pinterest.systems/web/avatargroup#Collaborators-display) variant to learn more.
    */
   collaborators: $ReadOnlyArray<{|
     name: string,
     src?: string,
   |}>,
   /**
-   * When supplied, wraps the component in a link, and directs users to the url when item is selected. See the [role](https://gestalt.pinterest.systems/avatargroup#Role) variant to learn more.
+   * When supplied, wraps the component in a link, and directs users to the url when item is selected. See the [role](https://gestalt.pinterest.systems/web/avatargroup#Role) variant to learn more.
    */
   href?: string,
   /**
-   * Callback fired when the component is clicked (pressed and released) with a mouse or keyboard. See the [role](https://gestalt.pinterest.systems/avatargroup#Role) variant to learn more and see [TapArea's `onTap`](https://gestalt.pinterest.systems/taparea#Props-onTap) for more info about `OnTapType`.
+   * Callback fired when the component is clicked (pressed and released) with a mouse or keyboard. See the [role](https://gestalt.pinterest.systems/web/avatargroup#Role) variant to learn more and see [TapArea's `onTap`](https://gestalt.pinterest.systems/web/taparea#Props-onTap) for more info about `OnTapType`.
    */
   onClick?: OnTapType,
   /**
-   * Forward the ref to the underlying div or anchor element. See the [role](https://gestalt.pinterest.systems/avatargroup#Role) variant to learn more.
+   * Forward the ref to the underlying div or anchor element. See the [role](https://gestalt.pinterest.systems/web/avatargroup#Role) variant to learn more.
    */
   ref?: UnionRefs, // eslint-disable-line react/no-unused-prop-types
   /**
-   * Allows user interaction with the component. See the [role](https://gestalt.pinterest.systems/avatargroup#Role) variant to learn more.
+   * Allows user interaction with the component. See the [role](https://gestalt.pinterest.systems/web/avatargroup#Role) variant to learn more.
    */
   role?: 'link' | 'button',
   /**
-   * The maximum height of AvatarGroup. If size is `fit`, AvatarGroup will fill 100% of the parent container width. See the [fixed size](https://gestalt.pinterest.systems/avatargroup#Fixed-sizes) and [responsive size](https://gestalt.pinterest.systems/avatargroup#Responsive-sizing) variant to learn more.
+   * The maximum height of AvatarGroup. If size is `fit`, AvatarGroup will fill 100% of the parent container width. See the [fixed size](https://gestalt.pinterest.systems/web/avatargroup#Fixed-sizes) and [responsive size](https://gestalt.pinterest.systems/web/avatargroup#Responsive-sizing) variant to learn more.
    */
   size?: 'xs' | 'sm' | 'md' | 'fit',
 |};
 
 /**
- * [AvatarGroup](https://gestalt.pinterest.systems/avatargroup) is used to both display a group of user avatars and, optionally, control actions related to the users group.
+ * [AvatarGroup](https://gestalt.pinterest.systems/web/avatargroup) is used to both display a group of user avatars and, optionally, control actions related to the users group.
  *
  * ![AvatarGroup light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/AvatarGroup.spec.mjs-snapshots/AvatarGroup-chromium-darwin.png)
  * ![AvatarGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/AvatarGroup-dark.spec.mjs-snapshots/AvatarGroup-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -17,7 +17,7 @@ export type TypeOptions =
 
 type Props = {|
   /**
-   * Badge position relative to its parent element. See the [positioning](https://gestalt.pinterest.systems/badge#Positioning) variant to learn more.
+   * Badge position relative to its parent element. See the [positioning](https://gestalt.pinterest.systems/web/badge#Positioning) variant to learn more.
    */
   position?: Position,
   /**
@@ -25,13 +25,13 @@ type Props = {|
    */
   text: string,
   /**
-   * Determines the style of the badge. See the [type](https://gestalt.pinterest.systems/badge#Type) variant to learn more.
+   * Determines the style of the badge. See the [type](https://gestalt.pinterest.systems/web/badge#Type) variant to learn more.
    */
   type?: TypeOptions,
 |};
 
 /**
- * [Badge](https://gestalt.pinterest.systems/badge) is a label that indicates status or importance. Badges should provide quick recognition.
+ * [Badge](https://gestalt.pinterest.systems/web/badge) is a label that indicates status or importance. Badges should provide quick recognition.
  *
  * ![Badge light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Badge.spec.mjs-snapshots/Badge-chromium-darwin.png)
  * ![Badge dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Badge-dark.spec.mjs-snapshots/Badge-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -85,21 +85,21 @@ type Props = {
   /**
    * Aligns a flex container's lines within when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    * Default: 'stretch'
    */
   alignContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch',
   /**
    * Defines the default behaviour for how flex items are laid out along the cross-axis on the current line. Think of it as the justify-content version for the cross-axis (perpendicular to the main-axis).
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    * Default: 'stretch'
    */
   alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch',
   /**
    * Allows the default alignment (or the one specified by align-items) to be overridden for individual flex items.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    * Default: 'stretch'
    */
   alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch',
@@ -122,17 +122,17 @@ type Props = {
     | 'section'
     | 'summary',
   /**
-   * Specify a border style for the box. For sizes, "sm" is 1px and "lg" is 2px. Setting a size will always default the border style to solid and color to lightGray. See the [borders](https://gestalt.pinterest.systems/box#Borders) variant for more details.
+   * Specify a border style for the box. For sizes, "sm" is 1px and "lg" is 2px. Setting a size will always default the border style to solid and color to lightGray. See the [borders](https://gestalt.pinterest.systems/web/box#Borders) variant for more details.
    * Default: 'none'
    */
   borderStyle?: 'sm' | 'lg' | 'shadow' | 'raisedTopShadow' | 'raisedBottomShadow' | 'none',
   /**
-   * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/box#Absolute-positioning) variant for more info.
+   * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/web/box#Absolute-positioning) variant for more info.
    * Default: false
    */
   bottom?: boolean,
   /**
-   * See the [color](https://gestalt.pinterest.systems/box#Colors) variant for more info.
+   * See the [color](https://gestalt.pinterest.systems/web/box#Colors) variant for more info.
    * Default: 'transparent'
    */
   color?:
@@ -165,27 +165,27 @@ type Props = {
     | 'dark'
     | 'light',
   /**
-   * See the [column layout](https://gestalt.pinterest.systems/box#Column-layout) variant for more info.
+   * See the [column layout](https://gestalt.pinterest.systems/web/box#Column-layout) variant for more info.
    *
    * Also available in responsive sizes: `smColumn`, `mdColumn`, `lgColumn`
    */
   column?: Column,
   /**
-   * See the [column layout](https://gestalt.pinterest.systems/box#Column-layout) variant for more info.
+   * See the [column layout](https://gestalt.pinterest.systems/web/box#Column-layout) variant for more info.
    */
   smColumn?: Column,
   /**
-   * See the [column layout](https://gestalt.pinterest.systems/box#Column-layout) variant for more info.
+   * See the [column layout](https://gestalt.pinterest.systems/web/box#Column-layout) variant for more info.
    */
   mdColumn?: Column,
   /**
-   * See the [column layout](https://gestalt.pinterest.systems/box#Column-layout) variant for more info.
+   * See the [column layout](https://gestalt.pinterest.systems/web/box#Column-layout) variant for more info.
    */
   lgColumn?: Column,
   /**
    * Establishes the main-axis, thus defining the direction flex items are placed in the flex container.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    *
    * Also available in responsive sizes: `smDirection`, `mdDirection`, `lgDirection`
    * Default: 'row'
@@ -194,65 +194,65 @@ type Props = {
   /**
    * Establishes the main-axis, thus defining the direction flex items are placed in the flex container in sm or larger viewports.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    */
   smDirection?: Direction,
   /**
    * Establishes the main-axis, thus defining the direction flex items are placed in the flex container in md or larger viewports.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    */
   mdDirection?: Direction,
   /**
    * Establishes the main-axis, thus defining the direction flex items are placed in the flex container in lg or larger viewports.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    */
   lgDirection?: Direction,
   /**
-   * The display style. See the [Accessibility guidelines](https://gestalt.pinterest.systems/box#Visually-hidden-content) to learn more about using \`visuallyHidden\`.
+   * The display style. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/box#Visually-hidden-content) to learn more about using \`visuallyHidden\`.
    *
    * Also available in responsive sizes: `smDisplay`, `mdDisplay`, `lgDisplay`
    * Default: 'block'
    */
   display?: Display,
   /**
-   * The display style in sm or larger viewports. See the [Accessibility guidelines](https://gestalt.pinterest.systems/box#Visually-hidden-content) to learn more about using \`visuallyHidden\`.
+   * The display style in sm or larger viewports. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/box#Visually-hidden-content) to learn more about using \`visuallyHidden\`.
    */
   smDisplay?: Display,
   /**
-   * The display style in md or larger viewports. See the [Accessibility guidelines](https://gestalt.pinterest.systems/box#Visually-hidden-content) to learn more about using \`visuallyHidden\`.
+   * The display style in md or larger viewports. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/box#Visually-hidden-content) to learn more about using \`visuallyHidden\`.
    */
   mdDisplay?: Display,
   /**
-   * The display style in lg or larger viewports. See the [Accessibility guidelines](https://gestalt.pinterest.systems/box#Visually-hidden-content) to learn more about using \`visuallyHidden\`.
+   * The display style in lg or larger viewports. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/box#Visually-hidden-content) to learn more about using \`visuallyHidden\`.
    */
   lgDisplay?: Display,
   /**
-   * Sets the max-width of the Box to 100%. See the [sizing](https://gestalt.pinterest.systems/box#Sizing) variant for more info.
+   * Sets the max-width of the Box to 100%. See the [sizing](https://gestalt.pinterest.systems/web/box#Sizing) variant for more info.
    * Default: false
    */
   fit?: boolean,
   /**
    * Defines how a flex item will be sized. "grow", equivalent to "flex: 1 1 auto", will size the Box relative to its parent, growing and shrinking based on available space. "shrink", equivalent to "flex: 0 1 auto" (the browser default), allows the Box to shrink if compressed but not grow if given extra space. Finally, "none", equivalent to "flex: 0 0 auto", preserves the Box's size based on child content regardless of its container's size.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    * Default: 'shrink'
    */
   flex?: 'grow' | 'shrink' | 'none',
   /**
-   * Use numbers for pixels: height={100} and strings for percentages: height="100%". See the [sizing](https://gestalt.pinterest.systems/box#Sizing) variant for more info.
+   * Use numbers for pixels: height={100} and strings for percentages: height="100%". See the [sizing](https://gestalt.pinterest.systems/web/box#Sizing) variant for more info.
    */
   height?: Dimension,
   /**
    * Defines the alignment along the main axis. It helps distribute extra free space left over when either all the flex items on a line are inflexible, or are flexible but have reached their maximum size. It also exerts some control over the alignment of items when they overflow the line.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    * Default: 'start'
    */
   justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly',
   /**
-   * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/box#Absolute-positioning) variant for more info.
+   * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/web/box#Absolute-positioning) variant for more info.
    * Default: false
    */
   left?: boolean,
@@ -314,7 +314,7 @@ type Props = {
    */
   lgMarginBottom?: Margin,
   /**
-   * Applies margin to the left in left-to-right languages, and to the right in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/box#Page-direction) to learn more about using `marginStart`.
+   * Applies margin to the left in left-to-right languages, and to the right in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/web/box#Page-direction) to learn more about using `marginStart`.
    * Scale is in 4px increments so a `marginStart` of 2 is 8px.
    *
    * Also available in responsive sizes: `smMarginStart`, `mdMarginStart`, `lgMarginStart`
@@ -322,22 +322,22 @@ type Props = {
    */
   marginStart?: Margin,
   /**
-   * Applies margin to the left in left-to-right languages, and to the right in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/box#Page-direction) to learn more about using `marginStart`.
+   * Applies margin to the left in left-to-right languages, and to the right in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/web/box#Page-direction) to learn more about using `marginStart`.
    * Scale is in 4px increments so a `marginStart` of 2 is 8px. For viewports of size sm and larger.
    */
   smMarginStart?: Margin,
   /**
-   * Applies margin to the left in left-to-right languages, and to the right in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/box#Page-direction) to learn more about using `marginStart`.
+   * Applies margin to the left in left-to-right languages, and to the right in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/web/box#Page-direction) to learn more about using `marginStart`.
    * Scale is in 4px increments so a `marginStart` of 2 is 8px. For viewports of size md and larger.
    */
   mdMarginStart?: Margin,
   /**
-   * Applies margin to the left in left-to-right languages, and to the right in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/box#Page-direction) to learn more about using `marginStart`.
+   * Applies margin to the left in left-to-right languages, and to the right in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/web/box#Page-direction) to learn more about using `marginStart`.
    * Scale is in 4px increments so a `marginStart` of 2 is 8px. For viewports of size lg and larger.
    */
   lgMarginStart?: Margin,
   /**
-   * Applies margin to the right in left-to-right languages, and to the left in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/box#Page-direction) to learn more about using `marginEnd`.
+   * Applies margin to the right in left-to-right languages, and to the left in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/web/box#Page-direction) to learn more about using `marginEnd`.
    * Scale is in 4px increments so a marginEnd of 2 is 8px.
    *
    * Also available in responsive sizes: `smMarginEnd`, `mdMarginEnd`, `lgMarginEnd`
@@ -345,62 +345,62 @@ type Props = {
    */
   marginEnd?: Margin,
   /**
-   * Applies margin to the right in left-to-right languages, and to the left in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/box#Page-direction) to learn more about using `marginEnd`.
+   * Applies margin to the right in left-to-right languages, and to the left in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/web/box#Page-direction) to learn more about using `marginEnd`.
    * Scale is in 4px increments so a marginEnd of 2 is 8px. For viewports of size sm and larger.
    */
   smMarginEnd?: Margin,
   /**
-   * Applies margin to the right in left-to-right languages, and to the left in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/box#Page-direction) to learn more about using `marginEnd`.
+   * Applies margin to the right in left-to-right languages, and to the left in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/web/box#Page-direction) to learn more about using `marginEnd`.
    * Scale is in 4px increments so a marginEnd of 2 is 8px. For viewports of size md and larger.
    */
   mdMarginEnd?: Margin,
   /**
-   * Applies margin to the right in left-to-right languages, and to the left in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/box#Page-direction) to learn more about using `marginEnd`.
+   * Applies margin to the right in left-to-right languages, and to the left in right-to-left languages. See the [Localization guidelines](https://gestalt.pinterest.systems/web/box#Page-direction) to learn more about using `marginEnd`.
    * Scale is in 4px increments so a marginEnd of 2 is 8px. For viewports of size lg and larger.
    */
   lgMarginEnd?: Margin,
   /**
-   * Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%". See the [sizing](https://gestalt.pinterest.systems/box#Sizing) variant for more info.
+   * Use numbers for pixels: maxHeight={100} and strings for percentages: maxHeight="100%". See the [sizing](https://gestalt.pinterest.systems/web/box#Sizing) variant for more info.
    */
   maxHeight?: Dimension,
   /**
-   * Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%". See the [sizing](https://gestalt.pinterest.systems/box#Sizing) variant for more info.
+   * Use numbers for pixels: maxWidth={100} and strings for percentages: maxWidth="100%". See the [sizing](https://gestalt.pinterest.systems/web/box#Sizing) variant for more info.
    */
   maxWidth?: Dimension,
   /**
-   * Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%". See the [sizing](https://gestalt.pinterest.systems/box#Sizing) variant for more info.
+   * Use numbers for pixels: minHeight={100} and strings for percentages: minHeight="100%". See the [sizing](https://gestalt.pinterest.systems/web/box#Sizing) variant for more info.
    */
   minHeight?: Dimension,
   /**
-   * Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%". See the [sizing](https://gestalt.pinterest.systems/box#Sizing) variant for more info.
+   * Use numbers for pixels: minWidth={100} and strings for percentages: minWidth="100%". See the [sizing](https://gestalt.pinterest.systems/web/box#Sizing) variant for more info.
    */
   minWidth?: Dimension,
   /**
-   * See the [opacity](https://gestalt.pinterest.systems/box#Opacity) variant for more info.
+   * See the [opacity](https://gestalt.pinterest.systems/web/box#Opacity) variant for more info.
    */
   opacity?: 0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1,
   /**
-   * See the [overflow](https://gestalt.pinterest.systems/box#Overflow) variant for more info.
+   * See the [overflow](https://gestalt.pinterest.systems/web/box#Overflow) variant for more info.
    * Default: 'visible'
    */
   overflow?: 'visible' | 'hidden' | 'scroll' | 'scrollX' | 'scrollY' | 'auto',
   /**
-   * Supports 3 responsive breakpoints: sm, md, lg. Each sets the padding from that breakpoint and up. See the [responsive padding](https://gestalt.pinterest.systems/box#Responsive-padding) variant for more info.
+   * Supports 3 responsive breakpoints: sm, md, lg. Each sets the padding from that breakpoint and up. See the [responsive padding](https://gestalt.pinterest.systems/web/box#Responsive-padding) variant for more info.
    *
    * Also available in responsive sizes: `smPadding`, `mdPadding`, `lgPadding`
    * Default: 0
    */
   padding?: Padding,
   /**
-   * Supports 3 responsive breakpoints: sm, md, lg. Each sets the padding from that breakpoint and up. See the [responsive padding](https://gestalt.pinterest.systems/box#Responsive-padding) variant for more info.
+   * Supports 3 responsive breakpoints: sm, md, lg. Each sets the padding from that breakpoint and up. See the [responsive padding](https://gestalt.pinterest.systems/web/box#Responsive-padding) variant for more info.
    */
   smPadding?: Padding,
   /**
-   * Supports 3 responsive breakpoints: sm, md, lg. Each sets the padding from that breakpoint and up. See the [responsive padding](https://gestalt.pinterest.systems/box#Responsive-padding) variant for more info.
+   * Supports 3 responsive breakpoints: sm, md, lg. Each sets the padding from that breakpoint and up. See the [responsive padding](https://gestalt.pinterest.systems/web/box#Responsive-padding) variant for more info.
    */
   mdPadding?: Padding,
   /**
-   * Supports 3 responsive breakpoints: sm, md, lg. Each sets the padding from that breakpoint and up. See the [responsive padding](https://gestalt.pinterest.systems/box#Responsive-padding) variant for more info.
+   * Supports 3 responsive breakpoints: sm, md, lg. Each sets the padding from that breakpoint and up. See the [responsive padding](https://gestalt.pinterest.systems/web/box#Responsive-padding) variant for more info.
    */
   lgPadding?: Padding,
   /**
@@ -442,12 +442,12 @@ type Props = {
    */
   lgPaddingY?: Padding,
   /**
-   * See the [absolute positioning](https://gestalt.pinterest.systems/box#Absolute-positioning) variant for more info.
+   * See the [absolute positioning](https://gestalt.pinterest.systems/web/box#Absolute-positioning) variant for more info.
    * Default: 'static'
    */
   position?: 'static' | 'absolute' | 'relative' | 'fixed',
   /**
-   * Ref that is forwarded to the underlying input element. See the [using as a ref](https://gestalt.pinterest.systems/box#Using-as-a-ref) variant for more info.
+   * Ref that is forwarded to the underlying input element. See the [using as a ref](https://gestalt.pinterest.systems/web/box#Using-as-a-ref) variant for more info.
    */
   ref?:
     | HTMLDivElement
@@ -463,20 +463,20 @@ type Props = {
     | Element<'section'>
     | Element<'summary'>,
   /**
-   * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/box#Absolute-positioning) variant for more info.
+   * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/web/box#Absolute-positioning) variant for more info.
    * Default: false
    */
   right?: boolean,
   /**
-   * Used to designate the Box as a type of element or landmark using ARIA roles. See the [Accessibility guidelines](https://gestalt.pinterest.systems/box#Using-role) to learn more about using `role`.
+   * Used to designate the Box as a type of element or landmark using ARIA roles. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/box#Using-role) to learn more about using `role`.
    */
   role?: string,
   /**
-   * See the [rounding](https://gestalt.pinterest.systems/box#Rounding) variant for more info.
+   * See the [rounding](https://gestalt.pinterest.systems/web/box#Rounding) variant for more info.
    */
   rounding?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill',
   /**
-   * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/box#Absolute-positioning) variant for more info.
+   * Helper to specify location when using absolute positioning. See the [absolute positioning](https://gestalt.pinterest.systems/web/box#Absolute-positioning) variant for more info.
    * Default: false
    */
   top?: boolean,
@@ -486,18 +486,18 @@ type Props = {
    */
   userSelect?: 'auto' | 'none',
   /**
-   * Use numbers for pixels: width={100} and strings for percentages: width="100%". See the [sizing](https://gestalt.pinterest.systems/box#Sizing) variant for more info.
+   * Use numbers for pixels: width={100} and strings for percentages: width="100%". See the [sizing](https://gestalt.pinterest.systems/web/box#Sizing) variant for more info.
    */
   width?: Dimension,
   /**
    * By default, flex items will all try to fit onto one line. You can change that and allow the items to wrap onto multiple lines, from top to bottom.
    *
-   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/flex)!
+   * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
    * Default: false
    */
   wrap?: boolean,
   /**
-   * An object representing the zIndex value of the Box. See the [Z-Index](https://gestalt.pinterest.systems/box#Z-Index) variant for more info.
+   * An object representing the zIndex value of the Box. See the [Z-Index](https://gestalt.pinterest.systems/web/box#Z-Index) variant for more info.
    */
   zIndex?: Indexable,
   ...
@@ -535,7 +535,7 @@ const disallowedProps = [
 type OutputType = Element<As>;
 
 /**
- * [Box](https://gestalt.pinterest.systems/box) is a component primitive that can be used to build the foundation of pretty much any other component. It keeps details like spacing, borders and colors consistent with the rest of Gestalt, while allowing the developer to focus on the content.
+ * [Box](https://gestalt.pinterest.systems/web/box) is a component primitive that can be used to build the foundation of pretty much any other component. It keeps details like spacing, borders and colors consistent with the rest of Gestalt, while allowing the developer to focus on the content.
  *
  * ![Box light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Box.spec.mjs-snapshots/Box-chromium-darwin.png)
  * ![Box dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Box-dark.spec.mjs-snapshots/Box-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -104,7 +104,7 @@ function IconEnd({
 }
 
 /**
- * [Buttons](https://gestalt.pinterest.systems/button) allow users to perform actions within a surface. They can be used alone for immediate action, or as a trigger for another component, like [Dropdown](https://gestalt.pinterest.systems/dropdown) or [Popover](https://gestalt.pinterest.systems/popover).
+ * [Buttons](https://gestalt.pinterest.systems/web/button) allow users to perform actions within a surface. They can be used alone for immediate action, or as a trigger for another component, like [Dropdown](https://gestalt.pinterest.systems/web/dropdown) or [Popover](https://gestalt.pinterest.systems/web/popover).
  *
  * ![Button light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Button.spec.mjs-snapshots/Button-chromium-darwin.png)
  * ![Button dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Button-dark.spec.mjs-snapshots/Button-dark-chromium-darwin.png)

--- a/packages/gestalt/src/ButtonGroup.js
+++ b/packages/gestalt/src/ButtonGroup.js
@@ -10,7 +10,7 @@ type Props = {|
 |};
 
 /**
- * [ButtonGroup](https://gestalt.pinterest.systems/buttongroup) is used to display a series of buttons.
+ * [ButtonGroup](https://gestalt.pinterest.systems/web/buttongroup) is used to display a series of buttons.
  *
  * ![ButtonGroup light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ButtonGroup.spec.mjs-snapshots/ButtonGroup-chromium-darwin.png)
  * ![ButtonGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ButtonGroup-dark.spec.mjs-snapshots/ButtonGroup-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -14,24 +14,24 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 
 type Props = {|
   /**
-   * Adds a dismiss button to Callout. See the [Dismissible variant](https://gestalt.pinterest.systems/callout#Dismissible) for more info.
-   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/callout#Accessibility).
+   * Adds a dismiss button to Callout. See the [Dismissible variant](https://gestalt.pinterest.systems/web/callout#Dismissible) for more info.
+   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/callout#Accessibility).
    */
   dismissButton?: {| accessibilityLabel: string, onDismiss: () => void |},
   /**
-   * Label to describe the icon’s purpose. See the [Accessibility guidelines](https://gestalt.pinterest.systems/callout#Accessibility) for details on proper usage.
+   * Label to describe the icon’s purpose. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/callout#Accessibility) for details on proper usage.
    */
   iconAccessibilityLabel: string,
   /**
-   * Main content of Callout. Content should be [localized](https://gestalt.pinterest.systems/callout#Localization).
+   * Main content of Callout. Content should be [localized](https://gestalt.pinterest.systems/web/callout#Localization).
    *
-   * See [Best Practices](https://gestalt.pinterest.systems/callout#Best-practices) for more info.
+   * See [Best Practices](https://gestalt.pinterest.systems/web/callout#Best-practices) for more info.
    */
   message: string,
   /**
-   * Main action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
+   * Main action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
-   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/callout#Accessibility).
+   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/callout#Accessibility).
    */
   primaryAction?: {|
     accessibilityLabel: string,
@@ -49,9 +49,9 @@ type Props = {|
     target?: null | 'self' | 'blank',
   |},
   /**
-   * Secondary action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
+   * Secondary action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
-   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/callout#Accessibility).
+   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/callout#Accessibility).
    */
   secondaryAction?: {|
     accessibilityLabel: string,
@@ -69,11 +69,11 @@ type Props = {|
     target?: null | 'self' | 'blank',
   |},
   /**
-   * The category of Callout. See [Variants](https://gestalt.pinterest.systems/callout#Variants) to learn more.
+   * The category of Callout. See [Variants](https://gestalt.pinterest.systems/web/callout#Variants) to learn more.
    */
   type: 'error' | 'info' | 'warning',
   /**
-   * Brief title summarizing Callout. Content should be [localized](https://gestalt.pinterest.systems/callout#Localization).
+   * Brief title summarizing Callout. Content should be [localized](https://gestalt.pinterest.systems/web/callout#Localization).
    */
   title?: string,
 |};
@@ -132,7 +132,7 @@ function CalloutAction({
 }
 
 /**
- * [Callout](https://gestalt.pinterest.systems/callout) is a banner displaying short messages with helpful information for a task on the page, or something that requires the user’s attention.
+ * [Callout](https://gestalt.pinterest.systems/web/callout) is a banner displaying short messages with helpful information for a task on the page, or something that requires the user’s attention.
  *
  * ![Callout light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Callout.spec.mjs-snapshots/Callout-chromium-darwin.png)
  * ![Callout dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Callout-dark.spec.mjs-snapshots/Callout-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Card.js
+++ b/packages/gestalt/src/Card.js
@@ -18,7 +18,7 @@ type Props = {|
    */
   children?: Node,
   /**
-   * An optional [Image](https://gestalt.pinterest.systems/image) to be displayed at the top of the layout.
+   * An optional [Image](https://gestalt.pinterest.systems/web/image) to be displayed at the top of the layout.
    */
   image?: Node,
   /**
@@ -32,7 +32,7 @@ type Props = {|
 |};
 
 /**
- * [Card](https://gestalt.pinterest.systems/card) is used to highlight content in grids. It visually shows that children elements belong together and can highlight the items on hover.
+ * [Card](https://gestalt.pinterest.systems/web/card) is used to highlight content in grids. It visually shows that children elements belong together and can highlight the items on hover.
  */
 export default function Card({ active, children, image, onMouseEnter, onMouseLeave }: Props): Node {
   const [hovered, setHovered] = useState(false);

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -14,15 +14,15 @@ import focusStyles from './Focus.css';
 
 type Props = {|
   /**
-   * Indicates whether or not Checkbox is checked. See the [state variant](https://gestalt.pinterest.systems/checkbox#State) to learn more.
+   * Indicates whether or not Checkbox is checked. See the [state variant](https://gestalt.pinterest.systems/web/checkbox#State) to learn more.
    */
   checked?: boolean,
   /**
-   * Indicates whether or not Checkbox is disabled. Disabled Checkboxes do not respond to mouse events and cannot be reached by the keyboard. See the [state variant](https://gestalt.pinterest.systems/checkbox#State) to learn more.
+   * Indicates whether or not Checkbox is disabled. Disabled Checkboxes do not respond to mouse events and cannot be reached by the keyboard. See the [state variant](https://gestalt.pinterest.systems/web/checkbox#State) to learn more.
    */
   disabled?: boolean,
   /**
-   * Displays an error message and error state. See the [accessibility section](https://gestalt.pinterest.systems/checkbox#Error-message) to learn more.
+   * Displays an error message and error state. See the [accessibility section](https://gestalt.pinterest.systems/web/checkbox#Error-message) to learn more.
    */
   errorMessage?: string,
   /**
@@ -34,15 +34,15 @@ type Props = {|
    */
   id: string,
   /**
-   * An optional Image can be supplied to add an image to each Checkbox. See the [with Image variant](https://gestalt.pinterest.systems/checkbox#With-Image) to learn more.
+   * An optional Image can be supplied to add an image to each Checkbox. See the [with Image variant](https://gestalt.pinterest.systems/web/checkbox#With-Image) to learn more.
    */
   image?: Node,
   /**
-   * Indicates a state that is neither checked nor unchecked. See the [state variant](https://gestalt.pinterest.systems/checkbox#State) to learn more.
+   * Indicates a state that is neither checked nor unchecked. See the [state variant](https://gestalt.pinterest.systems/web/checkbox#State) to learn more.
    */
   indeterminate?: boolean,
   /**
-   * The label for the input. Be sure to localize the text. See the [accessibility section](https://gestalt.pinterest.systems/checkbox#Labels) to learn more.
+   * The label for the input. Be sure to localize the text. See the [accessibility section](https://gestalt.pinterest.systems/web/checkbox#Labels) to learn more.
    */
   label?: string,
   /**
@@ -66,17 +66,17 @@ type Props = {|
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
-   * Determines the Checkbox size: sm = 16px, md = 24px. See the [size variant](https://gestalt.pinterest.systems/checkbox#Size) to learn more.
+   * Determines the Checkbox size: sm = 16px, md = 24px. See the [size variant](https://gestalt.pinterest.systems/web/checkbox#Size) to learn more.
    */
   size?: 'sm' | 'md',
   /**
-   * Optional description for Checkbox, used to provide more detail about an option. See the [with subtext variant](https://gestalt.pinterest.systems/checkbox#With-subtext) to learn more.
+   * Optional description for Checkbox, used to provide more detail about an option. See the [with subtext variant](https://gestalt.pinterest.systems/web/checkbox#With-subtext) to learn more.
    */
   subtext?: string,
 |};
 
 /**
- * [Checkbox](https://gestalt.pinterest.systems/checkbox) is used for multiple choice selection. They are independent of each other in a list, and therefore, different from [RadioButton](https://gestalt.pinterest.systems/radiobutton), one selection does not affect other checkboxes in the same list.
+ * [Checkbox](https://gestalt.pinterest.systems/web/checkbox) is used for multiple choice selection. They are independent of each other in a list, and therefore, different from [RadioButton](https://gestalt.pinterest.systems/web/radiobutton), one selection does not affect other checkboxes in the same list.
  *
  * ![Checkbox light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Checkbox.spec.mjs-snapshots/Checkbox-chromium-darwin.png)
  * ![Checkbox dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Checkbox-dark.spec.mjs-snapshots/Checkbox-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -174,7 +174,7 @@ type Props = {|
 |};
 
 /**
- *  [Collage](https://gestalt.pinterest.systems/collage), similarly to [Masonry](https://gestalt.pinterest.systems/masonry), creates a deterministic grid layout that can absolutely position and virtualize images.
+ *  [Collage](https://gestalt.pinterest.systems/web/collage), similarly to [Masonry](https://gestalt.pinterest.systems/web/masonry), creates a deterministic grid layout that can absolutely position and virtualize images.
  *
  * ![Collage light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Collage.spec.mjs-snapshots/Collage-chromium-darwin.png)
  * ![Collage dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Collage-dark.spec.mjs-snapshots/Collage-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Column.js
+++ b/packages/gestalt/src/Column.js
@@ -31,7 +31,7 @@ type ColumnProps = {|
 |};
 
 /**
- * Use [Column](https://gestalt.pinterest.systems/column) to implement a 12-column system.
+ * Use [Column](https://gestalt.pinterest.systems/web/column) to implement a 12-column system.
  *
  * ![Column light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Column.spec.mjs-snapshots/Column-chromium-darwin.png)
  *

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -42,11 +42,11 @@ type Props = {|
    */
   accessibilityClearButtonLabel: string,
   /**
-   * When disabled, ComboBox looks inactive and cannot be interacted with. If tags are passed, they will appear disabled as well and cannot be removed. See [tags](https://gestalt.pinterest.systems/combobox#Tags) variant to learn more.
+   * When disabled, ComboBox looks inactive and cannot be interacted with. If tags are passed, they will appear disabled as well and cannot be removed. See [tags](https://gestalt.pinterest.systems/web/combobox#Tags) variant to learn more.
    */
   disabled?: boolean,
   /**
-   * Provide feedback when an error on selection occurs. See [error message](https://gestalt.pinterest.systems/combobox#Error-message) variant.
+   * Provide feedback when an error on selection occurs. See [error message](https://gestalt.pinterest.systems/web/combobox#Error-message) variant.
    */
   errorMessage?: Node,
   /**
@@ -54,11 +54,11 @@ type Props = {|
    */
   helperText?: string,
   /**
-   * The user input in ComboBox for controlled components. See [controlled ComboBox](https://gestalt.pinterest.systems/combobox#Controlled-vs-Uncontrolled) variant to learn more.
+   * The user input in ComboBox for controlled components. See [controlled ComboBox](https://gestalt.pinterest.systems/web/combobox#Controlled-vs-Uncontrolled) variant to learn more.
    */
   inputValue?: string | null,
   /**
-   * Unique id to identify each ComboBox. Used for [accessibility](https://gestalt.pinterest.systems/combobox#Accessibility) purposes.
+   * Unique id to identify each ComboBox. Used for [accessibility](https://gestalt.pinterest.systems/web/combobox#Accessibility) purposes.
    */
   id: string,
   /**
@@ -66,7 +66,7 @@ type Props = {|
    */
   label: string,
   /**
-   * Whether the label should be visible or not. If `hidden`, the label is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems/combobox#Label-visibility) for more info.
+   * Whether the label should be visible or not. If `hidden`, the label is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems/web/combobox#Label-visibility) for more info.
    */
   labelDisplay?: 'visible' | 'hidden',
   /**
@@ -117,7 +117,7 @@ type Props = {|
     |},
   |}) => void,
   /**
-   * The data for each selection option. See [subtext](https://gestalt.pinterest.systems/combobox#With-subtext) variant to learn more.
+   * The data for each selection option. See [subtext](https://gestalt.pinterest.systems/web/combobox#With-subtext) variant to learn more.
    */
   options: $ReadOnlyArray<{|
     label: string,
@@ -130,11 +130,11 @@ type Props = {|
   placeholder?: string,
   // The ref prop is unused and listed here just for documentation purposes.
   /**
-   * Forward the ref to the underlying component container element. See the [Ref](https://gestalt.pinterest.systems/combobox#Ref) variant to learn more about focus management.
+   * Forward the ref to the underlying component container element. See the [Ref](https://gestalt.pinterest.systems/web/combobox#Ref) variant to learn more about focus management.
    */
   ref?: Ref<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
-   * The selected option in ComboBox for controlled components. See [controlled ComboBox](https://gestalt.pinterest.systems/combobox#Controlled-vs-Uncontrolled) variant to learn more.
+   * The selected option in ComboBox for controlled components. See [controlled ComboBox](https://gestalt.pinterest.systems/web/combobox#Controlled-vs-Uncontrolled) variant to learn more.
    */
   selectedOption?: OptionType,
   /**
@@ -142,17 +142,17 @@ type Props = {|
    */
   size?: Size,
   /**
-   * List of tags to display in the component. See [tags](https://gestalt.pinterest.systems/combobox#Tags) variant to learn more.
+   * List of tags to display in the component. See [tags](https://gestalt.pinterest.systems/web/combobox#Tags) variant to learn more.
    */
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   /**
-   * An object representing the zIndex value of the ComboBox list box. Learn more about [zIndex classes](https://gestalt.pinterest.systems/zindex_classes)
+   * An object representing the zIndex value of the ComboBox list box. Learn more about [zIndex classes](https://gestalt.pinterest.systems/web/zindex_classes)
    */
   zIndex?: Indexable,
 |};
 
 /**
- * [ComboBox](https://gestalt.pinterest.systems/combobox) is the combination of a [Textfield](https://gestalt.pinterest.systems/textfield) and an associated [Dropdown](https://gestalt.pinterest.systems/dropdown) that allows the user to filter a list when selecting an option. ComboBox allows users to type the full option, type part of the option and narrow the results, or select an option from the list.
+ * [ComboBox](https://gestalt.pinterest.systems/web/combobox) is the combination of a [Textfield](https://gestalt.pinterest.systems/web/textfield) and an associated [Dropdown](https://gestalt.pinterest.systems/web/dropdown) that allows the user to filter a list when selecting an option. ComboBox allows users to type the full option, type part of the option and narrow the results, or select an option from the list.
  * Note: this is a new version of the deprecated component "Typeahead".
  *
  * ![Combobox closed light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ComboBox-closed.spec.mjs-snapshots/ComboBox-closed-chromium-darwin.png)

--- a/packages/gestalt/src/Container.js
+++ b/packages/gestalt/src/Container.js
@@ -10,7 +10,7 @@ type Props = {|
 |};
 
 /**
- * [Containers](https://gestalt.pinterest.systems/container ) are useful in responsively laying out content on different screens.
+ * [Containers](https://gestalt.pinterest.systems/web/container ) are useful in responsively laying out content on different screens.
  *
  * ![Container light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Container.spec.mjs-snapshots/Container-chromium-darwin.png)
  *

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -37,7 +37,7 @@ type Props = {|
    */
   tooltipText?: string,
   /**
-   * Specifying the z-index of the tooltip may be necessary if other elements with higher z-indices overlap the tooltip. See [ZIndex Classes](https://gestalt.pinterest.systems/zindex_classes) to learn more.
+   * Specifying the z-index of the tooltip may be necessary if other elements with higher z-indices overlap the tooltip. See [ZIndex Classes](https://gestalt.pinterest.systems/web/zindex_classes) to learn more.
    */
   tooltipZIndex?: Indexable,
   /**
@@ -55,7 +55,7 @@ type Props = {|
 |};
 
 /**
- * [Datapoint](https://gestalt.pinterest.systems/datapoint) displays at-a-glance data for a user to quickly view key metrics.
+ * [Datapoint](https://gestalt.pinterest.systems/web/datapoint) displays at-a-glance data for a user to quickly view key metrics.
  *
  * ![Datapoint light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Datapoint.spec.mjs-snapshots/Datapoint-chromium-darwin.png)
  * ![Datapoint dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Datapoint-dark.spec.mjs-snapshots/Datapoint-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Divider.js
+++ b/packages/gestalt/src/Divider.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import styles from './Divider.css';
 
 /**
- * [Divider](https://gestalt.pinterest.systems/divider) is a light gray 1px horizontal or vertical line which groups and divides content in lists and layouts.
+ * [Divider](https://gestalt.pinterest.systems/web/divider) is a light gray 1px horizontal or vertical line which groups and divides content in lists and layouts.
  *
  * ![Divider light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Divider.spec.mjs-snapshots/Divider-chromium-darwin.png)
  * ![Divider dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Divider-dark.spec.mjs-snapshots/Divider-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -85,11 +85,11 @@ const renderChildrenWithIndex = (childrenArray) => {
 
 type Props = {|
   /**
-   * Ref for the element that the Dropdown will attach to, will most likely be a [Button](/button). See the [Accessibility](https://gestalt.pinterest.systems/dropdown#Accessibility) guidelines to learn more.
+   * Ref for the element that the Dropdown will attach to, will most likely be a [Button](/button). See the [Accessibility](https://gestalt.pinterest.systems/web/dropdown#Accessibility) guidelines to learn more.
    */
   anchor?: ?HTMLElement,
   /**
-   * Must be instances of [Dropdown.Item](https://gestalt.pinterest.systems/dropdown#Types-of-items), [Dropdown.Link](https://gestalt.pinterest.systems/dropdown#Types-of-items) or [Dropdown.Section](https://gestalt.pinterest.systems/dropdown#Sections) components. See the [Types of items](https://gestalt.pinterest.systems/dropdown#Types-of-items) variant to learn more.
+   * Must be instances of [Dropdown.Item](https://gestalt.pinterest.systems/web/dropdown#Types-of-items), [Dropdown.Link](https://gestalt.pinterest.systems/web/dropdown#Types-of-items) or [Dropdown.Section](https://gestalt.pinterest.systems/web/dropdown#Sections) components. See the [Types of items](https://gestalt.pinterest.systems/web/dropdown#Types-of-items) variant to learn more.
    */
   children: Node,
   /**
@@ -97,11 +97,11 @@ type Props = {|
    */
   isWithinFixedContainer?: boolean,
   /**
-   * Content to display at the top of the Dropdown before any items or sections. See the [Custom header](https://gestalt.pinterest.systems/dropdown#Custom-header) variant to learn more.
+   * Content to display at the top of the Dropdown before any items or sections. See the [Custom header](https://gestalt.pinterest.systems/web/dropdown#Custom-header) variant to learn more.
    */
   headerContent?: Node,
   /**
-   * Unique id to identify each Dropdown. Used for [Accessibility](https://gestalt.pinterest.systems/dropdown#Accessibility) purposes.
+   * Unique id to identify each Dropdown. Used for [Accessibility](https://gestalt.pinterest.systems/web/dropdown#Accessibility) purposes.
    */
   id: string,
   /**
@@ -113,13 +113,13 @@ type Props = {|
    */
   onDismiss: () => void,
   /**
-   * An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](https://gestalt.pinterest.systems/zindex_classes)
+   * An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](https://gestalt.pinterest.systems/web/zindex_classes)
    */
   zIndex?: Indexable,
 |};
 
 /**
- * [Dropdown](https://gestalt.pinterest.systems/dropdown) displays a list of actions, options or links. It is triggered when a user interacts with a Button, Textfield or other control. Dropdown allows for complex functionality that can’t be accomplished with SelectList.
+ * [Dropdown](https://gestalt.pinterest.systems/web/dropdown) displays a list of actions, options or links. It is triggered when a user interacts with a Button, Textfield or other control. Dropdown allows for complex functionality that can’t be accomplished with SelectList.
  *
  * ![Dropdown open light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Dropdown-open.spec.mjs-snapshots/Dropdown-open-chromium-darwin.png)
  * ![Dropdown open dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Dropdown-open-dark.spec.mjs-snapshots/Dropdown-open-dark-chromium-darwin.png)

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -16,11 +16,11 @@ type OptionItemType = {|
 
 type Props = {|
   /**
-   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/dropdown#Badges) variant to learn more.
+   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/web/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/web/dropdown#Badges) variant to learn more.
    */
   badge?: BadgeType,
   /**
-   * If needed, users can supply custom content to each Dropdown Item. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](https://gestalt.pinterest.systems/dropdown#Custom-item-content) variant to learn more.
+   * If needed, users can supply custom content to each Dropdown Item. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](https://gestalt.pinterest.systems/web/dropdown#Custom-item-content) variant to learn more.
    */
   children?: Node,
   /**
@@ -63,7 +63,7 @@ type Props = {|
 |};
 
 /**
- * Use [Dropdown.Item](https://gestalt.pinterest.systems/dropdown#Dropdown.Item) for action & selection, when the Dropdown item triggers an action or selects an option.
+ * Use [Dropdown.Item](https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item) for action & selection, when the Dropdown item triggers an action or selects an option.
  */
 export default function DropdownItem({
   badge,

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -16,11 +16,11 @@ type OptionItemType = {|
 
 type Props = {|
   /**
-   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/dropdown#Badges) variant to learn more.
+   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/web/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/web/dropdown#Badges) variant to learn more.
    */
   badge?: BadgeType,
   /**
-   * If needed, users can supply custom content to each Dropdown Link. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](https://gestalt.pinterest.systems/dropdown#Custom-item-content) variant to learn more.
+   * If needed, users can supply custom content to each Dropdown Link. This can be useful when extra functionality is needed beyond a basic Link. See the [Custom item content](https://gestalt.pinterest.systems/web/dropdown#Custom-item-content) variant to learn more.
    */
   children?: Node,
   /**
@@ -28,15 +28,15 @@ type Props = {|
    */
   dataTestId?: string,
   /**
-   * Directs users to the url when item is selected. See the [Types of items](https://gestalt.pinterest.systems/dropdown#Types-of-items) variant to learn more.
+   * Directs users to the url when item is selected. See the [Types of items](https://gestalt.pinterest.systems/web/dropdown#Types-of-items) variant to learn more.
    */
   href: string,
   /**
-   * When true, adds an arrow icon to the end of the item to signal this item takes users to an external source and opens the link in a new tab. Do not add if the item navigates users within the app. See the [Best practices](https://gestalt.pinterest.systems/dropdown#Best-practices) for more info.
+   * When true, adds an arrow icon to the end of the item to signal this item takes users to an external source and opens the link in a new tab. Do not add if the item navigates users within the app. See the [Best practices](https://gestalt.pinterest.systems/web/dropdown#Best-practices) for more info.
    */
   isExternal?: boolean,
   /**
-   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
+   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
    */
   onClick?: ({|
     event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,

--- a/packages/gestalt/src/DropdownSection.js
+++ b/packages/gestalt/src/DropdownSection.js
@@ -6,17 +6,17 @@ import styles from './Dropdown.css';
 
 type Props = {|
   /**
-   * Any [Dropdown.Items](https://gestalt.pinterest.systems/dropdown#Dropdown.ItemProps) and/or [Dropdown.Links](https://gestalt.pinterest.systems/dropdown#Dropdown.LinkProps) to be rendered
+   * Any [Dropdown.Items](https://gestalt.pinterest.systems/web/dropdown#Dropdown.ItemProps) and/or [Dropdown.Links](https://gestalt.pinterest.systems/web/dropdown#Dropdown.LinkProps) to be rendered
    */
   children: Node,
   /**
-   * Label for the section. See the [Sections](https://gestalt.pinterest.systems/dropdown#Sections) variant for more info.
+   * Label for the section. See the [Sections](https://gestalt.pinterest.systems/web/dropdown#Sections) variant for more info.
    */
   label: string,
 |};
 
 /**
- * Use [Dropdown.Section](https://gestalt.pinterest.systems/dropdown#Dropdown.Section) to create hierarchy within a single Dropdown.
+ * Use [Dropdown.Section](https://gestalt.pinterest.systems/web/dropdown#Dropdown.Section) to create hierarchy within a single Dropdown.
  */
 export default function DropdownSection({ label, children }: Props): Node {
   return (

--- a/packages/gestalt/src/Fieldset.js
+++ b/packages/gestalt/src/Fieldset.js
@@ -12,7 +12,7 @@ import whitespaceStyles from './Whitespace.css';
 
 type Props = {|
   /**
-   * The content of Fieldset, typically [RadioButtons](https://gestalt.pinterest.systems/radiobutton), [Checkboxes](https://gestalt.pinterest.systems/checkbox) or [TextFields](https://gestalt.pinterest.systems/textfield).
+   * The content of Fieldset, typically [RadioButtons](https://gestalt.pinterest.systems/web/radiobutton), [Checkboxes](https://gestalt.pinterest.systems/web/checkbox) or [TextFields](https://gestalt.pinterest.systems/web/textfield).
    */
   children: Node,
   /**
@@ -34,7 +34,7 @@ type Props = {|
 |};
 
 /**
- * [Fieldset](https://gestalt.pinterest.systems/fieldset) creates a fieldset and legend for a group of related form items, like [RadioButtons](https://gestalt.pinterest.systems/radiobutton) or [CheckBoxes](https://gestalt.pinterest.systems/checkbox), in order to clearly indicate related form items."
+ * [Fieldset](https://gestalt.pinterest.systems/web/fieldset) creates a fieldset and legend for a group of related form items, like [RadioButtons](https://gestalt.pinterest.systems/web/radiobutton) or [CheckBoxes](https://gestalt.pinterest.systems/web/checkbox), in order to clearly indicate related form items."
  *
  * ![Fieldset light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Fieldset.spec.mjs-snapshots/Fieldset-chromium-darwin.png)
  * ![Fieldset dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Fieldset-dark.spec.mjs-snapshots/Fieldset-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Flex.js
+++ b/packages/gestalt/src/Flex.js
@@ -94,7 +94,7 @@ const allowedProps = [
 ];
 
 /**
- * [Flex](https://gestalt.pinterest.systems/flex) is a layout component with a very limited subset of the props available to [Box](https://gestalt.pinterest.systems/box) and a special prop of its own.
+ * [Flex](https://gestalt.pinterest.systems/web/flex) is a layout component with a very limited subset of the props available to [Box](https://gestalt.pinterest.systems/web/box) and a special prop of its own.
 
  * Use this component for flexbox layouts, especially when even spacing between elements is desired (see the `gap` prop!).
  *

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -28,7 +28,7 @@ export type Props = {|
    */
   maxWidth?: Dimension,
   /**
-   * Use numbers for pixels: `minWidth={100}` and strings for percentages: `minWidth="100%"`. Can be used to fix overflowing children; see [the example](https://gestalt.pinterest.systems/flex#FlexItem-minWidth) to learn more.
+   * Use numbers for pixels: `minWidth={100}` and strings for percentages: `minWidth="100%"`. Can be used to fix overflowing children; see [the example](https://gestalt.pinterest.systems/web/flex#FlexItem-minWidth) to learn more.
    */
   minWidth?: Dimension,
 |};
@@ -36,7 +36,7 @@ export type Props = {|
 const allowedProps = ['alignSelf', 'children', 'flex', 'flexBasis', 'maxWidth', 'minWidth'];
 
 /**
- * Use [Flex.Item](https://gestalt.pinterest.systems/flex) within a Flex container for more precise control over the child element. Flex children that are not explicitly wrapped in Flex.Item will be wrapped in the the component automatically to apply `gap` spacing.
+ * Use [Flex.Item](https://gestalt.pinterest.systems/web/flex) within a Flex container for more precise control over the child element. Flex children that are not explicitly wrapped in Flex.Item will be wrapped in the the component automatically to apply `gap` spacing.
  */
 export default function FlexItem(props: Props): Node {
   const { passthroughProps, propsStyles } = buildStyles<Props>({

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -29,7 +29,7 @@ type Props = {|
    */
   accessibilityLevel?: AccessibilityLevel,
   /**
-   * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text. See [Alignment example](https://gestalt.pinterest.systems/heading#Alignment) for more details.
+   * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text. See [Alignment example](https://gestalt.pinterest.systems/web/heading#Alignment) for more details.
    */
   align?: 'start' | 'end' | 'center' | 'justify' | 'forceLeft' | 'forceRight',
   /**
@@ -37,7 +37,7 @@ type Props = {|
    */
   children?: Node,
   /**
-   * The color of the text. See [Text colors example](https://gestalt.pinterest.systems/design_tokens#Text-color) for more details.
+   * The color of the text. See [Text colors example](https://gestalt.pinterest.systems/foundations/design_tokens#Text-color) for more details.
    */
   color?:
     | 'default'
@@ -54,22 +54,22 @@ type Props = {|
    */
   id?: string,
   /**
-   * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers. See [Truncation example](https://gestalt.pinterest.systems/heading#Overflow-and-truncation) for more details.
+   * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers. See [Truncation example](https://gestalt.pinterest.systems/web/heading#Overflow-and-truncation) for more details.
    */
   lineClamp?: number,
   /**
-   * How truncation is handled when text overflows the line. See [Truncation example](https://gestalt.pinterest.systems/heading#Overflow-and-truncation) for more details.
+   * How truncation is handled when text overflows the line. See [Truncation example](https://gestalt.pinterest.systems/web/heading#Overflow-and-truncation) for more details.
    */
   overflow?: Overflow,
   /**
-   * The font size of the text. See [Sizes example](https://gestalt.pinterest.systems/heading#Size) for more details.
-   * The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/design_tokens#Font-size).
+   * The font size of the text. See [Sizes example](https://gestalt.pinterest.systems/web/heading#Size) for more details.
+   * The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size).
    */
   size?: Size,
 |};
 
 /**
- * [Heading](https://gestalt.pinterest.systems/heading) allows you to add H1–H6 level text on a page. They are generally placed underneath a PageHeader, and provide you with a way to create a logical text hierarchy.
+ * [Heading](https://gestalt.pinterest.systems/web/heading) allows you to add H1–H6 level text on a page. They are generally placed underneath a PageHeader, and provide you with a way to create a logical text hierarchy.
  *
  * ![Heading light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Heading.spec.mjs-snapshots/Heading-chromium-darwin.png)
  * ![Heading dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Heading-dark.spec.mjs-snapshots/Heading-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -23,25 +23,25 @@ type Props = {|
   /**
    * Label for screen readers to announce Icon.
    *
-   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/icon#Accessibility) for details on proper usage.
+   * See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/icon#Accessibility) for details on proper usage.
    */
   accessibilityLabel: string,
   /**
    * These are all the colors available to apply to the Icon. However, the literal options ("blue" , "darkGray" , "eggplant" , "gray" , "green" , "lightGray" , "maroon" , "midnight" , "navy" , "olive" , "orange" , "orchid" , "pine" , "purple" , "red" , "watermelon" and "white") will be deprecated soon. Avoid using them in any new implementations.
    *
-   * See the [color variant](https://gestalt.pinterest.systems/icon#Colors) to learn more.
+   * See the [color variant](https://gestalt.pinterest.systems/web/icon#Colors) to learn more.
    */
   color?: IconColor,
   /**
    * SVG icon from the Gestalt icon library to use within Icon..
    *
-   * See the [iconography and SVG](https://gestalt.pinterest.systems/iconography_and_svgs) guidelines to explore the Gestalt icon library.
+   * See the [iconography and SVG](https://gestalt.pinterest.systems/foundations/iconography/library) guidelines to explore the Gestalt icon library.
    */
   icon?: $Keys<typeof icons>,
   /**
    * Defines a new icon different from the built-in Gestalt icons.
    *
-   * See the [custom icon](https://gestalt.pinterest.systems/icon#Custom-icon) variant to learn more.
+   * See the [custom icon](https://gestalt.pinterest.systems/web/icon#Custom-icon) variant to learn more.
    */
   dangerouslySetSvgPath?: {| __path: string |},
   /**
@@ -51,7 +51,7 @@ type Props = {|
   /**
    * Use a number for pixel sizes or a string for percentage based sizes.
    *
-   * See the [size](https://gestalt.pinterest.systems/icon#Size) variant to learn more.
+   * See the [size](https://gestalt.pinterest.systems/web/icon#Size) variant to learn more.
    */
   size?: number | string,
 |};
@@ -84,9 +84,9 @@ const flipOnRtlIconNames = [
 ];
 
 /**
- * [Icons](https://gestalt.pinterest.systems/icon) are the symbolic representation of an action or information, providing visual context and improving usability.
+ * [Icons](https://gestalt.pinterest.systems/web/icon) are the symbolic representation of an action or information, providing visual context and improving usability.
  *
- * See the [Iconography and SVG guidelines](https://gestalt.pinterest.systems/iconography_and_svgs) to explore the full icon library.
+ * See the [Iconography and SVG guidelines](https://gestalt.pinterest.systems/foundations/iconography/library) to explore the full icon library.
  *
  * ![Icon light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Icon-list.spec.mjs-snapshots/Icon-list-chromium-darwin.png)
  * ![Icon dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Icon-list-dark.spec.mjs-snapshots/Icon-list-dark-chromium-darwin.png)

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -70,7 +70,7 @@ type unionProps = IconButtonType | LinkIconButtonType;
 type unionRefs = HTMLButtonElement | HTMLAnchorElement;
 
 /**
- * [IconButton](https://gestalt.pinterest.systems/iconbutton) allows users to take actions and make choices with a single click or tap. IconButtons use icons instead of text to convey available actions on a screen. IconButton is typically found in forms, dialogs and toolbars.
+ * [IconButton](https://gestalt.pinterest.systems/web/iconbutton) allows users to take actions and make choices with a single click or tap. IconButtons use icons instead of text to convey available actions on a screen. IconButton is typically found in forms, dialogs and toolbars.
  Some buttons are specialized for particular tasks, such as navigation or presenting menus.
  *
  * ![IconButton light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/IconButton.spec.mjs-snapshots/IconButton-chromium-darwin.png)

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -11,11 +11,11 @@ type Props = {|
    */
   alt: string,
   /**
-   * Children content will be overlaid on the image.  See the [Overlay example](https://gestalt.pinterest.systems/image#Overlay) for more details.
+   * Children content will be overlaid on the image.  See the [Overlay example](https://gestalt.pinterest.systems/web/image#Overlay) for more details.
    */
   children?: Node,
   /**
-   * Used as a visual placeholder while the image is loading.  See the [Placeholders example](https://gestalt.pinterest.systems/image#placeholders) for more details.
+   * Used as a visual placeholder while the image is loading.  See the [Placeholders example](https://gestalt.pinterest.systems/web/image#placeholders) for more details.
    */
   color: string,
   /**
@@ -31,7 +31,7 @@ type Props = {|
    */
   elementTiming?: string,
   /**
-   * Sets how the image is resized to fit its container. See the [Fit example](https://gestalt.pinterest.systems/image#fit) for more details.
+   * Sets how the image is resized to fit its container. See the [Fit example](https://gestalt.pinterest.systems/web/image#fit) for more details.
    * Note: this doesn't work with srcSet or sizes.
    */
   fit?: 'contain' | 'cover' | 'none',
@@ -41,15 +41,15 @@ type Props = {|
    */
   importance?: 'high' | 'low' | 'auto',
   /**
-   * Controls if loading the image should be deferred when it's off-screen. \`"lazy"\` defers the load until the image or iframe reaches a distance threshold from the viewport. \`"eager"\` loads the resource immediately. \`"auto"\` uses the default behavior, which is to eagerly load the resource. See the [Lazy example](https://gestalt.pinterest.systems/image#Lazy) for more details.
+   * Controls if loading the image should be deferred when it's off-screen. \`"lazy"\` defers the load until the image or iframe reaches a distance threshold from the viewport. \`"eager"\` loads the resource immediately. \`"auto"\` uses the default behavior, which is to eagerly load the resource. See the [Lazy example](https://gestalt.pinterest.systems/web/image#Lazy) for more details.
    */
   loading?: 'eager' | 'lazy' | 'auto',
   /**
-   * Exact height of source image. See the [Dimensions example](https://gestalt.pinterest.systems/image#Dimensions) for more details.
+   * Exact height of source image. See the [Dimensions example](https://gestalt.pinterest.systems/web/image#Dimensions) for more details.
    */
   naturalHeight: number,
   /**
-   * Exact width of source image. See the [Dimensions example](https://gestalt.pinterest.systems/image#Dimensions) for more details.
+   * Exact width of source image. See the [Dimensions example](https://gestalt.pinterest.systems/web/image#Dimensions) for more details.
    */
   naturalWidth: number,
   /**
@@ -61,7 +61,7 @@ type Props = {|
    */
   onLoad?: () => void,
   /**
-   * When Image is used purely as a presentational or decorative addition, the \`role\` should be set to "presentation" for better accessibility. See the [Presentational Images with Role example](https://gestalt.pinterest.systems/image#Presentational-Images-with-Role) for more details.
+   * When Image is used purely as a presentational or decorative addition, the \`role\` should be set to "presentation" for better accessibility. See the [Presentational Images with Role example](https://gestalt.pinterest.systems/web/image#Presentational-Images-with-Role) for more details.
    */
   role?: 'img' | 'presentation',
   /**
@@ -79,7 +79,7 @@ type Props = {|
 |};
 
 /**
- * [Image](https://gestalt.pinterest.systems/image) is the workhorse of Pinterest. If you define Pinterest to be all about collecting ideas, then images are how we choose to represent those ideas. In response, we've added a few extra superpowers to the regular img tag to make it even more awesome.
+ * [Image](https://gestalt.pinterest.systems/web/image) is the workhorse of Pinterest. If you define Pinterest to be all about collecting ideas, then images are how we choose to represent those ideas. In response, we've added a few extra superpowers to the regular img tag to make it even more awesome.
  *
  * ![Image light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Image.spec.mjs-snapshots/Image-chromium-darwin.png)
  * ![Image dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Image-dark.spec.mjs-snapshots/Image-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Label.js
+++ b/packages/gestalt/src/Label.js
@@ -14,7 +14,7 @@ type Props = {|
 |};
 
 /**
- * Use the [Label](https://gestalt.pinterest.systems/labels) component to connect a label with a form component in an accessible way.
+ * Use the [Label](https://gestalt.pinterest.systems/web/label) component to connect a label with a form component in an accessible way.
  *
  * ![Label light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Label.spec.mjs-snapshots/Label-chromium-darwin.png)
  * ![Label dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Label-dark.spec.mjs-snapshots/Label-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Label.js
+++ b/packages/gestalt/src/Label.js
@@ -4,7 +4,7 @@ import InternalLabel from './InternalLabel.js';
 
 type Props = {|
   /**
-   * The content of the label, typically [Text](https://gestalt.pinterest.systems/text) or similar.
+   * The content of the label, typically [Text](https://gestalt.pinterest.systems/web/text) or similar.
    */
   children?: Node,
   /**

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -12,13 +12,13 @@ type Props = {|
    */
   children: Node,
   /**
-   * An object representing the z-index value of the Layer. See the [z-index example](https://gestalt.pinterest.systems/layer#zIndex) for more details.
+   * An object representing the z-index value of the Layer. See the [z-index example](https://gestalt.pinterest.systems/web/layer#zIndex) for more details.
    */
   zIndex?: Indexable,
 |};
 
 /**
- * [Layers](https://gestalt.pinterest.systems/layer) allow you to render children outside the DOM hierarchy of the parent. It's a wrapper around React createPortal that lets you use it as a component. This is particularly useful for places you might have needed to use z-index to overlay the screen before.
+ * [Layers](https://gestalt.pinterest.systems/web/layer) allow you to render children outside the DOM hierarchy of the parent. It's a wrapper around React createPortal that lets you use it as a component. This is particularly useful for places you might have needed to use z-index to overlay the screen before.
  */
 export default function Layer({ children, zIndex: zIndexIndexable }: Props): Portal | Node {
   const [mounted, setMounted] = useState(false);

--- a/packages/gestalt/src/Letterbox.js
+++ b/packages/gestalt/src/Letterbox.js
@@ -33,7 +33,7 @@ type Props = {|
 |};
 
 /**
- * [Letterboxes](https://gestalt.pinterest.systems/letterbox) are useful if you have some source media which is larger than the area you want to display it in. For instance, you might have a really tall image and want it to be displayed in a neatly cropped square. While the ideal solution to this problem is to update the source image, this might not always be possible for either cost or performance reasons.
+ * [Letterboxes](https://gestalt.pinterest.systems/web/letterbox) are useful if you have some source media which is larger than the area you want to display it in. For instance, you might have a really tall image and want it to be displayed in a neatly cropped square. While the ideal solution to this problem is to update the source image, this might not always be possible for either cost or performance reasons.
  *
  * Letterbox should be used in situations where you would otherwise use the CSS property \`background-size: cover\`.
  */

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -64,15 +64,15 @@ type Rounding = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 'circle' | 'pill';
 
 type Props = {|
   /**
-   * Supply a short, descriptive label for screen-readers to replace link texts that don't provide sufficient context about the link component behavior. Texts like "Click Here", or "Read More" can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text. It populates `aria-label`. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text. See the [Accessibility guidelines](https://gestalt.pinterest.systems/link#Accessibility) for more information.
+   * Supply a short, descriptive label for screen-readers to replace link texts that don't provide sufficient context about the link component behavior. Texts like "Click Here", or "Read More" can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text. It populates `aria-label`. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/link#Accessibility) for more information.
    */
   accessibilityLabel?: string,
   /**
-   * Link is a wrapper around components (or children), most commonly text, so that they become hyperlinks. See the [Text and Link variant](https://gestalt.pinterest.systems/link#Link-and-Text) to learn more.
+   * Link is a wrapper around components (or children), most commonly text, so that they become hyperlinks. See the [Text and Link variant](https://gestalt.pinterest.systems/web/link#Link-and-Text) to learn more.
    */
   children?: Node,
   /**
-   * When supplied, a "visit" icon is shown at the end of Link. See the [externalLinkIcon and rel variant](https://gestalt.pinterest.systems/link#externalLinkIcon-and-rel) to learn more.
+   * When supplied, a "visit" icon is shown at the end of Link. See the [externalLinkIcon and rel variant](https://gestalt.pinterest.systems/web/link#externalLinkIcon-and-rel) to learn more.
    */
   externalLinkIcon?: ExternalLinkIcon,
   /**
@@ -84,7 +84,7 @@ type Props = {|
    */
   id?: string,
   /**
-   * Properly positions Link relative to an inline element, such as [Text](https://gestalt.pinterest.systems/text), using the inline property. See the [underline variant](https://gestalt.pinterest.systems/link#Underline) to learn more.
+   * Properly positions Link relative to an inline element, such as [Text](https://gestalt.pinterest.systems/web/text), using the inline property. See the [underline variant](https://gestalt.pinterest.systems/web/link#Underline) to learn more.
    */
   inline?: boolean,
   /**
@@ -92,7 +92,7 @@ type Props = {|
    */
   onBlur?: ({| event: SyntheticFocusEvent<HTMLAnchorElement> |}) => void,
   /**
-   * Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
+   * Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
    */
   onClick?: ({|
     event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
@@ -107,7 +107,7 @@ type Props = {|
    */
   ref?: Ref<'a'>,
   /**
-   * Establishes the relationship of the linked URL. Use `rel="nofollow"` for offsite links to inform search engines to ignore and not follow them. See the [externalLinkIcon and rel variant](https://gestalt.pinterest.systems/link#externalLinkIcon-and-rel) to learn more.
+   * Establishes the relationship of the linked URL. Use `rel="nofollow"` for offsite links to inform search engines to ignore and not follow them. See the [externalLinkIcon and rel variant](https://gestalt.pinterest.systems/web/link#externalLinkIcon-and-rel) to learn more.
    */
   rel?: 'none' | 'nofollow',
   /**
@@ -124,17 +124,17 @@ type Props = {|
 - 'blank' opens the anchor in a new window.
 - 'self' opens an anchor in the same frame.
 
-See the [target variant](https://gestalt.pinterest.systems/link#Target) to learn more.
+See the [target variant](https://gestalt.pinterest.systems/web/link#Target) to learn more.
    */
   target?: null | 'self' | 'blank',
   /**
-   * When `underline` is supplied, we override the underline style internally managed by the component. See the [underline variant](https://gestalt.pinterest.systems/link#Underline) to learn more.
+   * When `underline` is supplied, we override the underline style internally managed by the component. See the [underline variant](https://gestalt.pinterest.systems/web/link#Underline) to learn more.
    */
   underline?: 'auto' | 'none' | 'always' | 'hover',
 |};
 
 /**
- * [Link](https://gestalt.pinterest.systems/link) is mainly used as navigational element and usually appear within or directly following a paragraph or sentence.
+ * [Link](https://gestalt.pinterest.systems/web/link) is mainly used as navigational element and usually appear within or directly following a paragraph or sentence.
  *
  * ![Link light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Link.spec.mjs-snapshots/Link-chromium-darwin.png)
  * ![Link dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Link-dark.spec.mjs-snapshots/Link-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Mask.js
+++ b/packages/gestalt/src/Mask.js
@@ -16,11 +16,11 @@ type Props = {|
    */
   height?: number | string,
   /**
-   * Specifies the corner radius to apply. See the [Rounding example](https://gestalt.pinterest.systems/mask#roundingCombinations) for more details.
+   * Specifies the corner radius to apply. See the [Rounding example](https://gestalt.pinterest.systems/web/mask#roundingCombinations) for more details.
    */
   rounding?: Rounding,
   /**
-   * Applies a wash to provide contrast when the masked content is nearly white. See the [Wash example](https://gestalt.pinterest.systems/mask#wash) for more details.
+   * Applies a wash to provide contrast when the masked content is nearly white. See the [Wash example](https://gestalt.pinterest.systems/web/mask#wash) for more details.
    */
   wash?: boolean,
   /**
@@ -28,13 +28,13 @@ type Props = {|
    */
   width?: number | string,
   /**
-   * Mask applies the style `will-change: transform` by default as a performance optimization. In certain specific scenarios, this can be problematic. This prop can be used to turn off that optimization. See the [willChangeTransform example](https://gestalt.pinterest.systems/mask#willChangeTransform) for more details.
+   * Mask applies the style `will-change: transform` by default as a performance optimization. In certain specific scenarios, this can be problematic. This prop can be used to turn off that optimization. See the [willChangeTransform example](https://gestalt.pinterest.systems/web/mask#willChangeTransform) for more details.
    */
   willChangeTransform?: boolean,
 |};
 
 /**
- * [Mask](https://gestalt.pinterest.systems/mask) is used to display content in a specific shape.
+ * [Mask](https://gestalt.pinterest.systems/web/mask) is used to display content in a specific shape.
  */
 export default function Mask({
   children,

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -105,7 +105,7 @@ const VIRTUAL_BUFFER_FACTOR = 0.7;
 const layoutNumberToCssDimension = (n) => (n !== Infinity ? n : undefined);
 
 /**
- * [Masonry](https://gestalt.pinterest.systems/masonry) creates a deterministic grid layout, positioning items based on available vertical space. It contains performance optimizations like virtualization and support for infinite scrolling.
+ * [Masonry](https://gestalt.pinterest.systems/web/masonry) creates a deterministic grid layout, positioning items based on available vertical space. It contains performance optimizations like virtualization and support for infinite scrolling.
  */
 export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<T>> {
   static createMeasurementStore<T1: { ... }, T2>(): MeasurementStore<T1, T2> {

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -19,27 +19,27 @@ type Props = {|
    */
   _dangerouslyDisableScrollBoundaryContainer?: boolean,
   /**
-   * String that clients such as VoiceOver will read to describe the modal. Always localize the label. See [Accessibility section](https://gestalt.pinterest.systems/modal#Accessibility) for more info.
+   * String that clients such as VoiceOver will read to describe the modal. Always localize the label. See [Accessibility section](https://gestalt.pinterest.systems/web/modal#Accessibility) for more info.
    */
   accessibilityModalLabel: string,
   /**
-   * Specify the alignment of `heading` & `subHeading` strings. See the [Heading variant](https://gestalt.pinterest.systems/modal#Heading) for more info.
+   * Specify the alignment of `heading` & `subHeading` strings. See the [Heading variant](https://gestalt.pinterest.systems/web/modal#Heading) for more info.
    */
   align?: 'start' | 'center',
   /**
-   * Supply the element(s) that will be used as Modal's main content. See the [Best Practices](https://gestalt.pinterest.systems/modal#Best-practices) for more info.
+   * Supply the element(s) that will be used as Modal's main content. See the [Best Practices](https://gestalt.pinterest.systems/web/modal#Best-practices) for more info.
    */
   children?: Node,
   /**
-   * Close the modal when you click outside of it. See the [outside click variant](https://gestalt.pinterest.systems/modal#Preventing-close-on-outside-click) for more info.
+   * Close the modal when you click outside of it. See the [outside click variant](https://gestalt.pinterest.systems/web/modal#Preventing-close-on-outside-click) for more info.
    */
   closeOnOutsideClick?: boolean,
   /**
-   * Supply the element(s) that will be used as Modal's custom footer. See the [Best Practices](https://gestalt.pinterest.systems/modal#Best-practices) for more info.
+   * Supply the element(s) that will be used as Modal's custom footer. See the [Best Practices](https://gestalt.pinterest.systems/web/modal#Best-practices) for more info.
    */
   footer?: Node,
   /**
-   * The text used for Modal's heading. See the [Heading variant](https://gestalt.pinterest.systems/modal#Heading) for more info.
+   * The text used for Modal's heading. See the [Heading variant](https://gestalt.pinterest.systems/web/modal#Heading) for more info.
    */
   heading?: Node,
   /**
@@ -47,13 +47,13 @@ type Props = {|
    */
   onDismiss: () => void,
   /**
-   * The underlying ARIA role for the Modal. See the [Accessibility Role section](https://gestalt.pinterest.systems/modal#Role) for more info.
+   * The underlying ARIA role for the Modal. See the [Accessibility Role section](https://gestalt.pinterest.systems/web/modal#Role) for more info.
    *
    * Default: 'dialog'
    */
   role?: 'alertdialog' | 'dialog',
   /**
-   * Determines the width of the Modal. See the [size variant](https://gestalt.pinterest.systems/modal#Sizes) for more info.
+   * Determines the width of the Modal. See the [size variant](https://gestalt.pinterest.systems/web/modal#Sizes) for more info.
    *
    * sm: `540px` | md: `720px` | lg: `900px` | number
    *
@@ -61,7 +61,7 @@ type Props = {|
    */
   size?: 'sm' | 'md' | 'lg' | number,
   /**
-   * Subtext for Modal, only renders with `heading` strings. See the [sub-heading variant](https://gestalt.pinterest.systems/modal#Sub-heading) for more info.
+   * Subtext for Modal, only renders with `heading` strings. See the [sub-heading variant](https://gestalt.pinterest.systems/web/modal#Sub-heading) for more info.
    */
   subHeading?: string,
 |};
@@ -96,7 +96,7 @@ function Header({
 }
 
 /**
- * A [Modal](https://gestalt.pinterest.systems/modal) displays content that requires user interaction. Modals appear on a layer above the page and therefore block the content underneath, preventing users from interacting with anything else besides the Modal. The most common example of Modal is confirming an action the user has taken.
+ * A [Modal](https://gestalt.pinterest.systems/web/modal) displays content that requires user interaction. Modals appear on a layer above the page and therefore block the content underneath, preventing users from interacting with anything else besides the Modal. The most common example of Modal is confirming an action the user has taken.
  */
 export default function Modal({
   _dangerouslyDisableScrollBoundaryContainer = false,

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -33,7 +33,7 @@ export default function Module({
   /**
    * Add a badge displayed after the title. Will not be displayed if `title` is not provided. Not to be used with `icon` or `iconButton`. Be sure to localize the text.
    *
-   * Link: https://gestalt.pinterest.systems/text#static-badge
+   * Link: https://gestalt.pinterest.systems/web/text#static-badge
    */
   badge?: BadgeType,
   /**
@@ -43,7 +43,7 @@ export default function Module({
    */
   children?: Node,
   /**
-   * Name of icon to display in front of title. Will not be displayed if `title` is not provided. Not to be used with `badge` or `iconButton`. For a full list of icons, see [Iconography and SVGs](https://gestalt.pinterest.systems/iconography_and_svgs#Search-icon-library).
+   * Name of icon to display in front of title. Will not be displayed if `title` is not provided. Not to be used with `badge` or `iconButton`. For a full list of icons, see [Iconography and SVGs](https://gestalt.pinterest.systems/foundations/iconography/library#Search-icon-library).
    *
    * Link: https://gestalt.pinterest.systems/module#static-icon
    */

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -25,7 +25,7 @@ type Props = {|
    */
   disabled?: boolean,
   /**
-   * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/link) or [TapArea](https://gestalt.pinterest.systems/taparea).
+   * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/web/link) or [TapArea](https://gestalt.pinterest.systems/web/taparea).
    */
   errorMessage?: Node,
   /**
@@ -103,7 +103,7 @@ type Props = {|
 |};
 
 /**
- * [NumberField](https://gestalt.pinterest.systems/numberfield) allows for numerical input.
+ * [NumberField](https://gestalt.pinterest.systems/web/numberfield) allows for numerical input.
  *
  * ![NumberField light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/NumberField.spec.mjs-snapshots/NumberField-chromium-darwin.png)
  * ![NumberField dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/NumberField-dark.spec.mjs-snapshots/NumberField-dark-chromium-darwin.png)

--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -27,19 +27,19 @@ export type ActionType = Element<
 
 type Props = {|
   /**
-   * Add [Badge](https://gestalt.pinterest.systems/badge) displayed after the title. Be sure to localize the text. See the [title variant](https://gestalt.pinterest.systems/pageheader#Title) to learn more.
+   * Add [Badge](https://gestalt.pinterest.systems/web/badge) displayed after the title. Be sure to localize the text. See the [title variant](https://gestalt.pinterest.systems/web/pageheader#Title) to learn more.
    */
   badge?: {| text: string, tooltipText?: string |},
   /**
-   * Specify a bottom border style for PageHeader: "sm" is 1px. See the [max width & border variant](https://gestalt.pinterest.systems/pageheader#Max-width-and-border) to learn more.
+   * Specify a bottom border style for PageHeader: "sm" is 1px. See the [max width & border variant](https://gestalt.pinterest.systems/web/pageheader#Max-width-and-border) to learn more.
    */
   borderStyle?: 'sm' | 'none',
   /**
-   * Label used for screen readers to provide information about the action [IconButton](https://gestalt.pinterest.systems/iconbutton) displayed under the [sm breakpoint](https://gestalt.pinterest.systems/screen_sizes#Web-(px)). See the [primary action variant](https://gestalt.pinterest.systems/pageheader#Primary-action) or [secondary action variant](https://gestalt.pinterest.systems/pageheader#Secondary-action) to learn more.
+   * Label used for screen readers to provide information about the action [IconButton](https://gestalt.pinterest.systems/web/iconbutton) displayed under the [sm breakpoint](https://gestalt.pinterest.systems/foundations/screen_sizes#Web-(px)). See the [primary action variant](https://gestalt.pinterest.systems/web/pageheader#Primary-action) or [secondary action variant](https://gestalt.pinterest.systems/web/pageheader#Secondary-action) to learn more.
    */
   dropdownAccessibilityLabel?: string,
   /**
-   * Helper [IconButton](https://gestalt.pinterest.systems/iconbutton) to be placed after the title for a supplemental Call To Action (CTA). See the [title variant](https://gestalt.pinterest.systems/pageheader#Title) to learn more.
+   * Helper [IconButton](https://gestalt.pinterest.systems/web/iconbutton) to be placed after the title for a supplemental Call To Action (CTA). See the [title variant](https://gestalt.pinterest.systems/web/pageheader#Title) to learn more.
    */
   helperIconButton?: {|
     accessibilityLabel: string,
@@ -55,7 +55,7 @@ type Props = {|
     |}) => void,
   |},
   /**
-   * Helper [Link](https://gestalt.pinterest.systems/link) to be placed after the subtext. See the [subtext variant](https://gestalt.pinterest.systems/pageheader#Subtext) to learn more.
+   * Helper [Link](https://gestalt.pinterest.systems/web/link) to be placed after the subtext. See the [subtext variant](https://gestalt.pinterest.systems/web/pageheader#Subtext) to learn more.
    */
   helperLink?: {|
     text: string,
@@ -67,47 +67,47 @@ type Props = {|
     |}) => void,
   |},
   /**
-   * Optional row of components. We mostly recommend using [Datapoint](https://gestalt.pinterest.systems/datapoint). See the [complementary items variant](https://gestalt.pinterest.systems/pageheader#Complementary-items) to learn more.
+   * Optional row of components. We mostly recommend using [Datapoint](https://gestalt.pinterest.systems/web/datapoint). See the [complementary items variant](https://gestalt.pinterest.systems/web/pageheader#Complementary-items) to learn more.
    */
   items?: $ReadOnlyArray<Node>,
   /**
-   * Use numbers for pixels: \`maxWidth={100}\` and strings for percentages: \`maxWidth="100%"\`. See the [max width & border variant](https://gestalt.pinterest.systems/pageheader##Max-width-and-border) for more info.
+   * Use numbers for pixels: \`maxWidth={100}\` and strings for percentages: \`maxWidth="100%"\`. See the [max width & border variant](https://gestalt.pinterest.systems/web/pageheader##Max-width-and-border) for more info.
    */
   maxWidth?: Dimension,
   /**
-   * The primary action of the page. Can be [Button](https://gestalt.pinterest.systems/button), [Link](https://gestalt.pinterest.systems/link), [Tooltip](https://gestalt.pinterest.systems/tooltip) surrounding IconButton or a combination of [IconButton](https://gestalt.pinterest.systems/iconbutton), Tooltip and [Dropdown](https://gestalt.pinterest.systems/dropdown).
+   * The primary action of the page. Can be [Button](https://gestalt.pinterest.systems/web/button), [Link](https://gestalt.pinterest.systems/web/link), [Tooltip](https://gestalt.pinterest.systems/web/tooltip) surrounding IconButton or a combination of [IconButton](https://gestalt.pinterest.systems/web/iconbutton), Tooltip and [Dropdown](https://gestalt.pinterest.systems/web/dropdown).
    *
-   * Primary and secondary actions are consolidated into [Dropdown](https://gestalt.pinterest.systems/dropdown) below the [sm breakpoint](https://gestalt.pinterest.systems/screen_sizes#Web-(px)). `primaryAction` takes both the main component and its equivalent using Dropdown subcomponents. See the [primary action variant](https://gestalt.pinterest.systems/pageheader#Primary-action) to learn more.
+   * Primary and secondary actions are consolidated into [Dropdown](https://gestalt.pinterest.systems/web/dropdown) below the [sm breakpoint](https://gestalt.pinterest.systems/foundations/screen_sizes#Web-(px)). `primaryAction` takes both the main component and its equivalent using Dropdown subcomponents. See the [primary action variant](https://gestalt.pinterest.systems/web/pageheader#Primary-action) to learn more.
    */
   primaryAction?: {|
     component: ActionType,
     dropdownItems: $ReadOnlyArray<Element<typeof Dropdown.Item> | Element<typeof Dropdown.Link>>,
   |},
   /**
-   * A secondary action for the page. Can be [Button](https://gestalt.pinterest.systems/button), [Link](https://gestalt.pinterest.systems/link), [Tooltip](https://gestalt.pinterest.systems/tooltip) surrounding IconButton or a combination of IconButton, Tooltip and [Dropdown](https://gestalt.pinterest.systems/dropdown).
+   * A secondary action for the page. Can be [Button](https://gestalt.pinterest.systems/web/button), [Link](https://gestalt.pinterest.systems/web/link), [Tooltip](https://gestalt.pinterest.systems/web/tooltip) surrounding IconButton or a combination of IconButton, Tooltip and [Dropdown](https://gestalt.pinterest.systems/web/dropdown).
    *
-   * Primary and secondary actions are are consolidated into [Dropdown](https://gestalt.pinterest.systems/dropdown) below the [sm breakpoint](https://gestalt.pinterest.systems/screen_sizes#Web-(px)). `secondaryAction` takes both the main component and its equivalent using Dropdown subcomponents. See the [secondary action variant](https://gestalt.pinterest.systems/pageheader#Secondary-action) to learn more.
+   * Primary and secondary actions are are consolidated into [Dropdown](https://gestalt.pinterest.systems/web/dropdown) below the [sm breakpoint](https://gestalt.pinterest.systems/foundations/screen_sizes#Web-(px)). `secondaryAction` takes both the main component and its equivalent using Dropdown subcomponents. See the [secondary action variant](https://gestalt.pinterest.systems/web/pageheader#Secondary-action) to learn more.
    */
   secondaryAction?: {|
     component: ActionType,
     dropdownItems: $ReadOnlyArray<Element<typeof Dropdown.Item> | Element<typeof Dropdown.Link>>,
   |},
   /**
-   * Used primarily for metadata related to the current page, not designed to describe the title or the current surface. Content should be [localized](https://gestalt.pinterest.systems/pageheader#Localization). See the [subtext variant](https://gestalt.pinterest.systems/pageheader#Subtext) to learn more.
+   * Used primarily for metadata related to the current page, not designed to describe the title or the current surface. Content should be [localized](https://gestalt.pinterest.systems/web/pageheader#Localization). See the [subtext variant](https://gestalt.pinterest.systems/web/pageheader#Subtext) to learn more.
    */
   subtext?: string,
   /**
-   * Page title. Will always be a level 1 heading. Content should be [localized](https://gestalt.pinterest.systems/pageheader#Localization). See the [title variant](https://gestalt.pinterest.systems/pageheader#Title) to learn more.
+   * Page title. Will always be a level 1 heading. Content should be [localized](https://gestalt.pinterest.systems/web/pageheader#Localization). See the [title variant](https://gestalt.pinterest.systems/web/pageheader#Title) to learn more.
    */
   title: string,
   /**
-   * An optional thumbnail [Image](https://gestalt.pinterest.systems/image) to be displayed next to the title. See the [title variant](https://gestalt.pinterest.systems/pageheader#Title) to learn more.
+   * An optional thumbnail [Image](https://gestalt.pinterest.systems/web/image) to be displayed next to the title. See the [title variant](https://gestalt.pinterest.systems/web/pageheader#Title) to learn more.
    */
   thumbnail?: Element<typeof Image>,
 |};
 
 /**
- * [PageHeader](https://gestalt.pinterest.systems/pageheader) is used to indicate the title of the current screen and can also provide additional content and actions that relate to the current screen as a whole.
+ * [PageHeader](https://gestalt.pinterest.systems/web/pageheader) is used to indicate the title of the current screen and can also provide additional content and actions that relate to the current screen as a whole.
  *
  * ![PageHeader light mode secondary action](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/PageHeader-items-secondaryAction.spec.mjs-snapshots/PageHeader-items-secondaryAction-md-chromium-darwin.png)
  * ![PageHeader light mode badge](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/PageHeader-thumbnail-badge-iconButton.spec.mjs-snapshots/PageHeader-thumbnail-badge-iconButton-sm-chromium-darwin.png)

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -45,11 +45,11 @@ type Props = {|
    */
   accessibilityLabel?: string,
   /**
-   * Indicate if Pog is in an active state. See [state combinations](https://gestalt.pinterest.systems/pog#stateCombinations) for more details.
+   * Indicate if Pog is in an active state. See [state combinations](https://gestalt.pinterest.systems/web/pog#stateCombinations) for more details.
    */
   active?: boolean,
   /**
-   * The background color. See [color combinations](https://gestalt.pinterest.systems/pog#backgroundColorCombinations) for more details.
+   * The background color. See [color combinations](https://gestalt.pinterest.systems/web/pog#backgroundColorCombinations) for more details.
    */
   bgColor?:
     | 'transparent'
@@ -64,11 +64,11 @@ type Props = {|
    */
   dangerouslySetSvgPath?: {| __path: string |},
   /**
-   * Indicate if Pog is in a focused state. See [state combinations](https://gestalt.pinterest.systems/pog#stateCombinations) for more details.
+   * Indicate if Pog is in a focused state. See [state combinations](https://gestalt.pinterest.systems/web/pog#stateCombinations) for more details.
    */
   focused?: boolean,
   /**
-   * Indicate if Pog is in a hovered state. See [state combinations](https://gestalt.pinterest.systems/pog#stateCombinations) for more details.
+   * Indicate if Pog is in a hovered state. See [state combinations](https://gestalt.pinterest.systems/web/pog#stateCombinations) for more details.
    */
   hovered?: boolean,
   /**
@@ -76,25 +76,25 @@ type Props = {|
    */
   icon?: $Keys<typeof icons>,
   /**
-   * Color applied to the [Icon](https://gestalt.pinterest.systems/pog/icon). See [color combinations](https://gestalt.pinterest.systems/pog#iconColorCombinations) for more details.
+   * Color applied to the [Icon](https://gestalt.pinterest.systems/web/pog/icon). See [color combinations](https://gestalt.pinterest.systems/web/pog#iconColorCombinations) for more details.
    */
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
   /**
-   * Padding in boints. If omitted, padding is derived from the \`size\` prop. See [padding combinations](https://gestalt.pinterest.systems/pog#paddingCombinations) for more details.
+   * Padding in boints. If omitted, padding is derived from the \`size\` prop. See [padding combinations](https://gestalt.pinterest.systems/web/pog#paddingCombinations) for more details.
    */
   padding?: 1 | 2 | 3 | 4 | 5,
   /**
-   * Indicate if Pog is in a selected state. See [state combinations](https://gestalt.pinterest.systems/pog#stateCombinations) for more details.
+   * Indicate if Pog is in a selected state. See [state combinations](https://gestalt.pinterest.systems/web/pog#stateCombinations) for more details.
    */
   selected?: boolean,
   /**
-   * This controls the icon size and the default padding size. Available sizes are "xs" (12px), "sm" (16px), "md" (18px), "lg" (20px), and "xl" (24px). If padding is omitted, button sizes are "xs" (24px), "sm" (32px), "md" (40px), "lg" (48px), and "xl" (56px). See [size combinations](https://gestalt.pinterest.systems/pog#sizeCombinations) for more details.
+   * This controls the icon size and the default padding size. Available sizes are "xs" (12px), "sm" (16px), "md" (18px), "lg" (20px), and "xl" (24px). If padding is omitted, button sizes are "xs" (24px), "sm" (32px), "md" (40px), "lg" (48px), and "xl" (56px). See [size combinations](https://gestalt.pinterest.systems/web/pog#sizeCombinations) for more details.
    */
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
 |};
 
 /**
- * [Pog](https://gestalt.pinterest.systems/pog) is a lower-level functional component to show the active, hovered, & focused states of [IconButton](https://gestalt.pinterest.systems/pog/iconbutton).
+ * [Pog](https://gestalt.pinterest.systems/web/pog) is a lower-level functional component to show the active, hovered, & focused states of [IconButton](https://gestalt.pinterest.systems/web/pog/iconbutton).
  *
  * This is an abstraction to allow for links that look like IconButton.
  *

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -9,7 +9,7 @@ type Role = 'dialog' | 'listbox' | 'menu';
 
 type Props = {|
   /**
-   * The reference element, typically [Button](https://gestalt.pinterest.systems/button) or [IconButton](https://gestalt.pinterest.systems/iconbutton), that Popover uses to set its position.
+   * The reference element, typically [Button](https://gestalt.pinterest.systems/web/button) or [IconButton](https://gestalt.pinterest.systems/web/iconbutton), that Popover uses to set its position.
    */
   anchor: ?HTMLElement,
   /**
@@ -17,7 +17,7 @@ type Props = {|
    */
   children?: Node,
   /**
-   * The background color of Popover. See the [color and caret](https://gestalt.pinterest.systems/popover#Color-and-caret) variant to learn more.
+   * The background color of Popover. See the [color and caret](https://gestalt.pinterest.systems/web/popover#Color-and-caret) variant to learn more.
    */
   color?: Color,
   /**
@@ -25,11 +25,11 @@ type Props = {|
    */
   onKeyDown?: ({| event: SyntheticKeyboardEvent<HTMLElement> |}) => void,
   /**
-   * Unique id to identify each Popover. Used for [accessibility](https://gestalt.pinterest.systems/popover#ARIA-attributes) purposes.
+   * Unique id to identify each Popover. Used for [accessibility](https://gestalt.pinterest.systems/web/popover#ARIA-attributes) purposes.
    */
   id?: string,
   /**
-   * Specifies the preferred position of Popover relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/popover#Ideal-direction) variant to learn more.
+   * Specifies the preferred position of Popover relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/web/popover#Ideal-direction) variant to learn more.
    */
   idealDirection?: IdealDirection,
   /**
@@ -37,29 +37,29 @@ type Props = {|
    */
   onDismiss: () => void,
   /**
-   * Properly positions Popover relative to its anchor element. Set to false when used within [Layer](https://gestalt.pinterest.systems/layer). See the [with Layer](https://gestalt.pinterest.systems/popover#With-layer) variant to learn more.
+   * Properly positions Popover relative to its anchor element. Set to false when used within [Layer](https://gestalt.pinterest.systems/web/layer). See the [with Layer](https://gestalt.pinterest.systems/web/popover#With-layer) variant to learn more.
    */
   positionRelativeToAnchor?: boolean,
   /**
-   * The underlying ARIA role for Popover. See the [accessibility](https://gestalt.pinterest.systems/popover#ARIA-attributes) section for more info.
+   * The underlying ARIA role for Popover. See the [accessibility](https://gestalt.pinterest.systems/web/popover#ARIA-attributes) section for more info.
    */
   role?: Role,
   /**
-   * Puts the focus on Popover when it’s triggered. See [accessibility](https://gestalt.pinterest.systems/popover#Accessibility) to learn more.
+   * Puts the focus on Popover when it’s triggered. See [accessibility](https://gestalt.pinterest.systems/web/popover#Accessibility) to learn more.
    */
   shouldFocus?: boolean,
   /**
-   * Shows a caret on Popover. See the [color and caret](https://gestalt.pinterest.systems/popover#Color-and-caret) variant to learn more.
+   * Shows a caret on Popover. See the [color and caret](https://gestalt.pinterest.systems/web/popover#Color-and-caret) variant to learn more.
    */
   showCaret?: boolean,
   /**
-   * The maximum width of Popover. See the [size](https://gestalt.pinterest.systems/popover#Size) variant to learn more.
+   * The maximum width of Popover. See the [size](https://gestalt.pinterest.systems/web/popover#Size) variant to learn more.
    */
   size?: Size,
 |};
 
 /**
- * [Popover](https://gestalt.pinterest.systems/popover) is a floating view that contains a task related to the content on screen. It can be triggered when the user clicks or focuses on an element, typically [Button](/button) or [IconButton](/iconbutton). It can also be triggered automatically, as in the case of user education. Popover is non-modal and can be dismissed by interacting with another part of the screen or an item within Popover.
+ * [Popover](https://gestalt.pinterest.systems/web/popover) is a floating view that contains a task related to the content on screen. It can be triggered when the user clicks or focuses on an element, typically [Button](/button) or [IconButton](/iconbutton). It can also be triggered automatically, as in the case of user education. Popover is non-modal and can be dismissed by interacting with another part of the screen or an item within Popover.
  *
  * Popover is most appropriate for desktop screens and can contain a variety of elements, such as [Button](/button) and [Images](/image). Popover is also the container used to construct more complex elements like [Dropdown](/dropdown) and the board picker, pictured below, which allow people to choose the board to save a Pin to.
  */

--- a/packages/gestalt/src/Pulsar.js
+++ b/packages/gestalt/src/Pulsar.js
@@ -15,7 +15,7 @@ type Props = {|
 |};
 
 /**
- * [Pulsars](https://gestalt.pinterest.systems/pulsar ) bring focus to a specific element on the screen and act like training wheels to guide people towards the normal way to perform that action. They are used in isolation or combination with other education components for more instructions.
+ * [Pulsars](https://gestalt.pinterest.systems/web/pulsar ) bring focus to a specific element on the screen and act like training wheels to guide people towards the normal way to perform that action. They are used in isolation or combination with other education components for more instructions.
  */
 export default function Pulsar({ paused, size = 136 }: Props): Node {
   return (

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -12,11 +12,11 @@ import focusStyles from './Focus.css';
 
 type Props = {|
   /**
-   * Indicates if the input is checked. See the [combinations example](https://gestalt.pinterest.systems/radiobutton#radio-state-combos) for more details.
+   * Indicates if the input is checked. See the [combinations example](https://gestalt.pinterest.systems/web/radiobutton#radio-state-combos) for more details.
    */
   checked?: boolean,
   /**
-   * Indicates if the input is disabled. See the [combinations example](https://gestalt.pinterest.systems/radiobutton#radio-state-combos) for more details.
+   * Indicates if the input is disabled. See the [combinations example](https://gestalt.pinterest.systems/web/radiobutton#radio-state-combos) for more details.
    */
   disabled?: boolean,
   /**
@@ -24,7 +24,7 @@ type Props = {|
    */
   id: string,
   /**
-   * An optional [Image](https://gestalt.pinterest.systems/image) component can be supplied to add an image to each radio button. Spacing is already accounted for — simply specify the width and height. See the [images example](https://gestalt.pinterest.systems/radiobutton#images) for more details.
+   * An optional [Image](https://gestalt.pinterest.systems/web/image) component can be supplied to add an image to each radio button. Spacing is already accounted for — simply specify the width and height. See the [images example](https://gestalt.pinterest.systems/web/radiobutton#images) for more details.
    */
   image?: Node,
   /**
@@ -40,7 +40,7 @@ type Props = {|
    */
   onChange: AbstractEventHandler<SyntheticInputEvent<HTMLInputElement>, {| checked: boolean |}>,
   /**
-   * Ref forwarded to the underlying input element. See [ref example](https://gestalt.pinterest.systems/radiobutton#ref) for more details.
+   * Ref forwarded to the underlying input element. See [ref example](https://gestalt.pinterest.systems/web/radiobutton#ref) for more details.
    */
   ref?: HTMLInputElement, // eslint-disable-line react/no-unused-prop-types
   /**
@@ -48,7 +48,7 @@ type Props = {|
    */
   size?: 'sm' | 'md',
   /**
-   * Optional description for the input, used to provide more detail about an option. See the [subtext example](https://gestalt.pinterest.systems/radiobutton#subtext) for more details.
+   * Optional description for the input, used to provide more detail about an option. See the [subtext example](https://gestalt.pinterest.systems/web/radiobutton#subtext) for more details.
    */
   subtext?: string,
   /**
@@ -58,8 +58,8 @@ type Props = {|
 |};
 
 /**
- *  Use [RadioButtons](https://gestalt.pinterest.systems/radiobutton) when you have a few options that a user can choose from. Never use radio buttons if the user can select more than one option from a list.
- * **NOTE** The standalone RadioButton is soon to be deprecated, use [RadioGroup](https://gestalt.pinterest.systems/radiogroup) and RadioGroup.RadioButton instead.**NOTE**
+ *  Use [RadioButtons](https://gestalt.pinterest.systems/web/radiobutton) when you have a few options that a user can choose from. Never use radio buttons if the user can select more than one option from a list.
+ * **NOTE** The standalone RadioButton is soon to be deprecated, use [RadioGroup](https://gestalt.pinterest.systems/web/radiogroup) and RadioGroup.RadioButton instead.**NOTE**
  * ![RadioButton light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/RadioButton.spec.mjs-snapshots/RadioButton-chromium-darwin.png)
  * ![RadioButton dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/RadioButton-dark.spec.mjs-snapshots/RadioButton-dark-chromium-darwin.png)
  *

--- a/packages/gestalt/src/RadioGroup.js
+++ b/packages/gestalt/src/RadioGroup.js
@@ -22,24 +22,24 @@ type Props = {|
    */
   legend: string,
   /**
-   * Determines the layout of the group. See the [direction](https://gestalt.pinterest.systems/radiogroup#Direction) variant to learn more.
+   * Determines the layout of the group. See the [direction](https://gestalt.pinterest.systems/web/radiogroup#Direction) variant to learn more.
    *
    */
   direction?: 'column' | 'row',
   /**
-   * Adds an error message below the group of radio buttons. See the [error](https://gestalt.pinterest.systems/radiogroup#With-an-error) variant to learn more.
+   * Adds an error message below the group of radio buttons. See the [error](https://gestalt.pinterest.systems/web/radiogroup#With-an-error) variant to learn more.
    *
    */
   errorMessage?: string,
   /**
-   * Whether the legend should be visible or not. If hidden, the legend is still available for screen reader users, but does not appear visually. See the [legend visibility](https://gestalt.pinterest.systems/radiogroup#Legend-visibility) variant to learn more.
+   * Whether the legend should be visible or not. If hidden, the legend is still available for screen reader users, but does not appear visually. See the [legend visibility](https://gestalt.pinterest.systems/web/radiogroup#Legend-visibility) variant to learn more.
    *
    */
   legendDisplay?: 'visible' | 'hidden',
 |};
 
 /**
- *  [RadioGroups](https://gestalt.pinterest.systems/radiogroup) are used for selecting only 1 item from a list of 2 or more items. If you need multiple selection or have only one option, use [Checkbox](https://gestalt.pinterest.systems/checkbox). If you need to provide a binary on/off choice that takes effect immediately, use [Switch](https://gestalt.pinterest.systems/switch).
+ *  [RadioGroups](https://gestalt.pinterest.systems/web/radiogroup) are used for selecting only 1 item from a list of 2 or more items. If you need multiple selection or have only one option, use [Checkbox](https://gestalt.pinterest.systems/web/checkbox). If you need to provide a binary on/off choice that takes effect immediately, use [Switch](https://gestalt.pinterest.systems/web/switch).
  *
  */
 export default function RadioGroup({

--- a/packages/gestalt/src/RadioGroupButton.js
+++ b/packages/gestalt/src/RadioGroupButton.js
@@ -12,11 +12,11 @@ import { useRadioGroupContext } from './RadioGroupContext.js';
 
 type Props = {|
   /**
-   * Indicates if the input is checked. See the [state example](https://gestalt.pinterest.systems/radiogroup#States) for more details.
+   * Indicates if the input is checked. See the [state example](https://gestalt.pinterest.systems/web/radiogroup#States) for more details.
    */
   checked?: boolean,
   /**
-   * Indicates if the input is disabled. See the [state example](https://gestalt.pinterest.systems/radiogroup#States) for more details.
+   * Indicates if the input is disabled. See the [state example](https://gestalt.pinterest.systems/web/radiogroup#States) for more details.
    */
   disabled?: boolean,
   /**
@@ -24,7 +24,7 @@ type Props = {|
    */
   id: string,
   /**
-   * An optional [Image](https://gestalt.pinterest.systems/image) component can be supplied to add an image to each radio button. Spacing is already accounted for — simply specify the width and height. See the [images example](https://gestalt.pinterest.systems/radiogroup#With-Image) for more details.
+   * An optional [Image](https://gestalt.pinterest.systems/web/image) component can be supplied to add an image to each radio button. Spacing is already accounted for — simply specify the width and height. See the [images example](https://gestalt.pinterest.systems/web/radiogroup#With-Image) for more details.
    */
   image?: Node,
   /**
@@ -40,7 +40,7 @@ type Props = {|
    */
   onChange: ({| event: SyntheticInputEvent<HTMLInputElement>, checked: boolean |}) => void,
   /**
-   * Ref forwarded to the underlying input element. See [ref example](https://gestalt.pinterest.systems/radiogroup#Using-ref) for more details.
+   * Ref forwarded to the underlying input element. See [ref example](https://gestalt.pinterest.systems/web/radiogroup#Using-ref) for more details.
    */
   ref?: HTMLInputElement, // eslint-disable-line react/no-unused-prop-types
   /**
@@ -48,7 +48,7 @@ type Props = {|
    */
   size?: 'sm' | 'md',
   /**
-   * Optional description for the input, used to provide more detail about an option. See the [subtext example](https://gestalt.pinterest.systems/radiogroup#With-subtext) for more details.
+   * Optional description for the input, used to provide more detail about an option. See the [subtext example](https://gestalt.pinterest.systems/web/radiogroup#With-subtext) for more details.
    */
   subtext?: string,
   /**
@@ -58,7 +58,7 @@ type Props = {|
 |};
 
 /**
- *  Use [RadioGroup.RadioButtons](https://gestalt.pinterest.systems/radiogroup#RadioGroup.RadioButton) to present an option for selection to the user within a RadioGroup. They should not be used outside of RadioGroup or when the user can select more than one option from a list.
+ *  Use [RadioGroup.RadioButtons](https://gestalt.pinterest.systems/web/radiogroup#RadioGroup.RadioButton) to present an option for selection to the user within a RadioGroup. They should not be used outside of RadioGroup or when the user can select more than one option from a list.
  *
  * ![RadioGroup light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/RadioGroup.spec.mjs-snapshots/RadioGroup-chromium-darwin.png)
  * ![RadioGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/RadioGroup-dark.spec.mjs-snapshots/RadioGroup-dark-chromium-darwin.png)
@@ -121,7 +121,7 @@ const RadioGroupButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputEl
   const { parentName } = useRadioGroupContext();
   if (parentName !== 'RadioGroup') {
     throw new Error(
-      `RadioGroup.RadioButton must be used within a [RadioGroup](https://gestalt.pinterest.systems/radiogroup).`,
+      `RadioGroup.RadioButton must be used within a [RadioGroup](https://gestalt.pinterest.systems/web/radiogroup).`,
     );
   }
 

--- a/packages/gestalt/src/ScrollBoundaryContainer.js
+++ b/packages/gestalt/src/ScrollBoundaryContainer.js
@@ -25,14 +25,14 @@ type Props = {|
    *
    * Overflow property only works for elements with a specified height, however, it is not required if the parent component sets the height.
    *
-   * Link: https://gestalt.pinterest.systems/text#align
+   * Link: https://gestalt.pinterest.systems/web/text#align
    */
   height?: number | string,
   overflow?: ScrollBoundaryContainerOverflow,
 |};
 
 /**
- * [ScrollBoundaryContainer](https://gestalt.pinterest.systems/scrollboundarycontainer) is used with anchor-based components such as Popover, Tooltip, Dropdown or ComboBox. ScrollBoundaryContainer is needed for proper positioning when the anchor-based component is anchored to an element that is located within a scrolling container. The use of ScrollBoundaryContainer ensures the anchor-based component remains attached to its anchor when scrolling. Don't use ScrollBoundaryContainer to add scrolling to a container, use [Box's props](https://gestalt.pinterest.systems/box#Props) instead.
+ * [ScrollBoundaryContainer](https://gestalt.pinterest.systems/web/utilities/scrollboundarycontainer) is used with anchor-based components such as Popover, Tooltip, Dropdown or ComboBox. ScrollBoundaryContainer is needed for proper positioning when the anchor-based component is anchored to an element that is located within a scrolling container. The use of ScrollBoundaryContainer ensures the anchor-based component remains attached to its anchor when scrolling. Don't use ScrollBoundaryContainer to add scrolling to a container, use [Box's props](https://gestalt.pinterest.systems/web/box#Props) instead.
  */
 export default function ScrollBoundaryContainerWithProvider({
   children,

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -14,11 +14,11 @@ type UnionRefs = HTMLDivElement | HTMLAnchorElement;
 
 type Props = {|
   /**
-   * String that clients such as VoiceOver will read to describe the element. Always localize the label. See the [Accessibility section](https://gestalt.pinterest.systems/searchfield#Accessibility) for more info.
+   * String that clients such as VoiceOver will read to describe the element. Always localize the label. See the [Accessibility section](https://gestalt.pinterest.systems/web/searchfield#Accessibility) for more info.
    */
   accessibilityLabel: string,
   /**
-   * String that clients such as VoiceOver will read to describe the clear button element. Always localize the label. See the [Accessibility section](https://gestalt.pinterest.systems/searchfield#Accessibility) for more info.
+   * String that clients such as VoiceOver will read to describe the clear button element. Always localize the label. See the [Accessibility section](https://gestalt.pinterest.systems/web/searchfield#Accessibility) for more info.
    */
   accessibilityClearButtonLabel?: string,
   /**
@@ -34,7 +34,7 @@ type Props = {|
    */
   id: string,
   /**
-   * Text used to label the input. Be sure to localize the text. See the [Visible label variant](https://gestalt.pinterest.systems/searchfield#Visible-label) for more info.
+   * Text used to label the input. Be sure to localize the text. See the [Visible label variant](https://gestalt.pinterest.systems/web/searchfield#Visible-label) for more info.
    */
   label?: string,
   /**
@@ -81,7 +81,7 @@ type Props = {|
 |};
 
 /**
- * [SearchField](https://gestalt.pinterest.systems/searchfield) allows users to search for free-form content.
+ * [SearchField](https://gestalt.pinterest.systems/web/searchfield) allows users to search for free-form content.
  *
  * ![SearchField light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/SearchField.spec.mjs-snapshots/SearchField-chromium-darwin.png)
  * ![SearchField dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/SearchField-dark.spec.mjs-snapshots/SearchField-dark-chromium-darwin.png)

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -20,7 +20,7 @@ type Props = {|
    */
   onChange: OnChange,
   /**
-   * By default, items have equal widths. If this prop is true, the width of an item is based on its content. See the [responsive example](https://gestalt.pinterest.systems/segmentedcontrol#Example:-Responsive) for more details.
+   * By default, items have equal widths. If this prop is true, the width of an item is based on its content. See the [responsive example](https://gestalt.pinterest.systems/web/segmentedcontrol#Example:-Responsive) for more details.
    */
   responsive?: boolean,
   /**
@@ -72,7 +72,7 @@ function SegmentedControlItem({
 }
 
 /**
- * [SegmentedControl](https://gestalt.pinterest.systems/segmentedcontrol)  may be used to group multiple selections. The controls display the current state and related state.
+ * [SegmentedControl](https://gestalt.pinterest.systems/web/segmentedcontrol)  may be used to group multiple selections. The controls display the current state and related state.
  *
  * Create layout to convey clear sense of information hierarchy. When a control is engaged, information below the control should also be updated.
  */

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -17,11 +17,11 @@ type Props = {|
    */
   disabled?: boolean,
   /**
-   * Used to communicate error information to the user. Be sure to localize the text. See the [error message](https://gestalt.pinterest.systems/selectlist#Error-message) variant to learn more.
+   * Used to communicate error information to the user. Be sure to localize the text. See the [error message](https://gestalt.pinterest.systems/web/selectlist#Error-message) variant to learn more.
    */
   errorMessage?: string,
   /**
-   * Used to provide more information about the form field. Be sure to localize the text. See the [helper text](https://gestalt.pinterest.systems/selectlist#Helper-text) variant to learn more.
+   * Used to provide more information about the form field. Be sure to localize the text. See the [helper text](https://gestalt.pinterest.systems/web/selectlist#Helper-text) variant to learn more.
    */
   helperText?: string,
   /**
@@ -41,7 +41,7 @@ type Props = {|
    */
   name?: string,
   /**
-   * Callback triggered when the user selects a new option.  See the [controlled component](https://gestalt.pinterest.systems/selectlist#Controlled-component) variant to learn more.
+   * Callback triggered when the user selects a new option.  See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
   onChange: AbstractEventHandler<SyntheticInputEvent<HTMLSelectElement>, {| value: string |}>,
   /**
@@ -49,21 +49,21 @@ type Props = {|
    */
   options: $ReadOnlyArray<{| label: string, value: string, disabled?: boolean |}>,
   /**
-   * If not provided, the first item in the list will be shown. Be sure to localize the text. See the [controlled component](https://gestalt.pinterest.systems/selectlist#Controlled-component) variant to learn more.
+   * If not provided, the first item in the list will be shown. Be sure to localize the text. See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
   placeholder?: string,
   /**
-   * md: 40px, lg: 48px. See the [size](https://gestalt.pinterest.systems/selectlist#Size) variant to learn more.
+   * md: 40px, lg: 48px. See the [size](https://gestalt.pinterest.systems/web/selectlist#Size) variant to learn more.
    */
   size?: 'md' | 'lg',
   /**
-   * The currently-selected value. See the [controlled component](https://gestalt.pinterest.systems/selectlist#Controlled-component) variant to learn more.
+   * The currently-selected value. See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
   value?: ?string,
 |};
 
 /**
- * [SelectList](https://gestalt.pinterest.systems/selectlist) displays a list of actions or options using the browser’s native select.
+ * [SelectList](https://gestalt.pinterest.systems/web/selectlist) displays a list of actions or options using the browser’s native select.
  *
  * ![SelectList light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/SelectList.spec.mjs-snapshots/SelectList-chromium-darwin.png)
  * ![SelectList dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/SelectList-dark.spec.mjs-snapshots/SelectList-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -272,7 +272,7 @@ function Sheet(props: SheetProps): Node {
  */
 
 /**
- * [Sheets](https://gestalt.pinterest.systems/sheet ) are surfaces that allow users to view optional information or complete sub-tasks in a workflow while keeping the context of the current page. The most common example of Sheet displays content in a panel that opens from the side of the screen for the user to read or input information. Sheets have default, internal padding for content.
+ * [Sheets](https://gestalt.pinterest.systems/web/sheet ) are surfaces that allow users to view optional information or complete sub-tasks in a workflow while keeping the context of the current page. The most common example of Sheet displays content in a panel that opens from the side of the screen for the user to read or input information. Sheets have default, internal padding for content.
  */
 function AnimatedSheet(props: AnimatedSheetProps): Node {
   const {

--- a/packages/gestalt/src/SideNavigation.js
+++ b/packages/gestalt/src/SideNavigation.js
@@ -31,15 +31,15 @@ export type Props = {|
    */
   accessibilityLabel: string,
   /**
-   * The content shown in SideNavigation. See [subcomponents](https://gestalt.pinterest.systems/sidenavigation#Subcomponents).
+   * The content shown in SideNavigation. See [subcomponents](https://gestalt.pinterest.systems/web/sidenavigation#Subcomponents).
    */
   children: Node,
   /**
-   * Content to display at the bottom of SideNavigation. Open slot available to display other functionality required in the page. See the [Footer variant](https://gestalt.pinterest.systems/sidenavigation#Header) to learn more.
+   * Content to display at the bottom of SideNavigation. Open slot available to display other functionality required in the page. See the [Footer variant](https://gestalt.pinterest.systems/web/sidenavigation#Header) to learn more.
    */
   footer?: Node,
   /**
-   * Content to display at the top of SideNavigation. Open slot used for controlling the display of navigation items. See the [Header variant](https://gestalt.pinterest.systems/sidenavigation#Header) to learn more.
+   * Content to display at the top of SideNavigation. Open slot used for controlling the display of navigation items. See the [Header variant](https://gestalt.pinterest.systems/web/sidenavigation#Header) to learn more.
    */
   header?: Node,
   /**
@@ -48,7 +48,7 @@ export type Props = {|
   dismissButton?: {| accessibilityLabel?: string, onDismiss: () => void, tooltip: TooltipProps |},
   /**
   /**
-   * Displays a border in SideNavigation. See the [Border](https://gestalt.pinterest.systems/sidenavigation#Border) variant for more info.
+   * Displays a border in SideNavigation. See the [Border](https://gestalt.pinterest.systems/web/sidenavigation#Border) variant for more info.
    */
   showBorder?: boolean,
   /**
@@ -58,7 +58,7 @@ export type Props = {|
 |};
 
 /**
- * [SideNavigation](https://gestalt.pinterest.systems/sidenavigation) is start-aligned and arranged vertically. It is used to navigate between page urls or sections when you have too many menu items to fit in horizontal [Tabs](https://gestalt.pinterest.systems/tabs).
+ * [SideNavigation](https://gestalt.pinterest.systems/web/sidenavigation) is start-aligned and arranged vertically. It is used to navigate between page urls or sections when you have too many menu items to fit in horizontal [Tabs](https://gestalt.pinterest.systems/web/tabs).
  *
  * **NOTE**This component is on alpha phase, still under developoment. The component will support three levels and keyboard navigation. The component will change behavior and the API might also change in future component version releases.**NOTE**
  *

--- a/packages/gestalt/src/SideNavigationGroup.js
+++ b/packages/gestalt/src/SideNavigationGroup.js
@@ -22,7 +22,7 @@ type Counter = {| number: string, accessibilityLabel: string |};
 
 export type Props = {|
   /**
-   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/SideNavigation#Badge) variant to learn more.
+   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/web/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/SideNavigation#Badge) variant to learn more.
    */
   badge?: BadgeType,
   /**
@@ -52,7 +52,7 @@ export type Props = {|
 |};
 
 /**
- * Use [SideNavigation.Group](https://gestalt.pinterest.systems/sidenavigation#SideNavigation.Group) to hold SideNavigation.NestedItem and SideNavigation.NestedGroup at the top level of SideNavigation. It supports badges, icons, counters, and notifications.
+ * Use [SideNavigation.Group](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Group) to hold SideNavigation.NestedItem and SideNavigation.NestedGroup at the top level of SideNavigation. It supports badges, icons, counters, and notifications.
  */
 export default function SideNavigationGroup({
   badge,

--- a/packages/gestalt/src/SideNavigationNestedGroup.js
+++ b/packages/gestalt/src/SideNavigationNestedGroup.js
@@ -18,7 +18,7 @@ type Props = {|
 |};
 
 /**
- * Use [SideNavigation.NestedGroup](https://gestalt.pinterest.systems/sidenavigation#SideNavigation.NestedGroup) to hold SideNavigation.NestedItem in the second nested level of Pageheader.
+ * Use [SideNavigation.NestedGroup](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedGroup) to hold SideNavigation.NestedItem in the second nested level of Pageheader.
  */
 export default function SideNavigationNestedGroup({
   children,

--- a/packages/gestalt/src/SideNavigationNestedItem.js
+++ b/packages/gestalt/src/SideNavigationNestedItem.js
@@ -29,7 +29,7 @@ type Props = {|
 |};
 
 /**
- * Use [SideNavigation.NestedItem](https://gestalt.pinterest.systems/sidenavigation#SideNavigation.NestedItem) to redirect the user to a different page or section. SideNavigation.NestedItem must be used in second and third nested levels.
+ * Use [SideNavigation.NestedItem](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem) to redirect the user to a different page or section. SideNavigation.NestedItem must be used in second and third nested levels.
  */
 export default function SideNavigationNestedItem({ active, href, label, onClick }: Props): Node {
   return <SideNavigationTopItem active={active} href={href} label={label} onClick={onClick} />;

--- a/packages/gestalt/src/SideNavigationSection.js
+++ b/packages/gestalt/src/SideNavigationSection.js
@@ -8,11 +8,11 @@ import Text from './Text.js';
 
 type Props = {|
   /**
-   * Any [SideNavigation.TopItem](https://gestalt.pinterest.systems/sidenavigation#SideNavigation.TopItem) to be rendered
+   * Any [SideNavigation.TopItem](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.TopItem) to be rendered
    */
   children: Node,
   /**
-   * Label for the section. See the [Sections](https://gestalt.pinterest.systems/sidenavigation#Sections) variant for more info.
+   * Label for the section. See the [Sections](https://gestalt.pinterest.systems/web/sidenavigation#Sections) variant for more info.
    */
   label: string,
   /**
@@ -22,7 +22,7 @@ type Props = {|
 |};
 
 /**
- * Use [SideNavigation.Section](https://gestalt.pinterest.systems/sidenavigation#SideNavigation.Section) to categorize navigation menu items into groups and also avoid redundant language in labels.
+ * Use [SideNavigation.Section](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Section) to categorize navigation menu items into groups and also avoid redundant language in labels.
  */
 export default function SideNavigationSection({ _hasMarginTop, children, label }: Props): Node {
   return (

--- a/packages/gestalt/src/SideNavigationTopItem.js
+++ b/packages/gestalt/src/SideNavigationTopItem.js
@@ -25,7 +25,7 @@ type Props = {|
    */
   active?: 'page' | 'section',
   /**
-   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/SideNavigation#Badge) variant to learn more.
+   * When supplied, will display a [Badge](https://gestalt.pinterest.systems/web/badge) next to the item's label. See the [Badges](https://gestalt.pinterest.systems/SideNavigation#Badge) variant to learn more.
    */
   badge?: {|
     text: string,
@@ -65,7 +65,7 @@ type Props = {|
 |};
 
 /**
- * Use [SideNavigation.TopItem](https://gestalt.pinterest.systems/sidenavigation#SideNavigation.TopItem) to redirect the user to a different page or section. SideNavigation.TopItem must be used at the top level of SideNavigation. It supports badges, icons, counters, and notifications.
+ * Use [SideNavigation.TopItem](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.TopItem) to redirect the user to a different page or section. SideNavigation.TopItem must be used at the top level of SideNavigation. It supports badges, icons, counters, and notifications.
  */
 export default function SideNavigationTopItem({
   active,

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -109,36 +109,36 @@ function PrimaryAction({
 
 type Props = {|
   /**
-   * Adds a dismiss button to SlimBanner. See the [Dismissible variant](https://gestalt.pinterest.systems/slimbanner#Dismissible) for more info.
-   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/slimbanner#Accessibility).
+   * Adds a dismiss button to SlimBanner. See the [Dismissible variant](https://gestalt.pinterest.systems/web/slimbanner#Dismissible) for more info.
+   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/slimbanner#Accessibility).
    *
    * Note that compact ("___Bare" type) SlimBanners are not dismissable.
    */
   dismissButton?: DismissButtonType,
   /**
-   * Helper [Link](https://gestalt.pinterest.systems/link) to be placed after the message. See the [helperLink variant](https://gestalt.pinterest.systems/slimbanner#helperLink) to learn more.
+   * Helper [Link](https://gestalt.pinterest.systems/web/link) to be placed after the message. See the [helperLink variant](https://gestalt.pinterest.systems/web/slimbanner#helperLink) to learn more.
    */
   helperLink?: HelperLinkType,
   /**
-   * Label to describe the status icon’s purpose. See the [Accessibility guidelines](https://gestalt.pinterest.systems/slimbanner#Accessibility) for details on proper usage.
+   * Label to describe the status icon’s purpose. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/slimbanner#Accessibility) for details on proper usage.
    */
   iconAccessibilityLabel?: string,
   /**
-   * Main content of SlimBanner. Content should be [localized](https://gestalt.pinterest.systems/slimbanner#Localization).
+   * Main content of SlimBanner. Content should be [localized](https://gestalt.pinterest.systems/web/slimbanner#Localization).
    *
    */
   message: string,
   /**
-   * Main action for users to take on SlimBanner. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) to learn more about link navigation.
+   * Main action for users to take on SlimBanner. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
-   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/slimbanner#Accessibility).
-   * See the [Primary action](https://gestalt.pinterest.systems/slimbanner#Primary-action) variant to learn more.
+   * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/slimbanner#Accessibility).
+   * See the [Primary action](https://gestalt.pinterest.systems/web/slimbanner#Primary-action) variant to learn more.
    *
    * Note that actions are not available on compact ("___Bare" type) SlimBanners.
    */
   primaryAction?: PrimaryActionType,
   /**
-   * The type of SlimBanner. See the [variants](https://gestalt.pinterest.systems/slimbanner#Variants) to learn more.
+   * The type of SlimBanner. See the [variants](https://gestalt.pinterest.systems/web/slimbanner#Variants) to learn more.
    */
   type?:
     | 'neutral'
@@ -155,7 +155,7 @@ type Props = {|
 |};
 
 /**
- * [SlimBanner](https://gestalt.pinterest.systems/slimbanner) conveys brief information related to a specific section of a page. The message can relay success, warning, error or general information. Since they are about a specific section of a page or surface, SlimBanner sits inside of a container, and not at the top of the page. For alerts that apply to the whole page, use [Callout](https://gestalt.pinterest.systems/callout).
+ * [SlimBanner](https://gestalt.pinterest.systems/web/slimbanner) conveys brief information related to a specific section of a page. The message can relay success, warning, error or general information. Since they are about a specific section of a page or surface, SlimBanner sits inside of a container, and not at the top of the page. For alerts that apply to the whole page, use [Callout](https://gestalt.pinterest.systems/web/callout).
  *
  * ![SlimBanner light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/SlimBanner.spec.mjs-snapshots/SlimBanner-chromium-darwin.png)
  * ![SlimBanner dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/SlimBanner-dark.spec.mjs-snapshots/SlimBanner-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -30,7 +30,7 @@ type Props = {|
 |};
 
 /**
- * [Spinner](https://gestalt.pinterest.systems/spinner ) helps indicate that a surface's content or portion of content is currently loading.
+ * [Spinner](https://gestalt.pinterest.systems/web/spinner ) helps indicate that a surface's content or portion of content is currently loading.
  */
 export default function Spinner({
   accessibilityLabel,

--- a/packages/gestalt/src/Status.js
+++ b/packages/gestalt/src/Status.js
@@ -40,15 +40,15 @@ type StatusType = 'unstarted' | 'inProgress' | 'halted' | 'ok' | 'problem' | 'ca
 
 type Props = {|
   /**
-   * If not using `title`, provide an accessibility label to give the user context about the icon. Be sure to [localize](https://gestalt.pinterest.systems/status#Localization) the label.
+   * If not using `title`, provide an accessibility label to give the user context about the icon. Be sure to [localize](https://gestalt.pinterest.systems/web/status#Localization) the label.
    */
   accessibilityLabel?: string,
   /**
-   * Additional contextual information around the status. Only for use with `title`. See [localization](https://gestalt.pinterest.systems/status#Localization) to learn more.
+   * Additional contextual information around the status. Only for use with `title`. See [localization](https://gestalt.pinterest.systems/web/status#Localization) to learn more.
    */
   subtext?: string,
   /**
-   * A label to reinforce the meaning of the status icon. See [localization](https://gestalt.pinterest.systems/status#Localization) to learn more.
+   * A label to reinforce the meaning of the status icon. See [localization](https://gestalt.pinterest.systems/web/status#Localization) to learn more.
    */
   title?: string,
   /**
@@ -58,7 +58,7 @@ type Props = {|
 |};
 
 /**
- * [Status](https://gestalt.pinterest.systems/status) is a graphic indicator of an element’s state.
+ * [Status](https://gestalt.pinterest.systems/web/status) is a graphic indicator of an element’s state.
  *
  * ![Status light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Status.spec.mjs-snapshots/Status-chromium-darwin.png)
  * ![Status dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Status-dark.spec.mjs-snapshots/Status-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -29,7 +29,7 @@ type Props = {|
 const DEFAULT_ZINDEX = new FixedZIndex(1);
 
 /**
- * [Sticky](https://gestalt.pinterest.systems/sticky) allows an element to become fixed when it reaches a threshold (top, left, bottom, or right).
+ * [Sticky](https://gestalt.pinterest.systems/web/sticky) allows an element to become fixed when it reaches a threshold (top, left, bottom, or right).
  */
 export default function Sticky(props: Props): Node {
   const { children, height } = props;

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -7,7 +7,7 @@ import styles from './Switch.css';
 
 type Props = {|
   /**
-   * Indicates if the input is currently disabled. See [Switch combinations](https://gestalt.pinterest.systems/switch#Disabled-and-switched-combinations) for more details.
+   * Indicates if the input is currently disabled. See [Switch combinations](https://gestalt.pinterest.systems/web/switch#Disabled-and-switched-combinations) for more details.
    */
   disabled?: boolean,
   /**
@@ -23,13 +23,13 @@ type Props = {|
    */
   onChange: ({| event: SyntheticInputEvent<>, value: boolean |}) => void,
   /**
-   * Indicates the current value of the input. See [Switch combinations](https://gestalt.pinterest.systems/switch#Disabled-and-switched-combinations) for more details.
+   * Indicates the current value of the input. See [Switch combinations](https://gestalt.pinterest.systems/web/switch#Disabled-and-switched-combinations) for more details.
    */
   switched?: boolean,
 |};
 
 /**
- * Use [Switch](https://gestalt.pinterest.systems/switch) for single cell options that can be turned on and off only. If you have a cell with multiple options that can activated, consider using [Checkbox](https://gestalt.pinterest.systems/checkbox).
+ * Use [Switch](https://gestalt.pinterest.systems/web/switch) for single cell options that can be turned on and off only. If you have a cell with multiple options that can activated, consider using [Checkbox](https://gestalt.pinterest.systems/web/checkbox).
  *
  * Switch supports right-to-left(RTL) language locales layout (auto flip on RTL locales like Arabic).
  *

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -15,7 +15,7 @@ import { TableContextProvider } from './contexts/TableContext.js';
 
 type Props = {|
   /**
-   * Must be instances of Table.Header, Table.Body, and/or Table.Footer components. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   * Must be instances of Table.Header, Table.Body, and/or Table.Footer components. See the [Subcomponent section](https://gestalt.pinterest.systems/web/table#Subcomponents) to learn more.
    */
   children: Node,
   /**
@@ -31,13 +31,13 @@ type Props = {|
    */
   maxHeight?: number | string,
   /**
-   * Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](https://gestalt.pinterest.systems/table#Sticky-Column), [multiple sticky columns](https://gestalt.pinterest.systems/table#Multiple-sticky-columns), [sticky header and columns](https://gestalt.pinterest.systems/table#Sticky-header-and-sticky-columns), [expandable row with sticky columns](https://gestalt.pinterest.systems/table#Table-Row-Expandable-with-Sticky-Columns), and [sortable header cells with sticky columns](https://gestalt.pinterest.systems/table#Sortable-header-cells-with-sticky-columns) variants for details.
+   * Specify how many columns from the start of the Table should be sticky when scrolling horizontally. See the [sticky column](https://gestalt.pinterest.systems/web/table#Sticky-Column), [multiple sticky columns](https://gestalt.pinterest.systems/web/table#Multiple-sticky-columns), [sticky header and columns](https://gestalt.pinterest.systems/web/table#Sticky-header-and-sticky-columns), [expandable row with sticky columns](https://gestalt.pinterest.systems/web/table#Table-Row-Expandable-with-Sticky-Columns), and [sortable header cells with sticky columns](https://gestalt.pinterest.systems/web/table#Sortable-header-cells-with-sticky-columns) variants for details.
    */
   stickyColumns?: ?number,
 |};
 
 /**
- * [Table](https://gestalt.pinterest.systems/table) is a set of structured data that is easy for a user to scan, examine, and compare. Table data is displayed in a grid format and can be used to structure both interactive and static data.
+ * [Table](https://gestalt.pinterest.systems/web/table) is a set of structured data that is easy for a user to scan, examine, and compare. Table data is displayed in a grid format and can be used to structure both interactive and static data.
  *
  * ![Table light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Table.spec.mjs-snapshots/Table-chromium-darwin.png)
  *

--- a/packages/gestalt/src/TableBody.js
+++ b/packages/gestalt/src/TableBody.js
@@ -4,13 +4,13 @@ import styles from './Table.css';
 
 type Props = {|
   /**
-   * Must be instances of Table.Row and/or Table.RowExpandable components. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   * Must be instances of Table.Row and/or Table.RowExpandable components. See the [Subcomponent section](https://gestalt.pinterest.systems/web/table#Subcomponents) to learn more.
    */
   children: Node,
 |};
 
 /**
- * Use [Table.Body](https://gestalt.pinterest.systems/table#Table.Body) to group the body content in Table.
+ * Use [Table.Body](https://gestalt.pinterest.systems/web/table#Table.Body) to group the body content in Table.
  */
 export default function TableBody({ children }: Props): Node {
   return <tbody className={styles.tbody}>{children}</tbody>;

--- a/packages/gestalt/src/TableCell.js
+++ b/packages/gestalt/src/TableCell.js
@@ -31,7 +31,7 @@ type Props = {|
 |};
 
 /**
- * Use [Table.Cell](https://gestalt.pinterest.systems/table#Table.Cell) for individual table values.
+ * Use [Table.Cell](https://gestalt.pinterest.systems/web/table#Table.Cell) for individual table values.
  */
 export default function TableCell({
   children,

--- a/packages/gestalt/src/TableFooter.js
+++ b/packages/gestalt/src/TableFooter.js
@@ -3,13 +3,13 @@ import { type Node } from 'react';
 
 type Props = {|
   /**
-   * Must be instances of Table.Row and/or Table.RowExpandable components. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   * Must be instances of Table.Row and/or Table.RowExpandable components. See the [Subcomponent section](https://gestalt.pinterest.systems/web/table#Subcomponents) to learn more.
    */
   children: Node,
 |};
 
 /**
- * Use [Table.Footer](https://gestalt.pinterest.systems/table#Table.Footer) to group the footer content in Table.
+ * Use [Table.Footer](https://gestalt.pinterest.systems/web/table#Table.Footer) to group the footer content in Table.
  */
 export default function TableFooter({ children }: Props): Node {
   return <tfoot>{children}</tfoot>;

--- a/packages/gestalt/src/TableHeader.js
+++ b/packages/gestalt/src/TableHeader.js
@@ -6,7 +6,7 @@ import styles from './Table.css';
 
 type Props = {|
   /**
-   * Must be an instance of Table.Row. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   * Must be an instance of Table.Row. See the [Subcomponent section](https://gestalt.pinterest.systems/web/table#Subcomponents) to learn more.
    */
   children: Node,
   /**
@@ -14,13 +14,13 @@ type Props = {|
    */
   display?: 'tableHeaderGroup' | 'visuallyHidden',
   /**
-   * If true, the table header will be sticky and the table body will be scrollable. See the [sticky Header](https://gestalt.pinterest.systems/table#Sticky-header) and the [sticky header and columns](https://gestalt.pinterest.systems/table#Sticky-header-and-sticky-columns) variants for details.
+   * If true, the table header will be sticky and the table body will be scrollable. See the [sticky Header](https://gestalt.pinterest.systems/web/table#Sticky-header) and the [sticky header and columns](https://gestalt.pinterest.systems/web/table#Sticky-header-and-sticky-columns) variants for details.
    */
   sticky?: boolean,
 |};
 
 /**
- * Use [Table.Header](https://gestalt.pinterest.systems/table#Table.Header) to group the header content in Table.
+ * Use [Table.Header](https://gestalt.pinterest.systems/web/table#Table.Header) to group the header content in Table.
  */
 export default function TableHeader({
   children,

--- a/packages/gestalt/src/TableHeaderCell.js
+++ b/packages/gestalt/src/TableHeaderCell.js
@@ -35,7 +35,7 @@ type Props = {|
 |};
 
 /**
- * Use [Table.HeaderCell](https://gestalt.pinterest.systems/table#Table.HeaderCell) to define a header cell in Table.
+ * Use [Table.HeaderCell](https://gestalt.pinterest.systems/web/table#Table.HeaderCell) to define a header cell in Table.
  */
 export default function TableHeaderCell({
   children,

--- a/packages/gestalt/src/TableRow.js
+++ b/packages/gestalt/src/TableRow.js
@@ -4,13 +4,13 @@ import { useTableContext } from './contexts/TableContext.js';
 
 type Props = {|
   /**
-   * Must be instances of Table.Cell, Table.HeaderCell, or Table.SortableHeaderCell components. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   * Must be instances of Table.Cell, Table.HeaderCell, or Table.SortableHeaderCell components. See the [Subcomponent section](https://gestalt.pinterest.systems/web/table#Subcomponents) to learn more.
    */
   children: Node,
 |};
 
 /**
- * Use [Table.Row](https://gestalt.pinterest.systems/table#Table.Row) to define a row in Table.
+ * Use [Table.Row](https://gestalt.pinterest.systems/web/table#Table.Row) to define a row in Table.
  */
 export default function TableRow({ children }: Props): Node {
   const { stickyColumns } = useTableContext();

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -17,7 +17,7 @@ type Props = {|
    */
   accessibilityCollapseLabel: string,
   /**
-   * Must be instances of Table.Cell. See the [Subcomponent section](https://gestalt.pinterest.systems/table#Subcomponents) to learn more.
+   * Must be instances of Table.Cell. See the [Subcomponent section](https://gestalt.pinterest.systems/web/table#Subcomponents) to learn more.
    */
   children: Node,
   /**
@@ -46,7 +46,7 @@ type Props = {|
 |};
 
 /**
- * Use [Table.RowExpandable](https://gestalt.pinterest.systems/table#Table.RowExpandable) to define a row that expands and collapses additional content.
+ * Use [Table.RowExpandable](https://gestalt.pinterest.systems/web/table#Table.RowExpandable) to define a row that expands and collapses additional content.
  */
 export default function TableRowExpandable({
   accessibilityCollapseLabel,

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -56,7 +56,7 @@ type Props = {|
 |};
 
 /**
- * Use [Table.SortableHeaderCell](https://gestalt.pinterest.systems/table#Table.SortableHeaderCell) to define a header cell with sorting functionality in Table.
+ * Use [Table.SortableHeaderCell](https://gestalt.pinterest.systems/web/table#Table.SortableHeaderCell) to define a header cell with sorting functionality in Table.
  */
 export default function TableSortableHeaderCell({
   children,

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -196,11 +196,11 @@ type Props = {|
    */
   activeTabIndex: number,
   /**
-   * If Tabs is displayed in a container with a colored background, use this prop to remove the white tab background. See the [background color example](https://gestalt.pinterest.systems/tabs#Background-color) to learn more.
+   * If Tabs is displayed in a container with a colored background, use this prop to remove the white tab background. See the [background color example](https://gestalt.pinterest.systems/web/tabs#Background-color) to learn more.
    */
   bgColor?: BgColor,
   /**
-   * If your app requires client navigation, be sure to use [OnLinkNavigationProvider](`https://gestalt.pinterest.systems/onlinknavigationprovider`) and/or `onChange` to navigate instead of getting a full page refresh just using `href`.
+   * If your app requires client navigation, be sure to use [OnLinkNavigationProvider](`https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider`) and/or `onChange` to navigate instead of getting a full page refresh just using `href`.
    */
   onChange: OnChangeHandler,
   /**
@@ -220,7 +220,7 @@ type Props = {|
 |};
 
 /**
- * [Tabs](https://gestalt.pinterest.systems/tabs) may be used navigate between multiple URLs. Tabs are intended as page-level navigation - if you're looking at just switching panels of content, please use [SegmentedControl](https://gestalt.pinterest.systems/segmentedcontrol).
+ * [Tabs](https://gestalt.pinterest.systems/web/tabs) may be used navigate between multiple URLs. Tabs are intended as page-level navigation - if you're looking at just switching panels of content, please use [SegmentedControl](https://gestalt.pinterest.systems/web/segmentedcontrol).
  */
 export default function Tabs({
   activeTabIndex,

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -33,7 +33,7 @@ type Props = {|
 |};
 
 /**
- * [Tags](https://gestalt.pinterest.systems/tag) are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](https://gestalt.pinterest.systems/textfield#tagsExample), [TextAreas](https://gestalt.pinterest.systems/textarea#tagsExample), [ComboBox](https://gestalt.pinterest.systems/combobox#Tags) or as standalone components.
+ * [Tags](https://gestalt.pinterest.systems/web/tag) are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](https://gestalt.pinterest.systems/web/textfield#tagsExample), [TextAreas](https://gestalt.pinterest.systems/web/textarea#tagsExample), [ComboBox](https://gestalt.pinterest.systems/web/combobox#Tags) or as standalone components.
  *
  * ![Tag light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Tag.spec.mjs-snapshots/Tag-chromium-darwin.png)
  * ![Tag dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Tag-dark.spec.mjs-snapshots/Tag-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -17,12 +17,12 @@ type Props = {|
   /**
    * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text.
    *
-   * Link: https://gestalt.pinterest.systems/text#align
+   * Link: https://gestalt.pinterest.systems/web/text#align
    */
   align?: 'start' | 'end' | 'center' | 'justify' | 'forceLeft' | 'forceRight',
   children?: Node,
   /**
-   * Link: https://gestalt.pinterest.systems/text#color
+   * Link: https://gestalt.pinterest.systems/web/text#color
    */
   color?:
     | 'default'
@@ -36,45 +36,45 @@ type Props = {|
     | 'light'
     | 'dark',
   /**
-   * Link: https://gestalt.pinterest.systems/text#inline
+   * Link: https://gestalt.pinterest.systems/web/text#inline
    */
   inline?: boolean,
   /**
-   * Link: https://gestalt.pinterest.systems/text#styles
+   * Link: https://gestalt.pinterest.systems/web/text#styles
    */
   italic?: boolean,
   /**
    * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers.
    *
-   * Link: https://gestalt.pinterest.systems/text#Overflow-and-truncation
+   * Link: https://gestalt.pinterest.systems/web/text#Overflow-and-truncation
    */
   lineClamp?: number,
   /**
-   * Link: https://gestalt.pinterest.systems/text#Overflow-and-truncation
+   * Link: https://gestalt.pinterest.systems/web/text#Overflow-and-truncation
    */
   overflow?: Overflow,
   /**
-   * The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/design_tokens#Font-size).
+   * The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size).
    *
-   * Link: https://gestalt.pinterest.systems/text#size
+   * Link: https://gestalt.pinterest.systems/web/text#size
    */
   size?: Size,
   /**
-   * This populates the `title` attribute of the element, which is visible on hover in most browsers. This is useful when truncating the text with `lineClamp` when `children` is a `React.Node`. See the [Title variant](https://gestalt.pinterest.systems/text#Title) for more details.
+   * This populates the `title` attribute of the element, which is visible on hover in most browsers. This is useful when truncating the text with `lineClamp` when `children` is a `React.Node`. See the [Title variant](https://gestalt.pinterest.systems/web/text#Title) for more details.
    */
   title?: string,
   /**
-   * Link: https://gestalt.pinterest.systems/text#styles
+   * Link: https://gestalt.pinterest.systems/web/text#styles
    */
   underline?: boolean,
   /**
-   * Link: https://gestalt.pinterest.systems/text#styles
+   * Link: https://gestalt.pinterest.systems/web/text#styles
    */
   weight?: 'bold' | 'normal',
 |};
 
 /**
- * The [Text](https://gestalt.pinterest.systems/text) component is used for all non-heading text on all surfaces, whether inside of UI components or in long-form paragraph text.
+ * The [Text](https://gestalt.pinterest.systems/web/text) component is used for all non-heading text on all surfaces, whether inside of UI components or in long-form paragraph text.
  *
  * ![Text light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Text.spec.mjs-snapshots/Text-chromium-darwin.png)
  * ![Text dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Text-dark.spec.mjs-snapshots/Text-dark-chromium-darwin.png)

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -15,11 +15,11 @@ const INPUT_PADDING_WITH_TAGS = 20;
 
 type Props = {|
   /**
-   * Indicate if the input is currently disabled. See the [disabled example](https://gestalt.pinterest.systems/textarea#Disabled) for more details.
+   * Indicate if the input is currently disabled. See the [disabled example](https://gestalt.pinterest.systems/web/textarea#Disabled) for more details.
    */
   disabled?: boolean,
   /**
-   * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in Link or TapArea. See the [error message example](https://gestalt.pinterest.systems/textarea#Error-message) for more details.
+   * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in Link or TapArea. See the [error message example](https://gestalt.pinterest.systems/web/textarea#Error-message) for more details.
    */
   errorMessage?: Node,
   /**
@@ -27,7 +27,7 @@ type Props = {|
    */
   hasError?: boolean,
   /**
-   * More information about how to complete the form field. See the [helper text example](https://gestalt.pinterest.systems/textarea#Helper-text) for more details.
+   * More information about how to complete the form field. See the [helper text example](https://gestalt.pinterest.systems/web/textarea#Helper-text) for more details.
    */
   helperText?: string,
   /**
@@ -79,11 +79,11 @@ type Props = {|
    */
   placeholder?: string,
   /**
-   * Indicate if the input is currently readOnly. See the [readOnly example](https://gestalt.pinterest.systems/textarea#Read-only) for more details.
+   * Indicate if the input is currently readOnly. See the [readOnly example](https://gestalt.pinterest.systems/web/textarea#Read-only) for more details.
    */
   readOnly?: boolean,
   /**
-   * Ref that is forwarded to the underlying input element. See the [ref example](https://gestalt.pinterest.systems/textarea#With-a-ref) for more details.
+   * Ref that is forwarded to the underlying input element. See the [ref example](https://gestalt.pinterest.systems/web/textarea#With-a-ref) for more details.
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
@@ -91,7 +91,7 @@ type Props = {|
    */
   rows?: number,
   /**
-   * List of tags to display in the component. See the [tags example](https://gestalt.pinterest.systems/textarea#With-tags) for more details.
+   * List of tags to display in the component. See the [tags example](https://gestalt.pinterest.systems/web/textarea#With-tags) for more details.
    */
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   /**
@@ -101,7 +101,7 @@ type Props = {|
 |};
 
 /**
- * [TextArea](https://gestalt.pinterest.systems/textarea) allows for multi-line input.
+ * [TextArea](https://gestalt.pinterest.systems/web/textarea) allows for multi-line input.
  *
  * ![TextArea light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TextArea.spec.mjs-snapshots/TextArea-chromium-darwin.png)
  * ![TextArea dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TextArea-dark.spec.mjs-snapshots/TextArea-dark-chromium-darwin.png)

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -15,11 +15,11 @@ type Props = {|
    */
   autoComplete?: 'bday' | 'current-password' | 'email' | 'new-password' | 'on' | 'off' | 'username',
   /**
-   * Indicate if the input is disabled. See the [disabled example](https://gestalt.pinterest.systems/textfield#Disabled) for more details.
+   * Indicate if the input is disabled. See the [disabled example](https://gestalt.pinterest.systems/web/textfield#Disabled) for more details.
    */
   disabled?: boolean,
   /**
-   * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/link) or [TapArea](https://gestalt.pinterest.systems/taparea).
+   * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/web/link) or [TapArea](https://gestalt.pinterest.systems/web/taparea).
    */
   errorMessage?: Node,
   /**
@@ -79,7 +79,7 @@ type Props = {|
    */
   placeholder?: string,
   /**
-   * Indicate if the input is readOnly. See the [readOnly example](https://gestalt.pinterest.systems/textfield#Read-only) for more details.
+   * Indicate if the input is readOnly. See the [readOnly example](https://gestalt.pinterest.systems/web/textfield#Read-only) for more details.
    */
   readOnly?: boolean,
   /**
@@ -91,7 +91,7 @@ type Props = {|
    */
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
   /**
-   * The type of input. For non-telephone numerical input, please use [NumberField](https://gestalt.pinterest.systems/numberfield).
+   * The type of input. For non-telephone numerical input, please use [NumberField](https://gestalt.pinterest.systems/web/numberfield).
    */
   type?: Type,
   /**
@@ -105,7 +105,7 @@ type Props = {|
 |};
 
 /**
- * [TextField](https://gestalt.pinterest.systems/textfield) allows for multiple types of text input.
+ * [TextField](https://gestalt.pinterest.systems/web/textfield) allows for multiple types of text input.
  *
  * ![TextField light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TextField.spec.mjs-snapshots/TextField-chromium-darwin.png)
  * ![TextField dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TextField-dark.spec.mjs-snapshots/TextField-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -37,7 +37,7 @@ type Props = {|
 |};
 
 /**
- * [Toasts](https://gestalt.pinterest.systems/toast) can educate people on the content of the screen, provide confirmation when people complete an action, or simply communicate a short message.
+ * [Toasts](https://gestalt.pinterest.systems/web/toast) can educate people on the content of the screen, provide confirmation when people complete an action, or simply communicate a short message.
  *
  * Toast is purely visual. In order to properly handle the showing and dismissing of Toasts, as well as any animations, you will need to implement a Toast manager.
  *

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -45,39 +45,39 @@ const reducer = (state, action) => {
 
 type Props = {|
   /**
-   * Label to provide more context around the Tooltip’s function or purpose. By default `text` is used but this prop allows you to override it. Learn more about when to override it in the [Accessibility](https://gestalt.pinterest.systems/tooltip#Labels) section.
+   * Label to provide more context around the Tooltip’s function or purpose. By default `text` is used but this prop allows you to override it. Learn more about when to override it in the [Accessibility](https://gestalt.pinterest.systems/web/tooltip#Labels) section.
    */
   accessibilityLabel?: string,
   /**
-   * The anchor element, usually [Icon Button](https://gestalt.pinterest.systems/iconbutton), that triggers Tooltip on hover or focus.
+   * The anchor element, usually [Icon Button](https://gestalt.pinterest.systems/web/iconbutton), that triggers Tooltip on hover or focus.
    */
   children: Node,
   /**
-   * Specifies the preferred position of Tooltip relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/tooltip#Ideal-direction) variant to learn more.
+   * Specifies the preferred position of Tooltip relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/web/tooltip#Ideal-direction) variant to learn more.
    */
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   /**
-   * Properly positions Tooltip relative to an inline element, such as [Icon Button](https://gestalt.pinterest.systems/iconbutton) using the inline property. See the [inline](https://gestalt.pinterest.systems/tooltip#Inline) variant to learn more.
+   * Properly positions Tooltip relative to an inline element, such as [Icon Button](https://gestalt.pinterest.systems/web/iconbutton) using the inline property. See the [inline](https://gestalt.pinterest.systems/web/tooltip#Inline) variant to learn more.
    */
   inline?: boolean,
   /**
-   * Displays a link at the bottom of Tooltip. See the [link](https://gestalt.pinterest.systems/tooltip#Link) variant to learn more.
+   * Displays a link at the bottom of Tooltip. See the [link](https://gestalt.pinterest.systems/web/tooltip#Link) variant to learn more.
    */
   link?: Node,
   /**
-   * The text shown in Tooltip to describe its anchor element. See [localization ](https://gestalt.pinterest.systems/tooltip#Localization) to learn more.
+   * The text shown in Tooltip to describe its anchor element. See [localization ](https://gestalt.pinterest.systems/web/tooltip#Localization) to learn more.
    */
   text: string,
   /**
-   * Specifies the stacking order of Tooltip along the z-axis in the current stacking context. See the [z-index](https://gestalt.pinterest.systems/tooltip#Z-index) variant to learn more.
+   * Specifies the stacking order of Tooltip along the z-axis in the current stacking context. See the [z-index](https://gestalt.pinterest.systems/web/tooltip#Z-index) variant to learn more.
    */
   zIndex?: Indexable,
 |};
 
 /**
- * [Tooltip](https://gestalt.pinterest.systems/tooltip) is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/iconbutton). It’s displayed continuously as long as the user hovers over or focuses on the element.
+ * [Tooltip](https://gestalt.pinterest.systems/web/tooltip) is a floating text label that succinctly describes the function of an interactive element, typically [Icon Button](/iconbutton). It’s displayed continuously as long as the user hovers over or focuses on the element.
  *
- * **NOTE** Planning to use Tooltip with IconButton? Use [IconButton's built-in tooltip](https://gestalt.pinterest.systems/iconbutton#With-Tooltip) instead. **NOTE**
+ * **NOTE** Planning to use Tooltip with IconButton? Use [IconButton's built-in tooltip](https://gestalt.pinterest.systems/web/iconbutton#With-Tooltip) instead. **NOTE**
  *
  * ![Tooltip light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Tooltip.spec.mjs-snapshots/Tooltip-chromium-darwin.png)
  * ![Tooltip dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Tooltip-dark.spec.mjs-snapshots/Tooltip-dark-chromium-darwin.png)

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -129,7 +129,7 @@ type Props = {|
 |};
 
 /**
- * [Upsells](https://gestalt.pinterest.systems/upsell) are banners that display short messages that focus on promoting an action or upgrading something the user already has.
+ * [Upsells](https://gestalt.pinterest.systems/web/upsell) are banners that display short messages that focus on promoting an action or upgrading something the user already has.
  *
  *
  * ![Upsell light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Upsell.spec.mjs-snapshots/Upsell-chromium-darwin.png)

--- a/packages/gestalt/src/UpsellForm.js
+++ b/packages/gestalt/src/UpsellForm.js
@@ -7,7 +7,7 @@ import useResponsiveMinWidth from './useResponsiveMinWidth.js';
 
 type Props = {|
   /**
-   * Contents of the form, typically input components like [TextField](https://gestalt.pinterest.systems/textfield) or [NumberField](https://gestalt.pinterest.systems/numberfield).
+   * Contents of the form, typically input components like [TextField](https://gestalt.pinterest.systems/web/textfield) or [NumberField](https://gestalt.pinterest.systems/web/numberfield).
    */
   children: Node,
   /**
@@ -25,7 +25,7 @@ type Props = {|
    */
   submitButtonText: string,
   /**
-   * Label for the submit button used for screen readers. Should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/upsell#Accessibility). Be sure to localize!
+   * Label for the submit button used for screen readers. Should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/upsell#Accessibility). Be sure to localize!
    */
   submitButtonAccessibilityLabel: string,
   /**
@@ -35,7 +35,7 @@ type Props = {|
 |};
 
 /**
- * [Upsell.Form](https://gestalt.pinterest.systems/upsell#Upsell.Form) can be used to add a short form to Upsell for collecting data from the user.
+ * [Upsell.Form](https://gestalt.pinterest.systems/web/upsell#Upsell.Form) can be used to add a short form to Upsell for collecting data from the user.
  */
 export default function UpsellForm({
   children,

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -47,15 +47,15 @@ type Props = {|
    */
   accessibilityProgressBarLabel: string,
   /**
-   * Accessibility label for the button to show captions if controls are shown. See the [accessibility section](https://gestalt.pinterest.systems/video#Captions) to learn more.
+   * Accessibility label for the button to show captions if controls are shown. See the [accessibility section](https://gestalt.pinterest.systems/web/video#Captions) to learn more.
    */
   accessibilityShowCaptionsLabel?: string,
   /**
-   * Accessibility label for the unmute button if controls are shown. See the [accessibility section](https://gestalt.pinterest.systems/video#Captions) to learn more.
+   * Accessibility label for the unmute button if controls are shown. See the [accessibility section](https://gestalt.pinterest.systems/web/video#Captions) to learn more.
    */
   accessibilityUnmuteLabel: string,
   /**
-   * When set to autoplay, the video will automatically start playing. See the [autoplay and error detection variant](https://gestalt.pinterest.systems/video#Autoplay-and-error-detection) to learn more.
+   * When set to autoplay, the video will automatically start playing. See the [autoplay and error detection variant](https://gestalt.pinterest.systems/web/video#Autoplay-and-error-detection) to learn more.
    */
   autoplay?: boolean,
   /**
@@ -67,11 +67,11 @@ type Props = {|
    */
   backgroundColor: BackgroundColor,
   /**
-   * The URL of the captions track for the video (.vtt file). See the [accessibility section](https://gestalt.pinterest.systems/video#Captions) to learn more.
+   * The URL of the captions track for the video (.vtt file). See the [accessibility section](https://gestalt.pinterest.systems/web/video#Captions) to learn more.
    */
   captions?: string,
   /**
-   * This `children` prop is not same as children inside the native html `video` element. Instead, it serves to add overlays on top of the html video element, while still being under the video controls. See [children example](https://gestalt.pinterest.systems/video#video-with-children) for more details.
+   * This `children` prop is not same as children inside the native html `video` element. Instead, it serves to add overlays on top of the html video element, while still being under the video controls. See [children example](https://gestalt.pinterest.systems/web/video#video-with-children) for more details.
    */
   children?: Node,
   /**
@@ -79,7 +79,7 @@ type Props = {|
    */
   crossOrigin?: CrossOrigin,
   /**
-   * Show the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
+   * Show the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/web/video#Video-controls) to learn more.
    */
   controls?: boolean,
   /**
@@ -128,15 +128,15 @@ type Props = {|
   onPause?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
 
   /**
-   * Callback triggered when `pause` is changed from "true" to "false" or `autoplay`. See the [MDN Web Docs: play event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play_event) and the [autoplay and error detection variant](https://gestalt.pinterest.systems/video#Autoplay-and-error-detection) to learn more.
+   * Callback triggered when `pause` is changed from "true" to "false" or `autoplay`. See the [MDN Web Docs: play event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play_event) and the [autoplay and error detection variant](https://gestalt.pinterest.systems/web/video#Autoplay-and-error-detection) to learn more.
    */
   onPlay: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when a [play() method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play)'s Promise is [rejected](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions). See the [autoplay and error detection variant](https://gestalt.pinterest.systems/video#Autoplay-and-error-detection) to learn more.
+   * Callback triggered when a [play() method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play)'s Promise is [rejected](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions). See the [autoplay and error detection variant](https://gestalt.pinterest.systems/web/video#Autoplay-and-error-detection) to learn more.
    */
   onPlayError: ({| error: Error |}) => void,
   /**
-   * Callback triggered when the video full-screen status changes. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
+   * Callback triggered when the video full-screen status changes. See the [video controls variant](https://gestalt.pinterest.systems/web/video#Video-controls) to learn more.
    */
   onFullscreenChange?: ({| event: Event, fullscreen: boolean |}) => void,
   /**
@@ -152,11 +152,11 @@ type Props = {|
    */
   onPlaying?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Callback triggered when mousedown event occurs on the playhead via the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
+   * Callback triggered when mousedown event occurs on the playhead via the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/web/video#Video-controls) to learn more.
    */
   onPlayheadDown?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
   /**
-   * Callback triggered when mouseup event occurs on the playhead via the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
+   * Callback triggered when mouseup event occurs on the playhead via the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/web/video#Video-controls) to learn more.
    */
   onPlayheadUp?: ({| event: SyntheticMouseEvent<HTMLDivElement> |}) => void,
   /**
@@ -180,7 +180,7 @@ type Props = {|
    */
   onTimeChange?: ({| event: SyntheticEvent<HTMLVideoElement>, time: number |}) => void,
   /**
-   * Callback triggered when the audio volume changes via the video control interface. See the [video updates variant](https://gestalt.pinterest.systems/video#Video-updates) to learn more.
+   * Callback triggered when the audio volume changes via the video control interface. See the [video updates variant](https://gestalt.pinterest.systems/web/video#Video-updates) to learn more.
    */
   onVolumeChange?: ({|
     event: SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>,
@@ -191,11 +191,11 @@ type Props = {|
    */
   onWaiting?: ({| event: SyntheticEvent<HTMLVideoElement> |}) => void,
   /**
-   * Specifies the speed at which the video plays: 1 for normal. See the [video updates variant](https://gestalt.pinterest.systems/video#Video-updates) to learn more.
+   * Specifies the speed at which the video plays: 1 for normal. See the [video updates variant](https://gestalt.pinterest.systems/web/video#Video-updates) to learn more.
    */
   playbackRate: number,
   /**
-   * Specifies whether the video should play or not. See [autoplay and error detection variant](https://gestalt.pinterest.systems/video#Autoplay-and-error-detection) to learn more.
+   * Specifies whether the video should play or not. See [autoplay and error detection variant](https://gestalt.pinterest.systems/web/video#Autoplay-and-error-detection) to learn more.
    */
   playing: boolean,
   /**
@@ -203,7 +203,7 @@ type Props = {|
    */
   playsInline?: boolean,
   /**
-   * The image to show while the video is loading. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
+   * The image to show while the video is loading. See the [video controls variant](https://gestalt.pinterest.systems/web/video#Video-controls) to learn more.
    */
   poster?: string,
   /**
@@ -211,7 +211,7 @@ type Props = {|
    */
   preload: 'auto' | 'metadata' | 'none',
   /**
-   * The URL of the video file to play. This can also be supplied as a list of video types to respective video source urls in fallback order for support on various browsers. See [multiple sources example](https://gestalt.pinterest.systems/video#Video-multiple-sources) for more details.
+   * The URL of the video file to play. This can also be supplied as a list of video types to respective video source urls in fallback order for support on various browsers. See [multiple sources example](https://gestalt.pinterest.systems/web/video#Video-multiple-sources) for more details.
    */
   src: Source,
   /**
@@ -219,7 +219,7 @@ type Props = {|
    */
   startTime?: number,
   /**
-   * Specifies the volume of the video audio: 0 for muted, 1 for max. See the [video controls variant](https://gestalt.pinterest.systems/video#Video-controls) to learn more.
+   * Specifies the volume of the video audio: 0 for muted, 1 for max. See the [video controls variant](https://gestalt.pinterest.systems/web/video#Video-controls) to learn more.
    */
   volume: number,
 |};
@@ -324,7 +324,7 @@ const isNewSource = (oldSource: Source, newSource: Source): boolean => {
 };
 
 /**
- * [Video](https://gestalt.pinterest.systems/video) is used for media layout.
+ * [Video](https://gestalt.pinterest.systems/web/video) is used for media layout.
  *
  * ![Video light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Video.spec.mjs-snapshots/Video-chromium-darwin.png)
  */

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.js
@@ -140,7 +140,7 @@ type Props = {|
    */
   children: Node,
   /**
-   * The color scheme for components inside the ColorSchemeProvider. Use 'userPreference' to allow the end user to specify the color scheme via their browser settings, using the 'prefers-color-scheme' media query. See [color scheme](https://gestalt.pinterest.systems/colorschemeprovider#Color-scheme) variant for examples.
+   * The color scheme for components inside the ColorSchemeProvider. Use 'userPreference' to allow the end user to specify the color scheme via their browser settings, using the 'prefers-color-scheme' media query. See [color scheme](https://gestalt.pinterest.systems/web/utilities/colorschemeprovider#Color-scheme) variant for examples.
    */
   colorScheme?: ColorScheme,
   /**
@@ -150,7 +150,7 @@ type Props = {|
 |};
 
 /**
- * [ColorSchemeProvider](https://gestalt.pinterest.systems/colorschemeprovider) is an optional [React context provider](https://reactjs.org/docs/context.html#contextprovider) to enable dark mode.
+ * [ColorSchemeProvider](https://gestalt.pinterest.systems/web/utilities/colorschemeprovider) is an optional [React context provider](https://reactjs.org/docs/context.html#contextprovider) to enable dark mode.
  */
 export default function ColorSchemeProvider({
   children,

--- a/packages/gestalt/src/contexts/DeviceTypeProvider.js
+++ b/packages/gestalt/src/contexts/DeviceTypeProvider.js
@@ -20,7 +20,7 @@ type Props = {|
 
 /**
  * *ALPHA - DO NOT USE YET - MAY HAVE BREAKING CHANGES IN THE NEAR FUTURE*
- * [DeviceTypeProvider](https://gestalt.pinterest.systems/devicetypeprovider) is an optional [React Context provider](https://reactjs.org/docs/context.html#contextprovider) to enable device-specific UI for Gestalt components that support it.
+ * [DeviceTypeProvider](https://gestalt.pinterest.systems/web/utilities/devicetypeprovider) is an optional [React Context provider](https://reactjs.org/docs/context.html#contextprovider) to enable device-specific UI for Gestalt components that support it.
  */
 export default function DeviceTypeProvider({ children, deviceType }: Props): Node {
   return <DeviceTypeContext.Provider value={deviceType}>{children}</DeviceTypeContext.Provider>;

--- a/packages/gestalt/src/contexts/OnLinkNavigationProvider.js
+++ b/packages/gestalt/src/contexts/OnLinkNavigationProvider.js
@@ -16,7 +16,7 @@ type Props = {|
    */
   children: Node,
   /**
-   * If passed, it replaces the default link behavior with custom on navigation behavior. See [custom navigation context](https://gestalt.pinterest.systems/onlinknavigationprovider#Custom-link-navigation-context) variant for examples.
+   * If passed, it replaces the default link behavior with custom on navigation behavior. See [custom navigation context](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider#Custom-link-navigation-context) variant for examples.
    */
   onNavigation?: OnLinkNavigationType,
 |};
@@ -27,7 +27,7 @@ const OnLinkNavigationContext: Context<OnLinkNavigationContextType | void> =
 const { Provider } = OnLinkNavigationContext;
 
 /**
- * [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) is a [React context provider](https://reactjs.org/docs/context.html#contextprovider) to externally control the link behavior of components further down the tree.
+ * [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) is a [React context provider](https://reactjs.org/docs/context.html#contextprovider) to externally control the link behavior of components further down the tree.
  */
 export default function OnLinkNavigationProvider({
   children,

--- a/packages/gestalt/src/useFocusVisible.js
+++ b/packages/gestalt/src/useFocusVisible.js
@@ -113,7 +113,7 @@ function setupGlobalFocusEvents() {
 }
 
 /**
- * https://gestalt.pinterest.systems/usefocusvisible
+ * https://gestalt.pinterest.systems/web/utilities/usefocusvisible
  */
 export default function useFocusVisible(): {|
   isFocusVisible: boolean,

--- a/packages/gestalt/src/useReducedMotion.js
+++ b/packages/gestalt/src/useReducedMotion.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { addListener, removeListener } from './utils/matchMedia.js';
 
 /**
- * https://gestalt.pinterest.systems/usereducedmotion
+ * https://gestalt.pinterest.systems/web/utilities/usereducedmotion
  */
 export default function useReducedMotion(): boolean {
   const supportsMatchMedia = typeof window !== 'undefined' && window.matchMedia;

--- a/packages/gestalt/src/zIndex.js
+++ b/packages/gestalt/src/zIndex.js
@@ -5,7 +5,7 @@ export interface Indexable {
 }
 
 /**
- * https://gestalt.pinterest.systems/zindex_classes#FixedZIndex
+ * https://gestalt.pinterest.systems/web/zindex_classes#FixedZIndex
  */
 export class FixedZIndex implements Indexable {
   +z: number;
@@ -20,7 +20,7 @@ export class FixedZIndex implements Indexable {
 }
 
 /**
- * https://gestalt.pinterest.systems/zindex_classes#CompositeZIndex
+ * https://gestalt.pinterest.systems/web/zindex_classes#CompositeZIndex
  */
 export class CompositeZIndex implements Indexable {
   // eslint-disable-next-line no-use-before-define

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -18,10 +18,10 @@ changes to any of the Gestalt packages or its documentation.
 
 What constitutes a "substantial" change may include the following:
 
-- A new Gestalt building-block component that solves complex library issues (such as [ScrollBoundaryContainer](https://gestalt.pinterest.systems/scrollboundarycontainer) or [Z-Index classes](https://gestalt.pinterest.systems/zindex_classes)) and/or adds new developing patterns to Gestalt users (such as [Flex](https://gestalt.pinterest.systems/flex) or [TapArea](https://gestalt.pinterest.systems/taparea)).
-- A new Gestalt utility component (such as [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) or [useReducedMotion](https://gestalt.pinterest.systems/usereducedmotion)).
-- A new feature that creates new API surface area (such as [OnLinkNavigationProvider](https://gestalt.pinterest.systems/onlinknavigationprovider) and `dangerouslyDisableOnNavigation`).
-- The introduction of new idiomatic usage, conventions, or patterns (such as [Gestalt design tokens](https://gestalt.pinterest.systems/design_tokens), [boint units](https://gestalt.pinterest.systems/faq#Component-usage), or subcomponents modularity patterns like [Table](https://gestalt.pinterest.systems/table#Props) or [Dropdown](https://gestalt.pinterest.systems/dropdown) subcomponents).
+- A new Gestalt building-block component that solves complex library issues (such as [ScrollBoundaryContainer](https://gestalt.pinterest.systems/web/utilities/scrollboundarycontainer) or [Z-Index classes](https://gestalt.pinterest.systems/web/zindex_classes)) and/or adds new developing patterns to Gestalt users (such as [Flex](https://gestalt.pinterest.systems/web/flex) or [TapArea](https://gestalt.pinterest.systems/web/taparea)).
+- A new Gestalt utility component (such as [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) or [useReducedMotion](https://gestalt.pinterest.systems/web/utilities/usereducedmotion)).
+- A new feature that creates new API surface area (such as [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) and `dangerouslyDisableOnNavigation`).
+- The introduction of new idiomatic usage, conventions, or patterns (such as [Gestalt design tokens](https://gestalt.pinterest.systems/foundations/design_tokens), [boint units](https://gestalt.pinterest.systems/get_started/faq#Component-usage), or subcomponents modularity patterns like [Table](https://gestalt.pinterest.systems/web/table#Props) or [Dropdown](https://gestalt.pinterest.systems/web/dropdown) subcomponents).
 - Technology migrations (such as the [migration to Next.js](https://github.com/pinterest/gestalt/pull/1642))
 
 Some changes do not require an RFC:


### PR DESCRIPTION
Basically manually implementing the logic in [docs/redirects.js](https://github.com/pinterest/gestalt/blob/aedcffa171bd79d2dcacd2af9f63fea8140d4e0c/docs/redirects.js) to update all our internal links