### PR TITLE
Internal: add Node.js 18 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [16]
+        node_version: [16, 18]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v2


### PR DESCRIPTION
### Summary

#### What changed?

Add Node.js 18 to Github CI's test matrix

#### Why?

Node.js 18 is becoming the LTS version on 2022-10-25 ([releases](https://nodejs.org/en/about/releases/)) so let's make sure Gestalt's tests can run on it.
