### PR TITLE
Docs: use SegmentedControl for component overview sort control

### DIFF
--- a/docs/docs-components/MainSectionCard.js
+++ b/docs/docs-components/MainSectionCard.js
@@ -7,7 +7,7 @@ import { LiveProvider, LiveError, LivePreview } from 'react-live';
 import ExampleCode from './ExampleCode.js';
 import theme from './atomDark.js';
 import Markdown from './Markdown.js';
-import { capitalizeFirstLetter } from './utils.js';
+import capitalizeFirstLetter from '../utils/capitalizeFirstLetter.js';
 import OpenSandboxButton from './buttons/OpenSandboxButton.js';
 import handleCodeSandbox from './handleCodeSandbox.js';
 

--- a/docs/docs-components/Overview.js
+++ b/docs/docs-components/Overview.js
@@ -1,24 +1,29 @@
 // @flow strict
 import { Fragment, useState, type Node } from 'react';
-import { Box, RadioGroup, Flex, Text } from 'gestalt';
+import { Box, Flex, SegmentedControl } from 'gestalt';
 import Page from './Page.js';
 import PageHeader from './PageHeader.js';
 import List from './OverviewList.js';
 import IllustrationContainer from './IllustrationContainer.js';
 import { type ListItemType } from './COMPONENT_DATA.js';
+import capitalizeFirstLetter from '../utils/capitalizeFirstLetter.js';
+
+const sortOrders = ['alphabetical', 'categorical'];
+
+type Props = {|
+  buildingBlockComponents?: $ReadOnlyArray<ListItemType>,
+  generalComponents: $ReadOnlyArray<ListItemType>,
+  platform: 'Web' | 'Android' | 'iOS',
+  utilityComponents?: $ReadOnlyArray<ListItemType>,
+|};
 
 export default function Overview({
   buildingBlockComponents,
   generalComponents,
   platform,
   utilityComponents,
-}: {|
-  buildingBlockComponents?: $ReadOnlyArray<ListItemType>,
-  generalComponents: $ReadOnlyArray<ListItemType>,
-  platform: 'Web' | 'Android' | 'iOS',
-  utilityComponents?: $ReadOnlyArray<ListItemType>,
-|}): Node {
-  const [order, setOrder] = useState('alphabetical');
+}: Props): Node {
+  const [order, setOrder] = useState<'alphabetical' | 'categorical'>('alphabetical');
 
   const alphabeticalComponentList = [
     ...(utilityComponents ?? []),
@@ -48,38 +53,19 @@ Not sure which component to use? [Set up time with the Gestalt team.](/get_start
             type="guidelines"
           />
         </IllustrationContainer>
-        <IllustrationContainer justifyContent="start">
-          <Flex gap={6} alignItems="center">
-            <Box aria-hidden>
-              <Text size="200">Sort by</Text>
-            </Box>
-            <RadioGroup
-              id="overview"
-              legendDisplay="hidden"
-              legend="Sort Gestalt components alphabetically or categorically"
-              direction="row"
-            >
-              <RadioGroup.RadioButton
-                checked={order === 'alphabetical'}
-                id="alphabetical"
-                label="Alphabetical"
-                name="overviewSort"
-                onChange={() => setOrder('alphabetical')}
-                value="alphabetical"
-                size="sm"
-              />
-              <RadioGroup.RadioButton
-                checked={order === 'category'}
-                id="category"
-                label="Category"
-                name="overviewSort"
-                onChange={() => setOrder('category')}
-                value="category"
-                size="sm"
-              />
-            </RadioGroup>
-          </Flex>
+
+        <IllustrationContainer>
+          <Box flex="none" minWidth={230} width="40%">
+            <SegmentedControl
+              items={sortOrders.map(capitalizeFirstLetter)}
+              onChange={({ activeIndex }) => {
+                setOrder(sortOrders[activeIndex]);
+              }}
+              selectedItemIndex={sortOrders.findIndex((item) => item === order)}
+            />
+          </Box>
         </IllustrationContainer>
+
         {order === 'alphabetical' ? (
           <List platform={platform} headingLevel={2} array={alphabeticalComponentList} />
         ) : (

--- a/docs/docs-components/PropTable.js
+++ b/docs/docs-components/PropTable.js
@@ -5,7 +5,7 @@ import Card from './Card.js';
 import Markdown from './Markdown.js';
 import clipboardCopy from './clipboardCopy.js';
 import trackButtonClick from './buttons/trackButtonClick.js';
-import { capitalizeFirstLetter } from './utils.js';
+import capitalizeFirstLetter from '../utils/capitalizeFirstLetter.js';
 import { useAppContext } from './appContext.js';
 
 const unifyQuotes = (input) => input?.replace(/'/g, '"');

--- a/docs/docs-components/utils.js
+++ b/docs/docs-components/utils.js
@@ -1,5 +1,0 @@
-// @flow strict
-export const convertToSentenceCase = (name: string): string =>
-  name.charAt(0).toUpperCase() + name.slice(1).toLowerCase();
-export const capitalizeFirstLetter = (name: string): string =>
-  name.charAt(0).toUpperCase() + name.slice(1);

--- a/docs/pages/foundations/data_visualization/palette.js
+++ b/docs/pages/foundations/data_visualization/palette.js
@@ -5,7 +5,7 @@ import MainSection from '../../../docs-components/MainSection.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
 import ColorTile from '../../../docs-components/ColorTile.js';
 import Page from '../../../docs-components/Page.js';
-import { capitalizeFirstLetter } from '../../../docs-components/utils.js';
+import capitalizeFirstLetter from '../../../utils/capitalizeFirstLetter.js';
 
 const MAIN_STEPS = ['01', '02', '03', '04', '05', '06'];
 const EXTENDED_STEPS = ['07', '08', '09', '10', '11', '12'];

--- a/docs/utils/capitalizeFirstLetter.js
+++ b/docs/utils/capitalizeFirstLetter.js
@@ -1,0 +1,4 @@
+// @flow strict
+export default function capitalizeFirstLetter(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}


### PR DESCRIPTION
From recent survey feedback and my own personal use, the radio buttons at the top of the Component Overview page aren't very obvious. Per design recommendation from @hectoid, this PR swaps out the radio buttons for SegmentedControl.

Note that the "design spec" was a quick mock from [this Slack convo](https://pinterest.slack.com/archives/C014X9LTRCN/p1667346055685839), so pixel specifics were kinda guesses. 😅 

_Design "spec"_
<img width="886" alt="image" src="https://user-images.githubusercontent.com/12059539/200063245-8a50669b-460f-4dad-b1ef-67b9fca2ac7b.png">

_Implementation at normal widths_
![Screen Shot 2022-11-04 at 12 48 24 PM](https://user-images.githubusercontent.com/12059539/200063341-69b3a91c-fb0b-408a-9d2f-772c3ac31812.png)

_Implementation at most narrow width (before the side nav is hidden)_
![Screen Shot 2022-11-04 at 12 47 04 PM](https://user-images.githubusercontent.com/12059539/200063460-8bf28f47-9a1e-4834-851a-219daeacf19d.png)