### PR TITLE
Checkbox: standardize helper/error message style with other form/control fields, renamed subtext, deprecated hasError

### DIFF
--- a/docs/examples/modal/createBoardExample.js
+++ b/docs/examples/modal/createBoardExample.js
@@ -39,7 +39,7 @@ function ModalWithHeading({ onDismiss }: {| onDismiss: () => void |}) {
           checked={false}
           id="secret"
           label="Keep this board secret"
-          subtext="So only you and collaborators can see it."
+          helperText="So only you and collaborators can see it."
           name="languages"
           onChange={() => {}}
         />

--- a/docs/pages/visual-test/Checkbox-dark.js
+++ b/docs/pages/visual-test/Checkbox-dark.js
@@ -17,14 +17,14 @@ export default function Snapshot(): Node {
             checked
             id="english-info"
             label="English"
-            subtext="USA and India have the top number of English speakers "
+            helperText="USA and India have the top number of English speakers "
             onChange={() => {}}
           />
           <Checkbox
             checked={false}
             id="spanish-info"
             label="Spanish"
-            subtext="Mexico and Colombia have the top number of Spanish speakers"
+            helperText="Mexico and Colombia have the top number of Spanish speakers"
             onChange={() => {}}
           />
         </Flex>{' '}

--- a/docs/pages/visual-test/Checkbox.js
+++ b/docs/pages/visual-test/Checkbox.js
@@ -16,14 +16,14 @@ export default function Snapshot(): Node {
           checked
           id="english-info"
           label="English"
-          subtext="USA and India have the top number of English speakers"
+          helperText="USA and India have the top number of English speakers"
           onChange={() => {}}
         />
         <Checkbox
           checked={false}
           id="spanish-info"
           label="Spanish"
-          subtext="Mexico and Colombia have the top number of Spanish speakers"
+          helperText="Mexico and Colombia have the top number of Spanish speakers"
           onChange={() => {}}
         />
       </Flex>

--- a/docs/pages/visual-test/Fieldset-dark.js
+++ b/docs/pages/visual-test/Fieldset-dark.js
@@ -17,14 +17,14 @@ export default function Snapshot(): Node {
             <Checkbox
               id="english-info"
               label="English"
-              subtext="USA has the top number of English speakers "
+              helperText="USA has the top number of English speakers "
               name="languages"
               onChange={() => {}}
             />
             <Checkbox
               id="spanish-info"
               label="Spanish"
-              subtext="Mexico is the top Spanish speaking country"
+              helperText="Mexico is the top Spanish speaking country"
               name="languages"
               onChange={() => {}}
             />

--- a/docs/pages/visual-test/Fieldset.js
+++ b/docs/pages/visual-test/Fieldset.js
@@ -16,14 +16,14 @@ export default function Snapshot(): Node {
           <Checkbox
             id="english-info"
             label="English"
-            subtext="USA has the top number of English speakers "
+            helperText="USA has the top number of English speakers "
             name="languages"
             onChange={() => {}}
           />
           <Checkbox
             id="spanish-info"
             label="Spanish"
-            subtext="Mexico is the top Spanish speaking country"
+            helperText="Mexico is the top Spanish speaking country"
             name="languages"
             onChange={() => {}}
           />

--- a/docs/pages/web/checkbox.js
+++ b/docs/pages/web/checkbox.js
@@ -25,7 +25,7 @@ function Example() {
         id="checkbox"
         label="I agree that this is a checkbox"
         onChange={({ checked }) => setChecked1(checked)}
-        subtext="Nothing will happen if you disagree"
+        helperText="Nothing will happen if you disagree"
       />
   );
 }
@@ -202,7 +202,7 @@ function Example() {
       checked={checked1}
       id="location"
       label="Turn location tracking off"
-      subtext="Change will auto-save"
+      helperText="Change will auto-save"
       onChange={({ checked }) => setChecked1(checked)}
     />
 
@@ -215,7 +215,7 @@ function Example() {
           <MainSection.Card
             cardSize="md"
             type="do"
-            description="Keep labels and legends clear and brief to avoid too many lines of text that are hard to scan and slow the user down. If clarification is needed, use info [Tooltips](/web/tooltip) or subtext."
+            description="Keep labels and legends clear and brief to avoid too many lines of text that are hard to scan and slow the user down. If clarification is needed, use info [Tooltips](/web/tooltip) or helperText."
             defaultCode={`
 function Example() {
   const [checked1, setChecked1] = React.useState(false);
@@ -575,7 +575,7 @@ function CheckboxExample() {
 
       <MainSection
         name="Localization"
-        description={`Be sure to localize \`label\` and any \`subtext\`. Be mindful of label length so that it doesn’t truncate in languages with lengthier character counts.`}
+        description={`Be sure to localize \`label\` and any \`helperText\`. Be mindful of label length so that it doesn’t truncate in languages with lengthier character counts.`}
       />
       <MainSection name="Variants">
         <MainSection.Subsection
@@ -670,7 +670,7 @@ function Example() {
 `}
           />
         </MainSection.Subsection>
-        <MainSection.Subsection title="With subtext" description="Checkbox supports subtexts">
+        <MainSection.Subsection title="With helperText" description="Checkbox supports helperText">
           <MainSection.Card
             cardSize="lg"
             defaultCode={`
@@ -686,7 +686,7 @@ function Example() {
           checked={checkedEn}
           id="english-info"
           label="English"
-          subtext="USA, India, and Pakistan have the top number of English speakers "
+          helperText="USA, India, and Pakistan have the top number of English speakers "
           name="languages"
           onChange={({ checked }) => {
             setCheckedEn(checked);
@@ -696,7 +696,7 @@ function Example() {
           checked={checkedSp}
           id="spanish-info"
           label="Spanish"
-          subtext="Mexico, Colombia, and Spain are the top three Spanish-speaking countries"
+          helperText="Mexico, Colombia, and Spain are the top three Spanish-speaking countries"
           name="languages"
           onChange={({ checked }) => {
             setCheckedSp(checked);
@@ -706,7 +706,7 @@ function Example() {
           checked={checkedCh}
           id="chinese-info"
           label="Chinese"
-          subtext="Chinese has many varieties, including Cantonese and Mandarin"
+          helperText="Chinese has many varieties, including Cantonese and Mandarin"
           name="languages"
           onChange={({ checked }) => {
             setCheckedCh(checked);
@@ -722,7 +722,7 @@ function Example() {
 
         <MainSection.Subsection
           title="With Image"
-          description={`Checkbox supports images. When including images, you can use the subtext property to clearly describe the information being presented by the image, or use the image's alt text to provide more context.
+          description={`Checkbox supports images. When including images, you can use the helperText property to clearly describe the information being presented by the image, or use the image's alt text to provide more context.
 
 Spacing is already accounted for; simply specify the width and height.`}
         >
@@ -740,7 +740,7 @@ function CheckboxExample() {
           checked={checkedCoral}
           id="coral"
           label="Coral"
-          subtext="Botanical art in coral and green"
+          helperText="Botanical art in coral and green"
           image={<Box height={100} width={80}><Image alt="Botanical art in coral and green" src="https://i.ibb.co/7bQQYkX/stock2.jpg" fit="contain" naturalWidth={1} naturalHeight={1}/></Box>}
           name="favorite art"
           onChange={({ checked }) => {
@@ -751,7 +751,7 @@ function CheckboxExample() {
           checked={checkedBlue}
           id="blue"
           label="Blue"
-          subtext="Typography and shoe in blue"
+          helperText="Typography and shoe in blue"
           image={<Box height={100} width={80}><Image alt="Typography and shoe in blue" src="https://i.ibb.co/jVR29XV/stock5.jpg" fit="contain" naturalWidth={1} naturalHeight={1}/></Box>}
           name="favorite art"
           onChange={({ checked }) => {

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -308,7 +308,7 @@ function HeadingExample(props) {
             checked={false}
             id="secret"
             label="Keep this board secret"
-            subtext="So only you and collaborators can see it."
+            helperText="So only you and collaborators can see it."
             name="languages"
             onChange={({ checked }) => {
               console.log(checked);

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -11,6 +11,7 @@ import Label from './Label.js';
 import Text from './Text.js';
 import useFocusVisible from './useFocusVisible.js';
 import focusStyles from './Focus.css';
+import FormHelperText from './FormHelperText.js';
 
 type Props = {|
   /**
@@ -26,9 +27,9 @@ type Props = {|
    */
   errorMessage?: string,
   /**
-   * This field is deprecated and will be removed soon. Please do not use.
+   * Optional description for Checkbox, used to provide more detail about an option. See the [with helperText variant](https://gestalt.pinterest.systems/web/checkbox#With-helperText) to learn more.
    */
-  hasError?: boolean,
+  helperText?: string,
   /**
    * A unique identifier for the input.
    */
@@ -69,10 +70,6 @@ type Props = {|
    * Determines the Checkbox size: sm = 16px, md = 24px. See the [size variant](https://gestalt.pinterest.systems/web/checkbox#Size) to learn more.
    */
   size?: 'sm' | 'md',
-  /**
-   * Optional description for Checkbox, used to provide more detail about an option. See the [with subtext variant](https://gestalt.pinterest.systems/web/checkbox#With-subtext) to learn more.
-   */
-  subtext?: string,
 |};
 
 /**
@@ -90,7 +87,7 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
     checked = false,
     disabled = false,
     errorMessage,
-    hasError = false,
+    helperText,
     id,
     image,
     indeterminate = false,
@@ -100,7 +97,6 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
     onChange,
     onClick,
     size = 'md',
-    subtext,
   }: Props,
   ref,
 ): Node {
@@ -146,7 +142,7 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
     borderStyle = styles.borderDisabled;
   } else if (!disabled && (checked || indeterminate)) {
     borderStyle = styles.borderSelected;
-  } else if (hasError || errorMessage) {
+  } else if (errorMessage) {
     borderStyle = styles.borderError;
   } else if (!disabled && hovered) {
     borderStyle = styles.borderHovered;
@@ -161,7 +157,7 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
   return (
     <Box>
       <Box
-        alignItems={subtext || image ? 'start' : 'center'}
+        alignItems={helperText || errorMessage || image ? 'start' : 'center'}
         display="flex"
         justifyContent="start"
         marginStart={-1}
@@ -217,25 +213,13 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
                 <Text color={disabled ? 'subtle' : undefined} size={size === 'sm' ? '200' : '300'}>
                   {label}
                 </Text>
-                {subtext && (
-                  <Box paddingY={1}>
-                    <Text color="subtle" size={size === 'sm' ? '200' : '300'}>
-                      <Box display="visuallyHidden">:</Box> {subtext}
-                    </Text>
-                  </Box>
-                )}
+                {helperText && !errorMessage ? <FormHelperText text={helperText} /> : null}
+                {errorMessage ? <FormErrorMessage id={id} text={errorMessage} /> : null}
               </Box>
             </Label>
           </Box>
         )}
       </Box>
-      {errorMessage && (
-        <Box marginTop={2}>
-          <Text color="error" size="100">
-            <FormErrorMessage id={id} text={errorMessage} />
-          </Text>
-        </Box>
-      )}
     </Box>
   );
 });

--- a/packages/gestalt/src/Checkbox.test.js
+++ b/packages/gestalt/src/Checkbox.test.js
@@ -50,9 +50,9 @@ test('Checkbox with error', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('Checkbox with subtext', () => {
+test('Checkbox with helperText', () => {
   const tree = create(
-    <Checkbox subtext="Additional Info" size="sm" id="id" label="Name" onChange={() => {}} />,
+    <Checkbox helperText="Additional Info" size="sm" id="id" label="Name" onChange={() => {}} />,
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -452,7 +452,7 @@ exports[`Checkbox with error 1`] = `
   className="box"
 >
   <div
-    className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+    className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
   >
     <label
       className="label"
@@ -494,36 +494,28 @@ exports[`Checkbox with error 1`] = `
           >
             Name
           </div>
+          <div
+            className="box marginTop2"
+          >
+            <div
+              className="Text fontSize100 errorText alignStart breakWord fontWeightNormal"
+            >
+              <span
+                className="formErrorMessage"
+                id="id-error"
+              >
+                Error message
+              </span>
+            </div>
+          </div>
         </div>
       </label>
-    </div>
-  </div>
-  <div
-    className="box marginTop2"
-  >
-    <div
-      className="Text fontSize100 errorText alignStart breakWord fontWeightNormal"
-    >
-      <div
-        className="box marginTop2"
-      >
-        <div
-          className="Text fontSize100 errorText alignStart breakWord fontWeightNormal"
-        >
-          <span
-            className="formErrorMessage"
-            id="id-error"
-          >
-            Error message
-          </span>
-        </div>
-      </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`Checkbox with subtext 1`] = `
+exports[`Checkbox with helperText 1`] = `
 <div
   className="box"
 >
@@ -571,17 +563,11 @@ exports[`Checkbox with subtext 1`] = `
             Name
           </div>
           <div
-            className="box paddingY1"
+            className="box marginTop2"
           >
             <div
-              className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal"
+              className="Text fontSize100 subtleText alignStart breakWord fontWeightNormal"
             >
-              <div
-                className="box xsDisplayVisuallyHidden"
-              >
-                :
-              </div>
-               
               Additional Info
             </div>
           </div>


### PR DESCRIPTION
### Summary

#### What changed?

Checkbox: standardize helper/error message style with other form/control fields, renamed subtext, deprecated hasError

##### BEFORE
<img width="411" alt="Screen Shot 2022-09-16 at 4 22 42 PM" src="https://user-images.githubusercontent.com/10593890/190661944-2251739f-1093-4b1d-8290-c04fb2e5586f.png">
<img width="629" alt="Screen Shot 2022-09-16 at 4 22 36 PM" src="https://user-images.githubusercontent.com/10593890/190661935-28ea1dae-4561-4b2b-bcf8-dac376692811.png">

##### AFTER
<img width="369" alt="Screen Shot 2022-09-16 at 4 22 49 PM" src="https://user-images.githubusercontent.com/10593890/190661881-8d3eb4db-db13-42e6-b014-46ea80868a3e.png">
<img width="569" alt="Screen Shot 2022-09-16 at 4 22 22 PM" src="https://user-images.githubusercontent.com/10593890/190661921-bd492df2-dc5d-4567-b548-2b378e341fb8.png">


#### Why?

Form controls: Textfield, TextArea, have the same helperText / errorMessage prop and style. Refactoring Checkbox to match style and API of all form fields.


####  Breaking changes codemod

1st Run 

`yarn codemod modifyProp ~/code/pinboard/webapp
--component=Checkbox
--previousProp=subtext
--nextProp=helperText`

2nd Run 

#### IMPORTANT: On this second codemod run, review each change to make sure the hasError ain't a critical prop to the proper behavior of that Checkbox instance. Make adjustments so not to break the code.

`yarn codemod modifyProp ~/code/pinboard/webapp --component=Checkbox --previousProp=hasError
 `


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4843)