### PR TITLE
Textfield, Numberfield: new enterKeyHint prop

### DIFF
--- a/docs/pages/web/numberfield.js
+++ b/docs/pages/web/numberfield.js
@@ -557,6 +557,37 @@ function Example(props) {
         </MainSection.Subsection>
 
         <MainSection.Subsection
+          title="EnterKeyHint"
+          description={`The \`enterKeyHint\` prop presents to the user a more accurate action label for the enter key on virtual keyboards. These are the values for each use case:
+
+- "enter": inserting a new line
+- "done": there is nothing more to input and the input editor will be closed
+- "go": taking the user to the target of the text they typed
+- "next": taking the user to the next field that will accept text
+- "previous": taking the user to the previous field that will accept text
+- "search": taking the user to the results of searching for the text they have typed
+- "send": submitting the input, such as an email or chat
+          `}
+        >
+          <MainSection.Card
+            defaultCode={`
+function NumberFieldExample() {
+  return (
+    <NumberField
+      id="enterKeyHint"
+      enterKeyHint="next"
+      label="Age"
+      onChange={() => {}}
+      onBlur={() => {}}
+      onFocus={() => {}}
+    />
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
           title="Refs"
           description={`
     Set a ref on NumberField to use the [Constraint Validation API](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation) or to anchor a Popover-based element.

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -673,7 +673,36 @@ function Example(props) {
 `}
           />
         </MainSection.Subsection>
+        <MainSection.Subsection
+          title="EnterKeyHint"
+          description={`The \`enterKeyHint\` prop presents to the user a more accurate action label for the enter key on virtual keyboards. These are the values for each use case:
 
+- "enter": inserting a new line
+- "done": there is nothing more to input and the input editor will be closed
+- "go": taking the user to the target of the text they typed
+- "next": taking the user to the next field that will accept text
+- "previous": taking the user to the previous field that will accept text
+- "search": taking the user to the results of searching for the text they have typed
+- "send": delivering the text to its target
+          `}
+        >
+          <MainSection.Card
+            defaultCode={`
+function TextFieldExample() {
+  return (
+    <TextField
+      id="enterKeyHint"
+      enterKeyHint="next"
+      label="Address"
+      onChange={() => {}}
+      onBlur={() => {}}
+      onFocus={() => {}}
+    />
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
         <MainSection.Subsection
           title="Refs"
           description={`

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -25,6 +25,7 @@ type Props = {|
   accessibilityActiveDescendant?: string,
   autoComplete?: 'bday' | 'current-password' | 'email' | 'new-password' | 'on' | 'off' | 'username',
   disabled?: boolean,
+  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
   errorMessage?: Node,
   hasError?: boolean,
   helperText?: string,
@@ -67,6 +68,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
       autoComplete,
       disabled = false,
       errorMessage,
+      enterKeyHint,
       hasError = false,
       helperText,
       id,
@@ -152,6 +154,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
         autoComplete={autoComplete}
         className={tags ? unstyledClasses : styledClasses}
         disabled={disabled}
+        enterKeyHint={enterKeyHint}
         id={id}
         max={type === 'number' ? max : undefined}
         min={type === 'number' ? min : undefined}

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -25,6 +25,10 @@ type Props = {|
    */
   disabled?: boolean,
   /**
+   *  Optionally specify the action label to present for the enter key on virtual keyboards. See the [enterKeyHint variant](https://gestalt.pinterest.systems/web/numberfield#EnterKeyHint) for more info.
+   *
+   */ enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
+  /**
    * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/web/link) or [TapArea](https://gestalt.pinterest.systems/web/taparea).
    */
   errorMessage?: Node,
@@ -116,6 +120,7 @@ const NumberFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
   {
     autoComplete,
     disabled = false,
+    enterKeyHint,
     errorMessage,
     helperText,
     id,
@@ -138,6 +143,7 @@ const NumberFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
     <InternalTextField
       autoComplete={autoComplete}
       disabled={disabled}
+      enterKeyHint={enterKeyHint}
       errorMessage={errorMessage}
       helperText={helperText}
       id={id}

--- a/packages/gestalt/src/NumberField.test.js
+++ b/packages/gestalt/src/NumberField.test.js
@@ -35,6 +35,19 @@ describe('NumberField', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('NumberField with enterKeyHint', () => {
+    const tree = create(
+      <NumberField
+        enterKeyHint="go"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('NumberField with name', () => {
     const tree = create(
       <NumberField

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -19,6 +19,10 @@ type Props = {|
    */
   disabled?: boolean,
   /**
+   *  Optionally specify the action label to present for the enter key on virtual keyboards. See the [enterKeyHint variant](https://gestalt.pinterest.systems/web/textfield#EnterKeyHint) for more info.
+   */
+  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
+  /**
    * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/web/link) or [TapArea](https://gestalt.pinterest.systems/web/taparea).
    */
   errorMessage?: Node,
@@ -118,6 +122,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   {
     autoComplete,
     disabled = false,
+    enterKeyHint,
     errorMessage,
     hasError = false,
     helperText,
@@ -196,6 +201,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     <InternalTextField
       autoComplete={autoComplete}
       disabled={disabled}
+      enterKeyHint={enterKeyHint}
       errorMessage={errorMessage}
       hasError={hasError}
       helperText={helperText}

--- a/packages/gestalt/src/TextField.test.js
+++ b/packages/gestalt/src/TextField.test.js
@@ -38,6 +38,19 @@ describe('TextField', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('TextField with enterKeyHint', () => {
+    const tree = create(
+      <TextField
+        id="test"
+        enterKeyHint="go"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('TextField with hasError', () => {
     const tree = create(
       <TextField hasError id="test" onChange={jest.fn()} onFocus={jest.fn()} onBlur={jest.fn()} />,

--- a/packages/gestalt/src/__snapshots__/NumberField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/NumberField.test.js.snap
@@ -48,6 +48,30 @@ exports[`NumberField NumberField with autocomplete 1`] = `
 </span>
 `;
 
+exports[`NumberField NumberField with enterKeyHint 1`] = `
+<span>
+  <div
+    className="box relative"
+  >
+    <input
+      aria-describedby={null}
+      aria-invalid="false"
+      className="textField base enabled normal medium truncate"
+      disabled={false}
+      enterKeyHint="go"
+      id="test"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      pattern="\\\\d*"
+      type="number"
+    />
+  </div>
+</span>
+`;
+
 exports[`NumberField NumberField with error 1`] = `
 <span>
   <div

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -71,6 +71,30 @@ exports[`TextField TextField with disabled 1`] = `
 </span>
 `;
 
+exports[`TextField TextField with enterKeyHint 1`] = `
+<span>
+  <div
+    className="box relative"
+  >
+    <input
+      aria-describedby={null}
+      aria-invalid="false"
+      className="textField base enabled normal medium truncate"
+      disabled={false}
+      enterKeyHint="go"
+      id="test"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      readOnly={false}
+      type="text"
+    />
+  </div>
+</span>
+`;
+
 exports[`TextField TextField with error 1`] = `
 <span>
   <div


### PR DESCRIPTION
### Summary

#### What changed?

Textfield, Numberfield: new enterKeyHint prop

#### Why?

As a user, I want better context on my mobile keyboard's action key so I know what will happen when I tap it.

Acceptance criteria:

Implement the [`enterkeyhint` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint) in the TextField and NumberField components.


Allow the following values based on the spec found at https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute

Update the documentation for TextField and NumberField to include descriptions/guidance for each enterkeyhint value from [this spec](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute)

More info found here: https://css-tricks.com/enterkeyhint/?ref=sidebar

[JIRA](https://jira.pinadmin.com/browse/GESTALT-3382)

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
