### PR TITLE
Box: make dataTestId an explicit prop

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -42,7 +42,7 @@ function GestaltApp(
   if (router.pathname.startsWith('/visual-test/')) {
     return (
       <Providers isMobile={isMobile}>
-        <Box data-test-id="visual-test" display="inlineBlock">
+        <Box dataTestId="visual-test" display="inlineBlock">
           <Component {...pageProps} />
         </Box>
       </Providers>

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -73,7 +73,7 @@ export default function Avatar(props: Props): Node {
       height={height}
       position="relative"
       rounding="circle"
-      data-test-id="gestalt-avatar-svg"
+      dataTestId="gestalt-avatar-svg"
     >
       {src && isImageLoaded ? (
         <Mask rounding="circle" wash>

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -183,6 +183,10 @@ type Props = {
    */
   lgColumn?: Column,
   /**
+   * Used to identify the element for testing purposes.
+   */
+  dataTestId?: string,
+  /**
    * Establishes the main-axis, thus defining the direction flex items are placed in the flex container.
    *
    * Learn more about Flexbox layouts on [MDN](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox). If you're using Box strictly for Flexbox layouts, check out [Flex](https://gestalt.pinterest.systems/web/flex)!
@@ -542,7 +546,7 @@ type OutputType = Element<As>;
  *
  */
 const BoxWithForwardRef: AbstractComponent<Props, HTMLElement> = forwardRef<Props, HTMLElement>(
-  function Box({ as, ...props }: Props, ref): OutputType {
+  function Box({ as, dataTestId, ...props }: Props, ref): OutputType {
     const { passthroughProps, propsStyles } = buildStyles<$Diff<Props, {| as?: As |}>>({
       baseStyles: styles.box,
       props,
@@ -552,7 +556,9 @@ const BoxWithForwardRef: AbstractComponent<Props, HTMLElement> = forwardRef<Prop
     const BoxElement: As = as ?? 'div';
 
     // And... magic!
-    return <BoxElement {...passthroughProps} {...propsStyles} ref={ref} />;
+    return (
+      <BoxElement {...passthroughProps} {...propsStyles} data-test-id={dataTestId} ref={ref} />
+    );
   },
 );
 

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -521,19 +521,10 @@ type Props = {
 // to strip out a few naughty properties that break style encapsulation
 // (className, style) or accessibility (onClick).
 const disallowedProps = [
-  'onClick',
   'className',
+  'data-test-id', // in favor of the dataTestId prop
+  'onClick',
   'style',
-  // We're currently also explicitly disallowing the deprecated marginLeft/Right
-  // props, as they're not RTL-friendly.
-  'marginLeft',
-  'smMarginLeft',
-  'mdMarginLeft',
-  'lgMarginLeft',
-  'marginRight',
-  'smMarginRight',
-  'mdMarginRight',
-  'lgMarginRight',
 ];
 
 type OutputType = Element<As>;

--- a/packages/gestalt/src/ScrollBoundaryContainer.jsdom.test.js
+++ b/packages/gestalt/src/ScrollBoundaryContainer.jsdom.test.js
@@ -11,7 +11,7 @@ describe('ScrollBoundaryContainer', () => {
 
     const { getByTestId } = render(
       <ScrollBoundaryContainer overflow="scroll">
-        <Box data-test-id="childrenId" ref={ref} />
+        <Box dataTestId="childrenId" ref={ref} />
       </ScrollBoundaryContainer>,
     );
 


### PR DESCRIPTION
As a follow-up to #2451, this PR adds an explicit `dataTestId` prop to Box. Previously we've relied on the passthrough nature of Box to allow users to use `data-test-id`. However, this is a leaky abstraction, as the user has to be aware of the implementation of Box to know that they can pass through this undocumented "prop". By making this prop explicit, we ensure that users who are unfamiliar with Gestalt are able to easily add the test ids needed.

## CODEMOD

```bash
yarn codemod modifyProp ~/path/to/your/code --component=Box --previousProp='data-test-id' --nextProp=dataTestId
```