### PR TITLE
Tokens: Adjust dark mode error text and icon

### DIFF
--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -128,10 +128,8 @@ function DatePickerExample() {
 
       <MainSection name="Variants">
         <Example
-          description="
-    Use DatePicker to select date inputs.
-  "
-          name="Example: Basic Date Picker"
+          description="Use DatePicker to select date inputs."
+          name="Basic Date Picker"
           defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;
@@ -151,7 +149,7 @@ function DatePickerExample() {
     Provide pre-selected date values to DatePicker.
   "
           id="preselectedValue"
-          name="Example: Preselected Date"
+          name="Preselected Date"
           defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;
@@ -172,7 +170,7 @@ function DatePickerExample() {
           description="
     Use DatePicker to select date range inputs.
   "
-          name="Example: Date Range Picker"
+          name="Date Range Picker"
           defaultCode={`
 function DatePickerRangeExample() {
   const [startDate, setStartDate] = React.useState(undefined);
@@ -213,7 +211,7 @@ function DatePickerRangeExample() {
         />
         <Example
           id="disabled"
-          name="Example: Disabled"
+          name="Disabled"
           defaultCode={`
 function DatePickerExample() {
   const [date, setDate] = React.useState(new Date());
@@ -235,7 +233,7 @@ function DatePickerExample() {
           description="
     Disable dates outside of a min and max date range.
   "
-          name="Example: Delimited selection period"
+          name="Delimited selection period"
           defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;
@@ -257,7 +255,7 @@ function DatePickerExample() {
           description="
     Enable an array of dates.
   "
-          name="Example: Enabled dates"
+          name="Enabled dates"
           defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;
@@ -278,7 +276,7 @@ function DatePickerExample() {
           description="
     Disable an array of dates.
   "
-          name="Example: Disabled dates"
+          name="Disabled dates"
           defaultCode={`
 function DatePickerExample() {
   const handleChange = (value) => value;
@@ -300,7 +298,7 @@ function DatePickerExample() {
           description="
     Display a helper message for cases where you want to provide more information about the date field.
   "
-          name="Example: Helper Text"
+          name="Helper Text"
           defaultCode={`
 function DatePickerExample() {
   return (
@@ -320,7 +318,7 @@ function DatePickerExample() {
           description="
     Display an error message. Error message overrides the helper text.
   "
-          name="Example: Error Message"
+          name="Error Message"
           defaultCode={`
 function DatePickerExample() {
   const [date, setDate] = React.useState(undefined);
@@ -339,7 +337,7 @@ function DatePickerExample() {
         />
         <Combination
           id="idealDirection"
-          name="Example: Ideal Direction"
+          name="Ideal Direction"
           description="Define the preferred direction for the DatePicker popover to open. If that placement doesn't fit, the opposite direction will be used."
           layout="4column"
           idealDirection={['down', 'left', 'right', 'up']}
@@ -355,7 +353,7 @@ function DatePickerExample() {
         </Combination>
         <Combination
           id="localeData"
-          name="Example: Locales"
+          name="Supporting locales"
           description="
 Adjust the date format to each date-fns locale (https://date-fns.org/v2.14.0/docs/Locale).
 The following locale examples show the different locale format variants.

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -18,7 +18,7 @@
       },
       "error": {
         "value": "{color.red.pushpin.500.value}",
-        "darkValue": "{color.red.pushpin.400.value}",
+        "darkValue": "{color.red.pushpin.300.value}",
         "comment": "Text color to indicate an error"
       },
       "warning": {
@@ -67,7 +67,7 @@
         },
         "error": {
           "value": "{color.red.pushpin.500.value}",
-          "darkValue": "{color.red.pushpin.400.value}",
+          "darkValue": "{color.red.pushpin.300.value}",
           "comment": "Icon color to indicate an error"
         },
         "warning": {

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -29,7 +29,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-text-default: #ffffff;
   --color-text-subtle: #a5a5a5;
   --color-text-success: #39d377;
-  --color-text-error: #eb4242;
+  --color-text-error: #f47171;
   --color-text-warning: #e18d00;
   --color-text-inverse: #111111;
   --color-text-shopping: #75bfff;
@@ -37,7 +37,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-text-icon-default: #ffffff;
   --color-text-icon-subtle: #a5a5a5;
   --color-text-icon-success: #39d377;
-  --color-text-icon-error: #eb4242;
+  --color-text-icon-error: #f47171;
   --color-text-icon-warning: #e18d00;
   --color-text-icon-info: #75bfff;
   --color-text-icon-recommendation: #b190ff;
@@ -386,7 +386,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-text-default: #ffffff;
   --color-text-subtle: #a5a5a5;
   --color-text-success: #39d377;
-  --color-text-error: #eb4242;
+  --color-text-error: #f47171;
   --color-text-warning: #e18d00;
   --color-text-inverse: #111111;
   --color-text-shopping: #75bfff;
@@ -394,7 +394,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-text-icon-default: #ffffff;
   --color-text-icon-subtle: #a5a5a5;
   --color-text-icon-success: #39d377;
-  --color-text-icon-error: #eb4242;
+  --color-text-icon-error: #f47171;
   --color-text-icon-warning: #e18d00;
   --color-text-icon-info: #75bfff;
   --color-text-icon-recommendation: #b190ff;


### PR DESCRIPTION
### Summary

#### What changed?

Adjust error token for Text and Icon to have more contrast in dark mode

#### Why?

In order to provide better color contrast in dark mode, $color-text-error and $color-text-icon-error went from $color-red-pushpin-400 to $color-red-pushpin-300
