### PR TITLE
Toast: refactor 'button' prop to 'primaryAction' to enable upcoming redesign changes

### DIFF
--- a/docs/pages/visual-test/Toast-dark.js
+++ b/docs/pages/visual-test/Toast-dark.js
@@ -1,13 +1,13 @@
 // @flow strict
 import { type Node } from 'react';
-import { ColorSchemeProvider, Toast, Button, Image, Box } from 'gestalt';
+import { ColorSchemeProvider, Toast, Image, Box } from 'gestalt';
 
 export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="dark">
       <Box color="default">
         <Toast
-          button={<Button key="button-key" text="Undo" size="lg" />}
+          primaryAction={{ accessibilityLabel: 'Test', label: 'Undo', size: 'lg' }}
           text="Home decor"
           thumbnail={
             <Image

--- a/docs/pages/visual-test/Toast.js
+++ b/docs/pages/visual-test/Toast.js
@@ -1,11 +1,11 @@
 // @flow strict
 import { type Node } from 'react';
-import { Toast, Button, Image } from 'gestalt';
+import { Toast, Image } from 'gestalt';
 
 export default function Snapshot(): Node {
   return (
     <Toast
-      button={<Button key="button-key" text="Undo" size="lg" />}
+      primaryAction={{ accessibilityLabel: 'Test', label: 'Undo', size: 'lg' }}
       text="Home decor"
       thumbnail={
         <Image

--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -1,8 +1,5 @@
 // @flow strict
-import { Fragment, type Node } from 'react';
-import { Button, Link, Image, Text, Toast } from 'gestalt';
-import Combination from '../../docs-components/Combination.js';
-import Example from '../../docs-components/Example.js';
+import { type Node } from 'react';
 import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -13,22 +10,19 @@ import AccessibilitySection from '../../docs-components/AccessibilitySection.js'
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
-    <Page title="Toast">
+    <Page title={generatedDocGen?.displayName}>
       <PageHeader
-        name="Toast"
+        name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
         defaultCode={`
 <Toast
-  button={<Button key="button-key" text="Undo" size="lg" />}
+  primaryAction={{ accessibilityLabel: 'Test', label: 'Undo', size: 'lg' }}
   text={
-    <React.Fragment>
-      Saved to{' '}
-      <Text inline weight="bold">
-        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor" underline="hover">
-          Home decor
-        </Link>
-      </Text>
-    </React.Fragment>
+    <Text inline> Saved to
+      <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+        Home decor
+      </Link>
+    </Text>
   }
   thumbnail={
     <Image
@@ -71,11 +65,13 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <AccessibilitySection name={generatedDocGen?.displayName} />
 
       <MainSection name="Variants">
-        <Example
-          id="displayExample"
-          name="Example: How to display"
+        <MainSection.Subsection
           description="Toasts should be displayed in the center of the viewport, opposite the main navbar (e.g. at the top of the viewport on mobile, bottom of the viewport on desktop). Though not implemented here, Toasts are meant to be ephemeral and disappear after a few seconds."
-          defaultCode={`
+          title="How to display"
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 function ToastExample() {
   const [showToast, setShowToast] = React.useState(false);
 
@@ -101,16 +97,14 @@ function ToastExample() {
             position="fixed"
           >
             <Toast
-              button={<Button key="button-key" text="Undo" size="lg" />}
+              primaryAction={{ accessibilityLabel: 'Test', label: 'Undo', size: 'lg' }}
               text={
-                <React.Fragment>
+                <Text inline>
                   Saved to{' '}
-                  <Text inline weight="bold">
-                    <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor" underline="hover">
-                      Home decor
-                    </Link>
-                  </Text>
-                </React.Fragment>
+                  <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+                    Home decor
+                  </Link>
+                </Text>
               }
               thumbnail={
                 <Image
@@ -127,41 +121,35 @@ function ToastExample() {
     </Box>
   );
 }`}
-        />
-        <Example
-          id="textOnlyExample"
-          name="Example: Simple Text"
-          defaultCode={`
-<Flex justifyContent="center" width="100%">
-  <Toast text="Section created!" />
-</Flex>
-`}
-        />
-        <Example
-          id="complexTextExample"
-          name="Example: Complex Text"
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
           description="When passing in your own Text component for `text`, do not specify `color` on Text. Toast will automatically pick the correct text color for the given `variant`."
-          defaultCode={`
+          title="Complex Text"
+        >
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Flex justifyContent="center" width="100%">
   <Toast
     text={
-      <React.Fragment>
+      <Text inline>
         Saved to{' '}
-        <Text inline weight="bold">
-          <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor" underline="hover">
-            Home decor
-          </Link>
-        </Text>
-      </React.Fragment>
+        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+          Home decor
+        </Link>
+      </Text>
     }
   />
 </Flex>
 `}
-        />
-        <Example
-          id="errorVariantExample"
-          name="Example: Error variant"
-          defaultCode={`
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection title="Error">
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Flex justifyContent="center" width="100%">
   <Toast
     text="Oops! Something went wrong. Please try again later."
@@ -169,22 +157,22 @@ function ToastExample() {
   />
 </Flex>
 `}
-        />
-        <Example
-          id="imageTextExample"
-          name="Example: Image + Text"
-          defaultCode={`
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Thumbnail">
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Flex justifyContent="center" width="100%">
   <Toast
     text={
-      <React.Fragment>
+      <Text inline>
         Saved to{' '}
-        <Text inline weight="bold">
-          <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor" underline="hover">
-            Home decor
-          </Link>
-        </Text>
-      </React.Fragment>
+        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+          Home decor
+        </Link>
+      </Text>
     }
     thumbnail={
       <Image
@@ -197,109 +185,50 @@ function ToastExample() {
   />
 </Flex>
 `}
-        />
-        <Example
-          id="imageTextButtonExample"
-          name="Example: Image + Text + Button"
-          defaultCode={`
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Primary action">
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
 <Flex justifyContent="center" width="100%">
   <Toast
-    button={<Button key="button-key" text="Undo" size="lg" />}
+    primaryAction={{ accessibilityLabel: 'Test', label: 'Undo', size: 'lg' }}
     text={
-      <React.Fragment>
+      <Text inline>
         Saved to{' '}
-        <Text inline weight="bold">
-          <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor" underline="hover">
-            Home decor
-          </Link>
-        </Text>
-      </React.Fragment>
+        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+          Home decor
+        </Link>
+      </Text>
     }
-    thumbnail={
-      <Image
-        alt="Modern ceramic vase pin."
-        naturalHeight={564}
-        naturalWidth={564}
-        src="https://i.ibb.co/Lx54BCT/stock1.jpg"
-      />
+
+  />
+</Flex>`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="_dangerouslySetPrimaryAction">
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+<Flex justifyContent="center" width="100%">
+  <Toast
+    _dangerouslySetPrimaryAction={<Button accessibilityLabel="test" size="lg" text="Undo" />}
+    text={
+      <Text inline>
+        Saved to{' '}
+        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+          Home decor
+        </Link>
+      </Text>
     }
   />
 </Flex>
 `}
-        />
-        <Combination
-          id="combinations-overview"
-          layout="12column"
-          name="Combinations: Overview"
-          showValues={false}
-          text={[
-            'Section created!',
-            <Fragment key="saved-text">
-              Saved to{' '}
-              <Text inline weight="bold">
-                <Link
-                  inline
-                  target="blank"
-                  href="https://www.pinterest.com/search/pins/?q=home%20decor"
-                  underline="hover"
-                >
-                  Home decor
-                </Link>
-              </Text>
-            </Fragment>,
-          ]}
-          thumbnail={[
-            null,
-            <Image
-              key="image-key"
-              alt="Modern ceramic vase pin."
-              naturalHeight={564}
-              naturalWidth={564}
-              src="https://i.ibb.co/Lx54BCT/stock1.jpg"
-            />,
-          ]}
-          button={[null, <Button key="button-key" text="Undo" size="lg" />]}
-        >
-          {(props) => <Toast {...props} />}
-        </Combination>
-        <Combination
-          id="combinations-thumbnail"
-          layout="12column"
-          name="Combinations: Thumbnail shapes"
-          showValues={false}
-          thumbnailShape={['circle', 'square']}
-        >
-          {(props) => (
-            <Toast
-              {...props}
-              thumbnail={
-                <Image
-                  key="image-key"
-                  alt="Blush and sage plant print."
-                  naturalHeight={751}
-                  naturalWidth={564}
-                  src="https://i.ibb.co/7bQQYkX/stock2.jpg"
-                />
-              }
-              text={
-                <Fragment>
-                  Saved to{' '}
-                  <Text inline weight="bold">
-                    <Link
-                      inline
-                      target="blank"
-                      href="https://www.pinterest.com/search/pins/?q=home%20decor"
-                      underline="hover"
-                    >
-                      Home decor
-                    </Link>
-                  </Text>
-                </Fragment>
-              }
-              button={<Button key="button-key" text="Undo" size="lg" />}
-            />
-          )}
-        </Combination>
+          />
+        </MainSection.Subsection>
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />

--- a/packages/gestalt/src/Toast.test.js
+++ b/packages/gestalt/src/Toast.test.js
@@ -1,5 +1,4 @@
 // @flow strict
-import { Fragment } from 'react';
 import { create } from 'react-test-renderer';
 import Button from './Button.js';
 import Link from './Link.js';
@@ -31,18 +30,16 @@ describe('<Toast />', () => {
           />
         }
         text={
-          <Fragment>
+          <Text inline weight="bold">
             Saved to{' '}
-            <Text inline weight="bold">
-              <Link
-                inline
-                href="https://www.pinterest.com/search/pins/?q=home%20decor"
-                underline="hover"
-              >
-                Home decor
-              </Link>
-            </Text>
-          </Fragment>
+            <Link
+              inline
+              href="https://www.pinterest.com/search/pins/?q=home%20decor"
+              underline="hover"
+            >
+              Home decor
+            </Link>
+          </Text>
         }
       />,
     ).toJSON();
@@ -59,20 +56,39 @@ describe('<Toast />', () => {
           />
         }
         text={
-          <Fragment>
+          <Text inline weight="bold">
             Saved to{' '}
-            <Text inline weight="bold">
-              <Link
-                inline
-                href="https://www.pinterest.com/search/pins/?q=home%20decor"
-                underline="hover"
-              >
-                Home decor
-              </Link>
-            </Text>
-          </Fragment>
+            <Link
+              inline
+              href="https://www.pinterest.com/search/pins/?q=home%20decor"
+              underline="hover"
+            >
+              Home decor
+            </Link>
+          </Text>
         }
-        button={<Button size="lg" text="Undo" />}
+        primaryAction={{ accessibilityLabel: 'Test', label: 'Undo', size: 'lg' }}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('Text + _dangerouslySetPrimaryAction', () => {
+    const tree = create(
+      <Toast
+        text={
+          <Text inline weight="bold">
+            Saved to{' '}
+            <Link
+              inline
+              href="https://www.pinterest.com/search/pins/?q=home%20decor"
+              underline="hover"
+            >
+              Home decor
+            </Link>
+          </Text>
+        }
+        _dangerouslySetPrimaryAction={<Button accessibilityLabel="test" size="lg" text="Undo" />}
       />,
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/ToastPrimaryAction.js
+++ b/packages/gestalt/src/ToastPrimaryAction.js
@@ -1,0 +1,43 @@
+// @flow strict
+import { type Node } from 'react';
+import Button from './Button.js';
+import Link from './Link.js';
+
+type Props = {|
+  accessibilityLabel: string,
+  href?: string,
+  label: string,
+  onClick?: $ElementType<React$ElementConfig<typeof Button>, 'onClick'>,
+  rel?: $ElementType<React$ElementConfig<typeof Link>, 'rel'>,
+  size?: $ElementType<React$ElementConfig<typeof Button>, 'size'>,
+  target?: $ElementType<React$ElementConfig<typeof Link>, 'target'>,
+|};
+
+export default function ToastPrimaryAction({
+  accessibilityLabel,
+  href,
+  label,
+  onClick,
+  rel,
+  size,
+  target,
+}: Props): Node {
+  if (href && label)
+    return (
+      <Button
+        accessibilityLabel={accessibilityLabel}
+        href={href}
+        rel={rel}
+        target={target}
+        role="link"
+        text={label}
+        size={size}
+        onClick={onClick}
+      />
+    );
+
+  if (label)
+    return (
+      <Button accessibilityLabel={accessibilityLabel} text={label} size="lg" onClick={onClick} />
+    );
+}

--- a/packages/gestalt/src/__snapshots__/Toast.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Toast.test.js.snap
@@ -37,6 +37,99 @@ exports[`<Toast /> Error Toast 1`] = `
 </div>
 `;
 
+exports[`<Toast /> Text + _dangerouslySetPrimaryAction 1`] = `
+<div
+  className="box marginBottom3 paddingX4"
+  role="status"
+  style={
+    Object {
+      "maxWidth": "min(500px, 100vw)",
+      "minWidth": 330,
+      "width": 330,
+    }
+  }
+>
+  <div
+    className="box dark fit paddingX6 paddingY6 pill shadow"
+  >
+    <div
+      className="Flex rowGap4 columnGap0 itemsCenter xsDirectionRow"
+    >
+      <div
+        className="FlexItem flexGrow"
+        style={
+          Object {
+            "maxWidth": undefined,
+          }
+        }
+      >
+        <div
+          className="Text fontSize300 lightText alignCenter breakWord fontWeightNormal"
+        >
+          <span
+            className="textColorOverrideLight"
+          >
+            <span
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Saved to
+               
+              <a
+                className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
+                href="https://www.pinterest.com/search/pins/?q=home%20decor"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyPress={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                rel=""
+                target={null}
+              >
+                Home decor
+              </a>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        className="FlexItem flexNone"
+      >
+        <button
+          aria-label="test"
+          className="button hideOutline inline accessibilityOutline parentButton"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <div
+            className="button hideOutline inline accessibilityOutline tapTransition lg gray enabled childrenDiv"
+          >
+            <div
+              className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            >
+              Undo
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Toast /> Text + Image + Button 1`] = `
 <div
   className="box marginBottom3 paddingX4"
@@ -87,11 +180,11 @@ exports[`<Toast /> Text + Image + Button 1`] = `
           <span
             className="textColorOverrideLight"
           >
-            Saved to
-             
             <span
               className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
             >
+              Saved to
+               
               <a
                 className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
                 href="https://www.pinterest.com/search/pins/?q=home%20decor"
@@ -118,6 +211,7 @@ exports[`<Toast /> Text + Image + Button 1`] = `
         className="FlexItem flexNone"
       >
         <button
+          aria-label="Test"
           className="button hideOutline inline accessibilityOutline parentButton"
           disabled={false}
           onBlur={[Function]}
@@ -197,11 +291,11 @@ exports[`<Toast /> Text + Image 1`] = `
           <span
             className="textColorOverrideLight"
           >
-            Saved to
-             
             <span
               className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
             >
+              Saved to
+               
               <a
                 className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
                 href="https://www.pinterest.com/search/pins/?q=home%20decor"


### PR DESCRIPTION
## Breaking change

API change. From `button` (Node) to a restricted object `{ accessibilityLabel, href, label, onClick, rel, size, target }

Added a new undocumented prop `_dangerouslySetPrimaryAction`. Use `_dangerouslySetPrimaryAction` as an exception, only for legacy custom buttons components. 

Run the following codemod to detect button props and replace them manually:

```
yarn codemod detectManualReplacement ~/path/to/your/code
--component=Toast
--prop=button
```
 

### Summary

#### What changed?

Toast: refactor 'button' prop to enable upcoming redesign changes

#### Why?

'button' prop doesn't allow to control button sizes. refactoring to 'primaryAction' to enable upcoming redesign changes

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests