### PR TITLE
Toast: deprecating value thumbnailShape=rectangular 

### DIFF
--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -267,7 +267,7 @@ function ToastExample() {
           layout="12column"
           name="Combinations: Thumbnail shapes"
           showValues={false}
-          thumbnailShape={['circle', 'rectangle', 'square']}
+          thumbnailShape={['circle', 'square']}
         >
           {(props) => (
             <Toast

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -29,7 +29,7 @@ type Props = {|
   /**
    * The masked shape of the thumbnail.
    */
-  thumbnailShape?: 'circle' | 'rectangle' | 'square',
+  thumbnailShape?: 'circle' | 'square',
   /**
    * Use the `'error'` variant to indicate an error message. Generally not recommended given the ephemeral nature of Toasts.
    */


### PR DESCRIPTION
# Breaking change

Removing prop value thumbnailShape=**rectangular**

Run the following codemode to replace rectangular to square 

```
yarn codemod modifyPropValue ~/path/to/your/code
  --component=Toast
  --previousProp=thumbnailShape
  --previousValue=rectangular
  --nextValue=square
```
Run the following codemode to locate  rectangular value for manual change

```
yarn codemod detectManualReplacement ~/path/to/your/code
 --component=Toast
 --prop=thumbnailShape
 --value=rectangular
```
### Summary

#### What changed?

Toast: deprecating thumbnailShape=rectangular 

#### Why?

New redesigns deprecate this option. Cleaning up API to facilitate next changes

### Links

- [TDD](https://paper.dropbox.com/doc/Gestalt-TDD-Toast--BreAMsHjKfKyzyNISaHmYW_GAg-EC6LAr0uO808c6GrjH9FO)
- [Figma](https://www.figma.com/file/rVnMTnlB64QbKrF5c6KjUl/Gestalt-Toast-Design?node-id=16%3A402)

