### PR TITLE
Docs: fix Collage bug

### DIFF
--- a/docs/pages/web/collage.js
+++ b/docs/pages/web/collage.js
@@ -142,7 +142,7 @@ export default function CollagePage({ generatedDocGen }: {| generatedDocGen: Doc
           const image = images[index] || {};
           return (
             <Mask wash width={width} height={height}>
-              {image?.src ? (
+              {image.src ? (
                 <Image
                   alt="collage image"
                   color={image.color}
@@ -344,7 +344,7 @@ export default function CollagePage({ generatedDocGen }: {| generatedDocGen: Doc
           const image = images[index] || {};
           return (
             <Mask wash width={width} height={height}>
-              {image?.src ? (
+              {image.src ? (
                 <Image
                   alt="collage image"
                   color={image.color}


### PR DESCRIPTION
This fixes a bug that was introduced in #2236. Apparently the code editor can't handle optional chaining, so this PR removes it:
<img width="918" alt="Screen Shot 2022-08-09 at 5 26 57 PM" src="https://user-images.githubusercontent.com/12059539/183784466-fa81603d-b7c7-46a8-90c5-e25a4082802b.png">

