### PR TITLE
Internal: disallow console.* calls in tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -117,7 +117,7 @@
       "rules": {
         "jest/expect-expect": [
           "error",
-          { "assertFunctionNames": ["expect", "runInlineTest"] }
+          { "assertFunctionNames": ["expect", "runInlineTest", "runTest"] }
         ]
       }
     },

--- a/flow-typed/npm/jest_v26.x.x.js
+++ b/flow-typed/npm/jest_v26.x.x.js
@@ -256,6 +256,7 @@ type DomTestingLibraryType = {
   // 5.x
   toHaveDisplayValue(value: string | string[]): void,
   toBeChecked(): void,
+  toHaveAccessibleDescription(value: string | string[]): void,
   toHaveDescription(value: string | string[]): void,
   ...
 };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "28.0.3",
     "jest-environment-jsdom": "^28.0.2",
+    "jest-fail-on-console": "^2.4.2",
     "jscodeshift": "^0.11.0",
     "lint-staged": "^10.4.0",
     "netlify-cli": "^2.65.1",

--- a/packages/gestalt-codemods/34.0.0/__tests__/toast-replace-color-variant.test.js
+++ b/packages/gestalt-codemods/34.0.0/__tests__/toast-replace-color-variant.test.js
@@ -1,4 +1,4 @@
-import { defineTest } from 'jscodeshift/dist/testUtils.js';
+import { defineTest, runTest } from 'jscodeshift/dist/testUtils.js';
 
 jest.mock('../toast-replace-color-variant', () =>
   Object.assign(jest.requireActual('../toast-replace-color-variant'), {
@@ -7,17 +7,47 @@ jest.mock('../toast-replace-color-variant', () =>
 );
 
 describe('toast-replace-color-variant', () => {
-  [
-    'color-red',
-    'color-white',
-    'empty-string-color',
-    'no-color',
-    'null-color',
-    'renamed',
-    'ternary-color',
-    'undefined-color',
-    'variable-color',
-  ].forEach((test) => {
+  ['color-red', 'color-white', 'no-color', 'renamed'].forEach((test) => {
     defineTest(__dirname, 'toast-replace-color-variant', { quote: 'single' }, test);
+  });
+
+  it(`transforms correctly using "empty-string-color" data`, () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    runTest(__dirname, 'toast-replace-color-variant', { quote: 'single' }, 'empty-string-color');
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Toast component with color prop used an invalid or empty value'),
+    );
+  });
+
+  it(`transforms correctly using "null-color" data`, () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    runTest(__dirname, 'toast-replace-color-variant', { quote: 'single' }, 'null-color');
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Toast component with color prop passed "undefined" or "null"'),
+    );
+  });
+
+  it(`transforms correctly using "undefined-color" data`, () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    runTest(__dirname, 'toast-replace-color-variant', { quote: 'single' }, 'undefined-color');
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Toast component with color prop passed "undefined" or "null"'),
+    );
+  });
+
+  it(`transforms correctly using "ternary-color" data`, () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    runTest(__dirname, 'toast-replace-color-variant', { quote: 'single' }, 'ternary-color');
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Toast component with color prop used a dynamic value'),
+    );
+  });
+
+  it(`transforms correctly using "variable-color" data`, () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    runTest(__dirname, 'toast-replace-color-variant', { quote: 'single' }, 'variable-color');
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Toast component with color prop used a dynamic value'),
+    );
   });
 });

--- a/packages/gestalt-codemods/45.0.0/__tests__/rename-popover-handleKeyDown-to-onKeyDown.test.js
+++ b/packages/gestalt-codemods/45.0.0/__tests__/rename-popover-handleKeyDown-to-onKeyDown.test.js
@@ -1,4 +1,4 @@
-import { defineTest } from 'jscodeshift/dist/testUtils.js';
+import { runTest } from 'jscodeshift/dist/testUtils.js';
 
 jest.mock('../rename-popover-handleKeyDown-to-onKeyDown', () =>
   Object.assign(jest.requireActual('../rename-popover-handleKeyDown-to-onKeyDown'), {
@@ -11,6 +11,12 @@ describe('rename-popover-handleKeyDown-to-onKeyDown', () => {
     'rename-popover-handleKeyDown-to-onKeyDown',
     'rename-renamed-popover-handleKeyDown-to-onKeyDown',
   ].forEach((test) => {
-    defineTest(__dirname, 'rename-popover-handleKeyDown-to-onKeyDown', { quote: 'single' }, test);
+    it(`transforms correctly using "${test}" data`, () => {
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      runTest(__dirname, 'rename-popover-handleKeyDown-to-onKeyDown', { quote: 'single' }, test);
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Popover prop handleKeyDown has being renamed to onKeyDown'),
+      );
+    });
   });
 });

--- a/packages/gestalt-codemods/future-typo-changes/__tests__/replace-typography-sizes.test.js
+++ b/packages/gestalt-codemods/future-typo-changes/__tests__/replace-typography-sizes.test.js
@@ -1,4 +1,4 @@
-import { defineTest } from 'jscodeshift/dist/testUtils.js';
+import { defineTest, runTest } from 'jscodeshift/dist/testUtils.js';
 
 jest.mock('../replace-typography-sizes', () =>
   Object.assign(jest.requireActual('../replace-typography-sizes'), {
@@ -7,7 +7,19 @@ jest.mock('../replace-typography-sizes', () =>
 );
 
 describe('replace-typography-sizes', () => {
-  ['text', 'heading', 'text-renamed', 'heading-renamed'].forEach((test) => {
+  ['text', 'heading'].forEach((test) => {
+    it(`transforms correctly using ${test} data`, () => {
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      runTest(__dirname, 'replace-typography-sizes', { quote: 'single' }, test);
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Manually check any Heading and Text non-literal properties for size and rerun codemod',
+        ),
+      );
+    });
+  });
+
+  ['text-renamed', 'heading-renamed'].forEach((test) => {
     defineTest(__dirname, 'replace-typography-sizes', { quote: 'single' }, test);
   });
 });

--- a/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
+++ b/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 import { useState } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import { I18nProvider } from 'gestalt';
 import DatePicker from './DatePicker.js';
 
@@ -10,14 +10,20 @@ const translations = {
     accessibilityShowPasswordLabel: 'Show password',
   },
 };
+const initialDate = new Date(2018, 11, 14);
 
 function renderComp(comp) {
   return render(<I18nProvider value={translations}>{comp}</I18nProvider>);
 }
 
+function DatePickerWrap() {
+  const [date, setDate] = useState(initialDate);
+
+  return <DatePicker id="fake_id" onChange={(e) => setDate(e.value)} value={date} />;
+}
+
 describe('DatePicker', () => {
   const mockOnChange = jest.fn();
-  const initialDate = new Date(2018, 11, 14);
 
   global.document.createRange = () => ({
     setStart: () => {},
@@ -60,16 +66,13 @@ describe('DatePicker', () => {
     expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ value: newDate }));
   });
 
-  test('opens and closes DatePicker popover correctly', () => {
-    function DatePickerWrap() {
-      const [date, setDate] = useState(initialDate);
-
-      return <DatePicker id="fake_id" onChange={(e) => setDate(e.value)} value={date} />;
-    }
-
+  test('opens and closes DatePicker popover correctly', async () => {
     renderComp(<DatePickerWrap />);
 
-    fireEvent.focus(screen.getByDisplayValue('12/14/2018'));
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
+    await act(async () => {
+      await fireEvent.focus(screen.getByDisplayValue('12/14/2018'));
+    });
 
     // Test correct render of DatePicker popover
     // eslint-disable-next-line testing-library/prefer-presence-queries -- Please fix the next time this file is touched!
@@ -86,23 +89,23 @@ describe('DatePicker', () => {
     // Test correct unmount of DatePicker popover
     expect(screen.getByDisplayValue('12/13/2018')).toBeInTheDocument();
 
-    fireEvent.focus(screen.getByDisplayValue('12/13/2018'));
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
+    await act(async () => {
+      await fireEvent.focus(screen.getByDisplayValue('12/13/2018'));
+    });
 
     // Test correct render of DatePicker popover
     // eslint-disable-next-line testing-library/prefer-presence-queries -- Please fix the next time this file is touched!
     expect(screen.queryByText('December 2018')).toBeInTheDocument();
   });
 
-  test('accepts entering manual dates', () => {
-    function DatePickerWrap() {
-      const [date, setDate] = useState(initialDate);
-
-      return <DatePicker id="fake_id" onChange={(e) => setDate(e.value)} value={date} />;
-    }
-
+  test('accepts entering manual dates', async () => {
     renderComp(<DatePickerWrap />);
 
-    fireEvent.focus(screen.getByDisplayValue('12/14/2018'));
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
+    await act(async () => {
+      fireEvent.focus(screen.getByDisplayValue('12/14/2018'));
+    });
 
     const selectedInput = screen.getByDisplayValue('12/14/2018');
 

--- a/packages/gestalt/src/NumberField.jsdom.test.js
+++ b/packages/gestalt/src/NumberField.jsdom.test.js
@@ -40,7 +40,7 @@ describe('NumberField', () => {
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     const input = getByDisplayValue('42');
     fireEvent.focus(input);
-    expect(input).toHaveDescription('Error message');
+    expect(input).toHaveAccessibleDescription('Error message');
   });
 
   it('forwards a ref to <input />', () => {

--- a/packages/gestalt/src/TextField.jsdom.test.js
+++ b/packages/gestalt/src/TextField.jsdom.test.js
@@ -42,7 +42,7 @@ describe('TextField', () => {
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     const input = getByDisplayValue('TextField Text');
     fireEvent.focus(input);
-    expect(input).toHaveDescription('Error message');
+    expect(input).toHaveAccessibleDescription('Error message');
   });
 
   it('forwards a ref to <input />', () => {

--- a/packages/gestalt/src/contexts/I18nProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/I18nProvider.jsdom.test.js
@@ -32,6 +32,8 @@ describe('useI18nContext', () => {
   });
 
   it('throws on unsupported component', () => {
+    const consoleMock = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
     function TestComponent() {
       // $FlowExpectedError[prop-missing]
       const { foo } = useI18nContext('Foo');
@@ -42,9 +44,18 @@ describe('useI18nContext', () => {
     expect(() => {
       render(<TestComponent />);
     }).toThrow();
+
+    expect(consoleMock).toHaveBeenCalledTimes(3);
+    expect(consoleMock.mock.calls[0][0].message).toEqual(
+      expect.stringContaining(
+        'Foo translations not available — please add translations to I18nProvider',
+      ),
+    );
   });
 
   it('provides defaults for partial missing translations for supported component', () => {
+    const consoleMock = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
     function TestComponent() {
       const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
         useI18nContext('TextField');
@@ -63,6 +74,12 @@ describe('useI18nContext', () => {
       >
         <TestComponent />
       </I18nProvider>,
+    );
+
+    expect(consoleMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'TextField prop accessibilityShowPasswordLabel is missing translations — please add translations to I18nProvider',
+      ),
     );
 
     // This is a bit roundabout — we don't really care that these strings are in the document, but that they were returned from the Hook correctly

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -2,8 +2,13 @@ import '@testing-library/jest-dom/extend-expect.js';
 // Prevents `ReferenceError: regeneratorRuntime is not defined Babel 6` error due to using async/await syntax.
 // TODO: to be replaced with @babel/plugin-transform-runtime within babel.config.js
 import 'regenerator-runtime/runtime';
-
-// Set up react testing library.
+import failOnConsole from 'jest-fail-on-console';
 import { configure } from '@testing-library/react';
 
+// Set up react testing library.
 configure({ testIdAttribute: 'data-test-id' });
+
+// Fail tests on `console` calls
+failOnConsole({
+  shouldFailOnLog: true,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10210,6 +10210,13 @@ jest-environment-node@^28.0.2:
     jest-mock "^28.0.2"
     jest-util "^28.0.2"
 
+jest-fail-on-console@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/jest-fail-on-console/-/jest-fail-on-console-2.4.2.tgz#cfe790cc592e46119a6842f127039d01f046db87"
+  integrity sha512-CdulWZvfI+cz4+dXQr6p0BhhexFjLnIIBR/7YcpzPXFxrNozAruWkEjR1RU89cd7WXYwckX5ygvHuHQa3NjbOQ==
+  dependencies:
+    chalk "^4.1.0"
+
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz"


### PR DESCRIPTION
## Summary

#### What changed?

We disallow `console.*` calls such as `console.log` / `console.error` and `console.warn` in our jest tests.

### Why?

* Clean output when you run tests. No random console message when running the tests
* Find issues: deprecated or incorrect React testing usage / invalid examples
* Make `console.*` calls explicit, so it's intentional & clear when we use them (E.g. codemod runs)

#### Before
![Screen Shot 2022-08-10 at 3 05 29 PM](https://user-images.githubusercontent.com/127199/183909256-7cff562e-a5da-42f0-9a07-ec9815d0c98e.png)

#### After
![Screen Shot 2022-08-10 at 3 06 06 PM](https://user-images.githubusercontent.com/127199/183909269-b7842175-77d7-4252-a06d-c3780781903b.png)

### Example issues found

* `Error: Uncaught [Error: Foo translations not available — please add translations to I18nProvider] `
* `Warning: toHaveDescription has been deprecated and will be removed in future updates. Please use toHaveAccessibleDescription.`
* `Warning: An update to InnerPopper inside a test was not wrapped in act(…).`

### Notes

* Now, if we do find a `console.*` which we can't get rid off, we should mock the `console.*` call. There are a few examples in this diff
* Set this to a `patch` version since no runtime code has changed (only tests)
