### PR TITLE
Masonry: add support for RTL text direction

### DIFF
--- a/packages/gestalt/src/Masonry.css
+++ b/packages/gestalt/src/Masonry.css
@@ -8,14 +8,6 @@
   composes: absolute from "./Layout.css";
 }
 
-html[dir="rtl"] .Masonry__Item {
-  right: 0;
-}
-
-html:not([dir="rtl"]) .Masonry__Item {
-  left: 0;
-}
-
 .Masonry__Item__Mounted {
   transition: transform 0.2s;
 }

--- a/packages/gestalt/src/Masonry.css
+++ b/packages/gestalt/src/Masonry.css
@@ -8,6 +8,14 @@
   composes: absolute from "./Layout.css";
 }
 
+html[dir="rtl"] .Masonry__Item {
+  right: 0;
+}
+
+html:not([dir="rtl"]) .Masonry__Item {
+  left: 0;
+}
+
 .Masonry__Item__Mounted {
   transition: transform 0.2s;
 }

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -408,8 +408,8 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
         style={{
           top: 0,
           ...(isRtl ? { right: 0 } : { left: 0 }),
-          transform: `translateX(${isRtl ? '-' : ''}${left}px) translateY(${top}px)`,
-          WebkitTransform: `translateX(${isRtl ? '-' : ''}${left}px) translateY(${top}px)`,
+          transform: `translateX(${isRtl ? left * -1 : left}px) translateY(${top}px)`,
+          WebkitTransform: `translateX(${isRtl ? left * -1 : left}px) translateY(${top}px)`,
           width: layoutNumberToCssDimension(width),
           height: layoutNumberToCssDimension(height),
         }}

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -395,6 +395,8 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       isVisible = true;
     }
 
+    const isRtl = this.gridWrapper ? getComputedStyle(this.gridWrapper).direction === 'rtl' : false;
+
     const itemComponent = (
       <div
         className={[styles.Masonry__Item, styles.Masonry__Item__Mounted].join(' ')}
@@ -403,9 +405,8 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
         role="listitem"
         style={{
           top: 0,
-          left: 0,
-          transform: `translateX(${left}px) translateY(${top}px)`,
-          WebkitTransform: `translateX(${left}px) translateY(${top}px)`,
+          transform: `translateX(${isRtl ? '-' : ''}${left}px) translateY(${top}px)`,
+          WebkitTransform: `translateX(${isRtl ? '-' : ''}${left}px) translateY(${top}px)`,
           width: layoutNumberToCssDimension(width),
           height: layoutNumberToCssDimension(height),
         }}

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -405,6 +405,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
         role="listitem"
         style={{
           top: 0,
+          ...(isRtl ? { right: 0 } : { left: 0 }),
           transform: `translateX(${isRtl ? '-' : ''}${left}px) translateY(${top}px)`,
           WebkitTransform: `translateX(${isRtl ? '-' : ''}${left}px) translateY(${top}px)`,
           width: layoutNumberToCssDimension(width),

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -395,7 +395,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       isVisible = true;
     }
 
-    const isRtl = this.gridWrapper ? getComputedStyle(this.gridWrapper).direction === 'rtl' : false;
+    const isRtl = document?.dir === 'rtl';
 
     const itemComponent = (
       <div

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -395,6 +395,8 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       isVisible = true;
     }
 
+    // This assumes `document.dir` exists, since this method is only invoked
+    // on the client. If that assumption changes, this will need to be revisited
     const isRtl = document?.dir === 'rtl';
 
     const itemComponent = (


### PR DESCRIPTION
Masonry currently does nothing in response to the user's right-to-left (RTL) settings. This doesn't really matter in full-width, infinite grids, like homefeed; the user isn't likely to even be aware if the first item is in the top left or the top right. However, this _does_ matter when the grid width is constrained, particularly if there are a finite number of items or the user is likely to be aware of the order of the items, e.g. the Homefeed Tuner (pins and topics). 
![Page_Broken_HW](https://user-images.githubusercontent.com/12059539/184262805-81eb831a-ef2e-4411-920b-d80b1efbf94f.JPG)

This PR adds logic to support laying out Masonry items right-to-left according to the computed text direction for the Masonry container. This will typically match the style set on the entire page (typically on `<html>` or `<body>`), but will also respect more "local" settings, since [the `dir` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) can be set on any HTML element.

Note that when testing this out on our docs site, you'll need to refresh after toggling the site RTL setting. We could listen for changes to `dir` and force a reflow, but that seems quite unlikely given that users typically aren't toggling that setting.