### PR TITLE
Checkbox, RadioButton, RadioGroupButton: start align input

### DIFF
--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -156,13 +156,7 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
 
   return (
     <Box>
-      <Box
-        alignItems={helperText || errorMessage || image ? 'start' : 'center'}
-        display="flex"
-        justifyContent="start"
-        marginStart={-1}
-        marginEnd={-1}
-      >
+      <Box alignItems="start" display="flex" justifyContent="start" marginStart={-1} marginEnd={-1}>
         <Label htmlFor={id}>
           <Box paddingX={1} position="relative">
             <input
@@ -207,7 +201,11 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
         </Label>
         {Boolean(image) && <Box paddingX={1}>{image}</Box>}
         {label && (
-          <Box display={labelDisplay === 'hidden' ? 'visuallyHidden' : 'block'}>
+          <Box
+            display={labelDisplay === 'hidden' ? 'visuallyHidden' : 'block'}
+            //  marginTop: '2px' is needed to  visually align the label text & radiobutton input
+            dangerouslySetInlineStyle={{ __style: { marginTop: '2px' } }}
+          >
             <Label htmlFor={id}>
               <Box paddingX={1}>
                 <Text color={disabled ? 'subtle' : undefined} size={size === 'sm' ? '200' : '300'}>

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -119,13 +119,7 @@ const RadioButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
   const { isFocusVisible } = useFocusVisible();
 
   return (
-    <Box
-      alignItems={subtext || image ? 'start' : 'center'}
-      display="flex"
-      justifyContent="start"
-      marginStart={-1}
-      marginEnd={-1}
-    >
+    <Box alignItems="start" display="flex" justifyContent="start" marginStart={-1} marginEnd={-1}>
       <Label htmlFor={id}>
         <Box paddingX={1}>
           <div
@@ -163,7 +157,8 @@ const RadioButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
       {Boolean(image) && <Box paddingX={1}>{image}</Box>}
       {label && (
         <Label htmlFor={id}>
-          <Box paddingX={1}>
+          {/* marginTop: '2px' is needed to  visually align the label text & radiobutton input */}
+          <Box paddingX={1} dangerouslySetInlineStyle={{ __style: { marginTop: '2px' } }}>
             <Text color={disabled ? 'subtle' : undefined} size={size === 'sm' ? '200' : '300'}>
               {label}
             </Text>

--- a/packages/gestalt/src/RadioGroupButton.js
+++ b/packages/gestalt/src/RadioGroupButton.js
@@ -127,13 +127,7 @@ const RadioGroupButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputEl
   }
 
   return (
-    <Box
-      alignItems={helperText || image ? 'start' : 'center'}
-      display="flex"
-      justifyContent="start"
-      marginStart={-1}
-      marginEnd={-1}
-    >
+    <Box alignItems="start" display="flex" justifyContent="start" marginStart={-1} marginEnd={-1}>
       <Label htmlFor={id}>
         <Box paddingX={1}>
           <div
@@ -171,7 +165,8 @@ const RadioGroupButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputEl
       {Boolean(image) && <Box paddingX={1}>{image}</Box>}
       {label && (
         <Label htmlFor={id}>
-          <Box paddingX={1}>
+          {/* marginTop: '2px' is needed to  visually align the label text & radiobutton input */}
+          <Box paddingX={1} dangerouslySetInlineStyle={{ __style: { marginTop: '2px' } }}>
             <Text color={disabled ? 'subtle' : undefined} size={size === 'sm' ? '200' : '300'}>
               {label}
             </Text>

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -5,7 +5,7 @@ exports[`Checkbox 1`] = `
   className="box"
 >
   <div
-    className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+    className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
   >
     <label
       className="label"
@@ -34,6 +34,11 @@ exports[`Checkbox 1`] = `
     </label>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -59,7 +64,7 @@ exports[`Checkbox checked 1`] = `
   className="box"
 >
   <div
-    className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+    className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
   >
     <label
       className="label"
@@ -102,6 +107,11 @@ exports[`Checkbox checked 1`] = `
     </label>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -127,7 +137,7 @@ exports[`Checkbox disabled & checked 1`] = `
   className="box"
 >
   <div
-    className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+    className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
   >
     <label
       className="label"
@@ -170,6 +180,11 @@ exports[`Checkbox disabled & checked 1`] = `
     </label>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -195,7 +210,7 @@ exports[`Checkbox disabled 1`] = `
   className="box"
 >
   <div
-    className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+    className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
   >
     <label
       className="label"
@@ -224,6 +239,11 @@ exports[`Checkbox disabled 1`] = `
     </label>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -249,7 +269,7 @@ exports[`Checkbox indeterminate 1`] = `
   className="box"
 >
   <div
-    className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+    className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
   >
     <label
       className="label"
@@ -292,6 +312,11 @@ exports[`Checkbox indeterminate 1`] = `
     </label>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -317,7 +342,7 @@ exports[`Checkbox small 1`] = `
   className="box"
 >
   <div
-    className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+    className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
   >
     <label
       className="label"
@@ -346,6 +371,11 @@ exports[`Checkbox small 1`] = `
     </label>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -427,6 +457,11 @@ exports[`Checkbox with an image 1`] = `
     </div>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -481,6 +516,11 @@ exports[`Checkbox with error 1`] = `
     </label>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -549,6 +589,11 @@ exports[`Checkbox with helperText 1`] = `
     </label>
     <div
       className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <label
         className="label"
@@ -583,7 +628,7 @@ exports[`Checkbox without label 1`] = `
   className="box"
 >
   <div
-    className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+    className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
   >
     <label
       className="label"

--- a/packages/gestalt/src/__snapshots__/Fieldset.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Fieldset.test.js.snap
@@ -17,7 +17,7 @@ exports[`Fieldset renders 1`] = `
     className="box"
   >
     <div
-      className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+      className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
     >
       <label
         className="label"
@@ -46,6 +46,11 @@ exports[`Fieldset renders 1`] = `
       </label>
       <div
         className="box xsDisplayBlock"
+        style={
+          Object {
+            "marginTop": "2px",
+          }
+        }
       >
         <label
           className="label"
@@ -68,7 +73,7 @@ exports[`Fieldset renders 1`] = `
     className="box"
   >
     <div
-      className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+      className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
     >
       <label
         className="label"
@@ -97,6 +102,11 @@ exports[`Fieldset renders 1`] = `
       </label>
       <div
         className="box xsDisplayBlock"
+        style={
+          Object {
+            "marginTop": "2px",
+          }
+        }
       >
         <label
           className="label"
@@ -135,7 +145,7 @@ exports[`Fieldset renders a visually hidden legend 1`] = `
     className="box"
   >
     <div
-      className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+      className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
     >
       <label
         className="label"
@@ -164,6 +174,11 @@ exports[`Fieldset renders a visually hidden legend 1`] = `
       </label>
       <div
         className="box xsDisplayBlock"
+        style={
+          Object {
+            "marginTop": "2px",
+          }
+        }
       >
         <label
           className="label"
@@ -186,7 +201,7 @@ exports[`Fieldset renders a visually hidden legend 1`] = `
     className="box"
   >
     <div
-      className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+      className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
     >
       <label
         className="label"
@@ -215,6 +230,11 @@ exports[`Fieldset renders a visually hidden legend 1`] = `
       </label>
       <div
         className="box xsDisplayBlock"
+        style={
+          Object {
+            "marginTop": "2px",
+          }
+        }
       >
         <label
           className="label"
@@ -253,7 +273,7 @@ exports[`Fieldset renders with errorMessage 1`] = `
     className="box"
   >
     <div
-      className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+      className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
     >
       <label
         className="label"
@@ -282,6 +302,11 @@ exports[`Fieldset renders with errorMessage 1`] = `
       </label>
       <div
         className="box xsDisplayBlock"
+        style={
+          Object {
+            "marginTop": "2px",
+          }
+        }
       >
         <label
           className="label"
@@ -304,7 +329,7 @@ exports[`Fieldset renders with errorMessage 1`] = `
     className="box"
   >
     <div
-      className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+      className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
     >
       <label
         className="label"
@@ -333,6 +358,11 @@ exports[`Fieldset renders with errorMessage 1`] = `
       </label>
       <div
         className="box xsDisplayBlock"
+        style={
+          Object {
+            "marginTop": "2px",
+          }
+        }
       >
         <label
           className="label"

--- a/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`RadioButton 1`] = `
 <div
-  className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+  className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
 >
   <label
     className="label"
@@ -36,6 +36,11 @@ exports[`RadioButton 1`] = `
   >
     <div
       className="box paddingX1"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <div
         className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -49,7 +54,7 @@ exports[`RadioButton 1`] = `
 
 exports[`RadioButton checked 1`] = `
 <div
-  className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+  className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
 >
   <label
     className="label"
@@ -82,7 +87,7 @@ exports[`RadioButton checked 1`] = `
 
 exports[`RadioButton disabled 1`] = `
 <div
-  className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+  className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
 >
   <label
     className="label"
@@ -116,6 +121,11 @@ exports[`RadioButton disabled 1`] = `
   >
     <div
       className="box paddingX1"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <div
         className="Text fontSize300 subtleText alignStart breakWord fontWeightNormal"
@@ -129,7 +139,7 @@ exports[`RadioButton disabled 1`] = `
 
 exports[`RadioButton disabled small 1`] = `
 <div
-  className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+  className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
 >
   <label
     className="label"
@@ -163,6 +173,11 @@ exports[`RadioButton disabled small 1`] = `
   >
     <div
       className="box paddingX1"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <div
         className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal"
@@ -176,7 +191,7 @@ exports[`RadioButton disabled small 1`] = `
 
 exports[`RadioButton small 1`] = `
 <div
-  className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+  className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
 >
   <label
     className="label"
@@ -210,6 +225,11 @@ exports[`RadioButton small 1`] = `
   >
     <div
       className="box paddingX1"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <div
         className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
@@ -284,6 +304,11 @@ exports[`RadioButton with image 1`] = `
   >
     <div
       className="box paddingX1"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <div
         className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
@@ -331,6 +356,11 @@ exports[`RadioButton with subtext 1`] = `
   >
     <div
       className="box paddingX1"
+      style={
+        Object {
+          "marginTop": "2px",
+        }
+      }
     >
       <div
         className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
@@ -359,7 +389,7 @@ exports[`RadioButton with subtext 1`] = `
 
 exports[`RadioButton without label 1`] = `
 <div
-  className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+  className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
 >
   <label
     className="label"

--- a/packages/gestalt/src/__snapshots__/RadioGroup.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/RadioGroup.test.js.snap
@@ -20,7 +20,7 @@ exports[`RadioGroup renders 1`] = `
       className="FlexItem"
     >
       <div
-        className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+        className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
       >
         <label
           className="label"
@@ -75,7 +75,7 @@ exports[`RadioGroup renders a hidden legend 1`] = `
       className="FlexItem"
     >
       <div
-        className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+        className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
       >
         <label
           className="label"
@@ -130,7 +130,7 @@ exports[`RadioGroup renders an error 1`] = `
       className="FlexItem"
     >
       <div
-        className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+        className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
       >
         <label
           className="label"
@@ -199,7 +199,7 @@ exports[`RadioGroup renders in different direction 1`] = `
       className="FlexItem"
     >
       <div
-        className="box itemsCenter marginEndN1 marginStartN1 xsDisplayFlex"
+        className="box itemsStart marginEndN1 marginStartN1 xsDisplayFlex"
       >
         <label
           className="label"


### PR DESCRIPTION
### Summary

#### What changed?

Checkbox, RadioButton, RadioGroupButton: start align input

##### BEFORE
<img width="379" alt="Screen Shot 2022-09-20 at 1 06 12 AM" src="https://user-images.githubusercontent.com/10593890/191134433-46c1f798-3fa1-4657-a0d7-7e33382f9d7f.png">
<img width="386" alt="Screen Shot 2022-09-20 at 1 06 34 AM" src="https://user-images.githubusercontent.com/10593890/191134469-e0e232ce-5a56-4628-ab4d-b96970392328.png">


##### AFTER
<img width="390" alt="Screen Shot 2022-09-20 at 1 05 45 AM" src="https://user-images.githubusercontent.com/10593890/191134397-4a30a26a-5b4d-49b9-b7f8-2130dce57f56.png">
<img width="391" alt="Screen Shot 2022-09-20 at 1 07 06 AM" src="https://user-images.githubusercontent.com/10593890/191134545-fa46ebcd-f5af-423b-8971-d8612ff44aa2.png">


#### Why?

Checkbox and RadioGroup controls currently are vertically center-aligned with the label (see attached image)
The Checkbox and RadioGroup controls (e.g., the actual checkbox / radio inputs) should be top aligned with the label. So that if/when the label wraps, the position of the checkbox / radio should not change relative to the first line of the label.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4272)