### PR TITLE
Internal: remove commented-out lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,6 @@
     "flowtype/define-flow-type": "error",
     "flowtype/no-mutable-array": "error",
     "flowtype/no-types-missing-file-annotation": "error",
-    "flowtype/no-weak-types": "error",
     "flowtype/require-exact-type": ["error", "always"],
     "flowtype/require-valid-file-annotation": [
       "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,7 @@
     "flowtype/define-flow-type": "error",
     "flowtype/no-mutable-array": "error",
     "flowtype/no-types-missing-file-annotation": "error",
-    // "flowtype/no-weak-types": "error", #to-be-enabled rjames will do this in follow-up PR
+    "flowtype/no-weak-types": "error",
     "flowtype/require-exact-type": ["error", "always"],
     "flowtype/require-valid-file-annotation": [
       "error",


### PR DESCRIPTION
We don't seem to need `flowtype/no-weak-types` — this rule duplicates errors already thrown by Flow, without providing any additional safety that I can tell.