### PR TITLE
Docs: use actual h2 for aliases

### DIFF
--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -133,12 +133,10 @@ export default function PageHeader({
             <Flex direction="column" gap={1}>
               {description && <Markdown text={description} />}
               {aliases && (
-                <Text italic>
-                  {/* using heading level to indicate to Algolia search that this is important */}
-                  <div role="heading" aria-level="2">
-                    also known as {aliases.join(', ')}
-                  </div>
-                </Text>
+                // using h2 to indicate to Algolia search that this is important, but don't want native browser styling
+                <h2 className="reset">
+                  <Text italic>also known as {aliases.join(', ')}</Text>
+                </h2>
               )}
             </Flex>
             {slimBanner}

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -20,6 +20,15 @@ li {
   margin-top: 10px;
 }
 
+.reset {
+  border: 0;
+  font: inherit;
+  font-size: 100%;
+  margin: 0;
+  padding: 0;
+  vertical-align: baseline;
+}
+
 /**
  * LiveEditor overrides
  */


### PR DESCRIPTION
The new aliases aren't getting picked up by Algolia — probably because I used a div with heading roles instead of an actual `h2`. This PR switches out to use the native element, with a style reset to avoid native browser heading styles.