### PR TITLE
Docs: Add top of page examples

### DIFF
--- a/docs/examples/buttongroup/defaultExample.js
+++ b/docs/examples/buttongroup/defaultExample.js
@@ -1,0 +1,14 @@
+// @flow strict
+import { type Node } from 'react';
+import { Button, ButtonGroup, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <ButtonGroup>
+        <Button text="Cancel" />
+        <Button color="red" text="Send" />
+      </ButtonGroup>
+    </Flex>
+  );
+}

--- a/docs/examples/card/defaultExample.js
+++ b/docs/examples/card/defaultExample.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { type Node } from 'react';
+import { Avatar, Button, Box, Card, Flex, Link, Text } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box maxWidth={236} padding={8} column={12}>
+        <Card image={<Avatar name="James Jones" src="https://i.ibb.co/2Fc00R3/james.jpg" />}>
+          <Flex direction="column" justifyContent="center">
+            <Text align="center" weight="bold">
+              <Link href="https://pinterest.com">
+                <Box paddingX={3} paddingY={2}>
+                  James Jones
+                </Box>
+              </Link>
+            </Text>
+            <Button accessibilityLabel="Follow James Jones" color="red" text="Follow" />
+          </Flex>
+        </Card>
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/segmentedcontrol/defaultExample.js
+++ b/docs/examples/segmentedcontrol/defaultExample.js
@@ -1,0 +1,27 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Text, SegmentedControl, Icon } from 'gestalt';
+
+export default function Example(): Node {
+  const [itemIndex, setItemIndex] = useState(0);
+  const items = [
+    'News',
+    'You',
+    'Messages',
+    <Icon key="pin-icon" icon="pin" accessibilityLabel="Pin" color="default" />,
+  ];
+  const content = ['News content', 'You content', 'Messages content', 'Pins content'];
+  return (
+    <Box padding={4} height="100%">
+      <SegmentedControl
+        items={items}
+        selectedItemIndex={itemIndex}
+        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
+      />
+
+      <Box borderStyle="sm" marginTop={2} padding={6} rounding={2} height="80%">
+        <Text>{content[itemIndex]}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/tag/defaultExample.js
+++ b/docs/examples/tag/defaultExample.js
@@ -1,0 +1,11 @@
+// @flow strict
+import { type Node } from 'react';
+import { Tag, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Tag onRemove={() => {}} removeIconAccessibilityLabel="Remove New tag" text="New" />
+    </Flex>
+  );
+}

--- a/docs/pages/web/buttongroup.js
+++ b/docs/pages/web/buttongroup.js
@@ -8,11 +8,15 @@ import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import defaultExample from '../../examples/buttongroup/defaultExample.js';
 
 export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description} />
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
+        <SandpackExample code={defaultExample} name="ButtonGroup Main Example" hideEditor />
+      </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/web/card.js
+++ b/docs/pages/web/card.js
@@ -8,11 +8,15 @@ import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import Page from '../../docs-components/Page.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import defaultExample from '../../examples/card/defaultExample.js';
 
 export default function CardPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Card">
-      <PageHeader name="Card" description={generatedDocGen?.description} />
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
+        <SandpackExample code={defaultExample} name="Card Main Example" hideEditor />
+      </PageHeader>
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>

--- a/docs/pages/web/segmentedcontrol.js
+++ b/docs/pages/web/segmentedcontrol.js
@@ -8,11 +8,15 @@ import PageHeader from '../../docs-components/PageHeader.js';
 import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import defaultExample from '../../examples/segmentedcontrol/defaultExample.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="SegmentedControl">
-      <PageHeader name="SegmentedControl" description={generatedDocGen?.description} />
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
+        <SandpackExample code={defaultExample} name="SegmentedControl Main Example" hideEditor />
+      </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/web/tag.js
+++ b/docs/pages/web/tag.js
@@ -8,11 +8,15 @@ import Page from '../../docs-components/Page.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import defaultExample from '../../examples/tag/defaultExample.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
+        <SandpackExample code={defaultExample} name="Tag Main Example" hideEditor />
+      </PageHeader>
 
       <PropTable
         componentName={generatedDocGen?.displayName}


### PR DESCRIPTION
### Summary

#### What changed?

Add top-of-page example to Tag, Card, SegmentedControl, and ButtonGroup

#### Why?

Ensure folks can see the component at first glance 


