### PR TITLE
Docs: convert Hacking Gestalt page to use Sandpack

### DIFF
--- a/docs/examples/hacking_gestalt/dangerouslySetInlineStyle.js
+++ b/docs/examples/hacking_gestalt/dangerouslySetInlineStyle.js
@@ -1,0 +1,18 @@
+// @flow strict
+import { Box, Flex } from 'gestalt';
+
+export default function Example(): React$Node {
+  return (
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box
+        dangerouslySetInlineStyle={{
+          __style: {
+            backgroundColor: 'var(--color-pink-flaminglow-400)',
+          },
+        }}
+        height={100}
+        width={100}
+      />
+    </Flex>
+  );
+}

--- a/docs/examples/hacking_gestalt/ref.js
+++ b/docs/examples/hacking_gestalt/ref.js
@@ -1,0 +1,26 @@
+// @flow strict
+import { useEffect, useRef } from 'react';
+import { Flex, TextField } from 'gestalt';
+
+export default function Example(): React$Node {
+  const ref = useRef();
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.style.backgroundColor = 'aquamarine';
+    }
+  }, [ref]);
+
+  return (
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <TextField
+        errorMessage="Please don't do this!"
+        id="refExample"
+        onChange={() => {}}
+        readOnly
+        ref={ref}
+        value="Custom color"
+      />
+    </Flex>
+  );
+}

--- a/docs/examples/hacking_gestalt/wrappingComponents.js
+++ b/docs/examples/hacking_gestalt/wrappingComponents.js
@@ -1,0 +1,12 @@
+// @flow strict
+import { Flex, Text } from 'gestalt';
+
+export default function Example(): React$Node {
+  return (
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Text color="error">
+        <span style={{ fontFamily: 'cursive' }}>Custom text</span>
+      </Text>
+    </Flex>
+  );
+}

--- a/docs/pages/get_started/developers/hacking_gestalt.js
+++ b/docs/pages/get_started/developers/hacking_gestalt.js
@@ -3,6 +3,11 @@ import { type Node } from 'react';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
+import SandpackExample from '../../../docs-components/SandpackExample.js';
+// Examples
+import dangerouslySetInlineStyle from '../../../examples/hacking_gestalt/dangerouslySetInlineStyle.js';
+import ref from '../../../examples/hacking_gestalt/ref.js';
+import wrappingComponents from '../../../examples/hacking_gestalt/wrappingComponents.js';
 
 export default function DocsPage(): Node {
   return (
@@ -77,18 +82,12 @@ Custom components can also be made from scratch, using native DOM elements and C
 `}
         >
           <MainSection.Card
-            cardSize="lg" // this actually makes the rendered element smaller, which is desired
-            defaultCode={`
-<Box
-  dangerouslySetInlineStyle={{
-    __style: {
-      backgroundColor: 'var(--color-pink-flaminglow-400)',
-    },
-  }}
-  height={100}
-  width={100}
-/>
-          `}
+            sandpackExample={
+              <SandpackExample
+                code={dangerouslySetInlineStyle}
+                name="dangerouslySetInlineStyle Example"
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -108,14 +107,9 @@ _Alternative_: When possible, stick to the styles available on Gestalt component
 `}
         >
           <MainSection.Card
-            cardSize="lg" // this actually makes the rendered element smaller, which is desired
-            defaultCode={`
-<Text color="error">
-  <span style={{ fontFamily: 'cursive' }}>
-    Custom text
-  </span>
-</Text>
-          `}
+            sandpackExample={
+              <SandpackExample code={wrappingComponents} name="Wrapping Components Example" />
+            }
           />
         </MainSection.Subsection>
 
@@ -136,30 +130,7 @@ Components that accept refs (e.g. [Box](/web/box), [Button](/web/button), etc) c
 **Alternative:** When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
 `}
         >
-          <MainSection.Card
-            cardSize="lg" // this actually makes the rendered element smaller, which is desired
-            defaultCode={`
-function RefExample() {
-  const buttonRef = React.useRef();
-
-  React.useEffect(() => {
-    if (buttonRef.current) {
-      buttonRef.current.style.backgroundColor = 'aquamarine';
-    }
-  }, [buttonRef]);
-
-  return (
-    <Button
-      accessibilityLabel='Menu'
-      iconEnd="arrow-down"
-      ref={buttonRef}
-      size="lg"
-      text="Menu"
-    />
-  );
-}
-          `}
-          />
+          <MainSection.Card sandpackExample={<SandpackExample code={ref} name="Ref Example" />} />
         </MainSection.Subsection>
 
         <MainSection.Subsection

--- a/docs/pages/get_started/developers/hacking_gestalt.js
+++ b/docs/pages/get_started/developers/hacking_gestalt.js
@@ -103,7 +103,7 @@ Certain components have styles that can be overridden when wrapped by (or wrappe
 - Your UI may look disjointed with the rest of the design system
 - Overridden styles will not respond to dark mode or RTL
 
-_Alternative_: When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
+**Alternative**: When possible, stick to the styles available on Gestalt components natively. If your design calls for unsupported styles, please feel free to contact us to chat about design options.
 `}
         >
           <MainSection.Card
@@ -144,7 +144,7 @@ It is possible to use CSS selectors to peer "under the hood" of Gestalt componen
 - This is very, very brittle and subject to breaking changes at any point; we do not consider breaking changes to the underlying DOM structure when determining [semver](https://semver.org/) so even \`patch\` changes could break your UI
 - Overridden styles will not respond to dark mode or RTL
 
-_Alternative_: Absolutely anything — this is just about the worst way to hack Gestalt components. Your UI _will_ break in the future. Consider using a [ref](#Refs) if possible.
+**Alternative**: Absolutely anything — this is just about the worst way to hack Gestalt components. Your UI _will_ break in the future. Consider using a [ref](#Refs) if possible.
 `}
         />
       </MainSection>


### PR DESCRIPTION
Of note: the previous ref example was no longer functional (pretty good indicator of why this isn't a great technique! 😅), so I updated to use TextField instead:
![Screen Shot 2022-10-12 at 2 57 19 PM](https://user-images.githubusercontent.com/12059539/195455782-5cc71050-16cc-42f6-b9fb-ca2a6b15c085.png)
