### PR TITLE
Badge: Add recommendation type

### DIFF
--- a/docs/pages/web/badge.js
+++ b/docs/pages/web/badge.js
@@ -162,7 +162,7 @@ export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGe
           Indicates a general, non-critical status update. For example, 'Unavailable' or 'Not started'.
 
           6. **Recommendation**
-          Indicates a suggestion to improve the user's experience.
+          Highlights a suggestion that will improve the experience and achieve better results. For example, 'Recommended for you'.
  `}
         >
           <MainSection.Card

--- a/docs/pages/web/badge.js
+++ b/docs/pages/web/badge.js
@@ -160,6 +160,9 @@ export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGe
 
           5. **Neutral**
           Indicates a general, non-critical status update. For example, 'Unavailable' or 'Not started'.
+
+          6. **Recommendation**
+          Indicates a suggestion to improve the users experience.
  `}
         >
           <MainSection.Card
@@ -214,6 +217,14 @@ export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGe
         </Table.Cell>
         <Table.Cell>
           <Text size="300">Ads & Campaigns <Badge text="Not started" type="neutral"/></Text>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>
+          <Text>Recommendation</Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Text size="300">Ads & Campaigns <Badge text="Recommended for you" type="recommendation"/></Text>
         </Table.Cell>
       </Table.Row>
     </Table.Body>

--- a/docs/pages/web/badge.js
+++ b/docs/pages/web/badge.js
@@ -162,7 +162,7 @@ export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGe
           Indicates a general, non-critical status update. For example, 'Unavailable' or 'Not started'.
 
           6. **Recommendation**
-          Indicates a suggestion to improve the users experience.
+          Indicates a suggestion to improve the user's experience.
  `}
         >
           <MainSection.Card

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -12,6 +12,7 @@ export type TypeOptions =
   | 'warning'
   | 'success'
   | 'neutral'
+  | 'recommendation'
   | 'darkWash'
   | 'lightWash';
 
@@ -44,6 +45,7 @@ export default function Badge({ position = 'middle', text, type = 'info' }: Prop
     'warning': 'warningBase',
     'success': 'successBase',
     'neutral': 'tertiary',
+    'recommendation': 'recommendationBase',
     'darkWash': 'washDark',
     'lightWash': 'washLight',
   };


### PR DESCRIPTION
### Summary

#### What changed?

Add a Recommendation type for Badge

#### Why?

With the introduction of our recommendation tokens, we needed to add it to Badge as well as our banners


### Checklist

- [X] Added documentation + accessibility tests
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
