### PR TITLE
Docs: fix duplicate key issue

### DIFF
--- a/docs/docs-components/MainSectionSubsection.js
+++ b/docs/docs-components/MainSectionSubsection.js
@@ -94,8 +94,9 @@ function MainSectionSubsection({
               column: 4,
             }}
           >
-            {arrayChildren.map((child) => (
-              <Flex.Item flex="grow" key={child}>
+            {arrayChildren.map((child, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <Flex.Item flex="grow" key={index}>
                 {child}
               </Flex.Item>
             ))}


### PR DESCRIPTION
# Summary

## What changed?

Caused by #2472 - fixes a duplicate key issue on every docs page

## Why?

Resolves errors in the browser console (happens on every page):

![Screen Shot 2022-11-07 at 7 09 04 AM](https://user-images.githubusercontent.com/127199/200348600-1d90300e-195a-40d5-9729-e4e4467594f3.png)

## Alternatives

* Require a unique `id` for every `MainSectionSubsection` component
* Use combination of `title` and `description` - I tried this and it looks like we have quite a few places were both are empty
