### PR TITLE
Internal: turn on `react/no-array-index-key` lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,7 +84,7 @@
     "react/jsx-key": ["error", { "checkFragmentShorthand": true }],
     "react/jsx-props-no-spreading": "off",
     "react/no-access-state-in-setstate": "error",
-    "react/no-array-index-key": "off",
+    "react/no-array-index-key": "error",
     "react/react-in-jsx-scope": "off",
     "react/require-default-props": "off",
     "react/sort-comp": "off",

--- a/docs/docs-components/AccessibilityChecklist.js
+++ b/docs/docs-components/AccessibilityChecklist.js
@@ -39,28 +39,26 @@ function QualityTable({ accessibilityData }: {| accessibilityData?: AccessibleSt
         </Table.Header>
       </Box>
       <Table.Body>
-        {['a11yVisual', 'a11yScreenreader', 'a11yNavigation', 'a11yComprehension'].map(
-          (item, index) => {
-            const componentStatus = accessibilityData?.[item] ?? 'notAvailable';
+        {['a11yVisual', 'a11yScreenreader', 'a11yNavigation', 'a11yComprehension'].map((item) => {
+          const componentStatus = accessibilityData?.[item] ?? 'notAvailable';
 
-            return (
-              <Table.Row key={index}>
-                <Table.Cell>
-                  <Text>{COMPONENT_A11Y_STATUS_MESSAGING[item].title}</Text>
-                </Table.Cell>
-                <Table.Cell>
-                  <StatusData
-                    text={STATUS_DESCRIPTION[componentStatus].title}
-                    status={componentStatus}
-                  />
-                </Table.Cell>
-                <Table.Cell>
-                  <Text>{COMPONENT_A11Y_STATUS_MESSAGING[item][componentStatus]}</Text>
-                </Table.Cell>
-              </Table.Row>
-            );
-          },
-        )}
+          return (
+            <Table.Row key={item}>
+              <Table.Cell>
+                <Text>{COMPONENT_A11Y_STATUS_MESSAGING[item].title}</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <StatusData
+                  text={STATUS_DESCRIPTION[componentStatus].title}
+                  status={componentStatus}
+                />
+              </Table.Cell>
+              <Table.Cell>
+                <Text>{COMPONENT_A11Y_STATUS_MESSAGING[item][componentStatus]}</Text>
+              </Table.Cell>
+            </Table.Row>
+          );
+        })}
       </Table.Body>
     </Table>
   );

--- a/docs/docs-components/Combination.js
+++ b/docs/docs-components/Combination.js
@@ -108,7 +108,7 @@ export default function Combination({
       <Box display="flex" wrap>
         {combinations(props).map((combination, i) => {
           const combinationTitles = Object.keys(combination).map((key) => (
-            <Text align="center" size="200" key={`${i}-${key}`}>
+            <Text align="center" size="200" key={key}>
               {toReactAttribute(key, combination[key])}
             </Text>
           ));
@@ -117,7 +117,7 @@ export default function Combination({
               column={column}
               mdColumn={mdColumn}
               lgColumn={lgColumn}
-              key={i}
+              key={JSON.stringify(combination)}
               padding={4}
               display="flex"
               direction="column"

--- a/docs/docs-components/CombinationNew.js
+++ b/docs/docs-components/CombinationNew.js
@@ -75,7 +75,7 @@ export default function CombinationNew({
 
     return (
       <MainSectionCard
-        key={i}
+        key={JSON.stringify(combination)}
         cardSize="sm"
         shadeColor={cardShadeColor}
         title={hideTitle ? undefined : combinationTitles}

--- a/docs/docs-components/MainSectionSubsection.js
+++ b/docs/docs-components/MainSectionSubsection.js
@@ -94,8 +94,8 @@ function MainSectionSubsection({
               column: 4,
             }}
           >
-            {arrayChildren.map((child, idx) => (
-              <Flex.Item flex="grow" key={idx}>
+            {arrayChildren.map((child) => (
+              <Flex.Item flex="grow" key={child}>
                 {child}
               </Flex.Item>
             ))}

--- a/docs/docs-components/Overview.js
+++ b/docs/docs-components/Overview.js
@@ -86,11 +86,11 @@ Not sure which component to use? [Set up time with the Gestalt team.](/get_start
           <Fragment>
             {Object.keys(GENERAL_COMPONENT_CATEGORY_MAP)
               .sort()
-              .map((category, idx) => (
+              .map((category) => (
                 <List
                   platform={platform}
                   headingLevel={3}
-                  key={idx}
+                  key={category}
                   array={GENERAL_COMPONENT_CATEGORY_MAP[category]}
                   title={category}
                 />

--- a/docs/docs-components/OverviewList.js
+++ b/docs/docs-components/OverviewList.js
@@ -66,10 +66,10 @@ export default function List({
           }
           return 0;
         })
-        .map((element, idx) => (
+        .map((element) => (
           <IllustrationCard
             headingLevel={headingLevel}
-            key={idx}
+            key={element.name}
             href={
               element?.path ??
               `/${platform.toLowerCase()}/${element.name.replace(/\s/g, '_').toLowerCase()}`

--- a/docs/docs-components/Page.js
+++ b/docs/docs-components/Page.js
@@ -47,6 +47,7 @@ export default function Page({
             {sections.map((card, i) => (
               <Box
                 id={`card-${i}`}
+                // eslint-disable-next-line react/no-array-index-key
                 key={i}
                 dangerouslySetInlineStyle={{
                   __style: {

--- a/docs/docs-components/PropTable.js
+++ b/docs/docs-components/PropTable.js
@@ -48,8 +48,8 @@ function Description(lines: $ReadOnlyArray<string>): Node {
         column: 2,
       }}
     >
-      {lines.map((line, idx) => (
-        <Markdown key={idx} text={line} textColor="subtle" />
+      {lines.map((line) => (
+        <Markdown key={line} text={line} textColor="subtle" />
       ))}
     </Flex>
   );

--- a/docs/docs-components/QualityChecklist.js
+++ b/docs/docs-components/QualityChecklist.js
@@ -42,10 +42,10 @@ export default function QualityChecklist({ component }: Props): Node {
             </Table.Row>
           </Table.Header>
           <Table.Body>
-            {['figma', 'responsive', 'iOS', 'android'].map((item, index) => {
+            {['figma', 'responsive', 'iOS', 'android'].map((item) => {
               const componentStatus = componentData?.status?.[item] ?? 'notAvailable';
               return (
-                <Table.Row key={index}>
+                <Table.Row key={item}>
                   <Table.Cell>
                     <Text>{COMPONENT_STATUS_MESSAGING[item].title}</Text>
                   </Table.Cell>

--- a/docs/docs-components/useGetSideNavItems.js
+++ b/docs/docs-components/useGetSideNavItems.js
@@ -28,7 +28,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
     if (nestingLevel === 0) {
       return (
         <SideNavigation.Section key={`${navItem.sectionName}`} label={navItem.sectionName}>
-          {navItem.pages.map((pageInfo, i) => {
+          {navItem.pages.map((pageInfo) => {
             if (typeof pageInfo === 'string') {
               const href = `/${convertNamesForURL(navItem.sectionName)}/${convertNamesForURL(
                 pageInfo,
@@ -38,7 +38,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
                   active={isActiveTab(href)}
                   label={pageInfo}
                   onClick={() => setIsSidebarOpen?.(false)}
-                  key={`${pageInfo}--${i}`}
+                  key={pageInfo}
                   href={href}
                 />
               );
@@ -51,7 +51,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
     if (nestingLevel === 1) {
       return (
         <SideNavigation.Group key={`${navItem.sectionName}`} label={navItem.sectionName}>
-          {navItem.pages.map((nestedPage, i) => {
+          {navItem.pages.map((nestedPage) => {
             if (typeof nestedPage === 'string') {
               const href = `/${convertNamesForURL(previousSectionName)}/${convertNamesForURL(
                 navItem.sectionName,
@@ -61,7 +61,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
                   active={isActiveTab(href)}
                   label={nestedPage}
                   onClick={() => setIsSidebarOpen?.(false)}
-                  key={`${nestedPage}--${i}`}
+                  key={nestedPage}
                   href={href}
                 />
               );
@@ -74,7 +74,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
     }
     return (
       <SideNavigation.NestedGroup key={`${navItem.sectionName}`} label={navItem.sectionName}>
-        {navItem.pages.map((nestedPage, i) => {
+        {navItem.pages.map((nestedPage) => {
           if (typeof nestedPage === 'string') {
             const href = `/${convertNamesForURL(previousSectionName)}/${convertNamesForURL(
               navItem.sectionName,
@@ -84,7 +84,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
                 active={isActiveTab(href)}
                 label={nestedPage}
                 onClick={() => setIsSidebarOpen?.(false)}
-                key={`${nestedPage}--${i}`}
+                key={nestedPage}
                 href={href}
               />
             );

--- a/docs/examples/avatarGroup/roleButton.js
+++ b/docs/examples/avatarGroup/roleButton.js
@@ -20,8 +20,8 @@ const collaborators = [
 function List(): Node {
   return (
     <Flex direction="column" gap={{ column: 2, row: 0 }}>
-      {collaborators.map(({ name, src }, index) => (
-        <Flex key={index} alignItems="center" gap={{ row: 2, column: 0 }}>
+      {collaborators.map(({ name, src }) => (
+        <Flex key={name} alignItems="center" gap={{ row: 2, column: 0 }}>
           <Avatar size="md" name={name} src={src} />
           <Text weight="bold">{name}</Text>
         </Flex>

--- a/docs/examples/pageheader/multiplePrimaryActionsExample.js
+++ b/docs/examples/pageheader/multiplePrimaryActionsExample.js
@@ -23,8 +23,8 @@ function HeaderRow({ id }: {| id: string |}): Node {
           </Box>
           <Checkbox id={id} onChange={() => {}} indeterminate size="sm" />
         </Table.HeaderCell>
-        {['Status', 'Audience'].map((title, idx) => (
-          <Table.HeaderCell key={idx}>
+        {['Status', 'Audience'].map((title) => (
+          <Table.HeaderCell key={title}>
             <Text weight="bold">{title}</Text>
           </Table.HeaderCell>
         ))}

--- a/docs/examples/sidenavigation/footerExample.js
+++ b/docs/examples/sidenavigation/footerExample.js
@@ -55,9 +55,9 @@ export default function Example(): Node {
             label: 'Draft',
             counter: { number: '100', accessibilityLabel: '100 Pins' },
           },
-        ].map(({ label, counter }, idx) => (
+        ].map(({ label, counter }) => (
           <SideNavigation.TopItem
-            key={idx}
+            key={label}
             href="#"
             label={label}
             icon="ads-stats"

--- a/docs/pages/foundations/data_visualization/usage.js
+++ b/docs/pages/foundations/data_visualization/usage.js
@@ -16,10 +16,13 @@ import DataViz8Colors from '../../../graphics/color-examples/dataViz8Colors.svg'
 type ColorCardProps = {|
   count: number,
 |};
+
 function PaletteGenerator({ count }: ColorCardProps): Node {
   return [...Array(count)].map((step, idx) => {
     const tokenStep = idx + 1;
+
     return (
+      // eslint-disable-next-line react/no-array-index-key
       <Box marginBottom={1} key={`color-${idx}`}>
         <ColorTile
           textColor={tokenStep === 1 || tokenStep === 2 ? 'dark' : 'inverse'}

--- a/docs/pages/foundations/overview.js
+++ b/docs/pages/foundations/overview.js
@@ -20,10 +20,10 @@ export default function FoundationsOverview(): Node {
           />
         </IllustrationContainer>
         <IllustrationSection title="" grid="auto-fill" min={312}>
-          {COMPONENT_DATA.foundations.map((element, idx) => (
+          {COMPONENT_DATA.foundations.map((element) => (
             <IllustrationCard
               headingLevel={2}
-              key={idx}
+              key={element.name}
               href={element?.path ?? `/web/${element.name.replace(/\s/g, '_').toLowerCase()}`}
               title={element.name}
               description={element.description}

--- a/docs/pages/get_started/developers/tooling/web.js
+++ b/docs/pages/get_started/developers/tooling/web.js
@@ -99,8 +99,8 @@ export default function ToolingPage(): Node {
                 'Documentation site in gestalt.pinterest.systems',
                 'https://gestalt.pinterest.systems/',
               ],
-            ].map((item, idx) => (
-              <ListElement key={idx} text={item[0]} href={item[1]} />
+            ].map((item) => (
+              <ListElement key={item[0]} text={item[0]} href={item[1]} />
             ))}
           </ul>
         </Flex>
@@ -429,9 +429,9 @@ The following table lists the currently available metrics to track Gestalt adopt
                   '# most used CSS attributes passed to dangerouslySetInlineStyle; # per site',
                   'http://go/metrics_dangerouslySetInlineStyle_keys',
                 ],
-              ].map((item, idx) => (
+              ].map((item) => (
                 <TableEntry
-                  key={`table_entry_${idx}`}
+                  key={`table_entry: ${item[0]}`}
                   metric={item[0]}
                   description={item[1]}
                   href={item[2]}

--- a/docs/pages/visual-test/Icon-list-dark.js
+++ b/docs/pages/visual-test/Icon-list-dark.js
@@ -15,8 +15,8 @@ export default function Snapshot(): Node {
           }}
           wrap
         >
-          {icons.map((name, index) => (
-            <Box key={index} padding={2}>
+          {icons.map((name) => (
+            <Box key={name} padding={2}>
               <Icon color="default" accessibilityLabel="" icon={name} />
             </Box>
           ))}

--- a/docs/pages/visual-test/Icon-list.js
+++ b/docs/pages/visual-test/Icon-list.js
@@ -15,8 +15,8 @@ export default function Snapshot(): Node {
           }}
           wrap
         >
-          {icons.map((name, index) => (
-            <Box key={index} padding={2}>
+          {icons.map((name) => (
+            <Box key={name} padding={2}>
               <Icon color="default" accessibilityLabel="" icon={name} />
             </Box>
           ))}

--- a/docs/pages/visual-test/Table.js
+++ b/docs/pages/visual-test/Table.js
@@ -48,8 +48,8 @@ export default function Snapshot(): Node {
               </Box>
               <Checkbox id="header_checkbox" onChange={() => {}} indeterminate size="sm" />
             </Table.HeaderCell>
-            {['Campaign', 'Spend'].map((title, idx) => (
-              <Table.HeaderCell key={idx}>
+            {['Campaign', 'Spend'].map((title) => (
+              <Table.HeaderCell key={title}>
                 <Text align={title === 'Spend' ? 'end' : 'start'} weight="bold">
                   {title}
                 </Text>

--- a/docs/pages/web/component_status.js
+++ b/docs/pages/web/component_status.js
@@ -55,18 +55,16 @@ export default function ComponentStatus(): Node {
               </Table.Header>
             </Box>
             <Table.Body>
-              {['ready', 'partial', 'planned', 'deprecated', 'notAvailable'].map(
-                (typeStatus, index) => (
-                  <Table.Row key={index}>
-                    <Table.Cell>
-                      <StatusData status={typeStatus} />
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text>{STATUS_DESCRIPTION[typeStatus].description}</Text>
-                    </Table.Cell>
-                  </Table.Row>
-                ),
-              )}
+              {['ready', 'partial', 'planned', 'deprecated', 'notAvailable'].map((typeStatus) => (
+                <Table.Row key={typeStatus}>
+                  <Table.Cell>
+                    <StatusData status={typeStatus} />
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text>{STATUS_DESCRIPTION[typeStatus].description}</Text>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
             </Table.Body>
           </Table>
         </Column>
@@ -97,7 +95,7 @@ export default function ComponentStatus(): Node {
             </Table.Row>
           </Table.Header>
           <Table.Body>
-            {componentSortedList.map((item, index) => {
+            {componentSortedList.map((item) => {
               const {
                 badge,
                 android,
@@ -110,7 +108,7 @@ export default function ComponentStatus(): Node {
               } = item.status || {};
 
               return (
-                <Table.Row key={index}>
+                <Table.Row key={item.name}>
                   <Table.Cell>
                     <Text size="200" inline>
                       {figmaOnly ? (
@@ -140,13 +138,13 @@ export default function ComponentStatus(): Node {
                       )}
                     </Text>
                   </Table.Cell>
-                  {[figma, documentation, responsive, iOS, android].map((status, idx) =>
+                  {[figma, documentation, responsive, iOS, android].map((status) =>
                     deprecated ? (
-                      <Table.Cell key={item.name + idx}>
+                      <Table.Cell key={status}>
                         <DeprecatedStatus />
                       </Table.Cell>
                     ) : (
-                      <Table.Cell key={item.name + idx}>
+                      <Table.Cell key={status}>
                         <StatusData status={status || 'notAvailable'} />
                       </Table.Cell>
                     ),

--- a/packages/gestalt/src/AvatarGroup.js
+++ b/packages/gestalt/src/AvatarGroup.js
@@ -120,6 +120,7 @@ const AvatarGroupWithForwardRef: React$AbstractComponent<Props, UnionRefs> = for
     <CollaboratorAvatar
       hovered={hovered}
       index={index}
+      // eslint-disable-next-line react/no-array-index-key
       key={`collaboratorStack-${name}-${index}`}
       name={name}
       pileCount={pileCount}

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -388,6 +388,7 @@ const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
             isHovered={index === hoveredItemIndex}
             id={id}
             index={index}
+            // eslint-disable-next-line react/no-array-index-key
             key={`${id}${index}`}
             label={comboBoxItemlabel}
             subtext={subtext}

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -208,6 +208,7 @@ const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputE
           {tags ? (
             <div className={styledClasses} {...(tags ? { ref: innerRef } : {})}>
               {tags.map((tag, tagIndex) => (
+                // eslint-disable-next-line react/no-array-index-key
                 <Box key={tagIndex} marginEnd={1} marginBottom={1}>
                   {tag}
                 </Box>

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -489,6 +489,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
             <div // keep this in sync with renderMasonryComponent
               className="static"
               data-grid-item
+              // eslint-disable-next-line react/no-array-index-key
               key={i}
               ref={(el) => {
                 // purposely not checking for layout === 'serverRenderedFlexible' here

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -87,6 +87,7 @@ export default function ModuleExpandable({
           { badge, children, icon, iconAccessibilityLabel, iconButton, summary, title, type },
           index,
         ) => (
+          // eslint-disable-next-line react/no-array-index-key
           <Fragment key={index}>
             {index > 0 && <Divider />}
             <ModuleExpandableItem

--- a/packages/gestalt/src/ModuleExpandableItem.js
+++ b/packages/gestalt/src/ModuleExpandableItem.js
@@ -77,6 +77,7 @@ export default function ModuleExpandableItem({
                 <Box column={6} marginStart={6}>
                   <Flex direction="column" gap={{ column: 2, row: 0 }}>
                     {summary.map((item, i) => (
+                      // eslint-disable-next-line react/no-array-index-key
                       <Text key={i} size="200" lineClamp={1}>
                         {item}
                       </Text>

--- a/packages/gestalt/src/PageHeaderComponents.js
+++ b/packages/gestalt/src/PageHeaderComponents.js
@@ -213,6 +213,7 @@ export function PageHeaderItemsBlock({ items }: {| items: $ReadOnlyArray<Node> |
     <Box display="none" mdDisplay="block" overflow="hidden">
       <Flex gap={{ column: 0, row: 6 }}>
         {items.slice(0, 2).map((item, i) => (
+          // eslint-disable-next-line react/no-array-index-key
           <Flex.Item key={i}>{item}</Flex.Item>
         ))}
       </Flex>

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -87,6 +87,7 @@ export default function SegmentedControl({
     <div className={classnames(styles.SegmentedControl, layout.medium)} role="tablist">
       {items.map((item, i) => (
         <SegmentedControlItem
+          // eslint-disable-next-line react/no-array-index-key
           key={i}
           index={i}
           item={item}

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -229,6 +229,7 @@ const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement
       {tags ? (
         <div className={classes} style={tagsWrapperStyle}>
           {tags.map((tag, tagIndex) => (
+            // eslint-disable-next-line react/no-array-index-key
             <Box key={tagIndex} marginEnd={1} marginBottom={1}>
               {tag}
             </Box>


### PR DESCRIPTION
[Rule definition](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md)

[React uses `key` to identify items within arrays and maintain stability as those items change](https://reactjs.org/docs/lists-and-keys.html#keys). But it's generally [a bad idea to use array indices as keys](https://robinpokorny.com/blog/index-as-a-key-is-an-anti-pattern/).

While there are occasionally valid reasons to use indices as keys, in general we want to avoid that practice, so it makes sense to lint against it.