### PR TITLE
DeviceTypeProvider: new utility and documentation page

### DIFF
--- a/docs/docs-components/AccessibilitySection.js
+++ b/docs/docs-components/AccessibilitySection.js
@@ -8,13 +8,19 @@ import Markdown from './Markdown.js';
 type Props = {|
   children?: Node,
   description?: string,
+  hideChecklist?: boolean,
   name: string,
 |};
 
-function AccessibilityMainSection({ children, description, name }: Props): Node {
+function AccessibilityMainSection({
+  children,
+  description,
+  hideChecklist = false,
+  name,
+}: Props): Node {
   return (
     <Card name="Accessibility" showHeading>
-      <AccessibilityChecklist component={name} />
+      {hideChecklist ? null : <AccessibilityChecklist component={name} />}
       {description && (
         <Box marginTop={6} marginBottom={8} maxWidth={572}>
           <Markdown text={description} />

--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -88,7 +88,7 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
             zIndex={ABOVE_PAGE_HEADER_ZINDEX}
           >
             <DocsDeviceTypeProvider isMobile>
-              <DeviceTypeProvider deviceType="phone">
+              <DeviceTypeProvider deviceType="mobile">
                 <DocsSideNavigation showBorder />
               </DeviceTypeProvider>
             </DocsDeviceTypeProvider>

--- a/docs/docs-components/siteIndex.js
+++ b/docs/docs-components/siteIndex.js
@@ -61,6 +61,7 @@ const siteIndex: $ReadOnlyArray<siteIndexType> = [
         pages: [
           'ColorSchemeProvider',
           'OnLinkNavigationProvider',
+          'DeviceTypeProvider',
           'ScrollBoundaryContainer',
           'useFocusVisible',
           'useReducedMotion',

--- a/docs/examples/devicetypeprovider/implementation.js
+++ b/docs/examples/devicetypeprovider/implementation.js
@@ -1,0 +1,112 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { Box, SideNavigation, DeviceTypeProvider, Button, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  const [deviceType, setDeviceType] = React.useState('desktop');
+
+  return (
+    <Flex>
+      <Box padding={2}>
+        <Button
+          accessibilityControls="sidenav"
+          accessibilityLabel={`Toggle to ${deviceType === 'desktop' ? 'mobile' : 'desktop'} view`}
+          color="red"
+          text={`Toggle to ${deviceType === 'desktop' ? 'mobile' : 'desktop'} view`}
+          size="lg"
+          onClick={() => setDeviceType((value) => (value === 'desktop' ? 'mobile' : 'desktop'))}
+        />
+      </Box>
+      <Flex.Item flex="grow">
+        <DeviceTypeProvider deviceType={deviceType}>
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            color="secondary"
+            height={500}
+          >
+            <Box height={450} width={280} color="default" id="sidenav">
+              <SideNavigation
+                title="Advertisement"
+                accessibilityLabel="Mobile device example"
+                dismissButton={{
+                  onDismiss: () => {},
+                  accessibilityLabel: 'Close navigation',
+                  tooltip: {
+                    accessibilityLabel: 'Close side navigation',
+                    text: 'Close navigation',
+                  },
+                }}
+              >
+                <SideNavigation.TopItem
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="Reporting"
+                  icon="ads-stats"
+                />
+                <SideNavigation.TopItem
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="Conversions"
+                  icon="replace"
+                />
+                <SideNavigation.Section label="Audiences">
+                  <SideNavigation.TopItem
+                    href="#"
+                    onClick={({ event }) => event.preventDefault()}
+                    label="Thanksgiving"
+                    icon="people"
+                  />
+                  <SideNavigation.Group label="Christmas" icon="people">
+                    <SideNavigation.NestedItem
+                      href="#"
+                      onClick={({ event }) => event.preventDefault()}
+                      label="Luxury Christmas"
+                    />
+                    <SideNavigation.NestedGroup label="Classic Christmas">
+                      <SideNavigation.NestedItem
+                        href="#"
+                        onClick={({ event }) => event.preventDefault()}
+                        label="West Coast"
+                      />
+                      <SideNavigation.NestedItem
+                        href="#"
+                        onClick={({ event }) => event.preventDefault()}
+                        label="East Coast"
+                      />
+                    </SideNavigation.NestedGroup>
+                    <SideNavigation.NestedGroup label="Alternative Christmas">
+                      <SideNavigation.NestedItem
+                        href="#"
+                        onClick={({ event }) => event.preventDefault()}
+                        label="West Coast"
+                      />
+                      <SideNavigation.NestedItem
+                        href="#"
+                        onClick={({ event }) => event.preventDefault()}
+                        label="East Coast"
+                      />
+                    </SideNavigation.NestedGroup>
+                  </SideNavigation.Group>
+                  <SideNavigation.Group label="Halloween" icon="people" display="static">
+                    <SideNavigation.NestedItem
+                      href="#"
+                      onClick={({ event }) => event.preventDefault()}
+                      label="East Coast"
+                    />
+                    <SideNavigation.NestedItem
+                      href="#"
+                      onClick={({ event }) => event.preventDefault()}
+                      label="West Coast"
+                    />
+                  </SideNavigation.Group>
+                </SideNavigation.Section>
+              </SideNavigation>
+            </Box>
+          </Box>
+        </DeviceTypeProvider>
+      </Flex.Item>
+    </Flex>
+  );
+}

--- a/docs/examples/sidenavigation/mobileExample.js
+++ b/docs/examples/sidenavigation/mobileExample.js
@@ -6,98 +6,93 @@ export default function Example(): Node {
   const [showNav, setShowNav] = React.useState(false);
 
   return showNav ? (
-    <DeviceTypeProvider deviceType="phone">
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        color="secondary"
-        height={500}
-      >
-        <Box height={450} width={280} color="default">
-          <SideNavigation
-            title="Advertisement"
-            accessibilityLabel="Mobile device example"
-            dismissButton={{
-              onDismiss: () => setShowNav(false),
-              accessibilityLabel: 'Close navigation',
-              tooltip: { accessibilityLabel: 'Close side navigation', text: 'Close navigation' },
-            }}
-          >
+    <DeviceTypeProvider deviceType="mobile">
+      <Box position="absolute" top bottom left right id="sidenavigation">
+        <SideNavigation
+          title="Advertisement"
+          accessibilityLabel="Mobile device example"
+          dismissButton={{
+            onDismiss: () => setShowNav(false),
+            accessibilityLabel: 'Close navigation',
+            tooltip: { accessibilityLabel: 'Close side navigation', text: 'Close navigation' },
+          }}
+        >
+          <SideNavigation.TopItem
+            href="#"
+            onClick={({ event }) => event.preventDefault()}
+            label="Reporting"
+            icon="ads-stats"
+          />
+          <SideNavigation.TopItem
+            href="#"
+            onClick={({ event }) => event.preventDefault()}
+            label="Conversions"
+            icon="replace"
+          />
+          <SideNavigation.Section label="Audiences">
             <SideNavigation.TopItem
               href="#"
               onClick={({ event }) => event.preventDefault()}
-              label="Reporting"
-              icon="ads-stats"
+              label="Thanksgiving"
+              icon="people"
             />
-            <SideNavigation.TopItem
-              href="#"
-              onClick={({ event }) => event.preventDefault()}
-              label="Conversions"
-              icon="replace"
-            />
-            <SideNavigation.Section label="Audiences">
-              <SideNavigation.TopItem
+            <SideNavigation.Group label="Christmas" icon="people">
+              <SideNavigation.NestedItem
                 href="#"
                 onClick={({ event }) => event.preventDefault()}
-                label="Thanksgiving"
-                icon="people"
+                label="Luxury Christmas"
               />
-              <SideNavigation.Group label="Christmas" icon="people">
-                <SideNavigation.NestedItem
-                  href="#"
-                  onClick={({ event }) => event.preventDefault()}
-                  label="Luxury Christmas"
-                />
-                <SideNavigation.NestedGroup label="Classic Christmas">
-                  <SideNavigation.NestedItem
-                    href="#"
-                    onClick={({ event }) => event.preventDefault()}
-                    label="West Coast"
-                  />
-                  <SideNavigation.NestedItem
-                    href="#"
-                    onClick={({ event }) => event.preventDefault()}
-                    label="East Coast"
-                  />
-                </SideNavigation.NestedGroup>
-                <SideNavigation.NestedGroup label="Alternative Christmas">
-                  <SideNavigation.NestedItem
-                    href="#"
-                    onClick={({ event }) => event.preventDefault()}
-                    label="West Coast"
-                  />
-                  <SideNavigation.NestedItem
-                    href="#"
-                    onClick={({ event }) => event.preventDefault()}
-                    label="East Coast"
-                  />
-                </SideNavigation.NestedGroup>
-              </SideNavigation.Group>
-              <SideNavigation.Group label="Halloween" icon="people" display="static">
-                <SideNavigation.NestedItem
-                  href="#"
-                  onClick={({ event }) => event.preventDefault()}
-                  label="East Coast"
-                />
+              <SideNavigation.NestedGroup label="Classic Christmas">
                 <SideNavigation.NestedItem
                   href="#"
                   onClick={({ event }) => event.preventDefault()}
                   label="West Coast"
                 />
-              </SideNavigation.Group>
-            </SideNavigation.Section>
-          </SideNavigation>
-        </Box>
+                <SideNavigation.NestedItem
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="East Coast"
+                />
+              </SideNavigation.NestedGroup>
+              <SideNavigation.NestedGroup label="Alternative Christmas">
+                <SideNavigation.NestedItem
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="West Coast"
+                />
+                <SideNavigation.NestedItem
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="East Coast"
+                />
+              </SideNavigation.NestedGroup>
+            </SideNavigation.Group>
+            <SideNavigation.Group label="Halloween" icon="people" display="static">
+              <SideNavigation.NestedItem
+                href="#"
+                onClick={({ event }) => event.preventDefault()}
+                label="East Coast"
+              />
+              <SideNavigation.NestedItem
+                href="#"
+                onClick={({ event }) => event.preventDefault()}
+                label="West Coast"
+              />
+            </SideNavigation.Group>
+          </SideNavigation.Section>
+        </SideNavigation>
       </Box>
     </DeviceTypeProvider>
   ) : (
-    <Button
-      accessibilityLabel="Show navigation"
-      color="red"
-      text="Show navigation"
-      size="lg"
-      onClick={() => setShowNav(true)}
-    />
+    <Box padding={2}>
+      <Button
+        accessibilityLabel="Show navigation"
+        accessibilityControls="sidenavigation"
+        color="red"
+        text="Show navigation"
+        size="lg"
+        onClick={() => setShowNav(true)}
+      />
+    </Box>
   );
 }

--- a/docs/examples/sidenavigation/subcomponent.js
+++ b/docs/examples/sidenavigation/subcomponent.js
@@ -1,0 +1,90 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { SideNavigation } from 'gestalt';
+
+export default function Example(): Node {
+  const someCondition = true;
+
+  return (
+    <SideNavigation accessibilityLabel="Subcomponent composability example">
+      {someCondition && (
+        <SideNavigation.TopItem
+          href="#"
+          onClick={({ event }) => event.preventDefault()}
+          label="Trends"
+          icon="ads-stats"
+        />
+      )}
+
+      <SideNavigation.Section label="Analytics">
+        {someCondition && (
+          <SideNavigation.TopItem
+            href="#"
+            onClick={({ event }) => event.preventDefault()}
+            label="Reporting"
+            icon="ads-stats"
+          />
+        )}
+        {someCondition && (
+          <SideNavigation.TopItem
+            href="#"
+            onClick={({ event }) => event.preventDefault()}
+            label="Conversions"
+            icon="replace"
+          />
+        )}
+      </SideNavigation.Section>
+
+      <SideNavigation.Section label="Audiences">
+        <SideNavigation.Group label="Christmas" icon="people">
+          <SideNavigation.NestedItem
+            href="#"
+            onClick={({ event }) => event.preventDefault()}
+            label="Luxury Christmas"
+          />
+          <SideNavigation.NestedGroup label="Classic Christmas">
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="West Coast"
+            />
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="East Coast"
+            />
+          </SideNavigation.NestedGroup>
+
+          <SideNavigation.NestedGroup label="Alternative Christmas">
+            {['West Coast', 'East Coast'].map((x) => (
+              <SideNavigation.NestedItem
+                href="#"
+                key={`xmas${x}`}
+                onClick={({ event }) => event.preventDefault()}
+                label={x}
+              />
+            ))}
+            {['Southern', 'NorthEast'].map((x) => (
+              <SideNavigation.NestedItem
+                href="#"
+                key={`xmas${x}`}
+                onClick={({ event }) => event.preventDefault()}
+                label={x}
+              />
+            ))}
+          </SideNavigation.NestedGroup>
+        </SideNavigation.Group>
+        <SideNavigation.Group label="Halloween" icon="people">
+          {['West Coast', 'East Coast'].map((x) => (
+            <SideNavigation.NestedItem
+              href="#"
+              key={`halloween${x}`}
+              onClick={({ event }) => event.preventDefault()}
+              label={x}
+            />
+          ))}
+        </SideNavigation.Group>
+      </SideNavigation.Section>
+    </SideNavigation>
+  );
+}

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -22,7 +22,7 @@ function Providers({ children, isMobile }: {| children: Node, isMobile: boolean 
 
   return (
     <DocsDeviceTypeProvider isMobile={isMobileDevice}>
-      <DeviceTypeProvider deviceType={isMobileDevice ? 'phone' : 'desktop'}>
+      <DeviceTypeProvider deviceType={isMobileDevice ? 'mobile' : 'desktop'}>
         <DocsExperimentProvider>
           <DocsI18nProvider>{children}</DocsI18nProvider>
         </DocsExperimentProvider>

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -29,6 +29,7 @@ import headerExample from '../../examples/sidenavigation/headerExample.js';
 import nestedExample from '../../examples/sidenavigation/nestedExample.js';
 import notificationsExample from '../../examples/sidenavigation/notificationsExample.js';
 import mobileExample from '../../examples/sidenavigation/mobileExample.js';
+import subcomponent from '../../examples/sidenavigation/subcomponent.js';
 
 export default function SideNavigationPage({
   generatedDocGen,
@@ -428,84 +429,26 @@ When building SideNavigation, we might want to render different combinations of 
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<SideNavigation accessibilityLabel="Subcomponent composability example">
-
-  { true && <SideNavigation.TopItem
-      href="#"
-      onClick={({ event }) => event.preventDefault()}
-      label="Trends"
-      icon="ads-stats"
-    /> }
-
-  <SideNavigation.Section label="Analytics">
-    { true && <SideNavigation.TopItem
-      href="#"
-      onClick={({ event }) => event.preventDefault()}
-      label="Reporting"
-      icon="ads-stats"
-    /> }
-    { true && <SideNavigation.TopItem
-      href="#"
-      onClick={({ event }) => event.preventDefault()}
-      label="Conversions"
-      icon="replace"
-    /> }
-  </SideNavigation.Section>
-
-  <SideNavigation.Section label="Audiences">
-    <SideNavigation.Group label="Christmas" icon="people">
-      <SideNavigation.NestedItem
-        href="#"
-        onClick={({ event }) => event.preventDefault()}
-        label="Luxury Christmas"
-      />
-      <SideNavigation.NestedGroup label="Classic Christmas">
-        <SideNavigation.NestedItem
-          href="#"
-          onClick={({ event }) => event.preventDefault()}
-          label="West Coast"
-        />
-        <SideNavigation.NestedItem
-          href="#"
-          onClick={({ event }) => event.preventDefault()}
-          label="East Coast"
-        />
-      </SideNavigation.NestedGroup>
-
-      <SideNavigation.NestedGroup label="Alternative Christmas">
-        { ["West Coast","East Coast"].map(x => <SideNavigation.NestedItem
-          href="#"
-          key={"xmas" + x}
-          onClick={({ event }) => event.preventDefault()}
-          label={x}
-        />) }
-        { ["Southern","NorthEast"].map(x => <SideNavigation.NestedItem
-          href="#"
-          key={"xmas" + x}
-          onClick={({ event }) => event.preventDefault()}
-          label={x}
-        />) }
-      </SideNavigation.NestedGroup>
-
-    </SideNavigation.Group>
-    <SideNavigation.Group label="Halloween" icon="people">
-      { ["West Coast","East Coast"].map(x => <SideNavigation.NestedItem
-          href="#"
-          key={"halloween" + x}
-          onClick={({ event }) => event.preventDefault()}
-          label={x}
-        />) }
-    </SideNavigation.Group>
-
-  </SideNavigation.Section>
-</SideNavigation>
-            `}
+            sandpackExample={
+              <SandpackExample
+                code={subcomponent}
+                name="Subcomponent reusability example"
+                previewHeight={500}
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
 
-      <MainSection name="Mobile">
+      <MainSection
+        name="Mobile"
+        description={`SideNavigation requires [DeviceTypeProvider](/web/utilities/devicetypeprovider) to enable its mobile user interface. The example below shows the mobile platform UI and its implementation.
+
+For mobile, \`title\` and \`dismissButton\` become required props.
+
+Notice that the mobile UI requires logic to hide and show SideNavigation full width. If [Button](/web/button) or [TapArea](/web/taparea) control the visibility of SideNavigation, use \`accessibilityControls\` so that screen reader users can identify the relationship between elements.
+  `}
+      >
         <MainSection.Card
           sandpackExample={
             <SandpackExample code={mobileExample} name="Mobile example" previewHeight={500} />

--- a/docs/pages/web/utilities/devicetypeprovider.js
+++ b/docs/pages/web/utilities/devicetypeprovider.js
@@ -1,22 +1,50 @@
 // @flow strict
 import { type Node } from 'react';
+import { SlimBanner } from 'gestalt';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
-// To be used when this page is made live
-// import MainSection from '../../../docs-components/MainSection.js';
+import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
 import docgen, { type DocGen } from '../../../docs-components/docgen.js';
-
-// TODO: @rjames
-// - Add usage examples to this docs page
-// - Add reference to this docs page in docs/docs-components/sidebarIndex.js
+import SandpackExample from '../../../docs-components/SandpackExample.js';
+import implementation from '../../../examples/devicetypeprovider/implementation.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
-    <Page title="DeviceTypeProvider">
-      <PageHeader name="DeviceTypeProvider" description={generatedDocGen?.description} />
+    <Page title={generatedDocGen?.displayName}>
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+
+      <SlimBanner
+        type="info"
+        iconAccessibilityLabel="Recommendation"
+        message="Gestalt components that require DeviceTypeProvider to enable their mobile user interfaces have a Mobile variant section in their documentation page. Check each example to learn more about their particular implementations."
+      />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
+      <MainSection
+        name="Implementation"
+        description={`Gestalt components can have different interfaces depending on the user's device. We currently support "desktop" and "mobile".
+
+Components default to a responsive "desktop" UI. DeviceTypeProvider is required to enable mobile-specific variants where available.
+
+This provider should be implemented at the top level of your app. Any additional nested DeviceTypeProviders will override the top-level configuration.
+
+While device detection can (for now) be performed using the [user-agent string](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent), this is [not generally recommended](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent). Thankfully, there are [better solutions](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#avoiding_user_agent_detection)!
+
+The example shows a component with different desktop and mobile UIs.`}
+      >
+        <MainSection.Card
+          sandpackExample={
+            <SandpackExample
+              code={implementation}
+              name="Implementation example"
+              previewHeight={500}
+              layout="column"
+            />
+          }
+        />
+      </MainSection>
     </Page>
   );
 }

--- a/docs/pages/web/utilities/onlinknavigationprovider.js
+++ b/docs/pages/web/utilities/onlinknavigationprovider.js
@@ -6,7 +6,6 @@ import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
 import docgen, { type DocGen } from '../../../docs-components/docgen.js';
 import QualityChecklist from '../../../docs-components/QualityChecklist.js';
-import AccessibilitySection from '../../../docs-components/AccessibilitySection.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -18,8 +17,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
-
-      <AccessibilitySection name={generatedDocGen?.displayName} />
 
       <MainSection name="Variants">
         <MainSection.Subsection

--- a/packages/gestalt/src/SideNavigation.js
+++ b/packages/gestalt/src/SideNavigation.js
@@ -78,7 +78,7 @@ export default function SideNavigation({
   const navigationChildren = getChildrenToArray({ children, filterLevel: 'main' });
 
   const deviceType = useDeviceType();
-  const isMobile = deviceType === 'phone';
+  const isMobile = deviceType === 'mobile';
 
   if (isMobile) {
     return (

--- a/packages/gestalt/src/SideNavigationGroup.js
+++ b/packages/gestalt/src/SideNavigationGroup.js
@@ -102,7 +102,7 @@ export default function SideNavigationGroup({
 
   const deviceType = useDeviceType();
 
-  const isMobile = deviceType === 'phone';
+  const isMobile = deviceType === 'mobile';
 
   const itemColor = hovered ? 'secondary' : undefined;
 

--- a/packages/gestalt/src/SideNavigationGroupContent.js
+++ b/packages/gestalt/src/SideNavigationGroupContent.js
@@ -47,7 +47,7 @@ export default function SideNavigationGroupContent({
 |}): Node {
   const deviceType = useDeviceType();
 
-  const isMobile = deviceType === 'phone';
+  const isMobile = deviceType === 'mobile';
 
   return (
     <Box

--- a/packages/gestalt/src/SideNavigationTopItem.js
+++ b/packages/gestalt/src/SideNavigationTopItem.js
@@ -84,7 +84,7 @@ export default function SideNavigationTopItem({
 
   const deviceType = useDeviceType();
 
-  const isMobile = deviceType === 'phone';
+  const isMobile = deviceType === 'mobile';
 
   const isTopLevel = nestedLevel === 0;
 

--- a/packages/gestalt/src/contexts/DeviceTypeProvider.js
+++ b/packages/gestalt/src/contexts/DeviceTypeProvider.js
@@ -3,23 +3,19 @@ import { type Context, type Node, createContext, useContext } from 'react';
 
 const defaultDeviceType = 'desktop';
 
-type DeviceType = 'desktop' | 'phone' | 'tablet';
+type DeviceType = 'desktop' | 'mobile';
 
 const DeviceTypeContext: Context<DeviceType> = createContext<DeviceType>(defaultDeviceType);
 
 type Props = {|
-  /**
-   *
-   */
   children: Node,
   /**
-   * The device type as determined by logic within your app. This will be used within certain Gestalt components to render device-specific UI.
+   * The device type as determined by logic within your app.
    */
   deviceType: DeviceType,
 |};
 
 /**
- * *ALPHA - DO NOT USE YET - MAY HAVE BREAKING CHANGES IN THE NEAR FUTURE*
  * [DeviceTypeProvider](https://gestalt.pinterest.systems/web/utilities/devicetypeprovider) is an optional [React Context provider](https://reactjs.org/docs/context.html#contextprovider) to enable device-specific UI for Gestalt components that support it.
  */
 export default function DeviceTypeProvider({ children, deviceType }: Props): Node {


### PR DESCRIPTION
### Summary

#### What changed?

DeviceTypeProvider: new utility and documentation page

#### Why?

Gestalt components can enable their mobile user interfaces using DeviceTypeProvider.

WARNING: This PR introduces 2 main changes to the previously undocumented DeviceTypeProvider: removes 'tablet' from the Flow type as Gestalt doesn't support tablet UI (and this is not planned to change in the near future) and renames `phone` to `mobile` to follow the standard way of referring to mobile platform. 

Despite the fact that DeviceTypeProvider was an undocumented utility, we are releasing this change as a major version. Use the following codemod to find DeviceTypeProvider in your codebase and make adjustments to upgrade to this version.

`yarn codemod detectManualReplacement ~/path/to/your/code --component=DeviceTypeProvider
`

NOTE: To test the modified Sandpack examples, replace "mobile" with "phone" as Sandpack only works with the latest published Gestalt version.