### PR TITLE
Docs: implement a11y "Skip to content"

### DIFF
--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -2,6 +2,7 @@
 import { useEffect, Fragment, type Node } from 'react';
 import { Box, Divider, DeviceTypeProvider } from 'gestalt';
 import Header from './Header.js';
+import SkipToContent from './SkipToContent.js';
 import DocsSideNavigation, { MIN_NAV_WIDTH_PX } from './DocsSideNavigation.js';
 import Footer from './Footer.js';
 import ResourcesFooter from './ResourcesFooter.js';
@@ -47,6 +48,7 @@ export default function AppLayout({ children, colorScheme, isHomePage }: Props):
     </Box>
   ) : (
     <Box minHeight="100vh" color="default">
+      <SkipToContent />
       <Header />
       {isSidebarOpen && (
         <Fragment>

--- a/docs/docs-components/SkipToContent.js
+++ b/docs/docs-components/SkipToContent.js
@@ -1,0 +1,72 @@
+// @flow strict
+import { useState, useCallback, useEffect, type Node, Fragment } from 'react';
+import { Box, Text, TapArea, Flex } from 'gestalt';
+import { SKIP_TO_CONTENT_ZINDEX } from './z-indices.js';
+
+/**
+ * Skip to content allows you to skip directly to the content on the page
+ *
+ * Note: This TapArea will only show when people are tabbing through (for accessibility purposes)
+ */
+export default function SkipToContent(): Node {
+  const [focused, setFocused] = useState(false);
+  const [mainContent, setMainContent] = useState(null);
+
+  const handleTabIndex = useCallback(() => {
+    mainContent?.removeAttribute('tabindex');
+    mainContent?.removeEventListener('blur', handleTabIndex);
+    mainContent?.removeEventListener('focusout', handleTabIndex);
+  }, [mainContent]);
+
+  useEffect(() => {
+    if (!mainContent) setMainContent(document.querySelector('[role="main"]'));
+
+    return () => {
+      // remove event listener in case we unmount component without calling handleTabIndex
+      mainContent?.removeEventListener('blur', handleTabIndex);
+      mainContent?.removeEventListener('focusout', handleTabIndex);
+    };
+  }, [mainContent, handleTabIndex]);
+
+  const skipText = (
+    <Fragment>
+      <Box display="block" smDisplay="none" color="education">
+        <Flex width="100%" alignItems="center" justifyContent="center" height={56}>
+          <Text align="center" underline={focused} color="inverse" weight="bold">
+            Skip to content
+          </Text>
+        </Flex>
+      </Box>
+      <Box display="none" smDisplay="block" color="education">
+        <Flex width="100%" alignItems="center" justifyContent="center" height={75}>
+          <Text underline={focused} align="center" color="inverse" weight="bold">
+            Skip to content
+          </Text>
+        </Flex>
+      </Box>
+    </Fragment>
+  );
+
+  return (
+    <TapArea
+      onBlur={() => setFocused(false)}
+      onFocus={() => setFocused(true)}
+      onTap={() => {
+        mainContent?.setAttribute('tabindex', '-1');
+        mainContent?.focus({ preventScroll: true });
+        mainContent?.addEventListener('blur', handleTabIndex);
+        mainContent?.addEventListener('focusout', handleTabIndex);
+      }}
+    >
+      {focused ? (
+        <Box position="fixed" width="100%" zIndex={SKIP_TO_CONTENT_ZINDEX}>
+          {skipText}
+        </Box>
+      ) : (
+        <Box height={1} width={1} margin={-1} overflow="hidden" position="absolute">
+          {skipText}
+        </Box>
+      )}
+    </TapArea>
+  );
+}

--- a/docs/docs-components/z-indices.js
+++ b/docs/docs-components/z-indices.js
@@ -3,6 +3,10 @@ import { CompositeZIndex, FixedZIndex } from 'gestalt';
 
 export const PAGE_HEADER_ZINDEX: FixedZIndex = new FixedZIndex(10);
 export const ABOVE_PAGE_HEADER_ZINDEX: CompositeZIndex = new CompositeZIndex([PAGE_HEADER_ZINDEX]);
+export const SKIP_TO_CONTENT_ZINDEX: CompositeZIndex = new CompositeZIndex([
+  ABOVE_PAGE_HEADER_ZINDEX,
+]);
+
 // Z-index to use for any popovers on the Header
 export const PAGE_HEADER_POPOVER_ZINDEX = ABOVE_PAGE_HEADER_ZINDEX;
 


### PR DESCRIPTION
### Summary

#### What changed?

Docs: implement a11y "Skip to content"

#### Why?

For accessibility purposes. 

The skip to content link idea is this - put a link at the top of the page that allows keyboard users to jump over the navigation links and land on the main content of the page. For screen reader users this provides help with the structure of the page - where is the main content - and being able to get there. 

https://www.loom.com/share/beb2cc04d2e7496e998694d9c0287a72

I got logic from `app/packages/ui/SkipToContent.js` with a major code cleanup

For reference see https://www.w3.org/WAI/GL/2016/WD-WCAG20-TECHS-20160105/G1#maincontent  