### PR TITLE
Design tokens: Add opacity tokens

### DIFF
--- a/docs/docs-components/CombinationNew.js
+++ b/docs/docs-components/CombinationNew.js
@@ -1,12 +1,14 @@
 // @flow strict
-import { Flex } from 'gestalt';
+import { Box, Flex } from 'gestalt';
 import { type Node } from 'react';
 import MainSectionCard from './MainSectionCard.js';
+import Checkerboard from './Checkerboard.js';
 
 type Props = {
   // $FlowFixMe[unclear-type]
   children: (props: { [key: string]: any, ... }, index?: number) => Node,
   hideTitle?: boolean,
+  hasCheckerboard?: boolean,
   ...
 };
 
@@ -48,7 +50,12 @@ const toReactAttribute = (key, value) => {
   }
 };
 
-export default function CombinationNew({ children, hideTitle, ...props }: Props): Node {
+export default function CombinationNew({
+  children,
+  hideTitle,
+  hasCheckerboard,
+  ...props
+}: Props): Node {
   const CardArray = combinations(props).map((combination, i) => {
     const combinationTitles = Object.keys(combination).map((key) =>
       toReactAttribute(key, combination[key]),
@@ -73,6 +80,9 @@ export default function CombinationNew({ children, hideTitle, ...props }: Props)
         shadeColor={cardShadeColor}
         title={hideTitle ? undefined : combinationTitles}
       >
+        <Box position="absolute" top left bottom right>
+          {hasCheckerboard && <Checkerboard />}
+        </Box>
         {children(combination, i)}
       </MainSectionCard>
     );

--- a/docs/docs-components/TokenExample.js
+++ b/docs/docs-components/TokenExample.js
@@ -100,6 +100,28 @@ export function BorderBox({ token }: BaseProps): Node {
   );
 }
 
+export function OpacityBox({ token }: BaseProps): Node {
+  return (
+    <Box
+      color="recommendationWeak"
+      width={175}
+      height={75}
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Box
+        dangerouslySetInlineStyle={{
+          __style: { opacity: `var(--${token.name})` },
+        }}
+        height={50}
+        width={150}
+        color="inverse"
+      />
+    </Box>
+  );
+}
+
 export function ElevationBox({ token }: BaseProps): Node {
   return (
     <Box
@@ -165,6 +187,8 @@ export function TokenExample({ token, category }: ExampleProps): Node {
       return <BorderBox token={token} />;
     case 'elevation':
       return <ElevationBox token={token} />;
+    case 'opacity':
+      return <OpacityBox token={token} />;
     default:
       return <Box>{token.value}</Box>;
   }

--- a/docs/pages/foundations/design_tokens.js
+++ b/docs/pages/foundations/design_tokens.js
@@ -19,22 +19,32 @@ export type Token = {|
 
 const tokenCategories = [
   {
-    name: 'Spacing',
-    category: 'spacing',
-    id: 'space',
-    infoPage: { name: 'Box', path: 'web/box#Responsive-padding' },
-  },
-  {
     name: 'Background color',
     category: 'background-color',
     id: 'background',
     infoPage: { name: 'Box', path: 'web/box#Colors' },
   },
   {
-    name: 'Text color',
-    category: 'text-color',
-    id: 'color-text',
-    infoPage: { name: 'Text', path: 'web/text#Colors' },
+    name: 'Border color',
+    category: 'color-border',
+    id: 'color-border',
+    infoPage: { name: 'Box', path: 'web/box#Borders' },
+  },
+
+  {
+    name: 'Data visualization',
+    category: 'data-visualization',
+    id: 'data-visualization',
+    infoPage: {
+      name: 'Data Visualization Guidelines',
+      path: 'foundations/data_visualization/palette',
+    },
+  },
+  {
+    name: 'Elevation',
+    category: 'elevation',
+    id: 'elevation',
+    infoPage: { name: 'Box', path: 'web/box#Elevation' },
   },
   {
     name: 'Font size',
@@ -55,25 +65,22 @@ const tokenCategories = [
     infoPage: { name: 'Typography', path: 'foundations/typography/guidelines' },
   },
   {
-    name: 'Border color',
-    category: 'color-border',
-    id: 'color-border',
-    infoPage: { name: 'Box', path: 'web/box#Borders' },
+    name: 'Opacity',
+    category: 'opacity',
+    id: 'opacity',
+    infoPage: { name: 'Box', path: 'web/box#Opacity' },
   },
   {
-    name: 'Elevation',
-    category: 'elevation',
-    id: 'elevation',
-    infoPage: { name: 'Box', path: 'web/box#Elevation' },
+    name: 'Spacing',
+    category: 'spacing',
+    id: 'space',
+    infoPage: { name: 'Box', path: 'web/box#Responsive-padding' },
   },
   {
-    name: 'Data visualization',
-    category: 'data-visualization',
-    id: 'data-visualization',
-    infoPage: {
-      name: 'Data Visualization Guidelines',
-      path: 'foundations/data_visualization/palette',
-    },
+    name: 'Text color',
+    category: 'text-color',
+    id: 'color-text',
+    infoPage: { name: 'Text', path: 'web/text#Colors' },
   },
 ];
 

--- a/docs/pages/web/box.js
+++ b/docs/pages/web/box.js
@@ -351,7 +351,20 @@ If you need to use these features for animation purposes, use a \`<div>\` instea
           </CombinationNew>
         </MainSection.Subsection>
 
-        <MainSection.Subsection description="" title="Opacity">
+        <MainSection.Subsection
+          description="While we offer the full range of opacity options, below are usage guidelines for different values. See the [opacity design tokens](/foundations/design_tokens#Opacity)."
+          title="Opacity"
+        >
+          <MainSection.Card
+            description={`
+          - **3% (0.03)**: Use for Pin wash. Permanent overlay used on Pin images to ensure a visual separation between the white background and any Pin images that have pure white peripheries. For the time being, iOS uses 4%, but this will be reevaluated in the near future.
+              - Note: at the moment, this can only be accomplished using the \`$opacity-100\` token as an inline style on Box
+          - **20% (0.2)**: Overlay wash to be used sparingly. Only use it in situations where a high-level of opacity is needed and if the 40% doesn't fit the design goal.
+          - **40% (0.4)**: Overlay wash to supply a mid-range wash over an item (e.g. #FFFFFF media controls | #000000 wash behind modals, wash on images with text overlays).
+          - **80% (0.8)**: Overlay wash used on most surface's scrims. Used to supply a low-level of opacity over an element (e.g. #FFFFFF image overlay | #00000 Board cover overlay) .
+          - **90% (0.9)**: Component wash applied on IconButton and other elements as needed (e.g. image overlays). In dark mode we recommend an inverse wash.  For example: Use $color-background-wash-light instead of $color-background-wash-dark.
+          `}
+          />
           <CombinationNew opacity={[0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]}>
             {({ opacity }) => <Box color="selected" width={60} height={60} opacity={opacity} />}
           </CombinationNew>

--- a/docs/pages/web/box.js
+++ b/docs/pages/web/box.js
@@ -365,7 +365,10 @@ If you need to use these features for animation purposes, use a \`<div>\` instea
           - **90% (0.9)**: Component wash applied on IconButton and other elements as needed (e.g. image overlays). In dark mode we recommend an inverse wash.  For example: Use $color-background-wash-light instead of $color-background-wash-dark.
           `}
           />
-          <CombinationNew opacity={[0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]}>
+          <CombinationNew
+            hasCheckerboard
+            opacity={[0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]}
+          >
             {({ opacity }) => <Box color="selected" width={60} height={60} opacity={opacity} />}
           </CombinationNew>
         </MainSection.Subsection>

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -113,6 +113,16 @@
               "type": "size"
             }
           }
+        },
+        {
+          "destination": "opacity.xml",
+          "format": "android/resources",
+          "resourceType": "dimen",
+          "filter": {
+            "attributes": {
+              "category": "opacity"
+            }
+          }
         }
       ]
     },

--- a/packages/gestalt-design-tokens/tokens/opacity/base.json
+++ b/packages/gestalt-design-tokens/tokens/opacity/base.json
@@ -1,0 +1,24 @@
+{
+  "opacity": {
+    "100": {
+      "value": "0.03",
+      "comment": "Pin wash - Permanent overlay used on Pin images to ensure a visual separation between the white background and any Pin images that have pure white peripheries. Note: iOS uses 4%"
+    },
+    "200": {
+      "value": "0.2",
+      "comment": "Overlay wash to be used sparingly. Only use it in situations where a high-level of opacity is needed and if the 40% doesn't fit the design goal"
+    },
+    "300": {
+      "value": "0.4",
+      "comment": "Overlay wash to supply a mid-range wash over an item (e.g. #FFFFFF media controls | #000000 wash behind modals, wash on images with text overlays) "
+    },
+    "400": {
+      "value": "0.8",
+      "comment": "Overlay wash used on most surface's scrims. Used to supply a low-level of opacity over an element (e.g. #FFFFFF image overlay | #00000 Board cover overlay) "
+    },
+    "500": {
+      "value": "0.9",
+      "comment": "Component wash applied on IconButton and other elements as needed (e.g. image overlays). In dark mode we recommend an inverse wash ($color-background-wash-light instead of $color-background-wash-dark)."
+    }
+  }
+}

--- a/packages/gestalt-design-tokens/tokens/opacity/base.json
+++ b/packages/gestalt-design-tokens/tokens/opacity/base.json
@@ -1,5 +1,9 @@
 {
   "opacity": {
+    "0": {
+      "value": "0",
+      "comment": "Transparent - When a transparent alpha value is needed (without a background)"
+    },
     "100": {
       "value": "0.03",
       "comment": "Pin wash - Permanent overlay used on Pin images to ensure a visual separation between the white background and any Pin images that have pure white peripheries. Note: iOS uses 4%"


### PR DESCRIPTION
### Summary

#### What changed?

Add tokens for opacity values

![Screen Shot 2022-10-06 at 11 22 52 AM](https://user-images.githubusercontent.com/5125094/194389839-8898fd15-74d4-42be-a425-e4a587bfc096.png)


#### Why?

Allow cross platform consistency for opacity on objects (Pins, images, Boards, etc.)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-3661)
- [TDD](https://coda.io/d/Android-opacity-ramp_dQC4S2hCCxU/Opacity-ramp-Phase-1_suIbi)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
