### PR TITLE
DatePicker: standardize error message style and internal cleanup

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -226,7 +226,14 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
       )}
       <ReactDatePicker
         calendarClassName={classnames(styles['react-datepicker'])}
-        customInput={<DatePickerTextField name={name} id={id} />}
+        customInput={
+          <DatePickerTextField
+            name={name}
+            id={id}
+            errorMessage={errorMessage}
+            helperText={helperText}
+          />
+        }
         dateFormat={format}
         dayClassName={() => classnames(styles['react-datepicker__days'])}
         disabled={disabled}
@@ -273,13 +280,6 @@ const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> =
         showPopperArrow={false}
         startDate={rangeStartDate}
       />
-      {(!!errorMessage || !!helperText) && (
-        <Box marginTop={2}>
-          <Text color={errorMessage ? 'error' : 'subtle'} size="100">
-            {errorMessage || helperText}
-          </Text>
-        </Box>
-      )}
     </div>
   );
 });

--- a/packages/gestalt-datepicker/src/DatePickerTextField.js
+++ b/packages/gestalt-datepicker/src/DatePickerTextField.js
@@ -18,6 +18,8 @@ type InjectedProps = {|
   onKeyDown?: (event: SyntheticKeyboardEvent<HTMLInputElement>) => void,
   placeholder?: string,
   value?: string,
+  errorMessage?: string,
+  helperText?: string,
 |};
 
 type Props = {|
@@ -40,28 +42,34 @@ function DatePickerTextField(props: Props) {
     onKeyDown,
     placeholder,
     value,
+    errorMessage,
+    helperText,
   } = props;
 
   return (
     <Label htmlFor={id}>
-      <Box alignItems="center" column={12} display="flex" flex="grow" position="relative">
+      <Box
+        alignItems={!helperText && !errorMessage ? 'center' : undefined}
+        column={12}
+        display="flex"
+        flex="grow"
+        position="relative"
+      >
         <Box column={12} flex="grow">
           <TextField
             autoComplete="off"
             disabled={disabled}
             id={id}
-            onBlur={(data) => onBlur && onBlur(data.event)}
+            onBlur={(data) => onBlur?.(data.event)}
             onFocus={(data) => {
-              if (onFocus) {
-                onFocus(data.event);
-              }
-              if (onClick) {
-                onClick();
-              }
+              onFocus?.(data.event);
+              onClick?.();
             }}
+            errorMessage={errorMessage}
+            helperText={helperText}
             name={name}
-            onChange={(data) => onChange && onChange(data.event)}
-            onKeyDown={(data) => onKeyDown && onKeyDown(data.event)}
+            onChange={(data) => onChange?.(data.event)}
+            onKeyDown={(data) => onKeyDown?.(data.event)}
             placeholder={placeholder}
             ref={(input) => forwardedRef && forwardedRef(input || null)}
             size="lg"
@@ -69,7 +77,7 @@ function DatePickerTextField(props: Props) {
           />
         </Box>
         <div className={classnames(styles.calendarIcon)}>
-          <Box position="relative" marginEnd={4}>
+          <Box position="relative" marginEnd={4} display="flex" alignItems="center" minHeight={48}>
             <Icon accessibilityLabel="" color="default" icon="calendar" />
           </Box>
         </div>


### PR DESCRIPTION
### Summary

#### What changed?

DatePicker: standardize error message style and internal cleanup

#### Why?

Standardization in style. Whenever we implement error icons in error messages in textfield, Datepicker will get it for free

#### BEFORE

<img width="823" alt="Screen Shot 2022-09-17 at 12 14 40 AM" src="https://user-images.githubusercontent.com/10593890/190814169-7b21fedb-e5ef-48ac-9a07-6a2f9ff30c1e.png">

##### AFTER
<img width="874" alt="Screen Shot 2022-09-17 at 12 13 07 AM" src="https://user-images.githubusercontent.com/10593890/190814216-4388afff-602a-49d2-af72-965bbb99533a.png">

#### Why?

Form controls: Textfield, TextArea, have the same helperText / errorMessage prop and style. Refactoring Datepicker to match style

Internal Refactor to use Textfield built-in error and helper message