### PR TITLE
Docs: add formatting for prop types

### DIFF
--- a/docs/docs-components/PropTable.js
+++ b/docs/docs-components/PropTable.js
@@ -38,6 +38,14 @@ const transformDefaultValue = (input) => {
 
 const sortBy = (list, fn) => [...list].sort((a, b) => fn(a).localeCompare(fn(b)));
 
+function FormattedCode({ children }: {| children: Node |}) {
+  return (
+    <code>
+      <pre style={{ margin: 0, overflowX: 'scroll', minWidth: 510 }}>{children}</pre>
+    </code>
+  );
+}
+
 function Description(lines: $ReadOnlyArray<string>): Node {
   return (
     <Flex
@@ -231,7 +239,9 @@ export default function PropTable({
 
                         <Td border={!propNameHasSecondRow}>
                           <Flex justifyContent="between">
-                            <code>{nullable ? `?${unifyQuotes(type)}` : unifyQuotes(type)}</code>
+                            <FormattedCode>
+                              {nullable ? `?${unifyQuotes(type)}` : unifyQuotes(type)}
+                            </FormattedCode>
 
                             <IconButton
                               accessibilityLabel="Copy Flow type"


### PR DESCRIPTION
Our current display of complex Flow types, uh, leaves something to be desired. 😅 
![Screen Shot 2022-11-16 at 2 13 50 PM](https://user-images.githubusercontent.com/12059539/202306040-26841bf3-814b-49ad-b6dd-5430786a0519.png)

However, better formatting has been available all along, just waiting for us to use it! This PR adds `<pre>` tags, allowing us to use the available formatting for much prettier types! 🎉 
![Screen Shot 2022-11-16 at 2 14 28 PM](https://user-images.githubusercontent.com/12059539/202306203-ab2e1f33-7252-4405-b11e-3564174732fc.png)
