### PR TITLE
Text: Removing justify value prop

### DIFF
--- a/docs/pages/web/text.js
+++ b/docs/pages/web/text.js
@@ -166,8 +166,6 @@ export default function TextPage({ generatedDocGen }: {| generatedDocGen: DocGen
   <Divider />
   <Text align="center">Center</Text>
   <Divider />
-  <Text align="justify">Justify</Text>
-  <Divider />
   <Text align="forceLeft">Force left</Text>
   <Divider />
   <Text align="forceRight">Force right</Text>

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -19,7 +19,7 @@ type Props = {|
    *
    * Link: https://gestalt.pinterest.systems/web/text#align
    */
-  align?: 'start' | 'end' | 'center' | 'justify' | 'forceLeft' | 'forceRight',
+  align?: 'start' | 'end' | 'center' | 'forceLeft' | 'forceRight',
   children?: Node,
   /**
    * Link: https://gestalt.pinterest.systems/web/text#color


### PR DESCRIPTION
### Summary

Removing unused prop `justify` of `Text` component;

The following codemod help you to do the follow table replacement.

To modifyPropValue, please, use

```bash
yarn codemod modifyPropValue ~/path/to/your/code
  --component=Text
  --previousProp=align
  --previousValue=justify
```

To detect manual changes use

```bash
 yarn codemod detectManualReplacement ~/path/to/your/code
 --component=Text
 --prop=align
 --value=justify
 ```

#### What changed?

The value was removed of main file and code;

#### Why?

The value is not used and the design suggest your delete;

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4794)

### Checklist

- [x] Added documentation + accessibility tests
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
