### PR TITLE
Docs: Fixed accessibility section in Android Button guidelines

### DIFF
--- a/docs/markdown/android/button.md
+++ b/docs/markdown/android/button.md
@@ -67,10 +67,10 @@ For writing best practices, refer to the [web Button documentation](/web/button)
 
 ## Accessibility
 
-People use Apple’s accessibility features, such as reduced transparency, VoiceOver, and increased text size to personalize how they interact with their device. Supporting these personalizations ensures that everyone has a great user experience. See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+People use Android's accessibility features, such as TalkBack and dynamic text sizing to personalize how they interact with their devices. Supporting these personalizations ensures that everyone has a great user experience. See Material Design and development documentation about accessibility for Android:
 
-- [Accessible design on iOS](https://material.io/design/usability/accessibility.html#understanding-accessibility)
-- [Accessible development on iOS](https://developer.android.com/guide/topics/ui/accessibility)
+[Accessible design on Android](https://material.io/design/usability/accessibility.html#understanding-accessibility)
+[Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility)
 
 ## Localization
 


### PR DESCRIPTION
The accessibility section referenced iOS guidelines for an Android component