### PR TITLE
Docs: Update mobile spacing with new Flex gap

### DIFF
--- a/docs/pages/foundations/color/palette.js
+++ b/docs/pages/foundations/color/palette.js
@@ -80,6 +80,7 @@ export default function ColorPage(): Node {
             row: 4,
             column: 0,
           }}
+          wrap
         >
           <ColorSchemeCard colorScheme="light">
             <ColorTile

--- a/docs/pages/foundations/color/usage.js
+++ b/docs/pages/foundations/color/usage.js
@@ -14,8 +14,9 @@ function ColorSchemeLayout({ children }: ColorCardProps): Node {
     <Flex
       gap={{
         row: 4,
-        column: 0,
+        column: 4,
       }}
+      wrap
     >
       {['light', 'dark'].map((scheme) => (
         <ColorSchemeProvider key={scheme} colorScheme={scheme} id={scheme}>
@@ -77,7 +78,7 @@ export default function ColorUsagePage(): Node {
         <Flex
           gap={{
             row: 2,
-            column: 0,
+            column: 2,
           }}
         >
           <ColorSchemeLayout>

--- a/docs/pages/foundations/color/usage.js
+++ b/docs/pages/foundations/color/usage.js
@@ -11,13 +11,7 @@ type ColorCardProps = {|
 |};
 function ColorSchemeLayout({ children }: ColorCardProps): Node {
   return (
-    <Flex
-      gap={{
-        row: 4,
-        column: 4,
-      }}
-      wrap
-    >
+    <Flex gap={4} wrap>
       {['light', 'dark'].map((scheme) => (
         <ColorSchemeProvider key={scheme} colorScheme={scheme} id={scheme}>
           <Box padding={4} color="default">
@@ -75,12 +69,7 @@ export default function ColorUsagePage(): Node {
         **$color-background-primary-base** - Use when conveying a primary action.
         **$color-background-brand** - Use when a background color is needed to signify the Pinterest brand.        `}
       >
-        <Flex
-          gap={{
-            row: 2,
-            column: 2,
-          }}
-        >
+        <Flex gap={2}>
           <ColorSchemeLayout>
             <ColorTile
               description="Primary base"

--- a/docs/pages/foundations/data_visualization/palette.js
+++ b/docs/pages/foundations/data_visualization/palette.js
@@ -75,7 +75,7 @@ export default function ColorPage(): Node {
                 wrap
                 gap={{
                   row: 4,
-                  column: 0,
+                  column: 8,
                 }}
               >
                 <Flex
@@ -139,7 +139,7 @@ export default function ColorPage(): Node {
                 wrap
                 gap={{
                   row: 4,
-                  column: 0,
+                  column: 8,
                 }}
                 flex="none"
               >
@@ -202,7 +202,7 @@ export default function ColorPage(): Node {
         name="Semantic colors"
         description="Semantic colors are used to indicate trends in performance data. For successful trends, we use a slightly darker green color for text or icons associated with data to ensure the text has enough contrast."
       >
-        <Flex>
+        <Flex wrap gap={4}>
           <SemanticThemeExample colorScheme="light" />
           <SemanticThemeExample colorScheme="dark" />
         </Flex>

--- a/docs/pages/foundations/data_visualization/usage.js
+++ b/docs/pages/foundations/data_visualization/usage.js
@@ -70,13 +70,7 @@ export default function ColorPage(): Node {
             column: 4,
           }}
         >
-          <Flex
-            wrap
-            gap={{
-              row: 4,
-              column: 4,
-            }}
-          >
+          <Flex wrap gap={4}>
             <Flex
               direction="column"
               gap={{
@@ -230,13 +224,7 @@ export default function ColorPage(): Node {
         - for lines or small points under normal vision
         - for large areas under red-green or yellow-blue color blindness`}
       >
-        <Flex
-          gap={{
-            row: 6,
-            column: 6,
-          }}
-          wrap
-        >
+        <Flex gap={6} wrap>
           <Flex
             direction="column"
             gap={{

--- a/docs/pages/foundations/data_visualization/usage.js
+++ b/docs/pages/foundations/data_visualization/usage.js
@@ -74,29 +74,27 @@ export default function ColorPage(): Node {
             wrap
             gap={{
               row: 4,
-              column: 0,
+              column: 4,
             }}
           >
-            <Box marginBottom={4}>
-              <Flex
-                direction="column"
-                gap={{
-                  row: 0,
-                  column: 1,
-                }}
-              >
-                <ColorTile
-                  textColor="inverse"
-                  description="Success (Graph)"
-                  fullTokenName="color-data-visualization-success-graph"
-                />
-                <ColorTile
-                  textColor="inverse"
-                  description="Success (Text/Icon)"
-                  fullTokenName="color-data-visualization-success-text"
-                />
-              </Flex>
-            </Box>
+            <Flex
+              direction="column"
+              gap={{
+                row: 0,
+                column: 1,
+              }}
+            >
+              <ColorTile
+                textColor="inverse"
+                description="Success (Graph)"
+                fullTokenName="color-data-visualization-success-graph"
+              />
+              <ColorTile
+                textColor="inverse"
+                description="Success (Text/Icon)"
+                fullTokenName="color-data-visualization-success-text"
+              />
+            </Flex>
             <ColorTile
               textColor="inverse"
               description="Error (Graph and Text)"
@@ -235,7 +233,7 @@ export default function ColorPage(): Node {
         <Flex
           gap={{
             row: 6,
-            column: 0,
+            column: 6,
           }}
           wrap
         >
@@ -322,7 +320,7 @@ export default function ColorPage(): Node {
             <Flex
               direction="column"
               gap={{
-                row: 0,
+                row: 2,
                 column: 1,
               }}
             >
@@ -331,20 +329,17 @@ export default function ColorPage(): Node {
                 description="Data Visualization 08"
                 fullTokenName="color-data-visualization-08"
               />
-              {/* Margin bottom used for spacing when these columns wrap */}
-              <Box marginBottom={6}>
-                <ColorTile
-                  textColor="inverse"
-                  description="Data Visualization 11"
-                  fullTokenName="color-data-visualization-11"
-                />
-              </Box>
+              <ColorTile
+                textColor="inverse"
+                description="Data Visualization 11"
+                fullTokenName="color-data-visualization-11"
+              />
             </Flex>
           </Flex>
           <Flex
             direction="column"
             gap={{
-              row: 0,
+              row: 2,
               column: 6,
             }}
           >

--- a/docs/pages/foundations/elevation.js
+++ b/docs/pages/foundations/elevation.js
@@ -80,7 +80,7 @@ export default function ColorUsagePage(): Node {
             <Flex
               gap={{
                 row: 4,
-                column: 0,
+                column: 8,
               }}
               wrap
             >
@@ -141,7 +141,7 @@ export default function ColorUsagePage(): Node {
             <Flex
               gap={{
                 row: 4,
-                column: 0,
+                column: 8,
               }}
               wrap
             >
@@ -169,7 +169,7 @@ export default function ColorUsagePage(): Node {
             <Flex
               gap={{
                 row: 4,
-                column: 0,
+                column: 8,
               }}
               wrap
             >
@@ -226,7 +226,7 @@ export default function ColorUsagePage(): Node {
           <Flex
             gap={{
               row: 4,
-              column: 0,
+              column: 8,
             }}
             wrap
           >
@@ -281,7 +281,7 @@ export default function ColorUsagePage(): Node {
           <Flex
             gap={{
               row: 4,
-              column: 0,
+              column: 8,
             }}
             wrap
           >

--- a/docs/pages/foundations/iconography/usage.js
+++ b/docs/pages/foundations/iconography/usage.js
@@ -62,14 +62,7 @@ export default function IconographyPage(): Node {
       />
 
       <MainSection name="Principles">
-        <Flex
-          gap={{
-            row: 12,
-            column: 12,
-          }}
-          alignContent="between"
-          wrap
-        >
+        <Flex gap={12} alignContent="between" wrap>
           <Flex.Item flex="grow" flexBasis="0%" minWidth={275} maxWidth="45%">
             <PrincipleItem
               color="purple-mysticool-100"

--- a/docs/pages/foundations/iconography/usage.js
+++ b/docs/pages/foundations/iconography/usage.js
@@ -65,7 +65,7 @@ export default function IconographyPage(): Node {
         <Flex
           gap={{
             row: 12,
-            column: 0,
+            column: 12,
           }}
           alignContent="between"
           wrap

--- a/docs/pages/foundations/messaging/principles.js
+++ b/docs/pages/foundations/messaging/principles.js
@@ -58,14 +58,7 @@ export default function MessagingPrinciples(): Node {
 A message is different from a status indicator in that it includes a more detailed written explanation.`}
       />
       <MainSection name="Principles">
-        <Flex
-          gap={{
-            row: 12,
-            column: 12,
-          }}
-          alignContent="between"
-          wrap
-        >
+        <Flex gap={12} alignContent="between" wrap>
           <Flex.Item flex="grow" flexBasis="0%" minWidth={275} maxWidth="45%">
             <PrincipleItem
               color="purple-mysticool-450"

--- a/docs/pages/foundations/messaging/principles.js
+++ b/docs/pages/foundations/messaging/principles.js
@@ -61,7 +61,7 @@ A message is different from a status indicator in that it includes a more detail
         <Flex
           gap={{
             row: 12,
-            column: 0,
+            column: 12,
           }}
           alignContent="between"
           wrap

--- a/docs/pages/foundations/typography/guidelines.js
+++ b/docs/pages/foundations/typography/guidelines.js
@@ -69,14 +69,7 @@ export default function TypographyPage(): Node {
       />
 
       <MainSection name="Principles">
-        <Flex
-          gap={{
-            row: 12,
-            column: 12,
-          }}
-          alignContent="between"
-          wrap
-        >
+        <Flex gap={12} alignContent="between" wrap>
           <Flex.Item flex="grow" flexBasis="0%" minWidth={275} maxWidth="45%">
             <PrincipleItem
               color="teal-spabattical-100"

--- a/docs/pages/foundations/typography/guidelines.js
+++ b/docs/pages/foundations/typography/guidelines.js
@@ -72,7 +72,7 @@ export default function TypographyPage(): Node {
         <Flex
           gap={{
             row: 12,
-            column: 0,
+            column: 12,
           }}
           alignContent="between"
           wrap
@@ -252,7 +252,7 @@ We use browser defaults on web UIs so that lines of text are readable in all lan
           <Flex
             gap={{
               row: 4,
-              column: 0,
+              column: 8,
             }}
             width="100%"
             wrap
@@ -401,53 +401,61 @@ Line height is automatically determined by a font’s size. For more info, refer
           <Flex
             gap={{
               row: 4,
-              column: 0,
+              column: 10,
             }}
             wrap
           >
-            <Flex.Item flex="shrink" flexBasis={244}>
-              <Box color="infoWeak" marginBottom={4}>
-                <AlignmentCenter />
-              </Box>
-            </Flex.Item>
             <Flex
-              direction="column"
               gap={{
-                row: 0,
-                column: 2,
+                row: 4,
+                column: 0,
               }}
-              maxWidth={420}
+              wrap
             >
-              <Heading size="300" accessibilityLevel={4}>
-                Centered
-              </Heading>
-              <Markdown text="Use center-aligned text for very short blocks of content, like text inside of buttons or tabs." />
+              <Flex.Item flex="shrink" flexBasis={244}>
+                <Box color="infoWeak" marginBottom={4}>
+                  <AlignmentCenter />
+                </Box>
+              </Flex.Item>
+              <Flex
+                direction="column"
+                gap={{
+                  row: 0,
+                  column: 2,
+                }}
+                maxWidth={420}
+              >
+                <Heading size="300" accessibilityLevel={4}>
+                  Centered
+                </Heading>
+                <Markdown text="Use center-aligned text for very short blocks of content, like text inside of buttons or tabs." />
+              </Flex>
             </Flex>
-          </Flex>
-          <Flex
-            gap={{
-              row: 4,
-              column: 0,
-            }}
-            wrap
-          >
-            <Flex.Item flex="shrink" flexBasis={244}>
-              <Box color="infoWeak" marginBottom={4}>
-                <AlignmentEnd />
-              </Box>
-            </Flex.Item>
             <Flex
-              direction="column"
               gap={{
-                row: 0,
-                column: 2,
+                row: 4,
+                column: 0,
               }}
-              maxWidth={420}
+              wrap
             >
-              <Heading size="300" accessibilityLevel={4}>
-                End-aligned
-              </Heading>
-              <Markdown text="End-align integers in tables so that they are easy to compare." />
+              <Flex.Item flex="shrink" flexBasis={244}>
+                <Box color="infoWeak" marginBottom={4}>
+                  <AlignmentEnd />
+                </Box>
+              </Flex.Item>
+              <Flex
+                direction="column"
+                gap={{
+                  row: 0,
+                  column: 2,
+                }}
+                maxWidth={420}
+              >
+                <Heading size="300" accessibilityLevel={4}>
+                  End-aligned
+                </Heading>
+                <Markdown text="End-align integers in tables so that they are easy to compare." />
+              </Flex>
             </Flex>
           </Flex>
         </MainSection.Subsection>


### PR DESCRIPTION
### Summary

#### What changed?

Now that gap on Flex can be specified for both directions, we remove some outdated code and update spacing where needed

#### Why?

In some places we used marginBottom to help spacing after wrapping, in other places we just had bad spacing. This alleviates the spacing in many Foundations pages when rendered on Mobile


Before:
<img width="490" alt="Screen Shot 2022-08-23 at 11 35 13 PM" src="https://user-images.githubusercontent.com/5125094/186277979-f81f034a-2229-4ff5-9ac9-302548a47bea.png">

After
<img width="494" alt="Screen Shot 2022-08-23 at 11 34 50 PM" src="https://user-images.githubusercontent.com/5125094/186277974-7f288cbb-48aa-41bd-9662-52fcbeb32c0f.png">


