### PR TITLE
SelectList: Update labelVisbility example to show tooltip

### DIFF
--- a/docs/pages/web/selectlist.js
+++ b/docs/pages/web/selectlist.js
@@ -347,7 +347,20 @@ export default function DocsPage({
   </SelectList>
 
   <Flex gap={2} direction="column">
-    <Text weight="bold" size="300">Date range</Text>
+    <Flex gap={1} alignItems="center">
+      <Text size="300">
+        Date range
+      </Text>
+      <IconButton
+        accessibilityLabel="Info"
+        icon="info-circle"
+        size="sm"
+        tooltip={{
+          text: "Options available are based on your usage.",
+          idealDirection: "right"
+        }}
+      />
+    </Flex>
     <SelectList
       id="selectlistexampleA11yHiddenLabel"
       label="Date range"
@@ -433,7 +446,20 @@ export default function DocsPage({
             cardSize="lg"
             defaultCode={`
 <Flex gap={2} direction="column">
-  <Text weight="bold" size="300">Date range</Text>
+  <Flex gap={1} alignItems="center">
+    <Text weight="bold" size="300">
+      Date range
+    </Text>
+    <IconButton
+      accessibilityLabel="Info"
+      icon="info-circle"
+      size="sm"
+      tooltip={{
+        text: "Options available are based on your usage.",
+        idealDirection: "right"
+      }}
+    />
+  </Flex>
 
   <SelectList
     id="selectlistexampleHiddenLabel"


### PR DESCRIPTION
### Summary

#### What changed?

Show an example of how to add an IconButton/Tooltip to the SelectList label using the labelDisplay prop

#### Why?

This a frequent use case, so examples in docs would be helpful

![Screen Shot 2022-09-21 at 3 59 21 PM](https://user-images.githubusercontent.com/5125094/191624792-eafb6821-04dc-4ded-8115-c8c03a8b45f7.png)
