### PR TITLE
Internal: lint for array Flow type syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,8 @@
   },
   "rules": {
     "eslint-comments/no-unused-disable": "error",
+    "flowtype/array-style-complex-type": ["error", "verbose"],
+    "flowtype/array-style-simple-type": ["error", "verbose"],
     "flowtype/no-mutable-array": "error",
     "flowtype/require-exact-type": ["error", "always"],
     "flowtype/require-valid-file-annotation": [

--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -33,7 +33,7 @@ export default function MarkdownPage({ children, meta, pageSourceUrl }: Props): 
   const components = {
     small: (props) => <Text size="100">{props.children}</Text>,
     pre: (props: {|
-      children: {| props: {| className: string[], children: string | null |} |},
+      children: {| props: {| className: Array<string>, children: string | null |} |},
     |}) => (
       <Highlighter classNames={props.children.props.className}>
         {props.children.props.children}

--- a/docs/docs-components/highlight.js
+++ b/docs/docs-components/highlight.js
@@ -6,7 +6,7 @@ import 'highlight.js/styles/a11y-light.css';
 
 type Props = {|
   children: string | null,
-  classNames: string[],
+  classNames: Array<string>,
 |};
 
 export default function Highlighter({ children, classNames }: Props): React$Element<'pre'> {

--- a/docs/pages/[id].js
+++ b/docs/pages/[id].js
@@ -60,7 +60,7 @@ export async function getStaticProps(context: {| params: {| id: string |} |}): P
 }
 
 export async function getStaticPaths(): Promise<{|
-  paths: {| params: {| id: string |} |}[],
+  paths: Array<{| params: {| id: string |} |}>,
   fallback: boolean,
 |}> {
   // get all the paths that exist within ./markdown folder


### PR DESCRIPTION
Flow has two ways to declare an array type: "verbose" (`Array<string>`) or "shorthand" (`string[]`). For consistency, we should stick with one syntax across the repo. This PR adds a couple of [eslint rules](https://github.com/gajus/eslint-plugin-flowtype#array-style-complex-type) to enforce the verbose style, matching Pinboard's settings.