### PR TITLE
Revert "Popover: Add support to handle content that overflows the viewport height"

### DIFF
--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -63,8 +63,6 @@ type State = {|
   popoverRef: ?HTMLElement,
 |};
 
-type PopoverOverride = {| top: string |} | null;
-
 class Contents extends Component<Props, State> {
   static defaultProps: {| border: boolean, caret: boolean |} = {
     border: true,
@@ -204,39 +202,6 @@ class Contents extends Component<Props, State> {
     }
   };
 
-  /**
-   * Identify when is required to repositioning the popover, i.e., the windows popover has 90% of
-   * viewport (available screen height), and set the controller variable as `true`;
-   * When the height of popover is less than 90% the controller variable is `false`;
-   */
-  balancePopoverPosition(): PopoverOverride {
-    // Required because of SSR
-    if (!window || !document) {
-      return null;
-    }
-
-    const { id } = this.props;
-
-    const viewportAvailable = window.innerHeight;
-    const popoverHeight = document.getElementById(id ?? '')?.clientHeight;
-
-    // Trigger (in percentage) to indicate if it should handle the popover or not;
-    const percentageLimit = 90;
-    const shouldRenderOnScreenTop = popoverHeight
-      ? Math.round((popoverHeight / viewportAvailable) * 100) >= percentageLimit
-      : false;
-
-    // As the popover's `maxHeight` is 90%(90vh) we use the value below to keep the popover on viewport vertical center.
-    const defaultTopPadding = '5vh';
-
-    // The `scrollPosition` is required to cases which popover has opened on the scrolled screen
-    const overridePropsToMaxPopoverSize = shouldRenderOnScreenTop
-      ? { top: `calc(${document.documentElement?.scrollTop ?? 0}px + ${defaultTopPadding})` }
-      : null;
-
-    return overridePropsToMaxPopoverSize;
-  }
-
   render(): Node {
     const { accessibilityLabel, bgColor, border, caret, children, id, role, rounding, width } =
       this.props;
@@ -247,8 +212,6 @@ class Contents extends Component<Props, State> {
     const background = bgColor === 'white' ? `${bgColor}BgElevated` : `${bgColor}Bg`;
     const bgColorElevated = bgColor === 'white' ? 'whiteElevated' : bgColor;
     const isCaretVertical = ['down', 'up'].includes(popoverDir);
-
-    const overridePropsToMaxPopoverSize = this.balancePopoverPosition() ?? {};
 
     return (
       <div
@@ -263,11 +226,7 @@ class Contents extends Component<Props, State> {
         ref={this.setPopoverRef}
         tabIndex={-1}
         // popoverOffset positions the Popover component
-        style={{
-          visibility,
-          ...popoverOffset,
-          ...overridePropsToMaxPopoverSize,
-        }}
+        style={{ visibility, ...popoverOffset }}
       >
         {caret && popoverDir && (
           <div

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -221,14 +221,7 @@ export default function Dropdown({
       shouldFocus
       size="xl"
     >
-      <Box
-        alignItems="center"
-        direction="column"
-        display="flex"
-        flex="grow"
-        margin={2}
-        maxHeight="90vh"
-      >
+      <Box alignItems="center" direction="column" display="flex" flex="grow" margin={2}>
         {Boolean(headerContent) && <Box padding={2}>{headerContent}</Box>}
 
         <DropdownContextProvider value={{ id, hoveredItem, setHoveredItem, setOptionRef }}>

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -21,7 +21,6 @@ exports[`Dropdown renders a menu of 3 items conditionally 1`] = `
         >
           <div
             class="box flexGrow itemsCenter marginBottom2 marginEnd2 marginStart2 marginTop2 xsDirectionColumn xsDisplayFlex"
-            style="max-height: 90vh;"
           >
             <div
               class="rounding2 hideOutline accessibilityOutline accessibilityOutlineFocusWithin fullWidth pointer"
@@ -556,7 +555,6 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
         >
           <div
             class="box flexGrow itemsCenter marginBottom2 marginEnd2 marginStart2 marginTop2 xsDirectionColumn xsDisplayFlex"
-            style="max-height: 90vh;"
           >
             <div
               class="rounding2 hideOutline accessibilityOutline accessibilityOutlineFocusWithin fullWidth pointer"


### PR DESCRIPTION
This reverts commit [Popover: Add support to handle content that overflows the viewport height ([#2384](https://github.com/pinterest/gestalt/pull/2384))]

This was motivated by:
- https://pinterest.slack.com/archives/GG6T5UG3X/p1663601895689729
- https://pinterest.slack.com/archives/G01GN7CE99S/p1663265961230629

Bug repro: https://www.loom.com/share/50731be953b34c4e82521fc3c18d7f00 & https://www.loom.com/share/dfef5d196be5411caff4eb1b3f7b4f03