### PR TITLE
DefaultLabelProvider: add comments about updating translations

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
+++ b/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
@@ -1,26 +1,9 @@
 // @flow strict-local
 import { useState } from 'react';
 import { act, render, screen, fireEvent } from '@testing-library/react';
-import { DefaultLabelProvider } from 'gestalt';
 import DatePicker from './DatePicker.js';
 
-const accessibilityLabels = {
-  ModalAlert: {
-    accessibilityDismissButtonLabel: 'Close modal',
-  },
-  ComboBox: {
-    accessibilityClearButtonLabel: 'Clear input',
-  },
-  TextField: {
-    accessibilityHidePasswordLabel: 'Hide password',
-    accessibilityShowPasswordLabel: 'Show password',
-  },
-};
 const initialDate = new Date(2018, 11, 14);
-
-function renderComp(comp) {
-  return render(<DefaultLabelProvider labels={accessibilityLabels}>{comp}</DefaultLabelProvider>);
-}
 
 function DatePickerWrap() {
   const [date, setDate] = useState(initialDate);
@@ -41,7 +24,7 @@ describe('DatePicker', () => {
   });
 
   it('displays TextField with given initial date', () => {
-    renderComp(<DatePicker id="fake_id" onChange={() => {}} value={initialDate} />);
+    render(<DatePicker id="fake_id" onChange={() => {}} value={initialDate} />);
     // We only check for selected value upon rendering,
     // because onChange logic is outside DatePicker
     // So initial date value does not change upon firing click event
@@ -51,7 +34,7 @@ describe('DatePicker', () => {
   it('passes clicked date to onChange prop', () => {
     const newDate = new Date(2018, 11, 13);
 
-    renderComp(
+    render(
       <DatePicker
         id="fake_id"
         onChange={mockOnChange}
@@ -73,7 +56,7 @@ describe('DatePicker', () => {
   });
 
   test('opens and closes DatePicker popover correctly', async () => {
-    renderComp(<DatePickerWrap />);
+    render(<DatePickerWrap />);
 
     // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
     await act(async () => {
@@ -106,7 +89,7 @@ describe('DatePicker', () => {
   });
 
   test('accepts entering manual dates', async () => {
-    renderComp(<DatePickerWrap />);
+    render(<DatePickerWrap />);
 
     // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
     await act(async () => {

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.js
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.js
@@ -6,6 +6,11 @@ import { type Context, type Node, createContext, useContext } from 'react';
  * - Create a type for the component's labels (these types need to be flat, *not* nested)
  * - Add component labels type to DefaultLabelContextType keyed by component name
  * - Add fallback labels to fallbackLabels below
+ * - Update these files with the new labels:
+ *   - Test file for this Provider
+ *      packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.js
+ *   - Docs example for this Provider
+ *      docs/examples/defaultlabelprovider/translations.js
  */
 
 export type DefaultLabelContextType = {|


### PR DESCRIPTION
also removing the Provider from the DatePicker test file for now — we can re-add it when needed