### PR TITLE
Docs: Add summary option for What's New page

### DIFF
--- a/docs/pages/BlogPosts.json
+++ b/docs/pages/BlogPosts.json
@@ -3,6 +3,7 @@
   "digests": [
     {
       "week": "September 02, 2022",
+      "summary": "Handoff kit updates, Figma search improvements, and more mobile docs",
       "posts": [
         {
           "title": "Design handoff kit split!",
@@ -29,6 +30,7 @@
     },
     {
       "month": "August",
+      "summary": "Introducing SideNavigation, a monthly Eng newsletter, and new Box colors",
       "posts": [
         {
           "title": "Gestalt Eng August Newsletter",
@@ -67,6 +69,7 @@
     },
     {
       "week": "August 26, 2022",
+      "summary": "New messaging guidelines, Figma cleanups, and mobile docs",
       "posts": [
         {
           "title": "Gestalt now has mobile component docs!",

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -135,11 +135,14 @@ export default function Blog(): Node {
       </RadioGroup>
 
       <Flex direction="column" gap={12}>
-        {filteredDigests.map(({ month, week, posts }, i) => (
+        {filteredDigests.map(({ month, week, posts, summary }, i) => (
           <Flex key={`digest-${week ?? month}`} direction="column" gap={12}>
             {i > 0 && <Divider />}
 
-            <MainSection name={week ? `Week of ${week}` : `Month of ${month}`}>
+            <MainSection
+              name={week ? `Week of ${week}` : `Month of ${month}`}
+              description={summary}
+            >
               <Flex
                 direction="column"
                 gap={{


### PR DESCRIPTION
## Summary

#### What changed?

Add ability to show a summary for each What's New section

![Screen Shot 2022-09-06 at 11 15 44 AM](https://user-images.githubusercontent.com/5125094/189007490-9c2b2a17-f211-4af8-b04f-22a3fbc45d2c.png)


#### Why?

Give readers a high-level overview of the content