### PR TITLE
Internal: use multiline comments to enable flow docs

### DIFF
--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -18,11 +18,19 @@ const buildSourceLinkUrl = (componentName) =>
 
 type Props = {|
   badge?: 'pilot' | 'deprecated',
-  // DEPRECATED: Use `children` instead of `defaultCode`
+  /**
+   * @deprecated : Use `children` instead of `defaultCode`
+   */
   defaultCode?: string,
   description?: string,
-  fileName?: string, // only use if name !== file name
-  folderName?: string, // only use if name !== file name and the link should point to a directory
+  /**
+   * Only use if name !== file name
+   */
+  fileName?: string,
+  /**
+   * Only use if name !== file name and the link should point to a directory
+   */
+  folderName?: string,
   showCode?: boolean,
   name: string,
   margin?: 'default' | 'none',


### PR DESCRIPTION
### Summary

#### What changed?

Use multiline comments to enable flow docs

#### Why?

Makes the comments visible to where the props are being used, not just where they are defined.

<img width="351" alt="Screen Shot 2022-09-11 at 4 57 00 AM" src="https://user-images.githubusercontent.com/127199/189526441-cda689af-05b2-43c6-8230-38494d2e2283.png">
<img width="379" alt="Screen Shot 2022-09-11 at 4 56 49 AM" src="https://user-images.githubusercontent.com/127199/189526442-d55f31e7-1e44-4550-a4a0-3c4f8af66a31.png">

