### PR TITLE
Docs: add component aliases to page header

### DIFF
--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -115,13 +115,14 @@ type PlatformStatus = {|
 |};
 
 export type ListItemType = {|
+  aliases?: $ReadOnlyArray<string>,
+  android?: PlatformStatus,
   category: Category,
   description: string,
-  name: string,
   hasDarkBackground?: boolean,
-  path?: string,
   iOS?: PlatformStatus,
-  android?: PlatformStatus,
+  name: string,
+  path?: string,
   status?: {| ...PlatformStatus, iOS: StatusType, android: StatusType, responsive: StatusType |}, // web status
   svg: Element<typeof Accessibility>,
 |};
@@ -684,6 +685,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
   {
     svg: <ComboBox />,
     name: 'ComboBox',
+    aliases: ['Typeahead'],
     description:
       'ComboBox is the combination of a Textfield and an associated Dropdown that allows the user to filter a list when selecting an option.',
     category: 'Fields and forms',

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type Node, type Element } from 'react';
 import { Badge, Box, Flex, Heading, Text, Tooltip, SlimBanner, Link } from 'gestalt';
+import COMPONENT_DATA from './COMPONENT_DATA.js';
 import Markdown from './Markdown.js';
 import MainSection from './MainSection.js';
 import trackButtonClick from './buttons/trackButtonClick.js';
@@ -16,8 +17,13 @@ const buildSourceLinkUrl = (componentName) =>
     '/',
   );
 
+const componentData = [
+  ...COMPONENT_DATA.buildingBlockComponents,
+  ...COMPONENT_DATA.generalComponents,
+  ...COMPONENT_DATA.utilityComponents,
+];
+
 type Props = {|
-  aliases?: $ReadOnlyArray<string>,
   badge?: 'pilot' | 'deprecated',
   children?: Node,
   /**
@@ -42,7 +48,6 @@ type Props = {|
 |};
 
 export default function PageHeader({
-  aliases,
   badge,
   children,
   defaultCode,
@@ -62,6 +67,8 @@ export default function PageHeader({
     // Strip the file extension if linking to a folder
     sourceLink = sourceLink.replace(/\.js$/, '');
   }
+
+  const { aliases } = componentData.find((component) => component.name === name) ?? {};
 
   const badgeMap = {
     pilot: {

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -17,7 +17,9 @@ const buildSourceLinkUrl = (componentName) =>
   );
 
 type Props = {|
+  aliases?: $ReadOnlyArray<string>,
   badge?: 'pilot' | 'deprecated',
+  children?: Node,
   /**
    * @deprecated : Use `children` instead of `defaultCode`
    */
@@ -31,26 +33,26 @@ type Props = {|
    * Only use if name !== file name and the link should point to a directory
    */
   folderName?: string,
-  showCode?: boolean,
-  name: string,
   margin?: 'default' | 'none',
+  name: string,
   shadedCodeExample?: boolean,
+  showCode?: boolean,
   slimBanner?: Element<typeof SlimBanner> | null,
-  type?: 'guidelines' | 'component' | 'utils',
-  children?: Node,
+  type?: 'guidelines' | 'component' | 'utility',
 |};
 
 export default function PageHeader({
+  aliases,
   badge,
   children,
   defaultCode,
-  margin = 'default',
   description = '',
   fileName,
   folderName,
-  showCode = true,
+  margin = 'default',
   name,
   shadedCodeExample,
+  showCode = true,
   slimBanner = null,
   type = 'component',
 }: Props): Node {
@@ -92,54 +94,39 @@ export default function PageHeader({
           column: addGap ? 8 : 0,
         }}
       >
-        <Flex
-          direction="column"
-          gap={{
-            row: 0,
-            column: 2,
-          }}
-        >
-          <Flex
-            alignItems="baseline"
-            direction="row"
-            gap={{
-              row: 2,
-              column: 0,
-            }}
-            justifyContent="between"
-            wrap
-          >
-            <Heading>
-              {name}{' '}
-              {badge ? (
-                <Tooltip inline text={badgeMap[badge].tooltipText}>
-                  <Badge
-                    text={badgeMap[badge].text}
-                    position="top"
-                    type={badgeMap[badge].type || 'info'}
-                  />
-                </Tooltip>
-              ) : null}
-            </Heading>
+        <Flex direction="column" gap={3}>
+          <Flex alignItems="baseline" justifyContent="between" wrap>
+            <Flex direction="column" gap={1}>
+              <Heading>
+                {name}{' '}
+                {badge ? (
+                  <Tooltip inline text={badgeMap[badge].tooltipText}>
+                    <Badge
+                      text={badgeMap[badge].text}
+                      position="top"
+                      type={badgeMap[badge].type || 'info'}
+                    />
+                  </Tooltip>
+                ) : null}
+              </Heading>
 
-            {type === 'component' && (
+              {aliases && <Text italic>also known as {aliases.join(', ')}</Text>}
+            </Flex>
+
+            {/* Enable this when we have a consistent directory structure */}
+            {['component' /* 'utility' */].includes(type) && (
               <Link
                 href={sourceLink}
                 onClick={() => trackButtonClick('View source on GitHub', sourcePathName)}
                 target="blank"
+                underline="always"
               >
-                <Text underline>View source on GitHub</Text>
+                <Text>View source on GitHub</Text>
               </Link>
             )}
           </Flex>
 
-          <Flex
-            direction="column"
-            gap={{
-              row: 0,
-              column: 6,
-            }}
-          >
+          <Flex direction="column" gap={6}>
             {description && <Markdown text={description} />}
             {slimBanner}
             {type === 'component' ? <PageHeaderQualitySummary name={name} /> : null}

--- a/docs/pages/web/combobox.js
+++ b/docs/pages/web/combobox.js
@@ -25,7 +25,11 @@ const PREVIEW_HEIGHT = 320;
 export default function ComboBoxPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        aliases={['Typeahead']}
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+      >
         <SandpackExample
           code={main}
           name="Main Combobox example"

--- a/docs/pages/web/combobox.js
+++ b/docs/pages/web/combobox.js
@@ -25,11 +25,7 @@ const PREVIEW_HEIGHT = 320;
 export default function ComboBoxPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader
-        aliases={['Typeahead']}
-        name={generatedDocGen?.displayName}
-        description={generatedDocGen?.description}
-      >
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name="Main Combobox example"

--- a/docs/pages/web/utilities/colorschemeprovider.js
+++ b/docs/pages/web/utilities/colorschemeprovider.js
@@ -14,7 +14,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <PageHeader
         name="ColorSchemeProvider"
         description={generatedDocGen?.description}
-        type="utils"
+        type="utility"
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/web/utilities/devicetypeprovider.js
+++ b/docs/pages/web/utilities/devicetypeprovider.js
@@ -12,7 +12,11 @@ import implementation from '../../../examples/devicetypeprovider/implementation.
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        type="utility"
+      />
 
       <SlimBanner
         type="info"

--- a/docs/pages/web/utilities/onlinknavigationprovider.js
+++ b/docs/pages/web/utilities/onlinknavigationprovider.js
@@ -13,7 +13,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <PageHeader
         name="OnLinkNavigationProvider"
         description={generatedDocGen?.description}
-        type="utils"
+        type="utility"
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/web/utilities/usefocusvisible.js
+++ b/docs/pages/web/utilities/usefocusvisible.js
@@ -20,7 +20,7 @@ export default function DocsPage(): Node {
       <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible">:focus-visible CSS pseudo-class</a></li>
     </ul>
     `}
-        type="utils"
+        type="utility"
       />
       <AccessibilitySection name="useFocusVisible" />
 

--- a/docs/pages/web/utilities/usereducedmotion.js
+++ b/docs/pages/web/utilities/usereducedmotion.js
@@ -24,7 +24,7 @@ export default function DocsPage(): Node {
       <li><a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C39.html">WCAG C39: Using the CSS reduce-motion query to prevent motion</a></li>
     </ul>
     `}
-        type="utils"
+        type="utility"
       />
 
       <AccessibilitySection name="useReducedMotion" />

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -153,7 +153,6 @@ type Props = {|
 
 /**
  * [ComboBox](https://gestalt.pinterest.systems/web/combobox) is the combination of a [Textfield](https://gestalt.pinterest.systems/web/textfield) and an associated [Dropdown](https://gestalt.pinterest.systems/web/dropdown) that allows the user to filter a list when selecting an option. ComboBox allows users to type the full option, type part of the option and narrow the results, or select an option from the list.
- * Note: this is a new version of the deprecated component "Typeahead".
  *
  * ![Combobox closed light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ComboBox-closed.spec.mjs-snapshots/ComboBox-closed-chromium-darwin.png)
  * ![Combobox open light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ComboBox-open.spec.mjs-snapshots/ComboBox-open-chromium-darwin.png)


### PR DESCRIPTION
Naming is one of the more difficult things we struggle with, and similar components often have different names across the industry. While we need to settle on specific names for sanity's sake, our users may not be accustomed to those names. This PR adds an optional "aliases" section to the docs page header so we can add these other names components are commonly known by. This _should_ get picked up on the next Algolia crawl and improve search results for folks using these other names.

![Screen Shot 2022-10-05 at 4 11 21 PM](https://user-images.githubusercontent.com/12059539/194180654-c0f1d378-5c4b-41f8-9860-5ecec9d6e7f8.png)
