### PR TITLE
Callout: add "success", "recommendation" variants

### DIFF
--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -317,6 +317,59 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         </MainSection.Subsection>
 
         <MainSection.Subsection
+          description="Recommendation Callouts inform people of quick things they can do to improve their experience."
+          title="Recommendation"
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+<Callout
+  dismissButton={{
+    accessibilityLabel: 'Dismiss this banner',
+    onDismiss: () => {},
+  }}
+  iconAccessibilityLabel="Recommendation"
+  message="When you run ads on Pinterest, you'll find recommendations to improve them here."
+  primaryAction={{
+    accessibilityLabel: "Learn more: Ads on Pinterest",
+    href: "https://pinterest.com",
+    label: "Learn more",
+    target: "blank",
+  }}
+  title="Advertise with confidence!"
+  type="recommendation"
+/>
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          description="Success Callouts communicate confirmation regarding an action within a larger flow."
+          title="Success"
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+  <Callout
+    dismissButton={{
+      accessibilityLabel: 'Dismiss this banner',
+      onDismiss: () => {},
+    }}
+    iconAccessibilityLabel="Success"
+    message="Keep it up by using recommendations to optimize your ad spend."
+    primaryAction={{
+      accessibilityLabel: "Get started: Ad recommendations",
+      href: "https://pinterest.com",
+      label: "Get started",
+      target: "blank",
+    }}
+    title="Your ads are doing great!"
+    type="success"
+  />
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
           title="Warning"
           description="Warning Callouts communicate cautionary messages to users. Action shouldn't be required. The Callout should provide clear guidance on how to correct an issue and/or learn more about it."
         >

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -71,7 +71,7 @@ type Props = {|
   /**
    * The category of Callout. See [Variants](https://gestalt.pinterest.systems/web/callout#Variants) to learn more.
    */
-  type: 'error' | 'info' | 'warning',
+  type: 'error' | 'info' | 'recommendation' | 'success' | 'warning',
   /**
    * Brief title summarizing Callout. Content should be [localized](https://gestalt.pinterest.systems/web/callout#Localization).
    */


### PR DESCRIPTION
Add two new variants to Callout:
_success_
![Screen Shot 2022-08-11 at 5 53 52 PM](https://user-images.githubusercontent.com/12059539/184265935-3dcb7173-97bf-41d9-a51b-313348b3ca3c.png)

_recommendation_
![Screen Shot 2022-08-11 at 5 53 46 PM](https://user-images.githubusercontent.com/12059539/184265957-bbba7901-92a8-45d6-bfa1-a518a6396c53.png)