### PR TITLE
Popover: Add new option for dismiss button

### DIFF
--- a/docs/examples/defaultlabelprovider/translations.js
+++ b/docs/examples/defaultlabelprovider/translations.js
@@ -10,6 +10,9 @@ const labels = {
   ModalAlert: {
     accessibilityDismissButtonLabel: myI18nTranslator('Close modal'),
   },
+  Popover: {
+    accessibilityDismissButtonLabel: myI18nTranslator('Close popover'),
+  },
   ComboBox: {
     accessibilityClearButtonLabel: myI18nTranslator('Clear input'),
   },

--- a/docs/examples/popover/defaultExample.js
+++ b/docs/examples/popover/defaultExample.js
@@ -13,18 +13,6 @@ import {
   Image,
 } from 'gestalt';
 
-function SearchBoardField(): Node {
-  return (
-    <SearchField
-      accessibilityLabel="Search boards field"
-      id="searchField"
-      onChange={() => {}}
-      placeholder="Search boards"
-      size="lg"
-    />
-  );
-}
-
 function List({
   title,
   setSelectedBoard,
@@ -129,7 +117,13 @@ export default function DismissButton(): Node {
                   <Text align="center" color="default" weight="bold">
                     Save to board
                   </Text>
-                  <SearchBoardField />
+                  <SearchField
+                    accessibilityLabel="Search boards field"
+                    id="searchField"
+                    onChange={() => {}}
+                    placeholder="Search boards"
+                    size="lg"
+                  />
                 </Flex>
               </Box>
               <Box height={300} overflow="scrollY">

--- a/docs/examples/popover/defaultExample.js
+++ b/docs/examples/popover/defaultExample.js
@@ -1,0 +1,164 @@
+// @flow strict
+import { type Node, useRef, useState, useEffect } from 'react';
+import {
+  Popover,
+  Box,
+  Button,
+  Flex,
+  Layer,
+  Text,
+  SearchField,
+  TapArea,
+  Mask,
+  Image,
+} from 'gestalt';
+
+function SearchBoardField(): Node {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  return (
+    <SearchField
+      accessibilityLabel="Search boards field"
+      id="searchField"
+      onChange={() => {}}
+      placeholder="Search boards"
+      size="lg"
+      ref={ref}
+    />
+  );
+}
+
+function List({
+  title,
+  setSelectedBoard,
+  setOpen,
+}: {|
+  title: string,
+  setSelectedBoard: (string) => void,
+  setOpen: (boolean) => void,
+|}) {
+  return (
+    <Flex direction="column" gap={{ column: 4, row: 0 }}>
+      <Text color="default" size="100">
+        {title}
+      </Text>
+      <Flex direction="column" gap={{ column: 4, row: 0 }}>
+        {[
+          [
+            'https://i.ibb.co/s3PRJ8v/photo-1496747611176-843222e1e57c.webp',
+            'Fashion',
+            'Thumbnail image: a white dress with red flowers',
+          ],
+          [
+            'https://i.ibb.co/swC1qpp/IMG-0494.jpg',
+            'Food',
+            'Thumbnail image: a paella with shrimp, green peas, red peppers and yellow rice',
+          ],
+          [
+            'https://i.ibb.co/PFVF3JH/photo-1583847268964-b28dc8f51f92.webp',
+            'Home',
+            'Thumbnail image: a living room with a white couch, two paints in the wall and wooden furniture',
+          ],
+        ].map((data) => (
+          <TapArea
+            key={data[1]}
+            onTap={() => {
+              setSelectedBoard(data[1]);
+              setOpen(false);
+            }}
+          >
+            <Flex gap={{ row: 2, column: 0 }} alignItems="center">
+              <Box height={50} width={50} overflow="hidden" rounding={2}>
+                <Mask rounding={2}>
+                  <Image
+                    alt={data[2]}
+                    color="rgb(231, 186, 176)"
+                    naturalHeight={50}
+                    naturalWidth={50}
+                    src={data[0]}
+                  />
+                </Mask>
+              </Box>
+              <Text align="center" color="default" weight="bold">
+                {data[1]}
+              </Text>
+            </Flex>
+          </TapArea>
+        ))}
+      </Flex>
+    </Flex>
+  );
+}
+
+export default function DismissButton(): Node {
+  const [open, setOpen] = useState(false);
+  const [selectedBoard, setSelectedBoard] = useState('Fashion');
+  const anchorRef = useRef();
+
+  return (
+    <Flex alignItems="start" justifyContent="center" height="100%" width="100%">
+      <Box padding={3}>
+        <Flex alignItems="center" gap={{ row: 2, column: 0 }}>
+          <Button
+            accessibilityHaspopup
+            accessibilityExpanded={open}
+            accessibilityControls="main-example"
+            color="white"
+            iconEnd="arrow-down"
+            onClick={() => setOpen(!open)}
+            ref={anchorRef}
+            size="lg"
+            selected={open}
+            text={selectedBoard}
+          />
+          <Button color="red" onClick={() => {}} size="lg" text="Save" />
+        </Flex>
+      </Box>
+      {open && (
+        <Layer>
+          <Popover
+            accessibilityLabel="Save to board"
+            anchor={anchorRef.current}
+            id="main-example"
+            idealDirection="down"
+            onDismiss={() => setOpen(false)}
+            positionRelativeToAnchor={false}
+            showDismissButton
+            size="xl"
+          >
+            <Box width={360}>
+              <Box flex="grow" marginEnd={4} marginStart={4} marginTop={6} marginBottom={8}>
+                <Flex direction="column" gap={{ column: 6, row: 0 }}>
+                  <Text align="center" color="default" weight="bold">
+                    Save to board
+                  </Text>
+                  <SearchBoardField />
+                </Flex>
+              </Box>
+              <Box height={300} overflow="scrollY">
+                <Box marginEnd={4} marginStart={4}>
+                  <Flex direction="column" gap={{ column: 8, row: 0 }}>
+                    <List
+                      title="Top choices"
+                      setSelectedBoard={setSelectedBoard}
+                      setOpen={setOpen}
+                    />
+                    <List
+                      title="All boards"
+                      setSelectedBoard={setSelectedBoard}
+                      setOpen={setOpen}
+                    />
+                  </Flex>
+                </Box>
+              </Box>
+            </Box>
+          </Popover>
+        </Layer>
+      )}
+    </Flex>
+  );
+}

--- a/docs/examples/popover/defaultExample.js
+++ b/docs/examples/popover/defaultExample.js
@@ -131,7 +131,7 @@ export default function DismissButton(): Node {
             size="xl"
           >
             <Box width={360}>
-              <Box flex="grow" marginEnd={4} marginStart={4} marginTop={6} marginBottom={8}>
+              <Box flex="grow" marginEnd={4} marginStart={4} marginBottom={8}>
                 <Flex direction="column" gap={{ column: 6, row: 0 }}>
                   <Text align="center" color="default" weight="bold">
                     Save to board

--- a/docs/examples/popover/defaultExample.js
+++ b/docs/examples/popover/defaultExample.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useRef, useState, useEffect } from 'react';
+import { type Node, useRef, useState } from 'react';
 import {
   Popover,
   Box,
@@ -14,12 +14,6 @@ import {
 } from 'gestalt';
 
 function SearchBoardField(): Node {
-  const ref = useRef();
-
-  useEffect(() => {
-    ref.current?.focus();
-  }, []);
-
   return (
     <SearchField
       accessibilityLabel="Search boards field"
@@ -27,7 +21,6 @@ function SearchBoardField(): Node {
       onChange={() => {}}
       placeholder="Search boards"
       size="lg"
-      ref={ref}
     />
   );
 }

--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -6,8 +6,11 @@ import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import Page from '../../docs-components/Page.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
-
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import defaultExample from '../../examples/popover/defaultExample.js';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+
+const PREVIEW_HEIGHT = 550;
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -525,6 +528,7 @@ function PopoverExample() {
 We recommend passing the following ARIA attribute to Popover for a better screen reader experience:
 
 - \`accessibilityLabel\`: describes the main purpose of a Popover for the screen reader. Should be unique and concise. For example, "Save to board" instead of "Popover".  It populates [aria-label](https://w3c.github.io/aria-practices/#dialog_roles_states_props).
+- \`accessibilityDismissButtonLabel\`: describes the purpose of the dismiss button on Popover for the screen reader. Should be clear and concise. For example, "Close board selection popover" instead of "Close".
 
 To further assist screen readers, we recommend passing the following ARIA attributes to the _anchor element_:
 
@@ -540,128 +544,21 @@ For the \`role\` prop, use:
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function PopoverExample() {
-  const [open, setOpen] = React.useState(false);
-  const [selectedBoard, setSelectedBoard] = React.useState('Fashion');
-  const anchorRef = React.useRef();
-
-  const SearchBoardField = () => {
-    const ref = React.useRef();
-
-    React.useEffect(() => {
-      ref.current.focus();
-    }, []);
-
-    return (
-      <SearchField
-        accessibilityLabel="Search boards field"
-        id="searchField"
-        onChange={() => {}}
-        placeholder="Search boards"
-        size="lg"
-        ref={ref}
-      />
-    )
-  }
-
-  const List = ({ title }) => (
-    <Flex direction="column" gap={{ column: 4, row: 0 }}>
-      <Text color="default" size="100">
-        { title }
-      </Text>
-      <Flex direction="column" gap={{ column: 4, row: 0 }}>
-        {[
-          ['https://i.ibb.co/s3PRJ8v/photo-1496747611176-843222e1e57c.webp', 'Fashion', 'Thumbnail image: a white dress with red flowers'],
-          ['https://i.ibb.co/swC1qpp/IMG-0494.jpg', 'Food', 'Thumbnail image: a paella with shrimp, green peas, red peppers and yellow rice'],
-          ['https://i.ibb.co/PFVF3JH/photo-1583847268964-b28dc8f51f92.webp', 'Home', 'Thumbnail image: a living room with a white couch, two paints in the wall and wooden furniture'],
-        ].map((data, index) => (
-            <TapArea key={index} onTap={() => {
-              setSelectedBoard(data[1]);
-              setOpen(false);
-            }}>
-              <Flex gap={{ row: 2, column: 0 }} alignItems="center">
-                <Box height={50} width={50} overflow="hidden" rounding={2}>
-                  <Mask rounding={2}>
-                    <Image
-                      alt={data[2]}
-                      color="rgb(231, 186, 176)"
-                      naturalHeight={50}
-                      naturalWidth={50}
-                      src={data[0]}
-                    />
-                  </Mask>
-                </Box>
-                <Text align="center" color="default" weight="bold">
-                  {data[1]}
-                </Text>
-              </Flex>
-            </TapArea>
-        ))}
-      </Flex>
-    </Flex>
-  );
-
-  return (
-    <React.Fragment>
-      <Flex alignItems="center" gap={{ row: 2, column: 0 }}>
-        <Button
-          accessibilityHaspopup={true}
-          accessibilityExpanded={open}
-          accessibilityControls="example-a11y"
-          color="white"
-          iconEnd="arrow-down"
-          onClick={() => setOpen(!open)}
-          ref={anchorRef}
-          size="lg"
-          selected={open}
-          text={selectedBoard}
-        />
-        <Button color="red" onClick={() => {}} size="lg" text="Save" />
-      </Flex>
-      {open && (
-        <Layer>
-          <Popover
-            accessibilityLabel="Save to board"
-            anchor={anchorRef.current}
-            id="example-a11y"
-            idealDirection="down"
-            onDismiss={() => setOpen(false)}
-            positionRelativeToAnchor={false}
-            role="listbox"
-            size="xl"
-          >
-            <Box width={360}>
-              <Box flex="grow" marginEnd={4} marginStart={4} marginTop={6} marginBottom={8}>
-                <Flex direction="column" gap={{ column: 6, row: 0 }}>
-                  <Text align="center" color="default" weight="bold">
-                    Save to board
-                  </Text>
-                  <SearchBoardField />
-                </Flex>
-              </Box>
-              <Box height={300} overflow="scrollY">
-                <Box marginEnd={4} marginStart={4}>
-                  <Flex direction="column" gap={{ column: 8, row: 0 }}>
-                    <List title="Top choices"/>
-                    <List title="All boards"/>
-                  </Flex>
-                </Box>
-              </Box>
-            </Box>
-          </Popover>
-        </Layer>
-      )}
-    </React.Fragment>
-  );
-}
-  `}
+            sandpackExample={
+              <SandpackExample
+                code={defaultExample}
+                name="Double modal example"
+                hideEditor
+                hideControls
+                previewHeight={PREVIEW_HEIGHT}
+              />
+            }
           />
         </MainSection.Subsection>
       </AccessibilitySection>
       <MainSection
         name="Localization"
-        description="Be sure to localize any text elements within Popover. Note that localization can lengthen text by 20 to 30 percent."
+        description="Be sure to localize any text elements within Popover, along with `accessibilityLabel` and `accessibilityDismissButtonLabel`. Note that localization can lengthen text by 20 to 30 percent."
       />
       <MainSection name="Variants">
         <MainSection.Subsection
@@ -925,6 +822,24 @@ function PopoverExample() {
     </ScrollBoundaryContainer>
   )
 }`}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Dismiss button"
+          description={` We highly recommend including a dismiss button on all Popovers with \`showDismissButton\`. This improves accessibility and gives users an immediate action for closing Popover. A default label of "Close popover" is provided through [DefaultLabelProvider](/web/utilities/defaultlabelprovider), but a more unique label can be provided with the \`accessibilityDismissButtonLabel\` prop. Don't forget to localize this label as well.
+`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample
+                code={defaultExample}
+                name="Double modal example"
+                hideEditor
+                hideControls
+                previewHeight={PREVIEW_HEIGHT}
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection

--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
+import { SlimBanner } from 'gestalt';
 import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
 import docgen, { type DocGen } from '../../docs-components/docgen.js';
@@ -548,7 +549,7 @@ For the \`role\` prop, use:
             sandpackExample={
               <SandpackExample
                 code={defaultExample}
-                name="Double modal example"
+                name="Aria example"
                 hideEditor
                 hideControls
                 previewHeight={PREVIEW_HEIGHT}
@@ -560,7 +561,19 @@ For the \`role\` prop, use:
       <MainSection
         name="Localization"
         description="Be sure to localize any text elements within Popover, along with `accessibilityLabel` and `accessibilityDismissButtonLabel`. Note that localization can lengthen text by 20 to 30 percent."
-      />
+      >
+        <SlimBanner
+          iconAccessibilityLabel="Recommendation"
+          message="Popovers with a dismiss button announce to assistive technologies that the button will dismiss the Popover. Localize the default label with DefaultLabelProvider."
+          type="recommendationBare"
+          helperLink={{
+            text: 'Learn more',
+            accessibilityLabel: 'Learn more about DefaultLabelProvider',
+            href: '/web/utilities/defaultlabelprovider',
+            onClick: () => {},
+          }}
+        />
+      </MainSection>
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Size"
@@ -827,15 +840,26 @@ function PopoverExample() {
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Dismiss button"
-          description={` We highly recommend including a dismiss button on all Popovers with \`showDismissButton\`. This improves accessibility and gives users an immediate action for closing Popover. A default label of "Close popover" is provided through [DefaultLabelProvider](/web/utilities/defaultlabelprovider), but a more unique label can be provided with the \`accessibilityDismissButtonLabel\` prop. Don't forget to localize this label as well.
+          description={` We highly recommend including a dismiss button on all Popovers with \`showDismissButton\`. This improves accessibility and gives users an immediate action for closing Popover. A label for the button can be provided with the \`accessibilityDismissButtonLabel\` prop. Don't forget to localize this label as well.
 `}
         >
+          <SlimBanner
+            iconAccessibilityLabel="Recommendation"
+            message="Popovers with a dismiss button announce to assistive technologies that the button will dismiss the Popover with a default label of 'Close popover'. Localize the default label with DefaultLabelProvider."
+            type="recommendationBare"
+            helperLink={{
+              text: 'Learn more',
+              accessibilityLabel: 'Learn more about DefaultLabelProvider',
+              href: '/web/utilities/defaultlabelprovider',
+              onClick: () => {},
+            }}
+          />
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
               <SandpackExample
                 code={defaultExample}
-                name="Double modal example"
+                name="Dismiss button example"
                 hideEditor
                 hideControls
                 previewHeight={PREVIEW_HEIGHT}

--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -107,9 +107,10 @@ function PopoverExample() {
             onDismiss={() => setOpen(false)}
             positionRelativeToAnchor={false}
             size="xl"
+            showDismissButton
           >
             <Box width={360}>
-              <Box flex="grow" marginEnd={4} marginStart={4} marginTop={6} marginBottom={8}>
+              <Box flex="grow" marginEnd={4} marginStart={4} marginBottom={8}>
                 <Flex direction="column" gap={{ column: 6, row: 0 }}>
                   <Text align="center" color="default" weight="bold">
                     Save to board

--- a/packages/gestalt/src/InternalDismissButton.js
+++ b/packages/gestalt/src/InternalDismissButton.js
@@ -17,6 +17,7 @@ import useTapFeedback from './useTapFeedback.js';
 type Props = {|
   accessibilityLabel: string,
   accessibilityControls?: string,
+  iconColor?: $ElementType<React$ElementConfig<typeof Pog>, 'iconColor'>,
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>,
   >,
@@ -25,7 +26,13 @@ type Props = {|
 
 const InternalDismissIconButtonWithForwardRef: React$AbstractComponent<Props, HTMLButtonElement> =
   forwardRef<Props, HTMLButtonElement>(function IconButton(
-    { accessibilityLabel, accessibilityControls, onClick, size = 'lg' }: Props,
+    {
+      accessibilityLabel,
+      accessibilityControls,
+      iconColor = 'darkGray',
+      onClick,
+      size = 'lg',
+    }: Props,
     ref,
   ): Node {
     const innerRef = useRef(null);
@@ -96,6 +103,7 @@ const InternalDismissIconButtonWithForwardRef: React$AbstractComponent<Props, HT
             focused={isFocusVisible && isFocused}
             hovered={isHovered}
             icon="cancel"
+            iconColor={iconColor}
             size={size}
           />
         </div>

--- a/packages/gestalt/src/InternalDismissButton.js
+++ b/packages/gestalt/src/InternalDismissButton.js
@@ -20,11 +20,12 @@ type Props = {|
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>,
   >,
+  size?: $ElementType<React$ElementConfig<typeof Pog>, 'size'>,
 |};
 
 const InternalDismissIconButtonWithForwardRef: React$AbstractComponent<Props, HTMLButtonElement> =
   forwardRef<Props, HTMLButtonElement>(function IconButton(
-    { accessibilityLabel, accessibilityControls, onClick }: Props,
+    { accessibilityLabel, accessibilityControls, onClick, size = 'lg' }: Props,
     ref,
   ): Node {
     const innerRef = useRef(null);
@@ -91,7 +92,12 @@ const InternalDismissIconButtonWithForwardRef: React$AbstractComponent<Props, HT
           })}
           style={compressStyle || undefined}
         >
-          <Pog focused={isFocusVisible && isFocused} hovered={isHovered} icon="cancel" size="lg" />
+          <Pog
+            focused={isFocusVisible && isFocused}
+            hovered={isHovered}
+            icon="cancel"
+            size={size}
+          />
         </div>
       </button>
     );

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -1,8 +1,9 @@
 // @flow strict
-import { type Node } from 'react';
+import { type Node, useRef, useEffect } from 'react';
 import Controller from './Controller.js';
 import IconButton from './IconButton.js';
 import Box from './Box.js';
+import Flex from './Flex.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 
 type Color = 'blue' | 'orange' | 'red' | 'white' | 'darkGray';
@@ -98,6 +99,12 @@ export default function Popover({
   const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
     useDefaultLabelContext('Popover');
 
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
   if (!anchor) {
     return null;
   }
@@ -119,20 +126,25 @@ export default function Popover({
       shouldFocus={shouldFocus}
       size={size === 'flexible' ? null : size}
     >
-      {showDismissButton && (
-        <Box position="absolute" top right padding={1}>
-          <IconButton
-            icon="cancel"
-            accessibilityLabel={
-              accessibilityDismissButtonLabel ?? accessibilityDismissButtonLabelDefault
-            }
-            size="xs"
-            iconColor={color === 'white' ? 'darkGray' : 'white'}
-            onClick={onDismiss}
-          />
-        </Box>
+      {showDismissButton ? (
+        <Flex direction="column">
+          <Box alignSelf="end" padding={1}>
+            <IconButton
+              icon="cancel"
+              accessibilityLabel={
+                accessibilityDismissButtonLabel ?? accessibilityDismissButtonLabelDefault
+              }
+              size="xs"
+              iconColor={color === 'white' ? 'darkGray' : 'white'}
+              onClick={onDismiss}
+              ref={ref}
+            />
+          </Box>
+          {children}
+        </Flex>
+      ) : (
+        children
       )}
-      {children}
     </Controller>
   );
 }

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -128,7 +128,7 @@ export default function Popover({
     >
       {showDismissButton ? (
         <Flex direction="column">
-          <Box alignSelf="end" padding={1}>
+          <Box alignSelf="end" padding={2}>
             <InternalDismissButton
               accessibilityLabel={
                 accessibilityDismissButtonLabel ?? accessibilityDismissButtonLabelDefault

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -1,10 +1,10 @@
 // @flow strict
 import { type Node, useRef, useEffect } from 'react';
 import Controller from './Controller.js';
-import IconButton from './IconButton.js';
 import Box from './Box.js';
 import Flex from './Flex.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
+import InternalDismissButton from './InternalDismissButton.js';
 
 type Color = 'blue' | 'orange' | 'red' | 'white' | 'darkGray';
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number;
@@ -17,7 +17,7 @@ type Props = {|
    */
   accessibilityLabel?: string,
   /**
-   * Describe's the dismiss button's purpose. Default is "Close popover". Must be translated.
+   * Describe's the dismiss button's purpose. See the [dismiss button](https://gestalt.pinterest.systems/web/popover#Dismiss-button) variant to learn more. Must be localized.
    */
   accessibilityDismissButtonLabel?: string,
   /**
@@ -99,10 +99,10 @@ export default function Popover({
   const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
     useDefaultLabelContext('Popover');
 
-  const ref = useRef();
+  const dismissButtonRef = useRef();
 
   useEffect(() => {
-    ref.current?.focus();
+    dismissButtonRef.current?.focus();
   }, []);
 
   if (!anchor) {
@@ -129,15 +129,13 @@ export default function Popover({
       {showDismissButton ? (
         <Flex direction="column">
           <Box alignSelf="end" padding={1}>
-            <IconButton
-              icon="cancel"
+            <InternalDismissButton
               accessibilityLabel={
                 accessibilityDismissButtonLabel ?? accessibilityDismissButtonLabelDefault
               }
-              size="xs"
-              iconColor={color === 'white' ? 'darkGray' : 'white'}
               onClick={onDismiss}
-              ref={ref}
+              size="xs"
+              ref={dismissButtonRef}
             />
           </Box>
           {children}

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -1,6 +1,9 @@
 // @flow strict
 import { type Node } from 'react';
 import Controller from './Controller.js';
+import IconButton from './IconButton.js';
+import Box from './Box.js';
+import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 
 type Color = 'blue' | 'orange' | 'red' | 'white' | 'darkGray';
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number;
@@ -12,6 +15,10 @@ type Props = {|
    * Unique label to describe each Popover. Used for [accessibility](https://gestalt.pinterest.systems/web/popover#ARIA-attributes) purposes.
    */
   accessibilityLabel?: string,
+  /**
+   * Describe's the dismiss button's purpose. Default is "Close popover". Must be translated.
+   */
+  accessibilityDismissButtonLabel?: string,
   /**
    * The reference element, typically [Button](https://gestalt.pinterest.systems/web/button) or [IconButton](https://gestalt.pinterest.systems/web/iconbutton), that Popover uses to set its position.
    */
@@ -57,6 +64,10 @@ type Props = {|
    */
   showCaret?: boolean,
   /**
+   * Shows a dismiss button on Popover. See the [dismiss button](https://gestalt.pinterest.systems/web/popover#Dismiss-button) variant to learn more.
+   */
+  showDismissButton?: boolean,
+  /**
    * The maximum width of Popover. See the [size](https://gestalt.pinterest.systems/web/popover#Size) variant to learn more.
    */
   size?: Size,
@@ -69,8 +80,10 @@ type Props = {|
  */
 export default function Popover({
   accessibilityLabel = 'Popover',
+  accessibilityDismissButtonLabel,
   anchor,
   children,
+  showDismissButton,
   onKeyDown,
   id,
   idealDirection,
@@ -82,6 +95,9 @@ export default function Popover({
   showCaret = false,
   size = 'sm',
 }: Props): null | Node {
+  const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
+    useDefaultLabelContext('Popover');
+
   if (!anchor) {
     return null;
   }
@@ -103,6 +119,19 @@ export default function Popover({
       shouldFocus={shouldFocus}
       size={size === 'flexible' ? null : size}
     >
+      {showDismissButton && (
+        <Box position="absolute" top right padding={1}>
+          <IconButton
+            icon="cancel"
+            accessibilityLabel={
+              accessibilityDismissButtonLabel ?? accessibilityDismissButtonLabelDefault
+            }
+            size="xs"
+            iconColor={color === 'white' ? 'darkGray' : 'white'}
+            onClick={onDismiss}
+          />
+        </Box>
+      )}
       {children}
     </Controller>
   );

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -136,6 +136,7 @@ export default function Popover({
               onClick={onDismiss}
               size="xs"
               ref={dismissButtonRef}
+              iconColor={color === 'white' ? 'darkGray' : 'white'}
             />
           </Box>
           {children}

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -17,7 +17,7 @@ type Props = {|
    */
   accessibilityLabel?: string,
   /**
-   * Describe's the dismiss button's purpose. See the [dismiss button](https://gestalt.pinterest.systems/web/popover#Dismiss-button) variant to learn more. Must be localized.
+   * Describes the dismiss button's purpose. See the [dismiss button](https://gestalt.pinterest.systems/web/popover#Dismiss-button) variant to learn more. Must be localized.
    */
   accessibilityDismissButtonLabel?: string,
   /**

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.js
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.js
@@ -20,6 +20,9 @@ export type DefaultLabelContextType = {|
   ModalAlert: {|
     accessibilityDismissButtonLabel: string,
   |},
+  Popover: {|
+    accessibilityDismissButtonLabel: string,
+  |},
   ComboBox: {|
     accessibilityClearButtonLabel: string,
   |},
@@ -35,6 +38,9 @@ export const fallbackLabels: DefaultLabelContextType = {
   },
   ModalAlert: {
     accessibilityDismissButtonLabel: 'Close modal',
+  },
+  Popover: {
+    accessibilityDismissButtonLabel: 'Close popover',
   },
   ComboBox: {
     accessibilityClearButtonLabel: 'Clear input',

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.js
@@ -22,6 +22,9 @@ describe('useDefaultLabelContext', () => {
           ModalAlert: {
             accessibilityDismissButtonLabel: 'Close modal',
           },
+          Popover: {
+            accessibilityDismissButtonLabel: 'Close popover',
+          },
           ComboBox: {
             accessibilityClearButtonLabel: 'Clear input',
           },


### PR DESCRIPTION
### Summary

#### What changed?

Add a showDismissButton option for Popover to include a dismiss button

![Screen Shot 2022-11-14 at 5 15 07 PM](https://user-images.githubusercontent.com/5125094/201803315-a1560482-7780-44d5-b2cc-b7723e14d19f.png)


#### Why?

To improve accessibility, Popovers should include a dismiss button. This PR adds the option, which we will eventually turn on by default

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4178)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
