### PR TITLE
Toast: restricting `text` prop from Node to only string and Text

### DIFF
--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -64,6 +64,11 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
       <AccessibilitySection name={generatedDocGen?.displayName} />
 
+      <MainSection
+        name="Localization"
+        description={`Remember to localize \`text\` and any string within \`primaryAction\`.`}
+      />
+
       <MainSection name="Variants">
         <MainSection.Subsection
           description="Toasts should be displayed in the center of the viewport, opposite the main navbar (e.g. at the top of the viewport on mobile, bottom of the viewport on desktop). Though not implemented here, Toasts are meant to be ephemeral and disappear after a few seconds."
@@ -125,8 +130,12 @@ function ToastExample() {
         </MainSection.Subsection>
 
         <MainSection.Subsection
-          description="When passing in your own Text component for `text`, do not specify `color` on Text. Toast will automatically pick the correct text color for the given `variant`."
-          title="Complex Text"
+          description={`
+The \`text\` prop accepts either a string or [Text](/Text). Use a string for guide toasts without any visual style. Toast will handle the text style and adherence to design guidelines.
+
+If  confirmation toast's text with more complex style is required, such as bold text or inline links, use Text to wrap your message with any additional Text or Link usages contained within. When passing in your own Text component for \`text\`, do not specify \`color\` on Text. Toast will automatically pick the correct text color for the given \`variant\`.
+`}
+          title="Text"
         >
           <MainSection.Card
             cardSize="lg"

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { isValidElement, type Element, type Node } from 'react';
+import { Children, isValidElement, type Element, type Node } from 'react';
 import Box from './Box.js';
 import Flex from './Flex.js';
 import Link from './Link.js';
@@ -34,10 +34,9 @@ type Props = {|
   |},
 
   /**
-   * Use string for guide toasts (one line of text) and React.Node for confirmation toasts (complex text, potentially containing a Link). Do not specify a Text color within this property, as the color is automatically determined based on the `variant`.
+   * Main content of Toast. Content should be [localized](https://gestalt.pinterest.systems/web/toast#Localization). See the [Text variant](https://gestalt.pinterest.systems/web/toast#Text) to learn more.
    */
-  // $FlowFixMe[unclear-type]
-  text: string | Element<*>,
+  text: string | Element<typeof Text>,
   /**
    * An optional thumbnail image to displayed next to the text.
    */
@@ -76,10 +75,15 @@ export default function Toast({
 
   let containerColor = isDarkMode ? 'light' : 'dark';
   let textColor = isDarkMode ? 'dark' : 'light';
-  let textElement = text;
 
-  // If `text` is a Node, we need to override any text colors within to ensure they all match
-  if (typeof text !== 'string') {
+  let textElement: Element<'span'> | string;
+
+  if (typeof text === 'string') {
+    textElement = text;
+  }
+
+  // If `text` is a Text component, we need to override any text colors within to ensure they all match
+  if (typeof text !== 'string' && Children.only(text).type.displayName === 'Text') {
     let textColorOverrideStyles = isDarkMode
       ? styles.textColorOverrideDark
       : styles.textColorOverrideLight;


### PR DESCRIPTION
### Breaking change

Run the following codemod to list and manually replace those Node elements in `text` prop with Text

yarn codemod detectManualReplacement ~/path/to/your/code
--component=Toast
--prop=text

### Summary

#### What changed?

Toast: restricting `text` prop from Node to only string and Text
