### PR TITLE
Internal: increase Node memory to solve OOM issue on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,5 @@ jobs:
         run: yarn build
       - name: Run tests
         run: yarn test
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192


### PR DESCRIPTION
My [SelectList PR](https://github.com/pinterest/gestalt/pull/2219) has been failing CI due to OOM issues on an unrelated test. Per [this Stack Overflow answer](https://stackoverflow.com/a/38560292/5253702), this PR adds the `--max-old-space-size` option to Node for the CI test run. This gets past the (low) default memory settings for Node, which were causing the OOM issue. (We can tweak this actual value in the future if needed)