### PR TITLE
Docs: Update to new copy-to-clipboard icon

### DIFF
--- a/docs/docs-components/PropTable.js
+++ b/docs/docs-components/PropTable.js
@@ -235,7 +235,7 @@ export default function PropTable({
 
                             <IconButton
                               accessibilityLabel="Copy Flow type"
-                              icon="drag-drop"
+                              icon="copy-to-clipboard"
                               iconColor="darkGray"
                               onClick={() => {
                                 trackButtonClick('Copy Flow type', `${componentName} - ${name}`);

--- a/docs/docs-components/buttons/CopyCodeButton.js
+++ b/docs/docs-components/buttons/CopyCodeButton.js
@@ -13,7 +13,7 @@ export default function CopyCodeButton({ onClick }: Props): Node {
   return (
     <IconButton
       accessibilityLabel={label}
-      icon="drag-drop"
+      icon="copy-to-clipboard"
       iconColor="darkGray"
       onClick={() => {
         trackButtonClick(label);


### PR DESCRIPTION
### Summary

#### What changed?

Replace drag and drop icon with copy-to-clipboard icon

Before
![Screen Shot 2022-10-27 at 11 22 43 AM](https://user-images.githubusercontent.com/5125094/198368728-7d9e241e-2368-4d9c-9350-47b476a4a73c.png)


After
![Screen Shot 2022-10-27 at 11 22 28 AM](https://user-images.githubusercontent.com/5125094/198368761-39725981-a552-4f72-8b86-fd9c5f9bce4f.png)
