### PR TITLE
Docs: clean link urls to only use relative paths for Docs links

### DIFF
--- a/docs/examples/sidenavigation/badgeExample.js
+++ b/docs/examples/sidenavigation/badgeExample.js
@@ -6,27 +6,21 @@ export default function Example(): Node {
   return (
     <SideNavigation accessibilityLabel="Badge example">
       <SideNavigation.Section label="Navigation">
+        <SideNavigation.TopItem href="#" label="PageHeader" />
+        <SideNavigation.TopItem href="#" label="Tabs" />
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/web/pageheader"
-          label="PageHeader"
-        />
-        <SideNavigation.TopItem href="https://gestalt.pinterest.systems/web/tabs" label="Tabs" />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
+          href="#"
           label="SideNavigation"
           badge={{ text: 'New', type: 'info' }}
         />
       </SideNavigation.Section>
       <SideNavigation.Section label="Controls">
         <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/web/radiobutton"
+          href="#"
           label="RadioButton"
           badge={{ text: 'Deprecated', type: 'warning' }}
         />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/web/radiogroup"
-          label="RadioGroup"
-        />
+        <SideNavigation.TopItem href="#" label="RadioGroup" />
       </SideNavigation.Section>
     </SideNavigation>
   );

--- a/docs/examples/sidenavigation/borderExample.js
+++ b/docs/examples/sidenavigation/borderExample.js
@@ -6,25 +6,13 @@ export default function Example(): Node {
   return (
     <SideNavigation accessibilityLabel="Border example" showBorder>
       <SideNavigation.Section label="Navigation">
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/web/pageheader"
-          label="PageHeader"
-        />
-        <SideNavigation.TopItem href="https://gestalt.pinterest.systems/web/tabs" label="Tabs" />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
-          label="SideNavigation"
-        />
+        <SideNavigation.TopItem href="#" label="PageHeader" />
+        <SideNavigation.TopItem href="#" label="Tabs" />
+        <SideNavigation.TopItem href="#" label="SideNavigation" />
       </SideNavigation.Section>
       <SideNavigation.Section label="Controls">
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/web/radiobutton"
-          label="RadioButton"
-        />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/web/radiogroup"
-          label="RadioGroup"
-        />
+        <SideNavigation.TopItem href="#" label="RadioButton" />
+        <SideNavigation.TopItem href="#" label="RadioGroup" />
       </SideNavigation.Section>
     </SideNavigation>
   );

--- a/docs/examples/sidenavigation/headerExample.js
+++ b/docs/examples/sidenavigation/headerExample.js
@@ -41,53 +41,38 @@ export default function Example(): Node {
       {organisedBy === 'categorized' ? (
         <React.Fragment>
           <SideNavigation.Section label="Navigation">
+            <SideNavigation.TopItem href="#" label="PageHeader" />
+            <SideNavigation.TopItem href="#" label="Tabs" />
             <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/web/pageheader"
-              label="PageHeader"
-            />
-            <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/web/tabs"
-              label="Tabs"
-            />
-            <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
+              href="#"
               label="SideNavigation"
               badge={{ text: 'New', type: 'info' }}
             />
           </SideNavigation.Section>
           <SideNavigation.Section label="Controls">
             <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/web/radiobutton"
+              href="#"
               label="RadioButton"
               badge={{ text: 'Deprecated', type: 'warning' }}
             />
-            <SideNavigation.TopItem
-              href="https://gestalt.pinterest.systems/web/radiogroup"
-              label="RadioGroup"
-            />
+            <SideNavigation.TopItem href="#" label="RadioGroup" />
           </SideNavigation.Section>
         </React.Fragment>
       ) : (
         <React.Fragment>
+          <SideNavigation.TopItem href="#" label="PageHeader" />
           <SideNavigation.TopItem
-            href="https://gestalt.pinterest.systems/web/pageheader"
-            label="PageHeader"
-          />
-          <SideNavigation.TopItem
-            href="https://gestalt.pinterest.systems/web/radiobutton"
+            href="#"
             label="RadioButton"
             badge={{ text: 'Deprecated', type: 'warning' }}
           />
+          <SideNavigation.TopItem href="#" label="RadioGroup" />
           <SideNavigation.TopItem
-            href="https://gestalt.pinterest.systems/web/radiogroup"
-            label="RadioGroup"
-          />
-          <SideNavigation.TopItem
-            href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
+            href="#"
             label="SideNavigation"
             badge={{ text: 'New', type: 'info' }}
           />
-          <SideNavigation.TopItem href="https://gestalt.pinterest.systems/web/tabs" label="Tabs" />
+          <SideNavigation.TopItem href="/web/tabs" label="Tabs" />
         </React.Fragment>
       )}
     </SideNavigation>

--- a/docs/examples/sidenavigation/sectionsExample.js
+++ b/docs/examples/sidenavigation/sectionsExample.js
@@ -6,40 +6,16 @@ export default function Example(): Node {
   return (
     <SideNavigation accessibilityLabel="Sections example">
       <SideNavigation.Section label="Resources">
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/get_started/developers/eslint_plugin"
-          label="Eslint plugin"
-        />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/get_started/faq"
-          label="FAQ"
-        />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/get_started/developers/hacking_gestalt"
-          label="How to hack around Gestalt"
-        />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/get_started/developers/tooling/web"
-          label="Tooling"
-        />
+        <SideNavigation.TopItem href="#" label="Eslint plugin" />
+        <SideNavigation.TopItem href="#" label="FAQ" />
+        <SideNavigation.TopItem href="#" label="How to hack around Gestalt" />
+        <SideNavigation.TopItem href="#" label="Tooling" />
       </SideNavigation.Section>
       <SideNavigation.Section label="Foundations">
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/foundations/accessibility"
-          label="Accessibility"
-        />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/foundations/elevation"
-          label="Elevation"
-        />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/foundations/typography/guidelines"
-          label="Typography"
-        />
-        <SideNavigation.TopItem
-          href="https://gestalt.pinterest.systems/foundations/color/palette"
-          label="Color palette"
-        />
+        <SideNavigation.TopItem href="#" label="Accessibility" />
+        <SideNavigation.TopItem href="#" label="Elevation" />
+        <SideNavigation.TopItem href="#" label="Typography" />
+        <SideNavigation.TopItem href="#" label="Color palette" />
       </SideNavigation.Section>
     </SideNavigation>
   );

--- a/docs/markdown/android/avatar.md
+++ b/docs/markdown/android/avatar.md
@@ -15,7 +15,7 @@ fullwidth: true
   </Group>
   <Group>
   <Dont title="When not to use" />
-     - To represent a group of people, companies and/or brands. use [AvatarGroup](https://gestalt.pinterest.systems/web/avatargroup) instead
+     - To represent a group of people, companies and/or brands. Use [AvatarGroup](/web/avatargroup) instead
   </Group>
 </TwoCol>
 

--- a/docs/markdown/android/icon.md
+++ b/docs/markdown/android/icon.md
@@ -20,7 +20,7 @@ fullwidth: true
 - For decorative purposes or visual embellishment, like how you would use an illustration. Contact us if this is needed.
 - As a visual reinforcement for associated text without adding new meaning.
 - To communicate status or health. Use Status instead.
-- As an interactive element (e.g., hover, focus, click/tap). Use [IconButton](https://gestalt.pinterest.systems/web/iconbutton) instead.
+- As an interactive element (e.g., hover, focus, click/tap). Use [IconButton](/android/iconbutton) instead.
 </Group>
 </TwoCol>
 
@@ -31,7 +31,7 @@ fullwidth: true
 - When possible, include a visible text label.
 - Icons should always be a solid color and should inherit the color of the surrounding text if applicable.
 
-For general Icon best practices, refer to the web [Icon documentation](https://gestalt.pinterest.systems/web/icon).
+For general Icon best practices, refer to the web [Icon documentation](/web/icon).
 
 ## Accessibility
 
@@ -43,7 +43,7 @@ People use Android's accessibility features, such as TalkBack and dynamic text s
 ## Variants
 
 ### Styling
-For information on colors and states, refer to the [web Icon guidelines](https://gestalt.pinterest.systems/web/icon).
+For information on colors and states, refer to the [web Icon guidelines](/web/icon).
 
 ### Platform-specific icons
 
@@ -120,18 +120,18 @@ Used sparingly to draw attention to an icon that might otherwise be missed.
 <TwoCol>
 
 <IllustrationCard
-              title="Button"
-              description="Button allows users to take actions, and make choices using text labels to express what action will occur when the user interacts with it."
-              color="green-matchacado-50"
-              image="button"
-            />
+  title="Button"
+  description="Button allows users to take actions, and make choices using text labels to express what action will occur when the user interacts with it."
+  color="green-matchacado-50"
+  image="button"
+/>
 
 <IllustrationCard
-              title="IconButton"
-              description="Use IconButton when only an icon is needed instead of text."
-              color="green-matchacado-50"
-              image="icon-button"
-            />
+  title="IconButton"
+  description="Use IconButton when only an icon is needed instead of text."
+  color="green-matchacado-50"
+  image="icon-button"
+/>
 
 </TwoCol>
 */}

--- a/docs/markdown/android/textfield.md
+++ b/docs/markdown/android/textfield.md
@@ -16,7 +16,7 @@ fullwidth: true
 </Group>
 <Group>
 <Dont title="When not to use" />
-- Situations where long amounts of text need to be entered, since the full content of the TextField will be truncated. Use [TextArea](https://gestalt.pinterest.systems/web/textarea) instead.
+- Situations where long amounts of text need to be entered, since the full content of the TextField will be truncated. Use [TextArea](/web/textarea) instead.
 </Group>
 </TwoCol>
 
@@ -88,7 +88,7 @@ Place fields horizontally. This creates unnecessarily restricted fields and a mo
 </TwoCol>
 
 
-For general Icon best practices, refer to the web [Text Field Documentation](https://gestalt.pinterest.systems/web/textfield).
+For general Icon best practices, refer to the web [Text Field Documentation](/web/textfield).
 
 ## Accessibility
 

--- a/docs/markdown/get_started/developers/development_process.md
+++ b/docs/markdown/get_started/developers/development_process.md
@@ -129,7 +129,7 @@ yarn generate ComponentName
   yarn run flow-generate:css
   ```
 
-  - If you are introducing breaking changes, create a **[codemod](https://gestalt.pinterest.systems/development#codemods)** to help users migrate between versions.
+  - If you are introducing breaking changes, create a **[codemod](/development#codemods)** to help users migrate between versions.
 
   ```bash
   yarn run flow-generate:css
@@ -154,7 +154,7 @@ git push -f origin HEAD
 
 <Hint icon="lock"> If you are a Pinterest employee, please let us know on Slack (#gestalt-web) that your PR is ready for review. </Hint>
 
-- Ensure checks pass on your Pull Request - having the "Require Semver / Test (pull_request)" check fail is expected, because a Gestalt maintainer needs to add a correct semver label. Read our [versioning guidelines](https://gestalt.pinterest.systems/development#versioning).
+- Ensure checks pass on your Pull Request - having the "Require Semver / Test (pull_request)" check fail is expected, because a Gestalt maintainer needs to add a correct semver label. Read our [versioning guidelines](/development#versioning).
 
 - After a Gestalt maintainer adds a correct semver label and approves a Pull Request, the PR will be ready to merge. Coordinate with the reviewer to determine when the PR should be merged.
 

--- a/docs/markdown/ios/avatar.md
+++ b/docs/markdown/ios/avatar.md
@@ -15,7 +15,7 @@ fullwidth: true
   </Group>
   <Group>
   <Dont title="When not to use" />
-     - To represent a group of people, companies and/or brands. use [AvatarGroup](https://gestalt.pinterest.systems/web/avatargroup) instead
+     - To represent a group of people, companies and/or brands. Use [AvatarGroup](/web/avatargroup) instead
   </Group>
 </TwoCol>
 

--- a/docs/markdown/ios/icon.md
+++ b/docs/markdown/ios/icon.md
@@ -20,7 +20,7 @@ fullwidth: true
 - For decorative purposes or visual embellishment, like how you would use an illustration. Contact us if this is needed.
 - As a visual reinforcement for associated text without adding new meaning.
 - To communicate status or health. Use Status instead.
-- As an interactive element (e.g., hover, focus, click/tap). Use [IconButton](https://gestalt.pinterest.systems/web/iconbutton) instead.
+- As an interactive element (e.g., hover, focus, click/tap). Use [IconButton](/ios/iconbutton) instead.
 </Group>
 </TwoCol>
 
@@ -31,7 +31,7 @@ fullwidth: true
 - When possible, include a visible text label.
 - Icons should always be a solid color and should inherit the color of the surrounding text if applicable.
 
-For general Icon best practices, refer to the web [Icon documentation](https://gestalt.pinterest.systems/web/icon).
+For general Icon best practices, refer to the web [Icon documentation](/web/icon).
 
 ## Accessibility
 
@@ -43,7 +43,7 @@ People use Apple’s accessibility features, such as reduced transparency, Voice
 ## Variants
 
 ### Styling
-For information on colors and states, refer to the [web Icon guidelines](https://gestalt.pinterest.systems/web/icon).
+For information on colors and states, refer to the [web Icon guidelines](/web/icon).
 
 ### Platform Specific Icons
 
@@ -119,18 +119,18 @@ Used sparingly to draw attention to an icon that might otherwise be missed.
 <TwoCol>
 
 <IllustrationCard
-              title="Button"
-              description="Button allows users to take actions, and make choices using text labels to express what action will occur when the user interacts with it."
-              color="green-matchacado-50"
-              image="button"
-            />
+  title="Button"
+  description="Button allows users to take actions, and make choices using text labels to express what action will occur when the user interacts with it."
+  color="green-matchacado-50"
+  image="button"
+/>
 
 <IllustrationCard
-              title="IconButton"
-              description="Use IconButton when only an icon is needed instead of text."
-              color="green-matchacado-50"
-              image="icon-button"
-            />
+  title="IconButton"
+  description="Use IconButton when only an icon is needed instead of text."
+  color="green-matchacado-50"
+  image="icon-button"
+/>
 
 </TwoCol>
 */}

--- a/docs/markdown/ios/textfield.md
+++ b/docs/markdown/ios/textfield.md
@@ -16,7 +16,7 @@ fullwidth: true
 </Group>
 <Group>
 <Dont title="When not to use" />
-- Situations where long amounts of text need to be entered, since the full content of the TextField will be truncated. Use [TextArea](https://gestalt.pinterest.systems/web/textarea) instead.
+- Situations where long amounts of text need to be entered, since the full content of the TextField will be truncated. Use [TextArea](/web/textarea) instead.
 </Group>
 </TwoCol>
 
@@ -88,7 +88,7 @@ Place fields horizontally. This creates unnecessarily restricted fields and a mo
 </TwoCol>
 
 
-For general Icon best practices, refer to the web [Text Field Documentation](https://gestalt.pinterest.systems/web/textfield).
+For general Icon best practices, refer to the web [Text Field Documentation](/web/textfield).
 
 ## Accessibility
 

--- a/docs/markdown/testing/how-to.md
+++ b/docs/markdown/testing/how-to.md
@@ -84,7 +84,7 @@ The Gestalt team sends out twice-yearly surveys to the design and engineering or
 
 We are always happy to help answer questions regarding Gestalt component design and usage, design system best practices, accessibility, icons and colors. If it’s part of Gestalt, we’re here to help! If it’s outside of the realm of our design system, we’ll try our best to answer and/or point you to the person who can. Feel free to reach out to us on [Slack](http://gestalt.pinterest.systems/how_to_work_with_us#Slack-channels) anytime.
 
-We also offer documentation on this site ([go/GestaltWeb](https://gestalt.pinterest.systems/)) and a [Figma library](https://pinch/gestaltFigma) of components that exist within Gestalt.
+We also offer documentation on this [site](https://gestalt.pinterest.systems)) and a [Figma library](https://pinch/gestaltFigma) of components that exist within Gestalt.
 
 ## Resources, Slack, and meetings — oh my!
 
@@ -96,7 +96,7 @@ To see the bigger picture, you can view our [OKRs](https://pinch.pinadmin.com/ge
 
 ### Slack channels
 
-Before reaching out, take a look at our [documentation](https://gestalt.pinterest.systems/) to see if it answers your question, because it will likely get you the fastest answer. Still need help? Try searching Slack for your question, and then feel free to ask if your question hasn’t been answered in the past.
+Before reaching out, take a look at our [documentation](https://gestalt.pinterest.systems) to see if it answers your question, because it will likely get you the fastest answer. Still need help? Try searching Slack for your question, and then feel free to ask if your question hasn’t been answered in the past.
 
 You can also reference our [Communication Guidelines](https://pinch.pinadmin.com/gestaltCommsGuidelines) for more info.
 

--- a/docs/pages/foundations/color/examples.js
+++ b/docs/pages/foundations/color/examples.js
@@ -88,7 +88,7 @@ export default function ColorExamplesPage(): Node {
                   Having a limited range of colors supports consistency, making our product easier
                   to interact with. Keep in mind that continuous use of high-contrast and saturated
                   colors can create fatigue and eye strain. See our{' '}
-                  <Link inline href="https://gestalt.pinterest.systems/foundations/color/usage">
+                  <Link inline href="/foundations/color/usage">
                     <Text underline>color usage guidelines</Text>
                   </Link>{' '}
                   for more information about our color choices.
@@ -107,10 +107,7 @@ export default function ColorExamplesPage(): Node {
                   ways. For example, colors often change between light and dark modes to help
                   portray elevation and hierarchy, while ensuring proper contrast and legibility.
                   Any colors used should be consistent with the full{' '}
-                  <Link
-                    inline
-                    href="https://gestalt.pinterest.systems/foundations/color/palette#Extended-palette"
-                  >
+                  <Link inline href="/foundations/color/palette#Extended-palette">
                     <Text inline underline>
                       Pinterest color palette
                     </Text>
@@ -129,7 +126,7 @@ export default function ColorExamplesPage(): Node {
                 <Text>
                   All color pairings must pass WCAG&apos;s AA color contrast standards. Using our
                   color tokens properly ensures our colors meet legibility standards. Check out our{' '}
-                  <Link inline href="https://gestalt.pinterest.systems/foundations/accessibility">
+                  <Link inline href="/foundations/accessibility">
                     <Text inline underline>
                       accessibility guidelines
                     </Text>
@@ -277,7 +274,7 @@ export default function ColorExamplesPage(): Node {
           <MainSection.Card
             cardSize="md"
             type="don't"
-            description="Apply alternative colors not specified in our color tokens when switching between themes. If a new color value is needed for a specific use case, [let the Gestalt team know](https://gestalt.pinterest.systems/get_started/how_to_work_with_us#Meetings-and-events) and we will evaluate."
+            description="Apply alternative colors not specified in our color tokens when switching between themes. If a new color value is needed for a specific use case, [let the Gestalt team know](/get_started/how_to_work_with_us#Meetings-and-events) and we will evaluate."
             sandpackExample={
               <SandpackExample
                 code={alternativeColorTokensExample}
@@ -306,7 +303,7 @@ export default function ColorExamplesPage(): Node {
           <MainSection.Card
             cardSize="md"
             type="don't"
-            description="Apply colors and styles not available in our elevation tokens to elevate surfaces as it can create inconsistency, and eye strain. If a different color value is needed for a specific elevation use case, [let the Gestalt team know](https://gestalt.pinterest.systems/get_started/how_to_work_with_us#Meetings-and-events) and we will assist."
+            description="Apply colors and styles not available in our elevation tokens to elevate surfaces as it can create inconsistency, and eye strain. If a different color value is needed for a specific elevation use case, [let the Gestalt team know](/get_started/how_to_work_with_us#Meetings-and-events) and we will assist."
             sandpackExample={
               <SandpackExample
                 code={invalidElevationExample}

--- a/docs/pages/foundations/elevation.js
+++ b/docs/pages/foundations/elevation.js
@@ -67,7 +67,7 @@ export default function ColorUsagePage(): Node {
       >
         <MainSection.Subsection
           title="Floating"
-          description={`Default elevation level that elevates messages temporarily appearing in front of other surfaces, such as modals and banners. Available through the \`borderStyle\` prop in [Box](https://gestalt.pinterest.systems/web/box#Borders). For dark mode, we use the \`elevationFloating\` background of Box instead of a shadow.`}
+          description={`Default elevation level that elevates messages temporarily appearing in front of other surfaces, such as modals and banners. Available through the \`borderStyle\` prop in [Box](/web/box#Borders). For dark mode, we use the \`elevationFloating\` background of Box instead of a shadow.`}
         >
           <Flex
             gap={{
@@ -122,7 +122,7 @@ export default function ColorUsagePage(): Node {
         <MainSection.Subsection
           title="Raised"
           description={`
-          Presents a drop shadow on the edge of a top or bottom component, allowing surfaces to move behind when scrolled. Available through the \`borderStyle\` prop in [Box](https://gestalt.pinterest.systems/web/box#Borders). In dark mode, the raised border should be paired with the \`elevationRaised\` background color.
+          Presents a drop shadow on the edge of a top or bottom component, allowing surfaces to move behind when scrolled. Available through the \`borderStyle\` prop in [Box](/web/box#Borders). In dark mode, the raised border should be paired with the \`elevationRaised\` background color.
           `}
         >
           <Flex

--- a/docs/pages/foundations/messaging/available_components.js
+++ b/docs/pages/foundations/messaging/available_components.js
@@ -42,7 +42,7 @@ export default function MessagingComponentsPage(): Node {
           </Text>
 
           <Text>
-            <Link href="https://gestalt.pinterest.systems/web/callout" underline="always">
+            <Link href="/web/callout" underline="always">
               Go to the Callout component
             </Link>
           </Text>
@@ -78,7 +78,7 @@ export default function MessagingComponentsPage(): Node {
           </Text>
 
           <Text>
-            <Link href="https://gestalt.pinterest.systems/web/slimbanner" underline="always">
+            <Link href="/web/slimbanner" underline="always">
               Go to the SlimBanner component
             </Link>
           </Text>
@@ -94,7 +94,7 @@ export default function MessagingComponentsPage(): Node {
           </Text>
 
           <Text>
-            <Link href="https://gestalt.pinterest.systems/web/modal" underline="always">
+            <Link href="/web/modal" underline="always">
               Go to the Modal component
             </Link>
           </Text>
@@ -165,7 +165,7 @@ export default function MessagingComponentsPage(): Node {
             </ul>
           </Text>
           <Text>
-            <Link href="https://gestalt.pinterest.systems/web/toast" underline="always">
+            <Link href="/web/toast" underline="always">
               Go to the Toast component
             </Link>
           </Text>

--- a/docs/pages/get_started/developers/releases.js
+++ b/docs/pages/get_started/developers/releases.js
@@ -14,7 +14,7 @@ export default function ReleasesPage(): Node {
 
 Each major, minor, and patch change is merged to master and released as the latest supported Gestalt version. Check the [release log](https://github.com/pinterest/gestalt/releases).
 
-When a release will cause breaking changes — in usage or in typing — we provide a  codemod to ease the upgrade process. Read more about [codemods](https://gestalt.pinterest.systems/releases#Codemods)
+When a release will cause breaking changes — in usage or in typing — we provide a  codemod to ease the upgrade process. Read more about [codemods](/releases#Codemods)
 
 Our versioning guidelines follow those outlined at [semver.org](https://semver.org/):
 

--- a/docs/pages/get_started/how_to_work_with_us.js
+++ b/docs/pages/get_started/how_to_work_with_us.js
@@ -91,7 +91,7 @@ The Gestalt team sends out twice-yearly surveys to the design and engineering or
         <MainSection.Subsection
           description={`
 We are always happy to help answer questions regarding Gestalt component design and usage, design system best practices, accessibility, icons and colors. If it’s part of Gestalt, we’re here to help! If it’s outside of the realm of our design system, we’ll try our best to answer and/or point you to the person who can. Feel free to reach out to us on [Slack](http://gestalt.pinterest.systems/how_to_work_with_us#Slack-channels) anytime.
-We also offer documentation on this site ([go/GestaltWeb](https://gestalt.pinterest.systems/)) and a [Figma library](https://pinch/gestaltFigma) of components that exist within Gestalt.
+We also offer documentation on this [site](https://gestalt.pinterest.systems/)) and a [Figma library](https://pinch/gestaltFigma) of components that exist within Gestalt.
 `}
         />
       </MainSection>

--- a/docs/pages/web/combobox.js
+++ b/docs/pages/web/combobox.js
@@ -704,7 +704,7 @@ function ComboBoxExample(props) {
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Error message"
-          description="For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/web/link) or [TapArea](https://gestalt.pinterest.systems/web/taparea)"
+          description="For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](/web/link) or [TapArea](/web/taparea)"
         >
           <MainSection.Card
             cardSize="lg"

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -453,7 +453,7 @@ We recommend adding an external Link to inline content. However, use max of two 
 
 Also, consider adding external Links to elements where the "visit" icon will support the user's comprehension, letting them know they are leaving Pinterest content and going to an external domain. For example, links inside a footer element.
 
-For external links that an external Gestalt Link doesn't apply, check out [Button link role](https://gestalt.pinterest.systems/web/button#Role) or [IconButton link role](https://gestalt.pinterest.systems/component/web/iconbutton#Role).`}
+For external links that an external Gestalt Link doesn't apply, check out [Button link role](/web/button#Role) or [IconButton link role](/component/web/iconbutton#Role).`}
         />
       </AccessibilitySection>
 

--- a/docs/pages/web/pageheader.js
+++ b/docs/pages/web/pageheader.js
@@ -259,9 +259,9 @@ Be brief with text in all components to account for languages with longer words.
 
 If there's already a primary action elsewhere on the page, PageHeader can have 1 or 2 secondary actions. Use \`primaryAction\` as an additional secondary action.
 
-Primary and secondary actions are consolidated into [Dropdown](https://gestalt.pinterest.systems/web/dropdown) below the [sm breakpoint](https://gestalt.pinterest.systems/foundations/screen_sizes#Web-(px)). \`primaryAction\` takes both the main component and its equivalent using Dropdown subcomponents.
+Primary and secondary actions are consolidated into [Dropdown](/web/dropdown) below the [sm breakpoint](/foundations/screen_sizes#Web-(px)). \`primaryAction\` takes both the main component and its equivalent using Dropdown subcomponents.
 
-For example, Button should be complemented with [Dropdown.Item](https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item), Link should be complemented with [Dropdown.Link](https://gestalt.pinterest.systems/web/dropdown#Dropdown.Link), and an IconButton displaying a Dropdown should reuse the same Dropdown subcomponents. Don't forget to pass \`dropdownAccessibilityLabel\` for the IconButton consolidating all actions into [Dropdown](https://gestalt.pinterest.systems/web/dropdown) below the sm breakpoint.
+For example, Button should be complemented with [Dropdown.Item](/web/dropdown#Dropdown.Item), Link should be complemented with [Dropdown.Link](/web/dropdown#Dropdown.Link), and an IconButton displaying a Dropdown should reuse the same Dropdown subcomponents. Don't forget to pass \`dropdownAccessibilityLabel\` for the IconButton consolidating all actions into [Dropdown](/web/dropdown) below the sm breakpoint.
 
 Resize your window to observe how the PageHeaders below adapt to smaller screen widths.
 `}
@@ -282,9 +282,9 @@ Resize your window to observe how the PageHeaders below adapt to smaller screen 
           title="Secondary action"
           description={`PageHeader also supports an optional \`secondaryAction\`. It will likely be a [Button](/web/button) or an [IconButton](/web/iconbutton) with a [Tooltip](/web/tooltip) and optional [Dropdown](/web/dropdown). Any Buttons or IconButtons should be \`size="lg"\`.
 
-Primary and secondary actions are consolidated into [Dropdown](https://gestalt.pinterest.systems/web/dropdown) below the [sm breakpoint](https://gestalt.pinterest.systems/foundations/screen_sizes#Web-(px)). \`secondaryAction\` takes both the main component and its equivalent using Dropdown subcomponents.
+Primary and secondary actions are consolidated into [Dropdown](/web/dropdown) below the [sm breakpoint](/foundations/screen_sizes#Web-(px)). \`secondaryAction\` takes both the main component and its equivalent using Dropdown subcomponents.
 
-For example, Button should be complemented with [Dropdown.Item](https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item), Link should be complemented with [Dropdown.Link](https://gestalt.pinterest.systems/web/dropdown#Dropdown.Link), and an IconButton displaying a Dropdown should reused the same Dropdown subcomponents. Don't forget to pass \`dropdownAccessibilityLabel\` for the IconButton consolidating all actions into [Dropdown](https://gestalt.pinterest.systems/web/dropdown) below the sm breakpoint.
+For example, Button should be complemented with [Dropdown.Item](/web/dropdown#Dropdown.Item), Link should be complemented with [Dropdown.Link](/web/dropdown#Dropdown.Link), and an IconButton displaying a Dropdown should reused the same Dropdown subcomponents. Don't forget to pass \`dropdownAccessibilityLabel\` for the IconButton consolidating all actions into [Dropdown](/web/dropdown) below the sm breakpoint.
 
 Resize your window to observe how the PageHeaders below adapt to smaller screen widths.
 
@@ -304,7 +304,7 @@ Resize your window to observe how the PageHeaders below adapt to smaller screen 
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Complementary items"
-          description={`PageHeader supports an optional pair of components next to the CTA section. It's strongly recommended to limit this space to data display components, mostly [Datapoint](https://gestalt.pinterest.systems/web/datapoint). The complementary component section is hidden in small breakpoints.`}
+          description={`PageHeader supports an optional pair of components next to the CTA section. It's strongly recommended to limit this space to data display components, mostly [Datapoint](/web/datapoint). The complementary component section is hidden in small breakpoints.`}
         >
           <MainSection.Card
             cardSize="lg"
@@ -355,7 +355,7 @@ PageHeader also supports a bottom border to show the division between PageHeader
         <MainSection.Subsection
           title="Responsive"
           columns={2}
-          description={`PageHeader is responsive to different [viewport breakpoints](https://gestalt.pinterest.systems/foundations/screen_sizes#Web-(px)).
+          description={`PageHeader is responsive to different [viewport breakpoints](/foundations/screen_sizes#Web-(px)).
 
 Therefore, PageHeader’s behavior relies on the window size and requires PageHeader to be used on a full-window width to correctly respond to different breakpoints. Don’t use PageHeader right next to elements such as side-navigation bars that wouldn’t allow PageHeader to extend the full width of the window.
 

--- a/docs/pages/web/tag.js
+++ b/docs/pages/web/tag.js
@@ -14,7 +14,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     <Page title="Tag">
       <PageHeader
         name="Tag"
-        description="[Tags](https://gestalt.pinterest.systems/web/tag) are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](https://gestalt.pinterest.systems/web/textfield#tagsExample), [TextAreas](https://gestalt.pinterest.systems/web/textarea#tagsExample), [ComboBox](https://gestalt.pinterest.systems/web/combobox#Tags) or as standalone components."
+        description="[Tags](/web/tag) are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](/web/textfield#tagsExample), [TextAreas](/web/textarea#tagsExample), [ComboBox](/web/combobox#Tags) or as standalone components."
       />
       <PropTable
         props={[

--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -86,7 +86,7 @@ function Example(props) {
           <MainSection.Card
             cardSize="sm"
             type="don't"
-            description="Use TextArea when the text input is a single, non-sentence response — even in cases with long content. Use [TextField](https://gestalt.pinterest.systems/web/textfield) instead."
+            description="Use TextArea when the text input is a single, non-sentence response — even in cases with long content. Use [TextField](/web/textfield) instead."
             defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('https://www.pinterest.com/pin/768145280205600341/');

--- a/docs/pages/web/tooltip.js
+++ b/docs/pages/web/tooltip.js
@@ -80,7 +80,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             type="don't"
             title="When not to use"
             description={`
-          - Using a separate Tooltip instance with IconButton. Use [IconButton's built-in tooltip](https://gestalt.pinterest.systems/web/iconbutton#With-Tooltip) instead.
+          - Using a separate Tooltip instance with IconButton. Use [IconButton's built-in tooltip](/web/iconbutton#With-Tooltip) instead.
           - Displaying information that is critical to the understanding of an element/feature. Use inline text instead.
           - Offering context at the surface-level scope. Consider a [Callout](/web/callout) instead.
         `}


### PR DESCRIPTION
Docs: clean link urls to only use relative paths for Docs links