### PR TITLE
Table: new Table.RowDrawer subcomponent

### DIFF
--- a/docs/pages/web/table.js
+++ b/docs/pages/web/table.js
@@ -1521,8 +1521,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableHeader}
-            name="Table.Header"
-            id="Table.Header"
+            name={generatedDocGen?.TableHeader?.displayName}
+            id={generatedDocGen?.TableHeader?.displayName}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -1531,8 +1531,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableBody}
-            name="Table.Body"
-            id="Table.Body"
+            name={generatedDocGen?.TableBody?.displayName}
+            id={generatedDocGen?.TableBody?.displayName}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -1541,8 +1541,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableFooter}
-            name="Table.Footer"
-            id="Table.Footer"
+            name={generatedDocGen?.TableFooter?.displayName}
+            id={generatedDocGen?.TableFooter?.displayName}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -1551,8 +1551,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableCell}
-            name="Table.Cell"
-            id="Table.Cell"
+            name={generatedDocGen?.TableCell?.displayName}
+            id={generatedDocGen?.TableCell?.displayName}
             excludeProps={['shouldBeSticky', 'previousTotalWidth', 'shouldHaveShadow']}
           />
         </MainSection.Subsection>
@@ -1562,8 +1562,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableHeaderCell}
-            name="Table.HeaderCell"
-            id="Table.HeaderCell"
+            name={generatedDocGen?.TableHeaderCell?.displayName}
+            id={generatedDocGen?.TableHeaderCell?.displayName}
             excludeProps={['shouldBeSticky', 'previousTotalWidth', 'shouldHaveShadow']}
           />
         </MainSection.Subsection>
@@ -1573,8 +1573,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableSortableHeaderCell}
-            name="Table.SortableHeaderCell"
-            id="Table.SortableHeaderCell"
+            name={generatedDocGen?.TableSortableHeaderCell?.displayName}
+            id={generatedDocGen?.TableSortableHeaderCell?.displayName}
             excludeProps={['shouldBeSticky', 'previousTotalWidth', 'shouldHaveShadow']}
           />
         </MainSection.Subsection>
@@ -1584,8 +1584,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableRow}
-            name="Table.Row"
-            id="Table.Row"
+            name={generatedDocGen?.TableRow?.displayName}
+            id={generatedDocGen?.TableRow?.displayName}
           />
         </MainSection.Subsection>
 
@@ -1595,8 +1595,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableRowExpandable}
-            name="Table.RowExpandable"
-            id="Table.RowExpandable"
+            name={generatedDocGen?.TableRowExpandable?.displayName}
+            id={generatedDocGen?.TableRowExpandable?.displayName}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -1605,8 +1605,8 @@ function Example() {
         >
           <GeneratedPropTable
             generatedDocGen={generatedDocGen.TableRowDrawer}
-            name="Table.RowDrawer"
-            id="Table.RowDrawer"
+            name={generatedDocGen?.TableRowDrawer?.displayName}
+            id={generatedDocGen?.TableRowDrawer?.displayName}
           />
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/web/table.js
+++ b/docs/pages/web/table.js
@@ -1599,6 +1599,16 @@ function Example() {
             id="Table.RowExpandable"
           />
         </MainSection.Subsection>
+        <MainSection.Subsection
+          title={generatedDocGen?.TableRowDrawer?.displayName}
+          description={generatedDocGen?.TableRowDrawer?.description}
+        >
+          <GeneratedPropTable
+            generatedDocGen={generatedDocGen.TableRowDrawer}
+            name="Table.RowDrawer"
+            id="Table.RowDrawer"
+          />
+        </MainSection.Subsection>
       </MainSection>
 
       <MainSection name="Variants">
@@ -2487,6 +2497,80 @@ function Example() {
         />
       </MainSection.Subsection>
       <MainSection.Subsection
+        title="Table Row Drawer"
+        description="Drawer row that is able to hold additional content."
+      >
+        <MainSection.Card
+          cardSize="lg"
+          defaultCode={`
+<Table accessibilityLabel="Table Row Drawer">
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>
+        <Text weight="bold">Campaign</Text>
+      </Table.HeaderCell>
+      <Table.HeaderCell>
+        <Text align="forceRight" weight="bold">Spend</Text>
+      </Table.HeaderCell>
+      <Table.HeaderCell>
+        <Text align="forceRight" weight="bold">Impressions</Text>
+      </Table.HeaderCell>
+      <Table.HeaderCell>
+        <Text align="forceRight" weight="bold">CTR</Text>
+      </Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+
+  <Table.Body>
+    <Table.RowDrawer
+      id="drawerExample"
+      drawerContents={
+        <SlimBanner
+          type="recommendation"
+          iconAccessibilityLabel="Recommendation"
+          message="Increasing your daily spend could increase clicks by 20%"
+          primaryAction={{
+            accessibilityLabel: 'Apply for increasing your daily spend',
+            label: 'Apply',
+            onClick: () => {},
+          }}
+        />
+        }
+    >
+      <Table.Cell>
+        <Text>Training treats</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="forceRight">$3,200</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="forceRight">3.4k</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="forceRight">0.07%</Text>
+      </Table.Cell>
+    </Table.RowDrawer>
+    <Table.Row>
+      <Table.Cell>
+        <Text>Vegan cuisine</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="forceRight">$5,000</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="forceRight">20k</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="forceRight">0.10%</Text>
+      </Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table>
+        `}
+        />
+      </MainSection.Subsection>
+
+      <MainSection.Subsection
         title="Sortable header cells"
         description="Sortable header cells are clickable in an accessible way and have an icon to display whether the table is currently being sorted by that column."
       >
@@ -2609,6 +2693,7 @@ export async function getStaticProps(): Promise<{|
       'TableSortableHeaderCell',
       'TableRow',
       'TableRowExpandable',
+      'TableRowDrawer',
     ],
   });
 
@@ -2622,6 +2707,8 @@ export async function getStaticProps(): Promise<{|
   docGen.TableRow.props.children.flowType.raw =
     'React.ChildrenArray<React.Element<typeof Table.Cell | typeof Table.HeaderCell | typeof Table.SortableHeaderCell>>';
   docGen.TableRowExpandable.props.children.flowType.raw =
+    'React.ChildrenArray<React.Element<typeof Table.Cell>>';
+  docGen.TableRowDrawer.props.children.flowType.raw =
     'React.ChildrenArray<React.Element<typeof Table.Cell>>';
 
   return {

--- a/packages/gestalt/src/Table.css
+++ b/packages/gestalt/src/Table.css
@@ -42,12 +42,16 @@
   box-shadow: -8px 0 8px -8px var(--color-border-container);
 }
 
-.thead tr:last-child th {
-  border-bottom: 1px solid var(--color-border-container);
+.thead tr:not(:first-child) th {
+  border-top: 1px solid var(--color-border-container);
 }
 
-.tbody tr:not(:last-child) td {
-  border-bottom: 1px solid var(--color-border-container);
+.tbody tr td {
+  border-top: 1px solid var(--color-border-container);
+}
+
+.tbody tr td.drawer {
+  border-top: none;
 }
 
 .hoverShadeGray:hover {

--- a/packages/gestalt/src/Table.css.flow
+++ b/packages/gestalt/src/Table.css.flow
@@ -3,6 +3,7 @@
 declare module.exports: {|
   +'columnSticky': string,
   +'columnStickyShadow': string,
+  +'drawer': string,
   +'horizontalScrollLeft': string,
   +'horizontalScrollRight': string,
   +'hoverShadeGray': string,

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -9,6 +9,7 @@ import TableFooter from './TableFooter.js';
 import TableHeader from './TableHeader.js';
 import TableHeaderCell from './TableHeaderCell.js';
 import TableRowExpandable from './TableRowExpandable.js';
+import TableRowDrawer from './TableRowDrawer.js';
 import TableRow from './TableRow.js';
 import TableSortableHeaderCell from './TableSortableHeaderCell.js';
 import { TableContextProvider } from './contexts/TableContext.js';
@@ -122,3 +123,5 @@ Table.Row = TableRow;
 Table.SortableHeaderCell = TableSortableHeaderCell;
 
 Table.RowExpandable = TableRowExpandable;
+
+Table.RowDrawer = TableRowDrawer;

--- a/packages/gestalt/src/TableRowDrawer.js
+++ b/packages/gestalt/src/TableRowDrawer.js
@@ -1,0 +1,67 @@
+// @flow strict
+import { type Node, Children, cloneElement, Fragment, useEffect, useRef, useState } from 'react';
+import cx from 'classnames';
+import styles from './Table.css';
+import Box from './Box.js';
+import { useTableContext } from './contexts/TableContext.js';
+
+type Props = {|
+  /**
+   * Must be instances of Table.Cell. See the [Subcomponent section](https://gestalt.pinterest.systems/web/table#Subcomponents) to learn more.
+   */
+  children: Node,
+  /**
+   * The contents within the drawer.
+   */
+  drawerContents: Node,
+  /**
+   * Unique id for Table.RowDrawer.
+   */
+  id: string,
+|};
+
+/**
+ * Use [Table.RowDrawer](https://gestalt.pinterest.systems/web/table#Table.RowDrawer) to define a row drawer to display additional content.
+ */
+export default function TableRowDrawer({ children, drawerContents, id }: Props): Node {
+  const { stickyColumns } = useTableContext();
+  const rowRef = useRef();
+  const [columnWidths, setColumnWidths] = useState([]);
+
+  const cs = cx(styles.drawer);
+
+  useEffect(() => {
+    if (rowRef?.current && stickyColumns) {
+      const colWidths = [...rowRef.current.children].map((item) => item.clientWidth);
+      setColumnWidths(colWidths);
+    }
+  }, [stickyColumns]);
+
+  const renderCellWithAdjustedIndex = (child, index) => {
+    // Account for initial expandable column
+    const adjustedIndex = index + 1;
+    const shouldBeSticky = stickyColumns
+      ? stickyColumns >= 0 && adjustedIndex < stickyColumns
+      : false;
+    const shouldHaveShadow = stickyColumns ? stickyColumns - 1 === adjustedIndex : false;
+    const previousWidths = columnWidths.slice(0, adjustedIndex);
+    const previousTotalWidth =
+      previousWidths.length > 0 ? previousWidths.reduce((a, b) => a + b) : 0;
+    return cloneElement(child, { shouldBeSticky, previousTotalWidth, shouldHaveShadow });
+  };
+
+  return (
+    <Fragment>
+      <tr aria-details={id} ref={rowRef}>
+        {Number(stickyColumns) > 0 ? Children.map(children, renderCellWithAdjustedIndex) : children}
+      </tr>
+      <tr id={id}>
+        <td className={cs} colSpan={Children.count(children) + 1}>
+          <Box padding={2}>{drawerContents}</Box>
+        </td>
+      </tr>
+    </Fragment>
+  );
+}
+
+TableRowDrawer.displayName = 'Table.RowDrawer';

--- a/packages/gestalt/src/TableRowDrawer.js
+++ b/packages/gestalt/src/TableRowDrawer.js
@@ -1,6 +1,5 @@
 // @flow strict
 import { type Node, Children, cloneElement, Fragment, useEffect, useRef, useState } from 'react';
-import cx from 'classnames';
 import styles from './Table.css';
 import Box from './Box.js';
 import { useTableContext } from './contexts/TableContext.js';
@@ -28,8 +27,6 @@ export default function TableRowDrawer({ children, drawerContents, id }: Props):
   const rowRef = useRef();
   const [columnWidths, setColumnWidths] = useState([]);
 
-  const cs = cx(styles.drawer);
-
   useEffect(() => {
     if (rowRef?.current && stickyColumns) {
       const colWidths = [...rowRef.current.children].map((item) => item.clientWidth);
@@ -56,7 +53,7 @@ export default function TableRowDrawer({ children, drawerContents, id }: Props):
         {Number(stickyColumns) > 0 ? Children.map(children, renderCellWithAdjustedIndex) : children}
       </tr>
       <tr id={id}>
-        <td className={cs} colSpan={Children.count(children) + 1}>
+        <td className={styles.drawer} colSpan={Children.count(children) + 1}>
           <Box padding={2}>{drawerContents}</Box>
         </td>
       </tr>

--- a/packages/gestalt/src/TableRowDrawer.test.js
+++ b/packages/gestalt/src/TableRowDrawer.test.js
@@ -1,0 +1,71 @@
+// @flow strict
+import renderer from 'react-test-renderer';
+import Table from './Table.js';
+import Text from './Text.js';
+import SlimBanner from './SlimBanner.js';
+
+test('renders correctly with drawer', () => {
+  const tree = renderer
+    .create(
+      <Table accessibilityLabel="Table Row Drawer">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text>TestA</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text>TestB</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text>TestC</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text>TestD</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          <Table.RowDrawer
+            id="drawerTest"
+            drawerContents={
+              <SlimBanner
+                type="recommendation"
+                iconAccessibilityLabel="test"
+                message="Test SlimBanner"
+              />
+            }
+          >
+            <Table.Cell>
+              <Text>Row1A</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Row1B</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Row1C</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Row1D</Text>
+            </Table.Cell>
+          </Table.RowDrawer>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Row2A</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Row2B</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Row2C</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Row2D</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -58,7 +58,9 @@ export default function TableRowExpandable({
   hoverStyle = 'gray',
 }: Props): Node {
   const [expanded, setExpanded] = useState(false);
-  const cs = hoverStyle === 'gray' ? cx(styles.hoverShadeGray) : null;
+  const cstr = hoverStyle === 'gray' ? cx(styles.hoverShadeGray) : null;
+  const cstd = cx(styles.drawer);
+
   const { stickyColumns } = useTableContext();
   const rowRef = useRef();
   const [columnWidths, setColumnWidths] = useState([]);
@@ -92,7 +94,7 @@ export default function TableRowExpandable({
 
   return (
     <Fragment>
-      <tr className={cs} ref={rowRef}>
+      <tr className={cstr} ref={rowRef}>
         <TableCell
           shouldBeSticky={stickyColumns ? stickyColumns > 0 : false}
           previousTotalWidth={0}
@@ -111,7 +113,7 @@ export default function TableRowExpandable({
       </tr>
       {expanded && (
         <tr id={id}>
-          <td colSpan={Children.count(children) + 1}>
+          <td className={cstd} colSpan={Children.count(children) + 1}>
             <Box padding={6}>{expandedContents}</Box>
           </td>
         </tr>

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -1,6 +1,5 @@
 // @flow strict
 import { type Node, Children, cloneElement, Fragment, useEffect, useRef, useState } from 'react';
-import cx from 'classnames';
 import styles from './Table.css';
 import Box from './Box.js';
 import IconButton from './IconButton.js';
@@ -58,8 +57,6 @@ export default function TableRowExpandable({
   hoverStyle = 'gray',
 }: Props): Node {
   const [expanded, setExpanded] = useState(false);
-  const cstr = hoverStyle === 'gray' ? cx(styles.hoverShadeGray) : null;
-  const cstd = cx(styles.drawer);
 
   const { stickyColumns } = useTableContext();
   const rowRef = useRef();
@@ -94,7 +91,7 @@ export default function TableRowExpandable({
 
   return (
     <Fragment>
-      <tr className={cstr} ref={rowRef}>
+      <tr className={hoverStyle === 'gray' ? styles.hoverShadeGray : null} ref={rowRef}>
         <TableCell
           shouldBeSticky={stickyColumns ? stickyColumns > 0 : false}
           previousTotalWidth={0}
@@ -113,7 +110,7 @@ export default function TableRowExpandable({
       </tr>
       {expanded && (
         <tr id={id}>
-          <td className={cstd} colSpan={Children.count(children) + 1}>
+          <td className={styles.drawer} colSpan={Children.count(children) + 1}>
             <Box padding={6}>{expandedContents}</Box>
           </td>
         </tr>

--- a/packages/gestalt/src/__snapshots__/TableRowDrawer.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableRowDrawer.test.js.snap
@@ -1,0 +1,297 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly with drawer 1`] = `
+<div
+  className="box overflowAuto"
+  style={
+    Object {
+      "maxHeight": undefined,
+    }
+  }
+  tabIndex="0"
+>
+  <table
+    className="table"
+  >
+    <caption
+      className="absolute box overflowHidden"
+      style={
+        Object {
+          "clip": "rect(1px, 1px, 1px, 1px)",
+          "height": 1,
+          "whiteSpace": "nowrap",
+          "width": 1,
+        }
+      }
+    >
+      Table Row Drawer
+    </caption>
+    <thead
+      className="thead"
+    >
+      <tr>
+        <th
+          className="th"
+          scope="col"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            TestA
+          </div>
+        </th>
+        <th
+          className="th"
+          scope="col"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            TestB
+          </div>
+        </th>
+        <th
+          className="th"
+          scope="col"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            TestC
+          </div>
+        </th>
+        <th
+          className="th"
+          scope="col"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            TestD
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      className="tbody"
+    >
+      <tr
+        aria-details="drawerTest"
+      >
+        <td
+          className="td"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            Row1A
+          </div>
+        </td>
+        <td
+          className="td"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            Row1B
+          </div>
+        </td>
+        <td
+          className="td"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            Row1C
+          </div>
+        </td>
+        <td
+          className="td"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            Row1D
+          </div>
+        </td>
+      </tr>
+      <tr
+        id="drawerTest"
+      >
+        <td
+          className="drawer"
+          colSpan={5}
+        >
+          <div
+            className="box paddingX2 paddingY2"
+          >
+            <div
+              className="box itemsCenter mdDirectionRow paddingX4 paddingY0 paddingY4 recommendationWeak rounding4 xsDirectionColumn xsDisplayFlex"
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                className="Flex rowGap4 columnGap0 flexGrow itemsCenter xsDirectionRow"
+                style={
+                  Object {
+                    "width": "100%",
+                  }
+                }
+              >
+                <div
+                  className="FlexItem selfStart"
+                >
+                  <svg
+                    aria-hidden={null}
+                    aria-label="test"
+                    className="icon recommendationIcon iconBlock"
+                    height={16}
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width={16}
+                  >
+                    <path
+                      d="test-file-stub"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="FlexItem flexGrow"
+                >
+                  <div
+                    className="box"
+                    style={
+                      Object {
+                        "marginTop": "-1px",
+                      }
+                    }
+                  >
+                    <span
+                      className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                    >
+                      Test SlimBanner
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td
+          className="td"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            Row2A
+          </div>
+        </td>
+        <td
+          className="td"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            Row2B
+          </div>
+        </td>
+        <td
+          className="td"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            Row2C
+          </div>
+        </td>
+        <td
+          className="td"
+          style={
+            Object {
+              "left": undefined,
+              "right": undefined,
+            }
+          }
+        >
+          <div
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            Row2D
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;


### PR DESCRIPTION
### Summary

#### What changed?

Table: new Table.RowDrawer subcomponent

<img width="860" alt="Screen Shot 2022-11-11 at 12 23 18 PM" src="https://user-images.githubusercontent.com/10593890/201395201-f82d5739-ea81-4e46-be5e-b4982f54e918.png">

Also, removed divider between Row and RowExpandable and RowDrawer

<img width="571" alt="Screen Shot 2022-11-11 at 12 42 55 PM" src="https://user-images.githubusercontent.com/10593890/201398507-2a013ef9-4785-404b-97b9-033d684e1b94.png">

#### Why?

New component to support m10n requests. 

New featured (Drawer with SlimBanner) was tested under experimentation presenting good results.

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
