### PR TITLE
Masonry: rename `comp` to `Item`

### DIFF
--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -155,8 +155,8 @@ class ExampleMasonry extends Component<Props, State> {
           {scrollContainer && (
             <Masonry
               columnWidth={170}
-              comp={GridComponent}
               gutterWidth={5}
+              Item={GridComponent}
               items={this.state.pins}
               layout={this.props.layout}
               minCols={1}
@@ -187,7 +187,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
     ~~~jsx
     <Masonry
-      comp={Item}
+      Item={Item}
       items={this.state.pins}
       loadItems={this.loadItems}
       minCols={1}
@@ -201,7 +201,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     When layout is set to \`flexible\`, the item width will shrink/grow to fill the container. This is great for responsive designs.
 
     ~~~jsx
-    <Masonry layout="flexible" comp={Item} items={items} minCols={1} />
+    <Masonry layout="flexible" Item={Item} items={items} minCols={1} />
     ~~~
     `}
         name="Flexible item width"
@@ -213,7 +213,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     When the \`flexible\` property is omitted, the item width will be fixed to \`columnWidth\`.
 
     ~~~jsx
-    <Masonry comp={Item} items={items} minCols={1} />
+    <Masonry Item={Item} items={items} minCols={1} />
     ~~~
   `}
         name="Non-flexible item width"
@@ -226,7 +226,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
     ~~~jsx
     import { Masonry, MasonryUniformRowLayout } from 'gestalt';
-    <Masonry comp={Item} items={items} layout={MasonryUniformRowLayout} />;
+    <Masonry Item={Item} items={items} layout={MasonryUniformRowLayout} />;
     ~~~
   `}
         name="Uniform row heights"

--- a/packages/gestalt/src/Masonry.flowtest.js
+++ b/packages/gestalt/src/Masonry.flowtest.js
@@ -4,7 +4,7 @@ import Masonry from './Masonry.js';
 function Item() {
   return <div />;
 }
-const Valid = <Masonry items={[]} comp={Item} />;
+const Valid = <Masonry items={[]} Item={Item} />;
 
 // $FlowExpectedError[prop-missing]
 const MissingProp = <Masonry />;

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -23,19 +23,19 @@ type Props<T> = {|
    */
   columnWidth?: number,
   /**
+   * The amount of vertical and horizontal space between each item, specified in pixels.
+   */
+  gutterWidth?: number,
+  /**
    * A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item. *Note that this [must be a stable reference!](https://www.developerway.com/posts/react-re-renders-guide#part3.1)* If using a component declared within a parent function component, you must use [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback) to ensure a stable reference.
    */
-  comp: ComponentType<{|
+  Item: ComponentType<{|
     data: T,
     itemIdx: number,
     isMeasuring: boolean,
   |}>,
   /**
-   * The amount of vertical and horizontal space between each item, specified in pixels.
-   */
-  gutterWidth?: number,
-  /**
-   * An array of items to display that contains the information that `comp` needs to render.
+   * An array of items to display that contains the data to be rendered by `<Item />`.
    */
   items: $ReadOnlyArray<T>,
   /**
@@ -375,13 +375,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     idx,
     position,
   ) => {
-    const {
-      comp: Component,
-      scrollContainer,
-      virtualize,
-      virtualBoundsTop,
-      virtualBoundsBottom,
-    } = this.props;
+    const { Item, scrollContainer, virtualize, virtualBoundsTop, virtualBoundsBottom } = this.props;
     const { top, left, width, height } = position;
 
     let isVisible;
@@ -416,7 +410,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
           height: layoutNumberToCssDimension(height),
         }}
       >
-        <Component data={itemData} itemIdx={idx} isMeasuring={false} />
+        <Item data={itemData} itemIdx={idx} isMeasuring={false} />
       </div>
     );
 
@@ -426,8 +420,8 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
   render(): Node {
     const {
       columnWidth,
-      comp: Component,
       gutterWidth: gutter,
+      Item,
       items,
       layout,
       minCols,
@@ -502,7 +496,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
               }}
             >
-              <Component data={item} itemIdx={i} isMeasuring={false} />
+              <Item data={item} itemIdx={i} isMeasuring={false} />
             </div>
           ))}
         </div>
@@ -553,7 +547,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     }
                   }}
                 >
-                  <Component data={data} itemIdx={measurementIndex} isMeasuring />
+                  <Item data={data} itemIdx={measurementIndex} isMeasuring />
                 </div>
               );
             })}


### PR DESCRIPTION
The current prop name `comp` on Masonry doesn't make it clear how the prop will be used: is it a function? A function component? A component of any sort? It's not clear.

Renaming this prop to `Item` makes it more clear that the prop will be used as a component. The ultimate goal is to ensure that users know this always needs to be a stable reference, which this barely addresses. However, future work will add a lint rule to ensure that `Item` is always stable, and will possibly rethink how we treat the item component to completely preclude this possibility.

More context in [this Slack thread](https://pinterest.slack.com/archives/C13KLG5P0/p1661293861162029)

## Codemod
```zsh
yarn codemod modifyProp ~/path/to/your/code --component=Masonry --previousProp=comp --nextProp=Item
```

_Notes_
@ponori This isn't one for the weekly digest, just the monthly eng newsletter.