### PR TITLE
Docs: Add developer guide on adding a new page

### DIFF
--- a/docs/docs-components/siteIndex.js
+++ b/docs/docs-components/siteIndex.js
@@ -25,15 +25,18 @@ const siteIndex: $ReadOnlyArray<siteIndexType> = [
       {
         sectionName: 'Developers',
         pages: [
-          'Development process',
-          'Installation',
+          {
+            sectionName: 'Contributing',
+            pages: ['Creating and updating pages', 'Development process'],
+          },
           'Eslint plugin',
+          'Hacking Gestalt',
+          'Installation',
           'Releases',
           {
             sectionName: 'Tooling',
             pages: ['Web'],
           },
-          'Hacking Gestalt',
         ],
       },
       'How to work with us',

--- a/docs/markdown/get_started/developers/contributing/creating_and_updating_pages.md
+++ b/docs/markdown/get_started/developers/contributing/creating_and_updating_pages.md
@@ -1,0 +1,49 @@
+---
+title: Creating and updating pages in Gestalt
+description: The below steps detail the process for creating a new page, as well as considerations when moving or deleting a page
+fullwidth: true
+---
+
+## Adding a new page
+
+To add a new page, follow these 4 steps:
+
+
+1. Create the page under the correct folder
+    1. **Regular** page
+        1. Create the new file in `docs/pages`
+            1. The folder structure corresponds to the navigation structure of the site. For example, a new web component page should be created under `docs/pages/web`, and a new Tooling page should be found under `docs/pages/get_started/developers/tooling`
+                1. The file path (and structure in `docs/docs-components/siteIndex.js`) create the URL path for the page, so both the file location and `siteIndex` structure *must* be accurate to get the expected URL
+            2. Pages that do not fall under a main tab, like Roadmap, live at the root of `docs/pages`
+    2. **Markdown** Page
+        1. Create the file under the correct folder in `docs/markdown`
+            1. The folder structure corresponds to the navigation structure of the site. For example, a new iOS component page should be created under `docs/markdown/ios`, and a new Tooling page should be found under `docs/markdown/get_started/developers/tooling`
+2. Add the page name to `docs/docs-components/siteIndex.js`
+    1. Find the appropriate section within the JSON object
+3. Create an accessibility test for the new page in `playwright/accessibility`
+    1. Create a file named `[NEW PAGE TITLE].spec.mjs` 
+        1. The file name should match the page name
+        2. If the page is a duplicate (like Avatar on Web and Avatar on iOS), add a suffix with the platform, like `Avatar_iOS.spec.mjs`
+4. Update `docs/docs-components/COMPONENT_DATA.js`
+    1. If this is a net new component, you’ll need to add data under the correct array
+        1. The options are Building Blocks, General Components, Utilities, Figma-only, and Foundation guidelines. 
+            1. This info affects the layout of the Component Overview page
+        2. You may also need a new svg to represent this component on the [Overview pages](https://gestalt.pinterest.systems/web/overview). Reach out on Slack if you need assistance with the graphic.
+    2. If this is a new page for an existing component, like the Android page for an existing Web component, update the corresponding data for the object that already exists for that component. ([see example](https://github.com/pinterest/gestalt/pull/2334/files#diff-19b5af995282361ea4311af93f9268393d56c1da8964523c5ee74933a1c60de1))
+
+
+## Moving or Deleting a page
+
+When moving or deleting a page, there are multiple updates needed: 
+
+1. The organization of `docs/docs-components/siteIndex.js`
+    1. Make sure the data stays in sync with your change
+2. Any URLs within the docs or component pages referencing the page
+    1. If you’re moving or deleting a page, update any references to that URL
+3. Information in `docs/docs-components/COMPONENT_DATA.js`
+    1. Ensure any updates are reflected in the JSON data
+4. The associated `spec.mjs` accessibility test
+    1. Update the URL or remove the file if deleting a page
+5. List of redirects in `docs/redirects.js`
+    1. A redirect *must* be added anytime a file is moved to help folks find the new location
+

--- a/docs/markdown/get_started/developers/contributing/creating_and_updating_pages.md
+++ b/docs/markdown/get_started/developers/contributing/creating_and_updating_pages.md
@@ -29,7 +29,7 @@ To add a new page, follow these 4 steps:
         1. The options are Building Blocks, General Components, Utilities, Figma-only, and Foundation guidelines. 
             1. This info affects the layout of the Component Overview page
         2. You may also need a new svg to represent this component on the [Overview pages](https://gestalt.pinterest.systems/web/overview). Reach out on Slack if you need assistance with the graphic.
-    2. If this is a new page for an existing component, like the Android page for an existing Web component, update the corresponding data for the object that already exists for that component. ([see example](https://github.com/pinterest/gestalt/pull/2334/files#diff-19b5af995282361ea4311af93f9268393d56c1da8964523c5ee74933a1c60de1))
+    2. If this is a new page for an existing component, like the Android page for an existing Web component, update the corresponding data for the object that already exists for that component. ([See example](https://github.com/pinterest/gestalt/pull/2334/files#diff-19b5af995282361ea4311af93f9268393d56c1da8964523c5ee74933a1c60de1))
 
 
 ## Moving or Deleting a page

--- a/docs/markdown/get_started/developers/contributing/development_process.md
+++ b/docs/markdown/get_started/developers/contributing/development_process.md
@@ -16,7 +16,7 @@ Pinterest web engineers can visit the [internal Gestalt documentation](http://pi
 
 ## Set up your Gestalt repository
 
-- Clone the repo: Fork the Gestalt repo and work off your forked repo, not the `pintertest/gestalt` repo.
+- Clone the repo: Fork the Gestalt repo and work off your forked repo, not the `pinterest/gestalt` repo.
 - Once forked, clone to your local machine using the SSH option
 
 ```bash
@@ -190,7 +190,7 @@ Avoid:
 
 ## Technical Design Documents
 
-Before starting coding a new component, you must first detail the componentn specifications in Technical Design Documents (TDD). You can find the [TDD template here](http://pinch.pinadmin.com/TDD).
+Before starting coding a new component, you must first detail the component specifications in Technical Design Documents (TDD). You can find the [TDD template here](http://pinch.pinadmin.com/TDD).
 
 ## RFCs
 

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -128,7 +128,12 @@ const misc = [
   },
   {
     source: '/development',
-    destination: '/get_started/developers/development_process',
+    destination: '/get_started/developers/contributing/development_process',
+    permanent: true,
+  },
+  {
+    source: '/get_started/developers/development_process',
+    destination: '/get_started/developers/contributing/development_process',
     permanent: true,
   },
   {

--- a/playwright/accessibility/Creating and updating pages.spec.mjs
+++ b/playwright/accessibility/Creating and updating pages.spec.mjs
@@ -3,6 +3,8 @@ import { test } from '@playwright/test';
 import expectAccessiblePage from './expectAccessiblePage.mjs';
 
 test('Development Accessibility check', async ({ page }) => {
-  await page.goto('/get_started/developers/contributing/development_process');
+  await page.goto(
+    '/get_started/developers/contributing/creating_and_updating_pages'
+  );
   await expectAccessiblePage({ page });
 });


### PR DESCRIPTION
### Summary

#### What changed?

Add information on how to add, move, or delete a page in our Docs site

#### Why?

Make it easier for contributors to understand the docs site and process

### Links

- [TDD](https://paper.dropbox.com/doc/Creating-and-updating-pages-in-Gestalt--BpFMpCRbv5Ytj_HXJvzl3AYTAg-oDNv0d3zNOjkueLwlCDwA)

