### PR TITLE
Internal: use immutable arrays in docs components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -110,8 +110,7 @@
     {
       "files": ["docs/**/*.js"],
       "rules": {
-        "import/no-relative-parent-imports": "off",
-        "flowtype/no-mutable-array": "off"
+        "import/no-relative-parent-imports": "off"
       }
     },
     {

--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -74,7 +74,7 @@ import Layouts from '../graphics/foundations/layouts.svg';
 import ScreenSizes from '../graphics/foundations/screen-size.svg';
 import { type ListItemType } from '../pages/web/overview.js';
 
-const FOUNDATION_GUIDELINES_LIST: Array<ListItemType> = [
+const FOUNDATION_GUIDELINES_LIST: $ReadOnlyArray<ListItemType> = [
   {
     svg: <Accessibility />,
     name: 'Accessibility',
@@ -144,7 +144,7 @@ const FOUNDATION_GUIDELINES_LIST: Array<ListItemType> = [
   },
 ];
 
-const GENERAL_COMPONENT_LIST: Array<ListItemType> = [
+const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
   {
     svg: <ActivationCard />,
     name: 'ActivationCard',
@@ -1248,7 +1248,7 @@ const GENERAL_COMPONENT_LIST: Array<ListItemType> = [
   },
 ];
 
-const BUILDING_BLOCKS_LIST: Array<ListItemType> = [
+const BUILDING_BLOCKS_LIST: $ReadOnlyArray<ListItemType> = [
   {
     svg: <Box />,
     name: 'Box',
@@ -1523,7 +1523,7 @@ const BUILDING_BLOCKS_LIST: Array<ListItemType> = [
   },
 ];
 
-const FIGMA_ONLY_LIST: Array<ListItemType> = [
+const FIGMA_ONLY_LIST: $ReadOnlyArray<ListItemType> = [
   {
     svg: <svg />,
     name: 'BoardRep',
@@ -1618,7 +1618,7 @@ const FIGMA_ONLY_LIST: Array<ListItemType> = [
   },
 ];
 
-const UTILITIES_LIST: Array<ListItemType> = [
+const UTILITIES_LIST: $ReadOnlyArray<ListItemType> = [
   {
     svg: <HookFocusVisible />,
     name: 'useFocusVisible',
@@ -1718,11 +1718,11 @@ const UTILITIES_LIST: Array<ListItemType> = [
 ];
 
 const COMPONENT_DATA_MAP: {|
-  buildingBlockComponents: Array<ListItemType>,
-  generalComponents: Array<ListItemType>,
-  utilityComponents: Array<ListItemType>,
-  figmaOnlyComponents: Array<ListItemType>,
-  foundations: Array<ListItemType>,
+  buildingBlockComponents: $ReadOnlyArray<ListItemType>,
+  generalComponents: $ReadOnlyArray<ListItemType>,
+  utilityComponents: $ReadOnlyArray<ListItemType>,
+  figmaOnlyComponents: $ReadOnlyArray<ListItemType>,
+  foundations: $ReadOnlyArray<ListItemType>,
 |} = {
   buildingBlockComponents: BUILDING_BLOCKS_LIST,
   generalComponents: GENERAL_COMPONENT_LIST,

--- a/docs/docs-components/MainSectionCard.js
+++ b/docs/docs-components/MainSectionCard.js
@@ -21,7 +21,7 @@ type Props = {|
   shadeColor?: 'tertiary' | 'darkWash' | 'lightWash' | 'default',
   shaded?: boolean,
   showCode?: boolean,
-  title?: string | Array<string>,
+  title?: string | $ReadOnlyArray<string>,
   type?: 'do' | "don't" | 'info',
   marginBottom?: 'default' | 'none',
 |};

--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -33,7 +33,7 @@ type Props = {|
 const components = {
   small: (props) => <Text size="100">{props.children}</Text>,
   pre: (props: {|
-    children: {| props: {| className: Array<string>, children: string | null |} |},
+    children: {| props: {| className: $ReadOnlyArray<string>, children: string | null |} |},
   |}) => (
     <Highlighter classNames={props.children.props.className}>
       {props.children.props.children}

--- a/docs/docs-components/PropTable.js
+++ b/docs/docs-components/PropTable.js
@@ -8,7 +8,7 @@ import Markdown from './Markdown.js';
 
 const unifyQuotes = (input) => input?.replace(/'/g, '"');
 
-function Description(lines: Array<string>): Node {
+function Description(lines: $ReadOnlyArray<string>): Node {
   return (
     <Flex
       alignItems="start"
@@ -86,16 +86,16 @@ const transformDefaultValue = (input) => {
   return input;
 };
 
-const sortBy = (list, fn) => list.sort((a, b) => fn(a).localeCompare(fn(b)));
+const sortBy = (list, fn) => [...list].sort((a, b) => fn(a).localeCompare(fn(b)));
 
 type Props = {|
   // $FlowFixMe[unclear-type]
   Component?: ComponentType<any>,
   id?: string,
   name?: string,
-  props: Array<{|
+  props: $ReadOnlyArray<{|
     defaultValue?: boolean | string | number | null,
-    description?: string | Array<string>,
+    description?: string | $ReadOnlyArray<string>,
     href?: string,
     name: string,
     nullable?: boolean,

--- a/docs/docs-components/ResourcesFooter.js
+++ b/docs/docs-components/ResourcesFooter.js
@@ -53,7 +53,7 @@ const engResources = [
 ];
 
 type LinkListProps = {|
-  items: Array<{|
+  items: $ReadOnlyArray<{|
     title: string,
     url: string,
     a11yLabel?: string,

--- a/docs/docs-components/Toc.js
+++ b/docs/docs-components/Toc.js
@@ -64,7 +64,7 @@ function useThrottledOnScroll(callback, delay) {
 }
 
 type Props = {|
-  cards: Array<Node>,
+  cards: $ReadOnlyArray<Node>,
 |};
 
 export default function Toc({ cards }: Props): Node {

--- a/docs/docs-components/docgen.js
+++ b/docs/docs-components/docgen.js
@@ -27,7 +27,11 @@ export default function docgen({ componentName }: {| componentName: string |}): 
   return metadata[componentName];
 }
 
-export function multipledocgen({ componentName }: {| componentName: Array<string> | string |}): {|
+export function multipledocgen({
+  componentName,
+}: {|
+  componentName: $ReadOnlyArray<string> | string,
+|}): {|
   [string]: DocGen,
 |} {
   return Array.isArray(componentName)

--- a/docs/docs-components/handleCodeSandbox.js
+++ b/docs/docs-components/handleCodeSandbox.js
@@ -17,7 +17,7 @@ ${code}
 
 export default Demo;`;
 
-const dedupeArray = <T>(arr: Array<T>): Array<T> => [...new Set(arr)];
+const dedupeArray = <T>(arr: $ReadOnlyArray<T>): $ReadOnlyArray<T> => [...new Set(arr)];
 
 const handleCodeSandbox = async ({ code, title }: {| code: string, title: string |}) => {
   const gestaltComponents = Object.keys(gestalt);

--- a/docs/docs-components/highlight.js
+++ b/docs/docs-components/highlight.js
@@ -6,7 +6,7 @@ import 'highlight.js/styles/a11y-light.css';
 
 type Props = {|
   children: string | null,
-  classNames: Array<string>,
+  classNames: $ReadOnlyArray<string>,
 |};
 
 export default function Highlighter({ children, classNames }: Props): React$Element<'pre'> {

--- a/docs/docs-components/siteIndex.js
+++ b/docs/docs-components/siteIndex.js
@@ -2,7 +2,7 @@
 
 export type siteIndexType = {|
   sectionName: string,
-  pages: Array<string | siteIndexType>,
+  pages: $ReadOnlyArray<string | siteIndexType>,
 |};
 
 // siteIndex is the source of truth for the side navigation menu.
@@ -16,7 +16,7 @@ export type siteIndexType = {|
 //    >>> page 2
 //    >>> page 3
 // Any new section/page must be added to siteIndex to be displayed.
-const siteIndex: Array<siteIndexType> = [
+const siteIndex: $ReadOnlyArray<siteIndexType> = [
   {
     sectionName: 'Get started',
     pages: [

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -4,13 +4,13 @@
 type WebpackConfig = {|
   watchOptions: {| poll: number | false |},
   module: {|
-    rules: Array<{test: RegExp, use: string}>
+    rules: $ReadOnlyArray<{test: RegExp, use: string}>
   |},
   resolve: {fallback: { fs: false, path: false }}
 |};
 
 type RedirectsReturn = Promise<
-  Array<{|
+  $ReadOnlyArray<{|
     source: string,
     destination: string,
     permanent: boolean,

--- a/docs/pages/[...id].js
+++ b/docs/pages/[...id].js
@@ -42,7 +42,9 @@ export default function DocumentPage({ content, meta, pageSourceUrl }: Props): N
   );
 }
 
-export async function getStaticProps(context: {| params: {| id: Array<string> |} |}): Promise<{|
+export async function getStaticProps(context: {|
+  params: {| id: $ReadOnlyArray<string> |},
+|}): Promise<{|
   props: {| meta: { [key: string]: string }, content: {||}, pageSourceUrl: string |},
 |}> {
   const { id } = context.params;
@@ -64,7 +66,7 @@ export async function getStaticProps(context: {| params: {| id: Array<string> |}
 }
 
 export async function getStaticPaths(): Promise<{|
-  paths: Array<{| params: {| id: string | Array<string> |} |}>,
+  paths: $ReadOnlyArray<{| params: {| id: string | $ReadOnlyArray<string> |} |}>,
   fallback: boolean,
 |}> {
   // get all the possible paths that exist within ./markdown folder

--- a/docs/pages/roadmap/whats_new.js
+++ b/docs/pages/roadmap/whats_new.js
@@ -12,7 +12,7 @@ const POST_WIDTH_PX = 600;
 const POST_IMAGE_HEIGHT_PX = 340;
 
 type PostProps = {|
-  audience: Array<string>,
+  audience: $ReadOnlyArray<string>,
   content: string,
   imageAltText?: string,
   imageSrc?: string,

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -23,55 +23,52 @@ type Pin = {|
 |};
 
 type State = {|
-  pins: Array<Pin>,
+  pins: $ReadOnlyArray<Pin>,
   width: number,
 |};
-
-const pins = [
-  {
-    color: '#2b3938',
-    height: 316,
-    src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
-    width: 474,
-    name: 'the Hang Son Doong cave in Vietnam',
-  },
-  {
-    color: '#8e7439',
-    height: 1081,
-    src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
-    width: 474,
-    name: 'La Gran Muralla, Pekín, China',
-  },
-  {
-    color: '#698157',
-    height: 711,
-    src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
-    width: 474,
-    name: 'Plitvice Lakes National Park, Croatia',
-  },
-  {
-    color: '#4e5d50',
-    height: 632,
-    src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
-    width: 474,
-    name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
-  },
-  {
-    color: '#6d6368',
-    height: 710,
-    src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
-    width: 474,
-    name: 'Border of China and Vietnam',
-  },
-];
 
 const inputStyle = { width: '700px', display: 'block', margin: '10px auto' };
 
 const getPins = () => {
-  let pinList = [];
-  for (let i = 0; i < 3; i += 1) {
-    pinList = pinList.concat(pins.slice());
-  }
+  const pins = [
+    {
+      color: '#2b3938',
+      height: 316,
+      src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
+      width: 474,
+      name: 'the Hang Son Doong cave in Vietnam',
+    },
+    {
+      color: '#8e7439',
+      height: 1081,
+      src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
+      width: 474,
+      name: 'La Gran Muralla, Pekín, China',
+    },
+    {
+      color: '#698157',
+      height: 711,
+      src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
+      width: 474,
+      name: 'Plitvice Lakes National Park, Croatia',
+    },
+    {
+      color: '#4e5d50',
+      height: 632,
+      src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
+      width: 474,
+      name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
+    },
+    {
+      color: '#6d6368',
+      height: 710,
+      src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
+      width: 474,
+      name: 'Border of China and Vietnam',
+    },
+  ];
+
+  const pinList = [...new Array(3)].map(() => [...pins]).flat();
   return Promise.resolve(pinList);
 };
 

--- a/docs/pages/web/overview.js
+++ b/docs/pages/web/overview.js
@@ -113,13 +113,13 @@ function List({
   headingLevel,
   title = '',
 }: {|
-  array: Array<ListItemType>,
+  array: $ReadOnlyArray<ListItemType>,
   headingLevel: 2 | 3,
   title?: string,
 |}): Node {
   return (
     <IllustrationSection title={title} grid="auto-fill" min={312}>
-      {array
+      {[...array]
         .sort((a, b) => {
           if (a.name < b.name) {
             return -1;

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -169,7 +169,7 @@ const misc = [
 ];
 
 /*::
-type Redirects = Array<{|
+type Redirects = $ReadOnlyArray<{|
     source: string,
     destination: string,
     permanent: boolean,

--- a/docs/utils/mdHelper.js
+++ b/docs/utils/mdHelper.js
@@ -29,7 +29,7 @@ export async function getDocByRoute(route: string): Promise<{|
   }
 }
 
-export async function getAllMarkdownPosts(): Promise<Array<Array<string>>> {
+export async function getAllMarkdownPosts(): Promise<$ReadOnlyArray<$ReadOnlyArray<string>>> {
   function convertNamesForURL(name: string): string {
     return name.replace(/ /g, '_').replace(/'/g, '').toLowerCase();
   }
@@ -39,7 +39,10 @@ export async function getAllMarkdownPosts(): Promise<Array<Array<string>>> {
   const getAllSitePaths = () => {
     const pagePaths = [];
 
-    const addUrlPaths = (pageItems: Array<siteIndexType | string>, pages: Array<string>) => {
+    const addUrlPaths = (
+      pageItems: $ReadOnlyArray<siteIndexType | string>,
+      pages: $ReadOnlyArray<string>,
+    ) => {
       // for each choice
       pageItems.forEach((page) => {
         if (page.sectionName) {
@@ -63,7 +66,7 @@ export async function getAllMarkdownPosts(): Promise<Array<Array<string>>> {
 
   const pagePaths = getAllSitePaths();
 
-  const checkIfPathExists = async (pagePath: Array<string>) => {
+  const checkIfPathExists = async (pagePath: $ReadOnlyArray<string>) => {
     const pathName = pagePath.join('/');
 
     try {


### PR DESCRIPTION
When @jackhsu978 [first implemented read-only arrays in Gestalt](https://github.com/pinterest/gestalt/pull/1321/) a couple of years ago, he specifically didn't include our docs components. I don't see any reason why we wouldn't want to also enforce immutable arrays in those components, so this PR removes that override and fixes all current violations.

_…but why?_
A great explanation from Jack's PR:

> General reasons for using immutable data structures:
> 
> - They are simpler to construct, test, and use
> - They help to avoid temporal coupling
> - Their usage is side-effect free (no defensive copies)
> - Identity mutability problem is avoided
> - They always have failure atomicity
> - They are much easier to cache
> 
> When a prop/argument of a component/function is typed as the mutable Array, one cannot pass a variable that is typed as a read-only array $ReadOnlyArray. This PR will make it possible for projects that use Gestalt to pass $ReadOnlyArray data structure to Gestalt components.

So, same benefits — just for our docs components! 🎉 