### PR TITLE
DefaultLabelProvider: add fallback objects to prevent destructuring errors

### DIFF
--- a/packages/gestalt/src/contexts/DefaultLabelProvider.js
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.js
@@ -76,8 +76,8 @@ export function useDefaultLabelContext<C: ValidComponent>(
 
   // If no Context value provided, return fallback labels
   if (!labels) {
-    return fallbackLabels[componentName];
+    return fallbackLabels[componentName] ?? {};
   }
 
-  return labels[componentName];
+  return labels[componentName] ?? {};
 }


### PR DESCRIPTION
Attempting to solve [this issue](https://pinterest.slack.com/archives/G01GN7CE99S/p1667574386047009), where the proper mock isn't being used and destructuring throws.