### PR TITLE
Design Tokens: Add transparent token

### DIFF
--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -313,6 +313,10 @@
         "darkValue": "{color.red.pushpin.300.value}",
         "comment": "Used to indicate an error on a contained element, like TextField or TextArea"
       }
+    },
+    "transparent": {
+      "value": "transparent",
+      "comment": "Used for transparent backgrounds and fills"
     }
   }
 }

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -313,10 +313,6 @@
         "darkValue": "{color.red.pushpin.300.value}",
         "comment": "Used to indicate an error on a contained element, like TextField or TextArea"
       }
-    },
-    "transparent": {
-      "value": "transparent",
-      "comment": "Used for transparent backgrounds and fills"
     }
   }
 }

--- a/packages/gestalt-design-tokens/tokens/color/base.json
+++ b/packages/gestalt-design-tokens/tokens/color/base.json
@@ -150,6 +150,9 @@
       "cosmicore": {
         "900": { "value": "#111111" }
       }
+    },
+    "transparent": {
+      "value": "transparent"
     }
   }
 }


### PR DESCRIPTION
### Summary

#### What changed?

New transparent base token

#### Why?

Support transparent backgrounds and fills cross-platform