### PR TITLE
Icons: Update Icon library page

### DIFF
--- a/docs/docs-components/siteIndex.js
+++ b/docs/docs-components/siteIndex.js
@@ -173,7 +173,7 @@ const siteIndex: $ReadOnlyArray<siteIndexType> = [
       'Elevation',
       {
         sectionName: 'Iconography',
-        pages: ['Library', 'Usage', 'Creating icons'],
+        pages: ['Library', 'Custom and brand icons', 'Usage', 'Creating icons'],
       },
       'Layouts',
       {

--- a/docs/pages/foundations/iconography/ICON_DATA.json
+++ b/docs/pages/foundations/iconography/ICON_DATA.json
@@ -1,0 +1,805 @@
+{
+  "icons": [
+    {
+      "name": "add",
+      "categories": "Add"
+    },
+    {
+      "name": "add-circle",
+      "categories": "Add"
+    },
+    {
+      "name": "add-layout",
+      "categories": "Add"
+    },
+    {
+      "name": "add-person",
+      "categories": "Add"
+    },
+    {
+      "name": "add-pin",
+      "categories": "Add"
+    },
+    {
+      "name": "ad",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "ad-group",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "ads-overview",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "ads-stats",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "graph-bar",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "graph-pie",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "insights-audience",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "insights-conversions",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "overview",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "target",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "trending",
+      "categories": "Ads and measurements"
+    },
+    {
+      "name": "align-bottom",
+      "categories": "Alignment"
+    },
+    {
+      "name": "align-bottom-center",
+      "categories": "Alignment"
+    },
+    {
+      "name": "align-bottom-left",
+      "categories": "Alignment"
+    },
+    {
+      "name": "align-bottom-right",
+      "categories": "Alignment"
+    },
+    {
+      "name": "align-middle",
+      "categories": "Alignment"
+    },
+    {
+      "name": "align-top",
+      "categories": "Alignment"
+    },
+    {
+      "name": "align-top-center",
+      "categories": "Alignment"
+    },
+    {
+      "name": "align-top-left",
+      "categories": "Alignment"
+    },
+    {
+      "name": "align-top-right",
+      "categories": "Alignment"
+    },
+    {
+      "name": "arrow-back",
+      "categories": ["Arrows", "Platform specific"]
+    },
+    {
+      "name": "arrow-circle-down",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-circle-forward",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-circle-left",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-circle-up",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-counter-clockwise",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-down",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-end",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-forward",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-start",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-up",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-up-left",
+      "categories": "Arrows"
+    },
+    {
+      "name": "arrow-up-right",
+      "categories": "Arrows"
+    },
+    {
+      "name": "scale",
+      "categories": ["Arrows", "Utility and tools"]
+    },
+    {
+      "name": "switch-account",
+      "categories": "Arrows"
+    },
+    {
+      "name": "minimize",
+      "categories": ["Arrows", "Utility and tools"]
+    },
+    {
+      "name": "maximize",
+      "categories": ["Arrows", "Utility and tools"]
+    },
+    {
+      "name": "chevron-up-circle",
+      "categories": "Arrows"
+    },
+    {
+      "name": "directional-arrow-left",
+      "categories": ["Arrows", "Platform specific"]
+    },
+    {
+      "name": "directional-arrow-right",
+      "categories": "Arrows"
+    },
+    {
+      "name": "sort-ascending",
+      "categories": "Arrows"
+    },
+    {
+      "name": "sort-descending",
+      "categories": "Arrows"
+    },
+    {
+      "name": "camera",
+      "categories": "Media controls"
+    },
+    {
+      "name": "camera-roll",
+      "categories": "Media controls"
+    },
+    {
+      "name": "captions",
+      "categories": "Media controls"
+    },
+    {
+      "name": "forward",
+      "categories": "Media controls"
+    },
+    {
+      "name": "flash",
+      "categories": "Media controls"
+    },
+    {
+      "name": "mute",
+      "categories": ["Media controls", "Toggle"]
+    },
+    {
+      "name": "music-off",
+      "categories": ["Media controls", "Toggle"]
+    },
+    {
+      "name": "music-on",
+      "categories": ["Media controls", "Toggle"]
+    },
+    {
+      "name": "pause",
+      "categories": "Media controls"
+    },
+    {
+      "name": "play",
+      "categories": "Media controls"
+    },
+    {
+      "name": "rewind",
+      "categories": "Media controls"
+    },
+    {
+      "name": "sound",
+      "categories": ["Media controls", "Toggle"]
+    },
+    {
+      "name": "video-camera",
+      "categories": "Media controls"
+    },
+    {
+      "name": "android-share",
+      "categories": "Platform specific"
+    },
+    {
+      "name": "check",
+      "categories": "Platform specific"
+    },
+    {
+      "name": "hand-pointing",
+      "categories": "Platform specific"
+    },
+    {
+      "name": "share",
+      "categories": "Platform specific"
+    },
+    {
+      "name": "send",
+      "categories": "Platform specific"
+    },
+    {
+      "name": "face-happy",
+      "categories": "Reactions and ratings"
+    },
+    {
+      "name": "face-neutral",
+      "categories": "Reactions and ratings"
+    },
+    {
+      "name": "face-sad",
+      "categories": "Reactions and ratings"
+    },
+    {
+      "name": "face-smiley",
+      "categories": "Reactions and ratings"
+    },
+    {
+      "name": "heart",
+      "categories": ["Reactions and ratings", "Toggle"]
+    },
+    {
+      "name": "heart-outline",
+      "categories": ["Reactions and ratings", "Toggle"]
+    },
+    {
+      "name": "star",
+      "categories": "Reactions and ratings"
+    },
+    {
+      "name": "star-half",
+      "categories": "Reactions and ratings"
+    },
+    {
+      "name": "smiley-outline",
+      "categories": "Reactions and ratings"
+    },
+    {
+      "name": "facebook",
+      "categories": "Social"
+    },
+    {
+      "name": "gmail",
+      "categories": "Social"
+    },
+    {
+      "name": "google-plus",
+      "categories": "Social"
+    },
+    {
+      "name": "twitter",
+      "categories": "Social"
+    },
+    {
+      "name": "pinterest",
+      "categories": ["Social", "Utility and tools"]
+    },
+    {
+      "name": "workflow-status-all",
+      "categories": "Status"
+    },
+    {
+      "name": "workflow-status-canceled",
+      "categories": "Status"
+    },
+    {
+      "name": "workflow-status-halted",
+      "categories": "Status"
+    },
+    {
+      "name": "workflow-status-in-progress",
+      "categories": "Status"
+    },
+    {
+      "name": "workflow-status-ok",
+      "categories": "Status"
+    },
+    {
+      "name": "workflow-status-problem",
+      "categories": "Status"
+    },
+    {
+      "name": "workflow-status-unstarted",
+      "categories": "Status"
+    },
+    {
+      "name": "workflow-status-warning",
+      "categories": "Status"
+    },
+    {
+      "name": "alphabetical",
+      "categories": "Text"
+    },
+    {
+      "name": "text-align-center",
+      "categories": "Text"
+    },
+    {
+      "name": "text-align-left",
+      "categories": "Text"
+    },
+    {
+      "name": "text-align-right",
+      "categories": "Text"
+    },
+    {
+      "name": "text-all-caps",
+      "categories": "Text"
+    },
+    {
+      "name": "text-extra-small",
+      "categories": "Text"
+    },
+    {
+      "name": "text-large",
+      "categories": "Text"
+    },
+    {
+      "name": "text-line-height",
+      "categories": "Text"
+    },
+    {
+      "name": "text-medium",
+      "categories": "Text"
+    },
+    {
+      "name": "overlay-text",
+      "categories": "Text"
+    },
+    {
+      "name": "text-sentence-case",
+      "categories": "Text"
+    },
+    {
+      "name": "text-size",
+      "categories": "Text"
+    },
+    {
+      "name": "text-small",
+      "categories": "Text"
+    },
+    {
+      "name": "text-spacing",
+      "categories": "Text"
+    },
+    {
+      "name": "calendar",
+      "categories": "Time"
+    },
+    {
+      "name": "clock",
+      "categories": "Time"
+    },
+    {
+      "name": "history",
+      "categories": "Time"
+    },
+    {
+      "name": "eye",
+      "categories": "Toggle"
+    },
+    {
+      "name": "eye-hide",
+      "categories": "Toggle"
+    },
+    {
+      "name": "globe",
+      "categories": "Toggle"
+    },
+    {
+      "name": "globe-checked",
+      "categories": "Toggle"
+    },
+    {
+      "name": "360",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "accessibility",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "apps",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "alert",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "angled-pin",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "bell",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "cancel",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "canonical-pin",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "check-circle",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "clear",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "code",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "color-picker",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "color-solid",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "color-split",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "compass",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "compose",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "conversion-tag",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "copy-to-clipboard",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "credit-card",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "crop",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "dash",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "download",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "drag-drop",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "duplicate",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "edit",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "ellipsis",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "envelope",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "file-box",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "file-unknown",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "fill-opaque",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "fill-transparent",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "filter",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "folder",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "flag",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "flashlight",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "flip-horizontal",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "flip-vertical",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "gif",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "handle",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "home",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "idea-pin",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "impressum",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "info-circle",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "information",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "key",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "knoop",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "layout",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "lightbulb",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "lips",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "link",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "location",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "lock",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "logo-large",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "logo-small",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "logout",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "megaphone",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "menu",
+      "categories": "Utility and tools"
+    },
+
+    {
+      "name": "nut",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "people",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "person",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "phone",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "pin",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "pincode",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "publish",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "question-mark",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "refresh",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "reorder-images",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "replace",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "report",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "remove",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "rotate",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "search",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "security",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "shopping-bag",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "skintone",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "sparkle",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "speech",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "speech-ellipsis",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "speech-exclamation-point",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "story-pin",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "tag",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "terms",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "trash-can",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "upload-feed",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "visit",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "margins-large",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "margins-medium",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "margins-small",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "view-type-default",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "view-type-dense",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "view-type-list",
+      "categories": "Utility and tools"
+    },
+    {
+      "name": "view-type-space",
+      "categories": "Utility and tools"
+    }
+  ]
+}

--- a/docs/pages/foundations/iconography/custom_and_brand_icons.js
+++ b/docs/pages/foundations/iconography/custom_and_brand_icons.js
@@ -11,7 +11,7 @@ export default function IconPage(): Node {
       <MainSection name="Custom SVG icons">
         <MainSection.Subsection
           description={`
-If you need a new icon for an experiment that is not listed on our [Icon](/web/icon) documentation, use the \`dangerouslySetSvgPath\` prop on [Icon](/web/icon), [IconButton](/web/iconbutton), and [Pog](/web/pog).
+If you need a new icon for an experiment that is not listed on our [Icon](/web/icon) documentation, use the \`dangerouslySetSvgPath\` prop on [Icon](/web/icon), [IconButton](/web/iconbutton) or [Pog](/web/pog).
 
 However, \`dangerouslySetSvgPath\` only works with one SVG path. For icons with multiple paths and groups, use [Box](/web/box) and \`dangerouslySetInlineStyle\` to pass the custom icon as \`backgroundImage\`.
 
@@ -19,13 +19,15 @@ Once your experiment ships to 100%, ask your designer to follow the directions i
 
 Gestalt icon svg files follow a particular format and use automatic file validation testing.
 
-\`<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+\`
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
 <path d="_______________"/>
-</svg>\`
+</svg>
+\`
 
-We override the color in the Gestalt Icon component and Gestalt only uses the \`d\` attribute in the \`path\` tag and the basic attributes for visualizing the raw file in the \`svg\` tag . For consistency, we don't include unnecessary attributes in the \`svg\` and \`path\` tags.
+We override the color in the Gestalt Icon component and Gestalt only uses the \`d\` attribute in the \`path\` tag and the basic attributes for visualizing the raw file in the \`svg\` tag . For consistency and for smaller bundle sizes, we don't include unnecessary attributes in the \`svg\` and \`path\` tags.
 
-We recommend streamlining (removing strokes, transforms, etc.) and optimizing the SVGs to improve performance and the pinner experience using the tools [svgo](https://github.com/svg/svgo) or [ImageOptim](https://imageoptim.com/mac)
+We recommend streamlining (removing strokes, transforms, etc.) and optimizing the SVGs to improve performance and the Pinner experience using the tools [svgo](https://github.com/svg/svgo) or [ImageOptim](https://imageoptim.com/mac).
 
 To use svgo, install
 

--- a/docs/pages/foundations/iconography/custom_and_brand_icons.js
+++ b/docs/pages/foundations/iconography/custom_and_brand_icons.js
@@ -1,0 +1,48 @@
+// @flow strict
+import { type Node } from 'react';
+import MainSection from '../../../docs-components/MainSection.js';
+import Page from '../../../docs-components/Page.js';
+import PageHeader from '../../../docs-components/PageHeader.js';
+
+export default function IconPage(): Node {
+  return (
+    <Page title="Custom and brand icons">
+      <PageHeader name="Custom and brand icons" folderName="icons" type="guidelines" />
+      <MainSection name="Custom SVG icons">
+        <MainSection.Subsection
+          description={`
+If you need a new icon for an experiment that is not listed on our [Icon](/web/icon) documentation, use the \`dangerouslySetSvgPath\` prop on [Icon](/web/icon), [IconButton](/web/iconbutton), and [Pog](/web/pog).
+
+However, \`dangerouslySetSvgPath\` only works with one SVG path. For icons with multiple paths and groups, use [Box](/web/box) and \`dangerouslySetInlineStyle\` to pass the custom icon as \`backgroundImage\`.
+
+Once your experiment ships to 100%, ask your designer to follow the directions in the [Icon kit](https://www.figma.com/file/N60WnDx9j6Moz3Dt1rNsq9/Icon-Kit). Once the asset is ready, we can add the icon to Gestalt.
+
+Gestalt icon svg files follow a particular format and use automatic file validation testing.
+
+\`<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+<path d="_______________"/>
+</svg>\`
+
+We override the color in the Gestalt Icon component and Gestalt only uses the \`d\` attribute in the \`path\` tag and the basic attributes for visualizing the raw file in the \`svg\` tag . For consistency, we don't include unnecessary attributes in the \`svg\` and \`path\` tags.
+
+We recommend streamlining (removing strokes, transforms, etc.) and optimizing the SVGs to improve performance and the pinner experience using the tools [svgo](https://github.com/svg/svgo) or [ImageOptim](https://imageoptim.com/mac)
+
+To use svgo, install
+
+\`npm -g install svgo\`
+
+and run
+
+\`svgo -f packages/gestalt/src/icons --config=packages/gestalt/src/icons/svgo.config.js\``}
+        />
+      </MainSection>
+      <MainSection name="Brand icons">
+        <MainSection.Subsection
+          description={`
+  All brand icons are trademarks of their respective owners. The inclusion of these trademarks does not indicate endorsement of the trademark holder by Pinterest, nor vice-versa. Please do not use brand logos for any purpose except to represent the company, product, or service to which they refer.
+  `}
+        />
+      </MainSection>
+    </Page>
+  );
+}

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -73,7 +73,6 @@ function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void 
         borderStyle="sm"
         rounding={2}
         padding={2}
-        paddingX={2}
         width={150}
         height={110}
         color={hovered ? 'inverse' : 'default'}
@@ -165,21 +164,21 @@ export default function IconPage(): Node {
   const renderIconTiles = () =>
     sortedAlphabetical ? (
       <Flex gap={3} wrap>
-        {(suggestedOptions || iconOptions).map(({ label: iconName }, index) => {
+        {(suggestedOptions || iconOptions).map(({ label: iconName }) => {
           const icon = findIcon(iconName);
           return icon ? (
-            <IconTile key={index} iconName={icon} onTap={buildHandleIconClick(icon)} />
+            <IconTile key={iconName} iconName={icon} onTap={buildHandleIconClick(icon)} />
           ) : null;
         })}
       </Flex>
     ) : (
-      CATEGORIES.map((category, idx) => {
+      CATEGORIES.map((category) => {
         const iconsToRenderByCategory = (suggestedOptions || iconOptions).map(
-          ({ label: iconName }, index) => {
+          ({ label: iconName }) => {
             const iconData = findIconByCategory(iconName, category);
             return iconData ? (
               <IconTile
-                key={index}
+                key={iconName}
                 iconName={iconData.name}
                 onTap={buildHandleIconClick(iconData.name)}
               />
@@ -190,7 +189,7 @@ export default function IconPage(): Node {
           return null;
         }
         return (
-          <Flex key={idx} direction="column" gap={4}>
+          <Flex key={category} direction="column" gap={4}>
             <Heading size="400">{category}</Heading>
             <Flex gap={3} wrap>
               {iconsToRenderByCategory}

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -66,14 +66,16 @@ function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void 
       onTap={onTap}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      onFocus={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
     >
       <Box
         borderStyle="sm"
         rounding={2}
         padding={2}
-        paddingX={hovered ? 6 : 2}
-        width={180}
-        height={90}
+        paddingX={2}
+        width={150}
+        height={110}
         color={hovered ? 'inverse' : 'default'}
         position="relative"
       >
@@ -83,7 +85,7 @@ function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void 
           direction="column"
           gap={2}
           alignItems="center"
-          justifyContent="end"
+          justifyContent="center"
         >
           <Icon
             color={hovered ? 'inverse' : 'default'}
@@ -280,17 +282,6 @@ export default function IconPage(): Node {
             </Box>
           </Layer>
         )}
-      </MainSection>
-
-      <MainSection name="Accessibility">
-        <MainSection.Subsection
-          description="
-- Icons must meet the [Non-Text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) requirement.
-- Avoid using unfamiliar icons. Always refer to Gestalt available icons. A new icon needs to be user tested to evaluate comprehension.
-- Icons should be universal across cultures, regions, ages, and backgrounds without need for translation. Be mindful of your audience and use symbols and labels that resonate with them.
-- Some icons don't translate well in all cultures, so it's preferred to user-test each icon before it is added to Gestalt.
-"
-        />
       </MainSection>
     </Page>
   );

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -1,19 +1,67 @@
 // @flow strict
 import { useState, type Node, type ElementProps } from 'react';
-import { Box, ComboBox, Flex, Icon, RadioGroup, TapArea, Text, Layer, Toast } from 'gestalt';
+import {
+  Box,
+  Flex,
+  Heading,
+  Icon,
+  Pog,
+  Layer,
+  Link,
+  RadioGroup,
+  SearchField,
+  TapArea,
+  Text,
+  Toast,
+} from 'gestalt';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
+// $FlowExpectedError[untyped-import]
+import iconCategoryData from './ICON_DATA.json';
 
 const { icons } = Icon;
+const CATEGORIES = [
+  'Add',
+  'Ads and measurements',
+  'Alignment',
+  'Arrows',
+  'Media controls',
+  'Platform specific',
+  'Reactions and ratings',
+  'Social',
+  'Status',
+  'Text',
+  'Time',
+  'Toggle',
+  'Utility and tools',
+];
+
 type IconName = $NonMaybeType<$ElementType<ElementProps<typeof Icon>, 'icon'>>;
+type IconData = {|
+  name: $NonMaybeType<$ElementType<ElementProps<typeof Icon>, 'icon'>>,
+  category:
+    | 'Add'
+    | 'Ads and measurements'
+    | 'Alignment'
+    | 'Arrows'
+    | 'Media controls'
+    | 'Platform specific'
+    | 'Reactions and ratings'
+    | 'Social'
+    | 'Status'
+    | 'Text'
+    | 'Time'
+    | 'Toggle'
+    | 'Utility and tools',
+|};
 
 function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void |}) {
   const [hovered, setHovered] = useState();
 
   return (
     <TapArea
-      rounding="circle"
+      rounding={2}
       tapStyle="compress"
       onTap={onTap}
       onMouseEnter={() => setHovered(true)}
@@ -23,9 +71,11 @@ function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void 
         borderStyle="sm"
         rounding={2}
         padding={2}
-        width={172}
-        height={84}
+        paddingX={hovered ? 6 : 2}
+        width={180}
+        height={90}
         color={hovered ? 'dark' : 'default'}
+        position="relative"
       >
         <Flex
           height="100%"
@@ -33,17 +83,33 @@ function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void 
           direction="column"
           gap={2}
           alignItems="center"
-          justifyContent="center"
+          justifyContent="end"
         >
           <Icon
             color={hovered ? 'light' : 'default'}
             accessibilityLabel={iconName}
             icon={iconName}
+            size="24"
           />
           <Text color={hovered ? 'light' : 'default'} size="100">
             {iconName}
           </Text>
         </Flex>
+        <Box
+          position="absolute"
+          bottom
+          right
+          display={hovered ? 'block' : 'none'}
+          dangerouslySetInlineStyle={{ __style: { bottom: '8px', right: '8px' } }}
+        >
+          <Pog
+            icon="copy-to-clipboard"
+            size="xs"
+            iconColor="darkGray"
+            bgColor="lightGray"
+            padding={1}
+          />
+        </Box>
       </Box>
     </TapArea>
   );
@@ -51,6 +117,16 @@ function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void 
 
 function findIcon(icon?: string): ?IconName {
   return icons.find((name) => name === icon);
+}
+
+function findIconByCategory(icon?: string, category: string): IconData {
+  // This check ensures there is an actual matching icon in our component
+  // so we don't accidentally show icons that are only in Figma.
+  const iconComponentName = icons.find((name) => name === icon);
+
+  return iconCategoryData.icons.find(
+    ({ name, categories }) => name === iconComponentName && categories.includes(category),
+  );
 }
 
 export default function IconPage(): Node {
@@ -63,23 +139,15 @@ export default function IconPage(): Node {
 
   const [suggestedOptions, setSuggestedOptions] = useState(iconOptions);
   const [inputValue, setInputValue] = useState();
-  const [selected, setSelected] = useState();
-  const [sortedAlphatbetical, setSortedAlphabetical] = useState(true);
+  const [sortedAlphabetical, setSortedAlphabetical] = useState(true);
 
   const handleOnChange = ({ value }) => {
-    setSelected();
     setInputValue(value);
     setSuggestedOptions(
       value
         ? iconOptions.filter(({ label }) => label.toLowerCase().includes(value.toLowerCase()))
         : iconOptions,
     );
-  };
-
-  const handleSelect = ({ item }) => {
-    setInputValue(item.label);
-    setSuggestedOptions(iconOptions);
-    setSelected(item);
   };
 
   const buildHandleIconClick = (iconName: string) => () => {
@@ -92,7 +160,62 @@ export default function IconPage(): Node {
     }
   };
 
-  const selectedIcon = findIcon(selected?.label);
+  const renderIconTiles = () =>
+    sortedAlphabetical ? (
+      <Flex gap={3} wrap>
+        {(suggestedOptions || iconOptions).map(({ label: iconName }, index) => {
+          const icon = findIcon(iconName);
+          return icon ? (
+            <IconTile key={index} iconName={icon} onTap={buildHandleIconClick(icon)} />
+          ) : null;
+        })}
+      </Flex>
+    ) : (
+      CATEGORIES.map((category, idx) => {
+        const iconsToRenderByCategory = (suggestedOptions || iconOptions).map(
+          ({ label: iconName }, index) => {
+            const iconData = findIconByCategory(iconName, category);
+            return iconData ? (
+              <IconTile
+                key={index}
+                iconName={iconData.name}
+                onTap={buildHandleIconClick(iconData.name)}
+              />
+            ) : null;
+          },
+        );
+        if (iconsToRenderByCategory.filter(Boolean).length === 0) {
+          return null;
+        }
+        return (
+          <Flex key={idx} direction="column" gap={4}>
+            <Heading size="400">{category}</Heading>
+            <Flex gap={3} wrap>
+              {iconsToRenderByCategory}
+            </Flex>
+          </Flex>
+        );
+      })
+    );
+
+  const renderEmptyState = () => (
+    <Flex direction="column" gap={3}>
+      <Heading color="error" size="400">
+        No result found
+      </Heading>
+      <Text>
+        It appears we don&apos;t have an icon that matches your search. Check your spelling or try a
+        different search term.
+      </Text>
+      <Text>
+        Need a new icon?{' '}
+        <Link inline href="/get_started/how_to_work_with_us#Slack-channels">
+          Reach out to us
+        </Link>
+        , and we can evaluate your request.
+      </Text>
+    </Flex>
+  );
 
   return (
     <Page title="Iconography collection">
@@ -104,30 +227,18 @@ export default function IconPage(): Node {
       >
         <Flex width="100%" direction="column" gap={8}>
           <Flex gap={6} alignItems="end">
-            <ComboBox
-              accessibilityClearButtonLabel="Clear the current value"
+            <SearchField
+              accessibilityLabel="Search icons by name"
+              autoComplete="off"
+              accessibilityClearButtonLabel="Clear search field"
               label="Search icons by name"
-              id="controlled"
-              inputValue={inputValue}
-              noResultText="No results for your selection"
-              options={suggestedOptions}
-              onBlur={() => {
-                if (!selected) setInputValue('');
-                setSuggestedOptions(iconOptions);
-              }}
-              onClear={() => {
-                setInputValue('');
-                setSelected();
-                setSuggestedOptions(iconOptions);
-              }}
-              selectedOption={selected}
-              placeholder="Search"
+              id="icon-search-field"
               onChange={handleOnChange}
-              onSelect={handleSelect}
+              value={inputValue}
             />
             <RadioGroup legend="Sort by" direction="row" id="directionExample">
               <RadioGroup.RadioButton
-                checked={sortedAlphatbetical}
+                checked={sortedAlphabetical}
                 id="sortAlphabetical"
                 label="Alphabetical"
                 name="sortOrder"
@@ -135,7 +246,7 @@ export default function IconPage(): Node {
                 value="alphabetical"
               />
               <RadioGroup.RadioButton
-                checked={!sortedAlphatbetical}
+                checked={!sortedAlphabetical}
                 id="sortCategory"
                 label="Category"
                 name="sortOrder"
@@ -145,17 +256,8 @@ export default function IconPage(): Node {
             </RadioGroup>
           </Flex>
           <Box>
-            <Flex gap={3} wrap>
-              {selectedIcon ? (
-                <IconTile iconName={selectedIcon} onTap={buildHandleIconClick(selectedIcon)} />
-              ) : (
-                (suggestedOptions || iconOptions).map(({ label: iconName }, index) => {
-                  const icon = findIcon(iconName);
-                  return icon ? (
-                    <IconTile key={index} iconName={icon} onTap={buildHandleIconClick(icon)} />
-                  ) : null;
-                })
-              )}
+            <Flex direction="column" gap={8}>
+              {suggestedOptions.length === 0 ? renderEmptyState() : renderIconTiles()}
             </Flex>
           </Box>
         </Flex>

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -74,7 +74,7 @@ function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void 
         paddingX={hovered ? 6 : 2}
         width={180}
         height={90}
-        color={hovered ? 'dark' : 'default'}
+        color={hovered ? 'inverse' : 'default'}
         position="relative"
       >
         <Flex
@@ -86,12 +86,12 @@ function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void 
           justifyContent="end"
         >
           <Icon
-            color={hovered ? 'light' : 'default'}
+            color={hovered ? 'inverse' : 'default'}
             accessibilityLabel={iconName}
             icon={iconName}
             size="24"
           />
-          <Text color={hovered ? 'light' : 'default'} size="100">
+          <Text color={hovered ? 'inverse' : 'default'} size="100">
             {iconName}
           </Text>
         </Flex>

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -227,16 +227,18 @@ export default function IconPage(): Node {
         description="Use the icon grid to visually search for icons. On click, the icon name will be copied. You can use the search input below to search icons by name, or filter your search by alphabetical or category."
       >
         <Flex width="100%" direction="column" gap={8}>
-          <Flex gap={6} alignItems="end">
-            <SearchField
-              accessibilityLabel="Search icons by name"
-              autoComplete="off"
-              accessibilityClearButtonLabel="Clear search field"
-              label="Search icons by name"
-              id="icon-search-field"
-              onChange={handleOnChange}
-              value={inputValue}
-            />
+          <Flex gap={6} alignItems="end" wrap>
+            <Flex.Item maxWidth={300} flex="grow">
+              <SearchField
+                accessibilityLabel="Search icons by name"
+                autoComplete="off"
+                accessibilityClearButtonLabel="Clear search field"
+                label="Search icons by name"
+                id="icon-search-field"
+                onChange={handleOnChange}
+                value={inputValue}
+              />
+            </Flex.Item>
             <RadioGroup legend="Sort by" direction="row" id="directionExample">
               <RadioGroup.RadioButton
                 checked={sortedAlphabetical}

--- a/docs/pages/foundations/iconography/usage.js
+++ b/docs/pages/foundations/iconography/usage.js
@@ -107,7 +107,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                   alignItems="center"
                   width={64}
                 >
-                  <Icon icon="home" accessibilityLabel="home" size={24} color="dark" />
+                  <Icon icon="home" accessibilityLabel="home" size={24} color="default" />
                   <Text size="100">home</Text>
                 </Flex>
                 <Flex
@@ -119,7 +119,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                   alignItems="center"
                   width={64}
                 >
-                  <Icon icon="heart" accessibilityLabel="heart" size={24} color="dark" />
+                  <Icon icon="heart" accessibilityLabel="heart" size={24} color="default" />
                   <Text size="100">heart</Text>
                 </Flex>
                 <Flex
@@ -131,7 +131,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                   alignItems="center"
                   width={64}
                 >
-                  <Icon icon="lock" accessibilityLabel="lock" size={24} color="dark" />
+                  <Icon icon="lock" accessibilityLabel="lock" size={24} color="default" />
                   <Text size="100">lock</Text>
                 </Flex>
                 <Flex
@@ -143,7 +143,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                   alignItems="center"
                   width={64}
                 >
-                  <Icon icon="trash-can" accessibilityLabel="trash can" size={24} color="dark" />
+                  <Icon icon="trash-can" accessibilityLabel="trash can" size={24} color="default" />
                   <Text size="100">trash-can</Text>
                 </Flex>
               </Flex>
@@ -163,7 +163,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                   alignItems="center"
                   width={64}
                 >
-                  <Icon icon="search" accessibilityLabel="search" size={24} color="dark" />
+                  <Icon icon="search" accessibilityLabel="search" size={24} color="default" />
                   <Text size="100">search</Text>
                 </Flex>
                 <Flex
@@ -175,7 +175,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                   alignItems="center"
                   width={64}
                 >
-                  <Icon icon="calendar" accessibilityLabel="calendar" size={24} color="dark" />
+                  <Icon icon="calendar" accessibilityLabel="calendar" size={24} color="default" />
                   <Text size="100">calendar</Text>
                 </Flex>
                 <Flex
@@ -187,7 +187,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                   alignItems="center"
                   width={64}
                 >
-                  <Icon icon="visit" accessibilityLabel="visit" size={24} color="dark" />
+                  <Icon icon="visit" accessibilityLabel="visit" size={24} color="default" />
                   <Text size="100">visit</Text>
                 </Flex>
                 <Flex
@@ -199,7 +199,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                   alignItems="center"
                   width={64}
                 >
-                  <Icon icon="globe" accessibilityLabel="globe" size={24} color="dark" />
+                  <Icon icon="globe" accessibilityLabel="globe" size={24} color="default" />
                   <Text size="100">globe</Text>
                 </Flex>
               </Flex>
@@ -231,7 +231,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                 justifyContent="center"
               >
                 <Flex alignItems="center" justifyContent="center" width={32} height={32}>
-                  <Icon icon="bell" accessibilityLabel="bell" size={12} color="dark" />
+                  <Icon icon="bell" accessibilityLabel="bell" size={12} color="default" />
                 </Flex>
                 <Text size="100">12px</Text>
               </Flex>
@@ -245,7 +245,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                 justifyContent="center"
               >
                 <Flex alignItems="center" justifyContent="center" width={32} height={32}>
-                  <Icon icon="bell" accessibilityLabel="bell" size={14} color="dark" />
+                  <Icon icon="bell" accessibilityLabel="bell" size={14} color="default" />
                 </Flex>
                 <Text size="100">14px</Text>
               </Flex>
@@ -259,7 +259,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                 justifyContent="center"
               >
                 <Flex alignItems="center" justifyContent="center" width={32} height={32}>
-                  <Icon icon="bell" accessibilityLabel="bell" size={16} color="dark" />
+                  <Icon icon="bell" accessibilityLabel="bell" size={16} color="default" />
                 </Flex>
                 <Text size="100">16px</Text>
               </Flex>
@@ -273,7 +273,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                 justifyContent="center"
               >
                 <Flex alignItems="center" justifyContent="center" width={32} height={32}>
-                  <Icon icon="bell" accessibilityLabel="bell" size={24} color="dark" />
+                  <Icon icon="bell" accessibilityLabel="bell" size={24} color="default" />
                 </Flex>
                 <Text size="100">24px</Text>
               </Flex>
@@ -286,7 +286,7 @@ Get in touch with us if an aesthetic change is needed, and we will evaluate the 
                 alignItems="center"
               >
                 <Flex alignItems="center" justifyContent="center" width={32} height={32}>
-                  <Icon icon="bell" accessibilityLabel="bell" size={32} color="dark" />
+                  <Icon icon="bell" accessibilityLabel="bell" size={32} color="default" />
                 </Flex>
                 <Text size="100">32px </Text>
               </Flex>
@@ -353,7 +353,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
                 }}
                 alignItems="center"
               >
-                <Icon icon="heart" accessibilityLabel="heart" size={24} color="dark" />
+                <Icon icon="heart" accessibilityLabel="heart" size={24} color="default" />
               </Flex>
               <Flex
                 direction="column"
@@ -422,7 +422,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
                     icon="android-share"
                     accessibilityLabel="share for android"
                     size={24}
-                    color="dark"
+                    color="default"
                   />
                   <Text size="100">Android share</Text>
                 </Flex>
@@ -444,7 +444,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
                   }}
                   alignItems="center"
                 >
-                  <Icon icon="share" accessibilityLabel="share for iOS" size={24} color="dark" />
+                  <Icon icon="share" accessibilityLabel="share for iOS" size={24} color="default" />
                   <Text size="100">iOS share</Text>
                 </Flex>
               </Flex>
@@ -474,7 +474,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
             description="A11y: Use icons semantically and provide meaningful text whenever it is possible."
             defaultCode={`
 <Flex gap={{ row: 2, column: 0 }} alignItems="center">
-  <Icon icon="sparkle" accessibilityLabel="sparkle" color="dark" size={16} />
+  <Icon icon="sparkle" accessibilityLabel="sparkle" color="default" size={16} />
   <Text>Recommendation text</Text>
 </Flex>
 `}
@@ -484,7 +484,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
             type="don't"
             description="Use icons without labels for decoration or visual interest."
             defaultCode={`
-<Icon icon="sparkle" accessibilityLabel="sparkle" color="dark" size={16} />
+<Icon icon="sparkle" accessibilityLabel="sparkle" color="default" size={16} />
 `}
           />
         </MainSection.Subsection>
@@ -496,7 +496,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
             description="A11y: Stick to our [design tokens](/foundations/color/usage#Iconography-color) and use color combinations with at least 3:1 contrast ratio between foreground and background."
             defaultCode={`
 <Box color="infoWeak" padding={12} display="inlineBlock" rounding={4}>
-  <Icon icon="shopping-bag" accessibilityLabel="shopping bag" color="dark" size={24} />
+  <Icon icon="shopping-bag" accessibilityLabel="shopping bag" color="default" size={24} />
 </Box>
 `}
           />
@@ -518,7 +518,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
             type="do"
             description="Style: Use our icons following the Gestalt design specs."
             defaultCode={`
-<Icon icon="pincode" accessibilityLabel="pin code" color="dark" size={32} />
+<Icon icon="pincode" accessibilityLabel="pin code" color="default" size={32} />
 `}
           />
           <MainSection.Card

--- a/docs/pages/foundations/iconography/usage.js
+++ b/docs/pages/foundations/iconography/usage.js
@@ -564,6 +564,17 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
         </MainSection.Subsection>
       </MainSection>
 
+      <MainSection name="Accessibility">
+        <MainSection.Subsection
+          description="
+- Icons must meet the [Non-Text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) requirement.
+- Avoid using unfamiliar icons. Always refer to Gestalt available icons. A new icon needs to be user tested to evaluate comprehension.
+- Icons should be universal across cultures, regions, ages, and backgrounds without need for translation. Be mindful of your audience and use symbols and labels that resonate with them.
+- Some icons don't translate well in all cultures, so it's preferred to user-test each icon before it is added to Gestalt.
+"
+        />
+      </MainSection>
+
       <MainSection name="Logos as icons">
         <MainSection.Subsection
           description={`Logos are third-party visual elements we only recommend setting as an icon when it is understandable by a global audience of users and meet our icon's principles and usage guidelines. For example, a payment credit card flag is required as an icon in a payment flow to support comprehension. In this case, aim for an internationally recognized logo in place of a locally recognized logo that may only apply to a specific background or culture.`}

--- a/docs/pages/foundations/iconography/usage.js
+++ b/docs/pages/foundations/iconography/usage.js
@@ -568,8 +568,8 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
         <MainSection.Subsection
           description="
 - Icons must meet the [Non-Text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) requirement.
-- Avoid using unfamiliar icons. Always refer to Gestalt available icons. A new icon needs to be user tested to evaluate comprehension.
-- Icons should be universal across cultures, regions, ages, and backgrounds without need for translation. Be mindful of your audience and use symbols and labels that resonate with them.
+- Avoid using unfamiliar icons. Always refer to Gestalt available icons. A new icon needs to be user-tested to evaluate comprehension.
+- Icons should be universal across cultures, regions, ages and backgrounds without need for translation. Be mindful of your audience and use symbols and labels that resonate with them.
 - Some icons don't translate well in all cultures, so it's preferred to user-test each icon before it is added to Gestalt.
 "
         />

--- a/playwright/accessibility/Custom and brand icons.spec.mjs
+++ b/playwright/accessibility/Custom and brand icons.spec.mjs
@@ -1,0 +1,8 @@
+// @flow strict
+import { test } from '@playwright/test';
+import expectAccessiblePage from './expectAccessiblePage.mjs';
+
+test('Custom brand icons check', async ({ page }) => {
+  await page.goto('/foundations/iconography/custom_and_brand_icons');
+  await expectAccessiblePage({ page });
+});


### PR DESCRIPTION
### Summary

#### What changed?

Update the Icon library page to support better search and categories. Move custom and brand info to own page

#### Why?

Make it easier to find icons by name or by category

![Screen Shot 2022-11-03 at 11 27 15 AM](https://user-images.githubusercontent.com/5125094/199804773-7d6a6ed1-fb8e-4d5f-af16-c4647bc1a1b4.png)
![Screen Shot 2022-11-03 at 11 27 23 AM](https://user-images.githubusercontent.com/5125094/199804781-1947c05c-19c5-4b23-89c4-200689560f66.png)


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4673)
- [Figma](https://www.figma.com/file/RBlfOYmL123whCtlglXIsG/Iconography-page-redesign?node-id=1%3A2)

### Checklist

- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
