### PR TITLE
Docs: Fix page jumps on Sheet & Modal pages

### DIFF
--- a/packages/gestalt/src/behaviors/TrapFocusBehavior.js
+++ b/packages/gestalt/src/behaviors/TrapFocusBehavior.js
@@ -53,7 +53,8 @@ export default function TrapFocusBehavior({ children }: Props): ReactNode {
 
     // Focus the first child element among all the focusable, interactive elements within `children`
     const focusFirstChild = () => {
-      if (element) {
+      const withinIframe = window !== window.parent;
+      if (element && !withinIframe) {
         focusElement(queryFocusableAll(element)[0]);
       }
     };


### PR DESCRIPTION
# Summary

## What changed?

No longer scroll jump on `Sheet` and `Modal` pages

## Why?

It's a very annoying experience for folks using our documentation pages.

## Notes

* Both `Sheet` and `Modal` use `TrapFocusBehavior`
* `focusFirstChild` is only used within `useEffect`, so it's not necessary to do a `window` check: `typeof window !== 'undefined'`
* Other approaches like preventing the focus or scroll in the parent window did not work
