### PR TITLE
Docs: added cookies to support activation/deactivation of experiments from ExperimentProvidern in Docs

### DIFF
--- a/docs/docs-components/App.js
+++ b/docs/docs-components/App.js
@@ -56,8 +56,8 @@ export default function App({ children, files }: Props): Node {
 
   // See additional Providers added in pages/_app.js (dependent for Playwright visual diff testing)
   return (
-    <DocsExperimentProvider>
-      <AppContextProvider>
+    <AppContextProvider>
+      <DocsExperimentProvider>
         <AppContextConsumer>
           {({ colorScheme }) => (
             <ColorSchemeProvider colorScheme={colorScheme} id="gestalt-docs">
@@ -71,7 +71,7 @@ export default function App({ children, files }: Props): Node {
             </ColorSchemeProvider>
           )}
         </AppContextConsumer>
-      </AppContextProvider>
-    </DocsExperimentProvider>
+      </DocsExperimentProvider>
+    </AppContextProvider>
   );
 }

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -1,11 +1,12 @@
 // @flow strict
 import { type Node, type Element } from 'react';
-import { Badge, Box, Flex, Heading, Text, Tooltip, SlimBanner, Link } from 'gestalt';
+import { Badge, Box, Flex, Heading, Text, Tooltip, Link, SlimBanner } from 'gestalt';
 import COMPONENT_DATA from './COMPONENT_DATA.js';
 import Markdown from './Markdown.js';
 import MainSection from './MainSection.js';
 import trackButtonClick from './buttons/trackButtonClick.js';
 import PageHeaderQualitySummary from './PageHeaderQualitySummary.js';
+import { SlimBannerExperiment } from './SlimBannerExperiment.js';
 
 const buildSourceLinkPath = (componentName) => {
   const packageName = componentName === 'DatePicker' ? 'gestalt-datepicker' : 'gestalt';
@@ -43,7 +44,7 @@ type Props = {|
   name: string,
   shadedCodeExample?: boolean,
   showCode?: boolean,
-  slimBanner?: Element<typeof SlimBanner> | null,
+  slimBanner?: Element<typeof SlimBanner | typeof SlimBannerExperiment> | null,
   type?: 'guidelines' | 'component' | 'utility',
 |};
 

--- a/docs/docs-components/SlimBannerExperiment.js
+++ b/docs/docs-components/SlimBannerExperiment.js
@@ -1,0 +1,67 @@
+// @flow strict
+import { type Node } from 'react';
+import { SlimBanner } from 'gestalt';
+import { useAppContext } from './appContext.js';
+
+export function BareSlimBannerExperiment({ componentName }: {| componentName: string |}): Node {
+  const { experiments } = useAppContext();
+
+  return (
+    <SlimBanner
+      iconAccessibilityLabel="Component under experiment"
+      message={
+        experiments === componentName
+          ? `The current ${componentName} example is displaying experimental changes.`
+          : `The current ${componentName} example is NOT displaying experimental changes.`
+      }
+      type="warningBare"
+      helperLink={{
+        text:
+          experiments === componentName
+            ? 'Learn more and/or deactivate the experimental changes.'
+            : 'Learn more and/or activate the experimental changes.',
+        accessibilityLabel: '',
+        href: '#',
+        onClick: () => {},
+      }}
+    />
+  );
+}
+
+export function SlimBannerExperiment({
+  componentName,
+  description,
+  pullRequest,
+  section,
+}: {|
+  componentName: string,
+  description: string,
+  pullRequest: number,
+  section: string,
+|}): Node {
+  const { experiments, setExperiments } = useAppContext();
+
+  return (
+    <SlimBanner
+      iconAccessibilityLabel="Component under experiment"
+      message={`${componentName} is under an experiment to ${description}.`}
+      type="warning"
+      helperLink={{
+        text: 'Visit the Pull Request to learn more.',
+        accessibilityLabel: '',
+        href: `https://github.com/pinterest/gestalt/pull/${pullRequest}/`,
+        onClick: () => {},
+        target: 'blank',
+      }}
+      primaryAction={{
+        accessibilityLabel:
+          experiments === componentName
+            ? 'Deactivate component experiments in the Docs'
+            : 'Activate component experiments in the Docs',
+        label: experiments === componentName ? 'Deactivate experiments' : 'Activate experiments',
+        onClick: () => setExperiments(experiments === componentName ? '' : componentName),
+        href: section,
+      }}
+    />
+  );
+}

--- a/docs/docs-components/appContext.js
+++ b/docs/docs-components/appContext.js
@@ -6,10 +6,12 @@ import createHydra, { type Hydra } from './createHydra.js';
 const colorSchemeKey = 'gestalt-color-scheme';
 const propTableVariantKey = 'gestalt-propTable-variant';
 const textDirectionKey = 'gestalt-text-direction';
+const experimentsKey = 'gestalt-experiments';
 
 type PropTableVariant = 'collapsed' | 'expanded';
 type ColorScheme = 'light' | 'dark';
 type DirectionScheme = 'ltr' | 'rtl';
+type Experiments = string;
 
 export type AppContextType = {|
   propTableVariant: PropTableVariant,
@@ -18,6 +20,8 @@ export type AppContextType = {|
   setColorScheme: (val: ColorScheme) => void,
   textDirection: DirectionScheme,
   setTextDirection: (val: DirectionScheme) => void,
+  experiments: Experiments,
+  setExperiments: (val: Experiments) => void,
 |};
 
 const {
@@ -27,16 +31,26 @@ const {
 }: Hydra<AppContextType> = createHydra<AppContextType>('AppContext');
 
 function AppContextProvider({ children }: {| children?: Node |}): Node {
-  const [cookies, setCookies] = useCookies([colorSchemeKey, propTableVariantKey, textDirectionKey]);
+  const [cookies, setCookies] = useCookies([
+    colorSchemeKey,
+    propTableVariantKey,
+    textDirectionKey,
+    experimentsKey,
+  ]);
 
   const colorScheme: ColorScheme = cookies[colorSchemeKey] === 'dark' ? 'dark' : 'light';
   const propTableVariant: PropTableVariant =
     cookies[propTableVariantKey] === 'collapsed' ? 'collapsed' : 'expanded';
   const textDirection: DirectionScheme = cookies[textDirectionKey] === 'rtl' ? 'rtl' : 'ltr';
 
+  const experiments: Experiments = cookies[experimentsKey] ?? [];
+
   const setColorScheme = (newColorScheme) => setCookies(colorSchemeKey, newColorScheme);
   const setPropTableVariant = (variant) => setCookies(propTableVariantKey, variant);
   const setTextDirection = (direction) => setCookies(textDirectionKey, direction);
+  const setExperiments = (component) => {
+    setCookies(experimentsKey, component);
+  };
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -53,6 +67,8 @@ function AppContextProvider({ children }: {| children?: Node |}): Node {
         setColorScheme,
         textDirection,
         setTextDirection,
+        experiments,
+        setExperiments,
       }}
     >
       {children}

--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import { ExperimentProvider } from 'gestalt';
+import { useAppContext } from '../appContext.js';
 
 /**
  * To implement experimental behavior in the docs:
@@ -8,7 +9,9 @@ import { ExperimentProvider } from 'gestalt';
  * - Unless you want the experimental behavior live on the docs for everyone, REMOVE YOUR EXPERIMENT HERE before merging your PR!
  * */
 
-const enabledExperiments = [];
+const enabledExperiments = {
+  TextField: ['web_unauth_show_password_button', 'mweb_unauth_show_password_button'],
+};
 
 function buildExperimentsObj(experiments: $ReadOnlyArray<string>) {
   return experiments.reduce(
@@ -31,8 +34,12 @@ function buildExperimentsObj(experiments: $ReadOnlyArray<string>) {
 type Props = {| children: Node |};
 
 export default function DocsExperimentProvider({ children }: Props): Node {
+  const { experiments } = useAppContext();
+
   return (
-    <ExperimentProvider value={buildExperimentsObj(enabledExperiments)}>
+    <ExperimentProvider
+      value={buildExperimentsObj(!experiments ? [] : enabledExperiments[experiments] ?? [])}
+    >
       {children}
     </ExperimentProvider>
   );

--- a/docs/pages/web/badge.js
+++ b/docs/pages/web/badge.js
@@ -6,7 +6,6 @@ import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
-
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 
 export default function BadgePage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -6,8 +6,11 @@ import Page from '../../docs-components/Page.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
-
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+import {
+  BareSlimBannerExperiment,
+  SlimBannerExperiment,
+} from '../../docs-components/SlimBannerExperiment.js';
 
 export default function TextFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -36,6 +39,14 @@ function Example(props) {
   );
 }
 `}
+        slimBanner={
+          <SlimBannerExperiment
+            componentName={generatedDocGen?.displayName}
+            description="is under an experiment to improve its password typing UI: adds an 'show/hide password' icon button for type='password'."
+            pullRequest={1995}
+            section="#Password"
+          />
+        }
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
@@ -536,6 +547,28 @@ function Example(props) {
       placeholder="Name"
       value={value}
       readOnly
+    />
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Password">
+          <BareSlimBannerExperiment componentName={generatedDocGen?.displayName} />
+          <MainSection.Card
+            defaultCode={`
+function Example(props) {
+  const [value, setValue] = React.useState();
+
+  return (
+    <TextField
+      id="enter-password"
+      label="Account password"
+      onChange={({ value }) => setValue(value)}
+      placeholder="Password"
+      value={value}
+      type="password"
     />
   );
 }


### PR DESCRIPTION
### Summary

#### What changed?

Docs: added cookies to support activation/deactivation of experiments from ExperimentProvidern in Docs

#### Why?
Be able to support SlimBanner's primaryAction to toggle between active/inactive experiments to visualize changes from experiments.

Implemented in Textfield. See https://deploy-preview-2511--gestalt.netlify.app/web/textfield

Next ones:
![Screen Shot 2022-11-18 at 1 12 00 PM](https://user-images.githubusercontent.com/10593890/202774149-70b65ebd-1009-4b7f-9608-e97dd9a0395c.png)
![Screen Shot 2022-11-18 at 1 56 21 PM](https://user-images.githubusercontent.com/10593890/202781613-2e637a58-8f32-4beb-bd96-25faf42cc9de.png)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
