### PR TITLE
Textfield, TextArea: add maxLength prop

### DIFF
--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -462,19 +462,18 @@ function Example(props) {
           title="Maximum length"
           description={`TextArea supports the native [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) input attribute. \`maxLength\` sets the maximum number of characters allowed to be entered by the user in TextArea. \`maxLength\` must be an integer value 0 or higher.
 
-When \`maxLength\` is passed to TextArea, the component displays a character counter as well as an [error Status](/status) when the user reaches or the controlled value exceeds the maximum length of characters.
+The user cannot exceed the maximum number of characters interacting with the component. Whenever possible, avoid setting initial values from the parent component's state that already exceed the \`maxLength\`.
 
-For controlled TextAreas, if the initial value in the external state exceeds the \`maxLength\` value, TextArea will display the full value; however, the user won't be able to add additional characters and they will only be allowed to delete characters. This case should be prevented.
+When \`maxLength\` is passed to TextArea, the component displays a character counter as well as a [warning or problem Status](/status) when the user reaches or the prepopulated controlled value exceeds the maximum length of characters.
 
-
-The first example shows an empty TextArea with \`maxLength\` set to 200 characters. The second example shows the error Status.`}
+The first example shows an empty TextArea with \`maxLength\` set to 200 characters. The second example shows the warning and problem Status.`}
         >
           <MainSection.Card
             cardSize="sm"
             defaultCode={`
 function TextAreaExample() {
   const [value, setValue] = React.useState('');
-  const maxLength = 200;
+  const characterCount = 200;
 
   return (
     <TextArea
@@ -487,7 +486,7 @@ function TextAreaExample() {
         onBlur={() => {}}
         onFocus={() => {}}
         rows={4}
-        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel: 'Limit reached. You can only use 20 characters in this field.' }}
+        maxLength={{ characterCount, errorAccessibilityLabel: 'Limit reached. You can only use 200 characters in this field.' }}
       />
   );
 }
@@ -500,7 +499,7 @@ function TextAreaExample() {
   const [valueA, setValueA] = React.useState('Before and after via side by side display of pale woman with auburn hair using concealer. The image shows her using a brush with concealer under her eyes.  The second image shows her with full makeup.');
   const [valueB, setValueB] = React.useState('Before and after via side by side display of pale woman with auburn hair using concealer. The image shows her using a brush with concealer under her eyes, second image shows her with full makeup and says new.');
 
-  const maxLength = 200;
+  const characterCount = 200;
   const errorAccessibilityLabel = "Limit reached. You can only use 20 characters in this field.";
 
   return (
@@ -515,7 +514,7 @@ function TextAreaExample() {
         onBlur={() => {}}
         onFocus={() => {}}
         rows={4}
-        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
+        maxLength={{ characterCount, errorAccessibilityLabel }}
       />
       <TextArea
         id="maxLengthExceeded"
@@ -527,7 +526,7 @@ function TextAreaExample() {
         onBlur={() => {}}
         onFocus={() => {}}
         rows={4}
-        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
+        maxLength={{ characterCount, errorAccessibilityLabel }}
       />
     </Flex>
   );

--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -460,16 +460,17 @@ function Example(props) {
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Maximum length"
-          columns={2}
-          description={`TextArea supports the native [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) input attribute. \`maxLength\` sets the maximum number of characters allowed to be entered by the user in TextArea.
-          
-For controlled TextAreas, if the initial value in the external state exceeds the \`maxLength\` value, TextArea will display the long value; however, the user won't be able to add additional characters and they will only be allowed to delete characters. 
-          
-When \`maxLength\` is passed to TextArea, the component displays a character counter as well as an [error Status](/status) when the user reaches or the controlled value exceeds the maximum length of characters. 
+          description={`TextArea supports the native [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) input attribute. \`maxLength\` sets the maximum number of characters allowed to be entered by the user in TextArea. \`maxLength\` must be an integer value 0 or higher.
 
-The first example shows an empty TextArea with \`maxLength\` set to 200 characters. The second example shows the error Status. The example below should be prevented as it shows TextArea displaying the error Status when the value lenght is exceeded.`}
+When \`maxLength\` is passed to TextArea, the component displays a character counter as well as an [error Status](/status) when the user reaches or the controlled value exceeds the maximum length of characters.
+
+For controlled TextAreas, if the initial value in the external state exceeds the \`maxLength\` value, TextArea will display the full value; however, the user won't be able to add additional characters and they will only be allowed to delete characters. This case should be prevented.
+
+
+The first example shows an empty TextArea with \`maxLength\` set to 200 characters. The second example shows the error Status.`}
         >
           <MainSection.Card
+            cardSize="sm"
             defaultCode={`
 function TextAreaExample() {
   const [value, setValue] = React.useState('');
@@ -485,7 +486,7 @@ function TextAreaExample() {
         value={value}
         onBlur={() => {}}
         onFocus={() => {}}
-        rows={2}
+        rows={4}
         maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel: 'Limit reached. You can only use 20 characters in this field.' }}
       />
   );
@@ -493,6 +494,7 @@ function TextAreaExample() {
 `}
           />
           <MainSection.Card
+            cardSize="lg"
             defaultCode={`
             function TextAreaExample() {
   const [valueA, setValueA] = React.useState('Before and after via side by side display of pale woman with auburn hair using concealer. The image shows her using a brush with concealer under her eyes.  The second image shows her with full makeup.');
@@ -502,7 +504,7 @@ function TextAreaExample() {
   const errorAccessibilityLabel = "Limit reached. You can only use 20 characters in this field.";
 
   return (
-    <Flex direction="column" gap={4}>
+    <Flex direction="column" gap={12}>
       <TextArea
         id="maxLengthReached"
         label="Alt text"
@@ -512,7 +514,7 @@ function TextAreaExample() {
         value={valueA}
         onBlur={() => {}}
         onFocus={() => {}}
-        rows={2}
+        rows={4}
         maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
       />
       <TextArea
@@ -524,7 +526,7 @@ function TextAreaExample() {
         value={valueB}
         onBlur={() => {}}
         onFocus={() => {}}
-        rows={2}
+        rows={4}
         maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
       />
     </Flex>

--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -459,6 +459,81 @@ function Example(props) {
           />
         </MainSection.Subsection>
         <MainSection.Subsection
+          title="Maximum length"
+          columns={2}
+          description={`TextArea supports the native [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) input attribute. \`maxLength\` sets the maximum number of characters allowed to be entered by the user in TextArea.
+          
+For controlled TextAreas, if the initial value in the external state exceeds the \`maxLength\` value, TextArea will display the long value; however, the user won't be able to add additional characters and they will only be allowed to delete characters. 
+          
+When \`maxLength\` is passed to TextArea, the component displays a character counter as well as an [error Status](/status) when the user reaches or the controlled value exceeds the maximum length of characters. 
+
+The first example shows an empty TextArea with \`maxLength\` set to 200 characters. The second example shows the error Status. The example below should be prevented as it shows TextArea displaying the error Status when the value lenght is exceeded.`}
+        >
+          <MainSection.Card
+            defaultCode={`
+function TextAreaExample() {
+  const [value, setValue] = React.useState('');
+  const maxLength = 200;
+
+  return (
+    <TextArea
+        id="maxLength"
+        label="Alt text"
+        helperText="Describe your image with detail so visually impaired users can understand your Pin"
+        onChange={({ value }) => setValue(value)}
+        placeholder="Enter the image alt text"
+        value={value}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        rows={2}
+        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel: 'Limit reached. You can only use 20 characters in this field.' }}
+      />
+  );
+}
+`}
+          />
+          <MainSection.Card
+            defaultCode={`
+            function TextAreaExample() {
+  const [valueA, setValueA] = React.useState('Before and after via side by side display of pale woman with auburn hair using concealer. The image shows her using a brush with concealer under her eyes.  The second image shows her with full makeup.');
+  const [valueB, setValueB] = React.useState('Before and after via side by side display of pale woman with auburn hair using concealer. The image shows her using a brush with concealer under her eyes, second image shows her with full makeup and says new.');
+
+  const maxLength = 200;
+  const errorAccessibilityLabel = "Limit reached. You can only use 20 characters in this field.";
+
+  return (
+    <Flex direction="column" gap={4}>
+      <TextArea
+        id="maxLengthReached"
+        label="Alt text"
+        helperText="Describe your image with detail so visually impaired users can understand your Pin"
+        onChange={({ value }) => setValueA(value)}
+        placeholder="Enter the image alt text"
+        value={valueA}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        rows={2}
+        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
+      />
+      <TextArea
+        id="maxLengthExceeded"
+        label="Alt text"
+        helperText="Describe your image with detail so visually impaired users can understand your Pin"
+        onChange={({ value }) => setValueB(value)}
+        placeholder="Enter the image alt text"
+        value={valueB}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        rows={2}
+        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
+      />
+    </Flex>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
           title="With a ref"
           description={`
           A \`TextArea\` with an anchor ref to a Popover component

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -31,7 +31,7 @@ function Example(props) {
         placeholder="Please enter your username"
         type="text"
         value={value}
-      /> 
+      />
     </Box>
   );
 }
@@ -532,7 +532,7 @@ function Example(props) {
     <TextField
       id="variants-readonly"
       label="Email address"
-      onChange={({ value }) => setValue(value)}}
+      onChange={({ value }) => setValue(value)}
       placeholder="Name"
       value={value}
       readOnly
@@ -704,13 +704,13 @@ function TextFieldExample() {
         <MainSection.Subsection
           title="Maximum length"
           columns={2}
-          description={`Textfield supports the native [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) input attribute. \`maxLength\` sets the maximum number of characters allowed to be entered by the user in Textfield.
-          
-For controlled TextFields, if the initial value in the external state exceeds the \`maxLength\` value, Textfield will display the long value; however, the user won't be able to add additional characters and they will only be allowed to delete characters. 
-          
-When \`maxLength\` is passed to TextField, the component displays a character counter as well as an [error Status](/status) when the user reaches or the controlled value exceeds the maximum length of characters. 
+          description={`Textfield supports the native [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) input attribute. \`maxLength\` sets the maximum number of characters allowed to be entered by the user in Textfield. \`maxLength\` must be an integer value 0 or higher.
 
-The first example shows an empty Textfield with \`maxLength\` set to 20 characters. The second example shows the error Status. The example below should be prevented as it shows Textfield displaying the error Status when the value lenght is exceeded.`}
+When \`maxLength\` is passed to TextField, the component displays a character counter as well as an [error Status](/status) when the user reaches or the controlled value exceeds the maximum length of characters.
+
+For controlled TextFields, if the initial value in the external state exceeds the \`maxLength\` value, Textfield will display the full value; however, the user won't be able to add additional characters and they will only be allowed to delete characters.
+
+The first example shows an empty Textfield with \`maxLength\` set to 20 characters. The second example shows the error Status.`}
         >
           <MainSection.Card
             defaultCode={`
@@ -744,7 +744,7 @@ function TextFieldExample() {
   const errorAccessibilityLabel = "Limit reached. You can only use 20 characters in this field.";
 
   return (
-    <Flex direction="column" gap={4}>
+    <Flex direction="column" gap={12}>
       <TextField
         id="maxLengthReached"
         label="Title"

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -706,17 +706,17 @@ function TextFieldExample() {
           columns={2}
           description={`Textfield supports the native [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) input attribute. \`maxLength\` sets the maximum number of characters allowed to be entered by the user in Textfield. \`maxLength\` must be an integer value 0 or higher.
 
-When \`maxLength\` is passed to TextField, the component displays a character counter as well as an [error Status](/status) when the user reaches or the controlled value exceeds the maximum length of characters.
+The user cannot exceed the maximum number of characters interacting with the component. Whenever possible, avoid setting initial values from the parent component's state that already exceed the \`maxLength\`.
 
-For controlled TextFields, if the initial value in the external state exceeds the \`maxLength\` value, Textfield will display the full value; however, the user won't be able to add additional characters and they will only be allowed to delete characters.
+When \`maxLength\` is passed to TextField, the component displays a character counter as well as a [warning or problem Status](/status) when the user reaches or the prepopulated controlled value exceeds the maximum length of characters.
 
-The first example shows an empty Textfield with \`maxLength\` set to 20 characters. The second example shows the error Status.`}
+The first example shows an empty Textfield with \`maxLength\` set to 20 characters. The second example shows the warning and problem Status.`}
         >
           <MainSection.Card
             defaultCode={`
 function TextFieldExample() {
   const [value, setValue] = React.useState('');
-  const maxLength = 20;
+  const characterCount = 20;
 
   return (
     <TextField
@@ -728,7 +728,7 @@ function TextFieldExample() {
       value={value}
       onBlur={() => {}}
       onFocus={() => {}}
-      maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel: 'Limit reached. You can only use 20 characters in this field.' }}
+      maxLength={{ characterCount, errorAccessibilityLabel: 'Limit reached. You can only use 20 characters in this field.' }}
     />
   );
 }
@@ -740,7 +740,7 @@ function TextFieldExample() {
   const [valueA, setValueA] = React.useState('Delicious vegan soup');
   const [valueB, setValueB] = React.useState('Delicious vegan noodle soup');
 
-  const maxLength = 20;
+  const characterCount = 20;
   const errorAccessibilityLabel = "Limit reached. You can only use 20 characters in this field.";
 
   return (
@@ -754,7 +754,7 @@ function TextFieldExample() {
         value={valueA}
         onBlur={() => {}}
         onFocus={() => {}}
-        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
+        maxLength={{ characterCount, errorAccessibilityLabel }}
       />
       <TextField
         id="maxLengthExceeded"
@@ -765,7 +765,7 @@ function TextFieldExample() {
         value={valueB}
         onBlur={() => {}}
         onFocus={() => {}}
-        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
+        maxLength={{ characterCount, errorAccessibilityLabel }}
       />
     </Flex>
   );

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -31,7 +31,7 @@ function Example(props) {
         placeholder="Please enter your username"
         type="text"
         value={value}
-      />
+      /> 
     </Box>
   );
 }
@@ -464,7 +464,7 @@ function Example(props) {
 
       <MainSection
         name="Localization"
-        description={`Be sure to localize \`errorMessage\`, \`helperText\`, \`label\`, and \`placeholder\`.`}
+        description={`Be sure to localize \`errorMessage\`, \`helperText\`, \`label\`, \`maxLength\`'s \`errorAccessibilityLabel\` and \`placeholder\`.`}
       />
 
       <MainSection name="Variants">
@@ -532,9 +532,7 @@ function Example(props) {
     <TextField
       id="variants-readonly"
       label="Email address"
-      onChange={({ value }) => {
-        setValue(value);
-      }}
+      onChange={({ value }) => setValue(value)}}
       placeholder="Name"
       value={value}
       readOnly
@@ -698,6 +696,78 @@ function TextFieldExample() {
       onBlur={() => {}}
       onFocus={() => {}}
     />
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Maximum length"
+          columns={2}
+          description={`Textfield supports the native [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) input attribute. \`maxLength\` sets the maximum number of characters allowed to be entered by the user in Textfield.
+          
+For controlled TextFields, if the initial value in the external state exceeds the \`maxLength\` value, Textfield will display the long value; however, the user won't be able to add additional characters and they will only be allowed to delete characters. 
+          
+When \`maxLength\` is passed to TextField, the component displays a character counter as well as an [error Status](/status) when the user reaches or the controlled value exceeds the maximum length of characters. 
+
+The first example shows an empty Textfield with \`maxLength\` set to 20 characters. The second example shows the error Status. The example below should be prevented as it shows Textfield displaying the error Status when the value lenght is exceeded.`}
+        >
+          <MainSection.Card
+            defaultCode={`
+function TextFieldExample() {
+  const [value, setValue] = React.useState('');
+  const maxLength = 20;
+
+  return (
+    <TextField
+      id="maxLength"
+      label="Title"
+      helperText="Enter a title that captures the imagination of Pinners"
+      onChange={({ value }) => setValue(value)}
+      placeholder="Enter your pin title"
+      value={value}
+      onBlur={() => {}}
+      onFocus={() => {}}
+      maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel: 'Limit reached. You can only use 20 characters in this field.' }}
+    />
+  );
+}
+`}
+          />
+          <MainSection.Card
+            defaultCode={`
+            function TextFieldExample() {
+  const [valueA, setValueA] = React.useState('Delicious vegan soup');
+  const [valueB, setValueB] = React.useState('Delicious vegan noodle soup');
+
+  const maxLength = 20;
+  const errorAccessibilityLabel = "Limit reached. You can only use 20 characters in this field.";
+
+  return (
+    <Flex direction="column" gap={4}>
+      <TextField
+        id="maxLengthReached"
+        label="Title"
+        helperText="Enter a title that captures the imagination of Pinners"
+        onChange={({ value }) => setValueA(value)}
+        placeholder="Enter your pin title"
+        value={valueA}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
+      />
+      <TextField
+        id="maxLengthExceeded"
+        label="Title"
+        helperText="Enter a title that captures the imagination of Pinners"
+        onChange={({ value }) => setValueB(value)}
+        placeholder="Enter your pin title"
+        value={valueB}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        maxLength={{ maxLengthChar: maxLength, errorAccessibilityLabel }}
+      />
+    </Flex>
   );
 }
 `}

--- a/packages/gestalt/src/FormHelperText.js
+++ b/packages/gestalt/src/FormHelperText.js
@@ -1,9 +1,10 @@
 // @flow strict
-import { Fragment, useRef, useEffect, useState, type Node } from 'react';
+import { type Node } from 'react';
 import Box from './Box.js';
 import Flex from './Flex.js';
-import Status from './Status.js';
 import Text from './Text.js';
+import FormHelperTextCounter from './FormHelperTextCounter.js';
+
 import { type MaxLength } from './TextField.js';
 
 type Props = {|
@@ -19,18 +20,6 @@ export default function FormHelperText({
   maxLength,
   addA11yPause = false,
 }: Props): Node {
-  const ref = useRef();
-  const [width, setWidth] = useState(undefined);
-
-  useEffect(() => {
-    const containerWidth = ref?.current?.getBoundingClientRect().width;
-    setWidth(containerWidth ? Math.ceil(containerWidth) : undefined);
-  }, [ref]);
-
-  const maxLengthChars = maxLength?.maxLengthChar.toString() ?? '';
-
-  const maxLengthExceeded = (currentLength ?? 0) >= (maxLength?.maxLengthChar ?? 0);
-
   return (
     <Box marginTop={2}>
       <Flex gap={4}>
@@ -43,36 +32,7 @@ export default function FormHelperText({
           ) : null}
         </Flex.Item>
         {maxLength ? (
-          <Fragment>
-            {/* This hidden container is used to calculate the width of the character tracker and prevent spacing changes on each input value changes */}
-            <Box
-              position="absolute"
-              dangerouslySetInlineStyle={{ __style: { visibility: 'hidden' } }}
-              ref={ref}
-            >
-              <Text color="subtle" size="100">
-                {`${maxLengthChars}/${maxLengthChars}`}
-              </Text>
-            </Box>
-            <Flex gap={1}>
-              {maxLengthExceeded ? (
-                <Fragment>
-                  {/* This vvisually hidden error message is accessible by screenreaders. It alerts the user right after the maximum length is reached. */}
-                  <Box display="visuallyHidden" aria-live="assertive" role="alert">
-                    {maxLength?.errorAccessibilityLabel}
-                  </Box>
-                  <Status type="problem" accessibilityLabel={maxLength?.errorAccessibilityLabel} />
-                </Fragment>
-              ) : (
-                <Box width={16} />
-              )}
-              <Flex width={width} justifyContent="end">
-                <Text color={maxLengthExceeded ? 'error' : 'subtle'} size="100" align="end">
-                  {`${currentLength?.toString() ?? ''}/${maxLengthChars}`}
-                </Text>
-              </Flex>
-            </Flex>
-          </Fragment>
+          <FormHelperTextCounter currentLength={currentLength} maxLength={maxLength} />
         ) : null}
       </Flex>
     </Box>

--- a/packages/gestalt/src/FormHelperText.js
+++ b/packages/gestalt/src/FormHelperText.js
@@ -44,6 +44,7 @@ export default function FormHelperText({
         </Flex.Item>
         {maxLength ? (
           <Fragment>
+            {/* This hidden container is used to calculate the width of the character tracker and prevent spacing changes on each input value changes */}
             <Box
               position="absolute"
               dangerouslySetInlineStyle={{ __style: { visibility: 'hidden' } }}
@@ -56,6 +57,7 @@ export default function FormHelperText({
             <Flex gap={1}>
               {maxLengthExceeded ? (
                 <Fragment>
+                  {/* This vvisually hidden error message is accessible by screenreaders. It alerts the user right after the maximum length is reached. */}
                   <Box display="visuallyHidden" aria-live="assertive" role="alert">
                     {maxLength?.errorAccessibilityLabel}
                   </Box>

--- a/packages/gestalt/src/FormHelperText.js
+++ b/packages/gestalt/src/FormHelperText.js
@@ -1,21 +1,78 @@
 // @flow strict
-
-import { type Node } from 'react';
+import { Fragment, useRef, useEffect, useState, type Node } from 'react';
 import Box from './Box.js';
+import Flex from './Flex.js';
+import Status from './Status.js';
 import Text from './Text.js';
+import { type MaxLength } from './TextField.js';
 
 type Props = {|
-  text: string,
+  text: ?string,
+  maxLength?: ?MaxLength,
+  currentLength?: number,
   addA11yPause?: boolean,
 |};
 
-export default function FormHelperText({ text, addA11yPause = false }: Props): Node {
+export default function FormHelperText({
+  currentLength,
+  text,
+  maxLength,
+  addA11yPause = false,
+}: Props): Node {
+  const ref = useRef();
+  const [width, setWidth] = useState(undefined);
+
+  useEffect(() => {
+    const containerWidth = ref?.current?.getBoundingClientRect().width;
+    setWidth(containerWidth ? Math.ceil(containerWidth) : undefined);
+  }, [ref]);
+
+  const maxLengthChars = maxLength?.maxLengthChar.toString() ?? '';
+
+  const maxLengthExceeded = (currentLength ?? 0) >= (maxLength?.maxLengthChar ?? 0);
+
   return (
     <Box marginTop={2}>
-      <Text color="subtle" size="100">
-        {addA11yPause ? <Box display="visuallyHidden">:</Box> : null}
-        {text}
-      </Text>
+      <Flex gap={4}>
+        <Flex.Item flex="grow">
+          {text ? (
+            <Text color="subtle" size="100">
+              {addA11yPause ? <Box display="visuallyHidden">:</Box> : null}
+              {text}
+            </Text>
+          ) : null}
+        </Flex.Item>
+        {maxLength ? (
+          <Fragment>
+            <Box
+              position="absolute"
+              dangerouslySetInlineStyle={{ __style: { visibility: 'hidden' } }}
+              ref={ref}
+            >
+              <Text color="subtle" size="100">
+                {`${maxLengthChars}/${maxLengthChars}`}
+              </Text>
+            </Box>
+            <Flex gap={1}>
+              {maxLengthExceeded ? (
+                <Fragment>
+                  <Box display="visuallyHidden" aria-live="assertive" role="alert">
+                    {maxLength?.errorAccessibilityLabel}
+                  </Box>
+                  <Status type="problem" accessibilityLabel={maxLength?.errorAccessibilityLabel} />
+                </Fragment>
+              ) : (
+                <Box width={16} />
+              )}
+              <Flex width={width} justifyContent="end">
+                <Text color={maxLengthExceeded ? 'error' : 'subtle'} size="100" align="end">
+                  {`${currentLength?.toString() ?? ''}/${maxLengthChars}`}
+                </Text>
+              </Flex>
+            </Flex>
+          </Fragment>
+        ) : null}
+      </Flex>
     </Box>
   );
 }

--- a/packages/gestalt/src/FormHelperTextCounter.js
+++ b/packages/gestalt/src/FormHelperTextCounter.js
@@ -1,0 +1,71 @@
+// @flow strict
+import { Fragment, useRef, useEffect, useState, type Node } from 'react';
+import Box from './Box.js';
+import Flex from './Flex.js';
+import Status from './Status.js';
+import Text from './Text.js';
+import { type MaxLength } from './TextField.js';
+
+type Props = {|
+  maxLength: MaxLength,
+  currentLength?: number,
+|};
+
+export default function FormHelperTextCounter({ currentLength, maxLength }: Props): Node {
+  const ref = useRef();
+  const [width, setWidth] = useState(undefined);
+
+  useEffect(() => {
+    const containerWidth = ref?.current?.getBoundingClientRect().width;
+    setWidth(containerWidth ? Math.ceil(containerWidth) : undefined);
+  }, [ref]);
+
+  const maxLengthChars = maxLength?.characterCount.toString() ?? '';
+
+  const maxLengthReached = (currentLength ?? 0) >= (maxLength.characterCount ?? 0);
+
+  let status = 'warning';
+  let textColor = 'warning';
+
+  if (
+    typeof currentLength === 'number' &&
+    typeof maxLength?.characterCount === 'number' &&
+    currentLength > maxLength?.characterCount
+  ) {
+    status = 'problem';
+    textColor = 'error';
+  }
+
+  return (
+    <Fragment>
+      {/* This hidden container is used to calculate the width of the character tracker and prevent spacing changes on each input value changes */}
+      <Box
+        position="absolute"
+        dangerouslySetInlineStyle={{ __style: { visibility: 'hidden' } }}
+        ref={ref}
+      >
+        <Text color="subtle" size="100">
+          {`${maxLengthChars}/${maxLengthChars}`}
+        </Text>
+      </Box>
+      <Flex gap={1}>
+        {maxLengthReached ? (
+          <Fragment>
+            {/* This visually hidden error message is accessible by screenreaders. It alerts the user right after the maximum length is reached. */}
+            <Box display="visuallyHidden" aria-live="assertive" role="alert">
+              {maxLength?.errorAccessibilityLabel}
+            </Box>
+            <Status type={status} accessibilityLabel={maxLength?.errorAccessibilityLabel} />
+          </Fragment>
+        ) : (
+          <Box width={16} />
+        )}
+        <Flex width={width} justifyContent="end">
+          <Text color={maxLengthReached ? textColor : 'subtle'} size="100" align="end">
+            {`${currentLength?.toString() ?? ''}/${maxLengthChars}`}
+          </Text>
+        </Flex>
+      </Flex>
+    </Fragment>
+  );
+}

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -151,6 +151,10 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
 
     const unstyledClasses = classnames(styles.unstyledTextField);
 
+    if (maxLength && maxLength?.maxLengthChar < 0) {
+      throw new Error('`maxLength` must be an integer value 0 or higher.');
+    }
+
     const inputElement = (
       <input
         aria-activedescendant={accessibilityActiveDescendant}

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -151,7 +151,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
 
     const unstyledClasses = classnames(styles.unstyledTextField);
 
-    if (maxLength && maxLength?.maxLengthChar < 0) {
+    if (maxLength && maxLength.characterCount < 0) {
       throw new Error('`maxLength` must be an integer value 0 or higher.');
     }
 
@@ -166,7 +166,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
         disabled={disabled}
         enterKeyHint={enterKeyHint}
         id={id}
-        maxLength={maxLength?.maxLengthChar}
+        maxLength={maxLength?.characterCount}
         max={type === 'number' ? max : undefined}
         min={type === 'number' ? min : undefined}
         name={name}

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -2,6 +2,7 @@
 import { useImperativeHandle, useRef, forwardRef, type Element, type Node, useState } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
+import { type MaxLength } from './TextField.js';
 import FormErrorMessage from './FormErrorMessage.js';
 import FormHelperText from './FormHelperText.js';
 import FormLabel from './FormLabel.js';
@@ -33,6 +34,7 @@ type Props = {|
   label?: string,
   labelDisplay?: 'visible' | 'hidden',
   max?: number,
+  maxLength?: ?MaxLength,
   min?: number,
   name?: string,
   onBlur?: ({|
@@ -76,6 +78,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
       label,
       labelDisplay,
       max,
+      maxLength,
       min,
       name,
       onBlur,
@@ -101,6 +104,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
 
     // ==== STATE ====
     const [focused, setFocused] = useState(false);
+    const [currentLength, setCurrentLength] = useState(value?.length ?? 0);
 
     // ==== HANDLERS ====
     const handleBlur = (event: SyntheticFocusEvent<HTMLInputElement>) => {
@@ -111,8 +115,10 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
     const handleClick = (event: SyntheticInputEvent<HTMLInputElement>) =>
       onClick?.({ event, value: event.currentTarget.value });
 
-    const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) =>
+    const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
+      setCurrentLength(event.currentTarget.value?.length ?? 0);
       onChange({ event, value: event.currentTarget.value });
+    };
 
     const handleFocus = (event: SyntheticFocusEvent<HTMLInputElement>) => {
       setFocused(true);
@@ -156,6 +162,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
         disabled={disabled}
         enterKeyHint={enterKeyHint}
         id={id}
+        maxLength={maxLength?.maxLengthChar}
         max={type === 'number' ? max : undefined}
         min={type === 'number' ? min : undefined}
         name={name}
@@ -206,7 +213,9 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
           {!disabled && iconButton}
         </Box>
 
-        {helperText && !errorMessage ? <FormHelperText text={helperText} /> : null}
+        {(helperText || maxLength) && !errorMessage ? (
+          <FormHelperText text={helperText} maxLength={maxLength} currentLength={currentLength} />
+        ) : null}
 
         {hasErrorMessage ? <FormErrorMessage id={id} text={errorMessage} /> : null}
       </span>

--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -71,7 +71,7 @@ type Props = {|
    */
   items?: $ReadOnlyArray<Node>,
   /**
-   * Use numbers for pixels: \`maxWidth={100}\` and strings for percentages: \`maxWidth="100%"\`. See the [max width & border variant](https://gestalt.pinterest.systems/web/pageheader##Max-width-and-border) for more info.
+   * Use numbers for pixels: \`maxWidth={100}\` and strings for percentages: \`maxWidth="100%"\`. See the [max width & border variant](https://gestalt.pinterest.systems/web/pageheader#Max-width-and-border) for more info.
    */
   maxWidth?: Dimension,
   /**

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -43,10 +43,10 @@ type Props = {|
    */
   labelDisplay?: 'visible' | 'hidden',
   /**
-   * The maximum number of characters allowed in TextArea. \`maxLength\` must be an integer value 0 or higher. See the [maximum length variant](https://gestalt.pinterest.systems/web/textarea#Maximum-length) for more details.
+   * The maximum number of characters allowed in TextArea. `maxLength` must be an integer value 0 or higher. See the [maximum length variant](https://gestalt.pinterest.systems/web/textarea#Maximum-length) for more details.
    */
   maxLength?: {|
-    maxLengthChar: number,
+    characterCount: number,
     errorAccessibilityLabel: string,
   |},
   /**
@@ -183,7 +183,7 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
       : {},
   );
 
-  if (maxLength && maxLength?.maxLengthChar < 0) {
+  if (maxLength && maxLength.characterCount < 0) {
     throw new Error('`maxLength` must be an integer value 0 or higher.');
   }
 
@@ -194,7 +194,7 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
       className={tags ? styles.unstyledTextArea : classes}
       disabled={disabled}
       id={id}
-      maxLength={maxLength?.maxLengthChar}
+      maxLength={maxLength?.characterCount}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -43,6 +43,13 @@ type Props = {|
    */
   labelDisplay?: 'visible' | 'hidden',
   /**
+   * The maximum number of characters allowed in TextArea. See the [maximum lenght variant](https://gestalt.pinterest.systems/web/textarea##Maximum-length) for more details.
+   */
+  maxLength?: {|
+    maxLengthChar: number,
+    errorAccessibilityLabel: string,
+  |},
+  /**
    * A unique name for the input.
    */
   name?: string,
@@ -119,6 +126,7 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
     id,
     label,
     labelDisplay = 'visible',
+    maxLength,
     name,
     onBlur,
     onChange,
@@ -133,8 +141,10 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
   ref,
 ): Node {
   const [focused, setFocused] = useState(false);
+  const [currentLength, setCurrentLength] = useState(value?.length ?? 0);
 
   const handleChange = (event: SyntheticInputEvent<HTMLTextAreaElement>) => {
+    setCurrentLength(event.currentTarget.value?.length ?? 0);
     onChange({ event, value: event.currentTarget.value });
   };
 
@@ -180,6 +190,7 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
       className={tags ? styles.unstyledTextArea : classes}
       disabled={disabled}
       id={id}
+      maxLength={maxLength?.maxLengthChar}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}
@@ -222,7 +233,9 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
       ) : (
         inputElement
       )}
-      {helperText && !errorMessage ? <FormHelperText text={helperText} /> : null}
+      {(helperText || maxLength) && !errorMessage ? (
+        <FormHelperText text={helperText} maxLength={maxLength} currentLength={currentLength} />
+      ) : null}
       {hasErrorMessage && <FormErrorMessage id={id} text={errorMessage} />}
     </span>
   );

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -43,7 +43,7 @@ type Props = {|
    */
   labelDisplay?: 'visible' | 'hidden',
   /**
-   * The maximum number of characters allowed in TextArea. See the [maximum lenght variant](https://gestalt.pinterest.systems/web/textarea##Maximum-length) for more details.
+   * The maximum number of characters allowed in TextArea. \`maxLength\` must be an integer value 0 or higher. See the [maximum length variant](https://gestalt.pinterest.systems/web/textarea#Maximum-length) for more details.
    */
   maxLength?: {|
     maxLengthChar: number,
@@ -182,6 +182,10 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
         }
       : {},
   );
+
+  if (maxLength && maxLength?.maxLengthChar < 0) {
+    throw new Error('`maxLength` must be an integer value 0 or higher.');
+  }
 
   const inputElement = (
     <textarea

--- a/packages/gestalt/src/TextArea.jsdom.test.js
+++ b/packages/gestalt/src/TextArea.jsdom.test.js
@@ -1,9 +1,62 @@
 // @flow strict
 import { createRef } from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+// $FlowFixMe[untyped-import]
+import userEvent from '@testing-library/user-event';
 import TextArea from './TextArea.js';
 
+const LABEL = 'textfieldLabel';
+
+const renderTextArea = ({
+  // Cmp Props
+  id = 'test',
+  onChange = jest.fn(),
+  onFocus = jest.fn(),
+  onBlur = jest.fn(),
+  maxLength,
+}) =>
+  render(
+    <TextArea
+      id={id}
+      label={LABEL}
+      onChange={onChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      maxLength={maxLength}
+    />,
+  );
+
 describe('TextArea', () => {
+  it('has an accessible maxLength', async () => {
+    const errorAccessibilityLabel = 'Limit reached. You can only use 20 characters in this field.';
+
+    renderTextArea({
+      maxLength: {
+        maxLengthChar: 20,
+        errorAccessibilityLabel,
+      },
+    });
+
+    const userInput = 'text';
+    const userInput2 = 'very, very long text!';
+
+    expect(screen.getByText('0/20')).toBeVisible();
+
+    await userEvent.type(screen.getByLabelText(LABEL), userInput);
+
+    expect(screen.getByText('4/20')).toBeVisible();
+
+    await userEvent.type(screen.getByLabelText(LABEL), userInput2);
+
+    expect(screen.getByText('20/20', { ignore: '.errorText' })).not.toBeVisible();
+
+    expect(screen.getByText('20/20', { ignore: '.subtleText' })).toBeVisible();
+
+    expect(screen.getByText(errorAccessibilityLabel)).toBeVisible();
+
+    expect(screen.getByLabelText(errorAccessibilityLabel)).toBeVisible();
+  });
+
   it('TextArea with errorMessage prop change', () => {
     const { getByText, rerender } = render(
       <TextArea id="test" onChange={jest.fn()} onFocus={jest.fn()} onBlur={jest.fn()} />,

--- a/packages/gestalt/src/TextArea.jsdom.test.js
+++ b/packages/gestalt/src/TextArea.jsdom.test.js
@@ -37,7 +37,7 @@ describe('TextArea', () => {
 
     renderTextArea({
       maxLength: {
-        maxLengthChar: 20,
+        characterCount: 20,
         errorAccessibilityLabel,
       },
     });
@@ -53,7 +53,7 @@ describe('TextArea', () => {
 
     await userEvent.type(screen.getByLabelText(LABEL), userInput2);
 
-    expect(screen.getByText('20/20', { ignore: '.errorText' })).not.toBeVisible();
+    expect(screen.getByText('20/20', { ignore: '.warningText' })).not.toBeVisible();
 
     expect(screen.getByText('20/20', { ignore: '.subtleText' })).toBeVisible();
 
@@ -62,13 +62,14 @@ describe('TextArea', () => {
     expect(screen.getByLabelText(errorAccessibilityLabel)).toBeVisible();
   });
 
+  /* eslint-disable-next-line jest/expect-expect */
   it('throws error on invalid maxLength', async () => {
     const errorAccessibilityLabel = 'Limit reached. You can only use 20 characters in this field.';
 
     expectToThrow(() => {
       renderTextArea({
         maxLength: {
-          maxLengthChar: -20,
+          characterCount: -20,
           errorAccessibilityLabel,
         },
       });

--- a/packages/gestalt/src/TextArea.jsdom.test.js
+++ b/packages/gestalt/src/TextArea.jsdom.test.js
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 // $FlowFixMe[untyped-import]
 import userEvent from '@testing-library/user-event';
 import TextArea from './TextArea.js';
+import expectToThrow from './utils/testing/expectToThrow.js';
 
 const LABEL = 'textfieldLabel';
 
@@ -27,6 +28,10 @@ const renderTextArea = ({
   );
 
 describe('TextArea', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
   it('has an accessible maxLength', async () => {
     const errorAccessibilityLabel = 'Limit reached. You can only use 20 characters in this field.';
 
@@ -55,6 +60,19 @@ describe('TextArea', () => {
     expect(screen.getByText(errorAccessibilityLabel)).toBeVisible();
 
     expect(screen.getByLabelText(errorAccessibilityLabel)).toBeVisible();
+  });
+
+  it('throws error on invalid maxLength', async () => {
+    const errorAccessibilityLabel = 'Limit reached. You can only use 20 characters in this field.';
+
+    expectToThrow(() => {
+      renderTextArea({
+        maxLength: {
+          maxLengthChar: -20,
+          errorAccessibilityLabel,
+        },
+      });
+    }, '`maxLength` must be an integer value 0 or higher.');
   });
 
   it('TextArea with errorMessage prop change', () => {

--- a/packages/gestalt/src/TextArea.test.js
+++ b/packages/gestalt/src/TextArea.test.js
@@ -43,6 +43,23 @@ describe('TextArea', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('TextField with maxLength character counter', () => {
+    const tree = create(
+      <TextArea
+        name="maxLength"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+        maxLength={{
+          characterCount: 20,
+          errorAccessibilityLabel: 'Exceeded',
+        }}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('TextArea with readOnly', () => {
     const tree = create(
       <TextArea readOnly id="test" onChange={jest.fn()} onFocus={jest.fn()} onBlur={jest.fn()} />,

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -9,6 +9,11 @@ import { useDeviceType } from './contexts/DeviceTypeProvider.js';
 
 type Type = 'date' | 'email' | 'password' | 'tel' | 'text' | 'url';
 
+export type MaxLength = {|
+  maxLengthChar: number,
+  errorAccessibilityLabel: string,
+|};
+
 type Props = {|
   /**
    * Indicate if autocomplete should be available on the input, and the type of autocomplete. Autocomplete values are implemented upon request. [Reach out to the Gestalt team](https://gestalt.pinterest.systems/get_started/how_to_work_with_us#Slack-channels) if you need [additional autocomplete values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values) to be supported.
@@ -46,6 +51,10 @@ type Props = {|
    * Whether the label should be visible or not. If `hidden`, the label is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems#Label-visibility) for more info.
    */
   labelDisplay?: 'visible' | 'hidden',
+  /**
+   * The maximum number of characters allowed in Textfield. See the [maximum lenght variant](https://gestalt.pinterest.systems/web/textfield##Maximum-length) for more details.
+   */
+  maxLength?: MaxLength,
   /**
    * A unique name for the input.
    */
@@ -129,6 +138,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     id,
     label,
     labelDisplay = 'visible',
+    maxLength,
     name,
     onBlur,
     onChange,
@@ -209,6 +219,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
       id={id}
       label={label}
       labelDisplay={labelDisplay}
+      maxLength={maxLength}
       name={name}
       onBlur={onBlur}
       onChange={onChange}

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -10,7 +10,7 @@ import { useDeviceType } from './contexts/DeviceTypeProvider.js';
 type Type = 'date' | 'email' | 'password' | 'tel' | 'text' | 'url';
 
 export type MaxLength = {|
-  maxLengthChar: number,
+  characterCount: number,
   errorAccessibilityLabel: string,
 |};
 
@@ -52,7 +52,7 @@ type Props = {|
    */
   labelDisplay?: 'visible' | 'hidden',
   /**
-   * The maximum number of characters allowed in Textfield. See the [maximum length variant](https://gestalt.pinterest.systems/web/textfield#Maximum-length) for more details. \`maxLength\` must be an integer value 0 or higher.
+   * The maximum number of characters allowed in Textfield. `maxLength` must be an integer value 0 or higher. See the [maximum length variant](https://gestalt.pinterest.systems/web/textfield#Maximum-length) for more details.
    */
   maxLength?: MaxLength,
   /**

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -52,7 +52,7 @@ type Props = {|
    */
   labelDisplay?: 'visible' | 'hidden',
   /**
-   * The maximum number of characters allowed in Textfield. See the [maximum lenght variant](https://gestalt.pinterest.systems/web/textfield##Maximum-length) for more details.
+   * The maximum number of characters allowed in Textfield. See the [maximum length variant](https://gestalt.pinterest.systems/web/textfield#Maximum-length) for more details. \`maxLength\` must be an integer value 0 or higher.
    */
   maxLength?: MaxLength,
   /**

--- a/packages/gestalt/src/TextField.jsdom.test.js
+++ b/packages/gestalt/src/TextField.jsdom.test.js
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 // $FlowFixMe[untyped-import]
 import userEvent from '@testing-library/user-event';
 import TextField from './TextField.js';
+import expectToThrow from './utils/testing/expectToThrow.js';
 
 jest.mock('./contexts/I18nProvider.js');
 
@@ -57,6 +58,19 @@ describe('TextField', () => {
     expect(screen.getByText(errorAccessibilityLabel)).toBeVisible();
 
     expect(screen.getByLabelText(errorAccessibilityLabel)).toBeVisible();
+  });
+
+  it('throws error on invalid maxLength', async () => {
+    const errorAccessibilityLabel = 'Limit reached. You can only use 20 characters in this field.';
+
+    expectToThrow(() => {
+      renderTextField({
+        maxLength: {
+          maxLengthChar: -20,
+          errorAccessibilityLabel,
+        },
+      });
+    }, '`maxLength` must be an integer value 0 or higher.');
   });
 
   it('renders error message on errorMessage prop change', () => {

--- a/packages/gestalt/src/TextField.jsdom.test.js
+++ b/packages/gestalt/src/TextField.jsdom.test.js
@@ -35,7 +35,7 @@ describe('TextField', () => {
 
     renderTextField({
       maxLength: {
-        maxLengthChar: 20,
+        characterCount: 20,
         errorAccessibilityLabel,
       },
     });
@@ -51,7 +51,7 @@ describe('TextField', () => {
 
     await userEvent.type(screen.getByLabelText(LABEL), userInput2);
 
-    expect(screen.getByText('20/20', { ignore: '.errorText' })).not.toBeVisible();
+    expect(screen.getByText('20/20', { ignore: '.warningText' })).not.toBeVisible();
 
     expect(screen.getByText('20/20', { ignore: '.subtleText' })).toBeVisible();
 
@@ -60,13 +60,13 @@ describe('TextField', () => {
     expect(screen.getByLabelText(errorAccessibilityLabel)).toBeVisible();
   });
 
+  /* eslint-disable-next-line jest/expect-expect */
   it('throws error on invalid maxLength', async () => {
     const errorAccessibilityLabel = 'Limit reached. You can only use 20 characters in this field.';
-
     expectToThrow(() => {
       renderTextField({
         maxLength: {
-          maxLengthChar: -20,
+          characterCount: -20,
           errorAccessibilityLabel,
         },
       });

--- a/packages/gestalt/src/TextField.test.js
+++ b/packages/gestalt/src/TextField.test.js
@@ -85,6 +85,23 @@ describe('TextField', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('TextField with maxLength character counter', () => {
+    const tree = create(
+      <TextField
+        name="maxLength"
+        id="test"
+        onChange={jest.fn()}
+        onFocus={jest.fn()}
+        onBlur={jest.fn()}
+        maxLength={{
+          characterCount: 20,
+          errorAccessibilityLabel: 'Exceeded',
+        }}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('TextField with autocomplete', () => {
     const tree = create(
       <TextField

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -616,14 +616,22 @@ exports[`Checkbox with helperText 1`] = `
             className="box marginTop2"
           >
             <div
-              className="Text fontSize100 subtleText alignStart breakWord fontWeightNormal"
+              className="Flex rowGap4 columnGap4 xsDirectionRow"
             >
               <div
-                className="box xsDisplayVisuallyHidden"
+                className="FlexItem flexGrow"
               >
-                :
+                <div
+                  className="Text fontSize100 subtleText alignStart breakWord fontWeightNormal"
+                >
+                  <div
+                    className="box xsDisplayVisuallyHidden"
+                  >
+                    :
+                  </div>
+                  Additional Info
+                </div>
               </div>
-              Additional Info
             </div>
           </div>
         </div>

--- a/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
@@ -122,6 +122,89 @@ exports[`TextArea TextArea with rows 1`] = `
 </span>
 `;
 
+exports[`TextArea TextField with maxLength character counter 1`] = `
+<span>
+  <textarea
+    aria-describedby={null}
+    aria-invalid="false"
+    className="textArea base enabled normal"
+    disabled={false}
+    id="test"
+    maxLength={20}
+    name="maxLength"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    readOnly={false}
+    rows={3}
+  />
+  <div
+    className="box marginTop2"
+  >
+    <div
+      className="Flex rowGap4 columnGap4 xsDirectionRow"
+    >
+      <div
+        className="FlexItem flexGrow"
+      />
+      <div
+        className="FlexItem"
+      >
+        <div
+          className="absolute box"
+          style={
+            Object {
+              "visibility": "hidden",
+            }
+          }
+        >
+          <div
+            className="Text fontSize100 subtleText alignStart breakWord fontWeightNormal"
+          >
+            20/20
+          </div>
+        </div>
+        <div
+          className="Flex rowGap1 columnGap1 xsDirectionRow"
+        >
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="box"
+              style={
+                Object {
+                  "width": 16,
+                }
+              }
+            />
+          </div>
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Flex rowGap0 columnGap0 justifyEnd xsDirectionRow"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="Text fontSize100 subtleText alignEnd breakWord fontWeightNormal"
+              >
+                0/20
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</span>
+`;
+
 exports[`TextArea renders tags when supplied 1`] = `
 <span>
   <div

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -155,6 +155,94 @@ exports[`TextField TextField with hasError 1`] = `
 </span>
 `;
 
+exports[`TextField TextField with maxLength character counter 1`] = `
+<span>
+  <div
+    className="box relative"
+  >
+    <input
+      aria-describedby={null}
+      aria-invalid="false"
+      className="textField base enabled normal medium truncate"
+      disabled={false}
+      id="test"
+      maxLength={20}
+      name="maxLength"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      readOnly={false}
+      type="text"
+    />
+  </div>
+  <div
+    className="box marginTop2"
+  >
+    <div
+      className="Flex rowGap4 columnGap4 xsDirectionRow"
+    >
+      <div
+        className="FlexItem flexGrow"
+      />
+      <div
+        className="FlexItem"
+      >
+        <div
+          className="absolute box"
+          style={
+            Object {
+              "visibility": "hidden",
+            }
+          }
+        >
+          <div
+            className="Text fontSize100 subtleText alignStart breakWord fontWeightNormal"
+          >
+            20/20
+          </div>
+        </div>
+        <div
+          className="Flex rowGap1 columnGap1 xsDirectionRow"
+        >
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="box"
+              style={
+                Object {
+                  "width": 16,
+                }
+              }
+            />
+          </div>
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Flex rowGap0 columnGap0 justifyEnd xsDirectionRow"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="Text fontSize100 subtleText alignEnd breakWord fontWeightNormal"
+              >
+                0/20
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</span>
+`;
+
 exports[`TextField TextField with name 1`] = `
 <span>
   <div

--- a/packages/gestalt/src/utils/testing/expectToThrow.js
+++ b/packages/gestalt/src/utils/testing/expectToThrow.js
@@ -1,0 +1,12 @@
+// @flow strict
+
+export default function expectToThrow(
+  func: () => void,
+  message?: string | Error | Class<Error> | RegExp,
+) {
+  const virtualConsoleSpy = jest.spyOn(window._virtualConsole, 'emit').mockImplementation(() => {});
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  expect(func).toThrow(message);
+  consoleErrorSpy.mockRestore();
+  virtualConsoleSpy.mockRestore();
+}

--- a/packages/gestalt/src/utils/testing/expectToThrow.js
+++ b/packages/gestalt/src/utils/testing/expectToThrow.js
@@ -4,6 +4,7 @@ export default function expectToThrow(
   func: () => void,
   message?: string | Error | Class<Error> | RegExp,
 ) {
+  /* eslint-disable-next-line no-underscore-dangle */
   const virtualConsoleSpy = jest.spyOn(window._virtualConsole, 'emit').mockImplementation(() => {});
   const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   expect(func).toThrow(message);


### PR DESCRIPTION
### Summary

#### What changed?

Textfield, TextArea: add maxLength prop



#### Why?
<img width="856" alt="Screen Shot 2022-09-22 at 7 24 39 PM" src="https://user-images.githubusercontent.com/10593890/191868237-cc547e8e-8c8a-4d1b-8f80-224f5b7a6b03.png">

<img width="857" alt="Screen Shot 2022-09-22 at 7 23 21 PM" src="https://user-images.githubusercontent.com/10593890/191868128-3659c46d-00d9-4942-9e29-9784e634dd1b.png">

<img width="858" alt="Screen Shot 2022-09-22 at 7 24 07 PM" src="https://user-images.githubusercontent.com/10593890/191868180-53ae2e27-2810-4347-9c8b-23c89d723d8d.png">


![Kapture 2022-09-21 at 23 28 13](https://user-images.githubusercontent.com/10593890/191613920-6f3762f0-b7af-47de-be82-7bad1ef14dbb.gif)

As a user, I want to have a visual affordance for how many characters I can add to a TextArea so I can effectively write for the character limit.

Acceptance criteria

- The TextArea and TextField components should have a prop to enforce a maximum character limit.
maximum character limits should not be enforced unless the maxchars prop (or whatever name we give it) is explicitly set.
- The prop should only accept a positive integer.
When the prop is set with a valid number, a counter affordance should be displayed on the right side of TextField/TextArea below the input element (see Figma design link above).
- The counter should update whenever the number of characters within the input changes.

When helperText is displayed:
- The counter's width should be set by calculating the text set to the max character count and then adding 4 additional pixels to account for flex between variable number widths.
- Space should always be set aside for the Status error icon displayed in the error state so that helperText doesn't shift when the icon is made visible.

The following logic should control the counter's text:
- By default, the counter's text color should be set to "subtle"
- When the character count equal to 100% of the maximum characters, the text color should be set to "warning" and the warning Status icon displayed.
- When the maximum character limit has been hit, the input should not allow any more characters to be added.



### Links

- [Figma](https://www.figma.com/file/qi2yCevlp9ZZPYndRUl6bz/Input-maxchars-treatment?node-id=1543%3A3223)
- [Jira](https://jira.pinadmin.com/browse/GESTALT-4766)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
