### PR TITLE
Image: replace `importance` prop with `fetchPriority`

### DIFF
--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -31,15 +31,15 @@ type Props = {|
    */
   elementTiming?: string,
   /**
+   * Priority hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded (only available via Chrome Origin Trial). \`"high"\`: the developer considers the resource to be high priority. \`"low"\`: the developer considers the resource to be low priority. \`auto\` the developer does not indicate a preference.
+   * Note that this feature is currently experimental; please see the [attribute spec](https://wicg.github.io/priority-hints/) for more details.
+   */
+  fetchPriority?: 'high' | 'low' | 'auto',
+  /**
    * Sets how the image is resized to fit its container. See the [Fit example](https://gestalt.pinterest.systems/web/image#fit) for more details.
    * Note: this doesn't work with srcSet or sizes.
    */
   fit?: 'contain' | 'cover' | 'none',
-  /**
-   * Priority hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded (only available via Chrome Origin Trial). \`"high"\`: the developer considers the resource to be high priority. \`"low"\`: the developer considers the resource to be low priority. \`auto\` the developer does not indicate a preference.
-   * Note that this feature is currently experimental; please see the [attribute spec](https://wicg.github.io/priority-hints/) for more details.
-   */
-  importance?: 'high' | 'low' | 'auto',
   /**
    * Controls if loading the image should be deferred when it's off-screen. \`"lazy"\` defers the load until the image or iframe reaches a distance threshold from the viewport. \`"eager"\` loads the resource immediately. \`"auto"\` uses the default behavior, which is to eagerly load the resource. See the [Lazy example](https://gestalt.pinterest.systems/web/image#Lazy) for more details.
    */
@@ -88,14 +88,14 @@ type Props = {|
 export default class Image extends PureComponent<Props> {
   static defaultProps: {|
     color: string,
+    fetchPriority?: 'high' | 'low' | 'auto',
     fit?: 'contain' | 'cover' | 'none',
-    importance?: 'high' | 'low' | 'auto',
     loading?: 'eager' | 'lazy' | 'auto',
   |} = {
     // eslint-disable-next-line react/default-props-match-prop-types
     color: 'transparent',
+    fetchPriority: 'auto',
     fit: 'none',
-    importance: 'auto',
     loading: 'auto',
   };
 
@@ -141,8 +141,8 @@ export default class Image extends PureComponent<Props> {
       crossOrigin,
       decoding,
       elementTiming,
+      fetchPriority,
       fit,
-      importance,
       loading,
       naturalHeight,
       naturalWidth,
@@ -188,7 +188,7 @@ export default class Image extends PureComponent<Props> {
           crossOrigin={crossOrigin}
           decoding={decoding}
           elementtiming={elementTiming}
-          importance={importance}
+          fetchpriority={fetchPriority}
           loading={loading}
           onError={this.handleError}
           onLoad={this.handleLoad}

--- a/packages/gestalt/src/Image.test.js
+++ b/packages/gestalt/src/Image.test.js
@@ -65,6 +65,14 @@ test('Image with crossorigin specified matches snapshot', () => {
   expect(tree).toMatchSnapshot();
 });
 
+test('Image with fetchPriority specified matches snapshot', () => {
+  const component = renderer.create(
+    <Image alt="foo" fetchPriority="high" naturalHeight={50} naturalWidth={50} src="foo.png" />,
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
 test('Image with decoding specified matches snapshot', () => {
   const component = renderer.create(
     <Image alt="foo" decoding="sync" naturalHeight={50} naturalWidth={50} src="foo.png" />,

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -129,7 +129,7 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
+        fetchpriority="auto"
         loading="auto"
         onError={[Function]}
         onLoad={[Function]}
@@ -212,7 +212,7 @@ exports[`Avatar renders the correct size - lg 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
+        fetchpriority="auto"
         loading="auto"
         onError={[Function]}
         onLoad={[Function]}
@@ -258,7 +258,7 @@ exports[`Avatar renders the correct size - md 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
+        fetchpriority="auto"
         loading="auto"
         onError={[Function]}
         onLoad={[Function]}
@@ -304,7 +304,7 @@ exports[`Avatar renders the correct size - sm 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
+        fetchpriority="auto"
         loading="auto"
         onError={[Function]}
         onLoad={[Function]}
@@ -350,7 +350,7 @@ exports[`Avatar renders the correct size - xl 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
+        fetchpriority="auto"
         loading="auto"
         onError={[Function]}
         onLoad={[Function]}
@@ -396,7 +396,7 @@ exports[`Avatar renders the correct size - xs 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
+        fetchpriority="auto"
         loading="auto"
         onError={[Function]}
         onLoad={[Function]}
@@ -442,7 +442,7 @@ exports[`Avatar renders the correct src 1`] = `
       <img
         alt="Strava"
         className="img"
-        importance="auto"
+        fetchpriority="auto"
         loading="auto"
         onError={[Function]}
         onLoad={[Function]}

--- a/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
@@ -37,7 +37,7 @@ exports[`AvatarGroup renders AvatarGroup button with addCollaborators button 1`]
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
+                      fetchpriority="auto"
                       loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
@@ -140,7 +140,7 @@ exports[`AvatarGroup renders AvatarGroup link with addCollaborators button 1`] =
                       <img
                         alt="Keerthi"
                         class="img"
-                        importance="auto"
+                        fetchpriority="auto"
                         loading="auto"
                         src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                       />
@@ -238,7 +238,7 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
+                      fetchpriority="auto"
                       loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
@@ -278,7 +278,7 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
+                      fetchpriority="auto"
                       loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
@@ -450,7 +450,7 @@ exports[`AvatarGroup renders fit display-only AvatarGroup with image 1`] = `
                       <img
                         alt="Keerthi"
                         class="img"
-                        importance="auto"
+                        fetchpriority="auto"
                         loading="auto"
                         src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                       />
@@ -508,7 +508,7 @@ exports[`AvatarGroup renders md display-only AvatarGroup with image 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
+                      fetchpriority="auto"
                       loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
@@ -565,7 +565,7 @@ exports[`AvatarGroup renders sm display-only AvatarGroup with image 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
+                      fetchpriority="auto"
                       loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />
@@ -622,7 +622,7 @@ exports[`AvatarGroup renders xs display-only AvatarGroup with image 1`] = `
                     <img
                       alt="Keerthi"
                       class="img"
-                      importance="auto"
+                      fetchpriority="auto"
                       loading="auto"
                       src="https://i.ibb.co/ZfCZrY8/keerthi.jpg"
                     />

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.js.snap
@@ -436,7 +436,7 @@ exports[`Checkbox with an image 1`] = `
           <img
             alt=""
             className="img"
-            importance="auto"
+            fetchpriority="auto"
             loading="auto"
             onError={[Function]}
             onLoad={[Function]}

--- a/packages/gestalt/src/__snapshots__/Image.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Image.test.js.snap
@@ -13,7 +13,7 @@ exports[`Image matches snapshot 1`] = `
   <img
     alt="foo"
     className="img"
-    importance="auto"
+    fetchpriority="auto"
     loading="auto"
     onError={[Function]}
     onLoad={[Function]}
@@ -36,7 +36,7 @@ exports[`Image with crossorigin specified matches snapshot 1`] = `
     alt="foo"
     className="img"
     crossOrigin="anonymous"
-    importance="auto"
+    fetchpriority="auto"
     loading="auto"
     onError={[Function]}
     onLoad={[Function]}
@@ -59,7 +59,29 @@ exports[`Image with decoding specified matches snapshot 1`] = `
     alt="foo"
     className="img"
     decoding="sync"
-    importance="auto"
+    fetchpriority="auto"
+    loading="auto"
+    onError={[Function]}
+    onLoad={[Function]}
+    src="foo.png"
+  />
+</div>
+`;
+
+exports[`Image with fetchPriority specified matches snapshot 1`] = `
+<div
+  className="box relative"
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "paddingBottom": "100%",
+    }
+  }
+>
+  <img
+    alt="foo"
+    className="img"
+    fetchpriority="high"
     loading="auto"
     onError={[Function]}
     onLoad={[Function]}
@@ -164,7 +186,7 @@ exports[`Image with overlay matches snapshot 1`] = `
   <img
     alt="foo"
     className="img"
-    importance="auto"
+    fetchpriority="auto"
     loading="auto"
     onError={[Function]}
     onLoad={[Function]}

--- a/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/RadioButton.test.js.snap
@@ -308,7 +308,7 @@ exports[`RadioButton with image 1`] = `
         <img
           alt=""
           className="img"
-          importance="auto"
+          fetchpriority="auto"
           loading="auto"
           onError={[Function]}
           onLoad={[Function]}


### PR DESCRIPTION
## Breaking Change

major release - running a generic codemod to replace instances of 'importance' prop and replacing them with 'fetchPriority' 

```bash
yarn codemod modifyProp ~/path/to/your/code
--component=Image
--previousProp=importance
--nextProp=fetchPriority
```

### Summary

Updating 'importance' prop to 'fetchPriority' . This diff removes the deprecated 'importance' prop and replaces with fetchpriority.

There's an old PR [here](https://github.com/pinterest/gestalt/pull/2012) that aimed to do the same thing - just opening up a new one instead of having to jump through permissions hoops + rebasing troubles.

#### Why?

Now that fetchPriority is stable (at least for chromium-based browsers), we want to start running experiments with it to see if we can optimize Largest Contentful Paint on certain surfaces in order to improve SEO rankings, as Google uses LCP and other Core Web Vitals to rank pages in their search engine algorithm.

Specifically, one experiment we had in mind was to optimize for LCP on mWeb unauth BLP by increasing the fetchPriority of images in the viewport. Currently, LCP is potentially slowed down by JS bundles that are called at around the same time in the network waterfall - Chrome defaults these bundles to 'high' priority as well, so we want to see what happens to LCP as well as other potential side effects when upping the image priority to 'highest'.

Priority hints are only in Chromium-based browsers (Chrome, edge, etc). There's been a push for adding them to Firefox as well, but this hasn't been accomplished yet, so we'll need to add a flag for Chromium browsers in the future experiments. However, Chromium browsers make up a large percentage of our traffic (forget the exact number), so any experiment findings will still have a large impact.




### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
