### PR TITLE
Docs: Visual fixes to the site header

### DIFF
--- a/docs/docs-components/DocSearch.js
+++ b/docs/docs-components/DocSearch.js
@@ -6,6 +6,8 @@ import { PAGE_HEADER_POPOVER_ZINDEX } from './z-indices.js';
 const INPUT_ID = 'algolia-doc-search';
 
 function SearchBox({ popoverZIndex }: {| popoverZIndex?: CompositeZIndex |}) {
+  // Icon placement is copied directly from SearchField
+  // Try to maintain consistency w/ SearchField whenever possible
   return (
     <Tooltip inline text="Pro tip: press '/' to quickly access search" zIndex={popoverZIndex}>
       <form className="searchbox">

--- a/docs/docs-components/DocSearch.js
+++ b/docs/docs-components/DocSearch.js
@@ -17,8 +17,21 @@ function SearchBox({ popoverZIndex }: {| popoverZIndex?: CompositeZIndex |}) {
             placeholder="Search Gestalt"
             aria-label="Search Gestalt docs"
           />
-          <Box position="absolute" top left marginTop={3} marginStart={4}>
-            <Icon icon="search" accessibilityLabel="" size="16" color="default" />
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                pointerEvents: 'none',
+                // Added the following lines for Safari support
+                top: '50%',
+                transform: 'translateY(-50%)',
+              },
+            }}
+            left
+            right
+            paddingX={4}
+            position="absolute"
+          >
+            <Icon icon="search" accessibilityLabel="" />
           </Box>
         </div>
       </form>

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -217,7 +217,11 @@ function Header() {
             ref={anchorRef}
             selected={isSettingsDropdownOpen}
             size="sm"
-            tooltip={{ 'text': 'Site settings', 'zIndex': PAGE_HEADER_POPOVER_ZINDEX }}
+            tooltip={{
+              'text': 'Site settings',
+              'idealDirection': 'right',
+              'zIndex': PAGE_HEADER_POPOVER_ZINDEX,
+            }}
           />
         </Box>
         {isSettingsDropdownOpen && (

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -112,6 +112,9 @@ function Header() {
   const [isSettingsDropdownOpen, setSettingsDropdownOpen] = useState(false);
   const [isMobileSearchExpandedOpen, setMobileSearchExpanded] = useState(false);
 
+  const siteSettingsAnchorRef = useRef(null);
+  const searchAnchorRef = useRef(null);
+
   const mainNavigationTabs = useMemo(
     () => getTabs(componentPlatformFilteredBy),
     [componentPlatformFilteredBy],
@@ -126,8 +129,6 @@ function Header() {
           router.pathname.includes(`/${convertNamesForURL(tab.text)}`),
         ),
   );
-
-  const anchorRef = useRef(null);
 
   // If the route includes a platform, set the "components" tab active
   // Otherwise set it based on the route
@@ -214,7 +215,7 @@ function Header() {
             icon="filter"
             iconColor="darkGray"
             onClick={() => setSettingsDropdownOpen((prevVal) => !prevVal)}
-            ref={anchorRef}
+            ref={siteSettingsAnchorRef}
             selected={isSettingsDropdownOpen}
             size="sm"
             tooltip={{
@@ -226,7 +227,7 @@ function Header() {
         </Box>
         {isSettingsDropdownOpen && (
           <SettingsDropdown
-            anchorRef={anchorRef}
+            anchorRef={siteSettingsAnchorRef}
             closeDropdown={() => setSettingsDropdownOpen(false)}
           />
         )}
@@ -244,7 +245,7 @@ function Header() {
         </Box>
 
         <DocSearch
-          anchorRef={anchorRef}
+          anchorRef={searchAnchorRef}
           isMobileSearchExpandedOpen={isMobileSearchExpandedOpen}
           toggleSearchBarOpen={() => {
             setMobileSearchExpanded((prevVal) => !prevVal);

--- a/docs/docs-components/appContext.js
+++ b/docs/docs-components/appContext.js
@@ -39,6 +39,7 @@ function AppContextProvider({ children }: {| children?: Node |}): Node {
   const setTextDirection = (direction) => setCookies(textDirectionKey, direction);
 
   useEffect(() => {
+    console.log('***');
     if (document && document.documentElement) {
       document.documentElement.dir = textDirection;
     }

--- a/docs/docs-components/appContext.js
+++ b/docs/docs-components/appContext.js
@@ -39,7 +39,6 @@ function AppContextProvider({ children }: {| children?: Node |}): Node {
   const setTextDirection = (direction) => setCookies(textDirectionKey, direction);
 
   useEffect(() => {
-    console.log('***');
     if (document && document.documentElement) {
       document.documentElement.dir = textDirection;
     }

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -178,6 +178,7 @@ html[dir="rtl"] .Markdown ul + pre {
   font-size: 16px;
   height: 100%;
   padding: 0 32px 0 40px;
+  text-align: start;
   vertical-align: middle;
   white-space: normal;
   width: 100%;
@@ -304,10 +305,10 @@ html[dir="rtl"] .Markdown ul + pre {
 }
 
 .algolia-autocomplete .ds-dropdown-menu {
-  background: transparent;
+  background: var(--color-background-elevation-floating);
   border: none;
   border-radius: 16px;
-  box-shadow: 0 0 8px var(--g-colorTransparentGray100);
+  box-shadow: var(--elevation-floating);
   height: auto;
   margin: 6px 0 0;
   max-width: 600px;

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -178,7 +178,6 @@ html[dir="rtl"] .Markdown ul + pre {
   font-size: 16px;
   height: 100%;
   padding: 0 32px 0 40px;
-  text-align: start;
   vertical-align: middle;
   white-space: normal;
   width: 100%;

--- a/packages/gestalt/src/Divider.css
+++ b/packages/gestalt/src/Divider.css
@@ -1,6 +1,6 @@
 .divider {
   composes: block from "./Layout.css";
-  composes: borderTop from "./Borders.css";
+  composes: borderTop solid from "./Borders.css";
   composes: m0 from "./Whitespace.css";
   border-bottom: 0;
   border-left: 0;

--- a/packages/gestalt/src/SideNavigation.css
+++ b/packages/gestalt/src/SideNavigation.css
@@ -18,7 +18,7 @@
 }
 
 .section {
-  margin-top: 24px;
+  margin-top: var(--space-400);
 }
 
 .section:nth-child(1) {


### PR DESCRIPTION
### Summary

#### What changed?

Fix a few bugs in the header of our docs site

#### Why?

Ensure site settings dropdown always aligns properly, fix search icon in RTL, and Algolia popup in dark mode

[Tracker](https://coda.io/d/Gestalt-Team-Folder_d2LeXkQ1kVX/Gestalt-site-update-bug-tracker_sugaw#Bugs-August-18-Sprint-17_tuH4m/r4)

Before
![Screen Shot 2022-09-09 at 3 52 51 PM](https://user-images.githubusercontent.com/5125094/189456032-f92da3c6-7e18-436c-b329-20f22608ddbc.png)

After
![Screen Shot 2022-09-09 at 3 52 40 PM](https://user-images.githubusercontent.com/5125094/189456030-3a6fb6e8-6bb7-47cb-b527-c2f9cfbc8adb.png)


