### PR TITLE
Docs: Fix Flex wrapping in multiple pages

### DIFF
--- a/docs/pages/foundations/messaging/available_components.js
+++ b/docs/pages/foundations/messaging/available_components.js
@@ -179,7 +179,8 @@ export default function MessagingComponentsPage(): Node {
           </Text>
 
           <Box>
-            <iFrame
+            <iframe
+              title="Messaging Figma decision tree"
               style={{ border: 'none' }}
               width="100%"
               height="450"

--- a/docs/pages/web/badge.js
+++ b/docs/pages/web/badge.js
@@ -235,7 +235,7 @@ export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGe
         >
           <MainSection.Card
             defaultCode={`
-<Flex gap={{ column: 0, row: 4 }}>
+<Flex gap={{ column: 8, row: 4 }} wrap>
   <Mask height={150} width={280} rounding={2}>
     <Image alt="Botanical art in coral and green" fit="cover" src="https://i.ibb.co/cbjgZft/img-door.jpg" naturalWidth={1} naturalHeight={1}>
       <Box padding={4}>

--- a/docs/pages/web/box.js
+++ b/docs/pages/web/box.js
@@ -246,10 +246,10 @@ function MenuButtonExample() {
           <MainSection.Card
             cardSize="lg"
             defaultCode={`
-<Box>
+<Flex>
   <Text>Enable your screen reader to hear the following text:</Text>
-  <Box display="visuallyHidden">In the darkest night, Box will rise to bring the light. The Lloyd has spoken.</Box>
-</Box>
+  <Box display="visuallyHidden">Hi there.</Box>
+</Flex>
 `}
           />
         </MainSection.Subsection>
@@ -766,7 +766,7 @@ function BoxPopoverExample() {
   <Box position="absolute" bottom right padding={2} color="infoBase">
     <Text color="light">Bottom Right</Text>
   </Box>
-  <Box color="successBase" width={400} height="100%"/>
+  <Box color="successBase" minWidth={100} maxWidth={400} height="100%"/>
 </Box>
 `}
           />

--- a/docs/pages/web/checkbox.js
+++ b/docs/pages/web/checkbox.js
@@ -628,7 +628,7 @@ function Example() {
     const [checked5, setChecked5] = React.useState(false);
 
   return (
-    <Flex gap={{ column: 0, row: 6 }}>
+    <Flex gap={6} wrap>
       <Checkbox
         checked={false}
         id="Unchecked"

--- a/docs/pages/web/image.js
+++ b/docs/pages/web/image.js
@@ -101,9 +101,9 @@ Notes:
         name="Fit"
         defaultCode={`
 <Flex alignItems="start" direction="column" gap={{ column: 6, row: 0 }} wrap>
-  <Flex direction="column" gap={{ column: 2, row: 0 }}>
+  <Flex direction="column" gap={2}>
     <Text weight="bold" size="300">Square content: contain vs cover</Text>
-      <Flex gap={{ row: 8, column: 0 }} justifyContent="around">
+      <Flex gap={8} justifyContent="around" wrap>
         <Box color="darkGray" height={200} width={200}>
           <Image
             alt="square"
@@ -129,7 +129,7 @@ Notes:
 
   <Flex direction="column" gap={{ column: 2, row: 0 }}>
     <Text weight="bold" size="300">Wide content: contain vs cover</Text>
-      <Flex gap={{ row: 8, column: 0 }} justifyContent="around">
+      <Flex gap={8} justifyContent="around" wrap>
         <Box color="darkGray" height={200} width={200}>
           <Image
             alt="wide"
@@ -155,7 +155,7 @@ Notes:
 
   <Flex direction="column" gap={{ column: 2, row: 0 }}>
     <Text weight="bold" size="300">Tall content: contain vs cover</Text>
-      <Flex gap={{ row: 8, column: 0 }} justifyContent="around">
+      <Flex gap={8} justifyContent="around" wrap>
         <Box color="darkGray" height={200} width={200}>
           <Image
             alt="tall"

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -150,7 +150,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             defaultCode={`
 <Flex direction="column" width="70%" gap={{ column: 3, row: 0 }}>
   <Flex.Item>
-    <Box display="visuallyHidden" width="100%">
+    <Box display="visuallyHidden">
       <Label htmlFor="example-email-1">Email</Label>
     </Box>
     <TextField placeholder="Email" id="example-email-1" onChange={() => {}} type="email" value="" />
@@ -200,7 +200,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             defaultCode={`
 <Flex direction="column" width="70%" gap={{ column: 3, row: 0 }}>
   <Flex.Item>
-    <Box display="visuallyHidden" width="100%">
+    <Box display="visuallyHidden">
       <Label htmlFor="example-email-2">Email</Label>
     </Box>
     <TextField placeholder="Email" id="example-email-2" onChange={() => {}} type="email" value="" />

--- a/docs/pages/web/radiogroup.js
+++ b/docs/pages/web/radiogroup.js
@@ -367,7 +367,7 @@ function RadioButtonExample() {
   const [favoriteFood, setFavoriteFood] = React.useState();
 
   return (
-    <Flex gap={{ column: 0, row: 8 }}>
+    <Flex gap={8} wrap>
       <RadioGroup legend="What is your favorite pet?" id="directionExample-1">
         <RadioGroup.RadioButton
           checked={favorite === 'dogs'}
@@ -511,7 +511,7 @@ function RadioButtonExample() {
   const [favorite, setFavorite] = React.useState();
 
   return (
-      <RadioGroup legend="Which state is your favorite?" direction="row" id="rowExample">
+      <RadioGroup legend="Which state is your favorite?" id="rowExample">
         <RadioGroup.RadioButton
           checked={false}
           id="unchecked"

--- a/docs/pages/web/tabs.js
+++ b/docs/pages/web/tabs.js
@@ -365,7 +365,7 @@ function TabExample() {
         </Label>
         <Switch
           id="color"
-          onChange={() => setIsTransparent(!isTransparent)}
+          onChange={() => setIsTransparent( (value) => !value)}
           switched={isTransparent}
         />
       </Flex>

--- a/docs/pages/web/tabs.js
+++ b/docs/pages/web/tabs.js
@@ -292,9 +292,10 @@ function TabExample() {
         description={`Be sure to localize \`text\` and \`accessibilityLabel\`.
     The Tab's title should be 3 words or less: long enough to be understood by users but short enough to prevent text wrapping. Aim for a single word when possible.`}
       />
-      <Example
-        name="Example"
-        defaultCode={`
+      <MainSection name="Variants">
+        <Example
+          name="Wrapping"
+          defaultCode={`
 function TabExample() {
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [wrap, setWrap] = React.useState(false);
@@ -336,13 +337,13 @@ function TabExample() {
   );
 }
   `}
-      />
-      <Example
-        name="Background color"
-        defaultCode={`
+        />
+        <Example
+          name="Background color"
+          defaultCode={`
 function TabExample() {
   const [activeIndex, setActiveIndex] = React.useState(0);
-  const [wrap, setWrap] = React.useState(false);
+  const [isTransparent, setIsTransparent] = React.useState(true);
 
   const handleChange = ({ activeTabIndex, event }) => {
     event.preventDefault();
@@ -359,30 +360,31 @@ function TabExample() {
   return (
     <Flex alignItems="start" direction="column" gap={{ column: 4, row: 0 }}>
       <Flex gap={{ row: 4, column: 0 }}>
-        <Label htmlFor="wrap">
-          <Text>Wrap</Text>
+        <Label htmlFor="color">
+          <Text>Transparent background</Text>
         </Label>
         <Switch
-          id="wrap"
-          onChange={() => setWrap(!wrap)}
-          switched={wrap}
+          id="color"
+          onChange={() => setIsTransparent(!isTransparent)}
+          switched={isTransparent}
         />
       </Flex>
 
-      <Box borderStyle="sm" color="lightGray" maxWidth={500} overflow="auto" padding={1}>
+      <Box borderStyle="sm" color="secondary" maxWidth={500} overflow="auto" padding={1}>
         <Tabs
           activeTabIndex={activeIndex}
-          bgColor="transparent"
+          bgColor={isTransparent ? 'transparent' : 'default'}
           onChange={handleChange}
           tabs={tabs}
-          wrap={wrap}
+          wrap={true}
         />
       </Box>
     </Flex>
   );
 }
   `}
-      />
+        />
+      </MainSection>
       <QualityChecklist component={generatedDocGen?.displayName} />
 
       <MainSection name="Related">

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -346,7 +346,7 @@ function Example() {
 
   return (
     <Flex alignItems="start" direction="column" gap={{ column: 6, row: 0 }}>
-      <Flex gap={{ column: 0, row: 6 }}>
+      <Flex gap={6} wrap>
         <Tooltip text="Default TapArea">
           <TapArea
             tapStyle={compressed}
@@ -436,8 +436,8 @@ function Example() {
           name="Height & width"
           id="fullHeightWidth"
           defaultCode={`
-<Box color="olive" display="flex" width={500} height={250}>
-  <Box borderStyle="sm" margin={3} column={6}>
+<Flex gap={6} wrap maxWidth={500} height={250}>
+  <Box borderStyle="sm" margin={3} width="100%" height="100%">
     <TapArea fullHeight>
       <Box height="100%" color="secondary">
         <Text align="center">
@@ -446,7 +446,7 @@ function Example() {
       </Box>
     </TapArea>
   </Box>
-  <Box borderStyle="sm" margin={3} column={6}>
+  <Box borderStyle="sm" margin={3} width="100%" height="100%">
     <TapArea>
       <Box height="100%" color="secondary">
         <Text align="center">
@@ -455,7 +455,7 @@ function Example() {
       </Box>
     </TapArea>
   </Box>
-</Box>
+</Flex>
 `}
         />
 
@@ -464,7 +464,7 @@ function Example() {
           id="inlineUsage"
           description={`While TapArea doesn't provide an \`inline\` prop, this behavior can be achieved by wrapping with \`<Box display="inlineBlock">\`.`}
           defaultCode={`
-<Box color="warningBase" height={250} padding={3} width={500}>
+<Box color="warningBase" height={250} padding={3} maxWidth={500}>
   <Flex direction="column" gap={{ column: 6, row: 0 }}>
     <Flex.Item>
       <Text color="inverse" inline>Other content</Text>


### PR DESCRIPTION
### Summary

#### What changed?

Updates to multiple pages that weren't rendering well on mobile due to missing 'wrap' properties on Flex

#### Why?

Ensure code examples are properly responsive and render well on mobile