### PR TITLE
SlimBanner: Adjust layout in small viewports

### DIFF
--- a/docs/examples/slimbanner/responsiveExample.js
+++ b/docs/examples/slimbanner/responsiveExample.js
@@ -1,0 +1,24 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { Box, SlimBanner } from 'gestalt';
+
+export default function ResponsiveExample(): Node {
+  return (
+    <Box padding={4}>
+      <SlimBanner
+        type="info"
+        message="This ad group is part of a campaign that is using campaign budget optimization. Changes to schedule or budget must be made at the campaign level."
+        iconAccessibilityLabel="Information"
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        primaryAction={{
+          accessibilityLabel: 'Learn more about campaign budget optimization',
+          label: 'Learn more',
+          onClick: () => {},
+        }}
+      />
+    </Box>
+  );
+}

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -8,6 +8,8 @@ import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import responsiveExample from '../../examples/slimbanner/responsiveExample.js';
 
 export default function SlimBannerPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -517,10 +519,28 @@ Combine SlimBanners with other components like [Callouts](/web/callout) or [Upse
   iconAccessibilityLabel="Information"
   dismissButton={{
     accessibilityLabel: 'Dismiss banner',
-    onClick: () => {},
+    onDismiss: () => {},
   }}
 />
 `}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="Responsive"
+          description={`
+          SlimBanner is responsive to different [viewport breakpoints](/foundations/screen_sizes#Web-(px)).
+          `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample
+                code={responsiveExample}
+                name="SlimBanner responsive example"
+                layout="mobileRow"
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -181,6 +181,8 @@ export default function SlimBanner({
       alignItems="center"
       color={isBare ? 'transparent' : backgroundColor}
       display="flex"
+      direction="column"
+      mdDirection="row"
       padding={isBare ? 0 : 4}
       paddingY={isBare ? 1 : 0}
       rounding={4}
@@ -216,9 +218,9 @@ export default function SlimBanner({
           <Flex.Item flex="none">
             <Flex alignItems="center" gap={{ row: 4, column: 0 }}>
               {primaryAction && (
-                <Flex.Item flex="none">
+                <Box display="none" mdDisplay="flex" flex="none">
                   <PrimaryAction {...primaryAction} />
-                </Flex.Item>
+                </Box>
               )}
 
               {dismissButton && <DismissButton {...dismissButton} />}
@@ -226,6 +228,11 @@ export default function SlimBanner({
           </Flex.Item>
         )}
       </Flex>
+      {shouldShowButtons && primaryAction && (
+        <Box display="flex" mdDisplay="none" flex="none" alignSelf="end" marginTop={4}>
+          <PrimaryAction {...primaryAction} />
+        </Box>
+      )}
     </Box>
   );
 }

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -228,7 +228,7 @@ export default function SlimBanner({
           </Flex.Item>
         )}
       </Flex>
-      {shouldShowButtons && primaryAction && (
+      {!isBare && primaryAction && (
         <Box display="flex" mdDisplay="none" flex="none" alignSelf="end" marginTop={4}>
           <PrimaryAction {...primaryAction} />
         </Box>

--- a/packages/gestalt/src/__snapshots__/SlimBanner.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SlimBanner.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SlimBanner renders an icon with accessibility label 1`] = `
 <div
-  className="box errorWeak itemsCenter paddingX4 paddingY0 paddingY4 rounding4 xsDisplayFlex"
+  className="box errorWeak itemsCenter mdDirectionRow paddingX4 paddingY0 paddingY4 rounding4 xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "width": "100%",
@@ -53,7 +53,7 @@ exports[`SlimBanner renders an icon with accessibility label 1`] = `
 
 exports[`SlimBanner renders helper link 1`] = `
 <div
-  className="box itemsCenter paddingX4 paddingY0 paddingY4 rounding4 secondary xsDisplayFlex"
+  className="box itemsCenter mdDirectionRow paddingX4 paddingY0 paddingY4 rounding4 secondary xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "width": "100%",
@@ -106,7 +106,7 @@ exports[`SlimBanner renders helper link 1`] = `
 
 exports[`SlimBanner renders neutral type with message 1`] = `
 <div
-  className="box itemsCenter paddingX4 paddingY0 paddingY4 rounding4 secondary xsDisplayFlex"
+  className="box itemsCenter mdDirectionRow paddingX4 paddingY0 paddingY4 rounding4 secondary xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "width": "100%",
@@ -135,7 +135,7 @@ exports[`SlimBanner renders neutral type with message 1`] = `
 
 exports[`SlimBanner renders non-neutral compact with accessibility label 1`] = `
 <div
-  className="box itemsCenter paddingX0 paddingY0 paddingY1 rounding4 xsDisplayFlex"
+  className="box itemsCenter mdDirectionRow paddingX0 paddingY0 paddingY1 rounding4 xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "width": "100%",


### PR DESCRIPTION
### Summary

#### What changed?

Move SlimBanner action down to a new line in mobile viewports

#### Why?

Ensure the text is readable in small viewports. Note: This does not yet address the horizontal alignment of the icon and dismiss button in small viewports

Before:

![Screen Shot 2022-09-12 at 5 57 55 PM](https://user-images.githubusercontent.com/5125094/189784469-e238ee9a-e920-43c0-b200-2b96cf7dbb25.png)

After:
![Screen Shot 2022-09-12 at 5 58 25 PM](https://user-images.githubusercontent.com/5125094/189784471-b0be8c05-e433-4657-8908-fad4e845e1d3.png)


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4605)
- [Figma](https://www.figma.com/file/MInxIhLJSbGDebM0939W5G/Gestalt-SlimBanner-Hand-off?node-id=213%3A1766)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
