### PR TITLE
Internal: Retry playwright step

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,11 @@ jobs:
       - name: Run build
         run: yarn build
       - name: Run your tests
-        run: yarn run playwright:test --workers 2 --shard=${{ matrix.shard }}
+        run: |
+          # Retry 2 times before the steps actually fails
+          (echo "===== Playwright run attempt: 1 ====" && yarn run playwright:test --workers 2 --shard=${{ matrix.shard }}) || \
+          (echo "===== Playwright run attempt: 2 ====" && yarn run playwright:test --workers 2 --shard=${{ matrix.shard }}) || \
+          (echo "==== Playwright run attempt ====" && exit 1)
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
### Summary

#### What changed?

Retry the playwright step 2 times instead of failing immediately.

#### Why?

Playwright steps are occasionally failing, instead of requiring manual re-runs, let's retry the step.

### Notes

* GitHub doesn't supply a retry job out of the box. There are GitHub actions which do have this functionality but adding those are a security concern
  * https://github.com/marketplace/actions/retry-step
  * https://github.com/marketplace/actions/retry-action