### PR TITLE
Popover: Fix accessibility bug, add option for accessibilityLabel

### DIFF
--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -532,7 +532,7 @@ To further assist screen readers, we recommend passing the following ARIA attrib
 - \`accessibilityExpanded\`: informs the screen reader whether Popover is currently open or closed. It populates [aria-expanded](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html).
 - \`accessibilityControls\`: match with the \`id\` of the associated Popover whose contents or visibility are controlled by the interactive component so that screen reader users can identify the relationship between elements. It populates [aria-controls](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html).
 
-For role attribute, use:
+For the \`role\` prop, use:
 - 'dialog' if the Popover is a dialog that prompts the user to enter information or requires a response.
 - 'menu' if the Popover presents a list of choices to the user.
 - 'listbox' if the Popover is a widget that allows the user to select one or more items (whose role is option) from a list. May also include a search option.

--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -97,6 +97,7 @@ function PopoverExample() {
       {open && (
         <Layer>
           <Popover
+            accessibilityLabel="Save to board"
             anchor={anchorRef.current}
             id="main-example"
             idealDirection="down"
@@ -521,7 +522,11 @@ function PopoverExample() {
         <MainSection.Subsection
           title="ARIA attributes"
           description={`
-To assist screen readers, we recommend passing the following ARIA attributes to the anchor element:
+We recommend passing the following ARIA attribute to Popover for a better screen reader experience:
+
+- \`accessibilityLabel\`: describes the main purpose of a Popover for the screen reader. Should be unique and concise. For example, "Save to board" instead of "Popover".  It populates [aria-label](https://w3c.github.io/aria-practices/#dialog_roles_states_props).
+
+To further assist screen readers, we recommend passing the following ARIA attributes to the _anchor element_:
 
 - \`accessibilityHaspopup\`: informs the screen reader that there’s a Popover attached to the anchor element. It populates [aria-haspopup](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html).
 - \`accessibilityExpanded\`: informs the screen reader whether Popover is currently open or closed. It populates [aria-expanded](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html).
@@ -617,11 +622,13 @@ function PopoverExample() {
       {open && (
         <Layer>
           <Popover
+            accessibilityLabel="Save to board"
             anchor={anchorRef.current}
             id="example-a11y"
             idealDirection="down"
             onDismiss={() => setOpen(false)}
             positionRelativeToAnchor={false}
+            role="listbox"
             size="xl"
           >
             <Box width={360}>

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -28,6 +28,7 @@ import {
 export type Role = 'dialog' | 'listbox' | 'menu';
 
 type OwnProps = {|
+  accessibilityLabel?: string,
   anchor: HTMLElement,
   bgColor: 'blue' | 'darkGray' | 'orange' | 'red' | 'white',
   border?: boolean,
@@ -202,7 +203,8 @@ class Contents extends Component<Props, State> {
   };
 
   render(): Node {
-    const { bgColor, border, caret, children, id, role, rounding, width } = this.props;
+    const { accessibilityLabel, bgColor, border, caret, children, id, role, rounding, width } =
+      this.props;
     const { caretOffset, popoverOffset, popoverDir } = this.state;
 
     // Needed to prevent UI thrashing
@@ -240,6 +242,7 @@ class Contents extends Component<Props, State> {
           </div>
         )}
         <div
+          aria-label={accessibilityLabel}
           id={id}
           role={role}
           className={classnames(

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -15,6 +15,7 @@ const SIZE_WIDTH_MAP = {
   xl: 360,
 };
 type OwnProps = {|
+  accessibilityLabel?: string,
   anchor: HTMLElement,
   bgColor: 'blue' | 'darkGray' | 'orange' | 'red' | 'white',
   border?: boolean,
@@ -112,6 +113,7 @@ class Controller extends Component<Props, State> {
 
   render(): ReactNode {
     const {
+      accessibilityLabel,
       anchor,
       bgColor,
       border,
@@ -132,6 +134,7 @@ class Controller extends Component<Props, State> {
     return (
       <OutsideEventBehavior onClick={this.handlePageClick}>
         <Contents
+          accessibilityLabel={accessibilityLabel}
           anchor={anchor}
           bgColor={bgColor}
           border={border}

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -9,6 +9,10 @@ type Role = 'dialog' | 'listbox' | 'menu';
 
 type Props = {|
   /**
+   * Unique label to describe each Popover. Used for [accessibility](https://gestalt.pinterest.systems/web/popover#ARIA-attributes) purposes.
+   */
+  accessibilityLabel?: string,
+  /**
    * The reference element, typically [Button](https://gestalt.pinterest.systems/web/button) or [IconButton](https://gestalt.pinterest.systems/web/iconbutton), that Popover uses to set its position.
    */
   anchor: ?HTMLElement,
@@ -64,6 +68,7 @@ type Props = {|
  * Popover is most appropriate for desktop screens and can contain a variety of elements, such as [Button](/button) and [Images](/image). Popover is also the container used to construct more complex elements like [Dropdown](/dropdown) and the board picker, pictured below, which allow people to choose the board to save a Pin to.
  */
 export default function Popover({
+  accessibilityLabel = 'Popover',
   anchor,
   children,
   onKeyDown,
@@ -72,7 +77,7 @@ export default function Popover({
   onDismiss,
   positionRelativeToAnchor = true,
   color = 'white',
-  role,
+  role = 'dialog',
   shouldFocus = true,
   showCaret = false,
   size = 'sm',
@@ -83,6 +88,7 @@ export default function Popover({
 
   return (
     <Controller
+      accessibilityLabel={accessibilityLabel}
       anchor={anchor}
       bgColor={color}
       border

--- a/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
@@ -35,6 +35,7 @@ exports[`Controller renders 1`] = `
       </svg>
     </div>
     <div
+      aria-label="Popover"
       className="border darkGrayBg darkGray innerContents maxDimensions minDimensions"
       id=""
       style={

--- a/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
@@ -35,7 +35,6 @@ exports[`Controller renders 1`] = `
       </svg>
     </div>
     <div
-      aria-label="Popover"
       className="border darkGrayBg darkGray innerContents maxDimensions minDimensions"
       id=""
       style={

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -13,6 +13,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
         tabindex="-1"
       >
         <div
+          aria-label="Popover"
           class="border whiteBgElevated whiteElevated rounding4 innerContents maxDimensions minDimensions"
           id="ex-1"
           role="menu"

--- a/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
@@ -16,7 +16,9 @@ exports[`Popover renders 1`] = `
     tabIndex={-1}
   >
     <div
+      aria-label="Popover"
       className="border whiteBgElevated whiteElevated rounding4 innerContents maxDimensions minDimensions"
+      role="dialog"
       style={
         Object {
           "maxWidth": 230,
@@ -41,7 +43,9 @@ exports[`Popover renders as blue 1`] = `
     tabIndex={-1}
   >
     <div
+      aria-label="Popover"
       className="border blueBg blue rounding4 innerContents maxDimensions minDimensions"
+      role="dialog"
       style={
         Object {
           "maxWidth": 230,
@@ -66,7 +70,9 @@ exports[`Popover renders as error 1`] = `
     tabIndex={-1}
   >
     <div
+      aria-label="Popover"
       className="border redBg red rounding4 innerContents maxDimensions minDimensions"
+      role="dialog"
       style={
         Object {
           "maxWidth": 230,

--- a/playwright/accessibility/Popover.spec.mjs
+++ b/playwright/accessibility/Popover.spec.mjs
@@ -6,8 +6,5 @@ test('Popover Accessibility check', async ({ page }) => {
   await page.goto('/web/popover');
   await expectAccessiblePage({
     page,
-    rules: {
-      region: { enabled: false },
-    },
   });
 });


### PR DESCRIPTION
### Summary

#### What changed?
Update Popover (and its inner components) to always include a role and aria-label - a requirement for accessibility. Also allow users to specify an accessibilityLabel for their Popover

#### Why?

We were disabling an a11y check, which caused issues in the main repo. All non-modal dialogs (Popovers) need a role. All items with role = dialog or listbox need a label. So this PR adds defaults for both to ensure every Popover is accessible by default (but also allows users to override the label to be more specific, which is preferred).


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3554)


### Checklist

- [ ] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
