### PR TITLE
Docs: Updated component_data to set Tabs docs ready for Android and iOS

### DIFF
--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -2142,7 +2142,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
       },
       badge: null,
       deprecated: false,
-      documentation: 'notAvailable',
+      documentation: 'ready',
       figma: null,
     },
     iOS: {
@@ -2155,7 +2155,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
       },
       badge: null,
       deprecated: false,
-      documentation: 'notAvailable',
+      documentation: 'ready',
       figma: null,
     },
   },


### PR DESCRIPTION
Made Tabs available in Component Overview pages for Android and iOS