### PR TITLE
Docs: add button to copy Flow type

### DIFF
--- a/docs/docs-components/GeneratedPropTable.js
+++ b/docs/docs-components/GeneratedPropTable.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, type ComponentType } from 'react';
+import { type Node } from 'react';
 import { type DocGen } from './docgen.js';
 import PropTable from './PropTable.js';
 
@@ -48,8 +48,6 @@ function getHref(description?: string): {|
 }
 
 type Props = {|
-  // $FlowFixMe[unclear-type]
-  Component?: ComponentType<any>,
   excludeProps?: $ReadOnlyArray<string>,
   generatedDocGen: DocGen,
   id?: string,
@@ -57,7 +55,6 @@ type Props = {|
 |};
 
 export default function GeneratedPropTable({
-  Component,
   excludeProps = [],
   generatedDocGen,
   id,
@@ -124,5 +121,7 @@ export default function GeneratedPropTable({
     })
     .filter(Boolean);
 
-  return <PropTable Component={Component} name={name} id={id} props={props} />;
+  return (
+    <PropTable componentName={generatedDocGen.displayName} name={name} id={id} props={props} />
+  );
 }

--- a/docs/docs-components/PropTable.js
+++ b/docs/docs-components/PropTable.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, type ComponentType } from 'react';
+import { type Node } from 'react';
 import { Badge, Box, Flex, IconButton, Link, Text, Tooltip } from 'gestalt';
 import Card from './Card.js';
 import Markdown from './Markdown.js';
@@ -100,8 +100,7 @@ function Td({
 }
 
 type Props = {|
-  // $FlowFixMe[unclear-type]
-  Component?: ComponentType<any>,
+  componentName: string,
   id?: string,
   name?: string,
   props: $ReadOnlyArray<{|
@@ -117,31 +116,13 @@ type Props = {|
 |};
 
 export default function PropTable({
-  Component,
+  componentName,
   id = '',
   name: proptableName,
   props: properties,
 }: Props): Node {
   const { propTableVariant, setPropTableVariant } = useAppContext();
   const propsId = `${id}Props`;
-
-  if (process.env.NODE_ENV === 'development' && Component) {
-    const { displayName, propTypes } = Component; // eslint-disable-line react/forbid-foreign-prop-types
-    const missingProps = Object.keys(propTypes || {}).reduce((acc, prop) => {
-      if (!properties.find((p) => p.name === prop)) {
-        return acc.concat(prop);
-      }
-      return acc;
-    }, []);
-    if (missingProps.length > 0) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `${displayName || ''} is missing ${
-          missingProps.length
-        } PropTable definitions ${missingProps.join(', ')}`,
-      );
-    }
-  }
 
   return (
     <Card
@@ -154,7 +135,7 @@ export default function PropTable({
             icon={propTableVariant === 'expanded' ? 'minimize' : 'maximize'}
             accessibilityLabel={`${
               propTableVariant === 'expanded' ? 'Collapse' : 'Expand'
-            } props for ${Component?.displayName || ''}`}
+            } props for ${componentName || ''}`}
             iconColor="darkGray"
             size="xs"
             onClick={() =>
@@ -259,11 +240,11 @@ export default function PropTable({
                               onClick={() => {
                                 trackButtonClick(
                                   'Copy Flow type',
-                                  `${proptableName ?? 'No Component'} - ${name}`,
+                                  `${componentName ?? 'No Component'} - ${name}`,
                                 );
                                 copyFlowType(
                                   `$ElementType<React$ElementConfig<typeof ${
-                                    proptableName ?? '{ComponentName}'
+                                    componentName ?? '{ComponentName}'
                                   }>, '${name}'>`,
                                 );
                               }}

--- a/docs/docs-components/PropTable.js
+++ b/docs/docs-components/PropTable.js
@@ -238,14 +238,9 @@ export default function PropTable({
                               icon="drag-drop"
                               iconColor="darkGray"
                               onClick={() => {
-                                trackButtonClick(
-                                  'Copy Flow type',
-                                  `${componentName ?? 'No Component'} - ${name}`,
-                                );
+                                trackButtonClick('Copy Flow type', `${componentName} - ${name}`);
                                 copyFlowType(
-                                  `$ElementType<React$ElementConfig<typeof ${
-                                    componentName ?? '{ComponentName}'
-                                  }>, '${name}'>`,
+                                  `$ElementType<React$ElementConfig<typeof ${componentName}>, '${name}'>`,
                                 );
                               }}
                               size="xs"

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -22,7 +22,9 @@ export default function ButtonPage({ generatedDocGen }: {| generatedDocGen: DocG
 </Flex>
     `}
       />
+
       <PropTable
+        componentName={generatedDocGen?.displayName}
         props={[
           {
             name: 'accessibilityLabel',
@@ -171,6 +173,7 @@ export default function ButtonPage({ generatedDocGen }: {| generatedDocGen: DocG
           },
         ]}
       />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -1,6 +1,5 @@
 // @flow strict
 import { type Node } from 'react';
-import { Dropdown } from 'gestalt';
 import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
 import { multipledocgen, type DocGen } from '../../docs-components/docgen.js';
@@ -570,9 +569,8 @@ function TruncationDropdownExample() {
           description={generatedDocGen?.DropdownItem?.description}
         >
           <GeneratedPropTable
-            Component={Dropdown?.Item}
-            name="Dropdown.Item"
-            id="Dropdown.Item"
+            name={generatedDocGen?.DropdownItem.displayName}
+            id={generatedDocGen?.DropdownItem.displayName}
             generatedDocGen={generatedDocGen.DropdownItem}
           />
         </MainSection.Subsection>
@@ -581,9 +579,8 @@ function TruncationDropdownExample() {
           description={generatedDocGen?.DropdownLink?.description}
         >
           <GeneratedPropTable
-            Component={Dropdown?.Link}
-            name="Dropdown.Link"
-            id="Dropdown.Link"
+            name={generatedDocGen?.DropdownLink.displayName}
+            id={generatedDocGen?.DropdownLink.displayName}
             generatedDocGen={generatedDocGen.DropdownLink}
           />
         </MainSection.Subsection>
@@ -592,9 +589,8 @@ function TruncationDropdownExample() {
           description={generatedDocGen?.DropdownSection?.description}
         >
           <GeneratedPropTable
-            Component={Dropdown?.Section}
-            name="Dropdown.Section"
-            id="Dropdown.Section"
+            name={generatedDocGen?.DropdownSection.displayName}
+            id={generatedDocGen?.DropdownSection.displayName}
             generatedDocGen={generatedDocGen.DropdownSection}
           />
         </MainSection.Subsection>

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -33,7 +33,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         <SandpackExample code={main} name="Main example" hideEditor />
       </PageHeader>
       <PropTable
-        Component={IconButton}
+        componentName={generatedDocGen?.displayName}
         id="IconButton"
         props={[
           {
@@ -122,7 +122,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         ]}
       />
       <PropTable
-        Component={IconButton}
+        componentName={generatedDocGen?.displayName}
         name='Additional role="button"'
         id="role_button"
         props={[
@@ -166,7 +166,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         ]}
       />
       <PropTable
-        Component={IconButton}
+        componentName={generatedDocGen?.displayName}
         name='Additional role="link"'
         id="role_link"
         props={[

--- a/docs/pages/web/radiogroup.js
+++ b/docs/pages/web/radiogroup.js
@@ -1,6 +1,5 @@
 // @flow strict
 import { type Node } from 'react';
-import { RadioGroup } from 'gestalt';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -63,15 +62,15 @@ function RadioButtonExample() {
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen.RadioGroup} />
+
       <MainSection name="Subcomponents">
         <MainSection.Subsection
           title={generatedDocGen?.RadioGroupButton.displayName}
           description={generatedDocGen?.RadioGroupButton.description}
         >
           <GeneratedPropTable
-            Component={RadioGroup?.RadioButton}
-            name="RadioGroup.RadioButton"
-            id="RadioGroup.RadioButton"
+            name={generatedDocGen?.RadioGroupButton.displayName}
+            id={generatedDocGen?.RadioGroupButton.displayName}
             generatedDocGen={generatedDocGen.RadioGroupButton}
           />
         </MainSection.Subsection>

--- a/docs/pages/web/sheet.js
+++ b/docs/pages/web/sheet.js
@@ -29,7 +29,9 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
           previewHeight={PREVIEW_HEIGHT}
         />
       </PageHeader>
+
       <PropTable
+        componentName={generatedDocGen?.displayName}
         props={[
           {
             name: 'accessibilityDismissButtonLabel',
@@ -110,6 +112,7 @@ export default function SheetPage({ generatedDocGen }: {| generatedDocGen: DocGe
           },
         ]}
       />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -1,6 +1,5 @@
 // @flow strict
 import { type Node } from 'react';
-import { SideNavigation } from 'gestalt';
 import MainSection from '../../docs-components/MainSection.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import Page from '../../docs-components/Page.js';
@@ -229,7 +228,6 @@ export default function SideNavigationPage({
           description={generatedDocGen.SideNavigationSection?.description}
         >
           <GeneratedPropTable
-            Component={SideNavigation?.Section}
             name={generatedDocGen.SideNavigationSection?.displayName}
             id={generatedDocGen.SideNavigationSection?.displayName}
             generatedDocGen={generatedDocGen.SideNavigationSection}
@@ -240,7 +238,6 @@ export default function SideNavigationPage({
           description={generatedDocGen.SideNavigationTopItem?.description}
         >
           <GeneratedPropTable
-            Component={SideNavigation?.TopItem}
             name={generatedDocGen.SideNavigationTopItem?.displayName}
             id={generatedDocGen.SideNavigationTopItem?.displayName}
             generatedDocGen={generatedDocGen.SideNavigationTopItem}
@@ -251,7 +248,6 @@ export default function SideNavigationPage({
           description={generatedDocGen.SideNavigationNestedItem?.description}
         >
           <GeneratedPropTable
-            Component={SideNavigation?.NestedItem}
             name={generatedDocGen.SideNavigationNestedItem?.displayName}
             id={generatedDocGen.SideNavigationNestedItem?.displayName}
             generatedDocGen={generatedDocGen.SideNavigationNestedItem}
@@ -262,7 +258,6 @@ export default function SideNavigationPage({
           description={generatedDocGen.SideNavigationGroup?.description}
         >
           <GeneratedPropTable
-            Component={SideNavigation?.Group}
             name={generatedDocGen.SideNavigationGroup?.displayName}
             id={generatedDocGen.SideNavigationGroup?.displayName}
             generatedDocGen={generatedDocGen.SideNavigationGroup}
@@ -273,7 +268,6 @@ export default function SideNavigationPage({
           description={generatedDocGen.SideNavigationNestedGroup?.description}
         >
           <GeneratedPropTable
-            Component={SideNavigation?.NestedGroup}
             name={generatedDocGen.SideNavigationNestedGroup?.displayName}
             id={generatedDocGen.SideNavigationNestedGroup?.displayName}
             generatedDocGen={generatedDocGen.SideNavigationNestedGroup}

--- a/docs/pages/web/sticky.js
+++ b/docs/pages/web/sticky.js
@@ -11,9 +11,11 @@ import MainSection from '../../docs-components/MainSection.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
-    <Page title="Sticky">
-      <PageHeader name="Sticky" description={generatedDocGen?.description} />
+    <Page title={generatedDocGen?.displayName}>
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+
       <PropTable
+        componentName={generatedDocGen?.displayName}
         props={[
           {
             name: 'bottom',
@@ -51,6 +53,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           },
         ]}
       />
+
       <AccessibilitySection name={generatedDocGen?.displayName} />
 
       <MainSection name="Example">

--- a/docs/pages/web/tag.js
+++ b/docs/pages/web/tag.js
@@ -11,12 +11,11 @@ import AccessibilitySection from '../../docs-components/AccessibilitySection.js'
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
-    <Page title="Tag">
-      <PageHeader
-        name="Tag"
-        description="[Tags](/web/tag) are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](/web/textfield#tagsExample), [TextAreas](/web/textarea#tagsExample), [ComboBox](/web/combobox#Tags) or as standalone components."
-      />
+    <Page title={generatedDocGen?.displayName}>
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+
       <PropTable
+        componentName={generatedDocGen?.displayName}
         props={[
           {
             name: 'disabled',
@@ -51,6 +50,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           },
         ]}
       />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -17,6 +17,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
 
       <PropTable
+        componentName={generatedDocGen?.displayName}
         props={[
           {
             name: 'accessibilityLabel',
@@ -253,6 +254,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           },
         ]}
       />
+
       <AccessibilitySection name={generatedDocGen?.displayName} />
 
       <MainSection name="Variants">


### PR DESCRIPTION
Building on #2409, this PR adds a button to the Props table to allow for easy copying of the correct Flow syntax to access a component's prop type:
```js
 $ElementType<React$ElementConfig<typeof {ComponentName}>, '{propName}'>
```

![Screen Shot 2022-09-21 at 4 22 47 PM](https://user-images.githubusercontent.com/12059539/191628963-329ec8bc-a9ed-4ca4-a4db-83f2d80ae021.png)