### PR TITLE
Internal: run Prettier on CSS files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,5 @@
 __fixtures__
 __testfixtures__
-*.css
 build
 coverage
 dist

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -25,7 +25,6 @@
     ],
     "declaration-no-important": true,
     "function-url-quotes": "always",
-    "indentation": 2,
     "max-nesting-depth": 0,
     "media-feature-name-no-unknown": [
       true,

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -73,7 +73,6 @@ li {
   display: block;
 }
 
-
 .Markdown p {
   background-color: var(--g-colorGray0);
   margin: 0;
@@ -94,7 +93,6 @@ li {
 .Markdown ul ~ .md-hint {
   margin-left: 40px;
 }
-
 
 html[dir="rtl"] .Markdown ul + pre {
   margin-right: 40px;
@@ -119,7 +117,6 @@ html[dir="rtl"] .Markdown ul + pre {
   scroll-margin-top: 75px;
 }
 
-
 .Markdown .anchor {
   height: 14px;
   width: 14px;
@@ -134,7 +131,6 @@ html[dir="rtl"] .Markdown ul + pre {
   margin-left: 4px;
   width: 12px;
 }
-
 
 /**
  * Algolia overrides
@@ -278,7 +274,8 @@ html[dir="rtl"] .Markdown ul + pre {
   display: block;
 }
 
-@-webkit-keyframes sbx-reset-in { /* stylelint-disable-line at-rule-no-vendor-prefix */
+/* stylelint-disable-next-line at-rule-no-vendor-prefix */
+@-webkit-keyframes sbx-reset-in {
   0% {
     opacity: 0;
     transform: translate3d(-20%, 0, 0);
@@ -408,19 +405,30 @@ html[dir="rtl"] .Markdown ul + pre {
   padding: 0 0.05em;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
+.algolia-autocomplete
+  .algolia-docsearch-suggestion--text
+  .algolia-docsearch-suggestion--highlight {
   background: inherit;
   box-shadow: inset 0 -2px 0 0 rgb(69 142 225 / 0.8);
   color: inherit;
   padding: 0 0 1px;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion code .algolia-docsearch-suggestion--highlight {
+.algolia-autocomplete
+  .algolia-docsearch-suggestion
+  code
+  .algolia-docsearch-suggestion--highlight {
   background: none;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--category-header-lvl0 .algolia-docsearch-suggestion--highlight,
-.algolia-autocomplete .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--category-header-lvl1 .algolia-docsearch-suggestion--highlight {
+.algolia-autocomplete
+  .algolia-docsearch-suggestion--category-header
+  .algolia-docsearch-suggestion--category-header-lvl0
+  .algolia-docsearch-suggestion--highlight,
+.algolia-autocomplete
+  .algolia-docsearch-suggestion--category-header
+  .algolia-docsearch-suggestion--category-header-lvl1
+  .algolia-docsearch-suggestion--highlight {
   background: inherit;
   box-shadow: inset 0 -2px 0 0 rgb(69 142 225 / 0.8);
   color: inherit;
@@ -447,7 +455,11 @@ html[dir="rtl"] .Markdown ul + pre {
   width: 1px;
 }
 
-.algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion .algolia-docsearch-suggestion--content {
+.algolia-autocomplete
+  .ds-dropdown-menu
+  .ds-suggestion.ds-cursor
+  .algolia-docsearch-suggestion
+  .algolia-docsearch-suggestion--content {
   background-color: var(--g-colorTransparentGray60);
   color: #111;
 }
@@ -481,7 +493,8 @@ html[dir="rtl"] .Markdown ul + pre {
   word-wrap: break-word;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column::before {
+.algolia-autocomplete
+  .algolia-docsearch-suggestion--subcategory-column::before {
   background: #ddd;
   content: "";
   display: block;
@@ -496,11 +509,18 @@ html[dir="rtl"] .Markdown ul + pre {
   display: none;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion--no-results .algolia-docsearch-suggestion--title {
+.algolia-autocomplete
+  .algolia-docsearch-suggestion--no-results
+  .algolia-docsearch-suggestion--title {
   font-weight: normal;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion--title:not(.algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion .algolia-docsearch-suggestion--content) {
+.algolia-autocomplete
+  .algolia-docsearch-suggestion--title:not(.algolia-autocomplete
+    .ds-dropdown-menu
+    .ds-suggestion.ds-cursor
+    .algolia-docsearch-suggestion
+    .algolia-docsearch-suggestion--content) {
   color: var(--g-colorGray300);
   /* stylelint-disable-next-line unit-disallowed-list */
   font-size: 0.9em;
@@ -524,8 +544,6 @@ html[dir="rtl"] .Markdown ul + pre {
   width: 100%;
 }
 
-
-
 .algolia-autocomplete .algolia-docsearch-suggestion--no-results::before {
   display: none;
 }
@@ -540,22 +558,29 @@ html[dir="rtl"] .Markdown ul + pre {
   padding: 1px 5px;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion.algolia-docsearch-suggestion__main .algolia-docsearch-suggestion--category-header {
+.algolia-autocomplete
+  .algolia-docsearch-suggestion.algolia-docsearch-suggestion__main
+  .algolia-docsearch-suggestion--category-header {
   display: block;
 }
 
-.algolia-autocomplete .algolia-docsearch-suggestion.algolia-docsearch-suggestion__secondary {
+.algolia-autocomplete
+  .algolia-docsearch-suggestion.algolia-docsearch-suggestion__secondary {
   display: block;
 }
 
 @media all and (min-width: 768px) {
-  .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column {
+  .algolia-autocomplete
+    .algolia-docsearch-suggestion
+    .algolia-docsearch-suggestion--subcategory-column {
     display: block;
   }
 }
 
 @media all and (max-width: 768px) {
-  .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column {
+  .algolia-autocomplete
+    .algolia-docsearch-suggestion
+    .algolia-docsearch-suggestion--subcategory-column {
     color: var(--g-colorGray300);
     display: inline-block;
     float: left;
@@ -568,15 +593,21 @@ html[dir="rtl"] .Markdown ul + pre {
     width: auto;
   }
 
-  .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column::before {
+  .algolia-autocomplete
+    .algolia-docsearch-suggestion
+    .algolia-docsearch-suggestion--subcategory-column::before {
     display: none;
   }
 
-  .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column::after {
+  .algolia-autocomplete
+    .algolia-docsearch-suggestion
+    .algolia-docsearch-suggestion--subcategory-column::after {
     content: "|";
   }
 
-  .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--content {
+  .algolia-autocomplete
+    .algolia-docsearch-suggestion
+    .algolia-docsearch-suggestion--content {
     display: inline-block;
     float: left;
     padding: 0;
@@ -584,11 +615,15 @@ html[dir="rtl"] .Markdown ul + pre {
     width: auto;
   }
 
-  .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--content.algolia-docsearch-suggestion--no-results {
+  .algolia-autocomplete
+    .algolia-docsearch-suggestion
+    .algolia-docsearch-suggestion--content.algolia-docsearch-suggestion--no-results {
     padding: 16px 0;
   }
 
-  .algolia-autocomplete .algolia-docsearch-suggestion .algolia-docsearch-suggestion--content::before {
+  .algolia-autocomplete
+    .algolia-docsearch-suggestion
+    .algolia-docsearch-suggestion--content::before {
     display: none;
   }
 
@@ -675,14 +710,21 @@ html[dir="rtl"] .Markdown ul + pre {
 }
 
 @media (prefers-reduced-motion) {
-  .animation-1, .animation-2, .animation-3, .animation-4, .animation-5, .animation-6, .animation-draw {
+  .animation-1,
+  .animation-2,
+  .animation-3,
+  .animation-4,
+  .animation-5,
+  .animation-6,
+  .animation-draw {
     animation: none;
     opacity: 1;
-    stroke-dasharray: 8,8;
+    stroke-dasharray: 8, 8;
   }
 }
 
-.Markdown code.language-jsx, .Markdown code.language-bash, .Markdown pre.language-bash code {
+.Markdown code.language-jsx,
+.Markdown code.language-bash,
+.Markdown pre.language-bash code {
   background-color: var(--g-colorGray0);
 }
-

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -102,7 +102,9 @@ to prevent conflict with another CSS module */
   border-top-right-radius: var(--g-borderRadius-circle);
 }
 
-:global ._gestalt .react-datepicker__day--in-range:not(.react-datepicker__day--selected):hover::before {
+:global
+  ._gestalt
+  .react-datepicker__day--in-range:not(.react-datepicker__day--selected):hover::before {
   background: var(--g-colorTransparentGray60);
   border-radius: 0;
   content: "";
@@ -133,7 +135,9 @@ to prevent conflict with another CSS module */
   position: relative;
 }
 
-:global ._gestalt .react-datepicker__day--range-start:not(:last-child):not(.react-datepicker__day--range-end)::before {
+:global
+  ._gestalt
+  .react-datepicker__day--range-start:not(:last-child):not(.react-datepicker__day--range-end)::before {
   background: var(--g-colorTransparentGray60);
   border-radius: var(--g-borderRadius-halfCircle-Start);
   content: "";
@@ -175,7 +179,9 @@ to prevent conflict with another CSS module */
   position: relative;
 }
 
-:global ._gestalt .react-datepicker__day--range-end:not(:first-child):not(.react-datepicker__day--range-start)::before {
+:global
+  ._gestalt
+  .react-datepicker__day--range-end:not(:first-child):not(.react-datepicker__day--range-start)::before {
   background: var(--g-colorTransparentGray60);
   border-radius: var(--g-borderRadius-halfCircle-End);
   content: "";
@@ -211,8 +217,12 @@ to prevent conflict with another CSS module */
   z-index: -1;
 }
 
-:global ._gestalt .react-datepicker__day--selecting-range-start:not(.react-datepicker__day--in-range):not(.react-datepicker__day--highlighted),
-:global ._gestalt .react-datepicker__day--selecting-range-end:not(.react-datepicker__day--in-range):not(.react-datepicker__day--highlighted) {
+:global
+  ._gestalt
+  .react-datepicker__day--selecting-range-start:not(.react-datepicker__day--in-range):not(.react-datepicker__day--highlighted),
+:global
+  ._gestalt
+  .react-datepicker__day--selecting-range-end:not(.react-datepicker__day--in-range):not(.react-datepicker__day--highlighted) {
   background-color: var(--g-colorTransparentGray60);
 }
 
@@ -302,12 +312,14 @@ to prevent conflict with another CSS module */
   width: 100%;
 }
 
-
 html[dir="rtl"] :global ._gestalt .react-datepicker__navigation--previous {
   right: 8px;
 }
 
-html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--previous {
+html:not([dir="rtl"])
+  :global
+  ._gestalt
+  .react-datepicker__navigation--previous {
   left: 8px;
 }
 
@@ -372,6 +384,3 @@ html[dir="rtl"] .calendarIcon {
 html:not([dir="rtl"]) .calendarIcon {
   right: 0;
 }
-
-
-

--- a/packages/gestalt/src/Badge.css
+++ b/packages/gestalt/src/Badge.css
@@ -2,7 +2,7 @@
   composes: antialiased sansSerif from "./Typography.css";
   composes: inlineBlock from "./Layout.css";
   composes: rounding1 from "./Borders.css";
-  composes: fontWeightSemiBold from './Typography.css';
+  composes: fontWeightSemiBold from "./Typography.css";
   color: var(--color-text-inverse);
   font-size: 10px;
   height: min-content;

--- a/packages/gestalt/src/Borders.css
+++ b/packages/gestalt/src/Borders.css
@@ -3,7 +3,6 @@
   --g-border-width-lg: 2px;
 }
 
-
 /* Border lines */
 
 .border {

--- a/packages/gestalt/src/Dropdown.css
+++ b/packages/gestalt/src/Dropdown.css
@@ -1,7 +1,7 @@
 .DropdownSection {
-  width: 100%
+  width: 100%;
 }
 
-.DropdownSection:not(:first-child){
+.DropdownSection:not(:first-child) {
   margin-top: 16px;
 }

--- a/packages/gestalt/src/InternalTextField.css
+++ b/packages/gestalt/src/InternalTextField.css
@@ -10,7 +10,8 @@
   color: var(--g-colorGray200);
 }
 
-.unstyledTextField, .textFieldSpacer {
+.unstyledTextField,
+.textFieldSpacer {
   composes: unstyled from "./FormElement.css";
   composes: Text from "./Text.css";
   composes: fontSize300 from "./Typography.css";

--- a/packages/gestalt/src/SearchField.css
+++ b/packages/gestalt/src/SearchField.css
@@ -70,4 +70,3 @@ html:not([dir="rtl"]) .clear {
 html[dir="rtl"] .clear {
   left: var(--space-0);
 }
-

--- a/packages/gestalt/src/SelectList.css
+++ b/packages/gestalt/src/SelectList.css
@@ -1,5 +1,5 @@
 .select {
-  composes: Text  from "./Text.css";
+  composes: Text from "./Text.css";
   composes: fontSize300 from "./Typography.css";
   composes: darkGray from "./Colors.css";
   composes: pointer from "./Cursor.css";

--- a/packages/gestalt/src/Sheet.css
+++ b/packages/gestalt/src/Sheet.css
@@ -2,7 +2,7 @@
   from {
     transform: translateX(100%);
   }
-  
+
   to {
     transform: translateX(0%);
   }

--- a/packages/gestalt/src/TextArea.css
+++ b/packages/gestalt/src/TextArea.css
@@ -12,7 +12,8 @@
   color: var(--g-colorGray200);
 }
 
-.unstyledTextArea, .textAreaSpacer {
+.unstyledTextArea,
+.textAreaSpacer {
   composes: unstyled from "./FormElement.css";
   composes: Text from "./Text.css";
   composes: fontSize300 from "./Typography.css";

--- a/packages/gestalt/src/Toast.css
+++ b/packages/gestalt/src/Toast.css
@@ -1,7 +1,9 @@
 .textColorOverrideLight * {
-  color: var(--color-text-light) !important; /* stylelint-disable-line declaration-no-important */
+  /* stylelint-disable-next-line declaration-no-important */
+  color: var(--color-text-light) !important;
 }
 
 .textColorOverrideDark * {
-  color: var(--color-text-dark) !important; /* stylelint-disable-line declaration-no-important */
+  /* stylelint-disable-next-line declaration-no-important */
+  color: var(--color-text-dark) !important;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16212,7 +16212,7 @@ stylehacks@^4.0.0:
 
 stylelint-config-prettier@^9.0.3:
   version "9.0.3"
-  resolved "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz"
+  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz#0dccebeff359dcc393c9229184408b08964d561c"
   integrity sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==
 
 stylelint-config-recommended@^6.0.0:


### PR DESCRIPTION
# Summary

## What changed?

Use [Prettier](https://prettier.io/) on our CSS files

## Why?

* Consistent formatting across all of our codebase (JS & md already uses prettier

## Notes

* We already had [stylelint-config-prettier](https://www.npmjs.com/package/stylelint-config-prettier) installed but never used it.
