### PR TITLE
Internal: cleanup/refactor how we handle autogen props

### DIFF
--- a/docs/docs-components/GeneratedPropTable.js
+++ b/docs/docs-components/GeneratedPropTable.js
@@ -9,12 +9,12 @@ function getResponsive(description?: string): {|
   responsive?: boolean,
 |} {
   const input = description ?? '';
-  const match = input.match(/(?<main>Responsive: (?<typeOverride>.*))/);
+  const match = input.match(/(?<main>Responsive: (?<responsive>.*))/);
   const groups = match?.groups ?? {};
 
   return {
     description: groups.main ? input.replace(groups.main, '') : description,
-    responsive: Boolean(groups.typeOverride?.replace(/'/g, '')),
+    responsive: Boolean(groups.responsive?.replace(/'/g, '')),
   };
 }
 

--- a/docs/docs-components/GeneratedPropTable.js
+++ b/docs/docs-components/GeneratedPropTable.js
@@ -48,22 +48,6 @@ function getDefaultValue(description?: string): {|
   };
 }
 
-// Support the older-style links in props, where the prop name is a link
-// As of Nov '22, only used in Module and Text
-function getHref(description?: string): {|
-  description?: string,
-  href?: string,
-|} {
-  const input = description ?? '';
-  const match = input.match(/(?<main>Link: (?<href>.*))/);
-  const groups = match?.groups ?? {};
-
-  return {
-    description: groups.main ? input.replace(groups.main, '') : description,
-    href: groups.href ? [...groups.href.split('#')].pop() : undefined,
-  };
-}
-
 function removeDomain(description) {
   return { description: description?.replace(/https:\/\/gestalt\.pinterest\.systems/g, '') };
 }
@@ -98,7 +82,6 @@ export default function GeneratedPropTable({
 
       const { description: descriptionWithoutOverrides, ...overrides } = [
         removeDomain,
-        getHref,
         getDefaultValue,
         getTypeOverrideValue,
         getResponsive,

--- a/docs/docs-components/GeneratedPropTable.js
+++ b/docs/docs-components/GeneratedPropTable.js
@@ -3,6 +3,22 @@ import { type Node } from 'react';
 import { type DocGen } from './docgen.js';
 import PropTable from './PropTable.js';
 
+// Note if the prop has responsive versions (e.g. margin, smMargin, mdMargin, lgMargin)
+function getResponsive(description?: string): {|
+  description?: string,
+  responsive?: boolean,
+|} {
+  const input = description ?? '';
+  const match = input.match(/(?<main>Responsive: (?<typeOverride>.*))/);
+  const groups = match?.groups ?? {};
+
+  return {
+    description: groups.main ? input.replace(groups.main, '') : description,
+    responsive: Boolean(groups.typeOverride?.replace(/'/g, '')),
+  };
+}
+
+// Provide a different type to display when needed
 function getTypeOverrideValue(description?: string): {|
   description?: string,
   typeOverride?: string,
@@ -33,6 +49,7 @@ function getDefaultValue(description?: string): {|
 }
 
 // Support the older-style links in props, where the prop name is a link
+// As of Nov '22, only used in Module and Text
 function getHref(description?: string): {|
   description?: string,
   href?: string,
@@ -45,6 +62,10 @@ function getHref(description?: string): {|
     description: groups.main ? input.replace(groups.main, '') : description,
     href: groups.href ? [...groups.href.split('#')].pop() : undefined,
   };
+}
+
+function removeDomain(description) {
+  return { description: description?.replace(/https:\/\/gestalt\.pinterest\.systems/g, '') };
 }
 
 type Props = {|
@@ -75,21 +96,20 @@ export default function GeneratedPropTable({
         return null;
       }
 
-      // Remove domain so local development (localhost) isn't broken
-      const descriptionWithoutDomain = description?.replace(
-        /https:\/\/gestalt\.pinterest\.systems/g,
-        '',
+      const { description: descriptionWithoutOverrides, ...overrides } = [
+        removeDomain,
+        getHref,
+        getDefaultValue,
+        getTypeOverrideValue,
+        getResponsive,
+      ].reduce(
+        (acc, cur) => ({
+          // $FlowFixMe[exponential-spread]
+          ...acc,
+          ...cur(acc.description),
+        }),
+        { description: description ?? '' },
       );
-
-      // Parse out older-style links
-      const { description: descriptionWithoutLink, href } = getHref(descriptionWithoutDomain);
-
-      // Parse out default value override
-      const { description: descriptionWithoutDefault, defaultValue: defaultValueOverride } =
-        getDefaultValue(descriptionWithoutLink);
-
-      const { description: descriptionWithoutTypeOverride, typeOverride } =
-        getTypeOverrideValue(descriptionWithoutDefault);
 
       // Trim leading `|`
       const transformedType = (
@@ -111,12 +131,12 @@ export default function GeneratedPropTable({
 
       return {
         name: key,
-        type: typeOverride ?? transformedType,
-        description: descriptionWithoutTypeOverride?.trim(),
+        type: transformedType,
+        description: descriptionWithoutOverrides?.trim(),
         required,
-        defaultValue: defaultValueOverride ?? defaultValue?.value?.replace(/'/g, ''),
+        defaultValue: defaultValue?.value?.replace(/'/g, ''),
         nullable: flowType?.nullable || false,
-        href,
+        ...overrides,
       };
     })
     .filter(Boolean);

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -49,16 +49,12 @@ type Props = {|
   onDismiss: () => void,
   /**
    * The underlying ARIA role for the Modal. See the [Accessibility Role section](https://gestalt.pinterest.systems/web/modal#Role) for more info.
-   *
-   * Default: 'dialog'
    */
   role?: 'alertdialog' | 'dialog',
   /**
    * Determines the width of the Modal. See the [size variant](https://gestalt.pinterest.systems/web/modal#Sizes) for more info.
    *
-   * sm: `540px` | md: `720px` | lg: `900px` | number
-   *
-   * Default: 'sm'
+   * sm: `540px` | md: `720px` | lg: `900px`
    */
   size?: 'sm' | 'md' | 'lg' | number,
   /**

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -13,53 +13,36 @@ type BadgeType = {|
 |};
 
 type Props = {|
-  //
   /**
-   * Add a badge displayed after the title. Will not be displayed if `title` is not provided. Not to be used with `icon` or `iconButton`. Be sure to localize the text.
-   *
-   * Link: https://gestalt.pinterest.systems/web/text#static-badge
+   * Add a badge displayed after the title. Will not be displayed if `title` is not provided. Not to be used with `icon` or `iconButton`. Be sure to localize the text. See the [badge variant](https://gestalt.pinterest.systems/web/module#Static-Badge) for more details.
    */
   badge?: BadgeType,
   /**
-   * Content to display underneath Module title
-   *
-   * Link: https://gestalt.pinterest.systems/web/module#static-default
+   * Content to display underneath Module title.
    */
   children?: Node,
   /**
-   * Name of icon to display in front of title. Will not be displayed if `title` is not provided. Not to be used with `badge` or `iconButton`. For a full list of icons, see [Iconography and SVGs](https://gestalt.pinterest.systems/foundations/iconography/library#Search-icon-library).
-   *
-   * Link: https://gestalt.pinterest.systems/web/module#static-icon
+   * Name of icon to display in front of title. Will not be displayed if `title` is not provided. Not to be used with `badge` or `iconButton`. For a full list of icons, see [Iconography and SVGs](https://gestalt.pinterest.systems/foundations/iconography/library#Search-icon-library). See the [icon variant](https://gestalt.pinterest.systems/web/module#Static-Icon) for more details.
    */
   icon?: $Keys<typeof icons>,
   /**
-   * Label to provide information about the icon used for screen readers. Can be used in two scenarios: to describe the error icon that appears when `type` is `error`, and to describe the provided `icon` prop when `type` is `info`. Be sure to localize the label.
-   *
-   * Link: https://gestalt.pinterest.systems/web/module#static-icon
+   * Label to provide information about the icon used for screen readers. Can be used in two scenarios: to describe the error icon that appears when `type` is `error`, and to describe the provided `icon` prop when `type` is `info`. Be sure to localize the label. See the [icon variant](https://gestalt.pinterest.systems/web/module#Static-Icon) for more details.
    */
   iconAccessibilityLabel?: string,
   /**
-   * IconButton element to be placed after the `title` for a supplemental Call To Action (CTA). Will not be displayed if `title` is not provided. Not to be used with `badge` or `icon`.
-   *
-   * Link: https://gestalt.pinterest.systems/web/module#static-iconbutton
+   * IconButton element to be placed after the `title` for a supplemental Call To Action (CTA). Will not be displayed if `title` is not provided. Not to be used with `badge` or `icon`. See the [icon button variant](https://gestalt.pinterest.systems/web/module#Static-IconButton) for more details.
    */
   iconButton?: Element<typeof IconButton>,
   /**
    * Unique id to identify this Module
-   *
-   * Link: https://gestalt.pinterest.systems/web/module#static-default
    */
   id: string,
   /**
    * Title of this Module. Be sure to localize the text.
-   *
-   * Link: https://gestalt.pinterest.systems/web/module#static-default
    */
   title?: string,
   /**
-   * If set to `error`, displays error icon and changes title to red text. Be sure to provide an `iconAccessibilityLabel` when set to `error`.
-   *
-   * Link: https://gestalt.pinterest.systems/web/module#static-error
+   * If set to `error`, displays error icon and changes title to red text. Be sure to provide an `iconAccessibilityLabel` when set to `error`. See the [error variant](https://gestalt.pinterest.systems/web/module#Static-Error) for more details.
    */
   type?: 'error' | 'info',
 |};

--- a/packages/gestalt/src/ScrollBoundaryContainer.js
+++ b/packages/gestalt/src/ScrollBoundaryContainer.js
@@ -23,9 +23,7 @@ type Props = {|
   /**
    * Use numbers for pixels: height={100} and strings for percentages: height="100%".
    *
-   * Overflow property only works for elements with a specified height, however, it is not required if the parent component sets the height.
-   *
-   * Link: https://gestalt.pinterest.systems/web/text#align
+   * Overflow property only works for elements with a specified height. It is not required if the parent component sets the height. See the [height variant](https://gestalt.pinterest.systems/web/utilities/scrollboundarycontainer#Height) for more details.
    */
   height?: number | string,
   overflow?: ScrollBoundaryContainerOverflow,

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -15,14 +15,15 @@ type Size = '100' | '200' | '300' | '400' | '500' | '600';
 
 type Props = {|
   /**
-   * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text.
-   *
-   * Link: https://gestalt.pinterest.systems/web/text#align
+   * `"start"` and `"end"` should be used for regular alignment since they flip with locale direction. `"forceLeft"` and `"forceRight"` should only be used in special cases where locale direction should be ignored, such as tabular or numeric text. See the [alignment variant](https://gestalt.pinterest.systems/web/text#Alignment) for more details.
    */
   align?: 'start' | 'end' | 'center' | 'forceLeft' | 'forceRight',
+  /**
+   * The text content to be displayed.
+   */
   children?: Node,
   /**
-   * Link: https://gestalt.pinterest.systems/web/text#color
+   * The color of the text content. See the [colors variant](https://gestalt.pinterest.systems/web/text#Colors) for more details.
    */
   color?:
     | 'default'
@@ -36,27 +37,23 @@ type Props = {|
     | 'light'
     | 'dark',
   /**
-   * Link: https://gestalt.pinterest.systems/web/text#inline
+   * Indicates how the text should flow with the surrounding content. See the [block vs inline variant](https://gestalt.pinterest.systems/web/text#Block-vs.-inline) for more details.
    */
   inline?: boolean,
   /**
-   * Link: https://gestalt.pinterest.systems/web/text#styles
+   * Indicates if the text should be displayed in italic. See the [styles variant](https://gestalt.pinterest.systems/web/text#Styles) for more details.
    */
   italic?: boolean,
   /**
-   * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers.
-   *
-   * Link: https://gestalt.pinterest.systems/web/text#Overflow-and-truncation
+   * Visually truncate the text to the specified number of lines. This also adds the `title` attribute if `children` is a string, which displays the full text on hover in most browsers. See the [overflow and truncation variant](https://gestalt.pinterest.systems/web/text#Overflow-and-truncation) for more details.
    */
   lineClamp?: number,
   /**
-   * Link: https://gestalt.pinterest.systems/web/text#Overflow-and-truncation
+   * Indicates how the text content should handle overflowing its container. See the [overflow and truncation variant](https://gestalt.pinterest.systems/web/text#Overflow-and-truncation) for more details.
    */
   overflow?: Overflow,
   /**
-   * The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size).
-   *
-   * Link: https://gestalt.pinterest.systems/web/text#size
+   * The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [sizes variant](https://gestalt.pinterest.systems/web/text#Sizes) for more details.
    */
   size?: Size,
   /**
@@ -64,17 +61,17 @@ type Props = {|
    */
   title?: string,
   /**
-   * Link: https://gestalt.pinterest.systems/web/text#styles
+   * Indicates if the text content should be underlined. See the [styles variant](https://gestalt.pinterest.systems/web/text#Styles) for more details.
    */
   underline?: boolean,
   /**
-   * Link: https://gestalt.pinterest.systems/web/text#styles
+   * Indicates the font weight for the text content. See the [styles variant](https://gestalt.pinterest.systems/web/text#Styles) for more details.
    */
   weight?: 'bold' | 'normal',
 |};
 
 /**
- * The [Text](https://gestalt.pinterest.systems/web/text) component is used for all non-heading text on all surfaces, whether inside of UI components or in long-form paragraph text.
+ * [Text](https://gestalt.pinterest.systems/web/text) component is used for all non-heading text on all surfaces, whether inside of UI components or in long-form paragraph text.
  *
  * ![Text light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Text.spec.mjs-snapshots/Text-chromium-darwin.png)
  * ![Text dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Text-dark.spec.mjs-snapshots/Text-dark-chromium-darwin.png)

--- a/scripts/templates/ComponentName.js
+++ b/scripts/templates/ComponentName.js
@@ -6,14 +6,12 @@ import styles from './ComponentName.css';
 type Props = {|
   /**
    * Prop description.
-   *
-   * Link: https://gestalt.pinterest.systems/componentname#prop
    */
   accessibilityLabel?: string,
 |};
 
 /**
- * [ComponentName] https://gestalt.pinterest.systems/componentname component should be used for ... on the page.
+ * [ComponentName] https://gestalt.pinterest.systems/web/componentname component should be used for ... on the page.
  * ![ComponentName light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ComponentName.spec.mjs-snapshots/ComponentName-chromium-darwin.png)
  * ![ComponentName dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ComponentName-dark.spec.mjs-snapshots/ComponentName-dark-chromium-darwin.png)
  */


### PR DESCRIPTION
- Get the "responsive" part of the prop table working again (we don't actually use this currently, but at least it works again in case we decide to bring it back)
- Remove the "href" override and refactor the last few usages of it
- Refactor how we handle overrides for autogen metadata to be more scalable
- Clean up some cruft related to autogen metadata