### PR TITLE
Docs: add notes about types to FAQ

### DIFF
--- a/docs/pages/get_started/faq.js
+++ b/docs/pages/get_started/faq.js
@@ -1,24 +1,29 @@
 // @flow strict
-import { type Node } from 'react';
+import { Fragment, type Node } from 'react';
 import { Box, Flex, Heading, Link, Text } from 'gestalt';
 import Markdown from '../../docs-components/Markdown.js';
 import Card from '../../docs-components/Card.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import Page from '../../docs-components/Page.js';
 
+function InlineLink({ children, href }: {| children: string, href: string |}) {
+  return (
+    <Fragment>
+      {' '}
+      <Link inline href={href}>
+        {children}
+      </Link>{' '}
+    </Fragment>
+  );
+}
+
 export default function ContainerPage(): Node {
   return (
     <Page title="Frequently asked questions">
       <PageHeader name="Frequently asked questions" type="guidelines" />
+
       <Card name="Gestalt usage">
-        <Flex
-          alignItems="start"
-          direction="column"
-          gap={{
-            row: 0,
-            column: 4,
-          }}
-        >
+        <Flex alignItems="start" direction="column" gap={4}>
           <Heading size="400">What are the benefits of using the Gestalt library?</Heading>
           <Text>
             Using Gestalt guarantees adherence and compliance to Pinterest design standards and best
@@ -39,15 +44,9 @@ export default function ContainerPage(): Node {
           </Text>
         </Flex>
       </Card>
+
       <Card name="Component usage">
-        <Flex
-          alignItems="start"
-          direction="column"
-          gap={{
-            row: 0,
-            column: 4,
-          }}
-        >
+        <Flex alignItems="start" direction="column" gap={4}>
           <Heading size="400">What is a boint?</Heading>
           <Text>
             A boint is a Pinterest specific unit of spacing that is equivalent to 4px. 1 boint =
@@ -63,24 +62,20 @@ padding 0 .. 12
             />
           </Box>
 
-          <Text>
-            To add it to Gestalt, get a streamlined &amp; optimized version of the SVG not contain
-            strokes / transforms / ...
-          </Text>
-
           <Heading size="400">How do I add Gestalt as a dependency?</Heading>
           <Text>
-            Import exact versions. ^1.37.0 is imprecise and could import v1.38.0 which could affect
-            snapshots from version to version. Check{' '}
-            <Link inline href="https://devhints.io/semver">
-              <Text weight="bold">semver documentation</Text>
-            </Link>{' '}
+            Check out our
+            <InlineLink href="/get_started/developers/installation">installation guide</InlineLink>
+            for instructions. Note: we recommend using exact versions. ^1.37.0 is imprecise and
+            could import v1.38.0, which could affect snapshots from version to version. Check
+            <InlineLink href="https://devhints.io/semver">semver documentation</InlineLink>
             for hints on the differences.
           </Text>
 
           <Heading size="400">How do I import components from Gestalt?</Heading>
           <Text>
-            Add the following to your import declarations:
+            Gestalt uses named exports — there is no default export. Simply import the components
+            you need in your file:
             <Markdown
               text="
 ~~~jsx
@@ -88,6 +83,26 @@ import { Button, Text } from 'gestalt';
 ~~~"
             />
           </Text>
+
+          <Heading size="400">How do I import Flow types from Gestalt?</Heading>
+          <Text>
+            You don&apos;t! We do not explicitly export our Flow types — any types that are
+            available externally are considered internal and subject to breaking changes without
+            warning. We also recommend against manually copying type values into your codebase, as
+            those are also subject to change and you will need to manually update your copied types.
+          </Text>
+          <Text>
+            The recommended way of accessing Gestalt types (e.g. for a wrapper component) is to use
+            Flow&apos;s
+            <InlineLink href="https://flow.org/en/docs/types/utilities/">utility types</InlineLink>
+            to use the component&apos;s types directly:
+          </Text>
+          <Markdown
+            text="
+~~~jsx
+$ElementType<React$ElementConfig<typeof ComponentName>, 'propName'>
+~~~"
+          />
 
           <Heading size="400">What&apos;s required to support IE11?</Heading>
           <Text>
@@ -121,10 +136,8 @@ if (/MSIE \\d|Trident.*rv:/.test(navigator.userAgent)) {
         >
           <Heading size="400">How do I get access to the Gestalt repo?</Heading>
           <Text>
-            The{' '}
-            <Link href="https://github.com/pinterest/gestalt" inline>
-              <Text weight="bold">Gestalt repository</Text>
-            </Link>{' '}
+            The
+            <InlineLink href="https://github.com/pinterest/gestalt">Gestalt repository</InlineLink>
             is public and you do not need special permissions to make pull requests.
           </Text>
 
@@ -140,13 +153,10 @@ yarn generate ComponentName
           </Text>
 
           <Heading size="400">
-            What do we use for integration tests and how do we run the tests locally?{' '}
+            What do we use for integration tests and how do we run the tests locally?
           </Heading>
           <Text>
-            We use{' '}
-            <Link href="https://playwright.dev/" inline>
-              <Text weight="bold">Playwright</Text>
-            </Link>{' '}
+            We use <InlineLink href="https://playwright.dev/">Playwright</InlineLink>
             for our integration tests. If you want to run the tests locally:
             <Markdown
               text={`
@@ -159,11 +169,10 @@ yarn playwright:test
 
           <Heading size="400">Is there any internal Pinterest documentation for Gestalt?</Heading>
           <Text>
-            If you&apos;re a Pinterest employee, you can visit Pinterest&apos;s web platform
-            documentation for Gestalt{' '}
-            <Link inline href="http://pinch.pinadmin.com/gestalt_wiki">
-              <Text weight="bold">here.</Text>
-            </Link>
+            If you&apos;re a Pinterest employee, you can visit
+            <InlineLink href="http://pinch.pinadmin.com/gestalt_wiki">
+              Pinterest&apos;s web platform documentation for Gestalt.
+            </InlineLink>
           </Text>
         </Flex>
       </Card>

--- a/docs/pages/get_started/faq.js
+++ b/docs/pages/get_started/faq.js
@@ -104,6 +104,17 @@ $ElementType<React$ElementConfig<typeof ComponentName>, 'propName'>
 ~~~"
           />
 
+          <Heading size="400">Does Gestalt have TypeScript support?</Heading>
+          <Text>
+            Not officially. However, a group of dedicated engineers who work on internal tools at
+            Pinterest created
+            <InlineLink href="https://www.npmjs.com/package/@types/gestalt">
+              this package
+            </InlineLink>
+            with TypeScript definitions. We hope to offer better official TypeScript support in the
+            future, but currently lack the resources for proper support.
+          </Text>
+
           <Heading size="400">What&apos;s required to support IE11?</Heading>
           <Text>
             Gestalt supports IE11 currently, but you will need to use a polyfill because the css


### PR DESCRIPTION
We see frequent confusion on how to work with Gestalt types:
- How to properly use Flow types for a component's props (e.g. when creating a wrapper component that mirrors a Gestalt component's prop type)
- TypeScript support

This PR adds notes to the FAQ page about these two questions. In a future PR I'll add the ability to quickly copy the syntax for a given prop's type to Prop tables.