### PR TITLE
Docs: fix incorrect code wrapping on Masonry docs

### DIFF
--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -215,7 +215,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
     ~~~jsx
     <Masonry comp={Item} items={items} minCols={1} />
-    ~~~Pcard
+    ~~~
   `}
         name="Non-flexible item width"
       >


### PR DESCRIPTION
### Summary

#### What changed?

Fixes an issue where we saw the following the docs

```
~~~jsx

~~~Pcard
```

#### Why?

Issue was introduced at https://github.com/pinterest/gestalt/pull/2114/files#diff-3c424fdcf1b7cc45413983af04f026e91c1637527ca1d8c9cd0b74b05fb35054R220


#### Before

![Screen Shot 2022-08-11 at 9 49 25 AM](https://user-images.githubusercontent.com/127199/184088326-9313bd6c-59de-443c-bbcb-eaeed95d631b.png)

#### After
![Screen Shot 2022-08-11 at 9 49 34 AM](https://user-images.githubusercontent.com/127199/184088335-28f53001-b8e6-4677-bd23-3b1524c41f94.png)

