### PR TITLE
Link, Button, TapArea, IconButton: implemented default label to target="blank"

### DIFF
--- a/docs/examples/defaultlabelprovider/translations.js
+++ b/docs/examples/defaultlabelprovider/translations.js
@@ -4,6 +4,9 @@ import { Box, ComboBox, DefaultLabelProvider, Flex, Heading } from 'gestalt';
 
 const myI18nTranslator = (val) => val.toUpperCase();
 const labels = {
+  Link: {
+    accessibilityNewTabLabel: myI18nTranslator('Opens a new tab'),
+  },
   ModalAlert: {
     accessibilityDismissButtonLabel: myI18nTranslator('Close modal'),
   },

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -362,7 +362,20 @@ If Button is used as a control Button to show/hide a Popover-based component, we
       <MainSection
         name="Localization"
         description="Be sure to localize `text` and `accessibilityLabel`. Note that localization can lengthen text by 20 to 30 percent. Avoid truncating Button text whenever possible. Refer to the [Button usage guidelines](#Usage-guidelines) for more information. "
-      />
+      >
+        <SlimBanner
+          iconAccessibilityLabel="Localize the default label"
+          message="Buttons with link role announce to assistive technologies that the link opens in a new tab when setting target to 'blank'. Localize the default label with DefaultLabelProvider."
+          type="recommendationBare"
+          helperLink={{
+            text: 'Learn more',
+            accessibilityLabel: 'Learn more about DefaultLabelProvider',
+            href: '/web/utilities/defaultlabelprovider',
+            onClick: () => {},
+          }}
+        />
+      </MainSection>
+
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Size"
@@ -521,6 +534,17 @@ If Button is used as a control Button to show/hide a Popover-based component, we
 These optional props control the behavior of \`role="link"\` Buttons. External links commonly use \`target="_blank"\` to open the link in a new tab or window, and \`rel="nofollow"\` to provide hints for SEO.
 `}
         >
+          <SlimBanner
+            iconAccessibilityLabel="Localize the default label"
+            message="Button with link role announces to assistive technologies that the link opens in a new tab. Localize the default label with DefaultLabelProvider."
+            type="recommendationBare"
+            helperLink={{
+              text: 'Learn more',
+              accessibilityLabel: 'Learn more about DefaultLabelProvider',
+              href: '/web/utilities/defaultlabelprovider',
+              onClick: () => {},
+            }}
+          />
           <MainSection.Card
             cardSize="lg"
             sandpackExample={

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { IconButton } from 'gestalt';
+import { IconButton, SlimBanner } from 'gestalt';
 import PropTable from '../../docs-components/PropTable.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -317,7 +317,19 @@ If IconButton is disabled, it's also unreachable from keyboard navigation.`}
           />
         </MainSection.Subsection>
       </AccessibilitySection>
-      <MainSection name="Localization" description="Be sure to localize `accessibilityLabel`." />
+      <MainSection name="Localization" description="Be sure to localize `accessibilityLabel`.">
+        <SlimBanner
+          iconAccessibilityLabel="Localize the default label"
+          message="IconButtons with link role announce to assistive technologies that the link opens in a new tab when setting target to 'blank'. Localize the default label with DefaultLabelProvider."
+          type="recommendationBare"
+          helperLink={{
+            text: 'Learn more',
+            accessibilityLabel: 'Learn more about DefaultLabelProvider',
+            href: '/web/utilities/defaultlabelprovider',
+            onClick: () => {},
+          }}
+        />
+      </MainSection>
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Role"
@@ -331,7 +343,7 @@ If IconButton is disabled, it's also unreachable from keyboard navigation.`}
 
 \`target\` is optional and defines the frame or window to open the anchor defined on href:
 * "null" opens the anchor in the same window.
-* "blank" opens the anchor in a new window.
+* "blank" opens the anchor in a new window. IconButtons announce to assistive technologies that the link opens in a new tab. Localize the default label with [DefaultLabelProvider](/web/utilities/defaultlabelprovider).
 * "self" opens an anchor in the same frame.
 
 \`rel\` is optional. Use "nofollow" for external links to specify to web crawlers not follow the link.

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -1,12 +1,12 @@
 // @flow strict
 import { type Node } from 'react';
+import { SlimBanner } from 'gestalt';
 import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
 import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import Page from '../../docs-components/Page.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
-
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
@@ -460,7 +460,19 @@ For external links where an external Gestalt Link doesn't apply, check out [Butt
       <MainSection
         name="Localization"
         description={`Be sure to localize the \`accessibilityLabel\` as well as any children content.`}
-      />
+      >
+        <SlimBanner
+          iconAccessibilityLabel="Localize the default label"
+          message="Link announces to assistive technologies that the link opens in a new tab when setting target to 'blank'. Localize the default label with DefaultLabelProvider."
+          type="recommendationBare"
+          helperLink={{
+            text: 'Learn more',
+            accessibilityLabel: 'Learn more about DefaultLabelProvider',
+            href: '/web/utilities/defaultlabelprovider',
+            onClick: () => {},
+          }}
+        />
+      </MainSection>
 
       <MainSection name="Variants">
         <MainSection.Subsection
@@ -600,6 +612,17 @@ However, Link's underline style can be overridden at any time using the \`underl
 - "self" opens an anchor in the same frame.
 `}
         >
+          <SlimBanner
+            iconAccessibilityLabel="Localize the default label"
+            message="Link announces to assistive technologies that the link opens in a new tab. Localize the default label with DefaultLabelProvider."
+            type="recommendationBare"
+            helperLink={{
+              text: 'Learn more',
+              accessibilityLabel: 'Learn more about DefaultLabelProvider',
+              href: '/web/utilities/defaultlabelprovider',
+              onClick: () => {},
+            }}
+          />
           <MainSection.Card
             defaultCode={`
 <Text inline>

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Box, TapArea, Text } from 'gestalt';
+import { Box, TapArea, Text, SlimBanner } from 'gestalt';
 import PropTable from '../../docs-components/PropTable.js';
 import Combination from '../../docs-components/Combination.js';
 import Example from '../../docs-components/Example.js';
@@ -256,6 +256,20 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       />
 
       <AccessibilitySection name={generatedDocGen?.displayName} />
+
+      <MainSection name="Localization">
+        <SlimBanner
+          iconAccessibilityLabel="Localize the default label"
+          message="TapAreas with link role announce to assistive technologies that the link opens in a new tab when setting target to 'blank'. Localize the default label with DefaultLabelProvider."
+          type="recommendationBare"
+          helperLink={{
+            text: 'Learn more',
+            accessibilityLabel: 'Learn more about DefaultLabelProvider',
+            href: '/web/utilities/defaultlabelprovider',
+            onClick: () => {},
+          }}
+        />
+      </MainSection>
 
       <MainSection name="Variants">
         <Example

--- a/docs/pages/web/utilities/onlinknavigationprovider.js
+++ b/docs/pages/web/utilities/onlinknavigationprovider.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
+import { SlimBanner } from 'gestalt';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
@@ -38,6 +39,17 @@ In this example, the \`useOnNavigation\` hook function is passed to OnLinkNaviga
 The returned \`onNavigationClick\` function inside the hook function uses the event access to [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault). It could also be used to [stopPropagation()](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation).
       `}
         >
+          <SlimBanner
+            iconAccessibilityLabel="Localize the default label"
+            message="Accessible links in Gestalt announce to assistive technologies that the link opens in a new tab. Always make sure your external logic aligns with the 'target' prop values. For example, if your external logic opens a url in a new tab, set 'target' to 'blank'. Localize the default label with DefaultLabelProvider."
+            type="warning"
+            helperLink={{
+              text: 'Learn more',
+              accessibilityLabel: 'Learn more about DefaultLabelProvider',
+              href: '/web/utilities/defaultlabelprovider',
+              onClick: () => {},
+            }}
+          />
           <MainSection.Card
             title="Examples from start to end: Link, Button, IconButton, TapArea"
             cardSize="lg"

--- a/packages/gestalt/src/Button.jsdom.test.js
+++ b/packages/gestalt/src/Button.jsdom.test.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { createRef } from 'react';
-import { render } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import Button from './Button.js';
 
 describe('Button', () => {
@@ -25,6 +25,46 @@ describe('Button', () => {
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current?.type).toEqual('button');
     expect(ref.current instanceof HTMLButtonElement && ref.current?.tabIndex).toEqual(0);
+  });
+
+  it('renders a link button with correct new tab announcement with and without accessibilityLabel', () => {
+    render(
+      <Button
+        iconEnd="visit"
+        size="lg"
+        text="Visit Pinterest"
+        role="link"
+        rel="nofollow"
+        target="blank"
+        href="#"
+      />,
+    );
+    expect(
+      screen.getByText('Visit Pinterest', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('; Opens a new tab', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    render(
+      <Button
+        accessibilityLabel="Visit Pinterest"
+        iconEnd="visit"
+        size="lg"
+        text="Visit Pinterest"
+        role="link"
+        rel="nofollow"
+        target="blank"
+        href="#"
+      />,
+    );
+
+    expect(screen.getByLabelText('Visit Pinterest; Opens a new tab')).toBeVisible();
   });
 
   it('renders a link button with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {

--- a/packages/gestalt/src/DropdownLink.jsdom.test.js
+++ b/packages/gestalt/src/DropdownLink.jsdom.test.js
@@ -44,8 +44,13 @@ describe('Dropdown.Link', () => {
         option={{ value: 'item 4', label: 'Item 4' }}
       />,
     );
-    expect(screen.getByRole('img', { name: /, External/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
     // eslint-disable-next-line testing-library/prefer-presence-queries -- Please fix the next time this file is touched!
     expect(screen.queryByText('Beta Badge')).toBeInTheDocument();
+    expect(
+      screen.queryByText('; Opens a new tab', {
+        exact: true,
+      }),
+    ).toBeVisible();
   });
 });

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -11,6 +11,8 @@ import styles from './IconButton.css';
 import touchableStyles from './Touchable.css';
 import useFocusVisible from './useFocusVisible.js';
 import useTapFeedback from './useTapFeedback.js';
+import NewTabAccessibilityLabel, { getAriaLabel } from './NewTabAccessibilityLabel.js';
+import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 
 type TooltipProps = {|
   accessibilityLabel?: string,
@@ -119,6 +121,8 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
   const [isFocused, setFocused] = useState(false);
   const [isHovered, setHovered] = useState(false);
 
+  const { accessibilityNewTabLabel } = useDefaultLabelContext('Link');
+
   const { isFocusVisible } = useFocusVisible();
 
   const renderPogComponent = (selected?: boolean): Node => (
@@ -176,9 +180,12 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
 
   if (props.role === 'link') {
     const { href, rel, target } = props;
+
+    const ariaLabel = getAriaLabel({ target, accessibilityLabel, accessibilityNewTabLabel });
+
     buttonComponent = (
       <InternalLink
-        accessibilityLabel={accessibilityLabel}
+        accessibilityLabel={ariaLabel}
         disabled={disabled}
         href={href}
         onClick={handleLinkClick}
@@ -195,6 +202,7 @@ const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> =
         wrappedComponent="iconButton"
       >
         {renderPogComponent()}
+        <NewTabAccessibilityLabel target={target} />
       </InternalLink>
     );
   } else {

--- a/packages/gestalt/src/IconButton.jsdom.test.js
+++ b/packages/gestalt/src/IconButton.jsdom.test.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { createRef } from 'react';
-import { render } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import IconButton from './IconButton.js';
 
 describe('IconButton', () => {
@@ -86,5 +86,20 @@ describe('IconButton', () => {
     );
     expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
     expect(ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex).toEqual(-1);
+  });
+
+  it('renders a link button with correct new tab announcement with and without accessibilityLabel', () => {
+    render(
+      <IconButton
+        accessibilityLabel="Visit Pinterest"
+        icon="visit"
+        role="link"
+        target="blank"
+        href="https://www.pinterest.com"
+        tooltip={{ text: 'Link example' }}
+      />,
+    );
+
+    expect(screen.getByLabelText('Visit Pinterest; Opens a new tab')).toBeVisible();
   });
 });

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import classnames from 'classnames';
 import { useOnLinkNavigation } from './contexts/OnLinkNavigationProvider.js';
+import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import touchableStyles from './Touchable.css';
 import styles from './Link.css';
 import textStyles from './Typography.css';
@@ -21,6 +22,7 @@ import layoutStyles from './Layout.css';
 import Icon from './Icon.js';
 import Box from './Box.js';
 import Text from './Text.js';
+import NewTabAccessibilityLabel, { getAriaLabel } from './NewTabAccessibilityLabel.js';
 
 const externalLinkIconMap = {
   '100': 12,
@@ -181,6 +183,8 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     width: innerRef?.current?.clientWidth,
   });
 
+  const { accessibilityNewTabLabel } = useDefaultLabelContext('Link');
+
   const { isFocusVisible } = useFocusVisible();
 
   let underlineStyle = inline ? 'always' : 'hover';
@@ -219,9 +223,11 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     }
   };
 
+  const ariaLabel = getAriaLabel({ target, accessibilityLabel, accessibilityNewTabLabel });
+
   return (
     <a
-      aria-label={accessibilityLabel}
+      aria-label={ariaLabel}
       className={className}
       href={href}
       id={id}
@@ -268,6 +274,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
       target={target ? `_${target}` : null}
     >
       {children}
+      <NewTabAccessibilityLabel target={target} />
       <ExternalIcon externalLinkIcon={externalLinkIcon} />
     </a>
   );

--- a/packages/gestalt/src/Link.jsdom.test.js
+++ b/packages/gestalt/src/Link.jsdom.test.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { render } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import Link from './Link.js';
 
 describe('Link', () => {
@@ -13,5 +13,41 @@ describe('Link', () => {
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     getByText('Link').click();
     expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it('renders a link with correct new tab announcement with and without accessibilityLabel', () => {
+    render(
+      <Link
+        href="https://business.pinterest.com/advertise"
+        inline
+        externalLinkIcon="default"
+        target="blank"
+      >
+        Visit Pinterest
+      </Link>,
+    );
+    expect(
+      screen.getByText('Visit Pinterest', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('; Opens a new tab', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    render(
+      <Link
+        accessibilityLabel="Visit Pinterest"
+        href="https://business.pinterest.com/advertise"
+        inline
+        externalLinkIcon="default"
+        target="blank"
+      />,
+    );
+
+    expect(screen.getByLabelText('Visit Pinterest; Opens a new tab')).toBeVisible();
   });
 });

--- a/packages/gestalt/src/NewTabAccessibilityLabel.js
+++ b/packages/gestalt/src/NewTabAccessibilityLabel.js
@@ -1,0 +1,31 @@
+// @flow strict
+import { type Node } from 'react';
+import Box from './Box.js';
+import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
+
+export default function NewTabAccessibilityLabel({
+  target,
+}: {|
+  target?: null | 'self' | 'blank',
+|}): Node {
+  const { accessibilityNewTabLabel } = useDefaultLabelContext('Link');
+  return target === 'blank' ? (
+    <Box display="visuallyHidden">{`; ${accessibilityNewTabLabel}`}</Box>
+  ) : null;
+}
+
+export function getAriaLabel({
+  accessibilityLabel,
+  accessibilityNewTabLabel,
+  target,
+}: {|
+  accessibilityLabel?: string,
+  accessibilityNewTabLabel: string,
+  target?: null | 'self' | 'blank',
+|}): string | void {
+  let ariaLabel = accessibilityLabel ?? undefined;
+  if (ariaLabel && target === 'blank') {
+    ariaLabel = `${ariaLabel}; ${accessibilityNewTabLabel}`;
+  }
+  return ariaLabel;
+}

--- a/packages/gestalt/src/OptionItem.js
+++ b/packages/gestalt/src/OptionItem.js
@@ -131,6 +131,8 @@ const OptionItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = f
       </Box>
       {isExternal && (
         <Box
+          // aria-hidden is required to prevent assistive technologies from accessing the icon as the actual link already announces that the link opens a new tab
+          aria-hidden
           alignItems="center"
           color="transparent"
           display="flex"
@@ -138,8 +140,7 @@ const OptionItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = f
           // marginStart is for spacing relative to Badge, should not be moved to parent Flex's gap
           marginStart={2}
         >
-          {/* TODO: this label needs to be translated */}
-          <Icon accessibilityLabel=", External" color="default" icon="arrow-up-right" size={12} />
+          <Icon accessibilityLabel="" color="default" icon="arrow-up-right" size={12} />
         </Box>
       )}
     </Flex>

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -9,6 +9,8 @@ import { type AbstractEventHandler } from './AbstractEventHandler.js';
 import { type AriaCurrent } from './ariaTypes.js';
 import focusStyles from './Focus.css';
 import useFocusVisible from './useFocusVisible.js';
+import NewTabAccessibilityLabel, { getAriaLabel } from './NewTabAccessibilityLabel.js';
+import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 
 type FocusEventHandler = AbstractEventHandler<
   SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement>,
@@ -118,6 +120,8 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
     width: innerRef?.current?.clientWidth,
   });
 
+  const { accessibilityNewTabLabel } = useDefaultLabelContext('Link');
+
   const { isFocusVisible } = useFocusVisible();
 
   const buttonRoleClasses = classnames(
@@ -196,10 +200,12 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
   if (props.role === 'link') {
     const { accessibilityCurrent, href, rel = 'none', target = null } = props;
 
+    const ariaLabel = getAriaLabel({ target, accessibilityLabel, accessibilityNewTabLabel });
+
     return (
       <InternalLink
         accessibilityCurrent={accessibilityCurrent}
-        accessibilityLabel={accessibilityLabel}
+        accessibilityLabel={ariaLabel}
         disabled={disabled}
         href={href}
         fullHeight={fullHeight}
@@ -224,6 +230,7 @@ const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = fo
         wrappedComponent="tapArea"
       >
         {children}
+        <NewTabAccessibilityLabel target={target} />
       </InternalLink>
     );
   }

--- a/packages/gestalt/src/TapArea.jsdom.test.js
+++ b/packages/gestalt/src/TapArea.jsdom.test.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { createRef } from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { screen, fireEvent, render } from '@testing-library/react';
 import TapArea from './TapArea.js';
 
 describe('TapArea', () => {
@@ -108,5 +108,38 @@ describe('TapArea', () => {
     );
     expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
     expect(ref.current instanceof HTMLAnchorElement && ref.current?.tabIndex).toEqual(-1);
+  });
+
+  it('renders a link TapArea with correct new tab announcement with and without accessibilityLabel', () => {
+    render(
+      <TapArea role="link" target="blank" href="https://www.pinterest.com">
+        Visit Pinterest
+      </TapArea>,
+    );
+
+    expect(
+      screen.getByText('Visit Pinterest', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('; Opens a new tab', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    render(
+      <TapArea
+        accessibilityLabel="Visit Pinterest"
+        role="link"
+        target="blank"
+        href="https://www.pinterest.com"
+      >
+        Visit Pinterest
+      </TapArea>,
+    );
+
+    expect(screen.getByLabelText('Visit Pinterest; Opens a new tab')).toBeVisible();
   });
 });

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
@@ -337,9 +337,17 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
         target={null}
       >
         <div
-          className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+          className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
         >
-          Learn more
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            >
+              Learn more
+            </div>
+          </div>
         </div>
       </a>
     </div>
@@ -488,9 +496,17 @@ exports[`<ActivationCard /> message + title + link 1`] = `
         target={null}
       >
         <div
-          className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+          className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
         >
-          Learn more
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            >
+              Learn more
+            </div>
+          </div>
         </div>
       </a>
     </div>

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -253,9 +253,17 @@ exports[`<Callout /> message + title + primaryAction + dismissButton 1`] = `
           target={null}
         >
           <div
-            className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Visit Pinterest
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+              >
+                Visit Pinterest
+              </div>
+            </div>
           </div>
         </a>
       </div>
@@ -401,9 +409,17 @@ exports[`<Callout /> message + title + primaryAction + secondaryAction 1`] = `
           target={null}
         >
           <div
-            className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Learn more
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+              >
+                Learn more
+              </div>
+            </div>
           </div>
         </a>
       </div>
@@ -432,9 +448,17 @@ exports[`<Callout /> message + title + primaryAction + secondaryAction 1`] = `
           target={null}
         >
           <div
-            className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Visit Pinterest
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+              >
+                Visit Pinterest
+              </div>
+            </div>
           </div>
         </a>
       </div>
@@ -531,9 +555,17 @@ exports[`<Callout /> message + title + primaryAction with href 1`] = `
           target={null}
         >
           <div
-            className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Visit Pinterest
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+              >
+                Visit Pinterest
+              </div>
+            </div>
           </div>
         </a>
       </div>

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -686,10 +686,12 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                       />
                     </div>
                     <div
+                      aria-hidden="true"
                       class="box itemsCenter justifyCenter marginStart2 xsDisplayFlex"
                     >
                       <svg
-                        aria-label=", External"
+                        aria-hidden="true"
+                        aria-label=""
                         class="rtlSupport icon defaultIcon iconBlock"
                         height="12"
                         role="img"
@@ -701,6 +703,11 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                         />
                       </svg>
                     </div>
+                  </div>
+                  <div
+                    class="box xsDisplayVisuallyHidden"
+                  >
+                    ; Opens a new tab
                   </div>
                 </a>
               </div>
@@ -821,10 +828,12 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                       />
                     </div>
                     <div
+                      aria-hidden="true"
                       class="box itemsCenter justifyCenter marginStart2 xsDisplayFlex"
                     >
                       <svg
-                        aria-label=", External"
+                        aria-hidden="true"
+                        aria-label=""
                         class="rtlSupport icon defaultIcon iconBlock"
                         height="12"
                         role="img"
@@ -836,6 +845,11 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                         />
                       </svg>
                     </div>
+                  </div>
+                  <div
+                    class="box xsDisplayVisuallyHidden"
+                  >
+                    ; Opens a new tab
                   </div>
                 </a>
               </div>
@@ -886,10 +900,12 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                       />
                     </div>
                     <div
+                      aria-hidden="true"
                       class="box itemsCenter justifyCenter marginStart2 xsDisplayFlex"
                     >
                       <svg
-                        aria-label=", External"
+                        aria-hidden="true"
+                        aria-label=""
                         class="rtlSupport icon defaultIcon iconBlock"
                         height="12"
                         role="img"
@@ -901,6 +917,11 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                         />
                       </svg>
                     </div>
+                  </div>
+                  <div
+                    class="box xsDisplayVisuallyHidden"
+                  >
+                    ; Opens a new tab
                   </div>
                 </a>
               </div>

--- a/packages/gestalt/src/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.js.snap
@@ -162,6 +162,11 @@ exports[`target blank 1`] = `
   target="_blank"
 >
   Link
+  <div
+    className="box xsDisplayVisuallyHidden"
+  >
+    ; Opens a new tab
+  </div>
 </a>
 `;
 

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -177,9 +177,17 @@ exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
                   type="submit"
                 >
                   <div
-                    className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+                    className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
                   >
-                    Submit
+                    <div
+                      className="FlexItem"
+                    >
+                      <div
+                        className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+                      >
+                        Submit
+                      </div>
+                    </div>
                   </div>
                 </button>
               </div>
@@ -344,9 +352,17 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] 
           target={null}
         >
           <div
-            className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Visit Pinterest
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+              >
+                Visit Pinterest
+              </div>
+            </div>
           </div>
         </a>
       </div>
@@ -475,9 +491,17 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton 1`] = `
           target={null}
         >
           <div
-            className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Visit Pinterest
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+              >
+                Visit Pinterest
+              </div>
+            </div>
           </div>
         </a>
       </div>
@@ -606,9 +630,17 @@ exports[`<Upsell /> message + title + primaryAction + secondaryAction 1`] = `
           target={null}
         >
           <div
-            className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Learn more
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+              >
+                Learn more
+              </div>
+            </div>
           </div>
         </a>
       </div>
@@ -637,9 +669,17 @@ exports[`<Upsell /> message + title + primaryAction + secondaryAction 1`] = `
           target={null}
         >
           <div
-            className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Visit Pinterest
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+              >
+                Visit Pinterest
+              </div>
+            </div>
           </div>
         </a>
       </div>
@@ -719,9 +759,17 @@ exports[`<Upsell /> message + title + primaryAction with href 1`] = `
           target={null}
         >
           <div
-            className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+            className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
           >
-            Visit Pinterest
+            <div
+              className="FlexItem"
+            >
+              <div
+                className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+              >
+                Visit Pinterest
+              </div>
+            </div>
           </div>
         </a>
       </div>

--- a/packages/gestalt/src/__snapshots__/UpsellForm.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/UpsellForm.test.js.snap
@@ -59,9 +59,17 @@ exports[`UpsellForm renders 1`] = `
         type="submit"
       >
         <div
-          className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+          className="Flex rowGap2 columnGap0 itemsCenter justifyCenter xsDirectionRow"
         >
-          Submit
+          <div
+            className="FlexItem"
+          >
+            <div
+              className="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+            >
+              Submit
+            </div>
+          </div>
         </div>
       </button>
     </div>

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.js
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.js
@@ -14,6 +14,9 @@ import { type Context, type Node, createContext, useContext } from 'react';
  */
 
 export type DefaultLabelContextType = {|
+  Link: {|
+    accessibilityNewTabLabel: string,
+  |},
   ModalAlert: {|
     accessibilityDismissButtonLabel: string,
   |},
@@ -27,6 +30,9 @@ export type DefaultLabelContextType = {|
 |};
 
 export const fallbackLabels: DefaultLabelContextType = {
+  Link: {
+    accessibilityNewTabLabel: 'Opens a new tab',
+  },
   ModalAlert: {
     accessibilityDismissButtonLabel: 'Close modal',
   },

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.js
@@ -16,6 +16,9 @@ describe('useDefaultLabelContext', () => {
     render(
       <DefaultLabelProvider
         labels={{
+          Link: {
+            accessibilityNewTabLabel: 'Opens a new tab',
+          },
           ModalAlert: {
             accessibilityDismissButtonLabel: 'Close modal',
           },


### PR DESCRIPTION
### Breaking change for major release

Update `DefaultLabelProvider` with new label.

```
Link: {
    accessibilityNewTabLabel: myI18nTranslator('Opens a new tab'),
  },
```

### Summary

#### What changed?

Link, Button, TapArea, IconButton: implemented default label to target="blank" #2467

Added SlimBanners across the different documentation pages linking components to DefaultLabelProvider.

#### Why?

Note from WebAim — The vast majority of screen readers don't inform users that target= "_blank" links open in new tabs; folks could have a hard time realizing why they can't use the back button to return to the previous page and that they might need to switch back to the last tab to do so. 

We actually can create a label informing users that the link is going to open in a new tab. 
Label suggestion to announce: Opens a new tab

Reference: We must inform your users about this opening in a new tab behavior. Failure to do so goes against [WCAG 2.0 Guideline 3.2: Predictability](https://www.w3.org/TR/UNDERSTANDING-WCAG20/consistent-behavior.html).

####  TESTING

| COMPONENT      |  no accessibilityLabel | accessibilityLabel
| ----------- | ----------- | ----------- |
| Link             |  <img width="798" alt="Screen Shot 2022-11-01 at 2 37 21 PM" src="https://user-images.githubusercontent.com/10593890/199311822-60bc0e33-49bd-4a82-bd85-2f666097782a.png"> | <img width="858" alt="Screen Shot 2022-11-01 at 2 38 21 PM" src="https://user-images.githubusercontent.com/10593890/199312019-5b45eb99-f71f-4d8a-9fe4-da4b6e689a0b.png"> |
| Button         | <img width="800" alt="Screen Shot 2022-11-01 at 2 40 50 PM" src="https://user-images.githubusercontent.com/10593890/199312452-1974413c-de23-4564-9a80-558385140ae0.png"> | <img width="704" alt="Screen Shot 2022-11-01 at 2 40 36 PM" src="https://user-images.githubusercontent.com/10593890/199312522-162d351b-6bac-4702-8c9f-677e62f0ae6f.png">  |
| IconButton         | NA |  <img width="802" alt="Screen Shot 2022-11-02 at 10 27 14 AM" src="https://user-images.githubusercontent.com/10593890/199515682-6f92537c-573f-4c46-baa1-c84614cf4b5f.png"> |
| TapArea      |  <img width="991" alt="Screen Shot 2022-11-01 at 2 44 09 PM" src="https://user-images.githubusercontent.com/10593890/199313062-b5f52100-48eb-41c9-9323-41564d9dc26d.png"> | <img width="1099" alt="Screen Shot 2022-11-01 at 2 45 10 PM" src="https://user-images.githubusercontent.com/10593890/199313288-ba1a22b1-afa9-4735-a7b6-eecbd599020a.png">  |
| Dropdown  |    <img width="647" alt="Screen Shot 2022-11-01 at 2 46 25 PM" src="https://user-images.githubusercontent.com/10593890/199313622-55bedfa7-dd10-46c7-a267-44c7c21a4f68.png">    | NA           |




### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [NA] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
