### PR TITLE
Eslint plugin: extend gestalt/button-icon-restrictions to cover role=link icon restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -860,7 +860,7 @@
 
 ### Minor
 
-- Eslint plugin: Avoid "workflow-status-[..]" on Icon [#2228](https://github.com/pinterest/gestalt/pull/2228) - [PREVIEW URL](https://deploy-preview-2228--gestalt.netlify.app)
+- ESLint plugin: Avoid "workflow-status-[..]" on Icon [#2228](https://github.com/pinterest/gestalt/pull/2228) - [PREVIEW URL](https://deploy-preview-2228--gestalt.netlify.app)
 
 ## 62.4.8 (Aug 1, 2022)
 
@@ -1478,7 +1478,7 @@
 
 ### Patch
 
-- Eslint: Loosen Button iconEnd restrictions [#2121](https://github.com/pinterest/gestalt/pull/2121) - [PREVIEW URL](https://deploy-preview-2121--gestalt.netlify.app)
+- ESLint: Loosen Button iconEnd restrictions [#2121](https://github.com/pinterest/gestalt/pull/2121) - [PREVIEW URL](https://deploy-preview-2121--gestalt.netlify.app)
 
 ## 55.2.1 (May 16, 2022)
 
@@ -1514,7 +1514,7 @@
 
 ### Major
 
-- Eslint plugin: Remove excludeTests & excludePaths [#2116](https://github.com/pinterest/gestalt/pull/2116) - [PREVIEW URL](https://deploy-preview-2116--gestalt.netlify.app)
+- ESLint plugin: Remove excludeTests & excludePaths [#2116](https://github.com/pinterest/gestalt/pull/2116) - [PREVIEW URL](https://deploy-preview-2116--gestalt.netlify.app)
 
 ## 54.3.0 (May 11, 2022)
 
@@ -3058,7 +3058,7 @@
 
 ### Minor
 
-- Eslint plugin: `prefer-heading` + autofix/suggestions [#1802](https://github.com/pinterest/gestalt/pull/1802) - [PREVIEW URL](https://deploy-preview-1802--gestalt.netlify.app)
+- ESLint plugin: `prefer-heading` + autofix/suggestions [#1802](https://github.com/pinterest/gestalt/pull/1802) - [PREVIEW URL](https://deploy-preview-1802--gestalt.netlify.app)
 
 ## 40.2.4 (Dec 7, 2021)
 
@@ -3238,13 +3238,13 @@
 
 ### Patch
 
-- Internal: upgrade Eslint to 8.1.0, + configs+plugins [#1762](https://github.com/pinterest/gestalt/pull/1762) - [PREVIEW URL](https://deploy-preview-1762--gestalt.netlify.app)
+- Internal: upgrade ESLint to 8.1.0, + configs+plugins [#1762](https://github.com/pinterest/gestalt/pull/1762) - [PREVIEW URL](https://deploy-preview-1762--gestalt.netlify.app)
 
 ## 39.2.2 (Nov 3, 2021)
 
 ### Patch
 
-- Eslint plugin: prefer-link fixes and added suggestions [#1759](https://github.com/pinterest/gestalt/pull/1759) - [PREVIEW URL](https://deploy-preview-1759--gestalt.netlify.app)
+- ESLint plugin: prefer-link fixes and added suggestions [#1759](https://github.com/pinterest/gestalt/pull/1759) - [PREVIEW URL](https://deploy-preview-1759--gestalt.netlify.app)
 
 ## 39.2.1 (Nov 3, 2021)
 
@@ -3298,7 +3298,7 @@
 
 ### Minor
 
-- Eslint plugin: prefer-link, convert anchor tag to Gestalt Link [#1741](https://github.com/pinterest/gestalt/pull/1741) - [PREVIEW URL](https://deploy-preview-1741--gestalt.netlify.app)
+- ESLint plugin: prefer-link, convert anchor tag to Gestalt Link [#1741](https://github.com/pinterest/gestalt/pull/1741) - [PREVIEW URL](https://deploy-preview-1741--gestalt.netlify.app)
 
 ## 38.0.11 (Oct 20, 2021)
 
@@ -3472,7 +3472,7 @@
 
 ### Minor
 
-- Eslint plugin: add zIndex props coverage to gestalt/no-box-dangerous-style-duplicates [#1713](https://github.com/pinterest/gestalt/pull/1713) - [PREVIEW URL](https://deploy-preview-1713--gestalt.netlify.app)
+- ESLint plugin: add zIndex props coverage to gestalt/no-box-dangerous-style-duplicates [#1713](https://github.com/pinterest/gestalt/pull/1713) - [PREVIEW URL](https://deploy-preview-1713--gestalt.netlify.app)
 
 ## 35.4.0 (Sep 27, 2021)
 
@@ -3490,13 +3490,13 @@
 
 ### Minor
 
-- Eslint plugin: add full Box props coverage to gestalt/no-box-dangerous-style-duplicates [#1711](https://github.com/pinterest/gestalt/pull/1711) - [PREVIEW URL](https://deploy-preview-1711--gestalt.netlify.app)
+- ESLint plugin: add full Box props coverage to gestalt/no-box-dangerous-style-duplicates [#1711](https://github.com/pinterest/gestalt/pull/1711) - [PREVIEW URL](https://deploy-preview-1711--gestalt.netlify.app)
 
 ## 35.2.14 (Sep 23, 2021)
 
 ### Patch
 
-- Eslint plugin: gestalt/no-box-dangerous-style-duplicates fixes and refactor [#1709](https://github.com/pinterest/gestalt/pull/1709) - [PREVIEW URL](https://deploy-preview-1709--gestalt.netlify.app)
+- ESLint plugin: gestalt/no-box-dangerous-style-duplicates fixes and refactor [#1709](https://github.com/pinterest/gestalt/pull/1709) - [PREVIEW URL](https://deploy-preview-1709--gestalt.netlify.app)
 
 ## 35.2.13 (Sep 23, 2021)
 
@@ -3742,7 +3742,7 @@
 
 ### Patch
 
-- Eslint plugin: fix on 'prefer-box-no-disallowed' rule [#1668](https://github.com/pinterest/gestalt/pull/1668) - [PREVIEW URL](https://deploy-preview-1668--gestalt.netlify.app)
+- ESLint plugin: fix on 'prefer-box-no-disallowed' rule [#1668](https://github.com/pinterest/gestalt/pull/1668) - [PREVIEW URL](https://deploy-preview-1668--gestalt.netlify.app)
 
 ## 33.8.1 (Aug 30, 2021)
 
@@ -3754,7 +3754,7 @@
 
 ### Minor
 
-- Eslint plugin: added schema options to `prefer-box-no-disallowed` rule [#1667](https://github.com/pinterest/gestalt/pull/1667) - [PREVIEW URL](https://deploy-preview-1667--gestalt.netlify.app)
+- ESLint plugin: added schema options to `prefer-box-no-disallowed` rule [#1667](https://github.com/pinterest/gestalt/pull/1667) - [PREVIEW URL](https://deploy-preview-1667--gestalt.netlify.app)
 
 ## 33.7.10 (Aug 27, 2021)
 
@@ -3820,7 +3820,7 @@
 
 ### Minor
 
-- Eslint plugin: updated `gestalt/no-dangerous-style-duplicates` w/ autofix [#1641](https://github.com/pinterest/gestalt/pull/1641) - [PREVIEW URL](https://deploy-preview-1641--gestalt.netlify.app)
+- ESLint plugin: updated `gestalt/no-dangerous-style-duplicates` w/ autofix [#1641](https://github.com/pinterest/gestalt/pull/1641) - [PREVIEW URL](https://deploy-preview-1641--gestalt.netlify.app)
 
 ## 33.6.0 (Aug 24, 2021)
 
@@ -3892,7 +3892,7 @@
 
 ### Minor
 
-- Eslint plugin: `prefer-box-no-classname` rule w/ autofix + merged into `prefer-box-lonely-ref` [#1629](https://github.com/pinterest/gestalt/pull/1629) - [PREVIEW URL](https://deploy-preview-1629--gestalt.netlify.app)
+- ESLint plugin: `prefer-box-no-classname` rule w/ autofix + merged into `prefer-box-lonely-ref` [#1629](https://github.com/pinterest/gestalt/pull/1629) - [PREVIEW URL](https://deploy-preview-1629--gestalt.netlify.app)
 
 ## 33.0.1 (Aug 19, 2021)
 
@@ -3976,13 +3976,13 @@
 
 ### Patch
 
-- Eslint plugin: fix prefer-box-as-tag
+- ESLint plugin: fix prefer-box-as-tag
 
 ## 31.3.0 (Aug 11, 2021)
 
 ### Minor
 
-- Eslint plugin: prefer-box-as-tag rule w/ autofix
+- ESLint plugin: prefer-box-as-tag rule w/ autofix
 
 ## 31.2.1 (Aug 11, 2021)
 
@@ -4024,13 +4024,13 @@
 
 ### Patch
 
-- Eslint plugin: fixes to `prefer-box`, `no-spread-props` [#1615](https://github.com/pinterest/gestalt/pull/1615) - [PREVIEW URL](https://deploy-preview-1615--gestalt.netlify.app)
+- ESLint plugin: fixes to `prefer-box`, `no-spread-props` [#1615](https://github.com/pinterest/gestalt/pull/1615) - [PREVIEW URL](https://deploy-preview-1615--gestalt.netlify.app)
 
 ## 31.1.0 (Aug 9, 2021)
 
 ### Minor
 
-- Eslint plugin: prefer-box-lonely-ref rule w/ autofix + no-spread-props rule w/ autofix [#1608](https://github.com/pinterest/gestalt/pull/1608) - [PREVIEW URL](https://deploy-preview-1608--gestalt.netlify.app)
+- ESLint plugin: prefer-box-lonely-ref rule w/ autofix + no-spread-props rule w/ autofix [#1608](https://github.com/pinterest/gestalt/pull/1608) - [PREVIEW URL](https://deploy-preview-1608--gestalt.netlify.app)
 
 ## 31.0.1 (Aug 9, 2021)
 
@@ -4054,7 +4054,7 @@
 
 ### Patch
 
-- Eslint Plugin: Add missing ComboBox to "no-medium-formfields"
+- ESLint Plugin: Add missing ComboBox to "no-medium-formfields"
 
 ## 30.0.0 (Aug 4, 2021)
 
@@ -4090,7 +4090,7 @@
 
 ### Patch
 
-- Eslint Plugin: Add missing rules to Docs, categorize, and standardize rule config [#1601](https://github.com/pinterest/gestalt/pull/1601) - [PREVIEW URL](https://deploy-preview-1601--gestalt.netlify.app)
+- ESLint Plugin: Add missing rules to Docs, categorize, and standardize rule config [#1601](https://github.com/pinterest/gestalt/pull/1601) - [PREVIEW URL](https://deploy-preview-1601--gestalt.netlify.app)
 
 ## 29.6.0 (Jul 27, 2021)
 
@@ -5178,7 +5178,7 @@
 
 ### Minor
 
-- [Eslint] Add border to prefer-box eslint rule [#1381](https://github.com/pinterest/gestalt/pull/1381) - [PREVIEW URL](https://deploy-preview-1381--gestalt.netlify.app)
+- [ESLint] Add border to prefer-box eslint rule [#1381](https://github.com/pinterest/gestalt/pull/1381) - [PREVIEW URL](https://deploy-preview-1381--gestalt.netlify.app)
 
 ## 17.2.0 (Feb 10, 2021)
 
@@ -8187,7 +8187,7 @@ Run codemods for breaking changes in order:
 ### Minor
 
 - Enzyme: Upgrade to the latest `v3.10.0` version and pull in Flow library changes [#543](https://github.com/pinterest/gestalt/pull/543) - [PREVIEW URL](https://deploy-preview-543--gestalt.netlify.app)
-- Eslint: Bump all related packages/plugins to current latest version [#544](https://github.com/pinterest/gestalt/pull/544) - [PREVIEW URL](https://deploy-preview-544--gestalt.netlify.app)
+- ESLint: Bump all related packages/plugins to current latest version [#544](https://github.com/pinterest/gestalt/pull/544) - [PREVIEW URL](https://deploy-preview-544--gestalt.netlify.app)
 - Button: add new `textColor` prop to allow overriding of text color for buttons [#545](https://github.com/pinterest/gestalt/pull/545) - [PREVIEW URL](https://deploy-preview-545--gestalt.netlify.app)
 - Icon: Add new lightning icon [#547](https://github.com/pinterest/gestalt/pull/547) - [PREVIEW URL](https://deploy-preview-547--gestalt.netlify.app)
 - Icon: Update send icon [#549](https://github.com/pinterest/gestalt/pull/549) - [PREVIEW URL](https://deploy-preview-549--gestalt.netlify.app)

--- a/docs/docs-components/siteIndex.js
+++ b/docs/docs-components/siteIndex.js
@@ -29,7 +29,7 @@ const siteIndex: $ReadOnlyArray<siteIndexType> = [
             sectionName: 'Contributing',
             pages: ['Creating and updating pages', 'Development process'],
           },
-          'Eslint plugin',
+          'ESLint plugin',
           'Hacking Gestalt',
           'Installation',
           'Releases',

--- a/docs/examples/sidenavigation/sectionsExample.js
+++ b/docs/examples/sidenavigation/sectionsExample.js
@@ -6,7 +6,7 @@ export default function Example(): Node {
   return (
     <SideNavigation accessibilityLabel="Sections example">
       <SideNavigation.Section label="Resources">
-        <SideNavigation.TopItem href="#" label="Eslint plugin" />
+        <SideNavigation.TopItem href="#" label="ESLint plugin" />
         <SideNavigation.TopItem href="#" label="FAQ" />
         <SideNavigation.TopItem href="#" label="How to hack around Gestalt" />
         <SideNavigation.TopItem href="#" label="Tooling" />

--- a/docs/pages/get_started/developers/eslint_plugin.js
+++ b/docs/pages/get_started/developers/eslint_plugin.js
@@ -88,7 +88,8 @@ With AUTOFIX!
         <MainSection.Subsection
           title="gestalt/button-icon-restrictions"
           description={`
-        Require a specific icon when using an icon with Button. Buttons using \`iconEnd\` must use icon &quot;arrow-down&quot;
+        Require a specific value when using [Icon](/web/icon) with [Button](/web/button). Gestalt is more permissive than we recommend internally for adding icons to Buttons, so Buttons using \`iconEnd\` must use the &quot;arrow-down&quot; icon and Buttons with link role using \`iconEnd\` must use the &quot;visit&quot; icon.
+
       `}
         />
         <MainSection.Subsection

--- a/docs/pages/get_started/developers/eslint_plugin.js
+++ b/docs/pages/get_started/developers/eslint_plugin.js
@@ -6,15 +6,15 @@ import Page from '../../../docs-components/Page.js';
 
 export default function EslintPluginPage(): Node {
   return (
-    <Page title="Eslint plugin">
+    <Page title="ESLint plugin">
       <PageHeader
-        name="Eslint plugin"
+        name="ESLint plugin"
         description="Install the package eslint-plugin-gestalt to get lint rules encouraging the correct usage of Gestalt components"
         type="guidelines"
       />
       <MainSection
         name="Gestalt alternatives"
-        description="The following Eslint rules provide guidance on how to replace native HTML elements and attributes with available Gestalt equivalents"
+        description="The following ESLint rules provide guidance on how to replace native HTML elements and attributes with available Gestalt equivalents"
       >
         <MainSection.Subsection
           title="gestalt/prefer-box-inline-style"
@@ -26,7 +26,7 @@ export default function EslintPluginPage(): Node {
         />
         <MainSection.Subsection
           title="gestalt/prefer-box-no-disallowed"
-          description={`Prevent \`<div>\` tags that don't contain disallowed attributes in Box: className, onClick, and any attribute not included in Box's allowed-attribute [list](https://github.com/pinterest/gestalt/blob/68d5d550a7358fcb1e104b27865a14c74d5ac01f/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js#L8). Use Gestalt Box, instead. Other attributes are disallowed as well so this Eslint rule doesn't conflict with [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y).
+          description={`Prevent \`<div>\` tags that don't contain disallowed attributes in Box: className, onClick, and any attribute not included in Box's allowed-attribute [list](https://github.com/pinterest/gestalt/blob/68d5d550a7358fcb1e104b27865a14c74d5ac01f/packages/eslint-plugin-gestalt/src/no-box-disallowed-props.js#L8). Use Gestalt Box, instead. Other attributes are disallowed as well so this ESLint rule doesn't conflict with [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y).
 
 [Read more about Box](/web/box).
 
@@ -83,12 +83,12 @@ With AUTOFIX!
       </MainSection>
       <MainSection
         name="Gestalt restrictions"
-        description="The following Eslint rules restrict the usage of Gestalt component props to enforce design consistency, code safety and best practices."
+        description="The following ESLint rules restrict the usage of Gestalt component props to enforce design consistency, code safety and best practices."
       >
         <MainSection.Subsection
           title="gestalt/button-icon-restrictions"
           description={`
-        Require a specific value when using [Icon](/web/icon) with [Button](/web/button). Gestalt is more permissive than we recommend internally for adding icons to Buttons, so Buttons using \`iconEnd\` must use the &quot;arrow-down&quot; icon and Buttons with link role using \`iconEnd\` must use the &quot;visit&quot; icon.
+        Require a specific value when using an icon with [Button](/web/button). Gestalt is more permissive than we recommend internally for adding icons to Buttons, so Buttons using \`iconEnd\` must use the &quot;arrow-down&quot; icon and Buttons with link role using \`iconEnd\` must use the &quot;visit&quot; icon.
 
       `}
         />
@@ -225,7 +225,7 @@ yarn unlink eslint-plugin-gestalt
       />
       <MainSection
         name="Deprecated ESlint rules"
-        description="The following Eslint rules are no longer needed."
+        description="The following ESLint rules are no longer needed."
       >
         <MainSection.Subsection
           title="gestalt/no-box-marginleft-marginright"

--- a/docs/pages/get_started/developers/tooling/web.js
+++ b/docs/pages/get_started/developers/tooling/web.js
@@ -121,8 +121,8 @@ Any other engineers will highly benefit from reducing the amount of steps to ado
       </MainSection>
       <MainSection name="Developer velocity tools">
         <MainSection.Subsection
-          title="Eslint plugin"
-          description={`Visit the [Eslint plugin](/get_started/developers/eslint_plugin) guidance page to see all the available Eslint rules.
+          title="ESLint plugin"
+          description={`Visit the [ESLint plugin](/get_started/developers/eslint_plugin) guidance page to see all the available ESLint rules.
 
 Most rules come with out-of-the-box autofixes, automating the adoption of Gestalt best practices.`}
         />

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Button } from 'gestalt';
+import { Button, SlimBanner } from 'gestalt';
 import PropTable from '../../docs-components/PropTable.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -76,7 +76,9 @@ export default function ButtonPage({ generatedDocGen }: {| generatedDocGen: DocG
             name: 'iconEnd',
             type: '$Keys<typeof icons>',
             required: false,
-            description: ['An icon displayed after the text to help clarify the usage of Button.'],
+            description: [
+              'An icon displayed after the text to help clarify the usage of Button. See the [icon variant](#Icons) to learn more.',
+            ],
           },
           {
             name: 'fullWidth',
@@ -523,10 +525,19 @@ function SemiTransparentWhiteButtonExample() {
         <MainSection.Subsection
           title="Icons"
           description={`
-Icon end
-Adds an icon after the Button text. Icons should only be used to visually reinforce a specific function or interaction of the Button. Menus and external links are a common use case. Use \`visit\` when linking to an external URL or \`arrow-down\` when displaying a Popover on click. Note that iconEnd on Button is not accessible to screen readers.
+\`iconEnd\` adds an icon after the Button text. Icons should only be used to visually reinforce a specific function or interaction of the Button. Menus and external links are a common use case. Use \`visit\` when linking to an external URL or \`arrow-down\` when displaying a Popover on click. Note that iconEnd on Button is not accessible to screen readers.
 `}
         >
+          <SlimBanner
+            type="recommendationBare"
+            iconAccessibilityLabel="Recommendation"
+            message="Use Gestalt's Eslint rule to enforce the correct icons usage in Button."
+            helperLink={{
+              accessibilityLabel: 'Learn more about the "button-icon-restrictions" rule',
+              href: '/get_started/developers/eslint_plugin#gestaltbutton-icon-restrictions',
+              text: 'Learn more about the "button-icon-restrictions" rule',
+            }}
+          />
           <MainSection.Card
             cardSize="lg"
             defaultCode={`

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -531,7 +531,7 @@ function SemiTransparentWhiteButtonExample() {
           <SlimBanner
             type="recommendationBare"
             iconAccessibilityLabel="Recommendation"
-            message="Use Gestalt's Eslint rule to enforce the correct icons usage in Button."
+            message="Use Gestalt's ESLint rule to enforce the correct icons usage in Button."
             helperLink={{
               accessibilityLabel: 'Learn more about the "button-icon-restrictions" rule',
               href: '/get_started/developers/eslint_plugin#gestaltbutton-icon-restrictions',

--- a/packages/eslint-plugin-gestalt/package.json
+++ b/packages/eslint-plugin-gestalt/package.json
@@ -3,7 +3,7 @@
   "version": "72.0.4",
   "license": "Apache-2.0",
   "homepage": "https://gestalt.pinterest.systems/",
-  "description": "Eslint rules for Pinterest’s design language Gestalt",
+  "description": "ESLint rules for Pinterest’s design language Gestalt",
   "main": "dist/eslint-plugin-gestalt.js",
   "jsnext:main": "dist/eslint-plugin-gestalt.es.js",
   "module": "dist/eslint-plugin-gestalt.es.js",

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-wrong-link-role-icon.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/invalid/invalid-wrong-link-role-icon.js
@@ -1,0 +1,5 @@
+import { Button } from 'gestalt';
+
+export default function TestElement() {
+  return <Button color="white" iconEnd="arrow-up-right" size="lg" text="Link" role="link" />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/valid/valid-size.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/button-icon-restrictions/valid/valid-size.js
@@ -1,5 +1,10 @@
 import { Button } from 'gestalt';
 
 export default function TestElement() {
-  return <Button color="white" iconEnd="arrow-down" size="lg" text="Menu" />;
+  return (
+  <Box>
+    <Button color="white" iconEnd="arrow-down" size="lg" text="Menu" />
+    <Button role="link" iconEnd="visit" size="lg" text="link" />
+  </Box>
+  );
 }

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
@@ -64,16 +64,20 @@ const rule: ESLintRule = {
         }
 
         const iconAttribute = getAttribute(node, 'iconEnd');
-        const isCorrectIcon = getValue(iconAttribute) === 'arrow-down';
+        const iconEndValue = getValue(iconAttribute);
+
+        const roleAttribute = getAttribute(node, 'role');
+        const roleValue = getValue(roleAttribute);
 
         // Not using iconEnd, early return
         if (!iconAttribute) {
           return;
         }
-
         // Not using correct props
-        if (!isCorrectIcon) {
-          context.report(node, 'Buttons using iconEnd must use "arrow-down"');
+        if (roleValue === 'link' && iconEndValue !== 'visit') {
+          context.report(node, 'Buttons with="link" using iconEnd must use the "visit" icon');
+        } else if (roleValue !== 'link' && iconEndValue !== 'arrow-down') {
+          context.report(node, 'Buttons using iconEnd must use "arrow-down" icon');
         }
       },
     };

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
@@ -9,6 +9,10 @@
 // @flow strict
 import { type ESLintRule } from './helpers/eslintFlowTypes.js';
 
+export const errorMessage = 'Buttons with="link" using iconEnd must use the "visit" icon';
+
+export const errorMessage2 = 'Buttons using iconEnd must use "arrow-down" icon';
+
 const rule: ESLintRule = {
   meta: {
     type: 'suggestion',
@@ -75,9 +79,9 @@ const rule: ESLintRule = {
         }
         // Not using correct props
         if (roleValue === 'link' && iconEndValue !== 'visit') {
-          context.report(node, 'Buttons with="link" using iconEnd must use the "visit" icon');
+          context.report(node, errorMessage);
         } else if (roleValue !== 'link' && iconEndValue !== 'arrow-down') {
-          context.report(node, 'Buttons using iconEnd must use "arrow-down" icon');
+          context.report(node, errorMessage2);
         }
       },
     };

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.test.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.test.js
@@ -20,12 +20,30 @@ const invalidWrongIcon = readFileSync(
   'utf-8',
 );
 
-const errorMessage = 'Buttons using iconEnd must use "arrow-down"';
+const invalidWrongIconLinkRole = readFileSync(
+  path.resolve(
+    __dirname,
+    './__fixtures__/button-icon-restrictions/invalid/invalid-wrong-link-role-icon.js',
+  ),
+  'utf-8',
+);
+
+const errorMessage = 'Buttons using iconEnd must use "arrow-down" icon';
+
+const errorMessage2 = 'Buttons with="link" using iconEnd must use the "visit" icon';
 
 ruleTester.run('button-icon-restrictions', rule, {
   valid: [validWithSize].map((code) => ({ code })),
   invalid: [invalidRenamed, invalidWrongIcon].map((code) => ({
     code,
     errors: [{ message: errorMessage }],
+  })),
+});
+
+ruleTester.run('button-icon-restrictions', rule, {
+  valid: [validWithSize].map((code) => ({ code })),
+  invalid: [invalidWrongIconLinkRole].map((code) => ({
+    code,
+    errors: [{ message: errorMessage2 }],
   })),
 });

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.test.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.test.js
@@ -2,7 +2,7 @@
 import { RuleTester } from 'eslint';
 import { readFileSync } from 'fs';
 import path from 'path';
-import rule from './button-icon-restrictions.js';
+import rule, { errorMessage, errorMessage2 } from './button-icon-restrictions.js';
 import { parserOptions } from './helpers/testHelpers.js';
 
 const ruleTester = new RuleTester({ parserOptions });
@@ -28,15 +28,11 @@ const invalidWrongIconLinkRole = readFileSync(
   'utf-8',
 );
 
-const errorMessage = 'Buttons using iconEnd must use "arrow-down" icon';
-
-const errorMessage2 = 'Buttons with="link" using iconEnd must use the "visit" icon';
-
 ruleTester.run('button-icon-restrictions', rule, {
   valid: [validWithSize].map((code) => ({ code })),
   invalid: [invalidRenamed, invalidWrongIcon].map((code) => ({
     code,
-    errors: [{ message: errorMessage }],
+    errors: [{ message: errorMessage2 }],
   })),
 });
 
@@ -44,6 +40,6 @@ ruleTester.run('button-icon-restrictions', rule, {
   valid: [validWithSize].map((code) => ({ code })),
   invalid: [invalidWrongIconLinkRole].map((code) => ({
     code,
-    errors: [{ message: errorMessage2 }],
+    errors: [{ message: errorMessage }],
   })),
 });

--- a/packages/eslint-plugin-gestalt/src/helpers/noBoxDangerousStyleDuplicatesReducer.js
+++ b/packages/eslint-plugin-gestalt/src/helpers/noBoxDangerousStyleDuplicatesReducer.js
@@ -46,9 +46,9 @@ const buildNoBoxDangerousStyleDuplicatesReducer: BuildReducerType = ({ context }
       }
     };
 
-    // This function is guard clause for those opt-out props from Eslint configuration
+    // This function is guard clause for those opt-out props from ESLint configuration
     function includeKey(keyName) {
-      const { onlyKeys } = context?.options?.[0] ?? {}; // Access options from Eslint configuration
+      const { onlyKeys } = context?.options?.[0] ?? {}; // Access options from ESLint configuration
       return !onlyKeys || onlyKeys.includes(keyName);
     }
 

--- a/packages/eslint-plugin-gestalt/src/prefer-box-no-disallowed.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-no-disallowed.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Prefer Box: prevent <div> tags that don't contain disallowed attributes: className, onClick, or disallowed props on `Box` (no-box-disallowed-props Eslint rule)
+ * @fileoverview Prefer Box: prevent <div> tags that don't contain disallowed attributes: className, onClick, or disallowed props on `Box` (no-box-disallowed-props ESLint rule)
  */
 
 // @flow strict

--- a/playwright/accessibility/Eslint Plugin.spec.mjs
+++ b/playwright/accessibility/Eslint Plugin.spec.mjs
@@ -2,7 +2,7 @@
 import { test } from '@playwright/test';
 import expectAccessiblePage from './expectAccessiblePage.mjs';
 
-test('Eslint Plugin Accessibility check', async ({ page }) => {
+test('ESLint Plugin Accessibility check', async ({ page }) => {
   await page.goto('/get_started/developers/eslint_plugin');
   await expectAccessiblePage({ page });
 });


### PR DESCRIPTION
### Summary

#### What changed?

Eslint_plugin: extend gestalt/button-icon-restrictions to cover role=link icon restrictions

#### Why?

Require a specific value when using [Icon](http://localhost:8888/web/icon) with [Button](http://localhost:8888/web/button). Gestalt is more permissive than we recommend internally for adding icons to Buttons, so Buttons using iconEnd must use the "arrow-down" icon and Buttons with link role using iconEnd must use the "visit" icon.

This Eslint rule didn't cover the second restriction, a new best practice that  was recently implemented.


### Codemod

To facilitate the migration, run this codemod to find instances of Button role="link" 

```
yarn codemod detectManualReplacement ~/path/to/your/code
--component=Button
--prop=role
--value=link
```

However, the Eslint rule will through an ERROR/WARNING message anyway that can be used to detect places that need replacement.


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4644)