### PR TITLE
CheckBox, RadioGroupButton: fix spacing in size='sm'  with custom marginTop

### DIFF
--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -203,8 +203,8 @@ const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
         {label && (
           <Box
             display={labelDisplay === 'hidden' ? 'visuallyHidden' : 'block'}
-            //  marginTop: '2px' is needed to  visually align the label text & radiobutton input
-            dangerouslySetInlineStyle={{ __style: { marginTop: '2px' } }}
+            //  marginTop: '-1px'/'2px' is needed to  visually align the label text & radiobutton input
+            dangerouslySetInlineStyle={{ __style: { marginTop: size === 'md' ? '2px' : '-1px' } }}
           >
             <Label htmlFor={id}>
               <Box paddingX={1}>

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -157,8 +157,11 @@ const RadioButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputElement
       {Boolean(image) && <Box paddingX={1}>{image}</Box>}
       {label && (
         <Label htmlFor={id}>
-          {/* marginTop: '2px' is needed to  visually align the label text & radiobutton input */}
-          <Box paddingX={1} dangerouslySetInlineStyle={{ __style: { marginTop: '2px' } }}>
+          {/* marginTop: '-1px'/'2px' is needed to  visually align the label text & radiobutton input */}
+          <Box
+            paddingX={1}
+            dangerouslySetInlineStyle={{ __style: { marginTop: size === 'md' ? '2px' : '-1px' } }}
+          >
             <Text color={disabled ? 'subtle' : undefined} size={size === 'sm' ? '200' : '300'}>
               {label}
             </Text>

--- a/packages/gestalt/src/RadioGroupButton.js
+++ b/packages/gestalt/src/RadioGroupButton.js
@@ -165,8 +165,11 @@ const RadioGroupButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputEl
       {Boolean(image) && <Box paddingX={1}>{image}</Box>}
       {label && (
         <Label htmlFor={id}>
-          {/* marginTop: '2px' is needed to  visually align the label text & radiobutton input */}
-          <Box paddingX={1} dangerouslySetInlineStyle={{ __style: { marginTop: '2px' } }}>
+          {/* marginTop: '-1px'/'2px' is needed to  visually align the label text & radiobutton input */}
+          <Box
+            paddingX={1}
+            dangerouslySetInlineStyle={{ __style: { marginTop: size === 'md' ? '2px' : '-1px' } }}
+          >
             <Text color={disabled ? 'subtle' : undefined} size={size === 'sm' ? '200' : '300'}>
               {label}
             </Text>

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -182,7 +182,7 @@ exports[`Checkbox disabled & checked 1`] = `
       className="box xsDisplayBlock"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >
@@ -241,7 +241,7 @@ exports[`Checkbox disabled 1`] = `
       className="box xsDisplayBlock"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >
@@ -373,7 +373,7 @@ exports[`Checkbox small 1`] = `
       className="box xsDisplayBlock"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >
@@ -459,7 +459,7 @@ exports[`Checkbox with an image 1`] = `
       className="box xsDisplayBlock"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >
@@ -518,7 +518,7 @@ exports[`Checkbox with error 1`] = `
       className="box xsDisplayBlock"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >
@@ -596,7 +596,7 @@ exports[`Checkbox with helperText 1`] = `
       className="box xsDisplayBlock"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >

--- a/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
@@ -175,7 +175,7 @@ exports[`RadioButton disabled small 1`] = `
       className="box paddingX1"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >
@@ -227,7 +227,7 @@ exports[`RadioButton small 1`] = `
       className="box paddingX1"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >
@@ -306,7 +306,7 @@ exports[`RadioButton with image 1`] = `
       className="box paddingX1"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >
@@ -358,7 +358,7 @@ exports[`RadioButton with subtext 1`] = `
       className="box paddingX1"
       style={
         Object {
-          "marginTop": "2px",
+          "marginTop": "-1px",
         }
       }
     >


### PR DESCRIPTION
### Summary

#### What changed?

CheckBox, RadioGroupButton: fix spacing in size='sm'  with custom marginTop

#### Why?

Introduced in https://github.com/pinterest/gestalt/pull/2403

BEFORE
![Screen Shot 2022-09-26 at 4 06 29 PM](https://user-images.githubusercontent.com/10593890/192396124-8bb2a446-71da-488f-aa70-221a5fa80373.png)
![Screen Shot 2022-09-26 at 4 10 01 PM](https://user-images.githubusercontent.com/10593890/192396539-73d854ab-c476-4707-b571-f3924a64238b.png)


AFTER

![Screen Shot 2022-09-26 at 4 18 54 PM](https://user-images.githubusercontent.com/10593890/192397416-f13fb668-2e35-41bc-bf0d-a6385df551ed.png)

![Screen Shot 2022-09-26 at 4 19 13 PM](https://user-images.githubusercontent.com/10593890/192397421-325e1b02-32d8-4edf-a7f5-7acf125c838c.png)

