### PR TITLE
Internal: add links to PR in Changelog on every release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,505 +2,505 @@
 
 ### Major
 
-- SelectList: Add support for `<optgroup>`, replace `items` prop with subcomponents (#2219)
+- SelectList: Add support for `<optgroup>`, replace `items` prop with subcomponents [#2219](https://github.com/pinterest/gestalt/pull/2219)
 
 ## 70.1.1 (Aug 30, 2022)
 
 ### Patch
 
-- Docs: Update example sizes in Modal and Sheet (#2347)
+- Docs: Update example sizes in Modal and Sheet [#2347](https://github.com/pinterest/gestalt/pull/2347)
 
 ## 70.1.0 (Aug 30, 2022)
 
 ### Minor
 
-- Docs: implement a11y "Skip to content" (#2339)
+- Docs: implement a11y "Skip to content" [#2339](https://github.com/pinterest/gestalt/pull/2339)
 
 ## 70.0.0 (Aug 30, 2022)
 
 ### Major
 
-- Masonry: add support for RTL text direction (#2276)
+- Masonry: add support for RTL text direction [#2276](https://github.com/pinterest/gestalt/pull/2276)
 
 ## 69.2.3 (Aug 30, 2022)
 
 ### Patch
 
-- Docs: fix broken examples (#2346)
+- Docs: fix broken examples [#2346](https://github.com/pinterest/gestalt/pull/2346)
 
 ## 69.2.2 (Aug 30, 2022)
 
 ### Patch
 
-- Docs: add redirect from old domain to new one, now with splat! (#2345)
+- Docs: add redirect from old domain to new one, now with splat! [#2345](https://github.com/pinterest/gestalt/pull/2345)
 
 ## 69.2.1 (Aug 30, 2022)
 
 ### Patch
 
-- Docs: updated favicon with Gestalt logo variant for development environments (#2344)
+- Docs: updated favicon with Gestalt logo variant for development environments [#2344](https://github.com/pinterest/gestalt/pull/2344)
 
 ## 69.2.0 (Aug 30, 2022)
 
 ### Minor
 
-- Textfield, Numberfield: new enterKeyHint prop (#2337)
+- Textfield, Numberfield: new enterKeyHint prop [#2337](https://github.com/pinterest/gestalt/pull/2337)
 
 ## 69.1.6 (Aug 30, 2022)
 
 ### Patch
 
-- Docs: Add Android & iOS Icon Page (#2333)
+- Docs: Add Android & iOS Icon Page [#2333](https://github.com/pinterest/gestalt/pull/2333)
 
 ## 69.1.5 (Aug 29, 2022)
 
 ### Patch
 
-- Docs: Add iOS & Android text field (#2334)
+- Docs: Add iOS & Android text field [#2334](https://github.com/pinterest/gestalt/pull/2334)
 
 ## 69.1.4 (Aug 29, 2022)
 
 ### Patch
 
-- Docs: Added button and sheet for iOS Android (#2327)
+- Docs: Added button and sheet for iOS Android [#2327](https://github.com/pinterest/gestalt/pull/2327)
 
 ## 69.1.3 (Aug 29, 2022)
 
 ### Patch
 
-- Docs: Navigate to overview page with platform switcher (#2340)
+- Docs: Navigate to overview page with platform switcher [#2340](https://github.com/pinterest/gestalt/pull/2340)
 
 ## 69.1.2 (Aug 29, 2022)
 
 ### Patch
 
-- Docs: update favicon to Gestalt logo (#2343)
+- Docs: update favicon to Gestalt logo [#2343](https://github.com/pinterest/gestalt/pull/2343)
 
 ## 69.1.1 (Aug 29, 2022)
 
 ### Patch
 
-- Updated component_data to set Tabs docs ready for Android and iOS (#2338)
+- Updated component_data to set Tabs docs ready for Android and iOS [#2338](https://github.com/pinterest/gestalt/pull/2338)
 
 ## 69.1.0 (Aug 29, 2022)
 
 ### Minor
 
-- Docs: new iOS & Android overview pages (#2332)
+- Docs: new iOS & Android overview pages [#2332](https://github.com/pinterest/gestalt/pull/2332)
 
 ## 69.0.3 (Aug 29, 2022)
 
 ### Patch
 
-- Docs: Mobile docs added for Tabs (#2331)
+- Docs: Mobile docs added for Tabs [#2331](https://github.com/pinterest/gestalt/pull/2331)
 
 ## 69.0.2 (Aug 29, 2022)
 
 ### Patch
 
-- Docs: Fixed typo in 8/26 update (#2336)
+- Docs: Fixed typo in 8/26 update [#2336](https://github.com/pinterest/gestalt/pull/2336)
 
 ## 69.0.1 (Aug 26, 2022)
 
 ### Patch
 
-- Docs: Added 8/26 weekly update (#2335)
+- Docs: Added 8/26 weekly update [#2335](https://github.com/pinterest/gestalt/pull/2335)
 
 ## 69.0.0 (Aug 26, 2022)
 
 ### Major
 
-- IconButton: new size default (#2326)
+- IconButton: new size default [#2326](https://github.com/pinterest/gestalt/pull/2326)
 
 ## 68.1.0 (Aug 25, 2022)
 
 ### Minor
 
-- Popover: Fix accessibility bug, add option for accessibilityLabel (#2330)
+- Popover: Fix accessibility bug, add option for accessibilityLabel [#2330](https://github.com/pinterest/gestalt/pull/2330)
 
 ## 68.0.2 (Aug 24, 2022)
 
 ### Patch
 
-- Docs: Mobile IconButton docs for iOS and Android (#2328)
+- Docs: Mobile IconButton docs for iOS and Android [#2328](https://github.com/pinterest/gestalt/pull/2328)
 
 ## 68.0.1 (Aug 24, 2022)
 
 ### Patch
 
-- Avatar-Android: Added new guidelines (#2321)
+- Avatar-Android: Added new guidelines [#2321](https://github.com/pinterest/gestalt/pull/2321)
 
 ## 68.0.0 (Aug 24, 2022)
 
 ### Major
 
-- Masonry: rename `comp` to `Item` (#2325)
+- Masonry: rename `comp` to `Item` [#2325](https://github.com/pinterest/gestalt/pull/2325)
 
 ## 67.0.4 (Aug 24, 2022)
 
 ### Patch
 
-- Internal: use immutable arrays in docs components (#2324)
+- Internal: use immutable arrays in docs components [#2324](https://github.com/pinterest/gestalt/pull/2324)
 
 ## 67.0.3 (Aug 23, 2022)
 
 ### Patch
 
-- IconButton: codemod for upcoming default size changes (#2306)
+- IconButton: codemod for upcoming default size changes [#2306](https://github.com/pinterest/gestalt/pull/2306)
 
 ## 67.0.2 (Aug 23, 2022)
 
 ### Patch
 
-- Docs: Fix Overlapping Accessibility Checks (#2316)
+- Docs: Fix Overlapping Accessibility Checks [#2316](https://github.com/pinterest/gestalt/pull/2316)
 
 ## 67.0.1 (Aug 23, 2022)
 
 ### Patch
 
-- Masonry: add note about stable component references (#2323)
+- Masonry: add note about stable component references [#2323](https://github.com/pinterest/gestalt/pull/2323)
 
 ## 67.0.0 (Aug 23, 2022)
 
 ### Major
 
-- IconButton, Pog: change default iconColor prop value from "gray" to "darkGray" (#2320)
+- IconButton, Pog: change default iconColor prop value from "gray" to "darkGray" [#2320](https://github.com/pinterest/gestalt/pull/2320)
 
 ## 66.0.12 (Aug 23, 2022)
 
 ### Patch
 
-- Docs: Add Messaging guidelines (#2290)
+- Docs: Add Messaging guidelines [#2290](https://github.com/pinterest/gestalt/pull/2290)
 
 ## 66.0.11 (Aug 23, 2022)
 
 ### Patch
 
-- Avatar-iOS: Add docs page (#2319)
+- Avatar-iOS: Add docs page [#2319](https://github.com/pinterest/gestalt/pull/2319)
 
 ## 66.0.10 (Aug 22, 2022)
 
 ### Patch
 
-- Revert "Avatar-iOS: Add docs page (#2295)" (#2318)
+- Revert "Avatar-iOS: Add docs page [#2295](https://github.com/pinterest/gestalt/pull/2295)" [#2318](https://github.com/pinterest/gestalt/pull/2318)
 
 ## 66.0.9 (Aug 22, 2022)
 
 ### Patch
 
-- Docs: Fix links on overview page (#2314)
+- Docs: Fix links on overview page [#2314](https://github.com/pinterest/gestalt/pull/2314)
 
 ## 66.0.8 (Aug 22, 2022)
 
 ### Patch
 
-- Docs: update PR template with new title format (#2315)
+- Docs: update PR template with new title format [#2315](https://github.com/pinterest/gestalt/pull/2315)
 
 ## 66.0.7 (Aug 19, 2022)
 
 ### Patch
 
-- Docs: add link to Figma plugins doc (#2312)
+- Docs: add link to Figma plugins doc [#2312](https://github.com/pinterest/gestalt/pull/2312)
 
 ## 66.0.6 (Aug 19, 2022)
 
 ### Patch
 
-- Docs: 8/19 blog post update (#2311)
+- Docs: 8/19 blog post update [#2311](https://github.com/pinterest/gestalt/pull/2311)
 
 ## 66.0.5 (Aug 19, 2022)
 
 ### Patch
 
-- Internal: remove commented-out lint rule (#2310)
+- Internal: remove commented-out lint rule [#2310](https://github.com/pinterest/gestalt/pull/2310)
 
 ## 66.0.4 (Aug 19, 2022)
 
 ### Patch
 
-- Docs: fix typos in digest (#2309)
+- Docs: fix typos in digest [#2309](https://github.com/pinterest/gestalt/pull/2309)
 
 ## 66.0.3 (Aug 19, 2022)
 
 ### Patch
 
-- Docs: Weekly update for 8-19 (#2307)
+- Docs: Weekly update for 8-19 [#2307](https://github.com/pinterest/gestalt/pull/2307)
 
 ## 66.0.2 (Aug 19, 2022)
 
 ### Patch
 
-- Internal: more Flow lint rules (#2305)
+- Internal: more Flow lint rules [#2305](https://github.com/pinterest/gestalt/pull/2305)
 
 ## 66.0.1 (Aug 19, 2022)
 
 ### Patch
 
-- Revert " IconButton: change default iconColor prop value from "gray" to "darkGray" (#2304)" (#2308)
+- Revert " IconButton: change default iconColor prop value from "gray" to "darkGray" [#2304](https://github.com/pinterest/gestalt/pull/2304)" [#2308](https://github.com/pinterest/gestalt/pull/2308)
 
 ## 66.0.0 (Aug 19, 2022)
 
 ### Major
 
-- IconButton: change default iconColor prop value from "gray" to "darkGray" (#2304)
+- IconButton: change default iconColor prop value from "gray" to "darkGray" [#2304](https://github.com/pinterest/gestalt/pull/2304)
 
 ## 65.5.0 (Aug 19, 2022)
 
 ### Minor
 
-- Docs: Move Development Page to Markdown (#2227)
+- Docs: Move Development Page to Markdown [#2227](https://github.com/pinterest/gestalt/pull/2227)
 
 ## 65.4.2 (Aug 19, 2022)
 
 ### Patch
 
-- Heading: fix docs link to design tokens (#2303)
+- Heading: fix docs link to design tokens [#2303](https://github.com/pinterest/gestalt/pull/2303)
 
 ## 65.4.1 (Aug 18, 2022)
 
 ### Patch
 
-- Internal: lint for array Flow type syntax (#2302)
+- Internal: lint for array Flow type syntax [#2302](https://github.com/pinterest/gestalt/pull/2302)
 
 ## 65.4.0 (Aug 18, 2022)
 
 ### Minor
 
-- IconButton: codemod for upcoming default iconColor value changes (#2299)
+- IconButton: codemod for upcoming default iconColor value changes [#2299](https://github.com/pinterest/gestalt/pull/2299)
 
 ## 65.3.12 (Aug 18, 2022)
 
 ### Patch
 
-- Internal: Bump @actions/core from 1.2.6 to 1.9.1 (#2301)
+- Internal: Bump @actions/core from 1.2.6 to 1.9.1 [#2301](https://github.com/pinterest/gestalt/pull/2301)
 
 ## 65.3.11 (Aug 18, 2022)
 
 ### Patch
 
-- Bump undici from 5.8.0 to 5.9.1 (#2300)
+- Bump undici from 5.8.0 to 5.9.1 [#2300](https://github.com/pinterest/gestalt/pull/2300)
 
 ## 65.3.10 (Aug 18, 2022)
 
 ### Patch
 
-- Foundations: new Overview page (#2292)
+- Foundations: new Overview page [#2292](https://github.com/pinterest/gestalt/pull/2292)
 
 ## 65.3.9 (Aug 18, 2022)
 
 ### Patch
 
-- Internal: run prettier on CSS files (#2298)
+- Internal: run prettier on CSS files [#2298](https://github.com/pinterest/gestalt/pull/2298)
 
 ## 65.3.8 (Aug 18, 2022)
 
 ### Patch
 
-- Video: fix docs link for disableRemotePlayback (#2296)
+- Video: fix docs link for disableRemotePlayback [#2296](https://github.com/pinterest/gestalt/pull/2296)
 
 ## 65.3.7 (Aug 18, 2022)
 
 ### Patch
 
-- Docs: add Category type to catch regressions (#2294)
+- Docs: add Category type to catch regressions [#2294](https://github.com/pinterest/gestalt/pull/2294)
 
 ## 65.3.6 (Aug 18, 2022)
 
 ### Patch
 
-- Docs: add link to web overview page (#2293)
+- Docs: add link to web overview page [#2293](https://github.com/pinterest/gestalt/pull/2293)
 
 ## 65.3.5 (Aug 17, 2022)
 
 ### Patch
 
-- Component overview: updated per redesign (#2288)
+- Component overview: updated per redesign [#2288](https://github.com/pinterest/gestalt/pull/2288)
 
 ## 65.3.4 (Aug 17, 2022)
 
 ### Patch
 
-- SideNavigation: fixes in height and mobile implementation in sm breakpoint (#2282)
+- SideNavigation: fixes in height and mobile implementation in sm breakpoint [#2282](https://github.com/pinterest/gestalt/pull/2282)
 
 ## 65.3.3 (Aug 17, 2022)
 
 ### Patch
 
-- Internal: increase Node memory to solve OOM issue on CI (#2291)
+- Internal: increase Node memory to solve OOM issue on CI [#2291](https://github.com/pinterest/gestalt/pull/2291)
 
 ## 65.3.2 (Aug 17, 2022)
 
 ### Patch
 
-- Docs: refactored Homepage (#2287)
+- Docs: refactored Homepage [#2287](https://github.com/pinterest/gestalt/pull/2287)
 
 ## 65.3.1 (Aug 17, 2022)
 
 ### Patch
 
-- Internal: add Node.js 18 to test matrix (#2285)
+- Internal: add Node.js 18 to test matrix [#2285](https://github.com/pinterest/gestalt/pull/2285)
 
 ## 65.3.0 (Aug 17, 2022)
 
 ### Minor
 
-- Video: fix hydration issue (#2284)
+- Video: fix hydration issue [#2284](https://github.com/pinterest/gestalt/pull/2284)
 
 ## 65.2.3 (Aug 16, 2022)
 
 ### Patch
 
-- Docs: improve keyboard interactions for search bar (#2283)
+- Docs: improve keyboard interactions for search bar [#2283](https://github.com/pinterest/gestalt/pull/2283)
 
 ## 65.2.2 (Aug 15, 2022)
 
 ### Patch
 
-- Internal: lint shell files (#2281)
+- Internal: lint shell files [#2281](https://github.com/pinterest/gestalt/pull/2281)
 
 ## 65.2.1 (Aug 12, 2022)
 
 ### Patch
 
-- Docs: 8-12 update (#2278)
+- Docs: 8-12 update [#2278](https://github.com/pinterest/gestalt/pull/2278)
 
 ## 65.2.0 (Aug 12, 2022)
 
 ### Minor
 
-- Callout: add "success", "recommendation" variants (#2277)
+- Callout: add "success", "recommendation" variants [#2277](https://github.com/pinterest/gestalt/pull/2277)
 
 ## 65.1.2 (Aug 12, 2022)
 
 ### Patch
 
-- Internal: remove unused scripts (#2279)
+- Internal: remove unused scripts [#2279](https://github.com/pinterest/gestalt/pull/2279)
 
 ## 65.1.1 (Aug 12, 2022)
 
 ### Patch
 
-- Added an "Abandoned" section to our roadmap (#2280)
+- Added an "Abandoned" section to our roadmap [#2280](https://github.com/pinterest/gestalt/pull/2280)
 
 ## 65.1.0 (Aug 12, 2022)
 
 ### Minor
 
-- Sheet: fix flicker when closing Sheet with React 18 (#2275)
+- Sheet: fix flicker when closing Sheet with React 18 [#2275](https://github.com/pinterest/gestalt/pull/2275)
 
 ## 65.0.2 (Aug 11, 2022)
 
 ### Patch
 
-- Docs: fix incorrect code wrapping on Masonry docs (#2274)
+- Docs: fix incorrect code wrapping on Masonry docs [#2274](https://github.com/pinterest/gestalt/pull/2274)
 
 ## 65.0.1 (Aug 11, 2022)
 
 ### Patch
 
-- Internal: remove deepCloneReplacingUndefined (#2273)
+- Internal: remove deepCloneReplacingUndefined [#2273](https://github.com/pinterest/gestalt/pull/2273)
 
 ## 65.0.0 (Aug 11, 2022)
 
 ### Major
 
-- Removing justify value prop of Heading component (#2257)
+- Removing justify value prop of Heading component [#2257](https://github.com/pinterest/gestalt/pull/2257)
 
 ## 64.0.7 (Aug 11, 2022)
 
 ### Patch
 
-- Docs: convert mutliple foundation pages to use Sandpack (#2259)
+- Docs: convert mutliple foundation pages to use Sandpack [#2259](https://github.com/pinterest/gestalt/pull/2259)
 
 ## 64.0.6 (Aug 10, 2022)
 
 ### Patch
 
-- Internal: fix Flow issues with positioning utils (#2268)
+- Internal: fix Flow issues with positioning utils [#2268](https://github.com/pinterest/gestalt/pull/2268)
 
 ## 64.0.5 (Aug 10, 2022)
 
 ### Patch
 
-- Internal: disallow console.\* calls in tests (#2271)
+- Internal: disallow console.\* calls in tests [#2271](https://github.com/pinterest/gestalt/pull/2271)
 
 ## 64.0.4 (Aug 10, 2022)
 
 ### Patch
 
-- Docs: Fixed broken link in color palette page (#2272)
+- Docs: Fixed broken link in color palette page [#2272](https://github.com/pinterest/gestalt/pull/2272)
 
 ## 64.0.3 (Aug 10, 2022)
 
 ### Patch
 
-- Docs: fix Collage bug (#2270)
+- Docs: fix Collage bug [#2270](https://github.com/pinterest/gestalt/pull/2270)
 
 ## 64.0.2 (Aug 9, 2022)
 
 ### Patch
 
-- Docs: fix Flex issues (#2269)
+- Docs: fix Flex issues [#2269](https://github.com/pinterest/gestalt/pull/2269)
 
 ## 64.0.1 (Aug 9, 2022)
 
 ### Patch
 
-- Internal: upgrade caniuse (#2267)
+- Internal: upgrade caniuse [#2267](https://github.com/pinterest/gestalt/pull/2267)
 
 ## 64.0.0 (Aug 8, 2022)
 
 ### Major
 
-- Flex: modify `gap` to support row/column values (#2218)
+- Flex: modify `gap` to support row/column values [#2218](https://github.com/pinterest/gestalt/pull/2218)
 
 ## 63.3.3 (Aug 8, 2022)
 
 ### Patch
 
-- Flex: add link to Flexbox Froggy (#2266)
+- Flex: add link to Flexbox Froggy [#2266](https://github.com/pinterest/gestalt/pull/2266)
 
 ## 63.3.2 (Aug 8, 2022)
 
 ### Patch
 
-- Internal: Upgrade React Testing Library and update flow types (#2265)
+- Internal: Upgrade React Testing Library and update flow types [#2265](https://github.com/pinterest/gestalt/pull/2265)
 
 ## 63.3.1 (Aug 5, 2022)
 
 ### Patch
 
-- Docs: update all internal links to new URL structure (#2264)
+- Docs: update all internal links to new URL structure [#2264](https://github.com/pinterest/gestalt/pull/2264)
 
 ## 63.3.0 (Aug 5, 2022)
 
 ### Minor
 
-- SideNavigation: add self-opening group on active items (#2263)
+- SideNavigation: add self-opening group on active items [#2263](https://github.com/pinterest/gestalt/pull/2263)
 
 ## 63.2.2 (Aug 5, 2022)
 
 ### Patch
 
-- PageHeader: improved Docs with examples and descriptions (#2262)
+- PageHeader: improved Docs with examples and descriptions [#2262](https://github.com/pinterest/gestalt/pull/2262)
 
 ## 63.2.1 (Aug 4, 2022)
 
 ### Patch
 
-- Internal: upgrade flow-bin to 0.184.0, try out new inference mode (#2261)
+- Internal: upgrade flow-bin to 0.184.0, try out new inference mode [#2261](https://github.com/pinterest/gestalt/pull/2261)
 
 ## 63.2.0 (Aug 4, 2022)
 
 ### Minor
 
-- Releases: new developers/releases page (#2260)
+- Releases: new developers/releases page [#2260](https://github.com/pinterest/gestalt/pull/2260)
 
 ## 63.1.1 (Aug 3, 2022)
 
 ### Patch
 
-- Docs: adjustments to Sandpack code containers (#2255)
+- Docs: adjustments to Sandpack code containers [#2255](https://github.com/pinterest/gestalt/pull/2255)
 
 ## 63.1.0 (Aug 3, 2022)
 
@@ -512,1617 +512,1617 @@
 
 ### Patch
 
-- Docs: implement Tabs into Gestalt Documentation's SideNavigation for mobile (#2254)
+- Docs: implement Tabs into Gestalt Documentation's SideNavigation for mobile [#2254](https://github.com/pinterest/gestalt/pull/2254)
 
 ## 63.0.11 (Aug 3, 2022)
 
 ### Patch
 
-- Tooling: refactor renameComponent codemod to use new helper functions (#2235)
+- Tooling: refactor renameComponent codemod to use new helper functions [#2235](https://github.com/pinterest/gestalt/pull/2235)
 
 ## 63.0.10 (Aug 3, 2022)
 
 ### Patch
 
-- Tests: Update accessibility tests (#2251)
+- Tests: Update accessibility tests [#2251](https://github.com/pinterest/gestalt/pull/2251)
 
 ## 63.0.9 (Aug 3, 2022)
 
 ### Patch
 
-- Docs: convert accessibility page to Sandpack & fix useReducedMotion example (#2253)
+- Docs: convert accessibility page to Sandpack & fix useReducedMotion example [#2253](https://github.com/pinterest/gestalt/pull/2253)
 
 ## 63.0.8 (Aug 3, 2022)
 
 ### Patch
 
-- Internal: add eslint-plugin-validate-jsx-nesting (#2252)
+- Internal: add eslint-plugin-validate-jsx-nesting [#2252](https://github.com/pinterest/gestalt/pull/2252)
 
 ## 63.0.7 (Aug 2, 2022)
 
 ### Patch
 
-- Docs: Fix missing pages (#2250)
+- Docs: Fix missing pages [#2250](https://github.com/pinterest/gestalt/pull/2250)
 
 ## 63.0.6 (Aug 2, 2022)
 
 ### Patch
 
-- Docs: add redirects for old paths (#2248)
+- Docs: add redirects for old paths [#2248](https://github.com/pinterest/gestalt/pull/2248)
 
 ## 63.0.5 (Aug 2, 2022)
 
 ### Patch
 
-- Docs: Move development process page (#2249)
+- Docs: Move development process page [#2249](https://github.com/pinterest/gestalt/pull/2249)
 
 ## 63.0.4 (Aug 2, 2022)
 
 ### Patch
 
-- SideNavigation: implement Sandpack live code examples (#2240)
+- SideNavigation: implement Sandpack live code examples [#2240](https://github.com/pinterest/gestalt/pull/2240)
 
 ## 63.0.3 (Aug 2, 2022)
 
 ### Patch
 
-- Docs: site navigation updates (#2242)
+- Docs: site navigation updates [#2242](https://github.com/pinterest/gestalt/pull/2242)
 
 ## 63.0.2 (Aug 2, 2022)
 
 ### Patch
 
-- Docs: new SlimBanner, SideNavigation SVGs (#2247)
+- Docs: new SlimBanner, SideNavigation SVGs [#2247](https://github.com/pinterest/gestalt/pull/2247)
 
 ## 63.0.1 (Aug 2, 2022)
 
 ### Patch
 
-- Internal: remove unused cacache dependency (#2245)
+- Internal: remove unused cacache dependency [#2245](https://github.com/pinterest/gestalt/pull/2245)
 
 ## 63.0.0 (Aug 1, 2022)
 
 ### Major
 
-- Docs: Introduced new nested site navigation + platform sections (#2214)
+- Docs: Introduced new nested site navigation + platform sections [#2214](https://github.com/pinterest/gestalt/pull/2214)
 
 ## 62.5.1 (Aug 1, 2022)
 
 ### Patch
 
-- Docs: Fix /\_error renders on collage page (#2236)
+- Docs: Fix /\_error renders on collage page [#2236](https://github.com/pinterest/gestalt/pull/2236)
 
 ## 62.5.0 (Aug 1, 2022)
 
 ### Minor
 
-- Eslint plugin: Avoid "workflow-status-[..]" on Icon (#2228)
+- Eslint plugin: Avoid "workflow-status-[..]" on Icon [#2228](https://github.com/pinterest/gestalt/pull/2228)
 
 ## 62.4.8 (Aug 1, 2022)
 
 ### Patch
 
-- Internal: replace flow-lint suppressions with FlowFixMe (#2241)
+- Internal: replace flow-lint suppressions with FlowFixMe [#2241](https://github.com/pinterest/gestalt/pull/2241)
 
 ## 62.4.7 (Aug 1, 2022)
 
 ### Patch
 
-- Internal: add ability to use local Gestalt CSS & JS files (#2234)
+- Internal: add ability to use local Gestalt CSS & JS files [#2234](https://github.com/pinterest/gestalt/pull/2234)
 
 ## 62.4.6 (Aug 1, 2022)
 
 ### Patch
 
-- Internal: remove unused dependencies (#2232)
+- Internal: remove unused dependencies [#2232](https://github.com/pinterest/gestalt/pull/2232)
 
 ## 62.4.5 (Aug 1, 2022)
 
 ### Patch
 
-- Docs: fix web repository link (#2233)
+- Docs: fix web repository link [#2233](https://github.com/pinterest/gestalt/pull/2233)
 
 ## 62.4.4 (Aug 1, 2022)
 
 ### Patch
 
-- Docs: group sidebar toggles (#2238)
+- Docs: group sidebar toggles [#2238](https://github.com/pinterest/gestalt/pull/2238)
 
 ## 62.4.3 (Aug 1, 2022)
 
 ### Patch
 
-- Docs: fix received 'true' for a non-boolean attribute 'wsz' (#2237)
+- Docs: fix received 'true' for a non-boolean attribute 'wsz' [#2237](https://github.com/pinterest/gestalt/pull/2237)
 
 ## 62.4.2 (Aug 1, 2022)
 
 ### Patch
 
-- Docs: sidebar border should reach bottom (#2239)
+- Docs: sidebar border should reach bottom [#2239](https://github.com/pinterest/gestalt/pull/2239)
 
 ## 62.4.1 (Jul 29, 2022)
 
 ### Patch
 
-- Docs: fix heading scroll position (#2230)
+- Docs: fix heading scroll position [#2230](https://github.com/pinterest/gestalt/pull/2230)
 
 ## 62.4.0 (Jul 29, 2022)
 
 ### Minor
 
-- Docs: Introduce Sandpack for code examples (#2221)
+- Docs: Introduce Sandpack for code examples [#2221](https://github.com/pinterest/gestalt/pull/2221)
 
 ## 62.3.0 (Jul 28, 2022)
 
 ### Minor
 
-- SideNavigation: V3 (mobile) (#2217)
+- SideNavigation: V3 (mobile) [#2217](https://github.com/pinterest/gestalt/pull/2217)
 
 ## 62.2.0 (Jul 26, 2022)
 
 ### Minor
 
-- Docs: Add ability to write Markdown/MDX docs pages (#1981)
+- Docs: Add ability to write Markdown/MDX docs pages [#1981](https://github.com/pinterest/gestalt/pull/1981)
 
 ## 62.1.4 (Jul 26, 2022)
 
 ### Patch
 
-- Internal: upgrade flow-bin to 0.183.0 (#2223)
+- Internal: upgrade flow-bin to 0.183.0 [#2223](https://github.com/pinterest/gestalt/pull/2223)
 
 ## 62.1.3 (Jul 26, 2022)
 
 ### Patch
 
-- Docs: replace instances of old domain (#2224)
+- Docs: replace instances of old domain [#2224](https://github.com/pinterest/gestalt/pull/2224)
 
 ## 62.1.2 (Jul 25, 2022)
 
 ### Patch
 
-- Docs: Tweaks and fixes to Iconography guidelines (#2215)
+- Docs: Tweaks and fixes to Iconography guidelines [#2215](https://github.com/pinterest/gestalt/pull/2215)
 
 ## 62.1.1 (Jul 25, 2022)
 
 ### Patch
 
-- Bump undici from 5.5.1 to 5.8.0 (#2212)
+- Bump undici from 5.5.1 to 5.8.0 [#2212](https://github.com/pinterest/gestalt/pull/2212)
 
 ## 62.1.0 (Jul 25, 2022)
 
 ### Minor
 
-- Table.Header: add 'display' prop (#2220)
+- Table.Header: add 'display' prop [#2220](https://github.com/pinterest/gestalt/pull/2220)
 
 ## 62.0.11 (Jul 22, 2022)
 
 ### Patch
 
-- Docs: What's new 7-22 update (#2216)
+- Docs: What's new 7-22 update [#2216](https://github.com/pinterest/gestalt/pull/2216)
 
 ## 62.0.10 (Jul 22, 2022)
 
 ### Patch
 
-- Docs: Iconography guidelines (#2210)
+- Docs: Iconography guidelines [#2210](https://github.com/pinterest/gestalt/pull/2210)
 
 ## 62.0.9 (Jul 21, 2022)
 
 ### Patch
 
-- SideNavigation: quick fix docs (#2211)
+- SideNavigation: quick fix docs [#2211](https://github.com/pinterest/gestalt/pull/2211)
 
 ## 62.0.8 (Jul 20, 2022)
 
 ### Patch
 
-- SideNavigation: implement guidelines (#2209)
+- SideNavigation: implement guidelines [#2209](https://github.com/pinterest/gestalt/pull/2209)
 
 ## 62.0.7 (Jul 20, 2022)
 
 ### Patch
 
-- Bump terser from 5.3.4 to 5.14.2 (#2208)
+- Bump terser from 5.3.4 to 5.14.2 [#2208](https://github.com/pinterest/gestalt/pull/2208)
 
 ## 62.0.6 (Jul 18, 2022)
 
 ### Patch
 
-- Internal: remove unused greenkeeper files & references (#2207)
+- Internal: remove unused greenkeeper files & references [#2207](https://github.com/pinterest/gestalt/pull/2207)
 
 ## 62.0.5 (Jul 15, 2022)
 
 ### Patch
 
-- 7-15 update (#2206)
+- 7-15 update [#2206](https://github.com/pinterest/gestalt/pull/2206)
 
 ## 62.0.4 (Jul 15, 2022)
 
 ### Patch
 
-- Docs: Fix typos (#2205)
+- Docs: Fix typos [#2205](https://github.com/pinterest/gestalt/pull/2205)
 
 ## 62.0.3 (Jul 15, 2022)
 
 ### Patch
 
-- Revert "7/15 what's new update" (#2204)
+- Revert "7/15 what's new update" [#2204](https://github.com/pinterest/gestalt/pull/2204)
 
 ## 62.0.2 (Jul 15, 2022)
 
 ### Patch
 
-- SideNavigation: small fixes (#2203)
+- SideNavigation: small fixes [#2203](https://github.com/pinterest/gestalt/pull/2203)
 
 ## 62.0.1 (Jul 15, 2022)
 
 ### Patch
 
-- Link: design guidance copy updates (#2202)
+- Link: design guidance copy updates [#2202](https://github.com/pinterest/gestalt/pull/2202)
 
 ## 62.0.0 (Jul 15, 2022)
 
 ### Major
 
-- SideNavigation: V2 (#2200)
+- SideNavigation: V2 [#2200](https://github.com/pinterest/gestalt/pull/2200)
 
 ## 61.3.2 (Jul 12, 2022)
 
 ### Patch
 
-- Video: Updated support for captions (#2195)
+- Video: Updated support for captions [#2195](https://github.com/pinterest/gestalt/pull/2195)
 
 ## 61.3.1 (Jul 12, 2022)
 
 ### Patch
 
-- Roadmap updates for July (#2201)
+- Roadmap updates for July [#2201](https://github.com/pinterest/gestalt/pull/2201)
 
 ## 61.3.0 (Jul 12, 2022)
 
 ### Minor
 
-- Docs: Implement SideNavigation (#2198)
+- Docs: Implement SideNavigation [#2198](https://github.com/pinterest/gestalt/pull/2198)
 
 ## 61.2.2 (Jul 12, 2022)
 
 ### Patch
 
-- Masonry: Fix internal only flow issues (#2197)
+- Masonry: Fix internal only flow issues [#2197](https://github.com/pinterest/gestalt/pull/2197)
 
 ## 61.2.1 (Jul 12, 2022)
 
 ### Patch
 
-- Docs: Header tweak (#2196)
+- Docs: Header tweak [#2196](https://github.com/pinterest/gestalt/pull/2196)
 
 ## 61.2.0 (Jul 12, 2022)
 
 ### Minor
 
-- SideNavigation: new component (V1) (#2185)
+- SideNavigation: new component (V1) [#2185](https://github.com/pinterest/gestalt/pull/2185)
 
 ## 61.1.0 (Jul 11, 2022)
 
 ### Minor
 
-- Docs: New header navigation (#2194)
+- Docs: New header navigation [#2194](https://github.com/pinterest/gestalt/pull/2194)
 
 ## 61.0.1 (Jul 9, 2022)
 
 ### Patch
 
-- Docs: Blog posts for week of 07/08 (#2193)
+- Docs: Blog posts for week of 07/08 [#2193](https://github.com/pinterest/gestalt/pull/2193)
 
 ## 61.0.0 (Jul 8, 2022)
 
 ### Major
 
-- Box: Remove deprecated color options (#2187)
+- Box: Remove deprecated color options [#2187](https://github.com/pinterest/gestalt/pull/2187)
 
 ## 60.1.0 (Jul 7, 2022)
 
 ### Minor
 
-- SlimBanner: New Recommendation variant (#2190)
+- SlimBanner: New Recommendation variant [#2190](https://github.com/pinterest/gestalt/pull/2190)
 
 ## 60.0.2 (Jul 7, 2022)
 
 ### Patch
 
-- Internal: upgrade Next.js to 12.2.0 (#2191)
+- Internal: upgrade Next.js to 12.2.0 [#2191](https://github.com/pinterest/gestalt/pull/2191)
 
 ## 60.0.1 (Jul 7, 2022)
 
 ### Patch
 
-- Docs: Show code for top example and Do's in Best Practices (#2189)
+- Docs: Show code for top example and Do's in Best Practices [#2189](https://github.com/pinterest/gestalt/pull/2189)
 
 ## 60.0.0 (Jul 6, 2022)
 
 ### Major
 
-- Masonry: remove deprecated layouts (#2184)
+- Masonry: remove deprecated layouts [#2184](https://github.com/pinterest/gestalt/pull/2184)
 
 ## 59.0.0 (Jul 6, 2022)
 
 ### Major
 
-- Masonry: remove flexible prop (#2175)
+- Masonry: remove flexible prop [#2175](https://github.com/pinterest/gestalt/pull/2175)
 
 ## 58.4.4 (Jul 5, 2022)
 
 ### Patch
 
-- Toast: Update styling to ensure proper background color (#2178)
+- Toast: Update styling to ensure proper background color [#2178](https://github.com/pinterest/gestalt/pull/2178)
 
 ## 58.4.3 (Jul 5, 2022)
 
 ### Patch
 
-- Table: fix sortable header cell args bug (#2188)
+- Table: fix sortable header cell args bug [#2188](https://github.com/pinterest/gestalt/pull/2188)
 
 ## 58.4.2 (Jul 2, 2022)
 
 ### Patch
 
-- Docs: Blog update for 7/01 (#2186)
+- Docs: Blog update for 7/01 [#2186](https://github.com/pinterest/gestalt/pull/2186)
 
 ## 58.4.1 (Jul 1, 2022)
 
 ### Patch
 
-- Table: update sortable header cell behavior (#2183)
+- Table: update sortable header cell behavior [#2183](https://github.com/pinterest/gestalt/pull/2183)
 
 ## 58.4.0 (Jul 1, 2022)
 
 ### Minor
 
-- Slim banner upgrades (#2179)
+- Slim banner upgrades [#2179](https://github.com/pinterest/gestalt/pull/2179)
 
 ## 58.3.3 (Jun 30, 2022)
 
 ### Patch
 
-- Docs: updated Gestalt Sandbox (#2182)
+- Docs: updated Gestalt Sandbox [#2182](https://github.com/pinterest/gestalt/pull/2182)
 
 ## 58.3.2 (Jun 30, 2022)
 
 ### Patch
 
-- Docs: Updating Typography guidelines (#2181)
+- Docs: Updating Typography guidelines [#2181](https://github.com/pinterest/gestalt/pull/2181)
 
 ## 58.3.1 (Jun 30, 2022)
 
 ### Patch
 
-- Component status: quick link fix (#2180)
+- Component status: quick link fix [#2180](https://github.com/pinterest/gestalt/pull/2180)
 
 ## 58.3.0 (Jun 30, 2022)
 
 ### Minor
 
-- Component status: new page & Quality Checklist on a per component basis (#2114)
+- Component status: new page & Quality Checklist on a per component basis [#2114](https://github.com/pinterest/gestalt/pull/2114)
 
 ## 58.2.0 (Jun 30, 2022)
 
 ### Minor
 
-- Font weight: change font weight from bold to semibold (#2171)
+- Font weight: change font weight from bold to semibold [#2171](https://github.com/pinterest/gestalt/pull/2171)
 
 ## 58.1.22 (Jun 30, 2022)
 
 ### Patch
 
-- Docs: Fix Resource Slack eng link (#2177)
+- Docs: Fix Resource Slack eng link [#2177](https://github.com/pinterest/gestalt/pull/2177)
 
 ## 58.1.21 (Jun 30, 2022)
 
 ### Patch
 
-- PageHeader: Make onClick for helperLink optional (#2174)
+- PageHeader: Make onClick for helperLink optional [#2174](https://github.com/pinterest/gestalt/pull/2174)
 
 ## 58.1.20 (Jun 30, 2022)
 
 ### Patch
 
-- Docs: fix some OnLinkNavigationProvider links (#2176)
+- Docs: fix some OnLinkNavigationProvider links [#2176](https://github.com/pinterest/gestalt/pull/2176)
 
 ## 58.1.19 (Jun 28, 2022)
 
 ### Patch
 
-- Docs: Updates to Resources and Footer (#2172)
+- Docs: Updates to Resources and Footer [#2172](https://github.com/pinterest/gestalt/pull/2172)
 
 ## 58.1.18 (Jun 28, 2022)
 
 ### Patch
 
-- Design Tokens: Add cross-linking to various pages (#2169)
+- Design Tokens: Add cross-linking to various pages [#2169](https://github.com/pinterest/gestalt/pull/2169)
 
 ## 58.1.17 (Jun 28, 2022)
 
 ### Patch
 
-- Internal: flow type debounce and throttle methods (#2170)
+- Internal: flow type debounce and throttle methods [#2170](https://github.com/pinterest/gestalt/pull/2170)
 
 ## 58.1.16 (Jun 28, 2022)
 
 ### Patch
 
-- Dropdown: cleanup dead code (#2167)
+- Dropdown: cleanup dead code [#2167](https://github.com/pinterest/gestalt/pull/2167)
 
 ## 58.1.15 (Jun 27, 2022)
 
 ### Patch
 
-- ComboBox: Fix spacing with Tags (#2168)
+- ComboBox: Fix spacing with Tags [#2168](https://github.com/pinterest/gestalt/pull/2168)
 
 ## 58.1.14 (Jun 27, 2022)
 
 ### Patch
 
-- Docs: Cleanup layout and shaded color examples (#2080)
+- Docs: Cleanup layout and shaded color examples [#2080](https://github.com/pinterest/gestalt/pull/2080)
 
 ## 58.1.13 (Jun 24, 2022)
 
 ### Patch
 
-- Docs: Fix Footer in dark mode (#2166)
+- Docs: Fix Footer in dark mode [#2166](https://github.com/pinterest/gestalt/pull/2166)
 
 ## 58.1.12 (Jun 23, 2022)
 
 ### Patch
 
-- Docs: Add new Resource footers (#2163)
+- Docs: Add new Resource footers [#2163](https://github.com/pinterest/gestalt/pull/2163)
 
 ## 58.1.11 (Jun 23, 2022)
 
 ### Patch
 
-- Docs: Tweaks to 6-24 update (#2165)
+- Docs: Tweaks to 6-24 update [#2165](https://github.com/pinterest/gestalt/pull/2165)
 
 ## 58.1.10 (Jun 23, 2022)
 
 ### Patch
 
-- Docs: Heading improvements (#2155)
+- Docs: Heading improvements [#2155](https://github.com/pinterest/gestalt/pull/2155)
 
 ## 58.1.9 (Jun 23, 2022)
 
 ### Patch
 
-- Docs: 6/24 weekly update (#2164)
+- Docs: 6/24 weekly update [#2164](https://github.com/pinterest/gestalt/pull/2164)
 
 ## 58.1.8 (Jun 23, 2022)
 
 ### Patch
 
-- Link: Update a11y examples (#2162)
+- Link: Update a11y examples [#2162](https://github.com/pinterest/gestalt/pull/2162)
 
 ## 58.1.7 (Jun 22, 2022)
 
 ### Patch
 
-- Card: fix `active` logic to support `false` (#2161)
+- Card: fix `active` logic to support `false` [#2161](https://github.com/pinterest/gestalt/pull/2161)
 
 ## 58.1.6 (Jun 17, 2022)
 
 ### Patch
 
-- Docs: Added weekly update for June 17 (#2160)
+- Docs: Added weekly update for June 17 [#2160](https://github.com/pinterest/gestalt/pull/2160)
 
 ## 58.1.5 (Jun 17, 2022)
 
 ### Patch
 
-- Bump undici from 5.4.0 to 5.5.1 (#2159)
+- Bump undici from 5.4.0 to 5.5.1 [#2159](https://github.com/pinterest/gestalt/pull/2159)
 
 ## 58.1.4 (Jun 17, 2022)
 
 ### Patch
 
-- Docs: minor tweaks to Design Tokens page (#2158)
+- Docs: minor tweaks to Design Tokens page [#2158](https://github.com/pinterest/gestalt/pull/2158)
 
 ## 58.1.3 (Jun 16, 2022)
 
 ### Patch
 
-- Internal: upgrade husky to 8.0.1 (#2157)
+- Internal: upgrade husky to 8.0.1 [#2157](https://github.com/pinterest/gestalt/pull/2157)
 
 ## 58.1.2 (Jun 14, 2022)
 
 ### Patch
 
-- Docs: Text design guidelines (#2154)
+- Docs: Text design guidelines [#2154](https://github.com/pinterest/gestalt/pull/2154)
 
 ## 58.1.1 (Jun 14, 2022)
 
 ### Patch
 
-- Docs: Heading component design guidelines (#2153)
+- Docs: Heading component design guidelines [#2153](https://github.com/pinterest/gestalt/pull/2153)
 
 ## 58.1.0 (Jun 8, 2022)
 
 ### Minor
 
-- Icon: Added music-on and music-off icons (#2152)
+- Icon: Added music-on and music-off icons [#2152](https://github.com/pinterest/gestalt/pull/2152)
 
 ## 58.0.6 (Jun 8, 2022)
 
 ### Patch
 
-- Design Tokens: Update android output files (#2110)
+- Design Tokens: Update android output files [#2110](https://github.com/pinterest/gestalt/pull/2110)
 
 ## 58.0.5 (Jun 8, 2022)
 
 ### Patch
 
-- Upsell: Update doc examples (#2151)
+- Upsell: Update doc examples [#2151](https://github.com/pinterest/gestalt/pull/2151)
 
 ## 58.0.4 (Jun 6, 2022)
 
 ### Patch
 
-- Data Visualization: Add usage guidelines with examples (#2148)
+- Data Visualization: Add usage guidelines with examples [#2148](https://github.com/pinterest/gestalt/pull/2148)
 
 ## 58.0.3 (Jun 4, 2022)
 
 ### Patch
 
-- Docs: minor nits on Whats New page (#2149)
+- Docs: minor nits on Whats New page [#2149](https://github.com/pinterest/gestalt/pull/2149)
 
 ## 58.0.2 (Jun 3, 2022)
 
 ### Patch
 
-- Internal: upgrade Next (patch) and related packages (#2143)
+- Internal: upgrade Next (patch) and related packages [#2143](https://github.com/pinterest/gestalt/pull/2143)
 
 ## 58.0.1 (Jun 3, 2022)
 
 ### Patch
 
-- Docs: Weekly update for 6/3/2022 (#2146)
+- Docs: Weekly update for 6/3/2022 [#2146](https://github.com/pinterest/gestalt/pull/2146)
 
 ## 58.0.0 (Jun 3, 2022)
 
 ### Major
 
-- Text, Heading: Deprecate non-token-based size options (#2138)
+- Text, Heading: Deprecate non-token-based size options [#2138](https://github.com/pinterest/gestalt/pull/2138)
 
 ## 57.2.8 (Jun 2, 2022)
 
 ### Patch
 
-- Typography: new Typography guidelines in the Docs (#2132)
+- Typography: new Typography guidelines in the Docs [#2132](https://github.com/pinterest/gestalt/pull/2132)
 
 ## 57.2.7 (Jun 2, 2022)
 
 ### Patch
 
-- Docs: Revamp What's New page into our blog (#2145)
+- Docs: Revamp What's New page into our blog [#2145](https://github.com/pinterest/gestalt/pull/2145)
 
 ## 57.2.6 (Jun 2, 2022)
 
 ### Patch
 
-- Internal: Add Pinterest metadata tag to connect Gestalt Pinterest account w/ Gestalt site (#2139)
+- Internal: Add Pinterest metadata tag to connect Gestalt Pinterest account w/ Gestalt site [#2139](https://github.com/pinterest/gestalt/pull/2139)
 
 ## 57.2.5 (Jun 2, 2022)
 
 ### Patch
 
-- Docs: Updated roadmap for May 2022 (#2140)
+- Docs: Updated roadmap for May 2022 [#2140](https://github.com/pinterest/gestalt/pull/2140)
 
 ## 57.2.4 (Jun 2, 2022)
 
 ### Patch
 
-- Development, Internal: updated Development guidelines and Playwright visual comparisons (#2144)
+- Development, Internal: updated Development guidelines and Playwright visual comparisons [#2144](https://github.com/pinterest/gestalt/pull/2144)
 
 ## 57.2.3 (May 26, 2022)
 
 ### Patch
 
-- Docs: Small tweaks (#2137)
+- Docs: Small tweaks [#2137](https://github.com/pinterest/gestalt/pull/2137)
 
 ## 57.2.2 (May 25, 2022)
 
 ### Patch
 
-- Site: Move site settings into header dropdown menu (#2135)
+- Site: Move site settings into header dropdown menu [#2135](https://github.com/pinterest/gestalt/pull/2135)
 
 ## 57.2.1 (May 25, 2022)
 
 ### Patch
 
-- Flex: fix examples in Docs (#2134)
+- Flex: fix examples in Docs [#2134](https://github.com/pinterest/gestalt/pull/2134)
 
 ## 57.2.0 (May 25, 2022)
 
 ### Minor
 
-- Data Visualization: Add design tokens and color palette page (#2133)
+- Data Visualization: Add design tokens and color palette page [#2133](https://github.com/pinterest/gestalt/pull/2133)
 
 ## 57.1.0 (May 24, 2022)
 
 ### Minor
 
-- Video: Add startTime prop to explicitly set start time on video node (#2129)
+- Video: Add startTime prop to explicitly set start time on video node [#2129](https://github.com/pinterest/gestalt/pull/2129)
 
 ## 57.0.0 (May 24, 2022)
 
 ### Major
 
-- AvatarPair: component deprecation (#2130)
+- AvatarPair: component deprecation [#2130](https://github.com/pinterest/gestalt/pull/2130)
 
 ## 56.3.1 (May 23, 2022)
 
 ### Patch
 
-- Development, Installation: added Docker & Datepicker installation guidelines (#2131)
+- Development, Installation: added Docker & Datepicker installation guidelines [#2131](https://github.com/pinterest/gestalt/pull/2131)
 
 ## 56.3.0 (May 23, 2022)
 
 ### Minor
 
-- Internal: Use Playwright instead of Cypress (#2125)
+- Internal: Use Playwright instead of Cypress [#2125](https://github.com/pinterest/gestalt/pull/2125)
 
 ## 56.2.2 (May 20, 2022)
 
 ### Patch
 
-- Internal: upgrade Flow to 0.178.1 (#2127)
+- Internal: upgrade Flow to 0.178.1 [#2127](https://github.com/pinterest/gestalt/pull/2127)
 
 ## 56.2.1 (May 20, 2022)
 
 ### Patch
 
-- Docs: adding slimBanner prop into Docs' PageHeader to display information related to the component (#2126)
+- Docs: adding slimBanner prop into Docs' PageHeader to display information related to the component [#2126](https://github.com/pinterest/gestalt/pull/2126)
 
 ## 56.2.0 (May 20, 2022)
 
 ### Minor
 
-- Dark mode: Add support for Callout, Upsell, and SlimBanner (#2128)
+- Dark mode: Add support for Callout, Upsell, and SlimBanner [#2128](https://github.com/pinterest/gestalt/pull/2128)
 
 ## 56.1.1 (May 20, 2022)
 
 ### Patch
 
-- Docs: Unified Switch docs (#2122)
+- Docs: Unified Switch docs [#2122](https://github.com/pinterest/gestalt/pull/2122)
 
 ## 56.1.0 (May 20, 2022)
 
 ### Minor
 
-- RadioGroup: New component to ensure accessible radio button groups (#2123)
+- RadioGroup: New component to ensure accessible radio button groups [#2123](https://github.com/pinterest/gestalt/pull/2123)
 
 ## 56.0.1 (May 18, 2022)
 
 ### Patch
 
-- DatePicker: Add note about installing as a separate package (#2124)
+- DatePicker: Add note about installing as a separate package [#2124](https://github.com/pinterest/gestalt/pull/2124)
 
 ## 56.0.0 (May 17, 2022)
 
 ### Major
 
-- Internal: upgrade to React 18 (#2104)
+- Internal: upgrade to React 18 [#2104](https://github.com/pinterest/gestalt/pull/2104)
 
 ## 55.2.2 (May 16, 2022)
 
 ### Patch
 
-- Eslint: Loosen Button iconEnd restrictions (#2121)
+- Eslint: Loosen Button iconEnd restrictions [#2121](https://github.com/pinterest/gestalt/pull/2121)
 
 ## 55.2.1 (May 16, 2022)
 
 ### Patch
 
-- Module: Update for dark mode support (#2120)
+- Module: Update for dark mode support [#2120](https://github.com/pinterest/gestalt/pull/2120)
 
 ## 55.2.0 (May 13, 2022)
 
 ### Minor
 
-- SlimBanner, Callout: new SlimBanner component, fix darkMode Callout (#2108)
+- SlimBanner, Callout: new SlimBanner component, fix darkMode Callout [#2108](https://github.com/pinterest/gestalt/pull/2108)
 
 ## 55.1.2 (May 13, 2022)
 
 ### Patch
 
-- Icons: Update heart-outline svg (#2118)
+- Icons: Update heart-outline svg [#2118](https://github.com/pinterest/gestalt/pull/2118)
 
 ## 55.1.1 (May 12, 2022)
 
 ### Patch
 
-- Datapoint: add prop to set z-index on integrated tooltip (#2115)
+- Datapoint: add prop to set z-index on integrated tooltip [#2115](https://github.com/pinterest/gestalt/pull/2115)
 
 ## 55.1.0 (May 12, 2022)
 
 ### Minor
 
-- ComboBox: add `zIndex` prop (#2117)
+- ComboBox: add `zIndex` prop [#2117](https://github.com/pinterest/gestalt/pull/2117)
 
 ## 55.0.0 (May 12, 2022)
 
 ### Major
 
-- Eslint plugin: Remove excludeTests & excludePaths (#2116)
+- Eslint plugin: Remove excludeTests & excludePaths [#2116](https://github.com/pinterest/gestalt/pull/2116)
 
 ## 54.3.0 (May 11, 2022)
 
 ### Minor
 
-- TextField: add bday to autocomplete (#2113)
+- TextField: add bday to autocomplete [#2113](https://github.com/pinterest/gestalt/pull/2113)
 
 ## 54.2.3 (May 10, 2022)
 
 ### Patch
 
-- Docs: Update Open Forum details (#2112)
+- Docs: Update Open Forum details [#2112](https://github.com/pinterest/gestalt/pull/2112)
 
 ## 54.2.2 (May 10, 2022)
 
 ### Patch
 
-- Badge, Link: updated snapshots (#2111)
+- Badge, Link: updated snapshots [#2111](https://github.com/pinterest/gestalt/pull/2111)
 
 ## 54.2.1 (May 10, 2022)
 
 ### Patch
 
-- Tooltip: minor refactor (#2105)
+- Tooltip: minor refactor [#2105](https://github.com/pinterest/gestalt/pull/2105)
 
 ## 54.2.0 (May 9, 2022)
 
 ### Minor
 
-- Icon: Add info color option (#2109)
+- Icon: Add info color option [#2109](https://github.com/pinterest/gestalt/pull/2109)
 
 ## 54.1.0 (May 4, 2022)
 
 ### Minor
 
-- Icon: update gmail icon design (#2103)
+- Icon: update gmail icon design [#2103](https://github.com/pinterest/gestalt/pull/2103)
 
 ## 54.0.0 (May 4, 2022)
 
 ### Major
 
-- Link: remove `role` and `accessibilitySelected` props (#2102)
+- Link: remove `role` and `accessibilitySelected` props [#2102](https://github.com/pinterest/gestalt/pull/2102)
 
 ## 53.4.3 (May 4, 2022)
 
 ### Patch
 
-- Tabs: quick prop-table update (#2101)
+- Tabs: quick prop-table update [#2101](https://github.com/pinterest/gestalt/pull/2101)
 
 ## 53.4.2 (May 3, 2022)
 
 ### Patch
 
-- Avatar: Add data test id for testing (#2100)
+- Avatar: Add data test id for testing [#2100](https://github.com/pinterest/gestalt/pull/2100)
 
 ## 53.4.1 (May 2, 2022)
 
 ### Patch
 
-- Internal: upgrade Jest to v28 (#2098)
+- Internal: upgrade Jest to v28 [#2098](https://github.com/pinterest/gestalt/pull/2098)
 
 ## 53.4.0 (May 2, 2022)
 
 ### Minor
 
-- DatePicker: add name prop (#2097)
+- DatePicker: add name prop [#2097](https://github.com/pinterest/gestalt/pull/2097)
 
 ## 53.3.0 (May 2, 2022)
 
 ### Minor
 
-- Link: design changes (part II externalLinkIcon) (#2092)
+- Link: design changes (part II externalLinkIcon) [#2092](https://github.com/pinterest/gestalt/pull/2092)
 
 ## 53.2.0 (May 2, 2022)
 
 ### Minor
 
-- Box, Column, Container, Flex, Table: add visual diff testing and screenshot to description in VSCode (Flow extension) (#2096)
+- Box, Column, Container, Flex, Table: add visual diff testing and screenshot to description in VSCode (Flow extension) [#2096](https://github.com/pinterest/gestalt/pull/2096)
 
 ## 53.1.1 (Apr 28, 2022)
 
 ### Patch
 
-- Tooling: url fix (#2095)
+- Tooling: url fix [#2095](https://github.com/pinterest/gestalt/pull/2095)
 
 ## 53.1.0 (Apr 28, 2022)
 
 ### Minor
 
-- Checkbox: Added labelDisplay prop (#2090)
+- Checkbox: Added labelDisplay prop [#2090](https://github.com/pinterest/gestalt/pull/2090)
 
 ## 53.0.0 (Apr 28, 2022)
 
 ### Major
 
-- Icon: Deprecate old literal colors (#2087)
+- Icon: Deprecate old literal colors [#2087](https://github.com/pinterest/gestalt/pull/2087)
 
 ## 52.2.2 (Apr 28, 2022)
 
 ### Patch
 
-- Updated roadmap for April (#2093)
+- Updated roadmap for April [#2093](https://github.com/pinterest/gestalt/pull/2093)
 
 ## 52.2.1 (Apr 28, 2022)
 
 ### Patch
 
-- Docs: Typo fixes and link shortening (#2094)
+- Docs: Typo fixes and link shortening [#2094](https://github.com/pinterest/gestalt/pull/2094)
 
 ## 52.2.0 (Apr 27, 2022)
 
 ### Minor
 
-- Masonry: Fix hydration for server rendered flexible grids (#2084)
+- Masonry: Fix hydration for server rendered flexible grids [#2084](https://github.com/pinterest/gestalt/pull/2084)
 
 ## 52.1.2 (Apr 27, 2022)
 
 ### Patch
 
-- TextArea: design guidelines (#2088)
+- TextArea: design guidelines [#2088](https://github.com/pinterest/gestalt/pull/2088)
 
 ## 52.1.1 (Apr 27, 2022)
 
 ### Patch
 
-- Added default value to labelDisplay prop in TextArea component (#2089)
+- Added default value to labelDisplay prop in TextArea component [#2089](https://github.com/pinterest/gestalt/pull/2089)
 
 ## 52.1.0 (Apr 26, 2022)
 
 ### Minor
 
-- TextField & TextArea: Added labelDisplay prop (#2083)
+- TextField & TextArea: Added labelDisplay prop [#2083](https://github.com/pinterest/gestalt/pull/2083)
 
 ## 52.0.1 (Apr 26, 2022)
 
 ### Patch
 
-- Video: fix on Flow type (#2086)
+- Video: fix on Flow type [#2086](https://github.com/pinterest/gestalt/pull/2086)
 
 ## 52.0.0 (Apr 25, 2022)
 
 ### Major
 
-- Video: handle HTMLMediaElement.play() Promise rejection and autoplay blocking, and API improvements (#2063)
+- Video: handle HTMLMediaElement.play() Promise rejection and autoplay blocking, and API improvements [#2063](https://github.com/pinterest/gestalt/pull/2063)
 
 ## 51.0.0 (Apr 25, 2022)
 
 ### Major
 
-- Link: design changes (part I inline/underline) (#2073)
+- Link: design changes (part I inline/underline) [#2073](https://github.com/pinterest/gestalt/pull/2073)
 
 ## 50.3.0 (Apr 22, 2022)
 
 ### Minor
 
-- Icon: Add brandPrimary color option (#2081)
+- Icon: Add brandPrimary color option [#2081](https://github.com/pinterest/gestalt/pull/2081)
 
 ## 50.2.1 (Apr 22, 2022)
 
 ### Patch
 
-- ActivationCard: Apply new elevation token for dark mode (#2077)
+- ActivationCard: Apply new elevation token for dark mode [#2077](https://github.com/pinterest/gestalt/pull/2077)
 
 ## 50.2.0 (Apr 22, 2022)
 
 ### Minor
 
-- Font weight: implement experiment to change font weight from bold to semibold (#2047)
+- Font weight: implement experiment to change font weight from bold to semibold [#2047](https://github.com/pinterest/gestalt/pull/2047)
 
 ## 50.1.4 (Apr 20, 2022)
 
 ### Patch
 
-- Docs: Update palette info (#2079)
+- Docs: Update palette info [#2079](https://github.com/pinterest/gestalt/pull/2079)
 
 ## 50.1.3 (Apr 20, 2022)
 
 ### Patch
 
-- Docs: Tooltip / IconButton usage guidance (#2074)
+- Docs: Tooltip / IconButton usage guidance [#2074](https://github.com/pinterest/gestalt/pull/2074)
 
 ## 50.1.2 (Apr 20, 2022)
 
 ### Patch
 
-- Datepicker: fix useEffect side effect (#2076)
+- Datepicker: fix useEffect side effect [#2076](https://github.com/pinterest/gestalt/pull/2076)
 
 ## 50.1.1 (Apr 20, 2022)
 
 ### Patch
 
-- Internal: upgrade testing-library/hooks to 8.0.0 (#2078)
+- Internal: upgrade testing-library/hooks to 8.0.0 [#2078](https://github.com/pinterest/gestalt/pull/2078)
 
 ## 50.1.0 (Apr 18, 2022)
 
 ### Minor
 
-- Icon: Add support for new semantic colors (#2072)
+- Icon: Add support for new semantic colors [#2072](https://github.com/pinterest/gestalt/pull/2072)
 
 ## 50.0.9 (Apr 15, 2022)
 
 ### Patch
 
-- Checkbox: Updated Docs (v.1) (#2067)
+- Checkbox: Updated Docs (v.1) [#2067](https://github.com/pinterest/gestalt/pull/2067)
 
 ## 50.0.8 (Apr 14, 2022)
 
 ### Patch
 
-- Docs: Add color examples page (#2068)
+- Docs: Add color examples page [#2068](https://github.com/pinterest/gestalt/pull/2068)
 
 ## 50.0.7 (Apr 14, 2022)
 
 ### Patch
 
-- Button: prop table fixes (#2070)
+- Button: prop table fixes [#2070](https://github.com/pinterest/gestalt/pull/2070)
 
 ## 50.0.6 (Apr 14, 2022)
 
 ### Patch
 
-- Internal: Bump peer dependencies to support React 18 (#2069)
+- Internal: Bump peer dependencies to support React 18 [#2069](https://github.com/pinterest/gestalt/pull/2069)
 
 ## 50.0.5 (Apr 13, 2022)
 
 ### Patch
 
-- PageHeader: Best practice update (#2066)
+- PageHeader: Best practice update [#2066](https://github.com/pinterest/gestalt/pull/2066)
 
 ## 50.0.4 (Apr 13, 2022)
 
 ### Patch
 
-- Bump async from 3.2.0 to 3.2.3 (#2065)
+- Bump async from 3.2.0 to 3.2.3 [#2065](https://github.com/pinterest/gestalt/pull/2065)
 
 ## 50.0.3 (Apr 13, 2022)
 
 ### Patch
 
-- Datepicker: fix controlled state [bug] (#2064)
+- Datepicker: fix controlled state [bug] [#2064](https://github.com/pinterest/gestalt/pull/2064)
 
 ## 50.0.2 (Apr 12, 2022)
 
 ### Patch
 
-- PageHeader: New Docs (#2048)
+- PageHeader: New Docs [#2048](https://github.com/pinterest/gestalt/pull/2048)
 
 ## 50.0.1 (Apr 11, 2022)
 
 ### Patch
 
-- Internal: add eslint-plugin-testing-library (#2062)
+- Internal: add eslint-plugin-testing-library [#2062](https://github.com/pinterest/gestalt/pull/2062)
 
 ## 50.0.0 (Apr 11, 2022)
 
 ### Major
 
-- Heading: Deprecate old color options, add new semantic colors (#2058)
+- Heading: Deprecate old color options, add new semantic colors [#2058](https://github.com/pinterest/gestalt/pull/2058)
 
 ## 49.0.1 (Apr 11, 2022)
 
 ### Patch
 
-- Bump moment from 2.28.0 to 2.29.2 (#2061)
+- Bump moment from 2.28.0 to 2.29.2 [#2061](https://github.com/pinterest/gestalt/pull/2061)
 
 ## 49.0.0 (Apr 8, 2022)
 
 ### Major
 
-- PageHeader: PageHeader redesign v.2 (Part I: core changes) (#1996)
+- PageHeader: PageHeader redesign v.2 (Part I: core changes) [#1996](https://github.com/pinterest/gestalt/pull/1996)
 
 ## 48.0.12 (Apr 8, 2022)
 
 ### Patch
 
-- Button: Fix layout in docs (#2060)
+- Button: Fix layout in docs [#2060](https://github.com/pinterest/gestalt/pull/2060)
 
 ## 48.0.11 (Apr 8, 2022)
 
 ### Patch
 
-- Pog, Toast, Tooltip, Upsell, Video: add visual diff testing and screenshot to description in VSCode (Flow extension) (#2057)
+- Pog, Toast, Tooltip, Upsell, Video: add visual diff testing and screenshot to description in VSCode (Flow extension) [#2057](https://github.com/pinterest/gestalt/pull/2057)
 
 ## 48.0.10 (Apr 7, 2022)
 
 ### Patch
 
-- Image: update Docs to fix heading issues and other visual improvements (a11y bug) (#2056)
+- Image: update Docs to fix heading issues and other visual improvements (a11y bug) [#2056](https://github.com/pinterest/gestalt/pull/2056)
 
 ## 48.0.9 (Apr 7, 2022)
 
 ### Patch
 
-- ScrollBoundaryContainer: rename ScrollBoundaryContainer files to correctly autogenerate docs (bug) (#2055)
+- ScrollBoundaryContainer: rename ScrollBoundaryContainer files to correctly autogenerate docs (bug) [#2055](https://github.com/pinterest/gestalt/pull/2055)
 
 ## 48.0.8 (Apr 7, 2022)
 
 ### Patch
 
-- Avatar: adjustments in Avatar docs (#2054)
+- Avatar: adjustments in Avatar docs [#2054](https://github.com/pinterest/gestalt/pull/2054)
 
 ## 48.0.7 (Apr 7, 2022)
 
 ### Patch
 
-- Popover: remove unused caret stroke style (#2052)
+- Popover: remove unused caret stroke style [#2052](https://github.com/pinterest/gestalt/pull/2052)
 
 ## 48.0.6 (Apr 7, 2022)
 
 ### Patch
 
-- Updated README's language to reflect Gestalt's shift towards a designs system (#2053)
+- Updated README's language to reflect Gestalt's shift towards a designs system [#2053](https://github.com/pinterest/gestalt/pull/2053)
 
 ## 48.0.5 (Apr 6, 2022)
 
 ### Patch
 
-- Roadmap: updates for March (#2035)
+- Roadmap: updates for March [#2035](https://github.com/pinterest/gestalt/pull/2035)
 
 ## 48.0.4 (Apr 6, 2022)
 
 ### Patch
 
-- Internal: Fix flow issue without .map() in Iconography and SVGs docs (#2046)
+- Internal: Fix flow issue without .map() in Iconography and SVGs docs [#2046](https://github.com/pinterest/gestalt/pull/2046)
 
 ## 48.0.3 (Apr 6, 2022)
 
 ### Patch
 
-- Internal: upgrade Flow to 0.175.1 (#2051)
+- Internal: upgrade Flow to 0.175.1 [#2051](https://github.com/pinterest/gestalt/pull/2051)
 
 ## 48.0.2 (Apr 6, 2022)
 
 ### Patch
 
-- TextField: use device type in exp checks (#2050)
+- TextField: use device type in exp checks [#2050](https://github.com/pinterest/gestalt/pull/2050)
 
 ## 48.0.1 (Apr 6, 2022)
 
 ### Patch
 
-- Text: Fix type issue (#2049)
+- Text: Fix type issue [#2049](https://github.com/pinterest/gestalt/pull/2049)
 
 ## 48.0.0 (Apr 6, 2022)
 
 ### Major
 
-- Text: Deprecate old colors (#2028)
+- Text: Deprecate old colors [#2028](https://github.com/pinterest/gestalt/pull/2028)
 
 ## 47.2.0 (Apr 6, 2022)
 
 ### Minor
 
-- Box: Add new raised shadow options to borderStyle (#2044)
+- Box: Add new raised shadow options to borderStyle [#2044](https://github.com/pinterest/gestalt/pull/2044)
 
 ## 47.1.8 (Apr 5, 2022)
 
 ### Patch
 
-- Box: Create elevation section (#2037)
+- Box: Create elevation section [#2037](https://github.com/pinterest/gestalt/pull/2037)
 
 ## 47.1.7 (Apr 4, 2022)
 
 ### Patch
 
-- Internal: increase Cypress timeout threshold (#2041)
+- Internal: increase Cypress timeout threshold [#2041](https://github.com/pinterest/gestalt/pull/2041)
 
 ## 47.1.6 (Apr 4, 2022)
 
 ### Patch
 
-- TextField: fix stale type value when passed dynamically (#2039)
-- TextArea, TextField: Add support for readOnly fields (#2031)
-- Borders: Update border color for multiple components (#2023)
+- TextField: fix stale type value when passed dynamically [#2039](https://github.com/pinterest/gestalt/pull/2039)
+- TextArea, TextField: Add support for readOnly fields [#2031](https://github.com/pinterest/gestalt/pull/2031)
+- Borders: Update border color for multiple components [#2023](https://github.com/pinterest/gestalt/pull/2023)
 
 ## 47.1.5 (Apr 2, 2022)
 
 ### Patch
 
-- Icon: add back to sidebar index (#2038)
+- Icon: add back to sidebar index [#2038](https://github.com/pinterest/gestalt/pull/2038)
 
 ## 47.1.4 (Apr 1, 2022)
 
 ### Patch
 
-- I18nProvider: provide default strings, downgrade throwing errors to console (#2036)
+- I18nProvider: provide default strings, downgrade throwing errors to console [#2036](https://github.com/pinterest/gestalt/pull/2036)
 
 ## 47.1.3 (Mar 31, 2022)
 
 ### Patch
 
-- Internal: upgrade Prettier to 2.6.1 (#2033)
+- Internal: upgrade Prettier to 2.6.1 [#2033](https://github.com/pinterest/gestalt/pull/2033)
 
 ## 47.1.2 (Mar 31, 2022)
 
 ### Patch
 
-- Internal: remove deprecated Prettier option (#2032)
+- Internal: remove deprecated Prettier option [#2032](https://github.com/pinterest/gestalt/pull/2032)
 
 ## 47.1.1 (Mar 31, 2022)
 
 ### Patch
 
-- ComboBox: Update ComboBox tag variant example in Docs (#2029)
+- ComboBox: Update ComboBox tag variant example in Docs [#2029](https://github.com/pinterest/gestalt/pull/2029)
 
 ## 47.1.0 (Mar 31, 2022)
 
 ### Minor
 
-- TextField: Add experimental show/hide password button (#1995)
+- TextField: Add experimental show/hide password button [#1995](https://github.com/pinterest/gestalt/pull/1995)
 
 ## 47.0.0 (Mar 30, 2022)
 
 ### Major
 
-- Internal: add "gestalt" as external dependency for "gestalt-datepicker" (#2030)
+- Internal: add "gestalt" as external dependency for "gestalt-datepicker" [#2030](https://github.com/pinterest/gestalt/pull/2030)
 
 ## 46.7.15 (Mar 30, 2022)
 
 ### Patch
 
-- Internal: fix flow issue in Iconography and SVGs docs (#2025)
+- Internal: fix flow issue in Iconography and SVGs docs [#2025](https://github.com/pinterest/gestalt/pull/2025)
 
 ## 46.7.14 (Mar 30, 2022)
 
 ### Patch
 
-- TapArea: add inline example (#2027)
+- TapArea: add inline example [#2027](https://github.com/pinterest/gestalt/pull/2027)
 
 ## 46.7.13 (Mar 30, 2022)
 
 ### Patch
 
-- TextField: remove stray reference to type="number" (#2026)
+- TextField: remove stray reference to type="number" [#2026](https://github.com/pinterest/gestalt/pull/2026)
 
 ## 46.7.12 (Mar 29, 2022)
 
 ### Patch
 
-- Internal: update RFC template (#2024)
+- Internal: update RFC template [#2024](https://github.com/pinterest/gestalt/pull/2024)
 
 ## 46.7.11 (Mar 29, 2022)
 
 ### Patch
 
-- Development: Added RFCs (request for comments) section and /RFCS folder with process (#2018)
+- Development: Added RFCs (request for comments) section and /RFCS folder with process [#2018](https://github.com/pinterest/gestalt/pull/2018)
 
 ## 46.7.10 (Mar 28, 2022)
 
 ### Patch
 
-- Color usage: Add dark mode examples (#2019)
+- Color usage: Add dark mode examples [#2019](https://github.com/pinterest/gestalt/pull/2019)
 
 ## 46.7.9 (Mar 28, 2022)
 
 ### Patch
 
-- NumberField, TextField: update docs on usage (#2022)
+- NumberField, TextField: update docs on usage [#2022](https://github.com/pinterest/gestalt/pull/2022)
 
 ## 46.7.8 (Mar 28, 2022)
 
 ### Patch
 
-- Component overview: reclass Fieldset cmp (#2021)
+- Component overview: reclass Fieldset cmp [#2021](https://github.com/pinterest/gestalt/pull/2021)
 
 ## 46.7.7 (Mar 28, 2022)
 
 ### Patch
 
-- Component Overview: new page for visual component browsing (#2008)
+- Component Overview: new page for visual component browsing [#2008](https://github.com/pinterest/gestalt/pull/2008)
 
 ## 46.7.6 (Mar 26, 2022)
 
 ### Patch
 
-- Docs: add legal disclaimer re: brand icons (#2020)
+- Docs: add legal disclaimer re: brand icons [#2020](https://github.com/pinterest/gestalt/pull/2020)
 
 ## 46.7.5 (Mar 24, 2022)
 
 ### Patch
 
-- ButtonGroup, Label, Fieldset, Image, Collage: add visual diff testing and screenshot to description in VSCode (Flow extension) (#2017)
+- ButtonGroup, Label, Fieldset, Image, Collage: add visual diff testing and screenshot to description in VSCode (Flow extension) [#2017](https://github.com/pinterest/gestalt/pull/2017)
 
 ## 46.7.4 (Mar 23, 2022)
 
 ### Patch
 
-- Switch: Clean up docs (#2016)
+- Switch: Clean up docs [#2016](https://github.com/pinterest/gestalt/pull/2016)
 
 ## 46.7.3 (Mar 23, 2022)
 
 ### Patch
 
-- Docs: implemented OnLinkNavigationProvider in Docs to extend next/router to all Gestalt components used in Docs (#2011)
+- Docs: implemented OnLinkNavigationProvider in Docs to extend next/router to all Gestalt components used in Docs [#2011](https://github.com/pinterest/gestalt/pull/2011)
 
 ## 46.7.2 (Mar 23, 2022)
 
 ### Patch
 
-- I18nProvider: s/Text/TextField/ (#2014)
+- I18nProvider: s/Text/TextField/ [#2014](https://github.com/pinterest/gestalt/pull/2014)
 
 ## 46.7.1 (Mar 22, 2022)
 
 ### Patch
 
-- Bump node-forge from 1.2.1 to 1.3.0 (#2013)
+- Bump node-forge from 1.2.1 to 1.3.0 [#2013](https://github.com/pinterest/gestalt/pull/2013)
 
 ## 46.7.0 (Mar 22, 2022)
 
 ### Minor
 
-- Image: add decoding prop (#2005)
+- Image: add decoding prop [#2005](https://github.com/pinterest/gestalt/pull/2005)
 
 ## 46.6.0 (Mar 22, 2022)
 
 ### Minor
 
-- I18nProvider: create new Context (#2001)
+- I18nProvider: create new Context [#2001](https://github.com/pinterest/gestalt/pull/2001)
 
 ## 46.5.1 (Mar 22, 2022)
 
 ### Patch
 
-- Internal: add resolution for `minimist` to address vulnerability (#2010)
+- Internal: add resolution for `minimist` to address vulnerability [#2010](https://github.com/pinterest/gestalt/pull/2010)
 
 ## 46.5.0 (Mar 22, 2022)
 
 ### Minor
 
-- SelectList: Add option for hidden label (#2004)
+- SelectList: Add option for hidden label [#2004](https://github.com/pinterest/gestalt/pull/2004)
 
 ## 46.4.3 (Mar 22, 2022)
 
 ### Patch
 
-- Internal: upgrade prettier to 2.6.0 (#2002)
+- Internal: upgrade prettier to 2.6.0 [#2002](https://github.com/pinterest/gestalt/pull/2002)
 
 ## 46.4.2 (Mar 22, 2022)
 
 ### Patch
 
-- Docs: Roadmap (#1946)
+- Docs: Roadmap [#1946](https://github.com/pinterest/gestalt/pull/1946)
 
 ## 46.4.1 (Mar 21, 2022)
 
 ### Patch
 
-- Internal: Fix flaky flow issue on Text (#2007)
+- Internal: Fix flaky flow issue on Text [#2007](https://github.com/pinterest/gestalt/pull/2007)
 
 ## 46.4.0 (Mar 18, 2022)
 
 ### Minor
 
-- ExperimentProvider: create new Context (#2000)
+- ExperimentProvider: create new Context [#2000](https://github.com/pinterest/gestalt/pull/2000)
 
 ## 46.3.0 (Mar 18, 2022)
 
 ### Minor
 
-- Datapoint: Add option for Badge (#1999)
+- Datapoint: Add option for Badge [#1999](https://github.com/pinterest/gestalt/pull/1999)
 
 ## 46.2.1 (Mar 18, 2022)
 
 ### Patch
 
-- Docs: Add Elevation dark mode examples to guidelines (#1997)
+- Docs: Add Elevation dark mode examples to guidelines [#1997](https://github.com/pinterest/gestalt/pull/1997)
 
 ## 46.2.0 (Mar 17, 2022)
 
 ### Minor
 
-- IconButton: add type prop (#1998)
+- IconButton: add type prop [#1998](https://github.com/pinterest/gestalt/pull/1998)
 
 ## 46.1.4 (Mar 17, 2022)
 
 ### Patch
 
-- InternalTextFieldIconButton: create component from InternalTextField (#1993)
+- InternalTextFieldIconButton: create component from InternalTextField [#1993](https://github.com/pinterest/gestalt/pull/1993)
 
 ## 46.1.3 (Mar 17, 2022)
 
 ### Patch
 
-- PageHeader: add visual diff testing and screenshot to description in VSCode (Flow extension) (#1994)
+- PageHeader: add visual diff testing and screenshot to description in VSCode (Flow extension) [#1994](https://github.com/pinterest/gestalt/pull/1994)
 
 ## 46.1.2 (Mar 17, 2022)
 
 ### Patch
 
-- Internal: modified Cypress visual diff testing threshold to catch dark mode changes (#1990)
+- Internal: modified Cypress visual diff testing threshold to catch dark mode changes [#1990](https://github.com/pinterest/gestalt/pull/1990)
 
 ## 46.1.1 (Mar 16, 2022)
 
 ### Patch
 
-- Text: rework color class logic to appease Flow (#1992)
+- Text: rework color class logic to appease Flow [#1992](https://github.com/pinterest/gestalt/pull/1992)
 
 ## 46.1.0 (Mar 16, 2022)
 
 ### Minor
 
-- Text: Add title prop (#1989)
+- Text: Add title prop [#1989](https://github.com/pinterest/gestalt/pull/1989)
 
 ## 46.0.1 (Mar 16, 2022)
 
 ### Patch
 
-- Prevent errors (#1988)
+- Prevent errors [#1988](https://github.com/pinterest/gestalt/pull/1988)
 
 ## 46.0.0 (Mar 15, 2022)
 
 ### Major
 
-- Dropdown, Module: Change badge prop to allow type (#1982)
+- Dropdown, Module: Change badge prop to allow type [#1982](https://github.com/pinterest/gestalt/pull/1982)
 
 ## 45.11.3 (Mar 15, 2022)
 
 ### Patch
 
-- Tooling: fix in generic codemods to handle nested children components (#1983)
+- Tooling: fix in generic codemods to handle nested children components [#1983](https://github.com/pinterest/gestalt/pull/1983)
 
 ## 45.11.2 (Mar 15, 2022)
 
 ### Patch
 
-- ActivationCard: Use Text instead of Heading for UncompletedCard (#1986)
+- ActivationCard: Use Text instead of Heading for UncompletedCard [#1986](https://github.com/pinterest/gestalt/pull/1986)
 
 ## 45.11.1 (Mar 15, 2022)
 
 ### Patch
 
-- Docs: Update navigation and badge colors (#1984)
+- Docs: Update navigation and badge colors [#1984](https://github.com/pinterest/gestalt/pull/1984)
 
 ## 45.11.0 (Mar 11, 2022)
 
 ### Minor
 
-- Text: Add new semantic colors (#1973)
+- Text: Add new semantic colors [#1973](https://github.com/pinterest/gestalt/pull/1973)
 
 ## 45.10.7 (Mar 10, 2022)
 
 ### Patch
 
-- ActivationCard: Use Text instead of Heading (#1980)
+- ActivationCard: Use Text instead of Heading [#1980](https://github.com/pinterest/gestalt/pull/1980)
 
 ## 45.10.6 (Mar 10, 2022)
 
 ### Patch
 
-- Docs: Add Elevation guidelines page (#1979)
+- Docs: Add Elevation guidelines page [#1979](https://github.com/pinterest/gestalt/pull/1979)
 
 ## 45.10.5 (Mar 9, 2022)
 
 ### Patch
 
-- Development: updated info re updating Cypress visual diff snapshots tests (#1978)
+- Development: updated info re updating Cypress visual diff snapshots tests [#1978](https://github.com/pinterest/gestalt/pull/1978)
 
 ## 45.10.4 (Mar 9, 2022)
 
 ### Patch
 
-- Tooling: new `modifyPropValue` & `detectManualReplacement` codemods (#1969)
+- Tooling: new `modifyPropValue` & `detectManualReplacement` codemods [#1969](https://github.com/pinterest/gestalt/pull/1969)
 
 ## 45.10.3 (Mar 9, 2022)
 
 ### Patch
 
-- Docs: Sentence casing updates (#1977)
+- Docs: Sentence casing updates [#1977](https://github.com/pinterest/gestalt/pull/1977)
 
 ## 45.10.2 (Mar 9, 2022)
 
 ### Patch
 
-- Link, Module, NumberField, RadioButton, SearchField, SelectList, Status, Switch , TextArea, TextField: add visual diff testing and screenshot to description in VSCode (Flow extension) (#1972)
+- Link, Module, NumberField, RadioButton, SearchField, SelectList, Status, Switch , TextArea, TextField: add visual diff testing and screenshot to description in VSCode (Flow extension) [#1972](https://github.com/pinterest/gestalt/pull/1972)
 
 ## 45.10.1 (Mar 9, 2022)
 
 ### Patch
 
-- Datapoint: docs nits (#1976)
+- Datapoint: docs nits [#1976](https://github.com/pinterest/gestalt/pull/1976)
 
 ## 45.10.0 (Mar 9, 2022)
 
 ### Minor
 
-- Badge: Add new 'type' variations and Best practices, A11Y, Related documentation (#1971)
+- Badge: Add new 'type' variations and Best practices, A11Y, Related documentation [#1971](https://github.com/pinterest/gestalt/pull/1971)
 
 ## 45.9.2 (Mar 8, 2022)
 
 ### Patch
 
-- Docs: Added design guidelines to Datapoint docs (#1974)
+- Docs: Added design guidelines to Datapoint docs [#1974](https://github.com/pinterest/gestalt/pull/1974)
 
 ## 45.9.1 (Mar 8, 2022)
 
 ### Patch
 
-- Docs: Add About us page (#1975)
+- Docs: Add About us page [#1975](https://github.com/pinterest/gestalt/pull/1975)
 
 ## 45.9.0 (Mar 7, 2022)
 
 ### Minor
 
-- Box: add elevation accent color option (#1970)
+- Box: add elevation accent color option [#1970](https://github.com/pinterest/gestalt/pull/1970)
 
 ## 45.8.7 (Mar 4, 2022)
 
 ### Patch
 
-- Docs: Sentence case titles/navigation (#1965)
+- Docs: Sentence case titles/navigation [#1965](https://github.com/pinterest/gestalt/pull/1965)
 
 ## 45.8.6 (Mar 4, 2022)
 
 ### Patch
 
-- Toast: revert `text` type change (#1966)
+- Toast: revert `text` type change [#1966](https://github.com/pinterest/gestalt/pull/1966)
 
 ## 45.8.5 (Mar 4, 2022)
 
 ### Patch
 
-- Toast: fix layout bug with long text + button text (#1961)
+- Toast: fix layout bug with long text + button text [#1961](https://github.com/pinterest/gestalt/pull/1961)
 
 ## 45.8.4 (Mar 4, 2022)
 
 ### Patch
 
-- Docs: How to work with us design content update (#1959)
+- Docs: How to work with us design content update [#1959](https://github.com/pinterest/gestalt/pull/1959)
 
 ## 45.8.3 (Mar 3, 2022)
 
 ### Patch
 
-- Docs: fix npm badges wrapping (#1963)
+- Docs: fix npm badges wrapping [#1963](https://github.com/pinterest/gestalt/pull/1963)
 
 ## 45.8.2 (Mar 3, 2022)
 
 ### Patch
 
-- Docs: Add new Home page! (#1859)
+- Docs: Add new Home page! [#1859](https://github.com/pinterest/gestalt/pull/1859)
 
 ## 45.8.1 (Mar 2, 2022)
 
 ### Patch
 
-- TrapFocusBehavior: add notes as comments (#1962)
+- TrapFocusBehavior: add notes as comments [#1962](https://github.com/pinterest/gestalt/pull/1962)
 
 ## 45.8.0 (Mar 2, 2022)
 
 ### Minor
 
-- Modal: Fix infinite focus loop (#649) (#1442)
+- Modal: Fix infinite focus loop [#649](https://github.com/pinterest/gestalt/pull/649) [#1442](https://github.com/pinterest/gestalt/pull/1442)
 
 ## 45.7.2 (Mar 2, 2022)
 
 ### Patch
 
-- Docs: add npm badges for design token and eslint plugin packages (#1960)
+- Docs: add npm badges for design token and eslint plugin packages [#1960](https://github.com/pinterest/gestalt/pull/1960)
 
 ## 45.7.1 (Mar 2, 2022)
 
 ### Patch
 
-- Masonry: add a11y roles (#1958)
+- Masonry: add a11y roles [#1958](https://github.com/pinterest/gestalt/pull/1958)
 
 ## 45.7.0 (Feb 24, 2022)
 
 ### Minor
 
-- Tooling: generic codemods to rename components & modify props (#1943)
+- Tooling: generic codemods to rename components & modify props [#1943](https://github.com/pinterest/gestalt/pull/1943)
 
 ## 45.6.2 (Feb 24, 2022)
 
 ### Patch
 
-- ActivationCard, Avatar, Badge, Callout, Checkbox, ComboBox, Datapoint, Dropdown, Heading, IconButton: add visual diff testing and screenshot to description in VSCode (Flow extension) (#1954)
+- ActivationCard, Avatar, Badge, Callout, Checkbox, ComboBox, Datapoint, Dropdown, Heading, IconButton: add visual diff testing and screenshot to description in VSCode (Flow extension) [#1954](https://github.com/pinterest/gestalt/pull/1954)
 
 ## 45.6.1 (Feb 24, 2022)
 
 ### Patch
 
-- Internal: fix import style to unblock master (#1957)
+- Internal: fix import style to unblock master [#1957](https://github.com/pinterest/gestalt/pull/1957)
 
 ## 45.6.0 (Feb 24, 2022)
 
 ### Minor
 
-- DeviceTypeProvider: add new component (#1939)
+- DeviceTypeProvider: add new component [#1939](https://github.com/pinterest/gestalt/pull/1939)
 
 ## 45.5.10 (Feb 23, 2022)
 
 ### Patch
 
-- IconButton: Clarify color documentation (#1955)
+- IconButton: Clarify color documentation [#1955](https://github.com/pinterest/gestalt/pull/1955)
 
 ## 45.5.9 (Feb 23, 2022)
 
 ### Patch
 
-- Upsell: use autogen props for subcomponent (#1953)
+- Upsell: use autogen props for subcomponent [#1953](https://github.com/pinterest/gestalt/pull/1953)
 
 ## 45.5.8 (Feb 22, 2022)
 
 ### Patch
 
-- Dropdown, Module, Table: use autogen descriptions for subcomponents (#1950)
+- Dropdown, Module, Table: use autogen descriptions for subcomponents [#1950](https://github.com/pinterest/gestalt/pull/1950)
 
 ## 45.5.7 (Feb 22, 2022)
 
 ### Patch
 
-- Internal: Add explanatory comment to autogenerated metadata.json file (#1951)
+- Internal: Add explanatory comment to autogenerated metadata.json file [#1951](https://github.com/pinterest/gestalt/pull/1951)
 
 ## 45.5.6 (Feb 22, 2022)
 
 ### Patch
 
-- Docs: Fix page jumping bug (#1952)
+- Docs: Fix page jumping bug [#1952](https://github.com/pinterest/gestalt/pull/1952)
 
 ## 45.5.5 (Feb 18, 2022)
 
 ### Patch
 
-- Color Palette: Update terminology (#1949)
+- Color Palette: Update terminology [#1949](https://github.com/pinterest/gestalt/pull/1949)
 
 ## 45.5.4 (Feb 18, 2022)
 
 ### Patch
 
-- Table: Ensure tables are keyboard accessible (#1942)
+- Table: Ensure tables are keyboard accessible [#1942](https://github.com/pinterest/gestalt/pull/1942)
 
 ## 45.5.3 (Feb 18, 2022)
 
 ### Patch
 
-- Bump next from 12.0.9 to 12.1.0 (#1948)
+- Bump next from 12.0.9 to 12.1.0 [#1948](https://github.com/pinterest/gestalt/pull/1948)
 
 ## 45.5.2 (Feb 18, 2022)
 
 ### Patch
 
-- Flex: use autogenerated props/description (#1947)
+- Flex: use autogenerated props/description [#1947](https://github.com/pinterest/gestalt/pull/1947)
 
 ## 45.5.1 (Feb 17, 2022)
 
 ### Patch
 
-- Color: Add guidelines for color usage (#1941)
+- Color: Add guidelines for color usage [#1941](https://github.com/pinterest/gestalt/pull/1941)
 
 ## 45.5.0 (Feb 17, 2022)
 
 ### Minor
 
-- Tokens: Add elevation tokens (#1932)
+- Tokens: Add elevation tokens [#1932](https://github.com/pinterest/gestalt/pull/1932)
 
 ## 45.4.8 (Feb 17, 2022)
 
 ### Patch
 
-- Internal: enable flowtype/type-import-style (#1945)
+- Internal: enable flowtype/type-import-style [#1945](https://github.com/pinterest/gestalt/pull/1945)
 
 ## 45.4.7 (Feb 17, 2022)
 
 ### Patch
 
-- Internal: add note about Jira on bug template (#1944)
+- Internal: add note about Jira on bug template [#1944](https://github.com/pinterest/gestalt/pull/1944)
 
 ## 45.4.6 (Feb 17, 2022)
 
 ### Patch
 
-- Docs: Updated Status docs to include design guidelines (#1940)
+- Docs: Updated Status docs to include design guidelines [#1940](https://github.com/pinterest/gestalt/pull/1940)
 
 ## 45.4.5 (Feb 15, 2022)
 
@@ -2134,115 +2134,115 @@
 
 ### Patch
 
-- Heading, Text: Update internal usages to use new size values (#1936)
+- Heading, Text: Update internal usages to use new size values [#1936](https://github.com/pinterest/gestalt/pull/1936)
 
 ## 45.4.3 (Feb 14, 2022)
 
 ### Patch
 
-- Eslint_Plugin: eslint fix to prevent autoconverting divs that contain attributes not allowed in Box into Box. (#1934)
+- Eslint_Plugin: eslint fix to prevent autoconverting divs that contain attributes not allowed in Box into Box. [#1934](https://github.com/pinterest/gestalt/pull/1934)
 
 ## 45.4.2 (Feb 14, 2022)
 
 ### Patch
 
-- Bump follow-redirects from 1.14.7 to 1.14.8 (#1937)
+- Bump follow-redirects from 1.14.7 to 1.14.8 [#1937](https://github.com/pinterest/gestalt/pull/1937)
 
 ## 45.4.1 (Feb 11, 2022)
 
 ### Patch
 
-- Bump ajv from 6.12.0 to 6.12.6 (#1935)
+- Bump ajv from 6.12.0 to 6.12.6 [#1935](https://github.com/pinterest/gestalt/pull/1935)
 
 ## 45.4.0 (Feb 11, 2022)
 
 ### Minor
 
-- Docs: Change components pages to use ssr (#1910)
+- Docs: Change components pages to use ssr [#1910](https://github.com/pinterest/gestalt/pull/1910)
 
 ## 45.3.2 (Feb 11, 2022)
 
 ### Patch
 
-- Docs: Added Getting Started for Design page (#1933)
+- Docs: Added Getting Started for Design page [#1933](https://github.com/pinterest/gestalt/pull/1933)
 
 ## 45.3.1 (Feb 10, 2022)
 
 ### Patch
 
-- Internal: update eslint-config-airbnb to 19.0.4, fix/suppress new errors (#1931)
+- Internal: update eslint-config-airbnb to 19.0.4, fix/suppress new errors [#1931](https://github.com/pinterest/gestalt/pull/1931)
 
 ## 45.3.0 (Feb 10, 2022)
 
 ### Minor
 
-- Heading, Text: Make all 6 font sizes available + codemod (#1908)
+- Heading, Text: Make all 6 font sizes available + codemod [#1908](https://github.com/pinterest/gestalt/pull/1908)
 
 ## 45.2.5 (Feb 10, 2022)
 
 ### Patch
 
-- IconButton: refactor to fix Dropdown positioning shift on rerender + small fix (#1930)
+- IconButton: refactor to fix Dropdown positioning shift on rerender + small fix [#1930](https://github.com/pinterest/gestalt/pull/1930)
 
 ## 45.2.4 (Feb 9, 2022)
 
 ### Patch
 
-- Link: deprecate private "disabled" prop + codemod (#1928)
+- Link: deprecate private "disabled" prop + codemod [#1928](https://github.com/pinterest/gestalt/pull/1928)
 
 ## 45.2.3 (Feb 9, 2022)
 
 ### Patch
 
-- Table: updated Docs to use autogenerated prop table (#1919)
+- Table: updated Docs to use autogenerated prop table [#1919](https://github.com/pinterest/gestalt/pull/1919)
 
 ## 45.2.2 (Feb 8, 2022)
 
 ### Patch
 
-- ComboBox: add reference to Typeahead (#1929)
+- ComboBox: add reference to Typeahead [#1929](https://github.com/pinterest/gestalt/pull/1929)
 
 ## 45.2.1 (Feb 8, 2022)
 
 ### Patch
 
-- Revert "Revert "Dropdown: prefixed private props (index) with underscore (#1900)" (#1923)" (#1925)
+- Revert "Revert "Dropdown: prefixed private props (index) with underscore [#1900](https://github.com/pinterest/gestalt/pull/1900)" [#1923](https://github.com/pinterest/gestalt/pull/1923)" [#1925](https://github.com/pinterest/gestalt/pull/1925)
 
 ## 45.2.0 (Feb 8, 2022)
 
 ### Minor
 
-- Masonry: revert scroll state optimization (#1774) (#1917)
+- Masonry: revert scroll state optimization [#1774](https://github.com/pinterest/gestalt/pull/1774) [#1917](https://github.com/pinterest/gestalt/pull/1917)
 
 ## 45.1.4 (Feb 8, 2022)
 
 ### Patch
 
-- Link: updated Docs to use autogenerated prop table (#1915)
+- Link: updated Docs to use autogenerated prop table [#1915](https://github.com/pinterest/gestalt/pull/1915)
 
 ## 45.1.3 (Feb 8, 2022)
 
 ### Patch
 
-- Revert "IconButton: refactor to fix Dropdown positioning shift on rerender #1914" (#1924)
+- Revert "IconButton: refactor to fix Dropdown positioning shift on rerender #1914" [#1924](https://github.com/pinterest/gestalt/pull/1924)
 
 ## 45.1.2 (Feb 8, 2022)
 
 ### Patch
 
-- Revert "Dropdown: prefixed private props (index) with underscore (#1900)" (#1923)
+- Revert "Dropdown: prefixed private props (index) with underscore [#1900](https://github.com/pinterest/gestalt/pull/1900)" [#1923](https://github.com/pinterest/gestalt/pull/1923)
 
 ## 45.1.1 (Feb 7, 2022)
 
 ### Patch
 
-- Docs: Remove disabled accessibility tests (#1920)
+- Docs: Remove disabled accessibility tests [#1920](https://github.com/pinterest/gestalt/pull/1920)
 
 ## 45.1.0 (Feb 7, 2022)
 
 ### Minor
 
-- Badge: fix layout issues (#1899)
+- Badge: fix layout issues [#1899](https://github.com/pinterest/gestalt/pull/1899)
 
 ## 45.0.5 (Feb 7, 2022)
 
@@ -2260,235 +2260,235 @@
 
 ### Patch
 
-- Video: use autogen props table (#1912)
+- Video: use autogen props table [#1912](https://github.com/pinterest/gestalt/pull/1912)
 
 ## 45.0.2 (Feb 4, 2022)
 
 ### Patch
 
-- Dropdown: replace old URL in docs (#1918)
+- Dropdown: replace old URL in docs [#1918](https://github.com/pinterest/gestalt/pull/1918)
 
 ## 45.0.1 (Feb 3, 2022)
 
 ### Patch
 
-- Dropdown: prefixed private props (index) with underscore (#1900)
+- Dropdown: prefixed private props (index) with underscore [#1900](https://github.com/pinterest/gestalt/pull/1900)
 
 ## 45.0.0 (Feb 3, 2022)
 
 ### Major
 
-- Popover: rename handleOnKeyDown to onKeyDown and standardize event type (#1909)
+- Popover: rename handleOnKeyDown to onKeyDown and standardize event type [#1909](https://github.com/pinterest/gestalt/pull/1909)
 
 ## 44.0.5 (Feb 3, 2022)
 
 ### Patch
 
-- Internal: upgrade eslint react plugins (#1902)
+- Internal: upgrade eslint react plugins [#1902](https://github.com/pinterest/gestalt/pull/1902)
 
 ## 44.0.4 (Feb 3, 2022)
 
 ### Patch
 
-- Internal: upgrade eslint to 8.8.0 (#1905)
+- Internal: upgrade eslint to 8.8.0 [#1905](https://github.com/pinterest/gestalt/pull/1905)
 
 ## 44.0.3 (Feb 3, 2022)
 
 ### Patch
 
-- Internal: upgrade flow-bin to 0.171.0 (#1901)
+- Internal: upgrade flow-bin to 0.171.0 [#1901](https://github.com/pinterest/gestalt/pull/1901)
 
 ## 44.0.2 (Feb 3, 2022)
 
 ### Patch
 
-- Docs: fix right sidenav overlap bug (#1898)
+- Docs: fix right sidenav overlap bug [#1898](https://github.com/pinterest/gestalt/pull/1898)
 
 ## 44.0.1 (Feb 2, 2022)
 
 ### Patch
 
-- Dropdown: updated Docs to use autogenerated prop table (#1892)
+- Dropdown: updated Docs to use autogenerated prop table [#1892](https://github.com/pinterest/gestalt/pull/1892)
 
 ## 44.0.0 (Feb 2, 2022)
 
 ### Major
 
-- SegmentedControl: remove size prop (#1894)
+- SegmentedControl: remove size prop [#1894](https://github.com/pinterest/gestalt/pull/1894)
 
 ## 43.1.3 (Feb 2, 2022)
 
 ### Patch
 
-- DatePicker: add description for id prop (#1897)
+- DatePicker: add description for id prop [#1897](https://github.com/pinterest/gestalt/pull/1897)
 
 ## 43.1.2 (Feb 2, 2022)
 
 ### Patch
 
-- DatePicker: updated Docs to use autogenerated prop table (#1891)
+- DatePicker: updated Docs to use autogenerated prop table [#1891](https://github.com/pinterest/gestalt/pull/1891)
 
 ## 43.1.1 (Feb 1, 2022)
 
 ### Patch
 
-- ComboBox: updated Docs to use autogenerated prop table (#1885)
+- ComboBox: updated Docs to use autogenerated prop table [#1885](https://github.com/pinterest/gestalt/pull/1885)
 
 ## 43.1.0 (Feb 1, 2022)
 
 ### Minor
 
-- Box: Add new background colors (#1867)
+- Box: Add new background colors [#1867](https://github.com/pinterest/gestalt/pull/1867)
 
 ## 43.0.2 (Feb 1, 2022)
 
 ### Patch
 
-- Popover: updated Docs to use autogenerated prop table (#1895)
+- Popover: updated Docs to use autogenerated prop table [#1895](https://github.com/pinterest/gestalt/pull/1895)
 
 ## 43.0.1 (Feb 1, 2022)
 
 ### Patch
 
-- Internal: Fix broken master due to prettier error on CHANGELOG.md (#1896)
+- Internal: Fix broken master due to prettier error on CHANGELOG.md [#1896](https://github.com/pinterest/gestalt/pull/1896)
 
 ## 43.0.0 (Jan 31, 2022)
 
 ### Major
 
-- TextField: Remove type="number" and create codemod (#1890)
+- TextField: Remove type="number" and create codemod [#1890](https://github.com/pinterest/gestalt/pull/1890)
 
 ## 42.3.6 (Jan 31, 2022)
 
 ### Patch
 
-- Internal: upgrade @netlify/plugin-nextjs to address vulnerability (#1893)
+- Internal: upgrade @netlify/plugin-nextjs to address vulnerability [#1893](https://github.com/pinterest/gestalt/pull/1893)
 
 ## 42.3.5 (Jan 29, 2022)
 
 ### Patch
 
-- Tabs, TextArea: use generated props tables (#1889)
+- Tabs, TextArea: use generated props tables [#1889](https://github.com/pinterest/gestalt/pull/1889)
 
 ## 42.3.4 (Jan 28, 2022)
 
 ### Patch
 
-- Bump next from 12.0.5 to 12.0.9 (#1888)
+- Bump next from 12.0.5 to 12.0.9 [#1888](https://github.com/pinterest/gestalt/pull/1888)
 
 ## 42.3.3 (Jan 28, 2022)
 
 ### Patch
 
-- Masonry: use generated props table (#1887)
+- Masonry: use generated props table [#1887](https://github.com/pinterest/gestalt/pull/1887)
 
 ## 42.3.2 (Jan 28, 2022)
 
 ### Patch
 
-- Docs: automatically filter out "\_fooProp" internal-only props (#1886)
+- Docs: automatically filter out "\_fooProp" internal-only props [#1886](https://github.com/pinterest/gestalt/pull/1886)
 
 ## 42.3.1 (Jan 27, 2022)
 
 ### Patch
 
-- Docs: update Visual Studio Code extension for Gestalt extension information (#1884)
+- Docs: update Visual Studio Code extension for Gestalt extension information [#1884](https://github.com/pinterest/gestalt/pull/1884)
 
 ## 42.3.0 (Jan 27, 2022)
 
 ### Minor
 
-- IconButton, Tooltip: Update accessibility guidance (#1882)
+- IconButton, Tooltip: Update accessibility guidance [#1882](https://github.com/pinterest/gestalt/pull/1882)
 
 ## 42.2.6 (Jan 27, 2022)
 
 ### Patch
 
-- Toast: show examples directly in docs (#1883)
+- Toast: show examples directly in docs [#1883](https://github.com/pinterest/gestalt/pull/1883)
 
 ## 42.2.5 (Jan 26, 2022)
 
 ### Patch
 
-- Internal: add resolution for `node-fetch` to fix vulnerability (#1881)
+- Internal: add resolution for `node-fetch` to fix vulnerability [#1881](https://github.com/pinterest/gestalt/pull/1881)
 
 ## 42.2.4 (Jan 26, 2022)
 
 ### Patch
 
-- Typography: update components to use new design tokens (#1877)
+- Typography: update components to use new design tokens [#1877](https://github.com/pinterest/gestalt/pull/1877)
 
 ## 42.2.3 (Jan 26, 2022)
 
 ### Patch
 
-- Pog: use autogenerated props table (#1879)
+- Pog: use autogenerated props table [#1879](https://github.com/pinterest/gestalt/pull/1879)
 
 ## 42.2.2 (Jan 26, 2022)
 
 ### Patch
 
-- ColorSchemeProvider: use autogenerated props table (#1878)
+- ColorSchemeProvider: use autogenerated props table [#1878](https://github.com/pinterest/gestalt/pull/1878)
 
 ## 42.2.1 (Jan 25, 2022)
 
 ### Patch
 
-- Docs: fix Gestalt Visualizer script (#1875)
+- Docs: fix Gestalt Visualizer script [#1875](https://github.com/pinterest/gestalt/pull/1875)
 
 ## 42.2.0 (Jan 25, 2022)
 
 ### Minor
 
-- IconButton: Add Tooltip prop (#1871)
+- IconButton: Add Tooltip prop [#1871](https://github.com/pinterest/gestalt/pull/1871)
 
 ## 42.1.2 (Jan 25, 2022)
 
 ### Patch
 
-- Internal: upgrade eslint to 8.7.0 (#1876)
+- Internal: upgrade eslint to 8.7.0 [#1876](https://github.com/pinterest/gestalt/pull/1876)
 
 ## 42.1.1 (Jan 24, 2022)
 
 ### Patch
 
-- Bump nanoid from 3.1.25 to 3.2.0 (#1874)
+- Bump nanoid from 3.1.25 to 3.2.0 [#1874](https://github.com/pinterest/gestalt/pull/1874)
 
 ## 42.1.0 (Jan 21, 2022)
 
 ### Minor
 
-- Tooltip: add optional accessibilityLabel prop & fix Datapoint a11y integration test (#1873)
+- Tooltip: add optional accessibilityLabel prop & fix Datapoint a11y integration test [#1873](https://github.com/pinterest/gestalt/pull/1873)
 
 ## 42.0.2 (Jan 20, 2022)
 
 ### Patch
 
-- Upsell: Fix layout bug at small sizes (#1872)
+- Upsell: Fix layout bug at small sizes [#1872](https://github.com/pinterest/gestalt/pull/1872)
 
 ## 42.0.1 (Jan 20, 2022)
 
 ### Patch
 
-- OnLinkNavigationProvider, SegmentedControl: use autogenerated props tables (#1869)
+- OnLinkNavigationProvider, SegmentedControl: use autogenerated props tables [#1869](https://github.com/pinterest/gestalt/pull/1869)
 
 ## 42.0.0 (Jan 19, 2022)
 
 ### Major
 
-- Video: Add required accessibilityProgressbarLabel prop (#1870)
+- Video: Add required accessibilityProgressbarLabel prop [#1870](https://github.com/pinterest/gestalt/pull/1870)
 
 ## 41.3.2 (Jan 18, 2022)
 
 ### Patch
 
-- Internal: Bump marked from 2.0.0 to 4.0.10 (#1868)
+- Internal: Bump marked from 2.0.0 to 4.0.10 [#1868](https://github.com/pinterest/gestalt/pull/1868)
 
 ## 41.3.1 (Jan 18, 2022)
 
 ### Patch
 
-- Bump shelljs from 0.8.4 to 0.8.5 (#1865)
+- Bump shelljs from 0.8.4 to 0.8.5 [#1865](https://github.com/pinterest/gestalt/pull/1865)
 
 ## 41.3.0 (Jan 13, 2022)
 
@@ -2500,415 +2500,415 @@
 
 ### Patch
 
-- Internal: enable a11y test, remove test id (#1861)
+- Internal: enable a11y test, remove test id [#1861](https://github.com/pinterest/gestalt/pull/1861)
 
 ## 41.2.3 (Jan 13, 2022)
 
 ### Patch
 
-- Pulsar, RadioButton, Spinner, Switch, Tooltip: use autogenerated props tables (#1858)
+- Pulsar, RadioButton, Spinner, Switch, Tooltip: use autogenerated props tables [#1858](https://github.com/pinterest/gestalt/pull/1858)
 
 ## 41.2.2 (Jan 12, 2022)
 
 ### Patch
 
-- Bump follow-redirects from 1.14.1 to 1.14.7 (#1860)
+- Bump follow-redirects from 1.14.1 to 1.14.7 [#1860](https://github.com/pinterest/gestalt/pull/1860)
 
 ## 41.2.1 (Jan 12, 2022)
 
 ### Patch
 
-- Docs: add "How to Hack Gestalt" page (#1856)
+- Docs: add "How to Hack Gestalt" page [#1856](https://github.com/pinterest/gestalt/pull/1856)
 
 ## 41.2.0 (Jan 12, 2022)
 
 ### Minor
 
-- Design Tokens: Add dark mode values for alias tokens (#1852)
+- Design Tokens: Add dark mode values for alias tokens [#1852](https://github.com/pinterest/gestalt/pull/1852)
 
 ## 41.1.20 (Jan 11, 2022)
 
 ### Patch
 
-- Table: fix docs link (#1857)
+- Table: fix docs link [#1857](https://github.com/pinterest/gestalt/pull/1857)
 
 ## 41.1.19 (Jan 10, 2022)
 
 ### Patch
 
-- Table: Added Related section (#1848)
+- Table: Added Related section [#1848](https://github.com/pinterest/gestalt/pull/1848)
 
 ## 41.1.18 (Jan 10, 2022)
 
 ### Patch
 
-- Internal: add resolution for `node-forge` to fix vulnerability (#1855)
+- Internal: add resolution for `node-forge` to fix vulnerability [#1855](https://github.com/pinterest/gestalt/pull/1855)
 
 ## 41.1.17 (Jan 10, 2022)
 
 ### Patch
 
-- Internal: upgrade postcss to 8.4.5 (#1854)
+- Internal: upgrade postcss to 8.4.5 [#1854](https://github.com/pinterest/gestalt/pull/1854)
 
 ## 41.1.16 (Jan 10, 2022)
 
 ### Patch
 
-- Docs: make FAQ uppercase in sidebar index (#1853)
+- Docs: make FAQ uppercase in sidebar index [#1853](https://github.com/pinterest/gestalt/pull/1853)
 
 ## 41.1.15 (Jan 7, 2022)
 
 ### Patch
 
-- Image, Label, Layer, Letterbox, Mask: use generated props tables (#1849)
+- Image, Label, Layer, Letterbox, Mask: use generated props tables [#1849](https://github.com/pinterest/gestalt/pull/1849)
 
 ## 41.1.14 (Jan 7, 2022)
 
 ### Patch
 
-- Internal: upgrade eslint to 8.6.0 (#1851)
+- Internal: upgrade eslint to 8.6.0 [#1851](https://github.com/pinterest/gestalt/pull/1851)
 
 ## 41.1.13 (Jan 7, 2022)
 
 ### Patch
 
-- Internal: fix workflow id for VSCode Gestalt release step (#1850)
+- Internal: fix workflow id for VSCode Gestalt release step [#1850](https://github.com/pinterest/gestalt/pull/1850)
 
 ## 41.1.12 (Jan 7, 2022)
 
 ### Patch
 
-- Collage, Container, Datapoint, Fieldset, Heading: use generated props tables (#1843)
+- Collage, Container, Datapoint, Fieldset, Heading: use generated props tables [#1843](https://github.com/pinterest/gestalt/pull/1843)
 
 ## 41.1.11 (Jan 6, 2022)
 
 ### Patch
 
-- Docs: update How to Work With Us page (#1842)
+- Docs: update How to Work With Us page [#1842](https://github.com/pinterest/gestalt/pull/1842)
 
 ## 41.1.10 (Jan 6, 2022)
 
 ### Patch
 
-- Internal: upgrade actions/checkout in integration test workflow (#1846)
+- Internal: upgrade actions/checkout in integration test workflow [#1846](https://github.com/pinterest/gestalt/pull/1846)
 
 ## 41.1.9 (Jan 6, 2022)
 
 ### Patch
 
-- Docs: fix cookie issues (#1840)
+- Docs: fix cookie issues [#1840](https://github.com/pinterest/gestalt/pull/1840)
 
 ## 41.1.8 (Jan 6, 2022)
 
 ### Patch
 
-- Docs: fix SSR on what's new page (#1845)
+- Docs: fix SSR on what's new page [#1845](https://github.com/pinterest/gestalt/pull/1845)
 
 ## 41.1.7 (Jan 6, 2022)
 
 ### Patch
 
-- Internal: fix steps is not defined exception on VSCode Gestalt release step (#1847)
+- Internal: fix steps is not defined exception on VSCode Gestalt release step [#1847](https://github.com/pinterest/gestalt/pull/1847)
 
 ## 41.1.6 (Jan 6, 2022)
 
 ### Patch
 
-- Internal: disallow any ESLint warnings (#1841)
+- Internal: disallow any ESLint warnings [#1841](https://github.com/pinterest/gestalt/pull/1841)
 
 ## 41.1.5 (Jan 5, 2022)
 
 ### Patch
 
-- Docs: fix links to zIndex page (#1839)
+- Docs: fix links to zIndex page [#1839](https://github.com/pinterest/gestalt/pull/1839)
 
 ## 41.1.4 (Jan 5, 2022)
 
 ### Patch
 
-- Docs: Update Algolia keys (#1835)
+- Docs: Update Algolia keys [#1835](https://github.com/pinterest/gestalt/pull/1835)
 
 ## 41.1.3 (Jan 4, 2022)
 
 ### Patch
 
-- Docs: use inline SVG for header logo (#1826)
+- Docs: use inline SVG for header logo [#1826](https://github.com/pinterest/gestalt/pull/1826)
 
 ## 41.1.2 (Jan 4, 2022)
 
 ### Patch
 
-- Dropdown: Remove aria selected from menutiems (#1837)
+- Dropdown: Remove aria selected from menutiems [#1837](https://github.com/pinterest/gestalt/pull/1837)
 
 ## 41.1.1 (Jan 4, 2022)
 
 ### Patch
 
-- Internal: avoid TabWithForwardRef export to fix generated types (#1836)
+- Internal: avoid TabWithForwardRef export to fix generated types [#1836](https://github.com/pinterest/gestalt/pull/1836)
 
 ## 41.1.0 (Jan 4, 2022)
 
 ### Minor
 
-- Internal: publish a new version of VSCode Gestalt for every Gestalt change (#1833)
+- Internal: publish a new version of VSCode Gestalt for every Gestalt change [#1833](https://github.com/pinterest/gestalt/pull/1833)
 
 ## 41.0.10 (Jan 4, 2022)
 
 ### Patch
 
-- Docs: move all user preferences to cookies (#1831)
+- Docs: move all user preferences to cookies [#1831](https://github.com/pinterest/gestalt/pull/1831)
 
 ## 41.0.9 (Jan 4, 2022)
 
 ### Patch
 
-- Internal: Update GitHub actions to latest version (#1832)
+- Internal: Update GitHub actions to latest version [#1832](https://github.com/pinterest/gestalt/pull/1832)
 
 ## 41.0.8 (Jan 4, 2022)
 
 ### Patch
 
-- Internal: remove unused danger (#1829)
+- Internal: remove unused danger [#1829](https://github.com/pinterest/gestalt/pull/1829)
 
 ## 41.0.7 (Jan 4, 2022)
 
 ### Patch
 
-- Internal: optimize Gestalt logos (#1828)
+- Internal: optimize Gestalt logos [#1828](https://github.com/pinterest/gestalt/pull/1828)
 
 ## 41.0.6 (Dec 17, 2021)
 
 ### Patch
 
-- Box, Column: add comments for responsive props (#1825)
+- Box, Column: add comments for responsive props [#1825](https://github.com/pinterest/gestalt/pull/1825)
 
 ## 41.0.5 (Dec 17, 2021)
 
 ### Patch
 
-- Module: use generated proptable (#1809)
+- Module: use generated proptable [#1809](https://github.com/pinterest/gestalt/pull/1809)
 
 ## 41.0.4 (Dec 17, 2021)
 
 ### Patch
 
-- Card, Checkbox, Column: refactor to use generated props tables (#1821)
+- Card, Checkbox, Column: refactor to use generated props tables [#1821](https://github.com/pinterest/gestalt/pull/1821)
 
 ## 41.0.3 (Dec 17, 2021)
 
 ### Patch
 
-- Docs: avoid spinner on What's new page (#1824)
+- Docs: avoid spinner on What's new page [#1824](https://github.com/pinterest/gestalt/pull/1824)
 
 ## 41.0.2 (Dec 17, 2021)
 
 ### Patch
 
-- fixes (#1820)
+- fixes [#1820](https://github.com/pinterest/gestalt/pull/1820)
 
 ## 41.0.1 (Dec 16, 2021)
 
 ### Patch
 
-- Docs: Fixed broken Popover link on Accessibility page (#1822)
+- Docs: Fixed broken Popover link on Accessibility page [#1822](https://github.com/pinterest/gestalt/pull/1822)
 
 ## 41.0.0 (Dec 15, 2021)
 
 ### Major
 
-- Dropdown: fix position inside fixed container bug (#1819)
+- Dropdown: fix position inside fixed container bug [#1819](https://github.com/pinterest/gestalt/pull/1819)
 
 ## 40.4.9 (Dec 15, 2021)
 
 ### Patch
 
-- Upsell: convert to use generated props table (#1817)
+- Upsell: convert to use generated props table [#1817](https://github.com/pinterest/gestalt/pull/1817)
 
 ## 40.4.8 (Dec 15, 2021)
 
 ### Patch
 
-- Docs: Fixed broken links on Accessibility page (#1818)
+- Docs: Fixed broken links on Accessibility page [#1818](https://github.com/pinterest/gestalt/pull/1818)
 
 ## 40.4.7 (Dec 15, 2021)
 
 ### Patch
 
-- ComboBox: performance optimization (#1810)
+- ComboBox: performance optimization [#1810](https://github.com/pinterest/gestalt/pull/1810)
 
 ## 40.4.6 (Dec 14, 2021)
 
 ### Patch
 
-- Docs: Fixed links under Labels on the Accessibiity page (#1815)
+- Docs: Fixed links under Labels on the Accessibiity page [#1815](https://github.com/pinterest/gestalt/pull/1815)
 
 ## 40.4.5 (Dec 14, 2021)
 
 ### Patch
 
-- Docs: add logo!! (#1813)
+- Docs: add logo!! [#1813](https://github.com/pinterest/gestalt/pull/1813)
 
 ## 40.4.4 (Dec 14, 2021)
 
 ### Patch
 
-- Internal: CardPage.js deprecation in all Docs pages in favor of Page.js (#1814)
+- Internal: CardPage.js deprecation in all Docs pages in favor of Page.js [#1814](https://github.com/pinterest/gestalt/pull/1814)
 
 ## 40.4.3 (Dec 13, 2021)
 
 ### Patch
 
-- Internal: Upgrade Flow to 0.167.1 (#1811)
+- Internal: Upgrade Flow to 0.167.1 [#1811](https://github.com/pinterest/gestalt/pull/1811)
 
 ## 40.4.2 (Dec 10, 2021)
 
 ### Patch
 
-- Docs: Center main content for large screens (#1800)
+- Docs: Center main content for large screens [#1800](https://github.com/pinterest/gestalt/pull/1800)
 
 ## 40.4.1 (Dec 10, 2021)
 
 ### Patch
 
-- Tooltip: Add example alongside Label and TextField (#1808)
+- Tooltip: Add example alongside Label and TextField [#1808](https://github.com/pinterest/gestalt/pull/1808)
 
 ## 40.4.0 (Dec 10, 2021)
 
 ### Minor
 
-- Design tokens: Add font tokens for size, weight, and family (#1799)
+- Design tokens: Add font tokens for size, weight, and family [#1799](https://github.com/pinterest/gestalt/pull/1799)
 
 ## 40.3.2 (Dec 8, 2021)
 
 ### Patch
 
-- Docs: Updated the design section of the page "How to work with us" (#1807)
+- Docs: Updated the design section of the page "How to work with us" [#1807](https://github.com/pinterest/gestalt/pull/1807)
 
 ## 40.3.1 (Dec 8, 2021)
 
 ### Patch
 
-- Bump next from 12.0.1 to 12.0.5 (#1806)
+- Bump next from 12.0.1 to 12.0.5 [#1806](https://github.com/pinterest/gestalt/pull/1806)
 
 ## 40.3.0 (Dec 8, 2021)
 
 ### Minor
 
-- Eslint plugin: `prefer-heading` + autofix/suggestions (#1802)
+- Eslint plugin: `prefer-heading` + autofix/suggestions [#1802](https://github.com/pinterest/gestalt/pull/1802)
 
 ## 40.2.4 (Dec 7, 2021)
 
 ### Patch
 
-- Internal: update straggling references to the old docs domain (#1804)
+- Internal: update straggling references to the old docs domain [#1804](https://github.com/pinterest/gestalt/pull/1804)
 
 ## 40.2.3 (Dec 6, 2021)
 
 ### Patch
 
-- Internal: enable `no-access-state-in-setstate` lint rule (#1801)
+- Internal: enable `no-access-state-in-setstate` lint rule [#1801](https://github.com/pinterest/gestalt/pull/1801)
 
 ## 40.2.2 (Dec 2, 2021)
 
 ### Patch
 
-- Docs: Adding a section for making design contributions to Gestalt (#1786)
+- Docs: Adding a section for making design contributions to Gestalt [#1786](https://github.com/pinterest/gestalt/pull/1786)
 
 ## 40.2.1 (Dec 2, 2021)
 
 ### Patch
 
-- Divider: updated design guidelines (#1791)
+- Divider: updated design guidelines [#1791](https://github.com/pinterest/gestalt/pull/1791)
 
 ## 40.2.0 (Dec 2, 2021)
 
 ### Minor
 
-- Design tokens: Add Color alias tokens for text and background (#1784)
+- Design tokens: Add Color alias tokens for text and background [#1784](https://github.com/pinterest/gestalt/pull/1784)
 
 ## 40.1.9 (Dec 2, 2021)
 
 ### Patch
 
-- Internal: upgrade Flow to 0.165.1 (#1797)
+- Internal: upgrade Flow to 0.165.1 [#1797](https://github.com/pinterest/gestalt/pull/1797)
 
 ## 40.1.8 (Dec 1, 2021)
 
 ### Patch
 
-- NumberField: add Usage guidelines, Best practices, A11y+L10n (#1792)
+- NumberField: add Usage guidelines, Best practices, A11y+L10n [#1792](https://github.com/pinterest/gestalt/pull/1792)
 
 ## 40.1.7 (Dec 1, 2021)
 
 ### Patch
 
-- Docs: add a couple of tooltips to header elements (#1795)
+- Docs: add a couple of tooltips to header elements [#1795](https://github.com/pinterest/gestalt/pull/1795)
 
 ## 40.1.6 (Nov 30, 2021)
 
 ### Patch
 
-- fix: upgrade react-datepicker from 2.15.0 to 2.16.0 (#1787)
+- fix: upgrade react-datepicker from 2.15.0 to 2.16.0 [#1787](https://github.com/pinterest/gestalt/pull/1787)
 
 ## 40.1.5 (Nov 30, 2021)
 
 ### Patch
 
-- TextField: Update docs with Best Practices, Accessibility, Localization (#1785)
+- TextField: Update docs with Best Practices, Accessibility, Localization [#1785](https://github.com/pinterest/gestalt/pull/1785)
 
 ## 40.1.4 (Nov 30, 2021)
 
 ### Patch
 
-- Table: Update design guidelines in Docs (#1779)
+- Table: Update design guidelines in Docs [#1779](https://github.com/pinterest/gestalt/pull/1779)
 
 ## 40.1.3 (Nov 29, 2021)
 
 ### Patch
 
-- TextField: add "tel" option for `type` prop (#1790)
+- TextField: add "tel" option for `type` prop [#1790](https://github.com/pinterest/gestalt/pull/1790)
 
 ## 40.1.2 (Nov 17, 2021)
 
 ### Patch
 
-- Bump aws-sdk from 2.726.0 to 2.1030.0 (#1782)
+- Bump aws-sdk from 2.726.0 to 2.1030.0 [#1782](https://github.com/pinterest/gestalt/pull/1782)
 
 ## 40.1.1 (Nov 17, 2021)
 
 ### Patch
 
-- Masonry: fix error in downstream consumers (#1783)
+- Masonry: fix error in downstream consumers [#1783](https://github.com/pinterest/gestalt/pull/1783)
 
 ## 40.1.0 (Nov 17, 2021)
 
 ### Minor
 
-- Masonry: delay updating React scroll state until scroll events stop coming in (#1774)
+- Masonry: delay updating React scroll state until scroll events stop coming in [#1774](https://github.com/pinterest/gestalt/pull/1774)
 
 ## 40.0.7 (Nov 16, 2021)
 
 ### Patch
 
-- Avatar: Update docs and add Best Practices (#1781)
+- Avatar: Update docs and add Best Practices [#1781](https://github.com/pinterest/gestalt/pull/1781)
 
 ## 40.0.6 (Nov 11, 2021)
 
 ### Patch
 
-- Internal: upgrade stylelint to 14.0.1 (#1777)
+- Internal: upgrade stylelint to 14.0.1 [#1777](https://github.com/pinterest/gestalt/pull/1777)
 
 ## 40.0.5 (Nov 10, 2021)
 
 ### Patch
 
-- Divider: Add vertical example to docs (#1778)
+- Divider: Add vertical example to docs [#1778](https://github.com/pinterest/gestalt/pull/1778)
 
 ## 40.0.4 (Nov 10, 2021)
 
 ### Patch
 
-- Toast: fix layout issues (#1775)
+- Toast: fix layout issues [#1775](https://github.com/pinterest/gestalt/pull/1775)
 
 ## 40.0.3 (Nov 9, 2021)
 
@@ -2920,13 +2920,13 @@
 
 ### Patch
 
-- Docs: update Development page (#1772)
+- Docs: update Development page [#1772](https://github.com/pinterest/gestalt/pull/1772)
 
 ## 40.0.1 (Nov 8, 2021)
 
 ### Patch
 
-- Codemods: add README (#1771)
+- Codemods: add README [#1771](https://github.com/pinterest/gestalt/pull/1771)
 
 ## 40.0.0 (Nov 5, 2021)
 
@@ -2938,7 +2938,7 @@
 
 ### Patch
 
-- Internal: Upgrade to Node.js 16 (#1769)
+- Internal: Upgrade to Node.js 16 [#1769](https://github.com/pinterest/gestalt/pull/1769)
 
 ## 39.2.8 (Nov 5, 2021)
 
@@ -2968,745 +2968,745 @@
 
 ### Patch
 
-- Tabs: Add Best Practices and Accessibility guidelines (#1761)
+- Tabs: Add Best Practices and Accessibility guidelines [#1761](https://github.com/pinterest/gestalt/pull/1761)
 
 ## 39.2.3 (Nov 4, 2021)
 
 ### Patch
 
-- Internal: upgrade Eslint to 8.1.0, + configs+plugins (#1762)
+- Internal: upgrade Eslint to 8.1.0, + configs+plugins [#1762](https://github.com/pinterest/gestalt/pull/1762)
 
 ## 39.2.2 (Nov 3, 2021)
 
 ### Patch
 
-- Eslint plugin: prefer-link fixes and added suggestions (#1759)
+- Eslint plugin: prefer-link fixes and added suggestions [#1759](https://github.com/pinterest/gestalt/pull/1759)
 
 ## 39.2.1 (Nov 3, 2021)
 
 ### Patch
 
-- TextField: re-add "number" type for now (#1763)
+- TextField: re-add "number" type for now [#1763](https://github.com/pinterest/gestalt/pull/1763)
 
 ## 39.2.0 (Nov 3, 2021)
 
 ### Minor
 
-- NumberField: add new component (#1760)
+- NumberField: add new component [#1760](https://github.com/pinterest/gestalt/pull/1760)
 
 ## 39.1.0 (Oct 28, 2021)
 
 ### Minor
 
-- Internal: Upgrade to Next.js 12 (#1758)
+- Internal: Upgrade to Next.js 12 [#1758](https://github.com/pinterest/gestalt/pull/1758)
 
 ## 39.0.0 (Oct 26, 2021)
 
 ### Major
 
-- Typeahead: Remove component and references from Gestalt + codemod (#1755)
+- Typeahead: Remove component and references from Gestalt + codemod [#1755](https://github.com/pinterest/gestalt/pull/1755)
 
 ## 38.2.0 (Oct 25, 2021)
 
 ### Minor
 
-- Datapoint: text sizing adjustments (#1746)
+- Datapoint: text sizing adjustments [#1746](https://github.com/pinterest/gestalt/pull/1746)
 
 ## 38.1.3 (Oct 22, 2021)
 
 ### Patch
 
-- Docs: use generated description for many components (#1753)
+- Docs: use generated description for many components [#1753](https://github.com/pinterest/gestalt/pull/1753)
 
 ## 38.1.2 (Oct 22, 2021)
 
 ### Patch
 
-- ActivationCard, Avatar, AvatarPair, Badge: convert to generated props tables (#1751)
+- ActivationCard, Avatar, AvatarPair, Badge: convert to generated props tables [#1751](https://github.com/pinterest/gestalt/pull/1751)
 
 ## 38.1.1 (Oct 22, 2021)
 
 ### Patch
 
-- Dropdown: adds data-test-id prop to Dropdown.Item component (#1742)
+- Dropdown: adds data-test-id prop to Dropdown.Item component [#1742](https://github.com/pinterest/gestalt/pull/1742)
 
 ## 38.1.0 (Oct 21, 2021)
 
 ### Minor
 
-- Eslint plugin: prefer-link, convert anchor tag to Gestalt Link (#1741)
+- Eslint plugin: prefer-link, convert anchor tag to Gestalt Link [#1741](https://github.com/pinterest/gestalt/pull/1741)
 
 ## 38.0.11 (Oct 20, 2021)
 
 ### Patch
 
-- PageHeader: generated docs, add note about padding (#1749)
+- PageHeader: generated docs, add note about padding [#1749](https://github.com/pinterest/gestalt/pull/1749)
 
 ## 38.0.10 (Oct 20, 2021)
 
 ### Patch
 
-- Docs: fix home link styling in header (#1748)
+- Docs: fix home link styling in header [#1748](https://github.com/pinterest/gestalt/pull/1748)
 
 ## 38.0.9 (Oct 20, 2021)
 
 ### Patch
 
-- Tag: add visual diff testing (#1747)
+- Tag: add visual diff testing [#1747](https://github.com/pinterest/gestalt/pull/1747)
 
 ## 38.0.8 (Oct 20, 2021)
 
 ### Patch
 
-- Docs: fix header height on SSR (#1745)
+- Docs: fix header height on SSR [#1745](https://github.com/pinterest/gestalt/pull/1745)
 
 ## 38.0.7 (Oct 15, 2021)
 
 ### Patch
 
-- Iconography: fix source link (#1740)
+- Iconography: fix source link [#1740](https://github.com/pinterest/gestalt/pull/1740)
 
 ## 38.0.6 (Oct 14, 2021)
 
 ### Patch
 
-- Avatar: fix to bug (White bgcolor on Avatar component looks bad on dark backgrounds) (#1736)
+- Avatar: fix to bug (White bgcolor on Avatar component looks bad on dark backgrounds) [#1736](https://github.com/pinterest/gestalt/pull/1736)
 
 ## 38.0.5 (Oct 14, 2021)
 
 ### Patch
 
-- Internal: Upgrade Flow to 0.162.0 (#1738)
+- Internal: Upgrade Flow to 0.162.0 [#1738](https://github.com/pinterest/gestalt/pull/1738)
 
 ## 38.0.4 (Oct 14, 2021)
 
 ### Patch
 
-- Tooling: new Tooling page (#1725)
+- Tooling: new Tooling page [#1725](https://github.com/pinterest/gestalt/pull/1725)
 
 ## 38.0.3 (Oct 14, 2021)
 
 ### Patch
 
-- Docs: add Careers page link in footer (#1734)
+- Docs: add Careers page link in footer [#1734](https://github.com/pinterest/gestalt/pull/1734)
 
 ## 38.0.2 (Oct 8, 2021)
 
 ### Patch
 
-- Table: add a11yLabel to prop table (#1735)
+- Table: add a11yLabel to prop table [#1735](https://github.com/pinterest/gestalt/pull/1735)
 
 ## 38.0.1 (Oct 7, 2021)
 
 ### Patch
 
-- Docs: fix search (#1733)
+- Docs: fix search [#1733](https://github.com/pinterest/gestalt/pull/1733)
 
 ## 38.0.0 (Oct 6, 2021)
 
 ### Major
 
-- Table: add required accessibilityLabel to fix a11y (#1730)
+- Table: add required accessibilityLabel to fix a11y [#1730](https://github.com/pinterest/gestalt/pull/1730)
 
 ## 37.1.2 (Oct 6, 2021)
 
 ### Patch
 
-- Docs: fixes navigation a11y issues (#1729)
+- Docs: fixes navigation a11y issues [#1729](https://github.com/pinterest/gestalt/pull/1729)
 
 ## 37.1.1 (Oct 6, 2021)
 
 ### Patch
 
-- ColorSchemeProvider, OnLinkNavigation: fix source links (#1731)
+- ColorSchemeProvider, OnLinkNavigation: fix source links [#1731](https://github.com/pinterest/gestalt/pull/1731)
 
 ## 37.1.0 (Oct 4, 2021)
 
 ### Minor
 
-- Internal: enable Next.js ESLint linter (#1727)
+- Internal: enable Next.js ESLint linter [#1727](https://github.com/pinterest/gestalt/pull/1727)
 
 ## 37.0.2 (Oct 4, 2021)
 
 ### Patch
 
-- Status: make `title` optional, add `accessibilityLabel` (#1724)
+- Status: make `title` optional, add `accessibilityLabel` [#1724](https://github.com/pinterest/gestalt/pull/1724)
 
 ## 37.0.1 (Oct 4, 2021)
 
 ### Patch
 
-- Internal: run prettier directly (#1728)
+- Internal: run prettier directly [#1728](https://github.com/pinterest/gestalt/pull/1728)
 
 ## 37.0.0 (Oct 4, 2021)
 
 ### Major
 
-- Internal: remove prop-types (#1726)
+- Internal: remove prop-types [#1726](https://github.com/pinterest/gestalt/pull/1726)
 
 ## 36.0.7 (Oct 1, 2021)
 
 ### Patch
 
-- Status: use generated props table, general cleanup, add test for subtext (#1723)
+- Status: use generated props table, general cleanup, add test for subtext [#1723](https://github.com/pinterest/gestalt/pull/1723)
 
 ## 36.0.6 (Oct 1, 2021)
 
 ### Patch
 
-- Prevent iconButton firing collapse/expand events on Module.Expandable (#1722)
+- Prevent iconButton firing collapse/expand events on Module.Expandable [#1722](https://github.com/pinterest/gestalt/pull/1722)
 
 ## 36.0.5 (Oct 1, 2021)
 
 ### Patch
 
-- Icon: optimize SVG with svgo (#1716)
+- Icon: optimize SVG with svgo [#1716](https://github.com/pinterest/gestalt/pull/1716)
 
 ## 36.0.4 (Oct 1, 2021)
 
 ### Patch
 
-- Icon: visual testing implementation (#1720)
+- Icon: visual testing implementation [#1720](https://github.com/pinterest/gestalt/pull/1720)
 
 ## 36.0.3 (Oct 1, 2021)
 
 ### Patch
 
-- DatePicker: visual testing implementation (#1719)
+- DatePicker: visual testing implementation [#1719](https://github.com/pinterest/gestalt/pull/1719)
 
 ## 36.0.2 (Oct 1, 2021)
 
 ### Patch
 
-- Box: use generated props table (#1702)
+- Box: use generated props table [#1702](https://github.com/pinterest/gestalt/pull/1702)
 
 ## 36.0.1 (Sep 30, 2021)
 
 ### Patch
 
-- Internal: Upgrade Flow to 0.161.0 (#1718)
+- Internal: Upgrade Flow to 0.161.0 [#1718](https://github.com/pinterest/gestalt/pull/1718)
 
 ## 36.0.0 (Sep 30, 2021)
 
 ### Major
 
-- Link/Button/IconButton/TapArea +composed components: rename disableOnNavigation to dangerouslyDisableOnNavigation (#1717)
+- Link/Button/IconButton/TapArea +composed components: rename disableOnNavigation to dangerouslyDisableOnNavigation [#1717](https://github.com/pinterest/gestalt/pull/1717)
 
 ## 35.5.2 (Sep 29, 2021)
 
 ### Patch
 
-- Bump ansi-regex (#1715)
+- Bump ansi-regex [#1715](https://github.com/pinterest/gestalt/pull/1715)
 
 ## 35.5.1 (Sep 28, 2021)
 
 ### Patch
 
-- Upsell: don't render empty div if no actions and no children (#1714)
+- Upsell: don't render empty div if no actions and no children [#1714](https://github.com/pinterest/gestalt/pull/1714)
 
 ## 35.5.0 (Sep 28, 2021)
 
 ### Minor
 
-- Eslint plugin: add zIndex props coverage to gestalt/no-box-dangerous-style-duplicates (#1713)
+- Eslint plugin: add zIndex props coverage to gestalt/no-box-dangerous-style-duplicates [#1713](https://github.com/pinterest/gestalt/pull/1713)
 
 ## 35.4.0 (Sep 27, 2021)
 
 ### Minor
 
-- Module: iconButton prop (#1707)
+- Module: iconButton prop [#1707](https://github.com/pinterest/gestalt/pull/1707)
 
 ## 35.3.1 (Sep 27, 2021)
 
 ### Patch
 
-- Tooltip: fix "disabled elements" link in docs (#1712)
+- Tooltip: fix "disabled elements" link in docs [#1712](https://github.com/pinterest/gestalt/pull/1712)
 
 ## 35.3.0 (Sep 23, 2021)
 
 ### Minor
 
-- Eslint plugin: add full Box props coverage to gestalt/no-box-dangerous-style-duplicates (#1711)
+- Eslint plugin: add full Box props coverage to gestalt/no-box-dangerous-style-duplicates [#1711](https://github.com/pinterest/gestalt/pull/1711)
 
 ## 35.2.14 (Sep 23, 2021)
 
 ### Patch
 
-- Eslint plugin: gestalt/no-box-dangerous-style-duplicates fixes and refactor (#1709)
+- Eslint plugin: gestalt/no-box-dangerous-style-duplicates fixes and refactor [#1709](https://github.com/pinterest/gestalt/pull/1709)
 
 ## 35.2.13 (Sep 23, 2021)
 
 ### Patch
 
-- Internal: Upgrade Flow to 0.160.2 (#1710)
+- Internal: Upgrade Flow to 0.160.2 [#1710](https://github.com/pinterest/gestalt/pull/1710)
 
 ## 35.2.12 (Sep 23, 2021)
 
 ### Patch
 
-- Icon: new docs (#1698)
+- Icon: new docs [#1698](https://github.com/pinterest/gestalt/pull/1698)
 
 ## 35.2.11 (Sep 23, 2021)
 
 ### Patch
 
-- Internal: add ability to override default value and type in generated docs (#1708)
+- Internal: add ability to override default value and type in generated docs [#1708](https://github.com/pinterest/gestalt/pull/1708)
 
 ## 35.2.10 (Sep 22, 2021)
 
 ### Patch
 
-- SelectList: Tweaks to generated props (#1706)
+- SelectList: Tweaks to generated props [#1706](https://github.com/pinterest/gestalt/pull/1706)
 
 ## 35.2.9 (Sep 22, 2021)
 
 ### Patch
 
-- Callout: use generated props table in docs (#1705)
+- Callout: use generated props table in docs [#1705](https://github.com/pinterest/gestalt/pull/1705)
 
 ## 35.2.8 (Sep 22, 2021)
 
 ### Patch
 
-- SelectList: use generated props table in docs (#1704)
+- SelectList: use generated props table in docs [#1704](https://github.com/pinterest/gestalt/pull/1704)
 
 ## 35.2.7 (Sep 21, 2021)
 
 ### Patch
 
-- Color: copyediting (#1703)
+- Color: copyediting [#1703](https://github.com/pinterest/gestalt/pull/1703)
 
 ## 35.2.6 (Sep 21, 2021)
 
 ### Patch
 
-- Color: Add Brand color palette (#1693)
+- Color: Add Brand color palette [#1693](https://github.com/pinterest/gestalt/pull/1693)
 
 ## 35.2.5 (Sep 21, 2021)
 
 ### Patch
 
-- Bump tmpl from 1.0.4 to 1.0.5 (#1700)
+- Bump tmpl from 1.0.4 to 1.0.5 [#1700](https://github.com/pinterest/gestalt/pull/1700)
 
 ## 35.2.4 (Sep 21, 2021)
 
 ### Patch
 
-- Bump nth-check from 2.0.0 to 2.0.1 (#1701)
+- Bump nth-check from 2.0.0 to 2.0.1 [#1701](https://github.com/pinterest/gestalt/pull/1701)
 
 ## 35.2.3 (Sep 21, 2021)
 
 ### Patch
 
-- SearchField: Update docs to autogenerated props, design guidelines (#1696)
+- SearchField: Update docs to autogenerated props, design guidelines [#1696](https://github.com/pinterest/gestalt/pull/1696)
 
 ## 35.2.2 (Sep 20, 2021)
 
 ### Patch
 
-- Internal: Upgrade Flow to 0.160.1 (#1699)
+- Internal: Upgrade Flow to 0.160.1 [#1699](https://github.com/pinterest/gestalt/pull/1699)
 
 ## 35.2.1 (Sep 17, 2021)
 
 ### Patch
 
-- Button: fix style bug on selected state and role link (#1685)
+- Button: fix style bug on selected state and role link [#1685](https://github.com/pinterest/gestalt/pull/1685)
 
 ## 35.2.0 (Sep 17, 2021)
 
 ### Minor
 
-- Dropdown: add dangerouslyRemoveLayer prop (#1697)
+- Dropdown: add dangerouslyRemoveLayer prop [#1697](https://github.com/pinterest/gestalt/pull/1697)
 
 ## 35.1.1 (Sep 17, 2021)
 
 ### Patch
 
-- Toast: Add experimental prop for dark gray color (#1690)
+- Toast: Add experimental prop for dark gray color [#1690](https://github.com/pinterest/gestalt/pull/1690)
 
 ## 35.1.0 (Sep 16, 2021)
 
 ### Minor
 
-- Internal: use visual regression image & description in generated docs (#1694)
+- Internal: use visual regression image & description in generated docs [#1694](https://github.com/pinterest/gestalt/pull/1694)
 
 ## 35.0.2 (Sep 16, 2021)
 
 ### Patch
 
-- ComboBox: removed minWidth (#1695)
+- ComboBox: removed minWidth [#1695](https://github.com/pinterest/gestalt/pull/1695)
 
 ## 35.0.1 (Sep 15, 2021)
 
 ### Patch
 
-- Docs: Usage guidelines for SearchField, SegmentedControl and Tabs (#1692)
+- Docs: Usage guidelines for SearchField, SegmentedControl and Tabs [#1692](https://github.com/pinterest/gestalt/pull/1692)
 
 ## 35.0.0 (Sep 15, 2021)
 
 ### Major
 
-- Design Tokens: Update format for Android (#1679)
+- Design Tokens: Update format for Android [#1679](https://github.com/pinterest/gestalt/pull/1679)
 
 ## 34.3.4 (Sep 14, 2021)
 
 ### Patch
 
-- Updated Button docs (#1654)
+- Updated Button docs [#1654](https://github.com/pinterest/gestalt/pull/1654)
 
 ## 34.3.3 (Sep 14, 2021)
 
 ### Patch
 
-- IconButton: Fix `rel` docs typo (#1691)
+- IconButton: Fix `rel` docs typo [#1691](https://github.com/pinterest/gestalt/pull/1691)
 
 ## 34.3.2 (Sep 10, 2021)
 
 ### Patch
 
-- Video: add backgroundColor prop (#1610)
+- Video: add backgroundColor prop [#1610](https://github.com/pinterest/gestalt/pull/1610)
 
 ## 34.3.1 (Sep 10, 2021)
 
 ### Patch
 
-- Layouts: Refactor form layout to use Flex (#1687)
+- Layouts: Refactor form layout to use Flex [#1687](https://github.com/pinterest/gestalt/pull/1687)
 
 ## 34.3.0 (Sep 10, 2021)
 
 ### Minor
 
-- Docs: add autogenerated docs for AvatarGroup (forwardRef), automatically get default value & add ability to link to specific prop in docs (#1688)
+- Docs: add autogenerated docs for AvatarGroup (forwardRef), automatically get default value & add ability to link to specific prop in docs [#1688](https://github.com/pinterest/gestalt/pull/1688)
 
 ## 34.2.0 (Sep 10, 2021)
 
 ### Minor
 
-- ScrollBoundaryContainer: use generated docs (multiple exports) (#1689)
+- ScrollBoundaryContainer: use generated docs (multiple exports) [#1689](https://github.com/pinterest/gestalt/pull/1689)
 
 ## 34.1.1 (Sep 9, 2021)
 
 ### Patch
 
-- Internal: Keep URLs in flow docs (#1684)
+- Internal: Keep URLs in flow docs [#1684](https://github.com/pinterest/gestalt/pull/1684)
 
 ## 34.1.0 (Sep 9, 2021)
 
 ### Minor
 
-- Internal: add visual regression tests (#1682)
+- Internal: add visual regression tests [#1682](https://github.com/pinterest/gestalt/pull/1682)
 
 ## 34.0.2 (Sep 9, 2021)
 
 ### Patch
 
-- Internal: add license badge to Readme (#1683)
+- Internal: add license badge to Readme [#1683](https://github.com/pinterest/gestalt/pull/1683)
 
 ## 34.0.1 (Sep 8, 2021)
 
 ### Patch
 
-- Codemods: s/'next'/'34.0.0'/ (#1681)
+- Codemods: s/'next'/'34.0.0'/ [#1681](https://github.com/pinterest/gestalt/pull/1681)
 
 ## 34.0.0 (Sep 8, 2021)
 
 ### Major
 
-- Toast: Replace `color` with `variant` (#1677)
+- Toast: Replace `color` with `variant` [#1677](https://github.com/pinterest/gestalt/pull/1677)
 
 ## 33.10.3 (Sep 8, 2021)
 
 ### Patch
 
-- Docs: Update link to accessible design deck (#1678)
+- Docs: Update link to accessible design deck [#1678](https://github.com/pinterest/gestalt/pull/1678)
 
 ## 33.10.2 (Sep 8, 2021)
 
 ### Patch
 
-- Bump next from 11.1.0 to 11.1.1 (#1675)
+- Bump next from 11.1.0 to 11.1.1 [#1675](https://github.com/pinterest/gestalt/pull/1675)
 
 ## 33.10.1 (Sep 2, 2021)
 
 ### Patch
 
-- Docs: Add more usage guidelines (#1676)
+- Docs: Add more usage guidelines [#1676](https://github.com/pinterest/gestalt/pull/1676)
 
 ## 33.10.0 (Sep 1, 2021)
 
 ### Minor
 
-- Video: add disableRemotePlayback prop (#1670)
+- Video: add disableRemotePlayback prop [#1670](https://github.com/pinterest/gestalt/pull/1670)
 
 ## 33.9.4 (Sep 1, 2021)
 
 ### Patch
 
-- Internal: Upgrade Jest to 27.1.0 (#1674)
+- Internal: Upgrade Jest to 27.1.0 [#1674](https://github.com/pinterest/gestalt/pull/1674)
 
 ## 33.9.3 (Aug 31, 2021)
 
 ### Patch
 
-- Docs: Remove broken source links (#1673)
+- Docs: Remove broken source links [#1673](https://github.com/pinterest/gestalt/pull/1673)
 
 ## 33.9.2 (Aug 31, 2021)
 
 ### Patch
 
-- Bump tar from 6.1.3 to 6.1.11 (#1672)
+- Bump tar from 6.1.3 to 6.1.11 [#1672](https://github.com/pinterest/gestalt/pull/1672)
 
 ## 33.9.1 (Aug 31, 2021)
 
 ### Patch
 
-- Docs: use generated flow types for Text (#1671)
+- Docs: use generated flow types for Text [#1671](https://github.com/pinterest/gestalt/pull/1671)
 
 ## 33.9.0 (Aug 31, 2021)
 
 ### Minor
 
-- Docs: auto generate prop table from component (#1669)
+- Docs: auto generate prop table from component [#1669](https://github.com/pinterest/gestalt/pull/1669)
 
 ## 33.8.3 (Aug 30, 2021)
 
 ### Patch
 
-- Internal: fix Element type is invalid (#1666)
+- Internal: fix Element type is invalid [#1666](https://github.com/pinterest/gestalt/pull/1666)
 
 ## 33.8.2 (Aug 30, 2021)
 
 ### Patch
 
-- Eslint plugin: fix on 'prefer-box-no-disallowed' rule (#1668)
+- Eslint plugin: fix on 'prefer-box-no-disallowed' rule [#1668](https://github.com/pinterest/gestalt/pull/1668)
 
 ## 33.8.1 (Aug 30, 2021)
 
 ### Patch
 
-- Toast: Add role of status for accessibility (#1665)
+- Toast: Add role of status for accessibility [#1665](https://github.com/pinterest/gestalt/pull/1665)
 
 ## 33.8.0 (Aug 30, 2021)
 
 ### Minor
 
-- Eslint plugin: added schema options to `prefer-box-no-disallowed` rule (#1667)
+- Eslint plugin: added schema options to `prefer-box-no-disallowed` rule [#1667](https://github.com/pinterest/gestalt/pull/1667)
 
 ## 33.7.10 (Aug 27, 2021)
 
 ### Patch
 
-- Design Tokens: Switch to using new spacing tokens (#1664)
+- Design Tokens: Switch to using new spacing tokens [#1664](https://github.com/pinterest/gestalt/pull/1664)
 
 ## 33.7.9 (Aug 27, 2021)
 
 ### Patch
 
-- Collage: Fix collage bug in Docs (#1662)
+- Collage: Fix collage bug in Docs [#1662](https://github.com/pinterest/gestalt/pull/1662)
 
 ## 33.7.8 (Aug 27, 2021)
 
 ### Patch
 
-- Docs: cleanup link navigation (#1656)
+- Docs: cleanup link navigation [#1656](https://github.com/pinterest/gestalt/pull/1656)
 
 ## 33.7.7 (Aug 27, 2021)
 
 ### Patch
 
-- Lint rules: Another attempt at fixing `prefer-flex` import count bug (#1663)
+- Lint rules: Another attempt at fixing `prefer-flex` import count bug [#1663](https://github.com/pinterest/gestalt/pull/1663)
 
 ## 33.7.6 (Aug 26, 2021)
 
 ### Patch
 
-- Docs: persist scrollbar position across pages (#1661)
+- Docs: persist scrollbar position across pages [#1661](https://github.com/pinterest/gestalt/pull/1661)
 
 ## 33.7.5 (Aug 26, 2021)
 
 ### Patch
 
-- Lint rules: Fix `prefer-flex` import statement Box detection (#1660)
+- Lint rules: Fix `prefer-flex` import statement Box detection [#1660](https://github.com/pinterest/gestalt/pull/1660)
 
 ## 33.7.4 (Aug 26, 2021)
 
 ### Patch
 
-- Docs: fix color page export for Next (#1657)
+- Docs: fix color page export for Next [#1657](https://github.com/pinterest/gestalt/pull/1657)
 
 ## 33.7.3 (Aug 25, 2021)
 
 ### Patch
 
-- Lint rules: Fix closing element bug in helper (#1655)
+- Lint rules: Fix closing element bug in helper [#1655](https://github.com/pinterest/gestalt/pull/1655)
 
 ## 33.7.2 (Aug 25, 2021)
 
 ### Patch
 
-- Internal: Update build process for new package (#1653)
+- Internal: Update build process for new package [#1653](https://github.com/pinterest/gestalt/pull/1653)
 
 ## 33.7.1 (Aug 25, 2021)
 
 ### Patch
 
-- Internal: Upgrade Flow to 0.158.0 (#1644)
+- Internal: Upgrade Flow to 0.158.0 [#1644](https://github.com/pinterest/gestalt/pull/1644)
 
 ## 33.7.0 (Aug 25, 2021)
 
 ### Minor
 
-- Eslint plugin: updated `gestalt/no-dangerous-style-duplicates` w/ autofix (#1641)
+- Eslint plugin: updated `gestalt/no-dangerous-style-duplicates` w/ autofix [#1641](https://github.com/pinterest/gestalt/pull/1641)
 
 ## 33.6.0 (Aug 24, 2021)
 
 ### Minor
 
-- Image: Add crossorigin property (#1640)
+- Image: Add crossorigin property [#1640](https://github.com/pinterest/gestalt/pull/1640)
 
 ## 33.5.0 (Aug 24, 2021)
 
 ### Minor
 
-- Flex: Add `flexBasis` prop to Flex.Item (#1648)
+- Flex: Add `flexBasis` prop to Flex.Item [#1648](https://github.com/pinterest/gestalt/pull/1648)
 
 ## 33.4.4 (Aug 24, 2021)
 
 ### Patch
 
-- Docs: fix local redirects (#1651)
+- Docs: fix local redirects [#1651](https://github.com/pinterest/gestalt/pull/1651)
 
 ## 33.4.3 (Aug 23, 2021)
 
 ### Patch
 
-- Docs: fix favicon (#1650)
+- Docs: fix favicon [#1650](https://github.com/pinterest/gestalt/pull/1650)
 
 ## 33.4.2 (Aug 23, 2021)
 
 ### Patch
 
-- Lint rules: Add prefer-flex to the index (#1649)
+- Lint rules: Add prefer-flex to the index [#1649](https://github.com/pinterest/gestalt/pull/1649)
 
 ## 33.4.1 (Aug 23, 2021)
 
 ### Patch
 
-- Docs: fix active link in sidebar (#1647)
+- Docs: fix active link in sidebar [#1647](https://github.com/pinterest/gestalt/pull/1647)
 
 ## 33.4.0 (Aug 23, 2021)
 
 ### Minor
 
-- Lint rules: Add `prefer-flex` rule w/autofix (#1628)
+- Lint rules: Add `prefer-flex` rule w/autofix [#1628](https://github.com/pinterest/gestalt/pull/1628)
 
 ## 33.3.0 (Aug 23, 2021)
 
 ### Minor
 
-- Interal: Convert docs to Next.js (#1642)
+- Interal: Convert docs to Next.js [#1642](https://github.com/pinterest/gestalt/pull/1642)
 
 ## 33.2.2 (Aug 23, 2021)
 
 ### Patch
 
-- Docs: Remove tokens import temporarily (#1646)
+- Docs: Remove tokens import temporarily [#1646](https://github.com/pinterest/gestalt/pull/1646)
 
 ## 33.2.1 (Aug 20, 2021)
 
 ### Patch
 
-- Internal: fix gestalt-design-tokens variables import (#1643)
+- Internal: fix gestalt-design-tokens variables import [#1643](https://github.com/pinterest/gestalt/pull/1643)
 
 ## 33.2.0 (Aug 20, 2021)
 
 ### Minor
 
-- Color: Add design tokens package and color page (#1636)
+- Color: Add design tokens package and color page [#1636](https://github.com/pinterest/gestalt/pull/1636)
 
 ## 33.1.0 (Aug 19, 2021)
 
 ### Minor
 
-- Eslint plugin: `prefer-box-no-classname` rule w/ autofix + merged into `prefer-box-lonely-ref` (#1629)
+- Eslint plugin: `prefer-box-no-classname` rule w/ autofix + merged into `prefer-box-lonely-ref` [#1629](https://github.com/pinterest/gestalt/pull/1629)
 
 ## 33.0.1 (Aug 19, 2021)
 
 ### Patch
 
-- Modal: Add flow docs (#1635)
+- Modal: Add flow docs [#1635](https://github.com/pinterest/gestalt/pull/1635)
 
 ## 33.0.0 (Aug 18, 2021)
 
 ### Major
 
-- Heading: Replace `truncate` with `lineClamp` (#1637)
+- Heading: Replace `truncate` with `lineClamp` [#1637](https://github.com/pinterest/gestalt/pull/1637)
 
 ## 32.1.6 (Aug 18, 2021)
 
 ### Patch
 
-- Revert "Button: Add key to fix Safari bug, take two" (#1638)
+- Revert "Button: Add key to fix Safari bug, take two" [#1638](https://github.com/pinterest/gestalt/pull/1638)
 
 ## 32.1.5 (Aug 18, 2021)
 
 ### Patch
 
-- ZIndex Classes: Docs fixes (#1626)
+- ZIndex Classes: Docs fixes [#1626](https://github.com/pinterest/gestalt/pull/1626)
 
 ## 32.1.4 (Aug 18, 2021)
 
 ### Patch
 
-- Docs: Add more usage guidelines (#1634)
+- Docs: Add more usage guidelines [#1634](https://github.com/pinterest/gestalt/pull/1634)
 
 ## 32.1.3 (Aug 18, 2021)
 
 ### Patch
 
-- Lint rules: Fix name bug in no-box-useless-props (#1633)
+- Lint rules: Fix name bug in no-box-useless-props [#1633](https://github.com/pinterest/gestalt/pull/1633)
 
 ## 32.1.2 (Aug 17, 2021)
 
 ### Patch
 
-- Lint rules: Fix find bug in no-box-useless-props (#1632)
+- Lint rules: Fix find bug in no-box-useless-props [#1632](https://github.com/pinterest/gestalt/pull/1632)
 
 ## 32.1.1 (Aug 17, 2021)
 
 ### Patch
 
-- Lint rules: Fix reduce bug in no-box-useless-props (#1631)
+- Lint rules: Fix reduce bug in no-box-useless-props [#1631](https://github.com/pinterest/gestalt/pull/1631)
 
 ## 32.1.0 (Aug 16, 2021)
 
 ### Minor
 
-- Lint rules: Add support for dynamic/dangerous styles in `no-box-useless-props` (#1623)
+- Lint rules: Add support for dynamic/dangerous styles in `no-box-useless-props` [#1623](https://github.com/pinterest/gestalt/pull/1623)
 
 ## 32.0.0 (Aug 16, 2021)
 
 ### Major
 
-- Revert Color: Add design tokens package and color page (#1616) (#1627)
+- Revert Color: Add design tokens package and color page [#1616](https://github.com/pinterest/gestalt/pull/1616) [#1627](https://github.com/pinterest/gestalt/pull/1627)
 
 ## 31.5.0 (Aug 16, 2021)
 
 ### Minor
 
-- Sheet: new onAnimationEnd prop + fix for bug (#1625)
+- Sheet: new onAnimationEnd prop + fix for bug [#1625](https://github.com/pinterest/gestalt/pull/1625)
 
 ## 31.4.0 (Aug 14, 2021)
 
 ### Minor
 
-- Color: Add design tokens package and color page (#1616)
+- Color: Add design tokens package and color page [#1616](https://github.com/pinterest/gestalt/pull/1616)
 
 ## 31.3.2 (Aug 12, 2021)
 
 ### Patch
 
-- Avatar, AvatarGroup, AvatarPair: Add usage guidelines (#1624)
+- Avatar, AvatarGroup, AvatarPair: Add usage guidelines [#1624](https://github.com/pinterest/gestalt/pull/1624)
 
 ## 31.3.1 (Aug 12, 2021)
 
@@ -3724,67 +3724,67 @@
 
 ### Patch
 
-- Checkbox, RadioButton, Switch: Add usage guidelines (#1612)
+- Checkbox, RadioButton, Switch: Add usage guidelines [#1612](https://github.com/pinterest/gestalt/pull/1612)
 
 ## 31.2.0 (Aug 11, 2021)
 
 ### Minor
 
-- [Internal] Automatically launch docs & watcher when you open VSCode (#1620)
+- [Internal] Automatically launch docs & watcher when you open VSCode [#1620](https://github.com/pinterest/gestalt/pull/1620)
 
 ## 31.1.5 (Aug 11, 2021)
 
 ### Patch
 
-- Bump path-parse from 1.0.6 to 1.0.7 (#1617)
+- Bump path-parse from 1.0.6 to 1.0.7 [#1617](https://github.com/pinterest/gestalt/pull/1617)
 
 ## 31.1.4 (Aug 11, 2021)
 
 ### Patch
 
-- Bump url-parse from 1.5.1 to 1.5.3 (#1621)
+- Bump url-parse from 1.5.1 to 1.5.3 [#1621](https://github.com/pinterest/gestalt/pull/1621)
 
 ## 31.1.3 (Aug 11, 2021)
 
 ### Patch
 
-- [Internal] Remove deprecated prettier VSCode setting (#1618)
+- [Internal] Remove deprecated prettier VSCode setting [#1618](https://github.com/pinterest/gestalt/pull/1618)
 
 ## 31.1.2 (Aug 11, 2021)
 
 ### Patch
 
-- [Internal] Fix property of undefined exceptions (#1619)
+- [Internal] Fix property of undefined exceptions [#1619](https://github.com/pinterest/gestalt/pull/1619)
 
 ## 31.1.1 (Aug 11, 2021)
 
 ### Patch
 
-- Eslint plugin: fixes to `prefer-box`, `no-spread-props` (#1615)
+- Eslint plugin: fixes to `prefer-box`, `no-spread-props` [#1615](https://github.com/pinterest/gestalt/pull/1615)
 
 ## 31.1.0 (Aug 9, 2021)
 
 ### Minor
 
-- Eslint plugin: prefer-box-lonely-ref rule w/ autofix + no-spread-props rule w/ autofix (#1608)
+- Eslint plugin: prefer-box-lonely-ref rule w/ autofix + no-spread-props rule w/ autofix [#1608](https://github.com/pinterest/gestalt/pull/1608)
 
 ## 31.0.1 (Aug 9, 2021)
 
 ### Patch
 
-- Internal: s/'next'/'31.0.0' (#1614)
+- Internal: s/'next'/'31.0.0' [#1614](https://github.com/pinterest/gestalt/pull/1614)
 
 ## 31.0.0 (Aug 9, 2021)
 
 ### Major
 
-- Text: Remove `truncate`, document `lineClamp` (#1611)
+- Text: Remove `truncate`, document `lineClamp` [#1611](https://github.com/pinterest/gestalt/pull/1611)
 
 ## 30.1.0 (Aug 6, 2021)
 
 ### Minor
 
-- Fieldset: Add errorMessage prop (#1605)
+- Fieldset: Add errorMessage prop [#1605](https://github.com/pinterest/gestalt/pull/1605)
 
 ## 30.0.1 (Aug 5, 2021)
 
@@ -3796,619 +3796,619 @@
 
 ### Major
 
-- Upsell: Fix Upsell.Form onSubmit API to match convention (#1606)
+- Upsell: Fix Upsell.Form onSubmit API to match convention [#1606](https://github.com/pinterest/gestalt/pull/1606)
 
 ## 29.6.5 (Aug 3, 2021)
 
 ### Patch
 
-- Bump tar from 6.0.5 to 6.1.3 (#1607)
+- Bump tar from 6.0.5 to 6.1.3 [#1607](https://github.com/pinterest/gestalt/pull/1607)
 
 ## 29.6.4 (Aug 3, 2021)
 
 ### Patch
 
-- Callout, Upsell, Datapoint: Add note about dark mode support (#1603)
+- Callout, Upsell, Datapoint: Add note about dark mode support [#1603](https://github.com/pinterest/gestalt/pull/1603)
 
 ## 29.6.3 (Aug 3, 2021)
 
 ### Patch
 
-- Docs: Update design crit information (#1604)
+- Docs: Update design crit information [#1604](https://github.com/pinterest/gestalt/pull/1604)
 
 ## 29.6.2 (Jul 29, 2021)
 
 ### Patch
 
-- IconButton: New documentation and best practices (#1598)
+- IconButton: New documentation and best practices [#1598](https://github.com/pinterest/gestalt/pull/1598)
 
 ## 29.6.1 (Jul 29, 2021)
 
 ### Patch
 
-- Eslint Plugin: Add missing rules to Docs, categorize, and standardize rule config (#1601)
+- Eslint Plugin: Add missing rules to Docs, categorize, and standardize rule config [#1601](https://github.com/pinterest/gestalt/pull/1601)
 
 ## 29.6.0 (Jul 27, 2021)
 
 ### Minor
 
-- Callout, Upsell: Allow actions to be disabled (#1600)
+- Callout, Upsell: Allow actions to be disabled [#1600](https://github.com/pinterest/gestalt/pull/1600)
 
 ## 29.5.6 (Jul 26, 2021)
 
 ### Patch
 
-- Docs: Add usage guidelines for multiple components (#1599)
+- Docs: Add usage guidelines for multiple components [#1599](https://github.com/pinterest/gestalt/pull/1599)
 
 ## 29.5.5 (Jul 22, 2021)
 
 ### Patch
 
-- Docs: Clarify useFocusVisible Hook (#1597)
+- Docs: Clarify useFocusVisible Hook [#1597](https://github.com/pinterest/gestalt/pull/1597)
 
 ## 29.5.4 (Jul 21, 2021)
 
 ### Patch
 
-- Modal: Add usage guidelines (#1595)
+- Modal: Add usage guidelines [#1595](https://github.com/pinterest/gestalt/pull/1595)
 
 ## 29.5.3 (Jul 20, 2021)
 
 ### Patch
 
-- Updated Report icon (#1594)
+- Updated Report icon [#1594](https://github.com/pinterest/gestalt/pull/1594)
 
 ## 29.5.2 (Jul 20, 2021)
 
 ### Patch
 
-- Sheet: Added new Usage Guidelines (#1592)
+- Sheet: Added new Usage Guidelines [#1592](https://github.com/pinterest/gestalt/pull/1592)
 
 ## 29.5.1 (Jul 20, 2021)
 
 ### Patch
 
-- Lint Rules: Better error message for grid props (#1593)
+- Lint Rules: Better error message for grid props [#1593](https://github.com/pinterest/gestalt/pull/1593)
 
 ## 29.5.0 (Jul 20, 2021)
 
 ### Minor
 
-- Lint Rules: Add support for responsive props in no-box-useless-props (#1591)
+- Lint Rules: Add support for responsive props in no-box-useless-props [#1591](https://github.com/pinterest/gestalt/pull/1591)
 
 ## 29.4.1 (Jul 19, 2021)
 
 ### Patch
 
-- Docs: Add Accessibility guidelines page (#1588)
+- Docs: Add Accessibility guidelines page [#1588](https://github.com/pinterest/gestalt/pull/1588)
 
 ## 29.4.0 (Jul 19, 2021)
 
 ### Minor
 
-- Lint Rules: Fix no-box-useless-props rule (#1590)
+- Lint Rules: Fix no-box-useless-props rule [#1590](https://github.com/pinterest/gestalt/pull/1590)
 
 ## 29.3.2 (Jul 16, 2021)
 
 ### Patch
 
-- Lint Rules: Add `no-box-useless-props` to index (#1589)
+- Lint Rules: Add `no-box-useless-props` to index [#1589](https://github.com/pinterest/gestalt/pull/1589)
 
 ## 29.3.1 (Jul 15, 2021)
 
 ### Patch
 
-- Revert "Image: Refactor to function component (#1576)" (#1586)
+- Revert "Image: Refactor to function component [#1576](https://github.com/pinterest/gestalt/pull/1576)" [#1586](https://github.com/pinterest/gestalt/pull/1586)
 
 ## 29.3.0 (Jul 15, 2021)
 
 ### Minor
 
-- Lint rules: Add `no-box-useless-props` rule (#1585)
+- Lint rules: Add `no-box-useless-props` rule [#1585](https://github.com/pinterest/gestalt/pull/1585)
 
 ## 29.2.2 (Jul 14, 2021)
 
 ### Patch
 
-- Button: Add key to fix Safari bug (#1584)
+- Button: Add key to fix Safari bug [#1584](https://github.com/pinterest/gestalt/pull/1584)
 
 ## 29.2.1 (Jul 13, 2021)
 
 ### Patch
 
-- Codemods: Move 29.0.0 codemod to correct directory (#1583)
+- Codemods: Move 29.0.0 codemod to correct directory [#1583](https://github.com/pinterest/gestalt/pull/1583)
 
 ## 29.2.0 (Jul 12, 2021)
 
 ### Minor
 
-- Tabs: Add `bgColor` prop, tweak padding/states (#1582)
+- Tabs: Add `bgColor` prop, tweak padding/states [#1582](https://github.com/pinterest/gestalt/pull/1582)
 
 ## 29.1.1 (Jul 8, 2021)
 
 ### Patch
 
-- Upsell: docs cleanup (#1581)
+- Upsell: docs cleanup [#1581](https://github.com/pinterest/gestalt/pull/1581)
 
 ## 29.1.0 (Jul 2, 2021)
 
 ### Minor
 
-- ComboBox: new component (#1563)
+- ComboBox: new component [#1563](https://github.com/pinterest/gestalt/pull/1563)
 
 ## 29.0.0 (Jul 1, 2021)
 
 ### Major
 
-- Button: rename inline prop to fullWidth + codemod (#1564)
+- Button: rename inline prop to fullWidth + codemod [#1564](https://github.com/pinterest/gestalt/pull/1564)
 
 ## 28.0.1 (Jul 1, 2021)
 
 ### Patch
 
-- Image: Refactor to function component (#1576)
+- Image: Refactor to function component [#1576](https://github.com/pinterest/gestalt/pull/1576)
 
 ## 28.0.0 (Jul 1, 2021)
 
 ### Major
 
-- Modal, Sheet: deprecate ref (forwardRef removal) + codemod (#1578)
+- Modal, Sheet: deprecate ref (forwardRef removal) + codemod [#1578](https://github.com/pinterest/gestalt/pull/1578)
 
 ## 27.3.5 (Jun 30, 2021)
 
 ### Patch
 
-- Text: Update `word-break` style (#1577)
+- Text: Update `word-break` style [#1577](https://github.com/pinterest/gestalt/pull/1577)
 
 ## 27.3.4 (Jun 28, 2021)
 
 ### Patch
 
-- TextField: new InternalTextField for reusability (#1573)
+- TextField: new InternalTextField for reusability [#1573](https://github.com/pinterest/gestalt/pull/1573)
 
 ## 27.3.3 (Jun 24, 2021)
 
 ### Patch
 
-- Collection: Refactor to function component (#1574)
+- Collection: Refactor to function component [#1574](https://github.com/pinterest/gestalt/pull/1574)
 
 ## 27.3.2 (Jun 24, 2021)
 
 ### Patch
 
-- FetchItems: Refactor to function component (#1575)
+- FetchItems: Refactor to function component [#1575](https://github.com/pinterest/gestalt/pull/1575)
 
 ## 27.3.1 (Jun 24, 2021)
 
 ### Patch
 
-- Tabs, TapArea, InternalLink: Add support for aria-current (#1571)
+- Tabs, TapArea, InternalLink: Add support for aria-current [#1571](https://github.com/pinterest/gestalt/pull/1571)
 
 ## 27.3.0 (Jun 24, 2021)
 
 ### Minor
 
-- Table: Add sticky column support to sortable header (#1567)
+- Table: Add sticky column support to sortable header [#1567](https://github.com/pinterest/gestalt/pull/1567)
 
 ## 27.2.1 (Jun 23, 2021)
 
 ### Patch
 
-- SearchField: Add accessibilityClearButtonLabel to props table in docs (#1572)
+- SearchField: Add accessibilityClearButtonLabel to props table in docs [#1572](https://github.com/pinterest/gestalt/pull/1572)
 
 ## 27.2.0 (Jun 23, 2021)
 
 ### Minor
 
-- Image: Add option for presentation role (#1570)
+- Image: Add option for presentation role [#1570](https://github.com/pinterest/gestalt/pull/1570)
 
 ## 27.1.0 (Jun 22, 2021)
 
 ### Minor
 
-- Lint Rules: Remove Tabs from `no-medium-formfields` rule (#1569)
+- Lint Rules: Remove Tabs from `no-medium-formfields` rule [#1569](https://github.com/pinterest/gestalt/pull/1569)
 
 ## 27.0.0 (Jun 22, 2021)
 
 ### Major
 
-- Tabs: Ship V2 tab treatment (#1566)
+- Tabs: Ship V2 tab treatment [#1566](https://github.com/pinterest/gestalt/pull/1566)
 
 ## 26.0.2 (Jun 22, 2021)
 
 ### Patch
 
-- Bump color-string from 1.5.3 to 1.5.5 (#1568)
+- Bump color-string from 1.5.3 to 1.5.5 [#1568](https://github.com/pinterest/gestalt/pull/1568)
 
 ## 26.0.1 (Jun 22, 2021)
 
 ### Patch
 
-- Text: Add `lineClamp` prop (#1565)
+- Text: Add `lineClamp` prop [#1565](https://github.com/pinterest/gestalt/pull/1565)
 
 ## 26.0.0 (Jun 17, 2021)
 
 ### Major
 
-- ActivationCard, Upsell, Callout: Make accessibilityLabel required for actions (#1555)
+- ActivationCard, Upsell, Callout: Make accessibilityLabel required for actions [#1555](https://github.com/pinterest/gestalt/pull/1555)
 
 ## 25.0.1 (Jun 17, 2021)
 
 ### Patch
 
-- Dropdown: s/'next'/'25.0.0'/ for recent codemod (#1562)
+- Dropdown: s/'next'/'25.0.0'/ for recent codemod [#1562](https://github.com/pinterest/gestalt/pull/1562)
 
 ## 25.0.0 (Jun 17, 2021)
 
 ### Major
 
-- Dropdown: Remove parent onSelect, split Dropdown.Item to add Dropdown.Link (#1554)
+- Dropdown: Remove parent onSelect, split Dropdown.Item to add Dropdown.Link [#1554](https://github.com/pinterest/gestalt/pull/1554)
 
 ## 24.2.1 (Jun 17, 2021)
 
 ### Patch
 
-- Internal: fix stripping URLs from code (#1561)
+- Internal: fix stripping URLs from code [#1561](https://github.com/pinterest/gestalt/pull/1561)
 
 ## 24.2.0 (Jun 17, 2021)
 
 ### Minor
 
-- Internal: Add links in code to docs (#1558)
+- Internal: Add links in code to docs [#1558](https://github.com/pinterest/gestalt/pull/1558)
 
 ## 24.1.2 (Jun 16, 2021)
 
 ### Patch
 
-- Image: fit children (#1559)
+- Image: fit children [#1559](https://github.com/pinterest/gestalt/pull/1559)
 
 ## 24.1.1 (Jun 16, 2021)
 
 ### Patch
 
-- Box: Add documentation about new 'as' prop (#1552)
+- Box: Add documentation about new 'as' prop [#1552](https://github.com/pinterest/gestalt/pull/1552)
 
 ## 24.1.0 (Jun 10, 2021)
 
 ### Minor
 
-- Video: Use objectFit instead of object-fit (#1553)
+- Video: Use objectFit instead of object-fit [#1553](https://github.com/pinterest/gestalt/pull/1553)
 
 ## 24.0.5 (Jun 9, 2021)
 
 ### Patch
 
-- Internal: add resolution for `glob-parent` to fix vulnerability (#1551)
+- Internal: add resolution for `glob-parent` to fix vulnerability [#1551](https://github.com/pinterest/gestalt/pull/1551)
 
 ## 24.0.4 (Jun 9, 2021)
 
 ### Patch
 
-- Link: fix indentation in Docs code examples (#1549)
+- Link: fix indentation in Docs code examples [#1549](https://github.com/pinterest/gestalt/pull/1549)
 
 ## 24.0.3 (Jun 9, 2021)
 
 ### Patch
 
-- Internal: add resolution for `css-select` to fix `css-what` vulnerability (#1543)
+- Internal: add resolution for `css-select` to fix `css-what` vulnerability [#1543](https://github.com/pinterest/gestalt/pull/1543)
 
 ## 24.0.2 (Jun 9, 2021)
 
 ### Patch
 
-- Internal: add resolution for `trim-newlines` to fix vulnerability (#1546)
+- Internal: add resolution for `trim-newlines` to fix vulnerability [#1546](https://github.com/pinterest/gestalt/pull/1546)
 
 ## 24.0.1 (Jun 9, 2021)
 
 ### Patch
 
-- Internal: add resolution for `normalize-url` to fix vulnerability (#1545)
+- Internal: add resolution for `normalize-url` to fix vulnerability [#1545](https://github.com/pinterest/gestalt/pull/1545)
 
 ## 24.0.0 (Jun 9, 2021)
 
 ### Major
 
-- GroupAvatar: cmp deprecation from Gestalt library (#1542)
+- GroupAvatar: cmp deprecation from Gestalt library [#1542](https://github.com/pinterest/gestalt/pull/1542)
 
 ## 23.2.0 (Jun 8, 2021)
 
 ### Minor
 
-- Popover: new id and role props for accessibility (#1536)
+- Popover: new id and role props for accessibility [#1536](https://github.com/pinterest/gestalt/pull/1536)
 
 ## 23.1.0 (Jun 8, 2021)
 
 ### Minor
 
-- Tabs: pass disableOnNavigation arg in onChange for link behavior management (#1540)
+- Tabs: pass disableOnNavigation arg in onChange for link behavior management [#1540](https://github.com/pinterest/gestalt/pull/1540)
 
 ## 23.0.4 (Jun 7, 2021)
 
 ### Patch
 
-- Internal: add resolution for vulnerable `ws` package (#1539)
+- Internal: add resolution for vulnerable `ws` package [#1539](https://github.com/pinterest/gestalt/pull/1539)
 
 ## 23.0.3 (Jun 7, 2021)
 
 ### Patch
 
-- Internal: replace deprecated `postcss-cssnext` with `postcss-preset-env` (#1538)
+- Internal: replace deprecated `postcss-cssnext` with `postcss-preset-env` [#1538](https://github.com/pinterest/gestalt/pull/1538)
 
 ## 23.0.2 (Jun 7, 2021)
 
 ### Patch
 
-- Docs: Remove feedback callout (#1537)
+- Docs: Remove feedback callout [#1537](https://github.com/pinterest/gestalt/pull/1537)
 
 ## 23.0.1 (Jun 3, 2021)
 
 ### Patch
 
-- Bump ws from 6.2.1 to 6.2.2 (#1535)
+- Bump ws from 6.2.1 to 6.2.2 [#1535](https://github.com/pinterest/gestalt/pull/1535)
 
 ## 23.0.0 (Jun 3, 2021)
 
 ### Major
 
-- ColorSchemeProvider, OnLinkNavigationProvider: split Provider into individual providers (#1534)
+- ColorSchemeProvider, OnLinkNavigationProvider: split Provider into individual providers [#1534](https://github.com/pinterest/gestalt/pull/1534)
 
 ## 22.6.1 (May 27, 2021)
 
 ### Patch
 
-- Internal: update links to new docs domain (#1531)
+- Internal: update links to new docs domain [#1531](https://github.com/pinterest/gestalt/pull/1531)
 
 ## 22.6.0 (May 27, 2021)
 
 ### Minor
 
-- TextField: Add email option for autocomplete (#1530)
+- TextField: Add email option for autocomplete [#1530](https://github.com/pinterest/gestalt/pull/1530)
 
 ## 22.5.0 (May 27, 2021)
 
 ### Minor
 
-- Internal: src/ directories: remove test files & only publish .js.flow (second try) (#1529)
+- Internal: src/ directories: remove test files & only publish .js.flow (second try) [#1529](https://github.com/pinterest/gestalt/pull/1529)
 
 ## 22.4.0 (May 27, 2021)
 
 ### Minor
 
-- Revert "Internal: src/ directories: remove test files & only publish .js.flow (#1525)" (#1528)
+- Revert "Internal: src/ directories: remove test files & only publish .js.flow [#1525](https://github.com/pinterest/gestalt/pull/1525)" [#1528](https://github.com/pinterest/gestalt/pull/1528)
 
 ## 22.3.0 (May 27, 2021)
 
 ### Minor
 
-- SearchField: Add label option and improve keyboard accessibility (#1527)
+- SearchField: Add label option and improve keyboard accessibility [#1527](https://github.com/pinterest/gestalt/pull/1527)
 
 ## 22.2.1 (May 27, 2021)
 
 ### Patch
 
-- Modal: New docs and Best Practices (#1521)
+- Modal: New docs and Best Practices [#1521](https://github.com/pinterest/gestalt/pull/1521)
 
 ## 22.2.0 (May 27, 2021)
 
 ### Minor
 
-- Internal: src/ directories: remove test files & only publish .js.flow (#1525)
+- Internal: src/ directories: remove test files & only publish .js.flow [#1525](https://github.com/pinterest/gestalt/pull/1525)
 
 ## 22.1.0 (May 26, 2021)
 
 ### Minor
 
-- Internal: upgrade to Node.js 14 & add 16 to our CI test matrix (#1526)
+- Internal: upgrade to Node.js 14 & add 16 to our CI test matrix [#1526](https://github.com/pinterest/gestalt/pull/1526)
 
 ## 22.0.0 (May 26, 2021)
 
 ### Major
 
-- Text/Heading: update align values (#1522)
+- Text/Heading: update align values [#1522](https://github.com/pinterest/gestalt/pull/1522)
 
 ## 21.17.13 (May 26, 2021)
 
 ### Patch
 
-- Internal: Update browserslist dependency resolution (#1524)
+- Internal: Update browserslist dependency resolution [#1524](https://github.com/pinterest/gestalt/pull/1524)
 
 ## 21.17.12 (May 25, 2021)
 
 ### Patch
 
-- Internal: bump resolved version of multicast-dns due to security concern for dns-packet (#1523)
+- Internal: bump resolved version of multicast-dns due to security concern for dns-packet [#1523](https://github.com/pinterest/gestalt/pull/1523)
 
 ## 21.17.11 (May 25, 2021)
 
 ### Patch
 
-- Box: update links in API table (#1519)
+- Box: update links in API table [#1519](https://github.com/pinterest/gestalt/pull/1519)
 
 ## 21.17.10 (May 21, 2021)
 
 ### Patch
 
-- Dropdown: fixes and cleanup (#1517)
+- Dropdown: fixes and cleanup [#1517](https://github.com/pinterest/gestalt/pull/1517)
 
 ## 21.17.9 (May 20, 2021)
 
 ### Patch
 
-- Sheet: New docs and best practices (#1495)
+- Sheet: New docs and best practices [#1495](https://github.com/pinterest/gestalt/pull/1495)
 
 ## 21.17.8 (May 19, 2021)
 
 ### Patch
 
-- Tabs: Add ref to tab items (#1516)
+- Tabs: Add ref to tab items [#1516](https://github.com/pinterest/gestalt/pull/1516)
 
 ## 21.17.7 (May 17, 2021)
 
 ### Patch
 
-- Docs: Link to zIndex documentation in relevant components (#1514)
+- Docs: Link to zIndex documentation in relevant components [#1514](https://github.com/pinterest/gestalt/pull/1514)
 
 ## 21.17.6 (May 17, 2021)
 
 ### Patch
 
-- TextField, TextArea: Open errorMessage type to accept Node (#1513)
+- TextField, TextArea: Open errorMessage type to accept Node [#1513](https://github.com/pinterest/gestalt/pull/1513)
 
 ## 21.17.5 (May 17, 2021)
 
 ### Patch
 
-- Video: Add missing video event handlers (#1515)
+- Video: Add missing video event handlers [#1515](https://github.com/pinterest/gestalt/pull/1515)
 
 ## 21.17.4 (May 17, 2021)
 
 ### Patch
 
-- Updated trendSentiment docs to explicitly call out color treatments. (#1512)
+- Updated trendSentiment docs to explicitly call out color treatments. [#1512](https://github.com/pinterest/gestalt/pull/1512)
 
 ## 21.17.3 (May 17, 2021)
 
 ### Patch
 
-- ESLint: add native React props to no-box-disallowed-props (#1511)
+- ESLint: add native React props to no-box-disallowed-props [#1511](https://github.com/pinterest/gestalt/pull/1511)
 
 ## 21.17.2 (May 17, 2021)
 
 ### Patch
 
-- Datapoint: remove compression on click (#1508)
+- Datapoint: remove compression on click [#1508](https://github.com/pinterest/gestalt/pull/1508)
 
 ## 21.17.1 (May 17, 2021)
 
 ### Patch
 
-- ESLint: improve performance & bug fix for box-no-disallowed-props (#1510)
+- ESLint: improve performance & bug fix for box-no-disallowed-props [#1510](https://github.com/pinterest/gestalt/pull/1510)
 
 ## 21.17.0 (May 14, 2021)
 
 ### Minor
 
-- Button: add new transparentWhite color (#1507)
+- Button: add new transparentWhite color [#1507](https://github.com/pinterest/gestalt/pull/1507)
 
 ## 21.16.0 (May 12, 2021)
 
 ### Minor
 
-- ESLint: add rule to disallow non-standard Box props (#1501)
+- ESLint: add rule to disallow non-standard Box props [#1501](https://github.com/pinterest/gestalt/pull/1501)
 
 ## 21.15.5 (May 11, 2021)
 
 ### Patch
 
-- Internal: Add resolution to latest version of `lodash` (#1505)
+- Internal: Add resolution to latest version of `lodash` [#1505](https://github.com/pinterest/gestalt/pull/1505)
 
 ## 21.15.4 (May 11, 2021)
 
 ### Patch
 
-- Bugfix: Add units to `border-radius` values (#1506)
+- Bugfix: Add units to `border-radius` values [#1506](https://github.com/pinterest/gestalt/pull/1506)
 
 ## 21.15.3 (May 10, 2021)
 
 ### Patch
 
-- Internal: Upgrade `stylelint` dependency to obviate `trim` security vulnerability (#1504)
+- Internal: Upgrade `stylelint` dependency to obviate `trim` security vulnerability [#1504](https://github.com/pinterest/gestalt/pull/1504)
 
 ## 21.15.2 (May 10, 2021)
 
 ### Patch
 
-- Docs: Add page about screen size support (#1494)
+- Docs: Add page about screen size support [#1494](https://github.com/pinterest/gestalt/pull/1494)
 
 ## 21.15.1 (May 10, 2021)
 
 ### Patch
 
-- Bump hosted-git-info from 2.8.8 to 2.8.9 (#1502)
+- Bump hosted-git-info from 2.8.8 to 2.8.9 [#1502](https://github.com/pinterest/gestalt/pull/1502)
 
 ## 21.15.0 (May 10, 2021)
 
 ### Minor
 
-- Internal: reduce CSS bundle size by 31% (#1499)
+- Internal: reduce CSS bundle size by 31% [#1499](https://github.com/pinterest/gestalt/pull/1499)
 
 ## 21.14.1 (May 9, 2021)
 
 ### Patch
 
-- Bump ua-parser-js from 0.7.21 to 0.7.28 (#1496)
+- Bump ua-parser-js from 0.7.21 to 0.7.28 [#1496](https://github.com/pinterest/gestalt/pull/1496)
 
 ## 21.14.0 (May 5, 2021)
 
 ### Minor
 
-- Fieldset: New component for form accessibility (#1493)
+- Fieldset: New component for form accessibility [#1493](https://github.com/pinterest/gestalt/pull/1493)
 
 ## 21.13.0 (May 3, 2021)
 
 ### Minor
 
-- Datapoint: New component for data display (#1483)
+- Datapoint: New component for data display [#1483](https://github.com/pinterest/gestalt/pull/1483)
 
 ## 21.12.0 (Apr 30, 2021)
 
 ### Minor
 
-- Internal: Fix setExtraStackFrame exception (#1492)
+- Internal: Fix setExtraStackFrame exception [#1492](https://github.com/pinterest/gestalt/pull/1492)
 
 ## 21.11.2 (Apr 30, 2021)
 
 ### Patch
 
-- AvatarGroup: remove unnecessary attr in svg (#1490)
+- AvatarGroup: remove unnecessary attr in svg [#1490](https://github.com/pinterest/gestalt/pull/1490)
 
 ## 21.11.1 (Apr 30, 2021)
 
 ### Patch
 
-- Internal: Update PR template (#1489)
+- Internal: Update PR template [#1489](https://github.com/pinterest/gestalt/pull/1489)
 
 ## 21.11.0 (Apr 29, 2021)
 
 ### Minor
 
-- AvatarGroup: new component (#1466)
+- AvatarGroup: new component [#1466](https://github.com/pinterest/gestalt/pull/1466)
 
 ## 21.10.1 (Apr 29, 2021)
 
 ### Patch
 
-- Internal: Add .DS_Store to .gitignore (#1488)
+- Internal: Add .DS_Store to .gitignore [#1488](https://github.com/pinterest/gestalt/pull/1488)
 
 ## 21.10.0 (Apr 29, 2021)
 
 ### Minor
 
-- Module: Add badgeText prop (#1486)
+- Module: Add badgeText prop [#1486](https://github.com/pinterest/gestalt/pull/1486)
 
 ## 21.9.0 (Apr 28, 2021)
 
 ### Minor
 
-- Flex: add `minWidth` prop to Flex.Item (#1487)
+- Flex: add `minWidth` prop to Flex.Item [#1487](https://github.com/pinterest/gestalt/pull/1487)
 
 ## 21.8.4 (Apr 28, 2021)
 
 ### Patch
 
-- Button: fix inline in role="link" (#1485)
+- Button: fix inline in role="link" [#1485](https://github.com/pinterest/gestalt/pull/1485)
 
 ## 21.8.3 (Apr 28, 2021)
 
 ### Patch
 
-- Docs: Make unexpanded code example more obviously interactive (#1484)
+- Docs: Make unexpanded code example more obviously interactive [#1484](https://github.com/pinterest/gestalt/pull/1484)
 
 ## 21.8.2 (Apr 26, 2021)
 
 ### Patch
 
-- SegmentedControl: Update text color for accessibility (#1482)
+- SegmentedControl: Update text color for accessibility [#1482](https://github.com/pinterest/gestalt/pull/1482)
 
 ## 21.8.1 (Apr 23, 2021)
 
@@ -4420,43 +4420,43 @@
 
 ### Minor
 
-- Heading: add accessibilityLevel='none' option (#1480)
+- Heading: add accessibilityLevel='none' option [#1480](https://github.com/pinterest/gestalt/pull/1480)
 
 ## 21.7.7 (Apr 21, 2021)
 
 ### Patch
 
-- Internal: Upgrade ssri and is-svg dependencies for security alerts (#1477)
+- Internal: Upgrade ssri and is-svg dependencies for security alerts [#1477](https://github.com/pinterest/gestalt/pull/1477)
 
 ## 21.7.6 (Apr 21, 2021)
 
 ### Patch
 
-- Docs: Fix responsiveness on PageHeader (#1476)
+- Docs: Fix responsiveness on PageHeader [#1476](https://github.com/pinterest/gestalt/pull/1476)
 
 ## 21.7.5 (Apr 20, 2021)
 
 ### Patch
 
-- Docs: Fix Tooltip typos (#1475)
+- Docs: Fix Tooltip typos [#1475](https://github.com/pinterest/gestalt/pull/1475)
 
 ## 21.7.4 (Apr 20, 2021)
 
 ### Patch
 
-- Card: fix rtl hover bug (#1474)
+- Card: fix rtl hover bug [#1474](https://github.com/pinterest/gestalt/pull/1474)
 
 ## 21.7.3 (Apr 20, 2021)
 
 ### Patch
 
-- TapArea: Allow right clicks (#1473)
+- TapArea: Allow right clicks [#1473](https://github.com/pinterest/gestalt/pull/1473)
 
 ## 21.7.2 (Apr 19, 2021)
 
 ### Patch
 
-- Bump ssri from 6.0.1 to 6.0.2 (#1472)
+- Bump ssri from 6.0.1 to 6.0.2 [#1472](https://github.com/pinterest/gestalt/pull/1472)
 
 ## 21.7.1 (Apr 14, 2021)
 
@@ -4468,195 +4468,195 @@
 
 ### Minor
 
-- Internal: use new JSX transform & remove unnecessary react imports (#1471)
+- Internal: use new JSX transform & remove unnecessary react imports [#1471](https://github.com/pinterest/gestalt/pull/1471)
 
 ## 21.6.5 (Apr 13, 2021)
 
 ### Patch
 
-- Z-Index: copyediting new docs page (#1470)
+- Z-Index: copyediting new docs page [#1470](https://github.com/pinterest/gestalt/pull/1470)
 
 ## 21.6.4 (Apr 12, 2021)
 
 ### Patch
 
-- Docs: Add unique page titles (#1468)
+- Docs: Add unique page titles [#1468](https://github.com/pinterest/gestalt/pull/1468)
 
 ## 21.6.3 (Apr 9, 2021)
 
 ### Patch
 
-- Docs: Update Meetings on How to Work with Us (#1467)
+- Docs: Update Meetings on How to Work with Us [#1467](https://github.com/pinterest/gestalt/pull/1467)
 
 ## 21.6.2 (Apr 8, 2021)
 
 ### Patch
 
-- Typeahead: Fix static `value` bug (#1458)
+- Typeahead: Fix static `value` bug [#1458](https://github.com/pinterest/gestalt/pull/1458)
 
 ## 21.6.1 (Apr 8, 2021)
 
 ### Patch
 
-- Callout, Upsell: Convert title to text instead of heading (#1462)
+- Callout, Upsell: Convert title to text instead of heading [#1462](https://github.com/pinterest/gestalt/pull/1462)
 
 ## 21.6.0 (Apr 8, 2021)
 
 ### Minor
 
-- Internal: upgrade flow to 0.145.0 & fix 21 flow suppressions (#1463)
+- Internal: upgrade flow to 0.145.0 & fix 21 flow suppressions [#1463](https://github.com/pinterest/gestalt/pull/1463)
 
 ## 21.5.2 (Apr 8, 2021)
 
 ### Patch
 
-- Docs: convert ESLint docs to new format (#1465)
+- Docs: convert ESLint docs to new format [#1465](https://github.com/pinterest/gestalt/pull/1465)
 
 ## 21.5.1 (Apr 7, 2021)
 
 ### Patch
 
-- Modal: temp \_dangerouslyDisableScrollBoundaryContainer prop to disable ScrollBoundaryContainer in Modals (#1461)
+- Modal: temp \_dangerouslyDisableScrollBoundaryContainer prop to disable ScrollBoundaryContainer in Modals [#1461](https://github.com/pinterest/gestalt/pull/1461)
 
 ## 21.5.0 (Apr 7, 2021)
 
 ### Minor
 
-- Table: Add ability to specify sticky columns (#1395)
+- Table: Add ability to specify sticky columns [#1395](https://github.com/pinterest/gestalt/pull/1395)
 
 ## 21.4.8 (Apr 6, 2021)
 
 ### Patch
 
-- Docs: remove deprecated props from examples (#1460)
+- Docs: remove deprecated props from examples [#1460](https://github.com/pinterest/gestalt/pull/1460)
 
 ## 21.4.7 (Apr 6, 2021)
 
 ### Patch
 
-- Docs: updated Docs for ZIndex Classes (#1457)
+- Docs: updated Docs for ZIndex Classes [#1457](https://github.com/pinterest/gestalt/pull/1457)
 
 ## 21.4.6 (Apr 6, 2021)
 
 ### Patch
 
-- Modal/Sheet: Remove experimental \_dangerousScrollableExperimentEnabled to implement ScrollBoundaryContainer (#1456)
+- Modal/Sheet: Remove experimental \_dangerousScrollableExperimentEnabled to implement ScrollBoundaryContainer [#1456](https://github.com/pinterest/gestalt/pull/1456)
 
 ## 21.4.5 (Apr 6, 2021)
 
 ### Patch
 
-- Link/Button/IconButton/TapArea +composed components: refactored disableOnNavigation logic inside Link/InternalLink (#1455)
+- Link/Button/IconButton/TapArea +composed components: refactored disableOnNavigation logic inside Link/InternalLink [#1455](https://github.com/pinterest/gestalt/pull/1455)
 
 ## 21.4.4 (Apr 2, 2021)
 
 ### Patch
 
-- Dropdown: Fix link access through keyboard (#1453)
+- Dropdown: Fix link access through keyboard [#1453](https://github.com/pinterest/gestalt/pull/1453)
 
 ## 21.4.3 (Apr 1, 2021)
 
 ### Patch
 
-- Docs: Fix layout for two columns (#1452)
+- Docs: Fix layout for two columns [#1452](https://github.com/pinterest/gestalt/pull/1452)
 
 ## 21.4.2 (Apr 1, 2021)
 
 ### Patch
 
-- Docs: Fix outdated What's New Page (#1451)
+- Docs: Fix outdated What's New Page [#1451](https://github.com/pinterest/gestalt/pull/1451)
 
 ## 21.4.1 (Apr 1, 2021)
 
 ### Patch
 
-- Link/Button/IconButton/TapArea +composed components: always pass disableOnNavigation to onClick (#1450)
+- Link/Button/IconButton/TapArea +composed components: always pass disableOnNavigation to onClick [#1450](https://github.com/pinterest/gestalt/pull/1450)
 
 ## 21.4.0 (Mar 31, 2021)
 
 ### Minor
 
-- Status: new Status component (#1417)
+- Status: new Status component [#1417](https://github.com/pinterest/gestalt/pull/1417)
 
 ## 21.3.2 (Mar 31, 2021)
 
 ### Patch
 
-- Docs: fix Flow type in Docs for Tabs (#1448)
+- Docs: fix Flow type in Docs for Tabs [#1448](https://github.com/pinterest/gestalt/pull/1448)
 
 ## 21.3.1 (Mar 31, 2021)
 
 ### Patch
 
-- Docs: Bump up maxWidth (#1441)
+- Docs: Bump up maxWidth [#1441](https://github.com/pinterest/gestalt/pull/1441)
 
 ## 21.3.0 (Mar 31, 2021)
 
 ### Minor
 
-- Box: add `as` prop to use semantic tags (#1444)
+- Box: add `as` prop to use semantic tags [#1444](https://github.com/pinterest/gestalt/pull/1444)
 
 ## 21.2.1 (Mar 30, 2021)
 
 ### Patch
 
-- Docs: fix Provider types and on navigation descriptions (#1446)
+- Docs: fix Provider types and on navigation descriptions [#1446](https://github.com/pinterest/gestalt/pull/1446)
 
 ## 21.2.0 (Mar 29, 2021)
 
 ### Minor
 
-- Tabs: Add experimental redesign (#1440)
+- Tabs: Add experimental redesign [#1440](https://github.com/pinterest/gestalt/pull/1440)
 
 ## 21.1.2 (Mar 29, 2021)
 
 ### Patch
 
-- Bump y18n from 4.0.0 to 4.0.1 (#1445)
+- Bump y18n from 4.0.0 to 4.0.1 [#1445](https://github.com/pinterest/gestalt/pull/1445)
 
 ## 21.1.1 (Mar 29, 2021)
 
 ### Patch
 
-- Internal: renamed InternalLink disoplayName (#1443)
+- Internal: renamed InternalLink disoplayName [#1443](https://github.com/pinterest/gestalt/pull/1443)
 
 ## 21.1.0 (Mar 25, 2021)
 
 ### Minor
 
-- TapArea: Add onMouseDown and onMouseUp handlers (#1439)
+- TapArea: Add onMouseDown and onMouseUp handlers [#1439](https://github.com/pinterest/gestalt/pull/1439)
 
 ## 21.0.6 (Mar 24, 2021)
 
 ### Patch
 
-- Icon: Update `shopping-bag` icon (#1437)
+- Icon: Update `shopping-bag` icon [#1437](https://github.com/pinterest/gestalt/pull/1437)
 
 ## 21.0.5 (Mar 23, 2021)
 
 ### Patch
 
-- Dropdown: Update documentation and add Best Practices (#1433)
+- Dropdown: Update documentation and add Best Practices [#1433](https://github.com/pinterest/gestalt/pull/1433)
 
 ## 21.0.4 (Mar 23, 2021)
 
 ### Patch
 
-- Docs: Fix display style of titles (#1438)
-- Docs: Added "How to Work with Us" page to docs (#1425)
+- Docs: Fix display style of titles [#1438](https://github.com/pinterest/gestalt/pull/1438)
+- Docs: Added "How to Work with Us" page to docs [#1425](https://github.com/pinterest/gestalt/pull/1425)
 
 ## 21.0.3 (Mar 23, 2021)
 
 ### Patch
 
-- Typeahead: Close container on outside click, focus input (#1436)
-- ScrollBoundaryContainer: fix positioning within when no available space condition is met (#1435)
+- Typeahead: Close container on outside click, focus input [#1436](https://github.com/pinterest/gestalt/pull/1436)
+- ScrollBoundaryContainer: fix positioning within when no available space condition is met [#1435](https://github.com/pinterest/gestalt/pull/1435)
 
 ## 21.0.2 (Mar 22, 2021)
 
 ### Patch
 
-- Docs: fix example in Popover docs page (#1434)
+- Docs: fix example in Popover docs page [#1434](https://github.com/pinterest/gestalt/pull/1434)
 
 ## 21.0.1 (Mar 18, 2021)
 
@@ -4668,1957 +4668,1957 @@
 
 ### Major
 
-- Provider/Link/Button/IconButton/TapArea/+composed components: refactor link logic to support custom navigation within onClick prop in consumers + Codemode (#1398)
+- Provider/Link/Button/IconButton/TapArea/+composed components: refactor link logic to support custom navigation within onClick prop in consumers + Codemode [#1398](https://github.com/pinterest/gestalt/pull/1398)
 
 ## 20.3.5 (Mar 17, 2021)
 
 ### Patch
 
-- ScrollBoundaryContainer: fix positioning within when no available space condition is met (#1428)
+- ScrollBoundaryContainer: fix positioning within when no available space condition is met [#1428](https://github.com/pinterest/gestalt/pull/1428)
 
 ## 20.3.4 (Mar 17, 2021)
 
 ### Patch
 
-- SelectList: Update docs and add Best Practices (#1409)
+- SelectList: Update docs and add Best Practices [#1409](https://github.com/pinterest/gestalt/pull/1409)
 
 ## 20.3.3 (Mar 16, 2021)
 
 ### Patch
 
-- PageHeader: Add feedback Callout to docs (#1431)
+- PageHeader: Add feedback Callout to docs [#1431](https://github.com/pinterest/gestalt/pull/1431)
 
 ## 20.3.2 (Mar 16, 2021)
 
 ### Patch
 
-- SearchField: Add onKeyDown prop (#1400)
+- SearchField: Add onKeyDown prop [#1400](https://github.com/pinterest/gestalt/pull/1400)
 
 ## 20.3.1 (Mar 16, 2021)
 
 ### Patch
 
-- Tooltip: Only delay visibility on interaction if `link` present (#1430)
+- Tooltip: Only delay visibility on interaction if `link` present [#1430](https://github.com/pinterest/gestalt/pull/1430)
 
 ## 20.3.0 (Mar 16, 2021)
 
 ### Minor
 
-- PageHeader: New component and documentation (#1423)
+- PageHeader: New component and documentation [#1423](https://github.com/pinterest/gestalt/pull/1423)
 
 ## 20.2.1 (Mar 15, 2021)
 
 ### Patch
 
-- Docs: Add event tracking for buttons (#1419)
+- Docs: Add event tracking for buttons [#1419](https://github.com/pinterest/gestalt/pull/1419)
 
 ## 20.2.0 (Mar 15, 2021)
 
 ### Minor
 
-- Icon: add workflow-status-canceled icon (#1427)
+- Icon: add workflow-status-canceled icon [#1427](https://github.com/pinterest/gestalt/pull/1427)
 
 ## 20.1.3 (Mar 13, 2021)
 
 ### Patch
 
-- Bump react-dev-utils from 11.0.0 to 11.0.4 (#1426)
+- Bump react-dev-utils from 11.0.0 to 11.0.4 [#1426](https://github.com/pinterest/gestalt/pull/1426)
 
 ## 20.1.2 (Mar 11, 2021)
 
 ### Patch
 
-- Internal: Upgrade JSX transform so React no longer needs to be in scope (#1420)
+- Internal: Upgrade JSX transform so React no longer needs to be in scope [#1420](https://github.com/pinterest/gestalt/pull/1420)
 
 ## 20.1.1 (Mar 9, 2021)
 
 ### Patch
 
-- Upsell: Update docs and add Best Practices (#1404)
+- Upsell: Update docs and add Best Practices [#1404](https://github.com/pinterest/gestalt/pull/1404)
 
 ## 20.1.0 (Mar 9, 2021)
 
 ### Minor
 
-- Image: add elementtiming attribute for profiling (#1418)
+- Image: add elementtiming attribute for profiling [#1418](https://github.com/pinterest/gestalt/pull/1418)
 
 ## 20.0.2 (Mar 8, 2021)
 
 ### Patch
 
-- Popover: fix codemod (#1415)
+- Popover: fix codemod [#1415](https://github.com/pinterest/gestalt/pull/1415)
 
 ## 20.0.1 (Mar 8, 2021)
 
 ### Patch
 
-- Internal: Bump elliptic from 6.5.3 to 6.5.4 (#1414)
+- Internal: Bump elliptic from 6.5.3 to 6.5.4 [#1414](https://github.com/pinterest/gestalt/pull/1414)
 
 ## 20.0.0 (Mar 8, 2021)
 
 ### Major
 
-- Popover: Rename Flyout to Popover + Codemod (#1411)
+- Popover: Rename Flyout to Popover + Codemod [#1411](https://github.com/pinterest/gestalt/pull/1411)
 
 ## 19.2.2 (Mar 5, 2021)
 
 ### Patch
 
-- FeedbackCallout: Simplify API (#1413)
+- FeedbackCallout: Simplify API [#1413](https://github.com/pinterest/gestalt/pull/1413)
 
 ## 19.2.1 (Mar 5, 2021)
 
 ### Patch
 
-- Module: Fix border-radius + misc cleanup (#1410)
+- Module: Fix border-radius + misc cleanup [#1410](https://github.com/pinterest/gestalt/pull/1410)
 
 ## 19.2.0 (Mar 5, 2021)
 
 ### Minor
 
-- Upsell: Add Upsell.Form component (#1396)
+- Upsell: Add Upsell.Form component [#1396](https://github.com/pinterest/gestalt/pull/1396)
 
 ## 19.1.2 (Mar 3, 2021)
 
 ### Patch
 
-- Docs: fixes inlinks (#1408)
+- Docs: fixes inlinks [#1408](https://github.com/pinterest/gestalt/pull/1408)
 
 ## 19.1.1 (Mar 3, 2021)
 
 ### Patch
 
-- Docs: Add Feedback Callout component for docs (#1405)
+- Docs: Add Feedback Callout component for docs [#1405](https://github.com/pinterest/gestalt/pull/1405)
 
 ## 19.1.0 (Mar 3, 2021)
 
 ### Minor
 
-- Icon: update Dash icon (#1407)
+- Icon: update Dash icon [#1407](https://github.com/pinterest/gestalt/pull/1407)
 
 ## 19.0.0 (Mar 2, 2021)
 
 ### Major
 
-- Icon: Rename 'link' Icon to 'visit' + codemod, add new 'link' Icon, update Docs (#1406)
+- Icon: Rename 'link' Icon to 'visit' + codemod, add new 'link' Icon, update Docs [#1406](https://github.com/pinterest/gestalt/pull/1406)
 
 ## 18.1.2 (Mar 2, 2021)
 
 ### Patch
 
-- Internal: add CI for Icon svg file validation (#1402)
+- Internal: add CI for Icon svg file validation [#1402](https://github.com/pinterest/gestalt/pull/1402)
 
 ## 18.1.1 (Mar 1, 2021)
 
 ### Patch
 
-- Docs: fix Box z-index bug (#1403)
+- Docs: fix Box z-index bug [#1403](https://github.com/pinterest/gestalt/pull/1403)
 
 ## 18.1.0 (Mar 1, 2021)
 
 ### Minor
 
-- Icon: Add History Icon (#1399)
+- Icon: Add History Icon [#1399](https://github.com/pinterest/gestalt/pull/1399)
 
 ## 18.0.0 (Feb 27, 2021)
 
 ### Major
 
-- ScrollBoundaryContainer: ScrollableContainer renamed to ScrollBoundaryContainer (#1394)
+- ScrollBoundaryContainer: ScrollableContainer renamed to ScrollBoundaryContainer [#1394](https://github.com/pinterest/gestalt/pull/1394)
 
 ## 17.7.0 (Feb 25, 2021)
 
 ### Minor
 
-- ESLint: Add rule to check for unnecessary boxShadow (#1397)
+- ESLint: Add rule to check for unnecessary boxShadow [#1397](https://github.com/pinterest/gestalt/pull/1397)
 
 ## 17.6.3 (Feb 22, 2021)
 
 ### Patch
 
-- Box: Add Overflow variant and examples (#1392)
+- Box: Add Overflow variant and examples [#1392](https://github.com/pinterest/gestalt/pull/1392)
 
 ## 17.6.2 (Feb 19, 2021)
 
 ### Patch
 
-- Docs: Update Callout documentation, add Best practices (#1387)
+- Docs: Update Callout documentation, add Best practices [#1387](https://github.com/pinterest/gestalt/pull/1387)
 
 ## 17.6.1 (Feb 18, 2021)
 
 ### Patch
 
-- Docs: Update IconButton styling and size across docs (#1389)
+- Docs: Update IconButton styling and size across docs [#1389](https://github.com/pinterest/gestalt/pull/1389)
 
 ## 17.6.0 (Feb 18, 2021)
 
 ### Minor
 
-- Typeahead: Bugfix to ensure the current value of `options` is used, not just the initial (#1390)
+- Typeahead: Bugfix to ensure the current value of `options` is used, not just the initial [#1390](https://github.com/pinterest/gestalt/pull/1390)
 
 ## 17.5.6 (Feb 18, 2021)
 
 ### Patch
 
-- Docs: Make sure right sidebar doesn't extend over footer (#1391)
+- Docs: Make sure right sidebar doesn't extend over footer [#1391](https://github.com/pinterest/gestalt/pull/1391)
 
 ## 17.5.5 (Feb 17, 2021)
 
 ### Patch
 
-- Tooltip: update Tooltip documentation, add best practices (#1370)
+- Tooltip: update Tooltip documentation, add best practices [#1370](https://github.com/pinterest/gestalt/pull/1370)
 
 ## 17.5.4 (Feb 17, 2021)
 
 ### Patch
 
-- Update to React 17 (#1388)
+- Update to React 17 [#1388](https://github.com/pinterest/gestalt/pull/1388)
 
 ## 17.5.3 (Feb 12, 2021)
 
 ### Patch
 
-- ScrollableContainer: add Box to Related in Docs (#1386)
+- ScrollableContainer: add Box to Related in Docs [#1386](https://github.com/pinterest/gestalt/pull/1386)
 
 ## 17.5.2 (Feb 12, 2021)
 
 ### Patch
 
-- Callout, Upsell, ActivationCard: implemented missing target, ref props for link functionality (#1384)
+- Callout, Upsell, ActivationCard: implemented missing target, ref props for link functionality [#1384](https://github.com/pinterest/gestalt/pull/1384)
 
 ## 17.5.1 (Feb 12, 2021)
 
 ### Patch
 
-- Docs: Update Prop Table to support Markdown for descriptions (#1382)
+- Docs: Update Prop Table to support Markdown for descriptions [#1382](https://github.com/pinterest/gestalt/pull/1382)
 
 ## 17.5.0 (Feb 11, 2021)
 
 ### Minor
 
-- Docs: fix right sidebar scrolling bug (#1385)
+- Docs: fix right sidebar scrolling bug [#1385](https://github.com/pinterest/gestalt/pull/1385)
 
 ## 17.4.0 (Feb 11, 2021)
 
 ### Minor
 
-- Modal, Sheet: Implemented InternalScrollableContainer (#1376)
+- Modal, Sheet: Implemented InternalScrollableContainer [#1376](https://github.com/pinterest/gestalt/pull/1376)
 
 ## 17.3.1 (Feb 11, 2021)
 
 ### Patch
 
-- Provider: onNavigationOptions proptype fix (#1377)
+- Provider: onNavigationOptions proptype fix [#1377](https://github.com/pinterest/gestalt/pull/1377)
 
 ## 17.3.0 (Feb 10, 2021)
 
 ### Minor
 
-- [Eslint] Add border to prefer-box eslint rule (#1381)
+- [Eslint] Add border to prefer-box eslint rule [#1381](https://github.com/pinterest/gestalt/pull/1381)
 
 ## 17.2.0 (Feb 10, 2021)
 
 ### Minor
 
-- update types to match doc (#1380)
+- update types to match doc [#1380](https://github.com/pinterest/gestalt/pull/1380)
 
 ## 17.1.7 (Feb 10, 2021)
 
 ### Patch
 
-- Docs: Adjust spacing for large examples with titles (#1379)
+- Docs: Adjust spacing for large examples with titles [#1379](https://github.com/pinterest/gestalt/pull/1379)
 
 ## 17.1.6 (Feb 9, 2021)
 
 ### Patch
 
-- Docs: Update cypress accessibility testing, remove disabled contrast rules (#1373)
+- Docs: Update cypress accessibility testing, remove disabled contrast rules [#1373](https://github.com/pinterest/gestalt/pull/1373)
 
 ## 17.1.5 (Feb 9, 2021)
 
 ### Patch
 
-- Docs: Add ability for Do/Don't in bullet lists (#1378)
+- Docs: Add ability for Do/Don't in bullet lists [#1378](https://github.com/pinterest/gestalt/pull/1378)
 
 ## 17.1.4 (Feb 8, 2021)
 
 ### Patch
 
-- Bump marked from 1.1.1 to 2.0.0 (#1371)
+- Bump marked from 1.1.1 to 2.0.0 [#1371](https://github.com/pinterest/gestalt/pull/1371)
 
 ## 17.1.3 (Feb 8, 2021)
 
 ### Patch
 
-- Internal: Rename codemod folder (#1372)
+- Internal: Rename codemod folder [#1372](https://github.com/pinterest/gestalt/pull/1372)
 
 ## 17.1.2 (Feb 8, 2021)
 
 ### Patch
 
-- Provider: fixes in Provider, Provider Docs and OnNavigation-related component Docs (#1369)
+- Provider: fixes in Provider, Provider Docs and OnNavigation-related component Docs [#1369](https://github.com/pinterest/gestalt/pull/1369)
 
 ## 17.1.1 (Feb 8, 2021)
 
 ### Patch
 
-- Internal: disable Mergify (#1368)
+- Internal: disable Mergify [#1368](https://github.com/pinterest/gestalt/pull/1368)
 
 ## 17.1.0 (Feb 5, 2021)
 
 ### Minor
 
-- Provider/Link/Button/IconButton/TapArea: implement OnNavigation context for advanced link navigation (#1364)
+- Provider/Link/Button/IconButton/TapArea: implement OnNavigation context for advanced link navigation [#1364](https://github.com/pinterest/gestalt/pull/1364)
 
 ## 17.0.1 (Feb 5, 2021)
 
 ### Patch
 
-- Box: Add design guidelines and update documentation to new style (#1358)
+- Box: Add design guidelines and update documentation to new style [#1358](https://github.com/pinterest/gestalt/pull/1358)
 
 ## 17.0.0 (Feb 5, 2021)
 
 ### Major
 
-- Box: Remove marginLeft and marginRight props (#1363)
+- Box: Remove marginLeft and marginRight props [#1363](https://github.com/pinterest/gestalt/pull/1363)
 
 ## 16.10.4 (Feb 5, 2021)
 
 ### Patch
 
-- Docs: update Prop Table design (#1367)
+- Docs: update Prop Table design [#1367](https://github.com/pinterest/gestalt/pull/1367)
 
 ## 16.10.3 (Feb 4, 2021)
 
 ### Patch
 
-- Internal: update ScrollableContainer a11y test (#1365)
+- Internal: update ScrollableContainer a11y test [#1365](https://github.com/pinterest/gestalt/pull/1365)
 
 ## 16.10.2 (Feb 4, 2021)
 
 ### Patch
 
-- Box: fix margin-family props not overriding default 'auto' by @media with boints (#1362)
+- Box: fix margin-family props not overriding default 'auto' by @media with boints [#1362](https://github.com/pinterest/gestalt/pull/1362)
 
 ## 16.10.1 (Feb 3, 2021)
 
 ### Patch
 
-- Internal: Add lint rules to enforce fragment style and use of keys (#1361)
+- Internal: Add lint rules to enforce fragment style and use of keys [#1361](https://github.com/pinterest/gestalt/pull/1361)
 
 ## 16.10.0 (Feb 3, 2021)
 
 ### Minor
 
-- Gestalt: ScrollableContainer - new component with built-in scrollability logic to allow anchored-based components get correctly positioned inside scrolling containers (#1357)
+- Gestalt: ScrollableContainer - new component with built-in scrollability logic to allow anchored-based components get correctly positioned inside scrolling containers [#1357](https://github.com/pinterest/gestalt/pull/1357)
 
 ## 16.9.2 (Feb 2, 2021)
 
 ### Patch
 
-- Docs: copyPaste functionality implemented into linking icon (#1360)
+- Docs: copyPaste functionality implemented into linking icon [#1360](https://github.com/pinterest/gestalt/pull/1360)
 
 ## 16.9.1 (Feb 1, 2021)
 
 ### Patch
 
-- Docs: Update shared components for new Docs design (#1359)
+- Docs: Update shared components for new Docs design [#1359](https://github.com/pinterest/gestalt/pull/1359)
 
 ## 16.9.0 (Jan 29, 2021)
 
 ### Minor
 
-- Add eslint plugin for gestalt (#1353)
+- Add eslint plugin for gestalt [#1353](https://github.com/pinterest/gestalt/pull/1353)
 
 ## 16.8.4 (Jan 29, 2021)
 
 ### Patch
 
-- Internal: match Prettier config to Pinboard (#1355)
+- Internal: match Prettier config to Pinboard [#1355](https://github.com/pinterest/gestalt/pull/1355)
 
 ## 16.8.3 (Jan 27, 2021)
 
 ### Patch
 
-- Docs: Add shared documentation components for docs redesign (#1345)
+- Docs: Add shared documentation components for docs redesign [#1345](https://github.com/pinterest/gestalt/pull/1345)
 
 ## 16.8.2 (Jan 27, 2021)
 
 ### Patch
 
-- Internal: bump resolved version of immer due to security concern (#1352)
+- Internal: bump resolved version of immer due to security concern [#1352](https://github.com/pinterest/gestalt/pull/1352)
 
 ## 16.8.1 (Jan 26, 2021)
 
 ### Patch
 
-- Z-Index: Consolidate proptype to reduce needed suppressions (#1351)
+- Z-Index: Consolidate proptype to reduce needed suppressions [#1351](https://github.com/pinterest/gestalt/pull/1351)
 
 ## 16.8.0 (Jan 25, 2021)
 
 ### Minor
 
-- Typeahead: add zIndex prop to support component in Modals with zIndex (#1350)
+- Typeahead: add zIndex prop to support component in Modals with zIndex [#1350](https://github.com/pinterest/gestalt/pull/1350)
 
 ## 16.7.1 (Jan 22, 2021)
 
 ### Patch
 
-- Docs: component source link tweaks (#1347)
+- Docs: component source link tweaks [#1347](https://github.com/pinterest/gestalt/pull/1347)
 
 ## 16.7.0 (Jan 20, 2021)
 
 ### Minor
 
-- ModuleExpandable: added external collapsing control (expandedIndex and onExpandedChange) (#1323)
+- ModuleExpandable: added external collapsing control (expandedIndex and onExpandedChange) [#1323](https://github.com/pinterest/gestalt/pull/1323)
 
 ## 16.6.1 (Jan 16, 2021)
 
 ### Patch
 
-- Callout, Upsell: Fix action href type in docs, dedupe type definitions (#1340)
+- Callout, Upsell: Fix action href type in docs, dedupe type definitions [#1340](https://github.com/pinterest/gestalt/pull/1340)
 
 ## 16.6.0 (Jan 16, 2021)
 
 ### Minor
 
-- Module: Add Static version and update doc examples (#1336)
+- Module: Add Static version and update doc examples [#1336](https://github.com/pinterest/gestalt/pull/1336)
 
 ## 16.5.1 (Jan 15, 2021)
 
 ### Patch
 
-- Docs: replaced 'eye-icon' icon with Gestalt version (#1342)
+- Docs: replaced 'eye-icon' icon with Gestalt version [#1342](https://github.com/pinterest/gestalt/pull/1342)
 
 ## 16.5.0 (Jan 15, 2021)
 
 ### Minor
 
-- Icon: Add eye-hide icon. (#1337)
+- Icon: Add eye-hide icon. [#1337](https://github.com/pinterest/gestalt/pull/1337)
 
 ## 16.4.1 (Jan 13, 2021)
 
 ### Patch
 
-- Mark package as not having side effects (#1333)
+- Mark package as not having side effects [#1333](https://github.com/pinterest/gestalt/pull/1333)
 
 ## 16.4.0 (Jan 12, 2021)
 
 ### Minor
 
-- Box: Update box-shadow color in dark mode (#1325)
+- Box: Update box-shadow color in dark mode [#1325](https://github.com/pinterest/gestalt/pull/1325)
 
 ## 16.3.0 (Jan 11, 2021)
 
 ### Minor
 
-- Dropdown: New component to display actions or selectable options (#1305)
+- Dropdown: New component to display actions or selectable options [#1305](https://github.com/pinterest/gestalt/pull/1305)
 
 ## 16.2.2 (Jan 8, 2021)
 
 ### Patch
 
-- Tag: fix typo in documentation (#1331)
+- Tag: fix typo in documentation [#1331](https://github.com/pinterest/gestalt/pull/1331)
 
 ## 16.2.1 (Jan 8, 2021)
 
 ### Patch
 
-- Layer: fix a bug where Layer ummounts children on rerender when zIndex changes (#1327)
+- Layer: fix a bug where Layer ummounts children on rerender when zIndex changes [#1327](https://github.com/pinterest/gestalt/pull/1327)
 
 ## 16.2.0 (Jan 8, 2021)
 
 ### Minor
 
-- Typeahead: Add support for Tags (#1317)
+- Typeahead: Add support for Tags [#1317](https://github.com/pinterest/gestalt/pull/1317)
 
 ## 16.1.1 (Jan 8, 2021)
 
 ### Patch
 
-- Callout: Fix vertical padding in md viewport when no actions present (#1328)
+- Callout: Fix vertical padding in md viewport when no actions present [#1328](https://github.com/pinterest/gestalt/pull/1328)
 
 ## 16.1.0 (Jan 8, 2021)
 
 ### Minor
 
-- TextArea: Add support for Tags (#1315)
+- TextArea: Add support for Tags [#1315](https://github.com/pinterest/gestalt/pull/1315)
 
 ## 16.0.4 (Jan 7, 2021)
 
 ### Patch
 
-- Bump node-notifier from 8.0.0 to 8.0.1 (#1320)
+- Bump node-notifier from 8.0.0 to 8.0.1 [#1320](https://github.com/pinterest/gestalt/pull/1320)
 
 ## 16.0.3 (Jan 5, 2021)
 
 ### Patch
 
-- Layer: Update documentation examples around avoiding unwanted re-rendering (#1324)
+- Layer: Update documentation examples around avoiding unwanted re-rendering [#1324](https://github.com/pinterest/gestalt/pull/1324)
 
 ## 16.0.2 (Dec 22, 2020)
 
 ### Patch
 
-- Modal: fix bad flow types (#1322)
+- Modal: fix bad flow types [#1322](https://github.com/pinterest/gestalt/pull/1322)
 
 ## 16.0.1 (Dec 22, 2020)
 
 ### Patch
 
-- Internal: Enable the eslint rule flowtype/no-mutable-array (#1321)
+- Internal: Enable the eslint rule flowtype/no-mutable-array [#1321](https://github.com/pinterest/gestalt/pull/1321)
 
 ## 16.0.0 (Dec 18, 2020)
 
 ### Major
 
-- Callout/Upsell: update primary/secondaryLink to be primary/secondaryAction + Codemod (#1314)
+- Callout/Upsell: update primary/secondaryLink to be primary/secondaryAction + Codemod [#1314](https://github.com/pinterest/gestalt/pull/1314)
 
 ## 15.11.0 (Dec 18, 2020)
 
 ### Minor
 
-- Modal: Add subHeading and align props (#1316)
+- Modal: Add subHeading and align props [#1316](https://github.com/pinterest/gestalt/pull/1316)
 
 ## 15.10.2 (Dec 17, 2020)
 
 ### Patch
 
-- Textfield: update tags wrapping behavior (#1311)
+- Textfield: update tags wrapping behavior [#1311](https://github.com/pinterest/gestalt/pull/1311)
 
 ## 15.10.1 (Dec 16, 2020)
 
 ### Patch
 
-- Update Flyout Docs - Remove bold text (#1313)
+- Update Flyout Docs - Remove bold text [#1313](https://github.com/pinterest/gestalt/pull/1313)
 
 ## 15.10.0 (Dec 16, 2020)
 
 ### Minor
 
-- Bump ini from 1.3.5 to 1.3.8 (#1310)
+- Bump ini from 1.3.5 to 1.3.8 [#1310](https://github.com/pinterest/gestalt/pull/1310)
 
 ## 15.9.0 (Dec 14, 2020)
 
 ### Minor
 
-- Modal: Update backdrop wash to 80% opacity (#1309)
+- Modal: Update backdrop wash to 80% opacity [#1309](https://github.com/pinterest/gestalt/pull/1309)
 
 ## 15.8.0 (Dec 12, 2020)
 
 ### Minor
 
-- TextField: add tags prop (#1306)
+- TextField: add tags prop [#1306](https://github.com/pinterest/gestalt/pull/1306)
 
 ## 15.7.0 (Dec 10, 2020)
 
 ### Minor
 
-- Callout/Upsell: Implemented new useResponsiveMinWidth hook and utils (#1308)
+- Callout/Upsell: Implemented new useResponsiveMinWidth hook and utils [#1308](https://github.com/pinterest/gestalt/pull/1308)
 
 ## 15.6.0 (Dec 9, 2020)
 
 ### Minor
 
-- Tag component (#1301)
+- Tag component [#1301](https://github.com/pinterest/gestalt/pull/1301)
 
 ## 15.5.1 (Dec 8, 2020)
 
 ### Patch
 
-- Bump highlight.js from 10.2.0 to 10.4.1 (#1302)
+- Bump highlight.js from 10.2.0 to 10.4.1 [#1302](https://github.com/pinterest/gestalt/pull/1302)
 
 ## 15.5.0 (Dec 8, 2020)
 
 ### Minor
 
-- Callout: Responsiveness updates (#1304)
+- Callout: Responsiveness updates [#1304](https://github.com/pinterest/gestalt/pull/1304)
 
 ## 15.4.0 (Dec 8, 2020)
 
 ### Minor
 
-- Upsell: Add image prop (#1298)
+- Upsell: Add image prop [#1298](https://github.com/pinterest/gestalt/pull/1298)
 
 ## 15.3.0 (Dec 2, 2020)
 
 ### Minor
 
-- Docs: Add search autodiscovery (OpenSearch) (#1300)
+- Docs: Add search autodiscovery (OpenSearch) [#1300](https://github.com/pinterest/gestalt/pull/1300)
 
 ## 15.2.0 (Dec 2, 2020)
 
 ### Minor
 
-- Internal: Docs improvements; Contexts, header options, + minor fixes (#1297)
+- Internal: Docs improvements; Contexts, header options, + minor fixes [#1297](https://github.com/pinterest/gestalt/pull/1297)
 
 ## 15.1.2 (Dec 2, 2020)
 
 ### Patch
 
-- Internal: Fix a11y tests on master (#1299)
+- Internal: Fix a11y tests on master [#1299](https://github.com/pinterest/gestalt/pull/1299)
 
 ## 15.1.1 (Dec 2, 2020)
 
 ### Patch
 
-- Internal: Give Flex and FlexItem display names for debugging (#1296)
+- Internal: Give Flex and FlexItem display names for debugging [#1296](https://github.com/pinterest/gestalt/pull/1296)
 
 ## 15.1.0 (Dec 1, 2020)
 
 ### Minor
 
-- Internal: Upgrade cypress, cypress-axe and axe-core (#1295)
+- Internal: Upgrade cypress, cypress-axe and axe-core [#1295](https://github.com/pinterest/gestalt/pull/1295)
 
 ## 15.0.0 (Dec 1, 2020)
 
 ### Major
 
-- Box: Allow zero padding overrides (#1293)
+- Box: Allow zero padding overrides [#1293](https://github.com/pinterest/gestalt/pull/1293)
 
 ## 14.30.3 (Nov 19, 2020)
 
 ### Patch
 
-- Docs: unify quotes in the proptable (#1292)
+- Docs: unify quotes in the proptable [#1292](https://github.com/pinterest/gestalt/pull/1292)
 
 ## 14.30.2 (Nov 18, 2020)
 
 ### Patch
 
-- Flex: Update comment, update codemod directory name (#1290)
+- Flex: Update comment, update codemod directory name [#1290](https://github.com/pinterest/gestalt/pull/1290)
 
 ## 14.30.1 (Nov 18, 2020)
 
 ### Patch
 
-- Toast: Update documentation around Text property (#1291)
+- Toast: Update documentation around Text property [#1291](https://github.com/pinterest/gestalt/pull/1291)
 
 ## 14.30.0 (Nov 17, 2020)
 
 ### Minor
 
-- Flex: Replace Row/Stack with Flex (#1288)
+- Flex: Replace Row/Stack with Flex [#1288](https://github.com/pinterest/gestalt/pull/1288)
 
 ## 14.29.0 (Nov 17, 2020)
 
 ### Minor
 
-- Toast: color white as default & adding drop shadow + Codemode helper (#1287)
+- Toast: color white as default & adding drop shadow + Codemode helper [#1287](https://github.com/pinterest/gestalt/pull/1287)
 
 ## 14.28.1 (Nov 6, 2020)
 
 ### Patch
 
-- Docs: Update Upsell.doc.js with better examples (#1286)
+- Docs: Update Upsell.doc.js with better examples [#1286](https://github.com/pinterest/gestalt/pull/1286)
 
 ## 14.28.0 (Nov 6, 2020)
 
 ### Minor
 
-- Docs: improved Development and Faq (#1285)
+- Docs: improved Development and Faq [#1285](https://github.com/pinterest/gestalt/pull/1285)
 
 ## 14.27.0 (Nov 6, 2020)
 
 ### Minor
 
-- Upsell: Add component (#1283)
+- Upsell: Add component [#1283](https://github.com/pinterest/gestalt/pull/1283)
 
 ## 14.26.0 (Nov 4, 2020)
 
 ### Minor
 
-- Docs: Move props back to the top + make collapsible (#1282)
+- Docs: Move props back to the top + make collapsible [#1282](https://github.com/pinterest/gestalt/pull/1282)
 
 ## 14.25.2 (Nov 4, 2020)
 
 ### Patch
 
-- Internal: Add integration test retries (#1281)
+- Internal: Add integration test retries [#1281](https://github.com/pinterest/gestalt/pull/1281)
 
 ## 14.25.1 (Nov 4, 2020)
 
 ### Patch
 
-- Docs: Fix UniformRowLayout example (#1278)
+- Docs: Fix UniformRowLayout example [#1278](https://github.com/pinterest/gestalt/pull/1278)
 
 ## 14.25.0 (Nov 3, 2020)
 
 ### Minor
 
-- Tooltip: Add zIndex prop (#1279)
+- Tooltip: Add zIndex prop [#1279](https://github.com/pinterest/gestalt/pull/1279)
 
 ## 14.24.0 (Nov 3, 2020)
 
 ### Minor
 
-- Internal: remove exports from package.json (#1280)
+- Internal: remove exports from package.json [#1280](https://github.com/pinterest/gestalt/pull/1280)
 
 ## 14.23.1 (Nov 3, 2020)
 
 ### Patch
 
-- Callout: Fix responsiveness margin (#1277)
+- Callout: Fix responsiveness margin [#1277](https://github.com/pinterest/gestalt/pull/1277)
 
 ## 14.23.0 (Nov 2, 2020)
 
 ### Minor
 
-- Docs: upgrade to Create React App 4 (#1276)
+- Docs: upgrade to Create React App 4 [#1276](https://github.com/pinterest/gestalt/pull/1276)
 
 ## 14.22.0 (Nov 2, 2020)
 
 ### Minor
 
-- Callout: V2 Redesign for responsiveness (#1274)
+- Callout: V2 Redesign for responsiveness [#1274](https://github.com/pinterest/gestalt/pull/1274)
 
 ## 14.21.5 (Oct 28, 2020)
 
 ### Patch
 
-- Docs: persist dark mode + RTL settings across refreshes (#1272)
+- Docs: persist dark mode + RTL settings across refreshes [#1272](https://github.com/pinterest/gestalt/pull/1272)
 
 ## 14.21.4 (Oct 27, 2020)
 
 ### Patch
 
-- Docs: Enable accessibility tests for most pages (#1268)
+- Docs: Enable accessibility tests for most pages [#1268](https://github.com/pinterest/gestalt/pull/1268)
 
 ## 14.21.3 (Oct 27, 2020)
 
 ### Patch
 
-- Tests: Fix flaky test on master (#1273)
+- Tests: Fix flaky test on master [#1273](https://github.com/pinterest/gestalt/pull/1273)
 
 ## 14.21.2 (Oct 26, 2020)
 
 ### Patch
 
-- Internal: Add 'design system' to package.json keywords (#1271)
+- Internal: Add 'design system' to package.json keywords [#1271](https://github.com/pinterest/gestalt/pull/1271)
 
 ## 14.21.1 (Oct 26, 2020)
 
 ### Patch
 
-- Docs: Update codemod folder names and add dev instructions (#1269)
+- Docs: Update codemod folder names and add dev instructions [#1269](https://github.com/pinterest/gestalt/pull/1269)
 
 ## 14.21.0 (Oct 26, 2020)
 
 ### Minor
 
-- Internal: improve package.json with repository / keywords + exports information (#1270)
+- Internal: improve package.json with repository / keywords + exports information [#1270](https://github.com/pinterest/gestalt/pull/1270)
 
 ## 14.20.0 (Oct 21, 2020)
 
 ### Minor
 
-- Internal: Upgrade prettier to 2.x version (#1267)
+- Internal: Upgrade prettier to 2.x version [#1267](https://github.com/pinterest/gestalt/pull/1267)
 
 ## 14.19.0 (Oct 20, 2020)
 
 ### Minor
 
-- Docs: New What's New landing page (#1264)
+- Docs: New What's New landing page [#1264](https://github.com/pinterest/gestalt/pull/1264)
 
 ## 14.18.0 (Oct 20, 2020)
 
 ### Minor
 
-- ActivationCard: Add shadow border and polish docs (#1266)
+- ActivationCard: Add shadow border and polish docs [#1266](https://github.com/pinterest/gestalt/pull/1266)
 
 ## 14.17.0 (Oct 20, 2020)
 
 ### Minor
 
-- Layer: fix issue with Flyout when zIndex gets set (#1265)
+- Layer: fix issue with Flyout when zIndex gets set [#1265](https://github.com/pinterest/gestalt/pull/1265)
 
 ## 14.16.0 (Oct 20, 2020)
 
 ### Minor
 
-- Module: Add Module.Expandable component (#1253)
+- Module: Add Module.Expandable component [#1253](https://github.com/pinterest/gestalt/pull/1253)
 
 ## 14.15.0 (Oct 16, 2020)
 
 ### Minor
 
-- Table: Add onExpand function prop to RowExpandable (#1263)
+- Table: Add onExpand function prop to RowExpandable [#1263](https://github.com/pinterest/gestalt/pull/1263)
 
 ## 14.14.2 (Oct 14, 2020)
 
 ### Patch
 
-- Box: fix docs for Layout section (#1262)
+- Box: fix docs for Layout section [#1262](https://github.com/pinterest/gestalt/pull/1262)
 
 ## 14.14.1 (Oct 14, 2020)
 
 ### Patch
 
-- Checkbox/RadioButton: Add options to provide subtext and/or image for label (#1256)
+- Checkbox/RadioButton: Add options to provide subtext and/or image for label [#1256](https://github.com/pinterest/gestalt/pull/1256)
 
 ## 14.14.0 (Oct 13, 2020)
 
 ### Minor
 
-- Table: Update borderSize prop to borderStyle (#1259)
+- Table: Update borderSize prop to borderStyle [#1259](https://github.com/pinterest/gestalt/pull/1259)
 
 ## 14.13.4 (Oct 13, 2020)
 
 ### Patch
 
-- [Internal] Upgrade to flow 0.135.0 (#1260)
+- [Internal] Upgrade to flow 0.135.0 [#1260](https://github.com/pinterest/gestalt/pull/1260)
 
 ## 14.13.3 (Oct 9, 2020)
 
 ### Patch
 
-- Internal: update axe-core (#1258)
+- Internal: update axe-core [#1258](https://github.com/pinterest/gestalt/pull/1258)
 
 ## 14.13.2 (Oct 9, 2020)
 
 ### Patch
 
-- Internal: Update devDependencies + make stylelint stricter (#1257)
+- Internal: Update devDependencies + make stylelint stricter [#1257](https://github.com/pinterest/gestalt/pull/1257)
 
 ## 14.13.1 (Oct 8, 2020)
 
 ### Patch
 
-- Docs: update link icon for header target links (#1255)
+- Docs: update link icon for header target links [#1255](https://github.com/pinterest/gestalt/pull/1255)
 
 ## 14.13.0 (Oct 8, 2020)
 
 ### Minor
 
-- Table: Add ExpandableRow (#1252)
+- Table: Add ExpandableRow [#1252](https://github.com/pinterest/gestalt/pull/1252)
 
 ## 14.12.0 (Oct 8, 2020)
 
 ### Minor
 
-- Internal: Validate that each doc page has an a11y test (#1254)
+- Internal: Validate that each doc page has an a11y test [#1254](https://github.com/pinterest/gestalt/pull/1254)
 
 ## 14.11.2 (Oct 7, 2020)
 
 ### Patch
 
-- Docs: fix borderSize to borderStyle for Example (#1251)
+- Docs: fix borderSize to borderStyle for Example [#1251](https://github.com/pinterest/gestalt/pull/1251)
 
 ## 14.11.1 (Oct 7, 2020)
 
 ### Patch
 
-- Docs: update design for code examples (#1248)
+- Docs: update design for code examples [#1248](https://github.com/pinterest/gestalt/pull/1248)
 
 ## 14.11.0 (Oct 7, 2020)
 
 ### Minor
 
-- Box: Add option to specify 'shadow' for borderStyle prop (previously borderSize) (#1245)
+- Box: Add option to specify 'shadow' for borderStyle prop (previously borderSize) [#1245](https://github.com/pinterest/gestalt/pull/1245)
 
 ## 14.10.1 (Oct 7, 2020)
 
 ### Patch
 
-- Internal: fail CI on ESLint warnings (#1250)
+- Internal: fail CI on ESLint warnings [#1250](https://github.com/pinterest/gestalt/pull/1250)
 
 ## 14.10.0 (Oct 7, 2020)
 
 ### Minor
 
-- Button/IconButton/TapArea: added tabIndex prop (#1244)
+- Button/IconButton/TapArea: added tabIndex prop [#1244](https://github.com/pinterest/gestalt/pull/1244)
 
 ## 14.9.3 (Oct 7, 2020)
 
 ### Patch
 
-- Docs: Removed beta from DatePicker component (#1249)
+- Docs: Removed beta from DatePicker component [#1249](https://github.com/pinterest/gestalt/pull/1249)
 
 ## 14.9.2 (Oct 7, 2020)
 
 ### Patch
 
-- ActivationCard/Callout: Update docs and Fix proptypes (#1246)
+- ActivationCard/Callout: Update docs and Fix proptypes [#1246](https://github.com/pinterest/gestalt/pull/1246)
 
 ## 14.9.1 (Oct 7, 2020)
 
 ### Patch
 
-- Docs: explain how to generate component files (#1247)
+- Docs: explain how to generate component files [#1247](https://github.com/pinterest/gestalt/pull/1247)
 
 ## 14.9.0 (Oct 6, 2020)
 
 ### Minor
 
-- Internal: generate component script (#1243)
+- Internal: generate component script [#1243](https://github.com/pinterest/gestalt/pull/1243)
 
 ## 14.8.0 (Oct 6, 2020)
 
 ### Minor
 
-- Sheet: Add subHeading prop [Depends on #1236](#1242)
+- Sheet: Add subHeading prop [Depends on #1236][#1242](https://github.com/pinterest/gestalt/pull/1242)
 
 ## 14.7.0 (Oct 5, 2020)
 
 ### Minor
 
-- ActivationCard: Add component (#1238)
+- ActivationCard: Add component [#1238](https://github.com/pinterest/gestalt/pull/1238)
 
 ## 14.6.0 (Oct 5, 2020)
 
 ### Minor
 
-- Sheet: Control animation behavior with AnimationContext (#1236)
+- Sheet: Control animation behavior with AnimationContext [#1236](https://github.com/pinterest/gestalt/pull/1236)
 
 ## 14.5.3 (Oct 1, 2020)
 
 ### Patch
 
-- Internal: Bump @actions/core from 1.2.5 to 1.2.6 (#1241)
+- Internal: Bump @actions/core from 1.2.5 to 1.2.6 [#1241](https://github.com/pinterest/gestalt/pull/1241)
 
 ## 14.5.2 (Sep 30, 2020)
 
 ### Patch
 
-- Docs: fix zIndex issues (#1239)
+- Docs: fix zIndex issues [#1239](https://github.com/pinterest/gestalt/pull/1239)
 
 ## 14.5.1 (Sep 29, 2020)
 
 ### Patch
 
-- Doc: update Text size example (#1237)
+- Doc: update Text size example [#1237](https://github.com/pinterest/gestalt/pull/1237)
 
 ## 14.5.0 (Sep 28, 2020)
 
 ### Minor
 
-- Internal: Parallelize Cypress integration tests (2x speed improvement) (#1234)
+- Internal: Parallelize Cypress integration tests (2x speed improvement) [#1234](https://github.com/pinterest/gestalt/pull/1234)
 
 ## 14.4.1 (Sep 28, 2020)
 
 ### Patch
 
-- Docs: add copy code button (#1235)
+- Docs: add copy code button [#1235](https://github.com/pinterest/gestalt/pull/1235)
 
 ## 14.4.0 (Sep 25, 2020)
 
 ### Minor
 
-- Internal: Script to generate a11y tests + add tests for remaining components (#1233)
+- Internal: Script to generate a11y tests + add tests for remaining components [#1233](https://github.com/pinterest/gestalt/pull/1233)
 
 ## 14.3.2 (Sep 25, 2020)
 
 ### Patch
 
-- Docs: Add yarn installation and fix indentation on Development page (#1232)
+- Docs: Add yarn installation and fix indentation on Development page [#1232](https://github.com/pinterest/gestalt/pull/1232)
 
 ## 14.3.1 (Sep 24, 2020)
 
 ### Patch
 
-- Docs: move props section to the bottom (#1231)
+- Docs: move props section to the bottom [#1231](https://github.com/pinterest/gestalt/pull/1231)
 
 ## 14.3.0 (Sep 22, 2020)
 
 ### Minor
 
-- Video: add `objectFill` as a prop (#1227)
+- Video: add `objectFill` as a prop [#1227](https://github.com/pinterest/gestalt/pull/1227)
 
 ## 14.2.4 (Sep 22, 2020)
 
 ### Patch
 
-- Docs: add ability to expand code examples (#1230)
+- Docs: add ability to expand code examples [#1230](https://github.com/pinterest/gestalt/pull/1230)
 
 ## 14.2.3 (Sep 22, 2020)
 
 ### Patch
 
-- Internal: Add Cypress badge + link to Readme (#1229)
+- Internal: Add Cypress badge + link to Readme [#1229](https://github.com/pinterest/gestalt/pull/1229)
 
 ## 14.2.2 (Sep 22, 2020)
 
 ### Patch
 
-- Docs: typo fixes for TapArea (#1225)
+- Docs: typo fixes for TapArea [#1225](https://github.com/pinterest/gestalt/pull/1225)
 
 ## 14.2.1 (Sep 22, 2020)
 
 ### Patch
 
-- Internal: fix `flowtype/require-exact-type` errors (#1228)
+- Internal: fix `flowtype/require-exact-type` errors [#1228](https://github.com/pinterest/gestalt/pull/1228)
 
 ## 14.2.0 (Sep 21, 2020)
 
 ### Minor
 
-- Button: add accessibility integration tests (#1226)
+- Button: add accessibility integration tests [#1226](https://github.com/pinterest/gestalt/pull/1226)
 
 ## 14.1.0 (Sep 18, 2020)
 
 ### Minor
 
-- Sheet: Introduce component (#1217)
+- Sheet: Introduce component [#1217](https://github.com/pinterest/gestalt/pull/1217)
 
 ## 14.0.0 (Sep 17, 2020)
 
 ### Major
 
-- Sticky: remove deprecated dangerouslySetZIndex (#1224)
+- Sticky: remove deprecated dangerouslySetZIndex [#1224](https://github.com/pinterest/gestalt/pull/1224)
 
 ## 13.14.0 (Sep 17, 2020)
 
 ### Minor
 
-- Layer: add zIndex prop (#1223)
+- Layer: add zIndex prop [#1223](https://github.com/pinterest/gestalt/pull/1223)
 
 ## 13.13.0 (Sep 17, 2020)
 
 ### Minor
 
-- Internal: add Cypress integration tests (#1220)
+- Internal: add Cypress integration tests [#1220](https://github.com/pinterest/gestalt/pull/1220)
 
 ## 13.12.0 (Sep 17, 2020)
 
 ### Minor
 
-- Box: Extract types and transforms, cleanup (#1222)
+- Box: Extract types and transforms, cleanup [#1222](https://github.com/pinterest/gestalt/pull/1222)
 
 ## 13.11.0 (Sep 17, 2020)
 
 ### Minor
 
-- IconButton: Implemented href with InternalLink (#1219)
+- IconButton: Implemented href with InternalLink [#1219](https://github.com/pinterest/gestalt/pull/1219)
 
 ## 13.10.0 (Sep 16, 2020)
 
 ### Minor
 
-- Row/Stack: Revert better gap + update children type (#1221)
+- Row/Stack: Revert better gap + update children type [#1221](https://github.com/pinterest/gestalt/pull/1221)
 
 ## 13.9.0 (Sep 16, 2020)
 
 ### Minor
 
-- Row/Stack: Update `children` type (#1216)
+- Row/Stack: Update `children` type [#1216](https://github.com/pinterest/gestalt/pull/1216)
 
 ## 13.8.0 (Sep 16, 2020)
 
 ### Minor
 
-- Row/Stack: Second attempt to re-implement for better `gap` (#1214)
+- Row/Stack: Second attempt to re-implement for better `gap` [#1214](https://github.com/pinterest/gestalt/pull/1214)
 
 ## 13.7.0 (Sep 15, 2020)
 
 ### Minor
 
-- Revert "Row, Stack: Re-implement for better `gap` (#1193)" (#1213)
+- Revert "Row, Stack: Re-implement for better `gap` [#1193](https://github.com/pinterest/gestalt/pull/1193)" [#1213](https://github.com/pinterest/gestalt/pull/1213)
 
 ## 13.6.0 (Sep 15, 2020)
 
 ### Minor
 
-- Row/Stack: Re-implement for better `gap` (#1193)
+- Row/Stack: Re-implement for better `gap` [#1193](https://github.com/pinterest/gestalt/pull/1193)
 
 ## 13.5.1 (Sep 15, 2020)
 
 ### Patch
 
-- Docs: use PageHeader on all pages (#1212)
+- Docs: use PageHeader on all pages [#1212](https://github.com/pinterest/gestalt/pull/1212)
 
 ## 13.5.0 (Sep 14, 2020)
 
 ### Minor
 
-- TapArea: reimplement tapStyle (#1211)
+- TapArea: reimplement tapStyle [#1211](https://github.com/pinterest/gestalt/pull/1211)
 
 ## 13.4.1 (Sep 11, 2020)
 
 ### Patch
 
-- Docs: update Text wrap/overflow example (#1210)
+- Docs: update Text wrap/overflow example [#1210](https://github.com/pinterest/gestalt/pull/1210)
 
 ## 13.4.0 (Sep 11, 2020)
 
 ### Minor
 
-- Callout: implement Link Button on primary/secondary links (#1207)
+- Callout: implement Link Button on primary/secondary links [#1207](https://github.com/pinterest/gestalt/pull/1207)
 
 ## 13.3.0 (Sep 11, 2020)
 
 ### Minor
 
-- Table: fix stacking context on sticky Table.Header (#1209)
+- Table: fix stacking context on sticky Table.Header [#1209](https://github.com/pinterest/gestalt/pull/1209)
 
 ## 13.2.0 (Sep 11, 2020)
 
 ### Minor
 
-- TapArea: implemented href with InternalLink (#1199)
+- TapArea: implemented href with InternalLink [#1199](https://github.com/pinterest/gestalt/pull/1199)
 
 ## 13.1.0 (Sep 10, 2020)
 
 ### Minor
 
-- Button: link-role button logic refactor (#1190)
+- Button: link-role button logic refactor [#1190](https://github.com/pinterest/gestalt/pull/1190)
 
 ## 13.0.2 (Sep 10, 2020)
 
 ### Patch
 
-- Docs: use ButtonGroup in Modal examples (#1208)
+- Docs: use ButtonGroup in Modal examples [#1208](https://github.com/pinterest/gestalt/pull/1208)
 
 ## 13.0.1 (Sep 10, 2020)
 
 ### Patch
 
-- Docs: Improved Button ccolor Docs (#1205)
+- Docs: Improved Button ccolor Docs [#1205](https://github.com/pinterest/gestalt/pull/1205)
 
 ## 13.0.0 (Sep 10, 2020)
 
 ### Major
 
-- Internal: BREAKING only build css file with css vars (#1201)
+- Internal: BREAKING only build css file with css vars [#1201](https://github.com/pinterest/gestalt/pull/1201)
 
 ## 12.13.0 (Sep 9, 2020)
 
 ### Minor
 
-- Internal: update flowtyped definitions + docs depedencies (#1206)
+- Internal: update flowtyped definitions + docs depedencies [#1206](https://github.com/pinterest/gestalt/pull/1206)
 
 ## 12.12.0 (Sep 9, 2020)
 
 ### Minor
 
-- Internal: update most dev dependencies (#1204)
+- Internal: update most dev dependencies [#1204](https://github.com/pinterest/gestalt/pull/1204)
 
 ## 12.11.1 (Sep 9, 2020)
 
 ### Patch
 
-- Table: add bottom border to each row (apart from last item) (#1200)
+- Table: add bottom border to each row (apart from last item) [#1200](https://github.com/pinterest/gestalt/pull/1200)
 
 ## 12.11.0 (Sep 8, 2020)
 
 ### Minor
 
-- Button: deprecated textColor prop values (#1188)
+- Button: deprecated textColor prop values [#1188](https://github.com/pinterest/gestalt/pull/1188)
 
 ## 12.10.1 (Sep 8, 2020)
 
 ### Patch
 
-- Internal: avoid blank page on startup in dev + fix most docs exceptions in incremental builds (#1195)
+- Internal: avoid blank page on startup in dev + fix most docs exceptions in incremental builds [#1195](https://github.com/pinterest/gestalt/pull/1195)
 
 ## 12.10.0 (Sep 8, 2020)
 
 ### Minor
 
-- Box: removal xs, sm, md, lg props (#1196)
+- Box: removal xs, sm, md, lg props [#1196](https://github.com/pinterest/gestalt/pull/1196)
 
 ## 12.9.0 (Sep 8, 2020)
 
 ### Minor
 
-- Internal: fix 'undefined' CSS in future CSS (#1198)
+- Internal: fix 'undefined' CSS in future CSS [#1198](https://github.com/pinterest/gestalt/pull/1198)
 
 ## 12.8.2 (Sep 8, 2020)
 
 ### Patch
 
-- Codemod: error message for JSXSpreadAttribute (#1197)
+- Codemod: error message for JSXSpreadAttribute [#1197](https://github.com/pinterest/gestalt/pull/1197)
 
 ## 12.8.1 (Sep 8, 2020)
 
 ### Patch
 
-- Internal: make incremental builds 4x faster (#1191)
+- Internal: make incremental builds 4x faster [#1191](https://github.com/pinterest/gestalt/pull/1191)
 
 ## 12.8.0 (Sep 8, 2020)
 
 ### Minor
 
-- Layer: convert to function component (#1189)
+- Layer: convert to function component [#1189](https://github.com/pinterest/gestalt/pull/1189)
 
 ## 12.7.0 (Sep 8, 2020)
 
 ### Minor
 
-- Internal: Rename css var namespace (#1192)
+- Internal: Rename css var namespace [#1192](https://github.com/pinterest/gestalt/pull/1192)
 
 ## 12.6.1 (Sep 4, 2020)
 
 ### Patch
 
-- Layouts: Add form layout example (#1187)
+- Layouts: Add form layout example [#1187](https://github.com/pinterest/gestalt/pull/1187)
 
 ## 12.6.0 (Sep 3, 2020)
 
 ### Minor
 
-- ButtonGroup: Add component (#1186)
+- ButtonGroup: Add component [#1186](https://github.com/pinterest/gestalt/pull/1186)
 
 ## 12.5.0 (Sep 2, 2020)
 
 ### Minor
 
-- VideoControls: convert to function component (#1182)
+- VideoControls: convert to function component [#1182](https://github.com/pinterest/gestalt/pull/1182)
 
 ## 12.4.2 (Sep 2, 2020)
 
 ### Patch
 
-- Button: Flow + name prop fixes (#1184)
+- Button: Flow + name prop fixes [#1184](https://github.com/pinterest/gestalt/pull/1184)
 
 ## 12.4.1 (Sep 2, 2020)
 
 ### Patch
 
-- Internal: update bl package (security) (#1183)
+- Internal: update bl package (security) [#1183](https://github.com/pinterest/gestalt/pull/1183)
 
 ## 12.4.0 (Sep 2, 2020)
 
 ### Minor
 
-- Button: v.2. Added support for href and segmented Flow type (#1169)
+- Button: v.2. Added support for href and segmented Flow type [#1169](https://github.com/pinterest/gestalt/pull/1169)
 
 ## 12.3.0 (Sep 2, 2020)
 
 ### Minor
 
-- Modal: Prevent showing zoom out icon if closeOnOutsideClick is false (#1181)
+- Modal: Prevent showing zoom out icon if closeOnOutsideClick is false [#1181](https://github.com/pinterest/gestalt/pull/1181)
 
 ## 12.2.0 (Sep 1, 2020)
 
 ### Minor
 
-- Link: added accessibilityLabel / Docs: implemented support to Arrays in description (#1180)
+- Link: added accessibilityLabel / Docs: implemented support to Arrays in description [#1180](https://github.com/pinterest/gestalt/pull/1180)
 
 ## 12.1.0 (Aug 31, 2020)
 
 ### Minor
 
-- Column: removed deprecated xs, sm, md, lg props + codemod helper (#1165)
+- Column: removed deprecated xs, sm, md, lg props + codemod helper [#1165](https://github.com/pinterest/gestalt/pull/1165)
 
 ## 12.0.0 (Aug 31, 2020)
 
 ### Major
 
-- Modal: Add forwardRef (#1175)
+- Modal: Add forwardRef [#1175](https://github.com/pinterest/gestalt/pull/1175)
 
 ## 11.29.1 (Aug 31, 2020)
 
 ### Patch
 
-- Docs: fix Divider overlap on bottom of the page (#1178)
+- Docs: fix Divider overlap on bottom of the page [#1178](https://github.com/pinterest/gestalt/pull/1178)
 
 ## 11.29.0 (Aug 31, 2020)
 
 ### Minor
 
-- useFocusVisible: export hook & add docs (#1176)
+- useFocusVisible: export hook & add docs [#1176](https://github.com/pinterest/gestalt/pull/1176)
 
 ## 11.28.7 (Aug 31, 2020)
 
 ### Patch
 
-- Docs: Add search shortcut with forward slash (#1177)
+- Docs: Add search shortcut with forward slash [#1177](https://github.com/pinterest/gestalt/pull/1177)
 
 ## 11.28.6 (Aug 28, 2020)
 
 ### Patch
 
-- Flyout: Update docs to mention that size is max width (#1174)
+- Flyout: Update docs to mention that size is max width [#1174](https://github.com/pinterest/gestalt/pull/1174)
 
 ## 11.28.5 (Aug 28, 2020)
 
 ### Patch
 
-- Docs: enable flow types (#1173)
+- Docs: enable flow types [#1173](https://github.com/pinterest/gestalt/pull/1173)
 
 ## 11.28.4 (Aug 28, 2020)
 
 ### Patch
 
-- Docs: Add 'edit this page' link to every doc page (#1170)
+- Docs: Add 'edit this page' link to every doc page [#1170](https://github.com/pinterest/gestalt/pull/1170)
 
 ## 11.28.3 (Aug 27, 2020)
 
 ### Patch
 
-- Docs: remove heading for multiple Combination sections on Box (#1172)
+- Docs: remove heading for multiple Combination sections on Box [#1172](https://github.com/pinterest/gestalt/pull/1172)
 
 ## 11.28.2 (Aug 27, 2020)
 
 ### Patch
 
-- Docs: fix layer issue with search + TOC (#1171)
+- Docs: fix layer issue with search + TOC [#1171](https://github.com/pinterest/gestalt/pull/1171)
 
 ## 11.28.1 (Aug 27, 2020)
 
 ### Patch
 
-- Docs: Add in page content navigation (#1168)
+- Docs: Add in page content navigation [#1168](https://github.com/pinterest/gestalt/pull/1168)
 
 ## 11.28.0 (Aug 26, 2020)
 
 ### Minor
 
-- SearchField: Add errorMessage (#1155)
+- SearchField: Add errorMessage [#1155](https://github.com/pinterest/gestalt/pull/1155)
 
 ## 11.27.0 (Aug 25, 2020)
 
 ### Minor
 
-- SelectList: convert to function component (#1167)
+- SelectList: convert to function component [#1167](https://github.com/pinterest/gestalt/pull/1167)
 
 ## 11.26.1 (Aug 25, 2020)
 
 ### Patch
 
-- Docs: separate sidebar scrolling (#1166)
+- Docs: separate sidebar scrolling [#1166](https://github.com/pinterest/gestalt/pull/1166)
 
 ## 11.26.0 (Aug 24, 2020)
 
 ### Minor
 
-- Box: removed deprecated xs, sm, md, lg props + codemod helper (#1164)
+- Box: removed deprecated xs, sm, md, lg props + codemod helper [#1164](https://github.com/pinterest/gestalt/pull/1164)
 
 ## 11.25.2 (Aug 24, 2020)
 
 ### Patch
 
-- Docs: PropTable use Card + fix scrollMarginTop on main Heading (#1163)
+- Docs: PropTable use Card + fix scrollMarginTop on main Heading [#1163](https://github.com/pinterest/gestalt/pull/1163)
 
 ## 11.25.1 (Aug 24, 2020)
 
 ### Patch
 
-- Docs: update margin/padding for markdown elements (#1162)
+- Docs: update margin/padding for markdown elements [#1162](https://github.com/pinterest/gestalt/pull/1162)
 
 ## 11.25.0 (Aug 24, 2020)
 
 ### Minor
 
-- SegmentedControl: make use of useFocusVisible (#1157)
+- SegmentedControl: make use of useFocusVisible [#1157](https://github.com/pinterest/gestalt/pull/1157)
 
 ## 11.24.1 (Aug 21, 2020)
 
 ### Patch
 
-- Docs: add sidebar alphabetization toggle (#1154)
+- Docs: add sidebar alphabetization toggle [#1154](https://github.com/pinterest/gestalt/pull/1154)
 
 ## 11.24.0 (Aug 21, 2020)
 
 ### Minor
 
-- Docs: Added Development + FAQ section (#1145)
+- Docs: Added Development + FAQ section [#1145](https://github.com/pinterest/gestalt/pull/1145)
 
 ## 11.23.0 (Aug 19, 2020)
 
 ### Minor
 
-- Revert "Button/Checkbox/IconButton/Link/RadioButton/Switch/TapArea: Revert useFocusVisible (#1098) & Focus Styles: revert override CSS outline if a global one is specified (#1118) (#1141)" (#1153)
+- Revert "Button/Checkbox/IconButton/Link/RadioButton/Switch/TapArea: Revert useFocusVisible [#1098](https://github.com/pinterest/gestalt/pull/1098) & Focus Styles: revert override CSS outline if a global one is specified [#1118](https://github.com/pinterest/gestalt/pull/1118) [#1141](https://github.com/pinterest/gestalt/pull/1141)" [#1153](https://github.com/pinterest/gestalt/pull/1153)
 
 ## 11.22.0 (Aug 17, 2020)
 
 ### Minor
 
-- Video: add crossOrigin option (#1150)
+- Video: add crossOrigin option [#1150](https://github.com/pinterest/gestalt/pull/1150)
 
 ## 11.21.1 (Aug 17, 2020)
 
 ### Patch
 
-- Interal: remove console.log message in Markdown.js (#1152)
+- Interal: remove console.log message in Markdown.js [#1152](https://github.com/pinterest/gestalt/pull/1152)
 
 ## 11.21.0 (Aug 17, 2020)
 
 ### Minor
 
-- SelectList: fix Flowtype (#1151)
+- SelectList: fix Flowtype [#1151](https://github.com/pinterest/gestalt/pull/1151)
 
 ## 11.20.3 (Aug 17, 2020)
 
 ### Patch
 
-- SelectList: fix FlowType (#1146)
+- SelectList: fix FlowType [#1146](https://github.com/pinterest/gestalt/pull/1146)
 
 ## 11.20.2 (Aug 17, 2020)
 
 ### Patch
 
-- Internal: upgrade serialize-javascript (security) (#1149)
+- Internal: upgrade serialize-javascript (security) [#1149](https://github.com/pinterest/gestalt/pull/1149)
 
 ## 11.20.1 (Aug 17, 2020)
 
 ### Patch
 
-- Docs: fix blank installation page (#1148)
+- Docs: fix blank installation page [#1148](https://github.com/pinterest/gestalt/pull/1148)
 
 ## 11.20.0 (Aug 14, 2020)
 
 ### Minor
 
-- Avatar: Remove person icon fallback variant (#1139)
+- Avatar: Remove person icon fallback variant [#1139](https://github.com/pinterest/gestalt/pull/1139)
 
 ## 11.19.0 (Aug 14, 2020)
 
 ### Minor
 
-- SelectList: Add disabled to options prop (#1140)
+- SelectList: Add disabled to options prop [#1140](https://github.com/pinterest/gestalt/pull/1140)
 
 ## 11.18.0 (Aug 14, 2020)
 
 ### Minor
 
-- Docs: Implement markdown from md files as documentation sections (#1144)
+- Docs: Implement markdown from md files as documentation sections [#1144](https://github.com/pinterest/gestalt/pull/1144)
 
 ## 11.17.1 (Aug 13, 2020)
 
 ### Patch
 
-- [Pog]: Add red to prop type (#1138)
+- [Pog]: Add red to prop type [#1138](https://github.com/pinterest/gestalt/pull/1138)
 
 ## 11.17.0 (Aug 13, 2020)
 
 ### Minor
 
-- Callout: added RTL support in dismiss button, renamed description prop (#1143)
+- Callout: added RTL support in dismiss button, renamed description prop [#1143](https://github.com/pinterest/gestalt/pull/1143)
 
 ## 11.16.0 (Aug 12, 2020)
 
 ### Minor
 
-- [Dark mode] Color updates for dark mode (#1129)
+- [Dark mode] Color updates for dark mode [#1129](https://github.com/pinterest/gestalt/pull/1129)
 
 ## 11.15.2 (Aug 12, 2020)
 
 ### Patch
 
-- Datepicker: standardized date format & placeholder date format across… (#1135)
+- Datepicker: standardized date format & placeholder date format across… [#1135](https://github.com/pinterest/gestalt/pull/1135)
 
 ## 11.15.1 (Aug 12, 2020)
 
 ### Patch
 
-- ZIndexClasses: note on docs re extracting index values from classes (#1136)
+- ZIndexClasses: note on docs re extracting index values from classes [#1136](https://github.com/pinterest/gestalt/pull/1136)
 
 ## 11.15.0 (Aug 11, 2020)
 
 ### Minor
 
-- Button/Checkbox/IconButton/Link/RadioButton/Switch/TapArea: Revert useFocusVisible (#1098) & Focus Styles: revert override CSS outline if a global one is specified (#1118) (#1141)
+- Button/Checkbox/IconButton/Link/RadioButton/Switch/TapArea: Revert useFocusVisible [#1098](https://github.com/pinterest/gestalt/pull/1098) & Focus Styles: revert override CSS outline if a global one is specified [#1118](https://github.com/pinterest/gestalt/pull/1118) [#1141](https://github.com/pinterest/gestalt/pull/1141)
 
 ## 11.14.2 (Aug 7, 2020)
 
 ### Patch
 
-- [Docs] Update port number for running locally (#1130)
+- [Docs] Update port number for running locally [#1130](https://github.com/pinterest/gestalt/pull/1130)
 
 ## 11.14.1 (Aug 7, 2020)
 
 ### Patch
 
-- Box: s/blacklist/disallowed/ (#1131)
+- Box: s/blacklist/disallowed/ [#1131](https://github.com/pinterest/gestalt/pull/1131)
 
 ## 11.14.0 (Aug 7, 2020)
 
 ### Minor
 
-- Sticky: add height prop (#1137)
+- Sticky: add height prop [#1137](https://github.com/pinterest/gestalt/pull/1137)
 
 ## 11.13.0 (Aug 7, 2020)
 
 ### Minor
 
-- useReducedMotion: fix in Safari/Edge (#1134)
+- useReducedMotion: fix in Safari/Edge [#1134](https://github.com/pinterest/gestalt/pull/1134)
 
 ## 11.12.6 (Aug 7, 2020)
 
 ### Patch
 
-- Docs: nest anchor tag inside of heading (#1132)
+- Docs: nest anchor tag inside of heading [#1132](https://github.com/pinterest/gestalt/pull/1132)
 
 ## 11.12.5 (Aug 5, 2020)
 
 ### Patch
 
-- Internal: disallow flow warnings (#1127)
+- Internal: disallow flow warnings [#1127](https://github.com/pinterest/gestalt/pull/1127)
 
 ## 11.12.4 (Aug 5, 2020)
 
 ### Patch
 
-- Docs: track pageviews (#1126)
+- Docs: track pageviews [#1126](https://github.com/pinterest/gestalt/pull/1126)
 
 ## 11.12.3 (Aug 5, 2020)
 
 ### Patch
 
-- ZIndexClasses: Fix source url (#1125)
+- ZIndexClasses: Fix source url [#1125](https://github.com/pinterest/gestalt/pull/1125)
 
 ## 11.12.2 (Aug 5, 2020)
 
 ### Patch
 
-- Docs: single subdirectory URLs (#1124)
+- Docs: single subdirectory URLs [#1124](https://github.com/pinterest/gestalt/pull/1124)
 
 ## 11.12.1 (Aug 5, 2020)
 
 ### Patch
 
-- Docs: Add id to every heading (improves SEO & Search) (#1123)
+- Docs: Add id to every heading (improves SEO & Search) [#1123](https://github.com/pinterest/gestalt/pull/1123)
 
 ## 11.12.0 (Aug 5, 2020)
 
 ### Minor
 
-- Flyout: Update Caret (#1081)
+- Flyout: Update Caret [#1081](https://github.com/pinterest/gestalt/pull/1081)
 
 ## 11.11.3 (Aug 5, 2020)
 
 ### Patch
 
-- DatePicker: Fix proptype bug (#1122)
+- DatePicker: Fix proptype bug [#1122](https://github.com/pinterest/gestalt/pull/1122)
 
 ## 11.11.2 (Aug 5, 2020)
 
 ### Patch
 
-- ZIndexClasses: Fix typos and linting in docs (#1120)
+- ZIndexClasses: Fix typos and linting in docs [#1120](https://github.com/pinterest/gestalt/pull/1120)
 
 ## 11.11.1 (Aug 4, 2020)
 
 ### Patch
 
-- Internal: Remove the # from URLs in the docs (#1115)
+- Internal: Remove the # from URLs in the docs [#1115](https://github.com/pinterest/gestalt/pull/1115)
 
 ## 11.11.0 (Aug 4, 2020)
 
 ### Minor
 
-- Link/TapArea/DatePicker: Refactored forwardRef (#1113)
+- Link/TapArea/DatePicker: Refactored forwardRef [#1113](https://github.com/pinterest/gestalt/pull/1113)
 
 ## 11.10.0 (Aug 4, 2020)
 
 ### Minor
 
-- SearchField/Typeahead/TypeaheadInputField/TextField/TextArea: refactored forwardRef (#1110)
+- SearchField/Typeahead/TypeaheadInputField/TextField/TextArea: refactored forwardRef [#1110](https://github.com/pinterest/gestalt/pull/1110)
 
 ## 11.9.0 (Aug 4, 2020)
 
 ### Minor
 
-- Button/IconButton/CheckBox/RadioButton: refactored forwardRef (#1107)
+- Button/IconButton/CheckBox/RadioButton: refactored forwardRef [#1107](https://github.com/pinterest/gestalt/pull/1107)
 
 ## 11.8.0 (Aug 4, 2020)
 
 ### Minor
 
-- Box: Refactored forwardRef logic + forwardRef test + forwardRef example in Docs (#1079)
+- Box: Refactored forwardRef logic + forwardRef test + forwardRef example in Docs [#1079](https://github.com/pinterest/gestalt/pull/1079)
 
 ## 11.7.1 (Aug 4, 2020)
 
 ### Patch
 
-- Focus Styles: override CSS outline if a global one is specified (#1118)
+- Focus Styles: override CSS outline if a global one is specified [#1118](https://github.com/pinterest/gestalt/pull/1118)
 
 ## 11.7.0 (Aug 4, 2020)
 
 ### Minor
 
-- useReducedMotion: Accessibility hook to support prefers-reduced-motion (#1100)
+- useReducedMotion: Accessibility hook to support prefers-reduced-motion [#1100](https://github.com/pinterest/gestalt/pull/1100)
 
 ## 11.6.1 (Aug 4, 2020)
 
 ### Patch
 
-- Docs: Updated Video.doc.js to match flow types (#1117)
+- Docs: Updated Video.doc.js to match flow types [#1117](https://github.com/pinterest/gestalt/pull/1117)
 
 ## 11.6.0 (Aug 4, 2020)
 
 ### Minor
 
-- GestaltProvider: rename to Provider & move under configuration (#1114)
+- GestaltProvider: rename to Provider & move under configuration [#1114](https://github.com/pinterest/gestalt/pull/1114)
 
 ## 11.5.6 (Aug 4, 2020)
 
 ### Patch
 
-- Callout: Update info callout icon (#1108)
+- Callout: Update info callout icon [#1108](https://github.com/pinterest/gestalt/pull/1108)
 
 ## 11.5.5 (Aug 3, 2020)
 
 ### Patch
 
-- VSCode: add recommended extensions (#1109)
+- VSCode: add recommended extensions [#1109](https://github.com/pinterest/gestalt/pull/1109)
 
 ## 11.5.4 (Aug 3, 2020)
 
 ### Patch
 
-- Internal: enforce disallow namespace/wildcard imports + apply on docs (#1106)
+- Internal: enforce disallow namespace/wildcard imports + apply on docs [#1106](https://github.com/pinterest/gestalt/pull/1106)
 
 ## 11.5.3 (Aug 3, 2020)
 
 ### Patch
 
-- Internal: Refactored imports from namespacing \* to explicit Default Exports and Named Values Importing (#1103)
+- Internal: Refactored imports from namespacing \* to explicit Default Exports and Named Values Importing [#1103](https://github.com/pinterest/gestalt/pull/1103)
 
 ## 11.5.2 (Aug 3, 2020)
 
 ### Patch
 
-- Datepicker: move gestalt to peerDependencies (#1105)
+- Datepicker: move gestalt to peerDependencies [#1105](https://github.com/pinterest/gestalt/pull/1105)
 
 ## 11.5.1 (Aug 3, 2020)
 
 ### Patch
 
-- Callout: Reduced padding for sm (#1104)
+- Callout: Reduced padding for sm [#1104](https://github.com/pinterest/gestalt/pull/1104)
 
 ## 11.5.0 (Jul 31, 2020)
 
 ### Minor
 
-- Callout: Added responsiveness design (#1088)
+- Callout: Added responsiveness design [#1088](https://github.com/pinterest/gestalt/pull/1088)
 
 ## 11.4.0 (Jul 31, 2020)
 
 ### Minor
 
-- Button/Checkbox/IconButton/Link/RadioButton/Switch/TapArea: useFocusVisible (#1098)
+- Button/Checkbox/IconButton/Link/RadioButton/Switch/TapArea: useFocusVisible [#1098](https://github.com/pinterest/gestalt/pull/1098)
 
 ## 11.3.2 (Jul 31, 2020)
 
 ### Patch
 
-- Mergify: configuration update (#1101)
+- Mergify: configuration update [#1101](https://github.com/pinterest/gestalt/pull/1101)
 
 ## 11.3.1 (Jul 31, 2020)
 
 ### Patch
 
-- Flowtests: Add more tests to components + fix GestaltProvider flowtype (#1096)
+- Flowtests: Add more tests to components + fix GestaltProvider flowtype [#1096](https://github.com/pinterest/gestalt/pull/1096)
 
 ## 11.3.0 (Jul 31, 2020)
 
 ### Minor
 
-- Box: Added responsiveness to sm/md/lg 0px margins (#1091)
+- Box: Added responsiveness to sm/md/lg 0px margins [#1091](https://github.com/pinterest/gestalt/pull/1091)
 
 ## 11.2.5 (Jul 31, 2020)
 
 ### Patch
 
-- Fix prop type (#1099)
+- Fix prop type [#1099](https://github.com/pinterest/gestalt/pull/1099)
 
 ## 11.2.4 (Jul 30, 2020)
 
 ### Patch
 
-- RadioButton: fix warning in jest test (#1097)
+- RadioButton: fix warning in jest test [#1097](https://github.com/pinterest/gestalt/pull/1097)
 
 ## 11.2.3 (Jul 30, 2020)
 
 ### Patch
 
-- Make Semver workflow wording clearer (#1094)
+- Make Semver workflow wording clearer [#1094](https://github.com/pinterest/gestalt/pull/1094)
 
 ## 11.2.2 (Jul 30, 2020)
 
 ### Patch
 
-- Mergify: configuration update (#1095)
+- Mergify: configuration update [#1095](https://github.com/pinterest/gestalt/pull/1095)
 
 ## 11.2.1 (Jul 30, 2020)
 
 ### Patch
 
-- Mergify: configuration update (#1093)
+- Mergify: configuration update [#1093](https://github.com/pinterest/gestalt/pull/1093)
 
 ## 11.2.0 (Jul 30, 2020)
 
 ### Minor
 
-- Typeahead: Refactor to show all options when there's a defaultValue, renamed defaultItem + removed searchField prop, fix forwardedRef + test coverage, add example to Docs, (#1067)
+- Typeahead: Refactor to show all options when there's a defaultValue, renamed defaultItem + removed searchField prop, fix forwardedRef + test coverage, add example to Docs, [#1067](https://github.com/pinterest/gestalt/pull/1067)
 
 ## 11.1.2 (Jul 30, 2020)
 
 ### Patch
 
-- Bump elliptic from 6.5.2 to 6.5.3 (#1092)
+- Bump elliptic from 6.5.2 to 6.5.3 [#1092](https://github.com/pinterest/gestalt/pull/1092)
 
 ## 11.1.1 (Jul 30, 2020)
 
 ### Patch
 
-- Flowtest: Add flow specific test files (#1085)
+- Flowtest: Add flow specific test files [#1085](https://github.com/pinterest/gestalt/pull/1085)
 
 ## 11.1.0 (Jul 29, 2020)
 
 ### Minor
 
-- Box: added support to responsive marginEnd marginStart (#1087)
+- Box: added support to responsive marginEnd marginStart [#1087](https://github.com/pinterest/gestalt/pull/1087)
 
 ## 11.0.0 (Jul 28, 2020)
 
 ### Major
 
-- RadioButton: Add forward ref (BREAKING CHANGE) (#1071)
+- RadioButton: Add forward ref (BREAKING CHANGE) [#1071](https://github.com/pinterest/gestalt/pull/1071)
 
 ## 10.2.0 (Jul 28, 2020)
 
 ### Minor
 
-- Icon: Add drag-drop icon (#1083)
+- Icon: Add drag-drop icon [#1083](https://github.com/pinterest/gestalt/pull/1083)
 
 ## 10.1.0 (Jul 28, 2020)
 
 ### Minor
 
-- Callout: Add component (#1076)
+- Callout: Add component [#1076](https://github.com/pinterest/gestalt/pull/1076)
 
 ## 10.0.1 (Jul 28, 2020)
 
 ### Patch
 
-- Docs: Added ZIndexClasses in Layout (#1082)
+- Docs: Added ZIndexClasses in Layout [#1082](https://github.com/pinterest/gestalt/pull/1082)
 
 ## 10.0.0 (Jul 28, 2020)
 
 ### Major
 
-- Layer: Fix flow type return on render (#1084)
+- Layer: Fix flow type return on render [#1084](https://github.com/pinterest/gestalt/pull/1084)
 
 ## 9.2.2 (Jul 27, 2020)
 
 ### Patch
 
-- Sidebar: cleanup (#1080)
+- Sidebar: cleanup [#1080](https://github.com/pinterest/gestalt/pull/1080)
 
 ## 9.2.1 (Jul 27, 2020)
 
 ### Patch
 
-- Docs Sidebar: remove collapsing + update heading / selected styles (#1078)
+- Docs Sidebar: remove collapsing + update heading / selected styles [#1078](https://github.com/pinterest/gestalt/pull/1078)
 
 ## 9.2.0 (Jul 27, 2020)
 
 ### Minor
 
-- useFocusVisible: Only show focus ring on keyboard input (#1073)
+- useFocusVisible: Only show focus ring on keyboard input [#1073](https://github.com/pinterest/gestalt/pull/1073)
 
 ## 9.1.0 (Jul 27, 2020)
 
 ### Minor
 
-- Video: Fix failing CORS access and preventing playback (#1077)
+- Video: Fix failing CORS access and preventing playback [#1077](https://github.com/pinterest/gestalt/pull/1077)
 
 ## 9.0.0 (Jul 24, 2020)
 
 ### Major
 
-- InputButton/Button: Add forward ref (BREAKING CHANGE) (#1063)
+- InputButton/Button: Add forward ref (BREAKING CHANGE) [#1063](https://github.com/pinterest/gestalt/pull/1063)
 
 ## 8.2.2 (Jul 24, 2020)
 
 ### Patch
 
-- Docs: Fix Header to remove sticky header on reduced window size (#1074)
+- Docs: Fix Header to remove sticky header on reduced window size [#1074](https://github.com/pinterest/gestalt/pull/1074)
 
 ## 8.2.1 (Jul 23, 2020)
 
 ### Patch
 
-- Box: add test for flowtypes (#1070)
+- Box: add test for flowtypes [#1070](https://github.com/pinterest/gestalt/pull/1070)
 
 ## 8.2.0 (Jul 23, 2020)
 
 ### Minor
 
-- Button: remove border for transparent button (#1069)
+- Button: remove border for transparent button [#1069](https://github.com/pinterest/gestalt/pull/1069)
 
 ## 8.1.2 (Jul 22, 2020)
 
 ### Patch
 
-- Docs: Scroll to top on click in NavLink component (#1060)
+- Docs: Scroll to top on click in NavLink component [#1060](https://github.com/pinterest/gestalt/pull/1060)
 
 ## 8.1.1 (Jul 21, 2020)
 
 ### Patch
 
-- Docs: fix broken CodeSandbox links (#1066)
+- Docs: fix broken CodeSandbox links [#1066](https://github.com/pinterest/gestalt/pull/1066)
 
 ## 8.1.0 (Jul 21, 2020)
 
 ### Minor
 
-- Checkbox: fix bug in behaviour related to position (#1065)
+- Checkbox: fix bug in behaviour related to position [#1065](https://github.com/pinterest/gestalt/pull/1065)
 
 ## 8.0.4 (Jul 21, 2020)
 
 ### Patch
 
-- Bump codecov from 3.7.0 to 3.7.1 (#1064)
+- Bump codecov from 3.7.0 to 3.7.1 [#1064](https://github.com/pinterest/gestalt/pull/1064)
 
 ## 8.0.3 (Jul 20, 2020)
 
 ### Patch
 
-- Docs: Refactored Sticky example to use new Box's zIndex prop (#1062)
+- Docs: Refactored Sticky example to use new Box's zIndex prop [#1062](https://github.com/pinterest/gestalt/pull/1062)
 
 ## 8.0.2 (Jul 20, 2020)
 
 ### Patch
 
-- Pulsar: update default size from 135px to 136px (#1061)
+- Pulsar: update default size from 135px to 136px [#1061](https://github.com/pinterest/gestalt/pull/1061)
 
 ## 8.0.1 (Jul 20, 2020)
 
 ### Patch
 
-- Docs: Fixed automatic detection for Fixed/CompositeZIndex imports in Codesandbox (#1058)
+- Docs: Fixed automatic detection for Fixed/CompositeZIndex imports in Codesandbox [#1058](https://github.com/pinterest/gestalt/pull/1058)
 
 ## 8.0.0 (Jul 17, 2020)
 
 ### Major
 
-- Checkbox: Add forward ref (BREAKING CHANGE) (#1057)
+- Checkbox: Add forward ref (BREAKING CHANGE) [#1057](https://github.com/pinterest/gestalt/pull/1057)
 
 ## 7.1.1 (Jul 17, 2020)
 
 ### Patch
 
-- AbstractEventHandler type (#1045)
+- AbstractEventHandler type [#1045](https://github.com/pinterest/gestalt/pull/1045)
 
 ## 7.1.0 (Jul 17, 2020)
 
 ### Minor
 
-- Button/IconButton: compress onClick or onTouch (#1056)
+- Button/IconButton: compress onClick or onTouch [#1056](https://github.com/pinterest/gestalt/pull/1056)
 
 ## 7.0.0 (Jul 16, 2020)
 
 ### Major
 
-- TextArea: Add forward ref (BREAKING CHANGE) (#1053)
+- TextArea: Add forward ref (BREAKING CHANGE) [#1053](https://github.com/pinterest/gestalt/pull/1053)
 
 ## 6.3.0 (Jul 16, 2020)
 
 ### Minor
 
-- Typeahead: Add New Component (#907)
+- Typeahead: Add New Component [#907](https://github.com/pinterest/gestalt/pull/907)
 
 ## 6.2.0 (Jul 14, 2020)
 
 ### Minor
 
-- Docs: Added darkMode to Algolia's DocsSearch feature (#1038)
+- Docs: Added darkMode to Algolia's DocsSearch feature [#1038](https://github.com/pinterest/gestalt/pull/1038)
 
 ## 6.1.0 (Jul 14, 2020)
 
 ### Minor
 
-- Docs: restructure sidebar display order (#1051)
+- Docs: restructure sidebar display order [#1051](https://github.com/pinterest/gestalt/pull/1051)
 
 ## 6.0.0 (Jul 14, 2020)
 
 ### Major
 
-- Link: add React.forwardRef (#1050)
+- Link: add React.forwardRef [#1050](https://github.com/pinterest/gestalt/pull/1050)
 
 ## 5.33.0 (Jul 14, 2020)
 
 ### Minor
 
-- Video: Add captions + controls (#1046)
+- Video: Add captions + controls [#1046](https://github.com/pinterest/gestalt/pull/1046)
 
 ## 5.32.2 (Jul 14, 2020)
 
 ### Patch
 
-- Internal: Catch CSS variable usage in legacy build (#1049)
+- Internal: Catch CSS variable usage in legacy build [#1049](https://github.com/pinterest/gestalt/pull/1049)
 
 ## 5.32.1 (Jul 13, 2020)
 
 ### Patch
 
-- Fix transparent dark gray background color (#1048)
+- Fix transparent dark gray background color [#1048](https://github.com/pinterest/gestalt/pull/1048)
 
 ## 5.32.0 (Jul 13, 2020)
 
 ### Minor
 
-- DatePicker: Implementing DarkMode color scheme (#1008)
+- DatePicker: Implementing DarkMode color scheme [#1008](https://github.com/pinterest/gestalt/pull/1008)
 
 ## 5.31.0 (Jul 13, 2020)
 
 ### Minor
 
-- IconButton, Pog: fix padding prop (#1047)
+- IconButton, Pog: fix padding prop [#1047](https://github.com/pinterest/gestalt/pull/1047)
 
 ## 5.30.2 (Jul 10, 2020)
 
 ### Patch
 
-- Button: Default hover state color (#1025)
+- Button: Default hover state color [#1025](https://github.com/pinterest/gestalt/pull/1025)
 
 ## 5.30.1 (Jul 10, 2020)
 
 ### Patch
 
-- ColorScheme: Set transparent colors in dark mode (#1042)
+- ColorScheme: Set transparent colors in dark mode [#1042](https://github.com/pinterest/gestalt/pull/1042)
 
 ## 5.30.0 (Jul 10, 2020)
 
 ### Minor
 
-- Internal: Add CSS variables CI checks (#1041)
+- Internal: Add CSS variables CI checks [#1041](https://github.com/pinterest/gestalt/pull/1041)
 
 ## 5.29.1 (Jul 9, 2020)
 
 ### Patch
 
-- Merge: Remove status-check=0 check (#1040)
+- Merge: Remove status-check=0 check [#1040](https://github.com/pinterest/gestalt/pull/1040)
 
 ## 5.29.0 (Jul 9, 2020)
 
 ### Minor
 
-- Colors: Adding #colorGray150 + hover colors, and replacing inline colors to standard color var names (#1034)
+- Colors: Adding #colorGray150 + hover colors, and replacing inline colors to standard color var names [#1034](https://github.com/pinterest/gestalt/pull/1034)
 
 ## 5.28.5 (Jul 9, 2020)
 
 ### Patch
 
-- Merge: Better titles and obey branch protections (#1035)
+- Merge: Better titles and obey branch protections [#1035](https://github.com/pinterest/gestalt/pull/1035)
 
 ## 5.28.4 (Jul 9, 2020)
 
 ### Patch
 
-- Switch: Fix darkMode border colors by adhering to color scheme convention names (#1033)
+- Switch: Fix darkMode border colors by adhering to color scheme convention names [#1033](https://github.com/pinterest/gestalt/pull/1033)
 
 ## 5.28.3 (Jul 9, 2020)
 
 ### Patch
 
-- Colors: Update dark mode gray values to latest from design (#1030)
+- Colors: Update dark mode gray values to latest from design [#1030](https://github.com/pinterest/gestalt/pull/1030)
 
 ## 5.28.2 (Jul 9, 2020)
 
 ### Patch
 
-- Internal: Update Pull Request template (#988)
+- Internal: Update Pull Request template [#988](https://github.com/pinterest/gestalt/pull/988)
 
 ## 5.28.1 (Jul 9, 2020)
 
 ### Patch
 
-- Tabs: Fix indicator flowtype in docs (#1031)
+- Tabs: Fix indicator flowtype in docs [#1031](https://github.com/pinterest/gestalt/pull/1031)
 
 ## 5.28.0 (Jul 9, 2020)
 
@@ -6630,31 +6630,31 @@
 
 ### Minor
 
-- Box: fix flowtype for borderSize (#1026)
+- Box: fix flowtype for borderSize [#1026](https://github.com/pinterest/gestalt/pull/1026)
 
 ## 5.26.1 (Jul 9, 2020)
 
 ### Patch
 
-- Badge: set text color to always be white (#1022)
+- Badge: set text color to always be white [#1022](https://github.com/pinterest/gestalt/pull/1022)
 
 ## 5.26.0 (Jul 9, 2020)
 
 ### Minor
 
-- Icon: add protect icon (#1024)
+- Icon: add protect icon [#1024](https://github.com/pinterest/gestalt/pull/1024)
 
 ## 5.25.0 (Jul 9, 2020)
 
 ### Minor
 
-- Flyout: Fix caret appearance in dark mode (#1017)
+- Flyout: Fix caret appearance in dark mode [#1017](https://github.com/pinterest/gestalt/pull/1017)
 
 ## 5.24.7 (Jul 9, 2020)
 
 ### Patch
 
-- Mergify: configuration update (#1016)
+- Mergify: configuration update [#1016](https://github.com/pinterest/gestalt/pull/1016)
 
 ## 5.24.6 (Jul 9, 2020)
 
@@ -6666,19 +6666,19 @@
 
 ### Patch
 
-- Button: Use accessible colors for darkMode red button (#1009)
+- Button: Use accessible colors for darkMode red button [#1009](https://github.com/pinterest/gestalt/pull/1009)
 
 ## 5.24.4 (Jul 9, 2020)
 
 ### Patch
 
-- Avatar and GroupAvatar: Use correct outline for dark mode (#1011)
+- Avatar and GroupAvatar: Use correct outline for dark mode [#1011](https://github.com/pinterest/gestalt/pull/1011)
 
 ## 5.24.3 (Jul 9, 2020)
 
 ### Patch
 
-- [Borders.css][darkmode] Replaced naming in Borders.css to scheme standard (#978)
+- [Borders.css][darkmode] Replaced naming in Borders.css to scheme standard [#978](https://github.com/pinterest/gestalt/pull/978)
 
 ## 5.24.2 (Jul 9, 2020)
 
@@ -6690,511 +6690,511 @@
 
 ### Patch
 
-- [Docs: Link] Fixed/Improved examples (#1014)
+- [Docs: Link] Fixed/Improved examples [#1014](https://github.com/pinterest/gestalt/pull/1014)
 
 ## 5.24.0 (Jul 8, 2020)
 
 ### Minor
 
-- Rename Theme -> ColorScheme (#993)
+- Rename Theme -> ColorScheme [#993](https://github.com/pinterest/gestalt/pull/993)
 
 ## 5.23.1 (Jul 8, 2020)
 
 ### Patch
 
-- [Header] Reworded tooltips (#981)
+- [Header] Reworded tooltips [#981](https://github.com/pinterest/gestalt/pull/981)
 
 ## 5.23.0 (Jul 8, 2020)
 
 ### Minor
 
-- [Box] Fix types (#986)
+- [Box] Fix types [#986](https://github.com/pinterest/gestalt/pull/986)
 
 ## 5.22.3 (Jul 8, 2020)
 
 ### Patch
 
-- Avatar: Update hardcoded svg fills to use theme colors (#975)
+- Avatar: Update hardcoded svg fills to use theme colors [#975](https://github.com/pinterest/gestalt/pull/975)
 
 ## 5.22.2 (Jul 7, 2020)
 
 ### Patch
 
-- Dark Mode: update toggle in docs (#974)
+- Dark Mode: update toggle in docs [#974](https://github.com/pinterest/gestalt/pull/974)
 
 ## 5.22.1 (Jul 7, 2020)
 
 ### Patch
 
-- SearchField/TapArea/TextField: add ref to list of props (#972)
+- SearchField/TapArea/TextField: add ref to list of props [#972](https://github.com/pinterest/gestalt/pull/972)
 
 ## 5.22.0 (Jul 7, 2020)
 
 ### Minor
 
-- GestaltProvider: Adding a provider for color scheme and other future context used by Gestalt (#968)
+- GestaltProvider: Adding a provider for color scheme and other future context used by Gestalt [#968](https://github.com/pinterest/gestalt/pull/968)
 
 ## 5.21.0 (Jul 7, 2020)
 
 ### Minor
 
-- Video: Test video state before calling play | Default volume to Muted (#969)
+- Video: Test video state before calling play | Default volume to Muted [#969](https://github.com/pinterest/gestalt/pull/969)
 
 ## 5.20.0 (Jul 7, 2020)
 
 ### Minor
 
-- ZIndex: Add support for Fixed & Composite zIndexes (#966)
+- ZIndex: Add support for Fixed & Composite zIndexes [#966](https://github.com/pinterest/gestalt/pull/966)
 
 ## 5.19.0 (Jul 7, 2020)
 
 ### Minor
 
-- Tabs: Add optional dot indicator (#967)
+- Tabs: Add optional dot indicator [#967](https://github.com/pinterest/gestalt/pull/967)
 
 ## 5.18.0 (Jul 7, 2020)
 
 ### Minor
 
-- SearchField: RTL support (#970)
+- SearchField: RTL support [#970](https://github.com/pinterest/gestalt/pull/970)
 
 ## 5.17.0 (Jul 2, 2020)
 
 ### Minor
 
-- Styling: Prepare css for dark mode support (#963)
+- Styling: Prepare css for dark mode support [#963](https://github.com/pinterest/gestalt/pull/963)
 
 ## 5.16.0 (Jul 2, 2020)
 
 ### Minor
 
-- Docs: Expand Navigation subsections (#962)
+- Docs: Expand Navigation subsections [#962](https://github.com/pinterest/gestalt/pull/962)
 
 ## 5.15.0 (Jul 2, 2020)
 
 ### Minor
 
-- Avatar: Add accessibilityLabel (#961)
+- Avatar: Add accessibilityLabel [#961](https://github.com/pinterest/gestalt/pull/961)
 
 ## 5.14.3 (Jul 1, 2020)
 
 ### Patch
 
-- Tabs: lightgray background when tab is focussed (#960)
+- Tabs: lightgray background when tab is focussed [#960](https://github.com/pinterest/gestalt/pull/960)
 
 ## 5.14.2 (Jul 1, 2020)
 
 ### Patch
 
-- Link: add event to onFocus + onBlur (#959)
+- Link: add event to onFocus + onBlur [#959](https://github.com/pinterest/gestalt/pull/959)
 
 ## 5.14.1 (Jul 1, 2020)
 
 ### Patch
 
-- TapArea / Text: Refactored Docs examples for cleaner examples (#947)
+- TapArea / Text: Refactored Docs examples for cleaner examples [#947](https://github.com/pinterest/gestalt/pull/947)
 
 ## 5.14.0 (Jul 1, 2020)
 
 ### Minor
 
-- Docs: Refactored Gestalt Docs Sidebar Menu (#952)
+- Docs: Refactored Gestalt Docs Sidebar Menu [#952](https://github.com/pinterest/gestalt/pull/952)
 
 ## 5.13.0 (Jul 1, 2020)
 
 ### Minor
 
-- Tabs (and Box, Link, Text): force long tab label in one line with major refactor (#955)
+- Tabs (and Box, Link, Text): force long tab label in one line with major refactor [#955](https://github.com/pinterest/gestalt/pull/955)
 
 ## 5.12.1 (Jun 30, 2020)
 
 ### Patch
 
-- Internal: Support GitHub Codespaces (#956)
+- Internal: Support GitHub Codespaces [#956](https://github.com/pinterest/gestalt/pull/956)
 
 ## 5.12.0 (Jun 30, 2020)
 
 ### Minor
 
-- Modal: fix scroll behavior in IE11 (#958)
+- Modal: fix scroll behavior in IE11 [#958](https://github.com/pinterest/gestalt/pull/958)
 
 ## 5.11.2 (Jun 30, 2020)
 
 ### Patch
 
-- Docs: support IE11 (#957)
+- Docs: support IE11 [#957](https://github.com/pinterest/gestalt/pull/957)
 
 ## 5.11.1 (Jun 29, 2020)
 
 ### Patch
 
-- DatePicker/Tooltip: update idealDirection default value in docs (#954)
+- DatePicker/Tooltip: update idealDirection default value in docs [#954](https://github.com/pinterest/gestalt/pull/954)
 
 ## 5.11.0 (Jun 26, 2020)
 
 ### Minor
 
-- Box/Link: add role prop to both and accessibilitySelected prop to Link (#953)
+- Box/Link: add role prop to both and accessibilitySelected prop to Link [#953](https://github.com/pinterest/gestalt/pull/953)
 
 ## 5.10.0 (Jun 25, 2020)
 
 ### Minor
 
-- Button: Fix disabled state to prevent it to be interacted with and event bubbling (#951)
+- Button: Fix disabled state to prevent it to be interacted with and event bubbling [#951](https://github.com/pinterest/gestalt/pull/951)
 
 ## 5.9.2 (Jun 24, 2020)
 
 ### Patch
 
-- Internal: Update documentation link (#950)
+- Internal: Update documentation link [#950](https://github.com/pinterest/gestalt/pull/950)
 
 ## 5.9.1 (Jun 24, 2020)
 
 ### Patch
 
-- TapArea:Updated Doc Example: Accessibility (Popup) (#942)
+- TapArea:Updated Doc Example: Accessibility (Popup) [#942](https://github.com/pinterest/gestalt/pull/942)
 
 ## 5.9.0 (Jun 24, 2020)
 
 ### Minor
 
-- IconButton: add optional padding prop (#949)
+- IconButton: add optional padding prop [#949](https://github.com/pinterest/gestalt/pull/949)
 
 ## 5.8.0 (Jun 24, 2020)
 
 ### Minor
 
-- Link: fix context menu not showing (#948)
+- Link: fix context menu not showing [#948](https://github.com/pinterest/gestalt/pull/948)
 
 ## 5.7.0 (Jun 24, 2020)
 
 ### Minor
 
-- Internal: require flow exact types (#946)
+- Internal: require flow exact types [#946](https://github.com/pinterest/gestalt/pull/946)
 
 ## 5.6.0 (Jun 24, 2020)
 
 ### Minor
 
-- Internal: Upgrade dependencies (#944)
+- Internal: Upgrade dependencies [#944](https://github.com/pinterest/gestalt/pull/944)
 
 ## 5.5.0 (Jun 24, 2020)
 
 ### Minor
 
-- DatePicker: Fixed CSS for same date selection in range (#943)
+- DatePicker: Fixed CSS for same date selection in range [#943](https://github.com/pinterest/gestalt/pull/943)
 
 ## 5.4.0 (Jun 22, 2020)
 
 ### Minor
 
-- Internal: Enable flow types-first (#940)
+- Internal: Enable flow types-first [#940](https://github.com/pinterest/gestalt/pull/940)
 
 ## 5.3.0 (Jun 22, 2020)
 
 ### Minor
 
-- Link: add TapArea-like feedback (#933)
+- Link: add TapArea-like feedback [#933](https://github.com/pinterest/gestalt/pull/933)
 
 ## 5.2.5 (Jun 22, 2020)
 
 ### Patch
 
-- DatePicker: Fix "locale object was not found for the provided string" warning (#941)
+- DatePicker: Fix "locale object was not found for the provided string" warning [#941](https://github.com/pinterest/gestalt/pull/941)
 
 ## 5.2.4 (Jun 22, 2020)
 
 ### Patch
 
-- DatePicker: Fix onChange flowtype (#939)
+- DatePicker: Fix onChange flowtype [#939](https://github.com/pinterest/gestalt/pull/939)
 
 ## 5.2.3 (Jun 19, 2020)
 
 ### Patch
 
-- Docs: provide more layouts for <Combinantion /> (#934)
+- Docs: provide more layouts for <Combinantion /> [#934](https://github.com/pinterest/gestalt/pull/934)
 
 ## 5.2.2 (Jun 19, 2020)
 
 ### Patch
 
-- TapArea: Docs - Fix weird rounding on example (#935)
+- TapArea: Docs - Fix weird rounding on example [#935](https://github.com/pinterest/gestalt/pull/935)
 
 ## 5.2.1 (Jun 19, 2020)
 
 ### Patch
 
-- DatePicker: fix yarn flow-generate:css (#932)
+- DatePicker: fix yarn flow-generate:css [#932](https://github.com/pinterest/gestalt/pull/932)
 
 ## 5.2.0 (Jun 18, 2020)
 
 ### Minor
 
-- Masonry/defaultLayout: Add a layout `basicCentered` to center justify grid content (#929)
+- Masonry/defaultLayout: Add a layout `basicCentered` to center justify grid content [#929](https://github.com/pinterest/gestalt/pull/929)
 
 ## 5.1.0 (Jun 18, 2020)
 
 ### Minor
 
-- [DatePicker] New DatePicker component in new gestalt-datepicker package (#913)
+- [DatePicker] New DatePicker component in new gestalt-datepicker package [#913](https://github.com/pinterest/gestalt/pull/913)
 
 ## 5.0.1 (Jun 18, 2020)
 
 ### Patch
 
-- TapArea: fix codemod for React.Fragment use case (#930)
+- TapArea: fix codemod for React.Fragment use case [#930](https://github.com/pinterest/gestalt/pull/930)
 
 ## 5.0.0 (Jun 17, 2020)
 
 ### Major
 
-- Touchable/TapArea: replace Touchable with TapArea (#923)
+- Touchable/TapArea: replace Touchable with TapArea [#923](https://github.com/pinterest/gestalt/pull/923)
 
 ## 4.0.1 (Jun 16, 2020)
 
 ### Patch
 
-- [Video] Remove unused Flow suppression comment. (#928)
+- [Video] Remove unused Flow suppression comment. [#928](https://github.com/pinterest/gestalt/pull/928)
 
 ## 4.0.0 (Jun 16, 2020)
 
 ### Major
 
-- SearchField: Convert to Functional and Add ForwardRef (#926)
+- SearchField: Convert to Functional and Add ForwardRef [#926](https://github.com/pinterest/gestalt/pull/926)
 
 ## 3.2.0 (Jun 16, 2020)
 
 ### Minor
 
-- Row, Stack: Fix nullish child gap bug (#925)
+- Row, Stack: Fix nullish child gap bug [#925](https://github.com/pinterest/gestalt/pull/925)
 
 ## 3.1.0 (Jun 15, 2020)
 
 ### Minor
 
-- Internal: upgrade to flow 0.127.0 (#924)
+- Internal: upgrade to flow 0.127.0 [#924](https://github.com/pinterest/gestalt/pull/924)
 
 ## 3.0.2 (Jun 13, 2020)
 
 ### Patch
 
-- Internal: Request a Pinterest designer for design changes (#921)
+- Internal: Request a Pinterest designer for design changes [#921](https://github.com/pinterest/gestalt/pull/921)
 
 ## 3.0.1 (Jun 12, 2020)
 
 ### Patch
 
-- Touchable: displayName should still be Touchable (#922)
+- Touchable: displayName should still be Touchable [#922](https://github.com/pinterest/gestalt/pull/922)
 
 ## 3.0.0 (Jun 12, 2020)
 
 ### Major
 
-- Touchable: forward ref, touch feedback, and more (BREAKING CHANGE) (#906)
+- Touchable: forward ref, touch feedback, and more (BREAKING CHANGE) [#906](https://github.com/pinterest/gestalt/pull/906)
 
 ## 2.5.0 (Jun 12, 2020)
 
 ### Minor
 
-- Pog: Add padding prop (#911)
+- Pog: Add padding prop [#911](https://github.com/pinterest/gestalt/pull/911)
 
 ## 2.4.1 (Jun 12, 2020)
 
 ### Patch
 
-- Internal: Flow - enable exact_by_default (#920)
+- Internal: Flow - enable exact_by_default [#920](https://github.com/pinterest/gestalt/pull/920)
 
 ## 2.4.0 (Jun 12, 2020)
 
 ### Minor
 
-- Icon: add sparkle icon (#916)
+- Icon: add sparkle icon [#916](https://github.com/pinterest/gestalt/pull/916)
 
 ## 2.3.0 (Jun 11, 2020)
 
 ### Minor
 
-- Tabs: remove underline on hover/focus (#918)
+- Tabs: remove underline on hover/focus [#918](https://github.com/pinterest/gestalt/pull/918)
 
 ## 2.2.1 (Jun 10, 2020)
 
 ### Patch
 
-- Fix proptype (#914)
+- Fix proptype [#914](https://github.com/pinterest/gestalt/pull/914)
 
 ## 2.2.0 (Jun 10, 2020)
 
 ### Minor
 
-- Tooltip: fix state update on unmounted component warning (#912)
+- Tooltip: fix state update on unmounted component warning [#912](https://github.com/pinterest/gestalt/pull/912)
 
 ## 2.1.0 (Jun 9, 2020)
 
 ### Minor
 
-- TableHeader: Add optional sticky header (#900)
+- TableHeader: Add optional sticky header [#900](https://github.com/pinterest/gestalt/pull/900)
 
 ## 2.0.3 (Jun 9, 2020)
 
 ### Patch
 
-- Bump websocket-extensions from 0.1.3 to 0.1.4 (#904)
+- Bump websocket-extensions from 0.1.3 to 0.1.4 [#904](https://github.com/pinterest/gestalt/pull/904)
 
 ## 2.0.2 (Jun 9, 2020)
 
 ### Patch
 
-- Pulsar: change Flyout direction in docs (#908)
+- Pulsar: change Flyout direction in docs [#908](https://github.com/pinterest/gestalt/pull/908)
 
 ## 2.0.1 (Jun 5, 2020)
 
 ### Patch
 
-- TextField: fix forwardRef propType (#903)
+- TextField: fix forwardRef propType [#903](https://github.com/pinterest/gestalt/pull/903)
 
 ## 2.0.0 (Jun 5, 2020)
 
 ### Major
 
-- TextField: Add forward ref (BREAKING CHANGE) (#901)
+- TextField: Add forward ref (BREAKING CHANGE) [#901](https://github.com/pinterest/gestalt/pull/901)
 
 ## 1.63.0 (Jun 4, 2020)
 
 ### Minor
 
-- TableSortableHeaderCell: Change clickable area (#890)
+- TableSortableHeaderCell: Change clickable area [#890](https://github.com/pinterest/gestalt/pull/890)
 
 ## 1.62.0 (Jun 4, 2020)
 
 ### Minor
 
-- Docs: Add search (#895)
+- Docs: Add search [#895](https://github.com/pinterest/gestalt/pull/895)
 
 ## 1.61.1 (Jun 4, 2020)
 
 ### Patch
 
-- Box: don't add border properties for borderSize=none (#899)
+- Box: don't add border properties for borderSize=none [#899](https://github.com/pinterest/gestalt/pull/899)
 
 ## 1.61.0 (Jun 3, 2020)
 
 ### Minor
 
-- Docs: Use netlify for docs hosting + remove GitHub pages push (#897)
+- Docs: Use netlify for docs hosting + remove GitHub pages push [#897](https://github.com/pinterest/gestalt/pull/897)
 
 ## 1.60.3 (Jun 3, 2020)
 
 ### Patch
 
-- Docs: Add missing parameter for Toast (#896)
+- Docs: Add missing parameter for Toast [#896](https://github.com/pinterest/gestalt/pull/896)
 
 ## 1.60.2 (Jun 2, 2020)
 
 ### Patch
 
-- Internal: Add Pinterest Favicon to docs (#893)
+- Internal: Add Pinterest Favicon to docs [#893](https://github.com/pinterest/gestalt/pull/893)
 
 ## 1.60.1 (Jun 2, 2020)
 
 ### Patch
 
-- Button, IconButton, Touchable: Update docs and examples (#894)
+- Button, IconButton, Touchable: Update docs and examples [#894](https://github.com/pinterest/gestalt/pull/894)
 
 ## 1.60.0 (Jun 1, 2020)
 
 ### Minor
 
-- Touchable, Button, Icon: Add props so all of them have accessibilityControls, accessibilityExpanded, accessibilityHaspopup, accessibilityLabel and disabled (#889)
+- Touchable, Button, Icon: Add props so all of them have accessibilityControls, accessibilityExpanded, accessibilityHaspopup, accessibilityLabel and disabled [#889](https://github.com/pinterest/gestalt/pull/889)
 
 ## 1.59.0 (Jun 1, 2020)
 
 ### Minor
 
-- Tabs: Allow an id on tabs (#892)
+- Tabs: Allow an id on tabs [#892](https://github.com/pinterest/gestalt/pull/892)
 
 ## 1.58.1 (May 29, 2020)
 
 ### Patch
 
-- [Row, Stack] Add missing props to docs (#891)
+- [Row, Stack] Add missing props to docs [#891](https://github.com/pinterest/gestalt/pull/891)
 
 ## 1.58.0 (May 29, 2020)
 
 ### Minor
 
-- [Box, Flexbox, Row, Stack] Create Flexbox, Row, Stack components, DRY out Box types (#803)
+- [Box, Flexbox, Row, Stack] Create Flexbox, Row, Stack components, DRY out Box types [#803](https://github.com/pinterest/gestalt/pull/803)
 
 ## 1.57.1 (May 28, 2020)
 
 ### Patch
 
-- Table: Only show scrollbar when necessary (#887)
+- Table: Only show scrollbar when necessary [#887](https://github.com/pinterest/gestalt/pull/887)
 
 ## 1.57.0 (May 27, 2020)
 
 ### Minor
 
-- AvatarPair: add component (#880)
+- AvatarPair: add component [#880](https://github.com/pinterest/gestalt/pull/880)
 
 ## 1.56.0 (May 27, 2020)
 
 ### Minor
 
-- Table: Add sortable header cells (#878)
+- Table: Add sortable header cells [#878](https://github.com/pinterest/gestalt/pull/878)
 
 ## 1.55.5 (May 26, 2020)
 
 ### Patch
 
-- Icon: update check-circle (#881)
+- Icon: update check-circle [#881](https://github.com/pinterest/gestalt/pull/881)
 
 ## 1.55.4 (May 22, 2020)
 
 ### Patch
 
-- Internal: fix yarn watch keeps appending CSS (#877)
+- Internal: fix yarn watch keeps appending CSS [#877](https://github.com/pinterest/gestalt/pull/877)
 
 ## 1.55.3 (May 21, 2020)
 
 ### Patch
 
-- Modal: make focus state more specific (#875)
+- Modal: make focus state more specific [#875](https://github.com/pinterest/gestalt/pull/875)
 
 ## 1.55.2 (May 19, 2020)
 
 ### Patch
 
-- Flyout: shift caret left/right towards flyout to align with rounded corners (#844)
+- Flyout: shift caret left/right towards flyout to align with rounded corners [#844](https://github.com/pinterest/gestalt/pull/844)
 
 ## 1.55.1 (May 19, 2020)
 
 ### Patch
 
-- Internal: update flow-typed definitions (#873)
+- Internal: update flow-typed definitions [#873](https://github.com/pinterest/gestalt/pull/873)
 
 ## 1.55.0 (May 19, 2020)
 
 ### Minor
 
-- Internal: update devdependencies (Jest / Babel / StyleLint) (#872)
+- Internal: update devdependencies (Jest / Babel / StyleLint) [#872](https://github.com/pinterest/gestalt/pull/872)
 
 ## 1.54.0 (May 18, 2020)
 
 ### Minor
 
-- Modal: Fix shadows on scroll (#859)
+- Modal: Fix shadows on scroll [#859](https://github.com/pinterest/gestalt/pull/859)
 
 ## 1.53.0 (May 18, 2020)
 
 ### Minor
 
-- Icon: Update star icon (#858)
+- Icon: Update star icon [#858](https://github.com/pinterest/gestalt/pull/858)
 
 ## 1.52.3 (May 18, 2020)
 
 ### Patch
 
-- Internal: Remove unused boxperf.js (#868)
+- Internal: Remove unused boxperf.js [#868](https://github.com/pinterest/gestalt/pull/868)
 
 ## 1.52.2 (May 18, 2020)
 
@@ -7206,182 +7206,182 @@
 
 ### Patch
 
-- Internal: Use octokit/graphql-action@v2.0.0 (#867)
+- Internal: Use octokit/graphql-action@v2.0.0 [#867](https://github.com/pinterest/gestalt/pull/867)
 
 ## 1.52.0 (May 13, 2020)
 
 ### Minor
 
-- Table: Add TableFooter component (#850)
+- Table: Add TableFooter component [#850](https://github.com/pinterest/gestalt/pull/850)
 
 ## 1.51.0 (May 13, 2020)
 
 ### Minor
 
-- Table: Add table border prop (#851)
+- Table: Add table border prop [#851](https://github.com/pinterest/gestalt/pull/851)
 
 ## 1.50.0 (May 13, 2020)
 
 ### Minor
 
-- Icon: add star-half icon (#856)
+- Icon: add star-half icon [#856](https://github.com/pinterest/gestalt/pull/856)
 
 ## 1.49.4 (May 13, 2020)
 
 ### Patch
 
-- Internal: Fix Changelog formatting (#857)
+- Internal: Fix Changelog formatting [#857](https://github.com/pinterest/gestalt/pull/857)
 
 ## 1.49.3 (May 13, 2020)
 
 ### Patch
 
-- Internal: Cache yarn dependencies in CI (#854)
+- Internal: Cache yarn dependencies in CI [#854](https://github.com/pinterest/gestalt/pull/854)
 
 ## 1.49.2 (May 13, 2020)
 
 ### Patch
 
-- Internal: Require release type on every PR (#853)
+- Internal: Require release type on every PR [#853](https://github.com/pinterest/gestalt/pull/853)
 
 ## 1.49.1 (May 12, 2020)
 
 ### Patch
 
-- Button/IconButton: update white background colors (#852)
+- Button/IconButton: update white background colors [#852](https://github.com/pinterest/gestalt/pull/852)
 
 ## 1.49.0 (May 12, 2020)
 
 ### Minor
 
-- Internal: Release with every commit (#848)
+- Internal: Release with every commit [#848](https://github.com/pinterest/gestalt/pull/848)
 
 ## 1.48.0 (May 8, 2020)
 
 ### Minor
 
-- Table: add basic table components (#838)
-- Badge: Update to solid background and white text (#839)
-- Avatar: Update outline to 1px (#846)
+- Table: add basic table components [#838](https://github.com/pinterest/gestalt/pull/838)
+- Badge: Update to solid background and white text [#839](https://github.com/pinterest/gestalt/pull/839)
+- Avatar: Update outline to 1px [#846](https://github.com/pinterest/gestalt/pull/846)
 
 ### Patch
 
-- VideoControls: overwriting overflow default behavior on timestamp text (#845)
+- VideoControls: overwriting overflow default behavior on timestamp text [#845](https://github.com/pinterest/gestalt/pull/845)
 
 ## 1.47.0 (May 6, 2020)
 
 ### Minor
 
-- Flyout: Add flexible size prop to flyout (#840)
-- Icon: Add story pin icon (#842)
-- Internal: Enable + enforce flow strict on every file (#841)
+- Flyout: Add flexible size prop to flyout [#840](https://github.com/pinterest/gestalt/pull/840)
+- Icon: Add story pin icon [#842](https://github.com/pinterest/gestalt/pull/842)
+- Internal: Enable + enforce flow strict on every file [#841](https://github.com/pinterest/gestalt/pull/841)
 
 ### Patch
 
-- Flyout: Fix stroke on caret (#837)
+- Flyout: Fix stroke on caret [#837](https://github.com/pinterest/gestalt/pull/837)
 
 ## 1.46.1 (Apr 28, 2020)
 
 ### Patch
 
-- Readme: Remove greenkeeper reference (#835)
+- Readme: Remove greenkeeper reference [#835](https://github.com/pinterest/gestalt/pull/835)
 
 ## 1.46.0 (Apr 27, 2020)
 
 ### Minor
 
-- IconButton/Pog: Deprecated bgColor=blue in Pog and IconButton (#827)
-- Touchable: add optional onBlur / onFocus props (#832)
+- IconButton/Pog: Deprecated bgColor=blue in Pog and IconButton [#827](https://github.com/pinterest/gestalt/pull/827)
+- Touchable: add optional onBlur / onFocus props [#832](https://github.com/pinterest/gestalt/pull/832)
 
 ## 1.45.0 (Apr 23, 2020)
 
 ### Minor
 
-- SearchField: convert back to class component (#830)
+- SearchField: convert back to class component [#830](https://github.com/pinterest/gestalt/pull/830)
 
 ## 1.44.0 (Apr 23, 2020)
 
 ### Minor
 
-- SearchField: Update design (#819)
+- SearchField: Update design [#819](https://github.com/pinterest/gestalt/pull/819)
 
 ### Patch
 
-- Internal: Test builds on Node.js 14 (#826)
-- Docs: Refactored instances of class to function components in Docs (#817)
+- Internal: Test builds on Node.js 14 [#826](https://github.com/pinterest/gestalt/pull/826)
+- Docs: Refactored instances of class to function components in Docs [#817](https://github.com/pinterest/gestalt/pull/817)
 
 ## 1.43.0 (Apr 21, 2020)
 
 ### Minor
 
-- Tooltip: Show tooltip when React children have focus (#824)
-- IconButton/Pog: Removed unused iconColor options: blue, orange; added darkGray; added bgColor: darkGray (#823)
-- Docs: Replaced combinations in Pog with Combinations: Icon Color & Background Color. Removed IconButton-bgColor-blue option from Docs. (#823)
+- Tooltip: Show tooltip when React children have focus [#824](https://github.com/pinterest/gestalt/pull/824)
+- IconButton/Pog: Removed unused iconColor options: blue, orange; added darkGray; added bgColor: darkGray [#823](https://github.com/pinterest/gestalt/pull/823)
+- Docs: Replaced combinations in Pog with Combinations: Icon Color & Background Color. Removed IconButton-bgColor-blue option from Docs. [#823](https://github.com/pinterest/gestalt/pull/823)
 
 ### Patch
 
-- Internal: Enable React.Strict on documentation (#821)
-- Checkbox/Radiobutton: Updated checkbox and radiobutton borders for disabled state (disabled controls don't show outlines) (#795)
+- Internal: Enable React.Strict on documentation [#821](https://github.com/pinterest/gestalt/pull/821)
+- Checkbox/Radiobutton: Updated checkbox and radiobutton borders for disabled state (disabled controls don't show outlines) [#795](https://github.com/pinterest/gestalt/pull/795)
 
 ## 1.42.0 (Apr 20, 2020)
 
 ### Minor
 
-- RadioButton/Checkbox: Moved shared classes to RadioButtonCheckbox.css (#810)
-- Internal: update yarn.lock file (#814)
-- Internal: Minor version updates for several dependencies (#815)
-- Buttons/Tabs: Increase paddingX to 16px on lg Buttons and Tabs (#816)
+- RadioButton/Checkbox: Moved shared classes to RadioButtonCheckbox.css [#810](https://github.com/pinterest/gestalt/pull/810)
+- Internal: update yarn.lock file [#814](https://github.com/pinterest/gestalt/pull/814)
+- Internal: Minor version updates for several dependencies [#815](https://github.com/pinterest/gestalt/pull/815)
+- Buttons/Tabs: Increase paddingX to 16px on lg Buttons and Tabs [#816](https://github.com/pinterest/gestalt/pull/816)
 
 ### Patch
 
-- Docs: Add a note on the Tabs documentation about use with react-router (#813)
+- Docs: Add a note on the Tabs documentation about use with react-router [#813](https://github.com/pinterest/gestalt/pull/813)
 
 ## 1.41.0 (Apr 16, 2020)
 
 ### Minor
 
-- Color: update gray color to #767676 (#804)
-- Icon: update default #8e8e8e to #767676 (#811)
+- Color: update gray color to #767676 [#804](https://github.com/pinterest/gestalt/pull/804)
+- Icon: update default #8e8e8e to #767676 [#811](https://github.com/pinterest/gestalt/pull/811)
 
 ## 1.40.0 (Apr 15, 2020)
 
 ### Minor
 
-- Text/Heading: Use default (manual) hyphenation (#807)
+- Text/Heading: Use default (manual) hyphenation [#807](https://github.com/pinterest/gestalt/pull/807)
 
 ### Patch
 
-- Internal: remove reference to unused .integration.js (#808)
+- Internal: remove reference to unused .integration.js [#808](https://github.com/pinterest/gestalt/pull/808)
 
 ## 1.39.0 (Apr 14, 2020)
 
 ### Minor
 
-- SegmentedControl: Update the border radius from 8px outer / 6px inner to 16px outer / 14px inner (#798)
+- SegmentedControl: Update the border radius from 8px outer / 6px inner to 16px outer / 14px inner [#798](https://github.com/pinterest/gestalt/pull/798)
 
 ## 1.38.0 (Apr 13, 2020)
 
 ### Minor
 
-- Modal: support Flyout inside of a Modal (#793)
+- Modal: support Flyout inside of a Modal [#793](https://github.com/pinterest/gestalt/pull/793)
 
 ## 1.37.0 (Apr 3, 2020)
 
 ### Minor
 
-- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#782)
+- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) [#782](https://github.com/pinterest/gestalt/pull/782)
 
 ## 1.36.0 (Apr 3, 2020)
 
 ### Minor
 
-- Icon: Add code icon (#786)
+- Icon: Add code icon [#786](https://github.com/pinterest/gestalt/pull/786)
 
 ## 1.35.0 (Apr 2, 2020)
 
 ### Minor
 
-- Text: Remove prop `leading` and related css properties (#784)
+- Text: Remove prop `leading` and related css properties [#784](https://github.com/pinterest/gestalt/pull/784)
 
 Run codemods:
 cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.35.0-1.36.0/leading-text-remove.js ~/code/repo
@@ -7390,95 +7390,95 @@ cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.35.0-1
 
 ### Minor
 
-- Tooltip: Update border radius + adjust spacing (#786)
+- Tooltip: Update border radius + adjust spacing [#786](https://github.com/pinterest/gestalt/pull/786)
 
 ## 1.33.0 (Mar 31, 2020)
 
 ### Minor
 
-- Avatar: Add `__dangerouslyUseDefaultIcon` prop (#774)
+- Avatar: Add `__dangerouslyUseDefaultIcon` prop [#774](https://github.com/pinterest/gestalt/pull/774)
 
 ## 1.32.0 (Mar 31, 2020)
 
 ### Minor
 
-- Avatar/GroupAvatar: update sizes / default avatar / remove verified outline (#771)
+- Avatar/GroupAvatar: update sizes / default avatar / remove verified outline [#771](https://github.com/pinterest/gestalt/pull/771)
 
 ## 1.31.0 (Mar 31, 2020)
 
 ### Minor
 
-- [Revert] Modal: Update OutsideEventBehavior to work well with Portals (#778)
+- [Revert] Modal: Update OutsideEventBehavior to work well with Portals [#778](https://github.com/pinterest/gestalt/pull/778)
 
 ## 1.30.0 (Mar 30, 2020)
 
 ### Minor
 
-- Modal: Update OutsideEventBehavior to work well with Portals (#777)
+- Modal: Update OutsideEventBehavior to work well with Portals [#777](https://github.com/pinterest/gestalt/pull/777)
 
 ## 1.29.0 (Mar 27, 2020)
 
 ### Minor
 
-- IconButton/Pog: Add "red" backgroundColor + update icon sizes (#778)
+- IconButton/Pog: Add "red" backgroundColor + update icon sizes [#778](https://github.com/pinterest/gestalt/pull/778)
 
 ## 1.28.0 (Mar 27, 2020)
 
 ### Minor
 
-- Borders: Update lightgray border color to `#ddd` (#776)
+- Borders: Update lightgray border color to `#ddd` [#776](https://github.com/pinterest/gestalt/pull/776)
 
 ### Patch
 
-- Docs: Fix layout for 1 line code example (#779)
+- Docs: Fix layout for 1 line code example [#779](https://github.com/pinterest/gestalt/pull/779)
 
 ## 1.27.0 (Mar 26, 2020)
 
 ### Minor
 
-- Text: Remove deprecated prop `__dangerouslyIncreaseLineHeight` (#773)
+- Text: Remove deprecated prop `__dangerouslyIncreaseLineHeight` [#773](https://github.com/pinterest/gestalt/pull/773)
 
 ### Patch
 
-- SelectList: Remove selected prop from the placeholder option tag for better React support (#759)
+- SelectList: Remove selected prop from the placeholder option tag for better React support [#759](https://github.com/pinterest/gestalt/pull/759)
 
 ## 1.26.0 (Mar 25, 2020)
 
 ### Minor
 
-- Heading: Add align prop (#767)
-- Button: Add iconEnd prop (#766)
+- Heading: Add align prop [#767](https://github.com/pinterest/gestalt/pull/767)
+- Button: Add iconEnd prop [#766](https://github.com/pinterest/gestalt/pull/766)
 
 ## 1.25.0 (Mar 24, 2020)
 
 ### Minor
 
-- RadioButton: Updated style. Added built-in label (optional 'label' prop). (#749)
-- Checkbox: Updated style. Added built-in label (optional 'label' and 'errorMessage' props) (#749)
+- RadioButton: Updated style. Added built-in label (optional 'label' prop). [#749](https://github.com/pinterest/gestalt/pull/749)
+- Checkbox: Updated style. Added built-in label (optional 'label' and 'errorMessage' props) [#749](https://github.com/pinterest/gestalt/pull/749)
 
 ## 1.24.0 (Mar 23, 2020)
 
 ### Minor
 
-- Text/Heading: Update letter spacing to default (normal) (#764)
+- Text/Heading: Update letter spacing to default (normal) [#764](https://github.com/pinterest/gestalt/pull/764)
 
 ## 1.23.2 (Mar 20, 2020)
 
 ### Patch
 
-- Toast: Fix color proptypes (#762)
+- Toast: Fix color proptypes [#762](https://github.com/pinterest/gestalt/pull/762)
 
 ## 1.23.1 (Mar 20, 2020)
 
 ### Patch
 
-- Toast: add back the color `red` as a deprecated feature (#760)
+- Toast: add back the color `red` as a deprecated feature [#760](https://github.com/pinterest/gestalt/pull/760)
 
 ## 1.23.0 (Mar 20, 2020)
 
 ### Minor
 
-- Toast: Update design + remove icon/color + add thumbnailShape/button (#755)
+- Toast: Update design + remove icon/color + add thumbnailShape/button [#755](https://github.com/pinterest/gestalt/pull/755)
 
 Run codemods:
 `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.22.0-1.23.0/toast-remove-color-icon.js ~/code/repo`
@@ -7487,55 +7487,55 @@ Run codemods:
 
 ### Patch
 
-- SelectList: Update wrapper rounding (#756)
+- SelectList: Update wrapper rounding [#756](https://github.com/pinterest/gestalt/pull/756)
 
 ## 1.22.0 (Mar 16, 2020)
 
 ### Minor
 
-- Docs: Use same React version as package (#753)
+- Docs: Use same React version as package [#753](https://github.com/pinterest/gestalt/pull/753)
 
 ## 1.21.0 (Mar 16, 2020)
 
 ### Minor
 
-- Flyout: Responsive, updated sizes + minimum width (#743)
+- Flyout: Responsive, updated sizes + minimum width [#743](https://github.com/pinterest/gestalt/pull/743)
 
 ### Patch
 
-- Internal: upgrade packages (#751)
+- Internal: upgrade packages [#751](https://github.com/pinterest/gestalt/pull/751)
 
 ## 1.20.0 (Mar 12, 2020)
 
 ### Minor
 
-- RadioButton: Fix when container is set to overflow=auto (#745)
-- Icon: Add phone icon (#746)
+- RadioButton: Fix when container is set to overflow=auto [#745](https://github.com/pinterest/gestalt/pull/745)
+- Icon: Add phone icon [#746](https://github.com/pinterest/gestalt/pull/746)
 
 ### Patch
 
-- TextField / TextArea / SelectList: Fix error focus state (#744)
+- TextField / TextArea / SelectList: Fix error focus state [#744](https://github.com/pinterest/gestalt/pull/744)
 
 ## 1.19.0 (Mar 11, 2020)
 
 ### Minor
 
-- IconWithTooltip: Remove deprecated component (#741)
+- IconWithTooltip: Remove deprecated component [#741](https://github.com/pinterest/gestalt/pull/741)
 
 ## 1.18.0 (Mar 10, 2020)
 
 ### Minor
 
-- Flyout/Tooltip: Update spacing around to 8px when caret is hidden (#737)
-- Docs: Open in CodeSandbox & remove checkerbox from example (#735)
-- Internal: fail build when CSS flow changes are required (#738)
+- Flyout/Tooltip: Update spacing around to 8px when caret is hidden [#737](https://github.com/pinterest/gestalt/pull/737)
+- Docs: Open in CodeSandbox & remove checkerbox from example [#735](https://github.com/pinterest/gestalt/pull/735)
+- Internal: fail build when CSS flow changes are required [#738](https://github.com/pinterest/gestalt/pull/738)
 
 ## 1.17.0 (Mar 9, 2020)
 
 ### Minor
 
-- Icon: Add credit-card and conversion-tag icons (#716)
-- Box [Breaking]: Removes support to deprecated props deprecatedMargin & deprecatedPadding (#711)
+- Icon: Add credit-card and conversion-tag icons [#716](https://github.com/pinterest/gestalt/pull/716)
+- Box [Breaking]: Removes support to deprecated props deprecatedMargin & deprecatedPadding [#711](https://github.com/pinterest/gestalt/pull/711)
 
 Run codemods:
 
@@ -7546,17 +7546,17 @@ Run codemods:
 
 ### Minor
 
-- Tabs: Add white background, backgrounds for active and hover/focus states, 60px min width (#731)
+- Tabs: Add white background, backgrounds for active and hover/focus states, 60px min width [#731](https://github.com/pinterest/gestalt/pull/731)
 
 ### Patch
 
-- Internal: Detect and remove unused eslint disables (#723)
+- Internal: Detect and remove unused eslint disables [#723](https://github.com/pinterest/gestalt/pull/723)
 
 ## 1.15.0 (Mar 5, 2020)
 
 ### Minor
 
-- Text [Breaking]: Removes deprecated size=xl (#729)
+- Text [Breaking]: Removes deprecated size=xl [#729](https://github.com/pinterest/gestalt/pull/729)
 
 Run codemod:
 
@@ -7566,64 +7566,64 @@ Run codemod:
 
 ### Minor
 
-- Form Elements: Remove horizontal spacing for label / helperText and errorMessage (#727)
+- Form Elements: Remove horizontal spacing for label / helperText and errorMessage [#727](https://github.com/pinterest/gestalt/pull/727)
 
 ## 1.13.0 (Mar 5, 2020)
 
 ### Minor
 
-- Form fields: Add "lg" size option (#713)
+- Form fields: Add "lg" size option [#713](https://github.com/pinterest/gestalt/pull/713)
 
 ## 1.12.0 (Mar 4, 2020)
 
 ### Minor
 
-- Tabs: update horizontal padding to 12px (#698)
-- SelectList/TextArea/TextField: Update focus states (#720)
+- Tabs: update horizontal padding to 12px [#698](https://github.com/pinterest/gestalt/pull/698)
+- SelectList/TextArea/TextField: Update focus states [#720](https://github.com/pinterest/gestalt/pull/720)
 
 ### Patch
 
-- Docs: make checkerboard optional (#714)
+- Docs: make checkerboard optional [#714](https://github.com/pinterest/gestalt/pull/714)
 
 ## 1.11.1 (Mar 3, 2020)
 
 ### Patch
 
-- Tooltip: Bugfix: add layer (#717)
+- Tooltip: Bugfix: add layer [#717](https://github.com/pinterest/gestalt/pull/717)
 
 ## 1.11.0 (Mar 3, 2020)
 
 ### Minor
 
-- SelectList / TextField / TextArea: Add `label` and `helperText` props (#705)
-- Flyout: Make caret optional (#706)
+- SelectList / TextField / TextArea: Add `label` and `helperText` props [#705](https://github.com/pinterest/gestalt/pull/705)
+- Flyout: Make caret optional [#706](https://github.com/pinterest/gestalt/pull/706)
 
 ## 1.10.1 (Mar 2, 2020)
 
 ### Patch
 
-- Text / Heading: Made typography changes more backwards-compatible by adding xl size back in as deprecated feature (#707)
+- Text / Heading: Made typography changes more backwards-compatible by adding xl size back in as deprecated feature [#707](https://github.com/pinterest/gestalt/pull/707)
 
 ## 1.10.0 (Feb 28, 2020)
 
 ### Minor
 
-- Tooltip: Add ability to hover over tooltip and add a clickable link (#684)
-- Tooltip: Add idealDirection (#701)
-- IconWithTooltip: deprecate component (#690)
+- Tooltip: Add ability to hover over tooltip and add a clickable link [#684](https://github.com/pinterest/gestalt/pull/684)
+- Tooltip: Add idealDirection [#701](https://github.com/pinterest/gestalt/pull/701)
+- IconWithTooltip: deprecate component [#690](https://github.com/pinterest/gestalt/pull/690)
 
 ### Patch
 
-- Modal: [Docs] Fix default value for closeOnOutsideClick (#697)
-- Box/Mask/Sticky: [Docs] Added descriptions about usage to attributes accepting both string and number formats. (#703)
-- README: [Docs] Removed references and script to run integrations tests. (#702)
+- Modal: [Docs] Fix default value for closeOnOutsideClick [#697](https://github.com/pinterest/gestalt/pull/697)
+- Box/Mask/Sticky: [Docs] Added descriptions about usage to attributes accepting both string and number formats. [#703](https://github.com/pinterest/gestalt/pull/703)
+- README: [Docs] Removed references and script to run integrations tests. [#702](https://github.com/pinterest/gestalt/pull/702)
 
 ## 1.9.0 (Feb 27, 2020)
 
 ### Minor
 
-- Text / Heading [Breaking]: Added codemod to support breaking changes from #693 (removed support for responsive size prop values smSize, mdSize, and lgSize in Text and Heading component) (#696)
-- Heading / Text [Breaking]: Reduce size options from xs-xl to sm-lg (#693)
+- Text / Heading [Breaking]: Added codemod to support breaking changes from #693 (removed support for responsive size prop values smSize, mdSize, and lgSize in Text and Heading component) [#696](https://github.com/pinterest/gestalt/pull/696)
+- Heading / Text [Breaking]: Reduce size options from xs-xl to sm-lg [#693](https://github.com/pinterest/gestalt/pull/693)
 
 Run codemods for breaking changes in order:
 
@@ -7635,34 +7635,34 @@ Run codemods for breaking changes in order:
 
 ### Minor
 
-- SelectList / TextField / TextArea: Update design (#664)
+- SelectList / TextField / TextArea: Update design [#664](https://github.com/pinterest/gestalt/pull/664)
 
 ## 1.7.1 (Feb 26, 2020)
 
 ### Minor
 
-- Modal: Fix extra border between content / footer (#694)
-- Text/Heading: Revert letter spacing changes (#694)
+- Modal: Fix extra border between content / footer [#694](https://github.com/pinterest/gestalt/pull/694)
+- Text/Heading: Revert letter spacing changes [#694](https://github.com/pinterest/gestalt/pull/694)
 
 ## 1.7.0 (Feb 25, 2020)
 
 ### Minor
 
-- Button: update horizontal padding to 12px (#688)
-- [Revert] Flyout: Update spacing around items to 8px + remove caret code (#668)
-- [Revert] Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#667)
+- Button: update horizontal padding to 12px [#688](https://github.com/pinterest/gestalt/pull/688)
+- [Revert] Flyout: Update spacing around items to 8px + remove caret code [#668](https://github.com/pinterest/gestalt/pull/668)
+- [Revert] Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) [#667](https://github.com/pinterest/gestalt/pull/667)
 
 ## 1.6.0 (Feb 25, 2020)
 
-- Internal: Update Node.js version to 12.x (#686)
-- Internal: update yarn.lock file (#687)
+- Internal: Update Node.js version to 12.x [#686](https://github.com/pinterest/gestalt/pull/686)
+- Internal: update yarn.lock file [#687](https://github.com/pinterest/gestalt/pull/687)
 
 ## 1.5.0 (Feb 25, 2020)
 
 ### Minor
 
-- Box: Add `borderSize` prop for styling borders (#678)
-- Modal: visual refresh + heading optional + add closeOnOutsideClick (#680)
+- Box: Add `borderSize` prop for styling borders [#678](https://github.com/pinterest/gestalt/pull/678)
+- Modal: visual refresh + heading optional + add closeOnOutsideClick [#680](https://github.com/pinterest/gestalt/pull/680)
 
 Codemods:
 `cd gestalt; yarn run codemod --parser=flow -t=packages/gestalt-codemods/1.3.0-1.4.0/modal-remove-close-label.js ~/code/repo`
@@ -7671,37 +7671,37 @@ Codemods:
 
 ### Minor
 
-- Internal: Detect invalid composes in CSS modules (#676)
-- Internal: Flowtype CSS files in CI (#675)
-- Internal: Add code of conduct & powered by netlify link (#679)
-- Text/Heading: Update letter spacing to default (#681)
+- Internal: Detect invalid composes in CSS modules [#676](https://github.com/pinterest/gestalt/pull/676)
+- Internal: Flowtype CSS files in CI [#675](https://github.com/pinterest/gestalt/pull/675)
+- Internal: Add code of conduct & powered by netlify link [#679](https://github.com/pinterest/gestalt/pull/679)
+- Text/Heading: Update letter spacing to default [#681](https://github.com/pinterest/gestalt/pull/681)
 
 ## 1.3.0 (Feb 20, 2020)
 
-- Modal / SegmentedControl / Card: Fix corner radius (#672)
+- Modal / SegmentedControl / Card: Fix corner radius [#672](https://github.com/pinterest/gestalt/pull/672)
 
 ## 1.2.0 (Feb 20, 2020)
 
 ### Minor
 
-- Internal: Update dependencies (#671)
+- Internal: Update dependencies [#671](https://github.com/pinterest/gestalt/pull/671)
 
 ### Patch
 
-- Heading: removed unused weight prop from docs (#653)
+- Heading: removed unused weight prop from docs [#653](https://github.com/pinterest/gestalt/pull/653)
 
 ## 1.1.0 (Feb 20, 2020)
 
 ### Minor
 
-- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) (#667)
+- Masonry: Allow string enum types for Masonry layout prop (in prep of removing symbols/classes) [#667](https://github.com/pinterest/gestalt/pull/667)
 
 ## 1.0.0 (Feb 20, 2020)
 
 ### Major
 
-- Box / Touchable [Breaking]: Removed support for `shape` prop values `roundedTop`, `roundedRight`, `roundedBottom`, and `roundedLeft` (#657)
-- Box / Mask / Touchable [Breaking]: Replace `shape` prop with `rounding` (#666)
+- Box / Touchable [Breaking]: Removed support for `shape` prop values `roundedTop`, `roundedRight`, `roundedBottom`, and `roundedLeft` [#657](https://github.com/pinterest/gestalt/pull/657)
+- Box / Mask / Touchable [Breaking]: Replace `shape` prop with `rounding` [#666](https://github.com/pinterest/gestalt/pull/666)
 
 Run codemods for breaking changes in order:
 
@@ -7710,30 +7710,30 @@ Run codemods for breaking changes in order:
 
 ### Minor
 
-- Flyout: Remove caret, update shadow (#663)
-- Flyout: Update spacing around items to 8px + remove caret code (#668)
+- Flyout: Remove caret, update shadow [#663](https://github.com/pinterest/gestalt/pull/663)
+- Flyout: Update spacing around items to 8px + remove caret code [#668](https://github.com/pinterest/gestalt/pull/668)
 
 ## 0.125.0 (Feb 16, 2020)
 
 ### Minor
 
-- IconButton/Pog: Add darkGray background option (#659)
-- Tabs: update states + improve docs & test coverage (#658)
-- Button/IconButton/Pog: Convert 'darkGray' color to selected state (#661)
+- IconButton/Pog: Add darkGray background option [#659](https://github.com/pinterest/gestalt/pull/659)
+- Tabs: update states + improve docs & test coverage [#658](https://github.com/pinterest/gestalt/pull/658)
+- Button/IconButton/Pog: Convert 'darkGray' color to selected state [#661](https://github.com/pinterest/gestalt/pull/661)
 
 ## 0.124.0 (Feb 12, 2020)
 
 ### Minor
 
-- Box: Add new prop `opacity` to set css opacity with values 0 to 1 in tenth increments. (#654)
-- Button: Update border radius / small size + add dark gray option (#655)
+- Box: Add new prop `opacity` to set css opacity with values 0 to 1 in tenth increments. [#654](https://github.com/pinterest/gestalt/pull/654)
+- Button: Update border radius / small size + add dark gray option [#655](https://github.com/pinterest/gestalt/pull/655)
 
 ## 0.123.0 (Feb 7, 2020)
 
 ### Minor
 
-- Color: update dark gray color to #111 (#648)
-- Masonry: Shipped "fixFetchMoreBug" behavior and removed flag. This makes Masonry fetch less aggressively in some cases. (#651)
+- Color: update dark gray color to #111 [#648](https://github.com/pinterest/gestalt/pull/648)
+- Masonry: Shipped "fixFetchMoreBug" behavior and removed flag. This makes Masonry fetch less aggressively in some cases. [#651](https://github.com/pinterest/gestalt/pull/651)
 
 ## 0.122.3 (Jan 30, 2020)
 
@@ -7745,240 +7745,240 @@ Run codemods for breaking changes in order:
 
 ### Patch
 
-- Masonry: Reverts the past update to `wait`. Turns out this was more dangerous than expected, and we should experiment on it later. (#645)
+- Masonry: Reverts the past update to `wait`. Turns out this was more dangerous than expected, and we should experiment on it later. [#645](https://github.com/pinterest/gestalt/pull/645)
 
 ## 0.122.1 (Jan 29, 2020)
 
 ### Patch
 
-- Masonry: Add a `wait` value for throttling updateScrollPosition (#641)
+- Masonry: Add a `wait` value for throttling updateScrollPosition [#641](https://github.com/pinterest/gestalt/pull/641)
 
 ## 0.122.0 (Jan 28, 2020)
 
 ### Minor
 
-- Icon: Update existing workflow icon svg for ok, halted, problem, unstarted, in progress and warning (#638)
-- Icon: Added newline in css file and removed comment (#637)
-- Icon: Add right-to-left locales flip style support (#631)
+- Icon: Update existing workflow icon svg for ok, halted, problem, unstarted, in progress and warning [#638](https://github.com/pinterest/gestalt/pull/638)
+- Icon: Added newline in css file and removed comment [#637](https://github.com/pinterest/gestalt/pull/637)
+- Icon: Add right-to-left locales flip style support [#631](https://github.com/pinterest/gestalt/pull/631)
 
 ### Patch
 
-- Docs: Update docs to wrap Flyouts, Modals, and Tooltips in Layers so they don't get overlapped by example code (#639)
+- Docs: Update docs to wrap Flyouts, Modals, and Tooltips in Layers so they don't get overlapped by example code [#639](https://github.com/pinterest/gestalt/pull/639)
 
 ## 0.121.0 (Jan 21, 2020)
 
 ### Minor
 
-- Switch: Add right-to-left locales flip style support (#628)
-- Flow: Upgrade to version 0.116.1 (#635)
+- Switch: Add right-to-left locales flip style support [#628](https://github.com/pinterest/gestalt/pull/628)
+- Flow: Upgrade to version 0.116.1 [#635](https://github.com/pinterest/gestalt/pull/635)
 
 ## 0.120.0 (Jan 20, 2020)
 
 ### Patch
 
-- Stats: Calculate raw and percentage number of gestalt components vs native components (#627)
-- Masonry: Add a flag to optionally fix a bug (see PR notes) (#632)
+- Stats: Calculate raw and percentage number of gestalt components vs native components [#627](https://github.com/pinterest/gestalt/pull/627)
+- Masonry: Add a flag to optionally fix a bug (see PR notes) [#632](https://github.com/pinterest/gestalt/pull/632)
 
 ## 0.113.3 (Jan 13, 2020)
 
 ### Patch
 
-- Internal: Update GitHub pages publish script (#625)
+- Internal: Update GitHub pages publish script [#625](https://github.com/pinterest/gestalt/pull/625)
 
 ## 0.113.2 (Jan 13, 2020)
 
 ### Patch
 
-- Internal: Update GitHub pages publish script (#624)
+- Internal: Update GitHub pages publish script [#624](https://github.com/pinterest/gestalt/pull/624)
 
 ## 0.113.1 (Jan 13, 2020)
 
 ### Patch
 
-- Button: Fix spelling mistake in the docs (#622)
-- Internal: Fix the publish to GitHub pages (#621)
+- Button: Fix spelling mistake in the docs [#622](https://github.com/pinterest/gestalt/pull/622)
+- Internal: Fix the publish to GitHub pages [#621](https://github.com/pinterest/gestalt/pull/621)
 
 ## 0.113.0 (Jan 9, 2020)
 
 ### Minor
 
-- Icon: Add workflow-status-all icon (#614)
-- Icon: Add workflow-status-warning icon (#616)
-- IconWithTooltip: Add component and tests (#609)
-- IconWithTooltip: Improve accessibility and convert component to hooks (#618)
+- Icon: Add workflow-status-all icon [#614](https://github.com/pinterest/gestalt/pull/614)
+- Icon: Add workflow-status-warning icon [#616](https://github.com/pinterest/gestalt/pull/616)
+- IconWithTooltip: Add component and tests [#609](https://github.com/pinterest/gestalt/pull/609)
+- IconWithTooltip: Improve accessibility and convert component to hooks [#618](https://github.com/pinterest/gestalt/pull/618)
 
 ### Patch
 
-- IconButton: Convert examples & component to use hooks (#612)
-- Internal: Convert from Travis.ci to GitHub workflows (#610)
-- Internal: include flow warnings in error output (#611)
-- Internal: Perform releases with GitHub CI (#615)
-- Link: Convert component to use hooks (#613)
+- IconButton: Convert examples & component to use hooks [#612](https://github.com/pinterest/gestalt/pull/612)
+- Internal: Convert from Travis.ci to GitHub workflows [#610](https://github.com/pinterest/gestalt/pull/610)
+- Internal: include flow warnings in error output [#611](https://github.com/pinterest/gestalt/pull/611)
+- Internal: Perform releases with GitHub CI [#615](https://github.com/pinterest/gestalt/pull/615)
+- Link: Convert component to use hooks [#613](https://github.com/pinterest/gestalt/pull/613)
 
 ## 0.112.0 (Dec 10, 2019)
 
 ### Minor
 
-- Icon: Add info-circle icon (#604)
-- Icon: Add workflow-status-in-progress icon (#604)
-- Icon: Add workflow-status-ok icon (#604)
-- Icon: Add workflow-status-problem icon (#604)
-- Icon: Add workflow-status-unstarted icon (#604)
-- Text/Heading: Remove semibold (#607)
+- Icon: Add info-circle icon [#604](https://github.com/pinterest/gestalt/pull/604)
+- Icon: Add workflow-status-in-progress icon [#604](https://github.com/pinterest/gestalt/pull/604)
+- Icon: Add workflow-status-ok icon [#604](https://github.com/pinterest/gestalt/pull/604)
+- Icon: Add workflow-status-problem icon [#604](https://github.com/pinterest/gestalt/pull/604)
+- Icon: Add workflow-status-unstarted icon [#604](https://github.com/pinterest/gestalt/pull/604)
+- Text/Heading: Remove semibold [#607](https://github.com/pinterest/gestalt/pull/607)
 
 ## 0.111.0 (Dec 9, 2019)
 
 ### Minor
 
-- Pog: Add `orange` icon color prop to be passed as a value (#602)
-- Icon: Add directional-arrow-left icon (#605)
-- Icon: Add directional-arrow-right icon (#605)
-- IconButton: Allow `orange` icon color prop to be passed as a value (#602)
-- Video: Improve video seeking (#601)
+- Pog: Add `orange` icon color prop to be passed as a value [#602](https://github.com/pinterest/gestalt/pull/602)
+- Icon: Add directional-arrow-left icon [#605](https://github.com/pinterest/gestalt/pull/605)
+- Icon: Add directional-arrow-right icon [#605](https://github.com/pinterest/gestalt/pull/605)
+- IconButton: Allow `orange` icon color prop to be passed as a value [#602](https://github.com/pinterest/gestalt/pull/602)
+- Video: Improve video seeking [#601](https://github.com/pinterest/gestalt/pull/601)
 
 ### Patch
 
-- Avatar: Convert component to use hooks (#598)
-- Card: Convert examples & component to use hooks (#597)
-- Checkbox: Convert examples & component to use hooks (#600)
-- Internal: Add `react-testing-library` (#598)
-- Internal: Enable `react-hooks/exhaustive-deps` lint rule (#598)
-- Internal: Remove `concurrently` dependency (#599)
-- Internal: Convert tests to React Testing Library (#603)
+- Avatar: Convert component to use hooks [#598](https://github.com/pinterest/gestalt/pull/598)
+- Card: Convert examples & component to use hooks [#597](https://github.com/pinterest/gestalt/pull/597)
+- Checkbox: Convert examples & component to use hooks [#600](https://github.com/pinterest/gestalt/pull/600)
+- Internal: Add `react-testing-library` [#598](https://github.com/pinterest/gestalt/pull/598)
+- Internal: Enable `react-hooks/exhaustive-deps` lint rule [#598](https://github.com/pinterest/gestalt/pull/598)
+- Internal: Remove `concurrently` dependency [#599](https://github.com/pinterest/gestalt/pull/599)
+- Internal: Convert tests to React Testing Library [#603](https://github.com/pinterest/gestalt/pull/603)
 
 ## 0.110.0 (Nov 27, 2019)
 
 ### Minor
 
-- Internal: Upgrade react-scripts / babel7 & jest (#592)
-- Internal: upgrade gestalt package dependencies (#595)
+- Internal: Upgrade react-scripts / babel7 & jest [#592](https://github.com/pinterest/gestalt/pull/592)
+- Internal: upgrade gestalt package dependencies [#595](https://github.com/pinterest/gestalt/pull/595)
 
 ## 0.109.0 (Nov 25, 2019)
 
 ### Minor
 
-- Text / Heading: Add semibold weight (#591)
-- Internal: Introduce codemod unit tests (#591)
+- Text / Heading: Add semibold weight [#591](https://github.com/pinterest/gestalt/pull/591)
+- Internal: Introduce codemod unit tests [#591](https://github.com/pinterest/gestalt/pull/591)
 
 ## 0.108.0 (Nov 18, 2019)
 
 ### Minor
 
-- Colors: Update blue color with higher contrast version (improved a11y) (#589)
+- Colors: Update blue color with higher contrast version (improved a11y) [#589](https://github.com/pinterest/gestalt/pull/589)
 
 ## 0.107.0 (Nov 14, 2019)
 
 ### Minor
 
-- ScrollFetch: Fixed a tiny flow type bug on the default props (#587)
+- ScrollFetch: Fixed a tiny flow type bug on the default props [#587](https://github.com/pinterest/gestalt/pull/587)
 
 ## 0.106.0 (Nov 12, 2019)
 
 ### Minor
 
-- defaultProps: Remove the last React defaultProps and transfer it to the already existing but empty ES6 static defaultProps on the same file (#568)
-- Video: add onPlayheadDown and onPlayheadUp callbacks (#585)
+- defaultProps: Remove the last React defaultProps and transfer it to the already existing but empty ES6 static defaultProps on the same file [#568](https://github.com/pinterest/gestalt/pull/568)
+- Video: add onPlayheadDown and onPlayheadUp callbacks [#585](https://github.com/pinterest/gestalt/pull/585)
 
 ## 0.105.0 (Oct 22, 2019)
 
 ### Minor
 
-- IconButton: Allow `blue` background color prop to be passed as a value (#572)
-- Pog: Add `blue` background color prop to be passed as a value (#572)
-- Masonry: Fixed a bug where all grids shared the same default measurement store (#573)
-- Icon: Add new add-layout icon (#574)
-- Flyout: Remove the lightgray border between content and caret on white flyouts (#576)
-- Contents/Controller: Remove UNSAFE\_ methods in favor of supported ones (#570)
+- IconButton: Allow `blue` background color prop to be passed as a value [#572](https://github.com/pinterest/gestalt/pull/572)
+- Pog: Add `blue` background color prop to be passed as a value [#572](https://github.com/pinterest/gestalt/pull/572)
+- Masonry: Fixed a bug where all grids shared the same default measurement store [#573](https://github.com/pinterest/gestalt/pull/573)
+- Icon: Add new add-layout icon [#574](https://github.com/pinterest/gestalt/pull/574)
+- Flyout: Remove the lightgray border between content and caret on white flyouts [#576](https://github.com/pinterest/gestalt/pull/576)
+- Contents/Controller: Remove UNSAFE\_ methods in favor of supported ones [#570](https://github.com/pinterest/gestalt/pull/570)
 
 ## 0.104.0 (Oct 3, 2019)
 
 ### Minor
 
-- Icon: Replace existing filter icon (#565)
-- Contents/Controller: Replace componentWillReceiveProps with UNSAFE_componentWillReceiveProps (#566)
-- Icon: Add new replace/scale icons (#567)
+- Icon: Replace existing filter icon [#565](https://github.com/pinterest/gestalt/pull/565)
+- Contents/Controller: Replace componentWillReceiveProps with UNSAFE_componentWillReceiveProps [#566](https://github.com/pinterest/gestalt/pull/566)
+- Icon: Add new replace/scale icons [#567](https://github.com/pinterest/gestalt/pull/567)
 
 ## 0.103.0 (Aug 19, 2019)
 
 ### Minor
 
-- Spinner: Add `size` prop which can be passed `sm` or `md` as a value (#553)
-- Icon: Replace existing folder and file-unknown icon (#562)
+- Spinner: Add `size` prop which can be passed `sm` or `md` as a value [#553](https://github.com/pinterest/gestalt/pull/553)
+- Icon: Replace existing folder and file-unknown icon [#562](https://github.com/pinterest/gestalt/pull/562)
 
 ## 0.102.0 (Aug 6, 2019)
 
 ### Minor
 
-- Box: Allow `justifyContent` and `alignContent` props to be passed `evenly` as a value (#557)
+- Box: Allow `justifyContent` and `alignContent` props to be passed `evenly` as a value [#557](https://github.com/pinterest/gestalt/pull/557)
 
 ## 0.101.0 (Jul 31, 2019)
 
 ### Minor
 
-- SearchField: Remove the white background color of the outer box to make its corners looks correct on backgrounds with colors different than white (#552)
-- Icon: Add new folder and file-unknown icon (#554)
+- SearchField: Remove the white background color of the outer box to make its corners looks correct on backgrounds with colors different than white [#552](https://github.com/pinterest/gestalt/pull/552)
+- Icon: Add new folder and file-unknown icon [#554](https://github.com/pinterest/gestalt/pull/554)
 
 ## 0.100.0 (Jul 23, 2019)
 
 ### Minor
 
-- Enzyme: Upgrade to the latest `v3.10.0` version and pull in Flow library changes (#543)
-- Eslint: Bump all related packages/plugins to current latest version (#544)
-- Button: add new `textColor` prop to allow overriding of text color for buttons (#545)
-- Icon: Add new lightning icon (#547)
-- Icon: Update send icon (#549)
-- SegmentedControl: Fixup some extra CSS that was messing with Tooltips (#550)
+- Enzyme: Upgrade to the latest `v3.10.0` version and pull in Flow library changes [#543](https://github.com/pinterest/gestalt/pull/543)
+- Eslint: Bump all related packages/plugins to current latest version [#544](https://github.com/pinterest/gestalt/pull/544)
+- Button: add new `textColor` prop to allow overriding of text color for buttons [#545](https://github.com/pinterest/gestalt/pull/545)
+- Icon: Add new lightning icon [#547](https://github.com/pinterest/gestalt/pull/547)
+- Icon: Update send icon [#549](https://github.com/pinterest/gestalt/pull/549)
+- SegmentedControl: Fixup some extra CSS that was messing with Tooltips [#550](https://github.com/pinterest/gestalt/pull/550)
 
 ## 0.99.0 (Jun 21, 2019)
 
 ### Minor
 
-- SegmentedControl: Update outer border radius to 8px from new design spec (#530)
-- Masonry: remove `MasonryBeta` and `MasonryInfiniteBeta` from source code (#531)
-- Spinner: add `delay` prop to optionally remove 300ms delay to appear (#533)
-- Button: Undo Button border radii changes for full width buttons. Conform all to 8px (#534)
-- IconButton/Pog: Add `dangerouslySetSvgPath` support (#536)
-- Flow: Bumping to latest version `v0.101.0` (#539)
-- TextField/TextArea/SelectList/Checkbox: Switch from orange to red error states (#540)
+- SegmentedControl: Update outer border radius to 8px from new design spec [#530](https://github.com/pinterest/gestalt/pull/530)
+- Masonry: remove `MasonryBeta` and `MasonryInfiniteBeta` from source code [#531](https://github.com/pinterest/gestalt/pull/531)
+- Spinner: add `delay` prop to optionally remove 300ms delay to appear [#533](https://github.com/pinterest/gestalt/pull/533)
+- Button: Undo Button border radii changes for full width buttons. Conform all to 8px [#534](https://github.com/pinterest/gestalt/pull/534)
+- IconButton/Pog: Add `dangerouslySetSvgPath` support [#536](https://github.com/pinterest/gestalt/pull/536)
+- Flow: Bumping to latest version `v0.101.0` [#539](https://github.com/pinterest/gestalt/pull/539)
+- TextField/TextArea/SelectList/Checkbox: Switch from orange to red error states [#540](https://github.com/pinterest/gestalt/pull/540)
 
 ### Patch
 
-- Box: Fixed name minification bug and missing PropType from my recent margin:auto change (#532)
+- Box: Fixed name minification bug and missing PropType from my recent margin:auto change [#532](https://github.com/pinterest/gestalt/pull/532)
 
 ## 0.98.0 (May 28, 2019)
 
 ### Minor
 
-- Box: `margin` prop now supports `auto` for use in flexbox layouts (#528)
-- Icon: Update `flashlight` icon to use new asset (#527)
-- Icon: Add new icon of `heart-outline` and update icon of `heart` (#526)
+- Box: `margin` prop now supports `auto` for use in flexbox layouts [#528](https://github.com/pinterest/gestalt/pull/528)
+- Icon: Update `flashlight` icon to use new asset [#527](https://github.com/pinterest/gestalt/pull/527)
+- Icon: Add new icon of `heart-outline` and update icon of `heart` [#526](https://github.com/pinterest/gestalt/pull/526)
 
 ### Patch
 
-- Typography: Fixed a tiny bug where our CSS file had a few uses of curly quotes instead of regular quotes (#524)
+- Typography: Fixed a tiny bug where our CSS file had a few uses of curly quotes instead of regular quotes [#524](https://github.com/pinterest/gestalt/pull/524)
 
 ## 0.97.0 (May 15, 2019)
 
 ### Minor
 
-- IconButton: Add new `disabled` prop and stylings to `IconButton` component (#521)
-- Icon: Add new icon of `ads-stats` and `ads-overview` (#522)
+- IconButton: Add new `disabled` prop and stylings to `IconButton` component [#521](https://github.com/pinterest/gestalt/pull/521)
+- Icon: Add new icon of `ads-stats` and `ads-overview` [#522](https://github.com/pinterest/gestalt/pull/522)
 
 ## 0.96.0 (May 6, 2019)
 
 ### Minor
 
-- Icon: add calendar icon to gestalt (#512)
-- Icon: add lightning bolt icon (#513)
-- Flow: upgrade version to 0.97.0 (#515)
+- Icon: add calendar icon to gestalt [#512](https://github.com/pinterest/gestalt/pull/512)
+- Icon: add lightning bolt icon [#513](https://github.com/pinterest/gestalt/pull/513)
+- Flow: upgrade version to 0.97.0 [#515](https://github.com/pinterest/gestalt/pull/515)
 
 ## 0.95.0 (April 10, 2019)
 
 ### Minor
 
-- Tooltip: remove focus from revealing Tooltip (#506)
-- TextField: Add autocomplete prop value to TextField (#508)
-- Upgrade flow version to 0.96.0 (#509)
+- Tooltip: remove focus from revealing Tooltip [#506](https://github.com/pinterest/gestalt/pull/506)
+- TextField: Add autocomplete prop value to TextField [#508](https://github.com/pinterest/gestalt/pull/508)
+- Upgrade flow version to 0.96.0 [#509](https://github.com/pinterest/gestalt/pull/509)
 
 ### Patch
 
@@ -7986,402 +7986,402 @@ Run codemods for breaking changes in order:
 
 ### Minor
 
-- Icon: add some new text related icons (#496)
-- Modal: add a new sizing option to Modal to match Flyout (#499)
-- Modal: add the ability to set a custom header beyond text (#500)
-- Tooltip: introduce new Tooltip wrapper component (#501)
-- Touchable: cleanup event handlers (#502)
-- TextArea/TextField/SelectList: cleanup components and remove gDSFP (#503)
-- Upgrade React version to [16.8.5](https://github.com/facebook/react/releases/tag/v16.8.5) (#504)
+- Icon: add some new text related icons [#496](https://github.com/pinterest/gestalt/pull/496)
+- Modal: add a new sizing option to Modal to match Flyout [#499](https://github.com/pinterest/gestalt/pull/499)
+- Modal: add the ability to set a custom header beyond text [#500](https://github.com/pinterest/gestalt/pull/500)
+- Tooltip: introduce new Tooltip wrapper component [#501](https://github.com/pinterest/gestalt/pull/501)
+- Touchable: cleanup event handlers [#502](https://github.com/pinterest/gestalt/pull/502)
+- TextArea/TextField/SelectList: cleanup components and remove gDSFP [#503](https://github.com/pinterest/gestalt/pull/503)
+- Upgrade React version to [16.8.5](https://github.com/facebook/react/releases/tag/v16.8.5) [#504](https://github.com/pinterest/gestalt/pull/504)
 
 ## 0.93.0 (March 13, 2019)
 
-- Mask: add new prop `willChangeTransform` default true which can turn off willChange:transform property in CSS (#494)
+- Mask: add new prop `willChangeTransform` default true which can turn off willChange:transform property in CSS [#494](https://github.com/pinterest/gestalt/pull/494)
 
 ## 0.92.0 (March 7, 2019)
 
 ### Minor
 
-- SelectList, TextArea, TextField: Remove Flyout error message, use new FormErrorMessage (#486)
-- Icon: Add new video-camera icon (#491)
-- Avatar: Fixed a bug in MS Edge where text was not vertically centered (#492)
+- SelectList, TextArea, TextField: Remove Flyout error message, use new FormErrorMessage [#486](https://github.com/pinterest/gestalt/pull/486)
+- Icon: Add new video-camera icon [#491](https://github.com/pinterest/gestalt/pull/491)
+- Avatar: Fixed a bug in MS Edge where text was not vertically centered [#492](https://github.com/pinterest/gestalt/pull/492)
 
 ## 0.91.0 (March 1, 2019)
 
 ### Minor
 
-- Flyout: Apply the box shadow to Flyout at all times (#488)
+- Flyout: Apply the box shadow to Flyout at all times [#488](https://github.com/pinterest/gestalt/pull/488)
 
 ### Patch
 
-- Docs: Update remaining prop tables to include links to examples (#487)
-- Docs: Improve Image description (#481)
+- Docs: Update remaining prop tables to include links to examples [#487](https://github.com/pinterest/gestalt/pull/487)
+- Docs: Improve Image description [#481](https://github.com/pinterest/gestalt/pull/481)
 
 ## 0.90.0 (February 19, 2019)
 
 ### Minor
 
-- Update fill-transparent icon (#483)
-- Upgrade flow version to [0.84.0](https://github.com/facebook/flow/releases/tag/v0.84.0) (#479)
-- Layer: `children` prop is now required (#479)
+- Update fill-transparent icon [#483](https://github.com/pinterest/gestalt/pull/483)
+- Upgrade flow version to [0.84.0](https://github.com/facebook/flow/releases/tag/v0.84.0) [#479](https://github.com/pinterest/gestalt/pull/479)
+- Layer: `children` prop is now required [#479](https://github.com/pinterest/gestalt/pull/479)
 
 ## 0.89.0 (February 15, 2019)
 
 ### Minor
 
-- Upgrade React version to [16.8.0](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html) (#474)
-- SegmentedControl: items have equal width by default; add `responsive` prop which makes item width responsive to content width (#473)
-- Button: Update border radius (#476)
-- Icon: Add new alert and arrow-circle-up icons (#477)
+- Upgrade React version to [16.8.0](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html) [#474](https://github.com/pinterest/gestalt/pull/474)
+- SegmentedControl: items have equal width by default; add `responsive` prop which makes item width responsive to content width [#473](https://github.com/pinterest/gestalt/pull/473)
+- Button: Update border radius [#476](https://github.com/pinterest/gestalt/pull/476)
+- Icon: Add new alert and arrow-circle-up icons [#477](https://github.com/pinterest/gestalt/pull/477)
 
 ### Patch
 
-- Add [ESLint Plugin for React Hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) (#475)
-- Docs: Update Box prop table to include links to examples (#470)
+- Add [ESLint Plugin for React Hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) [#475](https://github.com/pinterest/gestalt/pull/475)
+- Docs: Update Box prop table to include links to examples [#470](https://github.com/pinterest/gestalt/pull/470)
 
 ## 0.88.0 (January 24, 2019)
 
 ### Minor
 
-- Icon: add new trashcan icon (#462)
-- Icon: rename icon name trashcan to trash-can (#463)
-- Internal: updated rollup build tools to use stable/predictable minified CSS classnames (#455)
-- Video: add children prop (#464)
-- Icon: add new icon reorder-images (#466)
-- Avatar: add property to use Pinterest icon for verified (#460)
+- Icon: add new trashcan icon [#462](https://github.com/pinterest/gestalt/pull/462)
+- Icon: rename icon name trashcan to trash-can [#463](https://github.com/pinterest/gestalt/pull/463)
+- Internal: updated rollup build tools to use stable/predictable minified CSS classnames [#455](https://github.com/pinterest/gestalt/pull/455)
+- Video: add children prop [#464](https://github.com/pinterest/gestalt/pull/464)
+- Icon: add new icon reorder-images [#466](https://github.com/pinterest/gestalt/pull/466)
+- Avatar: add property to use Pinterest icon for verified [#460](https://github.com/pinterest/gestalt/pull/460)
 
 ## 0.87.0 (January 17, 2019)
 
 ### Minor
 
-- IconButton, Pog, Icon: pass IconButton's `accessibilityLabel` down through Pog to Icon, where it is used as the `svg`s `title` for hover text (#456)
-- Box, IconButton, Pog: Add transparentDarkGray color option (#457)
+- IconButton, Pog, Icon: pass IconButton's `accessibilityLabel` down through Pog to Icon, where it is used as the `svg`s `title` for hover text [#456](https://github.com/pinterest/gestalt/pull/456)
+- Box, IconButton, Pog: Add transparentDarkGray color option [#457](https://github.com/pinterest/gestalt/pull/457)
 
 ### Patch
 
-- Box: Add orchid to color examples (#458)
+- Box: Add orchid to color examples [#458](https://github.com/pinterest/gestalt/pull/458)
 
 ## 0.86.2 (January 9, 2019)
 
 ### Patch
 
-- Box: update docs to mention new `ref` functionality (#450)
+- Box: update docs to mention new `ref` functionality [#450](https://github.com/pinterest/gestalt/pull/450)
 - IconButton: add `title` for hover text, using existing `accessibilityLabel` (453)
-- IconButton: add `title` for hover text, using existing `accessibilityLabel` (#453)
-- Internal: Reverts upgrade to `postcss-preset-env` due to a bug in how it interacts with CSS modules (#451)
-- Layer: Warn instead of erroring when server-rendering (#454)
+- IconButton: add `title` for hover text, using existing `accessibilityLabel` [#453](https://github.com/pinterest/gestalt/pull/453)
+- Internal: Reverts upgrade to `postcss-preset-env` due to a bug in how it interacts with CSS modules [#451](https://github.com/pinterest/gestalt/pull/451)
+- Layer: Warn instead of erroring when server-rendering [#454](https://github.com/pinterest/gestalt/pull/454)
 
 ## 0.86.1 (January 3, 2019)
 
 ### Patch
 
-- Box: add displayName to Box to maintain current naming in snapshots (#446)
+- Box: add displayName to Box to maintain current naming in snapshots [#446](https://github.com/pinterest/gestalt/pull/446)
 
 ## 0.86.0 (January 3, 2019)
 
 ### Minor
 
-- Icon: adding new icons for editing (#440)
-- Icon: adding canonical pin icon (#438)
-- Box: Add ref forwarding (#431)
-- Masonry: Removed onFinishedRendering prop because better test alternatives could be used (#435)
-- Internal: Removes integration tests (#439)
-- Tooltip: Deprecate component and remove from exports (includes codemod) (#412)
+- Icon: adding new icons for editing [#440](https://github.com/pinterest/gestalt/pull/440)
+- Icon: adding canonical pin icon [#438](https://github.com/pinterest/gestalt/pull/438)
+- Box: Add ref forwarding [#431](https://github.com/pinterest/gestalt/pull/431)
+- Masonry: Removed onFinishedRendering prop because better test alternatives could be used [#435](https://github.com/pinterest/gestalt/pull/435)
+- Internal: Removes integration tests [#439](https://github.com/pinterest/gestalt/pull/439)
+- Tooltip: Deprecate component and remove from exports (includes codemod) [#412](https://github.com/pinterest/gestalt/pull/412)
 
 ### Patch
 
-- Internal: Migrated `postcss-cssnext` to `postcss-preset-env` and removed `color()` function (#432)
-- Docs: Update `Link` docs to indicate `href` is required (#437)
+- Internal: Migrated `postcss-cssnext` to `postcss-preset-env` and removed `color()` function [#432](https://github.com/pinterest/gestalt/pull/432)
+- Docs: Update `Link` docs to indicate `href` is required [#437](https://github.com/pinterest/gestalt/pull/437)
 
 ## 0.85.0 (December 10, 2018)
 
 ### Minor
 
-- Icon: adding new icons (#425)
-- Color: Change Pinterest Red from BD081C to E60023 (#429)
+- Icon: adding new icons [#425](https://github.com/pinterest/gestalt/pull/425)
+- Color: Change Pinterest Red from BD081C to E60023 [#429](https://github.com/pinterest/gestalt/pull/429)
 
 ## 0.84.0 (November 29, 2018)
 
 ### Minor
 
-- Masonry: Add a onFinishedRendering prop which allows for better testing (#423)
-- Tabs: (Update to #368) Use composite of index and href for tab keys (#419)
-- Text: Default value for leading is now undefined to allow browser to determine line-height based on language (#421)
+- Masonry: Add a onFinishedRendering prop which allows for better testing [#423](https://github.com/pinterest/gestalt/pull/423)
+- Tabs: (Update to #368) Use composite of index and href for tab keys [#419](https://github.com/pinterest/gestalt/pull/419)
+- Text: Default value for leading is now undefined to allow browser to determine line-height based on language [#421](https://github.com/pinterest/gestalt/pull/421)
 
 ### Patch
 
-- Internal: Fixed a test that started flaking out with React 16.6 (#410)
-- Docs: Updated some Masonry props descriptions (#417)
+- Internal: Fixed a test that started flaking out with React 16.6 [#410](https://github.com/pinterest/gestalt/pull/410)
+- Docs: Updated some Masonry props descriptions [#417](https://github.com/pinterest/gestalt/pull/417)
 
 ## 0.83.0 (October 25, 2018)
 
 ### Minor
 
-- Internal: Bump version of React and related packages (#406)
-- Internal: Bump all eslint and stylelint packages (#400)
+- Internal: Bump version of React and related packages [#406](https://github.com/pinterest/gestalt/pull/406)
+- Internal: Bump all eslint and stylelint packages [#400](https://github.com/pinterest/gestalt/pull/400)
 - Icon: add new icons for text alignment
-- Tooltip: Merge abilities into Flyout for future deprecation (#403)
-- IconButton: Add new bgColor option "gray" (#405)
+- Tooltip: Merge abilities into Flyout for future deprecation [#403](https://github.com/pinterest/gestalt/pull/403)
+- IconButton: Add new bgColor option "gray" [#405](https://github.com/pinterest/gestalt/pull/405)
 
 ## 0.82.0 (October 12, 2018)
 
 ### Minor
 
-- Icon: Add compose icon (#358)
-- SearchField: Add `autoComplete` prop for parity with `TextField` (#363)
-- Tabs: Add optional wrap prop (#361)
-- Checkbox: Add optional onClick prop (#364)
-- Flow: Bump to version `0.81.0` (#376)
-- Tabs: Use href for key instead of index (#368)
-- Pulsar: Updated animation that hides ring, allowing full visibility of content underneath (#394)
+- Icon: Add compose icon [#358](https://github.com/pinterest/gestalt/pull/358)
+- SearchField: Add `autoComplete` prop for parity with `TextField` [#363](https://github.com/pinterest/gestalt/pull/363)
+- Tabs: Add optional wrap prop [#361](https://github.com/pinterest/gestalt/pull/361)
+- Checkbox: Add optional onClick prop [#364](https://github.com/pinterest/gestalt/pull/364)
+- Flow: Bump to version `0.81.0` [#376](https://github.com/pinterest/gestalt/pull/376)
+- Tabs: Use href for key instead of index [#368](https://github.com/pinterest/gestalt/pull/368)
+- Pulsar: Updated animation that hides ring, allowing full visibility of content underneath [#394](https://github.com/pinterest/gestalt/pull/394)
 
 ### Patch
 
-- Internal: Exclude node_modules from babelification (#382)
-- Internal: publish `README.md` (#367)
-- Internal: add `GH_TOKEN` to docker-compose file for greenkeeper (#378)
-- Internal: add greenkeeper env variables to docker-compose and buildkite files (#381)
+- Internal: Exclude node_modules from babelification [#382](https://github.com/pinterest/gestalt/pull/382)
+- Internal: publish `README.md` [#367](https://github.com/pinterest/gestalt/pull/367)
+- Internal: add `GH_TOKEN` to docker-compose file for greenkeeper [#378](https://github.com/pinterest/gestalt/pull/378)
+- Internal: add greenkeeper env variables to docker-compose and buildkite files [#381](https://github.com/pinterest/gestalt/pull/381)
 
 ## 0.81.0 (September 11, 2018)
 
 ### Minor
 
-- TextField / TextArea / SelectList: Fix issue with flyout when `errorMessage` is set (#350)
-- Icon: Add download svg (#341)
-- Masonry: Remove mention of server rendering (#342)
+- TextField / TextArea / SelectList: Fix issue with flyout when `errorMessage` is set [#350](https://github.com/pinterest/gestalt/pull/350)
+- Icon: Add download svg [#341](https://github.com/pinterest/gestalt/pull/341)
+- Masonry: Remove mention of server rendering [#342](https://github.com/pinterest/gestalt/pull/342)
 
 ## 0.80.0 (September 7, 2018)
 
 ### Minor
 
-- Internal: Update flow-typed def for jest to match jest version (#346)
-- Masonry: new MasonryInfiniteBeta and MasonryBeta (#329)
+- Internal: Update flow-typed def for jest to match jest version [#346](https://github.com/pinterest/gestalt/pull/346)
+- Masonry: new MasonryInfiniteBeta and MasonryBeta [#329](https://github.com/pinterest/gestalt/pull/329)
 
 ## 0.79.2 (September 5, 2018)
 
 ### Minor
 
-- Button: Fix transparent button on blue background (#316)
-- Flyout: Add new prop `shouldFocus` to override focus on open behavior. _Has codemod_ (#325)
-- Icon: Add camera roll icon (#317)
-- Video: Make a11y label props required in Video component (#321)
-- Internal: Add in greenkeeper-lockfile for auto updates (#327)
+- Button: Fix transparent button on blue background [#316](https://github.com/pinterest/gestalt/pull/316)
+- Flyout: Add new prop `shouldFocus` to override focus on open behavior. _Has codemod_ [#325](https://github.com/pinterest/gestalt/pull/325)
+- Icon: Add camera roll icon [#317](https://github.com/pinterest/gestalt/pull/317)
+- Video: Make a11y label props required in Video component [#321](https://github.com/pinterest/gestalt/pull/321)
+- Internal: Add in greenkeeper-lockfile for auto updates [#327](https://github.com/pinterest/gestalt/pull/327)
 
 ### Patch
 
-- Modal: set content width to 100% to prevent overflow bug in IE (#315)
-- Modal: change Box width from using column to width property (#338)
+- Modal: set content width to 100% to prevent overflow bug in IE [#315](https://github.com/pinterest/gestalt/pull/315)
+- Modal: change Box width from using column to width property [#338](https://github.com/pinterest/gestalt/pull/338)
 
 ## 0.79.1 (August 24, 2018)
 
 ### Patch
 
-- Masonry: Add missing defaultProps and handleResize (#313)
+- Masonry: Add missing defaultProps and handleResize [#313](https://github.com/pinterest/gestalt/pull/313)
 
 ## 0.79.0 (August 22, 2018)
 
 ### Minor
 
-- Masonry: MasonryInfinite for infinite fetching (#307)
+- Masonry: MasonryInfinite for infinite fetching [#307](https://github.com/pinterest/gestalt/pull/307)
 
 ## 0.78.0 (August 20, 2018)
 
 ### Minor
 
-- Internal: Turn on sketchy-number flow lint rules as an error (#293)
-- TextArea: Add an onKeyDown prop (#303)
-- TextField: Add an onKeyDown prop (#303)
-- Internal: Add flow types to `Box` transform functors (#299)
-- Icon: Fix cog icon rotation (#308)
+- Internal: Turn on sketchy-number flow lint rules as an error [#293](https://github.com/pinterest/gestalt/pull/293)
+- TextArea: Add an onKeyDown prop [#303](https://github.com/pinterest/gestalt/pull/303)
+- TextField: Add an onKeyDown prop [#303](https://github.com/pinterest/gestalt/pull/303)
+- Internal: Add flow types to `Box` transform functors [#299](https://github.com/pinterest/gestalt/pull/299)
+- Icon: Fix cog icon rotation [#308](https://github.com/pinterest/gestalt/pull/308)
 
 ## 0.77.0 (July 30, 2018)
 
 ### Minor
 
-- Checkbox: Add error prop and styling (#287)
-- Internal: Bump flow version to 0.77.0 (#289)
-- Internal: Add flow typed definitions for node-fetch and filesize (#290)
-- Collage: Add new Collage component to Gestalt (#291)
-- Internal: Turn on all non-sketchy flow lint rules as errors (#292)
-- Masonry: Add configurable virtual bounds (#294)
+- Checkbox: Add error prop and styling [#287](https://github.com/pinterest/gestalt/pull/287)
+- Internal: Bump flow version to 0.77.0 [#289](https://github.com/pinterest/gestalt/pull/289)
+- Internal: Add flow typed definitions for node-fetch and filesize [#290](https://github.com/pinterest/gestalt/pull/290)
+- Collage: Add new Collage component to Gestalt [#291](https://github.com/pinterest/gestalt/pull/291)
+- Internal: Turn on all non-sketchy flow lint rules as errors [#292](https://github.com/pinterest/gestalt/pull/292)
+- Masonry: Add configurable virtual bounds [#294](https://github.com/pinterest/gestalt/pull/294)
 
 ## 0.76.1 (July 17, 2018)
 
 ### Patch
 
-- Masonry: Fix React prop typing for `layout` (#284)
+- Masonry: Fix React prop typing for `layout` [#284](https://github.com/pinterest/gestalt/pull/284)
 
 ## 0.76.0 (July 17, 2018)
 
 ### Minor
 
-- Icon: reduce filesize of each icon with 40% + add new icons (#269)
-- Colors: Darken gray and darkGray so they're AA accessible at smaller sizes (#276)
-- Video: Add a gradient overlay on the control bar (#27)
+- Icon: reduce filesize of each icon with 40% + add new icons [#269](https://github.com/pinterest/gestalt/pull/269)
+- Colors: Darken gray and darkGray so they're AA accessible at smaller sizes [#276](https://github.com/pinterest/gestalt/pull/276)
+- Video: Add a gradient overlay on the control bar [#27](https://github.com/pinterest/gestalt/pull/27)
 - Layer: Layer component is now exported for use and has documentation
-- TextArea: Add a hasError prop (#280)
-- Icon: Add new `megaphone` icon (#281)
+- TextArea: Add a hasError prop [#280](https://github.com/pinterest/gestalt/pull/280)
+- Icon: Add new `megaphone` icon [#281](https://github.com/pinterest/gestalt/pull/281)
 
 ### Patch
 
-- Icon: Fix `envelope` icon + add `gmail` (#270)
-- Internal: Fix release script for gh-pages (#266)
-- Flow: Bump Flow to version 0.75.0 in gestalt (#268)
-- Internal: Bump all eslint plugin packages in prep for eslint5 (#273)
+- Icon: Fix `envelope` icon + add `gmail` [#270](https://github.com/pinterest/gestalt/pull/270)
+- Internal: Fix release script for gh-pages [#266](https://github.com/pinterest/gestalt/pull/266)
+- Flow: Bump Flow to version 0.75.0 in gestalt [#268](https://github.com/pinterest/gestalt/pull/268)
+- Internal: Bump all eslint plugin packages in prep for eslint5 [#273](https://github.com/pinterest/gestalt/pull/273)
 
 ## 0.75.0 (Jun 27, 2018)
 
 ### Minor
 
-- Box: Add `visuallyHidden` as a display option (#262)
-- Icon: Add one new icon (globe-checked) for claimed website (#264)
+- Box: Add `visuallyHidden` as a display option [#262](https://github.com/pinterest/gestalt/pull/262)
+- Icon: Add one new icon (globe-checked) for claimed website [#264](https://github.com/pinterest/gestalt/pull/264)
 
 ### Patch
 
-- Docs: Fix "fit" labels in Image docs example (#259)
-- Internal: Set up pre-commit hooks for linting and testing (#258)
-- Internal: Fix peer dependency issues with stylint and jest-pupeteer (#260)
-- Internal: Add eslint-import/no-relative-parent-imports rule (#261)
+- Docs: Fix "fit" labels in Image docs example [#259](https://github.com/pinterest/gestalt/pull/259)
+- Internal: Set up pre-commit hooks for linting and testing [#258](https://github.com/pinterest/gestalt/pull/258)
+- Internal: Fix peer dependency issues with stylint and jest-pupeteer [#260](https://github.com/pinterest/gestalt/pull/260)
+- Internal: Add eslint-import/no-relative-parent-imports rule [#261](https://github.com/pinterest/gestalt/pull/261)
 
 ## 0.74.0 (Jun 13, 2018)
 
 ### Minor
 
-- ErrorFlyout: Deprecate component and remove from Gestalt (#251)
+- ErrorFlyout: Deprecate component and remove from Gestalt [#251](https://github.com/pinterest/gestalt/pull/251)
 
 ### Patch
 
-- Danger: Separate danger rules out into separate files (#253)
-- Modal: Fix issue with outside click error bubbling (#254)
+- Danger: Separate danger rules out into separate files [#253](https://github.com/pinterest/gestalt/pull/253)
+- Modal: Fix issue with outside click error bubbling [#254](https://github.com/pinterest/gestalt/pull/254)
 
 ## 0.73.0 (Jun 8, 2018)
 
 ### Minor
 
-- Masonry: Makes Masonry React Async compatible (#227)
-- SegmentedControl: Change flow type of `items` to `React.Node` (#230)
-- Video: Add jsdom browser specific tests (#205)
-- Flyout: Merge ErrorFlyout abilities into Flyout (#242)
-- Flyout: Support blue Flyouts (#249)
-- Card: Make Card explicitely use box-sizing: content-box (#243)
-- GroupAvatar: Text sizes are consistent with Avatar and `size` prop is now optional. (#244)
-- Video: Move initial video setup calls to componentDidMount (#245)
+- Masonry: Makes Masonry React Async compatible [#227](https://github.com/pinterest/gestalt/pull/227)
+- SegmentedControl: Change flow type of `items` to `React.Node` [#230](https://github.com/pinterest/gestalt/pull/230)
+- Video: Add jsdom browser specific tests [#205](https://github.com/pinterest/gestalt/pull/205)
+- Flyout: Merge ErrorFlyout abilities into Flyout [#242](https://github.com/pinterest/gestalt/pull/242)
+- Flyout: Support blue Flyouts [#249](https://github.com/pinterest/gestalt/pull/249)
+- Card: Make Card explicitely use box-sizing: content-box [#243](https://github.com/pinterest/gestalt/pull/243)
+- GroupAvatar: Text sizes are consistent with Avatar and `size` prop is now optional. [#244](https://github.com/pinterest/gestalt/pull/244)
+- Video: Move initial video setup calls to componentDidMount [#245](https://github.com/pinterest/gestalt/pull/245)
 
 ### Patch
 
-- Internal: add better basic test coverage (#231)
-- Modal: Refactor internals and remove responsive behavior (#218)
-- Internal: update to jsdom only tests (#232)
-- Internal: Upgrade to Jest 23 (#233)
-- Internal: Upgrade to Stylelint 9.2.1 (#235)
-- Avatar/GroupAvatar: Add additional tests for 100% coverage (#236)
-- Avatar: fix error when name is falsey (#248)
-- Button/Icon: Add additional tests for 100% coverage (#237)
-- Flyout/SegmentedControl: Add additional tests for 100% coverage (#238)
-- Touchable: Add additional tests for 100% coverage (#239)
-- Internal: Add Codecov badge to README (#241)
+- Internal: add better basic test coverage [#231](https://github.com/pinterest/gestalt/pull/231)
+- Modal: Refactor internals and remove responsive behavior [#218](https://github.com/pinterest/gestalt/pull/218)
+- Internal: update to jsdom only tests [#232](https://github.com/pinterest/gestalt/pull/232)
+- Internal: Upgrade to Jest 23 [#233](https://github.com/pinterest/gestalt/pull/233)
+- Internal: Upgrade to Stylelint 9.2.1 [#235](https://github.com/pinterest/gestalt/pull/235)
+- Avatar/GroupAvatar: Add additional tests for 100% coverage [#236](https://github.com/pinterest/gestalt/pull/236)
+- Avatar: fix error when name is falsey [#248](https://github.com/pinterest/gestalt/pull/248)
+- Button/Icon: Add additional tests for 100% coverage [#237](https://github.com/pinterest/gestalt/pull/237)
+- Flyout/SegmentedControl: Add additional tests for 100% coverage [#238](https://github.com/pinterest/gestalt/pull/238)
+- Touchable: Add additional tests for 100% coverage [#239](https://github.com/pinterest/gestalt/pull/239)
+- Internal: Add Codecov badge to README [#241](https://github.com/pinterest/gestalt/pull/241)
 
 ## 0.72.0 (May 30, 2018)
 
 ### Minor
 
-- Video: Added new `onSeek` callback prop to `Video` component (#209)
-- Video: Added new `onReady` callback prop to `Video` component (#210)
-- Internal: Remove dead example code from docs (#211)
-- Internal: Fix react router dependencies (#212)
-- Internal: Fix package.json dependency locations (#213)
-- Flow: Fix Flow errors in the `docs/` directory (#214)
-- Flow: Fix remaining errors in the `docs/` directory and enable Flow (#215)
-- Docs: Fix indentation on gestalt docs code examples (#219)
-- Docs: Fix broken Link component in docs app (#220)
-- SelectList: Makes SelectList React Async compatible (#221)
-- TextArea: Makes TextArea React Async compatible (#222)
-- TextField: Makes TextField React Async compatible (#223)
-- ScrollContainer: Makes ScrollContainer React Async compatible (#224)
-- Video: Fix Video playback on SSR if playing is true on first mount (#225)
+- Video: Added new `onSeek` callback prop to `Video` component [#209](https://github.com/pinterest/gestalt/pull/209)
+- Video: Added new `onReady` callback prop to `Video` component [#210](https://github.com/pinterest/gestalt/pull/210)
+- Internal: Remove dead example code from docs [#211](https://github.com/pinterest/gestalt/pull/211)
+- Internal: Fix react router dependencies [#212](https://github.com/pinterest/gestalt/pull/212)
+- Internal: Fix package.json dependency locations [#213](https://github.com/pinterest/gestalt/pull/213)
+- Flow: Fix Flow errors in the `docs/` directory [#214](https://github.com/pinterest/gestalt/pull/214)
+- Flow: Fix remaining errors in the `docs/` directory and enable Flow [#215](https://github.com/pinterest/gestalt/pull/215)
+- Docs: Fix indentation on gestalt docs code examples [#219](https://github.com/pinterest/gestalt/pull/219)
+- Docs: Fix broken Link component in docs app [#220](https://github.com/pinterest/gestalt/pull/220)
+- SelectList: Makes SelectList React Async compatible [#221](https://github.com/pinterest/gestalt/pull/221)
+- TextArea: Makes TextArea React Async compatible [#222](https://github.com/pinterest/gestalt/pull/222)
+- TextField: Makes TextField React Async compatible [#223](https://github.com/pinterest/gestalt/pull/223)
+- ScrollContainer: Makes ScrollContainer React Async compatible [#224](https://github.com/pinterest/gestalt/pull/224)
+- Video: Fix Video playback on SSR if playing is true on first mount [#225](https://github.com/pinterest/gestalt/pull/225)
 
 ## 0.71.0 (May 23, 2018)
 
 ### Minor
 
-- Drop support for React 15 and bump React 16 version (#168)
-- Colors: Update blue color (#193)
-- Video: Fix background color for fullscreen video playback (#198)
-- Internal: Refactor Modal docs to kill StateRecorder (#199)
-- Internal: Add eslint-plugin-eslint-comments with recommended settings (#200)
-- Video: Makes `aspectRatio` a required prop for `Video` (#201)
-- Video: Pass events through to callback functions (#203)
-- Touchable: Add event targets to Flow typing for callbacks (#204)
-- Video: Add new `onEnded` prop for media end event (#207)
+- Drop support for React 15 and bump React 16 version [#168](https://github.com/pinterest/gestalt/pull/168)
+- Colors: Update blue color [#193](https://github.com/pinterest/gestalt/pull/193)
+- Video: Fix background color for fullscreen video playback [#198](https://github.com/pinterest/gestalt/pull/198)
+- Internal: Refactor Modal docs to kill StateRecorder [#199](https://github.com/pinterest/gestalt/pull/199)
+- Internal: Add eslint-plugin-eslint-comments with recommended settings [#200](https://github.com/pinterest/gestalt/pull/200)
+- Video: Makes `aspectRatio` a required prop for `Video` [#201](https://github.com/pinterest/gestalt/pull/201)
+- Video: Pass events through to callback functions [#203](https://github.com/pinterest/gestalt/pull/203)
+- Touchable: Add event targets to Flow typing for callbacks [#204](https://github.com/pinterest/gestalt/pull/204)
+- Video: Add new `onEnded` prop for media end event [#207](https://github.com/pinterest/gestalt/pull/207)
 
 ### Patch
 
-- Internal: Add code coverage to PRs (#185)
-- Internal: Internal: Convert ghostjs to puppeteer (#182)
-- Internal: Update Jest and use multi-project runner (#158)
-- Internal: Fix import path for boxperf script (#188)
-- Internal: Turn on eslint-plugin-import rules already being followed (#189)
-- Docs: Add live docs to Letterbox (#190)
-- Docs: Move CardPage rendering into the Route render prop (#191)
-- Internal: Turn on all react recommended linters (#192)
-- Internal: Merge jest-pupeteer eslint file into main one (#193)
-- Docs: Rewrite Column doc to remove scope prop from Example (#196)
-- Video: Fix broken equality check for Video `src` prop (#202)
-- Internal: Move stylelint config to separate file (#206)
+- Internal: Add code coverage to PRs [#185](https://github.com/pinterest/gestalt/pull/185)
+- Internal: Internal: Convert ghostjs to puppeteer [#182](https://github.com/pinterest/gestalt/pull/182)
+- Internal: Update Jest and use multi-project runner [#158](https://github.com/pinterest/gestalt/pull/158)
+- Internal: Fix import path for boxperf script [#188](https://github.com/pinterest/gestalt/pull/188)
+- Internal: Turn on eslint-plugin-import rules already being followed [#189](https://github.com/pinterest/gestalt/pull/189)
+- Docs: Add live docs to Letterbox [#190](https://github.com/pinterest/gestalt/pull/190)
+- Docs: Move CardPage rendering into the Route render prop [#191](https://github.com/pinterest/gestalt/pull/191)
+- Internal: Turn on all react recommended linters [#192](https://github.com/pinterest/gestalt/pull/192)
+- Internal: Merge jest-pupeteer eslint file into main one [#193](https://github.com/pinterest/gestalt/pull/193)
+- Docs: Rewrite Column doc to remove scope prop from Example [#196](https://github.com/pinterest/gestalt/pull/196)
+- Video: Fix broken equality check for Video `src` prop [#202](https://github.com/pinterest/gestalt/pull/202)
+- Internal: Move stylelint config to separate file [#206](https://github.com/pinterest/gestalt/pull/206)
 
 ## 0.70.0 (May 15, 2018)
 
 ### Minor
 
-- Avatar / GroupAvatar: make outline configurable(#173)
+- Avatar / GroupAvatar: make outline configurable[#173](https://github.com/pinterest/gestalt/pull/173)
 - Masonry: Update non-virtualized Masonry to render all items regardless of the window
-- ExperimentalMasonry: remove component (#183)
-- Internal: Add flow-typed files for third party packages (#174)
-- Internal: Remove unused linter suppressions (#180)
-- Internal: Add eslint-plugin-jest with recommended settings (#181)
-- Internal: Add Flow type checking to Jest test files (#184)
-- Video: Better existing callbacks, new playback rate prop, new loading callback (#174)
-- Internal: Turn the import/first rule back on (#186)
+- ExperimentalMasonry: remove component [#183](https://github.com/pinterest/gestalt/pull/183)
+- Internal: Add flow-typed files for third party packages [#174](https://github.com/pinterest/gestalt/pull/174)
+- Internal: Remove unused linter suppressions [#180](https://github.com/pinterest/gestalt/pull/180)
+- Internal: Add eslint-plugin-jest with recommended settings [#181](https://github.com/pinterest/gestalt/pull/181)
+- Internal: Add Flow type checking to Jest test files [#184](https://github.com/pinterest/gestalt/pull/184)
+- Video: Better existing callbacks, new playback rate prop, new loading callback [#174](https://github.com/pinterest/gestalt/pull/174)
+- Internal: Turn the import/first rule back on [#186](https://github.com/pinterest/gestalt/pull/186)
 
 ## 0.69.0 (May 10, 2018)
 
 ### Minor
 
-- Sticky: Expand threshold options to take string values (#166)
-- Avatar: Fall back to default letter if image does not load (#156)
-- Video: Add new Video component to Gestalt (#150)
-- Video: Add `aspectRatio` prop to Video and hide fullscreen on unsupported browsers (#171)
+- Sticky: Expand threshold options to take string values [#166](https://github.com/pinterest/gestalt/pull/166)
+- Avatar: Fall back to default letter if image does not load [#156](https://github.com/pinterest/gestalt/pull/156)
+- Video: Add new Video component to Gestalt [#150](https://github.com/pinterest/gestalt/pull/150)
+- Video: Add `aspectRatio` prop to Video and hide fullscreen on unsupported browsers [#171](https://github.com/pinterest/gestalt/pull/171)
 
 ### Patch
 
-- Internal: Add bundle size impact reporting (#146)
-- Pulsar: Updated styles to use border box so pulsar doesn't extend out of container div (#169)
-- Docs: Fix home link (#170)
+- Internal: Add bundle size impact reporting [#146](https://github.com/pinterest/gestalt/pull/146)
+- Pulsar: Updated styles to use border box so pulsar doesn't extend out of container div [#169](https://github.com/pinterest/gestalt/pull/169)
+- Docs: Fix home link [#170](https://github.com/pinterest/gestalt/pull/170)
 
 ## 0.68.1 (May 8, 2018)
 
 ### Patch
 
-- Masonry: Don't pass Infinity as style value (#163)
-- Internal: Generate stats file during build (#160)
-- Flow: Upgrade flow-bin to version 0.71.0 (#155)
-- Internal: update `yarn.lock` (#152)
-- Docs: include images in repo (#151)
-- Docs: updated design (#154)
+- Masonry: Don't pass Infinity as style value [#163](https://github.com/pinterest/gestalt/pull/163)
+- Internal: Generate stats file during build [#160](https://github.com/pinterest/gestalt/pull/160)
+- Flow: Upgrade flow-bin to version 0.71.0 [#155](https://github.com/pinterest/gestalt/pull/155)
+- Internal: update `yarn.lock` [#152](https://github.com/pinterest/gestalt/pull/152)
+- Docs: include images in repo [#151](https://github.com/pinterest/gestalt/pull/151)
+- Docs: updated design [#154](https://github.com/pinterest/gestalt/pull/154)
 
 ## 0.68.0 (May 3, 2018)
 
 ### Minor
 
-- Button / SearchField / SegmentedControl / SelectList / Tabs / TextField: consistent sizing + improve Windows compatibility (#148)
-- Icon: Add new prop to Icon -- dangerouslySetSvgPath (#142)
+- Button / SearchField / SegmentedControl / SelectList / Tabs / TextField: consistent sizing + improve Windows compatibility [#148](https://github.com/pinterest/gestalt/pull/148)
+- Icon: Add new prop to Icon -- dangerouslySetSvgPath [#142](https://github.com/pinterest/gestalt/pull/142)
 
 ## 0.67.0 (April 25, 2018)
 
 ### Minor
 
-- Flyout: make IE11 compatible (#138)
-- Icon: Add new GIF icon (#143)
+- Flyout: make IE11 compatible [#138](https://github.com/pinterest/gestalt/pull/138)
+- Icon: Add new GIF icon [#143](https://github.com/pinterest/gestalt/pull/143)
 
 ### Patch
 
@@ -8392,7 +8392,7 @@ Run codemods for breaking changes in order:
 
 ### Minor
 
-- Box: Added right to left language aware marginStart & marginEnd (#122)
+- Box: Added right to left language aware marginStart & marginEnd [#122](https://github.com/pinterest/gestalt/pull/122)
 
 ### Patch
 
@@ -8404,8 +8404,8 @@ Run codemods for breaking changes in order:
 
 ### Minor
 
-- Link: Remove duplicate CSS declaration (#118)
-- Pulsar: Fix default prop value for size to match new design (#126)
+- Link: Remove duplicate CSS declaration [#118](https://github.com/pinterest/gestalt/pull/118)
+- Pulsar: Fix default prop value for size to match new design [#126](https://github.com/pinterest/gestalt/pull/126)
 
 ### Patch
 
@@ -8420,56 +8420,56 @@ Run codemods for breaking changes in order:
 
 ### Minor
 
-- Icon: 4 new icons related to analytic stats (#105)
-- GroupAvatar: Fix when there are no collaborators (#112)
-- Flyout: Fix positioning during resize (#111)
-- Modal: Update heading size + fix docs (#114)
-- Pulsar: New blue ring design, size change from 96 to 136px (#115)
-- Icon: 1 icon (circle-arrow-down) for search (#119)
+- Icon: 4 new icons related to analytic stats [#105](https://github.com/pinterest/gestalt/pull/105)
+- GroupAvatar: Fix when there are no collaborators [#112](https://github.com/pinterest/gestalt/pull/112)
+- Flyout: Fix positioning during resize [#111](https://github.com/pinterest/gestalt/pull/111)
+- Modal: Update heading size + fix docs [#114](https://github.com/pinterest/gestalt/pull/114)
+- Pulsar: New blue ring design, size change from 96 to 136px [#115](https://github.com/pinterest/gestalt/pull/115)
+- Icon: 1 icon (circle-arrow-down) for search [#119](https://github.com/pinterest/gestalt/pull/119)
 
 ### Patch
 
-- Docs: Add live docs to TextField / TextArea (#116)
-- Internal: Fix navigation to allow opening in new tabs (#120)
+- Docs: Add live docs to TextField / TextArea [#116](https://github.com/pinterest/gestalt/pull/116)
+- Internal: Fix navigation to allow opening in new tabs [#120](https://github.com/pinterest/gestalt/pull/120)
 
 ## 0.63.0 (March 26, 2018)
 
 ### Minor
 
 - Masonry: Promotes ExperimentalMasonry to be Masonry. Complete re-write of
-  measuring etc. (#101)
-- Internal: Gestalt now is React 16.2.0 compatible. (#101)
+  measuring etc. [#101](https://github.com/pinterest/gestalt/pull/101)
+- Internal: Gestalt now is React 16.2.0 compatible. [#101](https://github.com/pinterest/gestalt/pull/101)
 
 ## 0.62.1 (March 22, 2018)
 
 ### Patch
 
-- Internal: Fix publish script to work for new Gestalt directory structure (#94)
-- Heading / Text / SegmentedControl: Fix flow types when truncation is enabled (#98)
+- Internal: Fix publish script to work for new Gestalt directory structure [#94](https://github.com/pinterest/gestalt/pull/94)
+- Heading / Text / SegmentedControl: Fix flow types when truncation is enabled [#98](https://github.com/pinterest/gestalt/pull/98)
 
 ## 0.62.0 (March 21, 2018)
 
 ### Minor
 
-- Heading / Text / SegmentedControl: Add `title` when `truncate` is set (#82)
+- Heading / Text / SegmentedControl: Add `title` when `truncate` is set [#82](https://github.com/pinterest/gestalt/pull/82)
 
 ### Patch
 
-- Docs: Masonry locally on port `3000` + update the `README` with the latest commands (#89)
-- Internal: No downtime when releasing the docs (#97)
+- Docs: Masonry locally on port `3000` + update the `README` with the latest commands [#89](https://github.com/pinterest/gestalt/pull/89)
+- Internal: No downtime when releasing the docs [#97](https://github.com/pinterest/gestalt/pull/97)
 
 ## 0.61.0 (March 20, 2018)
 
 ### Minor
 
-- Image: Don't show `alt` text when loading the image in FireFox. (#80)(#84)
-- Tabs: Update the background color to be transparent for unselected tabs (#79)
+- Image: Don't show `alt` text when loading the image in FireFox. [#80](https://github.com/pinterest/gestalt/pull/80)[#84](https://github.com/pinterest/gestalt/pull/84)
+- Tabs: Update the background color to be transparent for unselected tabs [#79](https://github.com/pinterest/gestalt/pull/79)
 
 ### Patch
 
-- Docs: Add live docs to Toast (#87)
-- Internal: Convert `BrowserRouter` to `HashRouter` - fixes directly going to a component (#88)
-- Docs: Add live docs to SegmentedControl (#90)
+- Docs: Add live docs to Toast [#87](https://github.com/pinterest/gestalt/pull/87)
+- Internal: Convert `BrowserRouter` to `HashRouter` - fixes directly going to a component [#88](https://github.com/pinterest/gestalt/pull/88)
+- Docs: Add live docs to SegmentedControl [#90](https://github.com/pinterest/gestalt/pull/90)
 
 ## 0.60.0 (March 13, 2018)
 
@@ -8483,45 +8483,45 @@ Run codemods for breaking changes in order:
 ### Minor
 
 - Masonry: Promotes ExperimentalMasonry to be Masonry. Complete re-write of
-  measuring etc. (#46)
-- Sticky: Fallback to position relative in IE11 (#51)
-- Internal: Gestalt now is React 16.2.0 compatible (#53)
-- SelectList: Hardcode 40px height for consistency (#57)
+  measuring etc. [#46](https://github.com/pinterest/gestalt/pull/46)
+- Sticky: Fallback to position relative in IE11 [#51](https://github.com/pinterest/gestalt/pull/51)
+- Internal: Gestalt now is React 16.2.0 compatible [#53](https://github.com/pinterest/gestalt/pull/53)
+- SelectList: Hardcode 40px height for consistency [#57](https://github.com/pinterest/gestalt/pull/57)
 
 ### Patch
 
-- Internal: Split docs & integration tests into individual packages (#22)
-- Flyout: Update the docs with correct flowtypes (#37)
-- Internal: Removes [corkboard](https://yarnpkg.com/en/package/corkboard) from the docs (#41)
-- Internal: User prettier for markdown and css (#45)
-- Internal: Add script to run watcher & docs build concurrently (#49)
-- Docs: Readme update to start docs server (#47)
-- Docs: fix github source link (#50)
-- Internal: IE11 fixes: fix images in docs / fix scrollbar always showing on proptable (#51)
-- Docs: Use [create-react-app](https://github.com/facebook/create-react-app) to build and run the docs (#42)
-- Docs: Add live docs for Tooltip (#63)
-- Docs: Add live docs to Tabs (#65)
-- Docs: Add live docs to Spinner (#66)
-- Docs: Add live docs to SelectList (#69)
-- Flow: Update the Flow typing for `children` prop to be up to date with Flow version (#70)
-- ErrorFlyout / Toast / Tooltip: Add missing React proptyping to components (#73)
-- Flow: Upgrade flow-bin to version 0.66.0 (#74)
+- Internal: Split docs & integration tests into individual packages [#22](https://github.com/pinterest/gestalt/pull/22)
+- Flyout: Update the docs with correct flowtypes [#37](https://github.com/pinterest/gestalt/pull/37)
+- Internal: Removes [corkboard](https://yarnpkg.com/en/package/corkboard) from the docs [#41](https://github.com/pinterest/gestalt/pull/41)
+- Internal: User prettier for markdown and css [#45](https://github.com/pinterest/gestalt/pull/45)
+- Internal: Add script to run watcher & docs build concurrently [#49](https://github.com/pinterest/gestalt/pull/49)
+- Docs: Readme update to start docs server [#47](https://github.com/pinterest/gestalt/pull/47)
+- Docs: fix github source link [#50](https://github.com/pinterest/gestalt/pull/50)
+- Internal: IE11 fixes: fix images in docs / fix scrollbar always showing on proptable [#51](https://github.com/pinterest/gestalt/pull/51)
+- Docs: Use [create-react-app](https://github.com/facebook/create-react-app) to build and run the docs [#42](https://github.com/pinterest/gestalt/pull/42)
+- Docs: Add live docs for Tooltip [#63](https://github.com/pinterest/gestalt/pull/63)
+- Docs: Add live docs to Tabs [#65](https://github.com/pinterest/gestalt/pull/65)
+- Docs: Add live docs to Spinner [#66](https://github.com/pinterest/gestalt/pull/66)
+- Docs: Add live docs to SelectList [#69](https://github.com/pinterest/gestalt/pull/69)
+- Flow: Update the Flow typing for `children` prop to be up to date with Flow version [#70](https://github.com/pinterest/gestalt/pull/70)
+- ErrorFlyout / Toast / Tooltip: Add missing React proptyping to components [#73](https://github.com/pinterest/gestalt/pull/73)
+- Flow: Upgrade flow-bin to version 0.66.0 [#74](https://github.com/pinterest/gestalt/pull/74)
 
 ## [0.58.0] (Feb 26, 2018)
 
 ### Minor
 
-- Card: Adds an extra "image" property to help separate content (#19)
-- GroupAvatar: Update sizes to be in line with other components (#30)
-- Touchable: Adds support for `fullHeight` prop (#31)
-- Toast: Fix Safari 9 thumbnail/text overlap (#33)
+- Card: Adds an extra "image" property to help separate content [#19](https://github.com/pinterest/gestalt/pull/19)
+- GroupAvatar: Update sizes to be in line with other components [#30](https://github.com/pinterest/gestalt/pull/30)
+- Touchable: Adds support for `fullHeight` prop [#31](https://github.com/pinterest/gestalt/pull/31)
+- Toast: Fix Safari 9 thumbnail/text overlap [#33](https://github.com/pinterest/gestalt/pull/33)
 
 ### Patch
 
-- GroupAvatar: Fix text sizes for 1 collaborator (#32)
-- Internal: Adds [Danger](http://danger.systems/js/) to pull requests. (#27)
-- TextField: Remove duplicate logic opening the error flyout (#34)
-- Internal: Re-exports flowtypes (#35)
+- GroupAvatar: Fix text sizes for 1 collaborator [#32](https://github.com/pinterest/gestalt/pull/32)
+- Internal: Adds [Danger](http://danger.systems/js/) to pull requests. [#27](https://github.com/pinterest/gestalt/pull/27)
+- TextField: Remove duplicate logic opening the error flyout [#34](https://github.com/pinterest/gestalt/pull/34)
+- Internal: Re-exports flowtypes [#35](https://github.com/pinterest/gestalt/pull/35)
 
 ## 0.57.1 (Feb 22, 2018)
 
@@ -8533,21 +8533,21 @@ Run codemods for breaking changes in order:
 
 ## Minor
 
-- Sticky: Add zIndex support (#21)
-- SearchField: Add custom `onBlur` prop / Rename syntheticEvent => event / Use stricter flowtype on event to remove if check (#17)
-- Flyout: Allow for custom width (#16)
-- ExperimentalMasonry: Reference measurementStore from props instead of instance (#14)
+- Sticky: Add zIndex support [#21](https://github.com/pinterest/gestalt/pull/21)
+- SearchField: Add custom `onBlur` prop / Rename syntheticEvent => event / Use stricter flowtype on event to remove if check [#17](https://github.com/pinterest/gestalt/pull/17)
+- Flyout: Allow for custom width [#16](https://github.com/pinterest/gestalt/pull/16)
+- ExperimentalMasonry: Reference measurementStore from props instead of instance [#14](https://github.com/pinterest/gestalt/pull/14)
 
 ## Patch
 
-- Docs: Netlify: Live preview with every PR (#18)
-- Docs: Updates Heading, Image, Label & Text to use Example (#10)
-- Docs: Container / ErrorFlyout / IconButton / Label / Pog / SearchField: add live docs (#12)
-- Docs: Flyout / Mask / Pulsar: add live docs (#15)
-- Docs: Readme updates (#3) (#8)
-- Docs: Publish docs when releasing (#1)
-- Docs: Fixes syntax errors in a few live examples (#6)
-- Docs: Move .corkboard/ to docs/ and isolate components (#9)
-- Docs: Removes function syntax from cards (#7)
-- Build: Fixes repo url in docs build script (#4)
-- Internal: Webpack 3 upgrade (#11)
+- Docs: Netlify: Live preview with every PR [#18](https://github.com/pinterest/gestalt/pull/18)
+- Docs: Updates Heading, Image, Label & Text to use Example [#10](https://github.com/pinterest/gestalt/pull/10)
+- Docs: Container / ErrorFlyout / IconButton / Label / Pog / SearchField: add live docs [#12](https://github.com/pinterest/gestalt/pull/12)
+- Docs: Flyout / Mask / Pulsar: add live docs [#15](https://github.com/pinterest/gestalt/pull/15)
+- Docs: Readme updates [#3](https://github.com/pinterest/gestalt/pull/3) [#8](https://github.com/pinterest/gestalt/pull/8)
+- Docs: Publish docs when releasing [#1](https://github.com/pinterest/gestalt/pull/1)
+- Docs: Fixes syntax errors in a few live examples [#6](https://github.com/pinterest/gestalt/pull/6)
+- Docs: Move .corkboard/ to docs/ and isolate components [#9](https://github.com/pinterest/gestalt/pull/9)
+- Docs: Removes function syntax from cards [#7](https://github.com/pinterest/gestalt/pull/7)
+- Build: Fixes repo url in docs build script [#4](https://github.com/pinterest/gestalt/pull/4)
+- Internal: Webpack 3 upgrade [#11](https://github.com/pinterest/gestalt/pull/11)

--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -54,7 +54,10 @@ async function getReleaseNotes({ lastCommitMessage, newVersion, releaseType }) {
 
 ### ${capitalizeFirstLetter(releaseType)}
 
-- ${lastCommitMessage}`;
+- ${lastCommitMessage.replace(/(\(#\d+\))/g, (value) => {
+    const PR = value.replace('(', '').replace(')', '').replace('#', '');
+    return `([#${PR}](https://github.com/pinterest/gestalt/pull/${PR}))`;
+  })}`;
 }
 
 async function bumpPackageVersion() {


### PR DESCRIPTION
### Summary

#### What changed?

Internal: add links to PR in Changelog on every release

#### Why?

Facilitate the access to PR urls
