### PR TITLE
SlimBanner: extend "message" prop to accept Text component for rich-styled messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### Minor
 
-- Icon: convert Tabs Docs to use Sandpack editor ([#2488](https://github.com/pinterest/gestalt/pull/2488)) - [Preview link](https://deploy-preview-2488--gestalt.netlify.app)
+- Icon: convert Icon Docs to use Sandpack editor ([#2488](https://github.com/pinterest/gestalt/pull/2488)) - [Preview link](https://deploy-preview-2488--gestalt.netlify.app)
 
 ## 81.2.0 (Nov 9, 2022)
 

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -444,49 +444,46 @@ Combine SlimBanners with other components like [Callouts](/web/callout) or [Upse
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description={`\`message\` props accepts both strings and [Text](/Text). Use strings for simple messages without any visual style. SlimBanner will handle the message style and the adherence to design guidelines. If a message with more complex style is required, such as bold text or inline links, use Text to inline texts and links within the same Text component.
+          description={`The \`message\` prop accepts both strings and [Text](/Text). Use strings for simple messages without any visual style. SlimBanner will handle the message style and the adherence to design guidelines. If a message with more complex style is required, such as bold text or inline links, use Text to inline text and links within the same Text component.
 
-The SlimBanner message strings can be complemented with a helper Link. When passing rich Text components, \`helperLink\` isn't rendered to prevent unnecessary visual load.
+The SlimBanner \`message\` string can be complemented with a \`helperLink\`. When passing a Text component, \`helperLink\` isn't rendered to prevent unnecessary visual load.
 
-Due to localization constrains, \`message\` and \`helperLink\` prop texts cannot belong to the same statement. They must be independent sentences separated by a period.
+Due to localization constrains, the contents of \`message\` and \`helperLink\` cannot belong to the same sentence. They must be independent sentences separated by a period.
 `}
           title="Message"
         >
           <MainSection.Card
-            title="Simple message string with helperText"
             cardSize="md"
             defaultCode={`
-<SlimBanner
-  type="info"
-  message="This ad group is part of a campaign that is using campaign budget optimization. Changes to schedule or budget must be made at the campaign level."
-  iconAccessibilityLabel="Information"
-  helperLink={{
-      text: 'Learn more',
-      accessibilityLabel: 'Learn more about campaign budget optimization',
-      href: 'http://www.pinterest.com',
+<Flex direction="column" gap={6}>
+  <Text weight="bold">Simple message string with helperText</Text>
+  <SlimBanner
+    type="info"
+    message="This ad group is part of a campaign that is using campaign budget optimization. Changes to schedule or budget must be made at the campaign level."
+    iconAccessibilityLabel="Information"
+    helperLink={{
+        text: 'Learn more',
+        accessibilityLabel: 'Learn more about campaign budget optimization',
+        href: 'http://www.pinterest.com',
+        onClick: () => {},
+      }}
+  />
+  <Text weight="bold">Rich message with Text component</Text>
+  <SlimBanner
+    type="recommendation"
+    message={<Text inline>The campaign <Text inline weight="bold">Back to School</Text> is regularly hitting its <Link inline href="">daily cap</Link>. Consider raising daily caps to increase scale for a similar CPC and CTR.</Text>}
+    primaryAction={{
+      accessibilityLabel: 'Increase spend',
+      label: 'Increase spend',
       onClick: () => {},
     }}
-/>
-`}
-          />
-          <MainSection.Card
-            title="Rich message with Text component"
-            cardSize="md"
-            defaultCode={`
-<SlimBanner
-  type="recommendation"
-  message={<Text inline>The campaign <Text inline weight="bold">Back to School</Text> is regularly hitting its <Link inline href="">daily cap</Link>. Consider raising daily caps to increase scale for a similar CPC and CTR.</Text>}
-  primaryAction={{
-    accessibilityLabel: 'Increase spend',
-    label: 'Increase spend',
-    onClick: () => {},
-  }}
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: () => {},
-  }}
-  iconAccessibilityLabel="Recommendation"
-/>
+    dismissButton={{
+      accessibilityLabel: 'Dismiss banner',
+      onDismiss: () => {},
+    }}
+    iconAccessibilityLabel="Recommendation"
+  />
+</Flex>
 `}
           />
         </MainSection.Subsection>

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -444,11 +444,12 @@ Combine SlimBanners with other components like [Callouts](/web/callout) or [Upse
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description={`The \`message\` prop accepts both strings and [Text](/Text). Use strings for simple messages without any visual style. SlimBanner will handle the message style and the adherence to design guidelines. If a message with more complex style is required, such as bold text or inline links, use Text to inline text and links within the same Text component.
+          description={`
+The \`message\` prop accepts either a string or [Text](/Text). Use a string for simple messages without any visual style. SlimBanner will handle the message style and adherence to design guidelines. If a message with more complex style is required, such as bold text or inline links, use Text to wrap your message with any additional Text or Link usages contained within.
 
 The SlimBanner \`message\` string can be complemented with a \`helperLink\`. When passing a Text component, \`helperLink\` isn't rendered to prevent unnecessary visual load.
 
-Due to localization constrains, the contents of \`message\` and \`helperLink\` cannot belong to the same sentence. They must be independent sentences separated by a period.
+Due to localization constraints, the contents of \`message\` and \`helperLink\` cannot belong to the same sentence. They must be independent sentences separated by a period. Don't attempt to construct a compound sentence using \`message\` and \`helperLink\`.
 `}
           title="Message"
         >
@@ -468,10 +469,12 @@ Due to localization constrains, the contents of \`message\` and \`helperLink\` c
         onClick: () => {},
       }}
   />
+
   <Text weight="bold">Rich message with Text component</Text>
+
   <SlimBanner
     type="recommendation"
-    message={<Text inline>The campaign <Text inline weight="bold">Back to School</Text> is regularly hitting its <Link inline href="">daily cap</Link>. Consider raising daily caps to increase scale for a similar CPC and CTR.</Text>}
+    message={<Text inline> The campaign <Text inline weight="bold">Back to School</Text> is regularly hitting its <Link inline href="">daily cap</Link>. Consider raising daily caps to increase scale for a similar CPC and CTR.</Text> }
     primaryAction={{
       accessibilityLabel: 'Increase spend',
       label: 'Increase spend',
@@ -483,6 +486,8 @@ Due to localization constrains, the contents of \`message\` and \`helperLink\` c
     }}
     iconAccessibilityLabel="Recommendation"
   />
+
+
 </Flex>
 `}
           />
@@ -491,15 +496,15 @@ Due to localization constrains, the contents of \`message\` and \`helperLink\` c
         <MainSection.Subsection
           title="Primary action"
           description={`
-          SlimBanners can have a primary action. This action can be a [Link](/web/link), by specifying the \`href\` property, or a [Button](/web/button), when no \`href\` is supplied.
+SlimBanners can have a primary action. This action can be a [Link](/web/link), by specifying the \`href\` property, or a [Button](/web/button), when no \`href\` is supplied.
 
-        SlimBanner actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+SlimBanner actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.
 
-        For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a button that opens a [Modal](/web/modal) with an application flow. Be sure to localize the labels of the actions.
+For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a button that opens a [Modal](/web/modal) with an application flow. Be sure to localize the labels of the actions.
 
-        If needed, actions can become disabled after clicking by setting \`disabled: true\` in the action data.
+If needed, actions can become disabled after clicking by setting \`disabled: true\` in the action data.
 
-        Note that actions are not available on compact ("___Bare" type) SlimBanners.
+Note that actions are not available on compact ("___Bare" type) SlimBanners.
           `}
         >
           <MainSection.Card
@@ -611,7 +616,11 @@ Tooltip provides helpful information regarding an interactive UI element, typica
 }
 
 export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
+  const docGen = await docgen({ componentName: 'SlimBanner' });
+
+  docGen.props.message.flowType.raw = '{| string | React.Element<typeof Text>>> |}';
+
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'SlimBanner' }) },
+    props: { generatedDocGen: docGen },
   };
 }

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -6,7 +6,6 @@ import Page from '../../docs-components/Page.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
-
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
 import responsiveExample from '../../examples/slimbanner/responsiveExample.js';
@@ -445,11 +444,17 @@ Combine SlimBanners with other components like [Callouts](/web/callout) or [Upse
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description="The SlimBanner message can be complemented with a helper Link."
-          title="helperLink"
+          description={`\`message\` props accepts both strings and [Text](/Text). Use strings for simple messages without any visual style. SlimBanner will handle the message style and the adherence to design guidelines. If a message with more complex style is required, such as bold text or inline links, use Text to inline texts and links within the same Text component.
+
+The SlimBanner message strings can be complemented with a helper Link. When passing rich Text components, \`helperLink\` isn't rendered to prevent unnecessary visual load.
+
+Due to localization constrains, \`message\` and \`helperLink\` prop texts cannot belong to the same statement. They must be independent sentences separated by a period.
+`}
+          title="Message"
         >
           <MainSection.Card
-            cardSize="lg"
+            title="Simple message string with helperText"
+            cardSize="md"
             defaultCode={`
 <SlimBanner
   type="info"
@@ -461,6 +466,26 @@ Combine SlimBanners with other components like [Callouts](/web/callout) or [Upse
       href: 'http://www.pinterest.com',
       onClick: () => {},
     }}
+/>
+`}
+          />
+          <MainSection.Card
+            title="Rich message with Text component"
+            cardSize="md"
+            defaultCode={`
+<SlimBanner
+  type="recommendation"
+  message={<Text inline>The campaign <Text inline weight="bold">Back to School</Text> is regularly hitting its <Link inline href="">daily cap</Link>. Consider raising daily caps to increase scale for a similar CPC and CTR.</Text>}
+  primaryAction={{
+    accessibilityLabel: 'Increase spend',
+    label: 'Increase spend',
+    onClick: () => {},
+  }}
+  dismissButton={{
+    accessibilityLabel: 'Dismiss banner',
+    onDismiss: () => {},
+  }}
+  iconAccessibilityLabel="Recommendation"
 />
 `}
           />

--- a/packages/gestalt/src/SideNavigation/getChildrenToArray.js
+++ b/packages/gestalt/src/SideNavigation/getChildrenToArray.js
@@ -17,7 +17,6 @@ const getChildrenToArray = ({
   const navigationChildren = [];
 
   let recursionLevel = 0;
-
   const getChildren = ({ nodeChildren }) =>
     Children.toArray(nodeChildren).forEach((child) => {
       // Detect incorrect subcomponent usage at the main level

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { isValidElement, Fragment, type Element, type Node } from 'react';
+import { Children, Fragment, type Element, type Node } from 'react';
 import Box from './Box.js';
 import Button from './Button.js';
 import Flex from './Flex.js';
@@ -213,7 +213,9 @@ export default function SlimBanner({
                 ) : null}
               </Text>
             ) : null}
-            {typeof message !== 'string' && isValidElement(message) ? message : null}
+            {typeof message !== 'string' && Children.only(message).type.displayName === 'Text'
+              ? message
+              : null}
           </Box>
         </Flex.Item>
 

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Fragment, type Node } from 'react';
+import { isValidElement, Fragment, type Element, type Node } from 'react';
 import Box from './Box.js';
 import Button from './Button.js';
 import Flex from './Flex.js';
@@ -116,7 +116,7 @@ type Props = {|
    */
   dismissButton?: DismissButtonType,
   /**
-   * Helper [Link](https://gestalt.pinterest.systems/web/link) to be placed after the message. See the [helperLink variant](https://gestalt.pinterest.systems/web/slimbanner#helperLink) to learn more.
+   * Helper [Link](https://gestalt.pinterest.systems/web/link) to be placed after the message. See the [Message variant](https://gestalt.pinterest.systems/web/slimbanner#Message) to learn more.
    */
   helperLink?: HelperLinkType,
   /**
@@ -124,10 +124,10 @@ type Props = {|
    */
   iconAccessibilityLabel?: string,
   /**
-   * Main content of SlimBanner. Content should be [localized](https://gestalt.pinterest.systems/web/slimbanner#Localization).
+   * Main content of SlimBanner. Content should be [localized](https://gestalt.pinterest.systems/web/slimbanner#Localization). See the [Message variant](https://gestalt.pinterest.systems/web/slimbanner#Message) to learn more.
    *
    */
-  message: string,
+  message: string | Element<typeof Text>,
   /**
    * Main action for users to take on SlimBanner. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
@@ -202,15 +202,18 @@ export default function SlimBanner({
 
         <Flex.Item flex="grow">
           <Box dangerouslySetInlineStyle={{ __style: !isDefault ? { marginTop: '-1px' } : {} }}>
-            <Text inline>
-              {message}
-              {helperLink ? (
-                <Fragment>
-                  {' '}
-                  <HelperLink {...helperLink} />
-                </Fragment>
-              ) : null}
-            </Text>
+            {typeof message === 'string' ? (
+              <Text inline>
+                {message}
+                {helperLink ? (
+                  <Fragment>
+                    {' '}
+                    <HelperLink {...helperLink} />
+                  </Fragment>
+                ) : null}
+              </Text>
+            ) : null}
+            {typeof message !== 'string' && isValidElement(message) ? message : null}
           </Box>
         </Flex.Item>
 

--- a/packages/gestalt/src/SlimBanner.test.js
+++ b/packages/gestalt/src/SlimBanner.test.js
@@ -1,6 +1,8 @@
 // @flow strict
 import { create } from 'react-test-renderer';
 import SlimBanner from './SlimBanner.js';
+import Text from './Text.js';
+import Link from './Link.js';
 
 describe('SlimBanner', () => {
   it('renders neutral type with message', () => {
@@ -30,7 +32,7 @@ describe('SlimBanner', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders helper link', () => {
+  it('renders simple message with helper link', () => {
     const tree = create(
       <SlimBanner
         message="test"
@@ -39,6 +41,45 @@ describe('SlimBanner', () => {
           accessibilityLabel: 'Learn more Pinterest.com',
           href: 'http://www.pinterest.com',
           onClick: () => {},
+        }}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders complex message', () => {
+    const tree = create(
+      <SlimBanner
+        message={
+          <Text inline>
+            The campaign{' '}
+            <Text inline weight="bold">
+              Back to School
+            </Text>{' '}
+            is regularly hitting its{' '}
+            <Link inline href="http://www.pinterest.com">
+              daily cap
+            </Link>
+            . Consider raising daily caps to increase scale for a similar CPC and CTR.
+          </Text>
+        }
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders primary action and dismiss button', () => {
+    const tree = create(
+      <SlimBanner
+        message="test"
+        primaryAction={{
+          accessibilityLabel: 'test',
+          label: 'test',
+          onClick: () => {},
+        }}
+        dismissButton={{
+          accessibilityLabel: 'test',
+          onDismiss: () => {},
         }}
       />,
     ).toJSON();

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -79,7 +79,7 @@ type Props = {|
  * ![Text light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Text.spec.mjs-snapshots/Text-chromium-darwin.png)
  * ![Text dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Text-dark.spec.mjs-snapshots/Text-dark-chromium-darwin.png)
  */
-export default function Text({
+function Text({
   align = 'start',
   children,
   color = 'default',
@@ -127,3 +127,7 @@ export default function Text({
     </Tag>
   );
 }
+
+Text.displayName = 'Text';
+
+export default Text;

--- a/packages/gestalt/src/__snapshots__/SlimBanner.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SlimBanner.test.js.snap
@@ -56,7 +56,7 @@ exports[`SlimBanner renders an icon with accessibility label 1`] = `
 </div>
 `;
 
-exports[`SlimBanner renders helper link 1`] = `
+exports[`SlimBanner renders complex message 1`] = `
 <div
   className="box itemsCenter mdDirectionRow paddingX4 paddingY0 paddingY4 rounding4 secondary xsDirectionColumn xsDisplayFlex"
   style={
@@ -82,31 +82,35 @@ exports[`SlimBanner renders helper link 1`] = `
         <span
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
         >
-          test
+          The campaign
            
           <span
-            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
           >
-            <a
-              aria-label="Learn more Pinterest.com"
-              className="link hideOutline tapTransition rounding0 inlineBlock underline hoverNoUnderline accessibilityOutline"
-              href="http://www.pinterest.com"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              rel=""
-              target={null}
-            >
-              Learn more
-            </a>
+            Back to School
           </span>
+           
+          is regularly hitting its
+           
+          <a
+            className="link hideOutline tapTransition rounding0 inlineBlock underline hoverNoUnderline accessibilityOutline"
+            href="http://www.pinterest.com"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            rel=""
+            target={null}
+          >
+            daily cap
+          </a>
+          . Consider raising daily caps to increase scale for a similar CPC and CTR.
         </span>
       </div>
     </div>
@@ -197,6 +201,217 @@ exports[`SlimBanner renders non-neutral compact with accessibility label 1`] = `
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
         >
           test
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SlimBanner renders primary action and dismiss button 1`] = `
+<div
+  className="box itemsCenter mdDirectionRow paddingX4 paddingY0 paddingY4 rounding4 secondary xsDirectionColumn xsDisplayFlex"
+  style={
+    Object {
+      "width": "100%",
+    }
+  }
+>
+  <div
+    className="Flex rowGap4 columnGap0 flexGrow itemsCenter xsDirectionRow"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="FlexItem flexGrow"
+    >
+      <div
+        className="box"
+      >
+        <span
+          className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+        >
+          test
+        </span>
+      </div>
+    </div>
+    <div
+      className="FlexItem flexNone"
+    >
+      <div
+        className="Flex rowGap4 columnGap0 itemsCenter xsDirectionRow"
+      >
+        <div
+          className="FlexItem"
+        >
+          <div
+            className="box flexNone mdDisplayFlex xsDisplayNone"
+          >
+            <button
+              aria-label="test"
+              className="button hideOutline block accessibilityOutline parentButton"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              <div
+                className="button hideOutline block accessibilityOutline tapTransition sm white enabled childrenDiv"
+              >
+                <div
+                  className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+                >
+                  test
+                </div>
+              </div>
+            </button>
+          </div>
+        </div>
+        <div
+          className="FlexItem"
+        >
+          <button
+            aria-label="test"
+            className="parentButton"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <div
+              className="button tapTransition enabled"
+            >
+              <div
+                className="pog transparent"
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-label=""
+                  className="icon defaultIcon iconBlock"
+                  height={12}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={12}
+                >
+                  <path
+                    d="test-file-stub"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="box flexNone marginTop4 mdDisplayNone selfEnd xsDisplayFlex"
+  >
+    <button
+      aria-label="test"
+      className="button hideOutline block accessibilityOutline parentButton"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="button hideOutline block accessibilityOutline tapTransition sm white enabled childrenDiv"
+      >
+        <div
+          className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+        >
+          test
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`SlimBanner renders simple message with helper link 1`] = `
+<div
+  className="box itemsCenter mdDirectionRow paddingX4 paddingY0 paddingY4 rounding4 secondary xsDirectionColumn xsDisplayFlex"
+  style={
+    Object {
+      "width": "100%",
+    }
+  }
+>
+  <div
+    className="Flex rowGap4 columnGap0 flexGrow itemsCenter xsDirectionRow"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="FlexItem flexGrow"
+    >
+      <div
+        className="box"
+      >
+        <span
+          className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+        >
+          test
+           
+          <span
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            <a
+              aria-label="Learn more Pinterest.com"
+              className="link hideOutline tapTransition rounding0 inlineBlock underline hoverNoUnderline accessibilityOutline"
+              href="http://www.pinterest.com"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              rel=""
+              target={null}
+            >
+              Learn more
+            </a>
+          </span>
         </span>
       </div>
     </div>


### PR DESCRIPTION
### Summary

#### What changed?

SlimBanner: extend "message" prop to accept Text component for rich-styled messages

#### Why?

Supporting Text and string in message prop will solve 2 problems: supporting rich-style messages such as inline bold text within Text and supporting links within Text allowing the correct localization of text with inlined links. helperText cannot be used with that purpose as localization not always follows the same word order in different locales.

- Left: Previously supported
- Center: Previously unsupported
- Right: Previously unsupported

<img width="1324" alt="Screen Shot 2022-11-07 at 5 54 28 PM" src="https://user-images.githubusercontent.com/10593890/200432737-0ff31298-2b6a-4c02-b106-d469170f9a43.png">

### Links

- [Figma]( https://www.figma.com/file/MInxIhLJSbGDebM0939W5G/Gestalt-SlimBanner-Hand-off?node-id=602%3A2520)



### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
