### PR TITLE
Docs: fix empty import from 'react'

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -6,6 +6,6 @@
    _Note: We usually use `main.js` for the top-level example on a component page._
 
 1. Build your example, or copy-paste the code from the existing example. You'll probably need to wrap the output in `<Flex alignItems="center" justifyContent="center" height="100%" width="100%">` to center it within the Sandpack view.
-   _Note: be sure to add the `// @flow strict` annotation at the top of your file. Don't import `React`, but only what you need specifically. You'll probably want to use `React$Node` as the return type for your function component, otherwise you will see `import {} from 'react';` if there are no other React imports._
+   \_Note: be sure to add the `// @flow strict` annotation at the top of your file. Don't import `React`, but only what you need specifically.
 
 1. Import your example into the relevant docs page file, then replace the existing example (or add your new example) using the SandpackExample component. _Note: Don't forget to set the `previewHeight` if necessary. Be sure to set `hideEditor` for the top-level example on a component page and for Best Practices Examples. "Don't" Best Practices examples should also include `hideControls`._

--- a/docs/removeFlowTypesLoader.js
+++ b/docs/removeFlowTypesLoader.js
@@ -11,11 +11,13 @@ module.exports = function removeFlowTypesLoader(source /*: string */) {
 
   // $FlowFixMe[prop-missing]
   prettier.resolveConfig(process.cwd()).then((prettierOptions) => {
-    // $FlowFixMe[prop-missing]
-    const formatted = prettier.format(removed, {
-      ...prettierOptions,
-      parser: 'babel',
-    });
+    const formatted = prettier
+      // $FlowFixMe[prop-missing]
+      .format(removed, {
+        ...prettierOptions,
+        parser: 'babel',
+      })
+      .replace(`import {} from 'react';\n`, '');
 
     const json = JSON.stringify(formatted)
       .replace(/\u2028/g, '\\u2028')


### PR DESCRIPTION
# Summary

## What changed?

Removes `import {} from 'react'` from our Sandpack examples

## Why?

It's unnecessary and confusing for developers

# Before/After

## Before
![Screen Shot 2022-11-08 at 7 14 08 AM](https://user-images.githubusercontent.com/127199/200603142-1d224c6b-0769-401f-9d53-a5c9a7ce2884.png)

## After
![Screen Shot 2022-11-08 at 7 17 35 AM](https://user-images.githubusercontent.com/127199/200603179-9abea753-0e92-4111-8424-f5f2ee0aead7.png)
