### PR TITLE
Flex: add dataTestId

### DIFF
--- a/packages/gestalt/src/Flex.js
+++ b/packages/gestalt/src/Flex.js
@@ -26,6 +26,10 @@ type Props = {|
    */
   children?: Node,
   /**
+   * Used to identify the element for testing purposes.
+   */
+  dataTestId?: string,
+  /**
    * Establishes the main axis, thus defining the direction flex items are placed in the flex container.
    */
   direction?: 'row' | 'column',
@@ -105,6 +109,7 @@ const allowedProps = [
 export default function Flex({
   alignItems,
   children: childrenProp,
+  dataTestId,
   direction = 'row',
   gap = 0,
   justifyContent,
@@ -141,7 +146,7 @@ export default function Flex({
     allowlistProps: allowedProps,
   });
 
-  return <div {...passthroughProps} {...propsStyles} />;
+  return <div {...passthroughProps} {...propsStyles} data-test-id={dataTestId} />;
 }
 
 Flex.Item = FlexItem;

--- a/packages/gestalt/src/FlexItem.js
+++ b/packages/gestalt/src/FlexItem.js
@@ -15,6 +15,10 @@ export type Props = {|
    */
   children?: Node,
   /**
+   * Used to identify the element for testing purposes.
+   */
+  dataTestId?: string,
+  /**
    * Defines how the flex item will be sized. `"grow"`, equivalent to `"flex: 1 1 auto"`, will size Flex.Item relative to its parent, growing and shrinking based on available space. `"shrink"`, equivalent to `"flex: 0 1 auto"` (the browser default), allows Flex.Item to shrink if compressed but not grow if given extra space. Finally, `"none"`, equivalent to `"flex: 0 0 auto"`, preserves Flex.Item's size based on child content regardless of its container's size.
    * Default: 'shrink'
    */
@@ -38,14 +42,14 @@ const allowedProps = ['alignSelf', 'children', 'flex', 'flexBasis', 'maxWidth', 
 /**
  * Use [Flex.Item](https://gestalt.pinterest.systems/web/flex) within a Flex container for more precise control over the child element. Flex children that are not explicitly wrapped in Flex.Item will be wrapped in the the component automatically to apply `gap` spacing.
  */
-export default function FlexItem(props: Props): Node {
+export default function FlexItem({ dataTestId, ...rest }: Props): Node {
   const { passthroughProps, propsStyles } = buildStyles<Props>({
     baseStyles: styles.FlexItem,
-    props,
+    props: rest,
     allowlistProps: allowedProps,
   });
 
-  return <div {...passthroughProps} {...propsStyles} />;
+  return <div {...passthroughProps} {...propsStyles} data-test-id={dataTestId} />;
 }
 
 FlexItem.displayName = 'Flex.Item';


### PR DESCRIPTION
This is a common request from folks, and often either results in people using Box instead, or wrapping Flex in an additional Box just to set the id (resulting in DOM bloat).

This could be implemented as a passthrough prop (similar to Box), but I think that's a leaky abstraction. Though it is a passthrough component under the hood, we don't treat Flex as such. And we shouldn't expect our users to know how Flex is implemented. Therefore, I implemented this as an "official" new prop, `dataTestId`. This matches our other non-Box test ids.

## Future work

I need to update the existing `prefer-flex` lint rule to accommodate this new prop.

I'll also look at ways of finding and refactoring Boxes that wrap Flexes only for the test id.