### PR TITLE
Fix: Adding MD Config Back to Prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -17,6 +17,12 @@
         "parser": "css",
         "singleQuote": false
       }
+    },
+    {
+      "files": "*.md",
+      "options": {
+        "parser": "markdown"
+      }
     }
   ]
 }


### PR DESCRIPTION
This is a fix for the release breaking.

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/5509813/186029386-c6837f68-ee69-42fb-a280-dc5df5f1abca.png">

Even though we're ignoring Markdown files, it seems that this portion of the config is necessary to not cause the release step to stop working.

This should fix it.