### PR TITLE
Toast: new Toast design adjustments

### DIFF
--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -109,9 +109,11 @@ function ToastExample() {
                 transform: 'translateX(-50%)',
               },
             }}
-            fit
+            width="100%"
             paddingX={1}
             position="fixed"
+            display="flex"
+            justifyContent="center"
           >
             <Toast
               primaryAction={{ accessibilityLabel: 'Test', label: 'Undo', size: 'lg' }}

--- a/packages/gestalt/src/Toast.css
+++ b/packages/gestalt/src/Toast.css
@@ -3,7 +3,37 @@
   color: var(--color-text-light) !important;
 }
 
+.textErrorColorOverrideLight * {
+  /* stylelint-disable-next-line declaration-no-important */
+  color: var(--color-text-light) !important;
+  /* stylelint-disable-next-line declaration-no-important */
+  font-weight: var(--font-weight-semibold) !important;
+}
+
 .textColorOverrideDark * {
   /* stylelint-disable-next-line declaration-no-important */
   color: var(--color-text-dark) !important;
+}
+
+.toast {
+  border-radius: 16px;
+  margin-left: 32px;
+  margin-right: 32px;
+
+  /*  Ensure that maxWidth isn't greater than viewport width (for small screens)  */
+  max-width: "min(716px, 100vw)";
+  width: 100%;
+}
+
+@media (--g-sm) {
+  .toast {
+    border-radius: 16px;
+    display: inline-block;
+    margin-left: 32px;
+    margin-right: 32px;
+
+    /*  Ensure that maxWidth isn't greater than viewport width (for small screens)  */
+    max-width: "min(716px, 100vw)";
+    width: auto;
+  }
 }

--- a/packages/gestalt/src/Toast.css.flow
+++ b/packages/gestalt/src/Toast.css.flow
@@ -3,4 +3,6 @@
 declare module.exports: {|
   +'textColorOverrideDark': string,
   +'textColorOverrideLight': string,
+  +'textErrorColorOverrideLight': string,
+  +'toast': string,
 |};

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -17,7 +17,7 @@ const TOAST_MAX_WIDTH_PX = 500;
 const TOAST_WIDTH_PX = 330;
 
 const EXP_SIZE_THUMBNAIL = 32;
-const EXP_TOAST_MAX_WIDTH = 716;
+const EXP_SIZE_ICON = 24;
 
 type Props = {|
   /**
@@ -96,8 +96,11 @@ export default function Toast({
     let textColorOverrideStyles = isDarkMode
       ? styles.textColorOverrideDark
       : styles.textColorOverrideLight;
+
     if (isErrorVariant) {
-      textColorOverrideStyles = styles.textColorOverrideLight;
+      textColorOverrideStyles = inToastExp
+        ? styles.textErrorColorOverrideLight
+        : styles.textColorOverrideLight;
     }
 
     textElement = <span className={textColorOverrideStyles}>{text}</span>;
@@ -112,68 +115,67 @@ export default function Toast({
   const hasPrimaryAction = primaryAction || _dangerouslySetPrimaryAction;
 
   if (inToastExp) {
-    return (
-      <Box
-        // Ensure that maxWidth isn't greater than viewport width (for small screens)
-        maxWidth={`min(${EXP_TOAST_MAX_WIDTH}px, 100vw)`}
-        role="status"
-        rounding={4}
-      >
-        <Box color={containerColor} paddingX={4} paddingY={3} fit rounding={4}>
-          <Flex alignItems="center" gap={4}>
-            {!!thumbnail && !isErrorVariant ? (
-              <Flex.Item flex="none">
-                <Mask
-                  height={EXP_SIZE_THUMBNAIL}
-                  rounding={thumbnailShape === 'circle' ? 'circle' : 2}
-                  width={EXP_SIZE_THUMBNAIL}
-                >
-                  {thumbnail}
-                </Mask>
-              </Flex.Item>
-            ) : null}
-            {isErrorVariant ? (
-              <Flex.Item flex="none">
-                <Icon
-                  color="inverse"
-                  icon="workflow-status-problem"
-                  accessibilityLabel="problem"
-                  size={32}
-                />
-              </Flex.Item>
-            ) : null}
-            <Flex.Item flex="grow">
-              <Text
-                weight={isErrorVariant ? 'bold' : undefined}
-                align={!thumbnail && !primaryAction ? 'center' : 'start'}
-                color={textColor}
+    const toastContent = (
+      <Box color={containerColor} paddingX={4} paddingY={3} width="100%" rounding={4}>
+        <Flex alignItems="center" gap={4}>
+          {!!thumbnail && !isErrorVariant ? (
+            <Flex.Item flex="none">
+              <Mask
+                height={EXP_SIZE_THUMBNAIL}
+                rounding={thumbnailShape === 'circle' ? 'circle' : 2}
+                width={EXP_SIZE_THUMBNAIL}
               >
-                {textElement}
-              </Text>
+                {thumbnail}
+              </Mask>
             </Flex.Item>
+          ) : null}
+          {isErrorVariant ? (
+            <Flex.Item flex="none">
+              <Icon
+                color="inverse"
+                icon="workflow-status-problem"
+                accessibilityLabel="problem"
+                size={EXP_SIZE_ICON}
+              />
+            </Flex.Item>
+          ) : null}
+          <Flex.Item flex="grow">
+            <Text
+              weight={isErrorVariant ? 'bold' : undefined}
+              align="start"
+              color={textColor}
+              lineClamp={2}
+            >
+              {textElement}
+            </Text>
+          </Flex.Item>
 
-            {primaryAction || _dangerouslySetPrimaryAction ? (
-              // Allow button text to wrap on mobile
-              <Flex.Item flex={isMobileWidth ? 'shrink' : 'none'}>
-                {isValidElement(_dangerouslySetPrimaryAction) ? _dangerouslySetPrimaryAction : null}
-                {!_dangerouslySetPrimaryAction &&
-                primaryAction?.accessibilityLabel &&
-                primaryAction?.label ? (
-                  <ToastPrimaryAction
-                    accessibilityLabel={primaryAction.accessibilityLabel}
-                    href={primaryAction.href}
-                    rel={primaryAction?.rel}
-                    size="sm"
-                    target={primaryAction?.target}
-                    label={primaryAction.label}
-                    onClick={primaryAction.onClick}
-                  />
-                ) : null}
-              </Flex.Item>
-            ) : null}
-          </Flex>
-        </Box>
+          {primaryAction || _dangerouslySetPrimaryAction ? (
+            // Allow button text to wrap on mobile
+            <Flex.Item flex={isMobileWidth ? 'shrink' : 'none'}>
+              {isValidElement(_dangerouslySetPrimaryAction) ? _dangerouslySetPrimaryAction : null}
+              {!_dangerouslySetPrimaryAction &&
+              primaryAction?.accessibilityLabel &&
+              primaryAction?.label ? (
+                <ToastPrimaryAction
+                  accessibilityLabel={primaryAction.accessibilityLabel}
+                  href={primaryAction.href}
+                  rel={primaryAction?.rel}
+                  size="sm"
+                  target={primaryAction?.target}
+                  label={primaryAction.label}
+                  onClick={primaryAction.onClick}
+                />
+              ) : null}
+            </Flex.Item>
+          ) : null}
+        </Flex>
       </Box>
+    );
+    return (
+      <div className={styles.toast} role="status">
+        {toastContent}
+      </div>
     );
   }
 


### PR DESCRIPTION
### Summary

#### What changed?

Toast: new Toast design adjustments

All changes behind experiments
| change      |  BEFORE | AFTER |
| ----------- | ----------- |  ----------- |
| Width under sm breakpoint: Fix so that below smallest breakpoint, width gets set to "100%"        |   ![Screen Shot 2022-11-28 at 5 12 47 PM](https://user-images.githubusercontent.com/10593890/204391966-46bb6b33-1ef3-4575-a3cd-4bd25c2a6235.png) ![Kapture 2022-11-28 at 11 45 45](https://user-images.githubusercontent.com/10593890/204334256-81ead66e-9fb6-4b45-87aa-d53d1a0e0baf.gif)     |    ![Kapture 2022-11-28 at 11 41 54](https://user-images.githubusercontent.com/10593890/204333199-42756f29-52ae-4072-b095-ea02b6a1da84.gif)    |
| lineClamp={2}       |    ![Screen Shot 2022-11-28 at 5 13 18 PM](https://user-images.githubusercontent.com/10593890/204391989-6c49cc14-7008-41f0-a677-2b928d50044e.png)    |   ![Screen Shot 2022-11-28 at 5 11 44 PM](https://user-images.githubusercontent.com/10593890/204392029-66f59792-c9b0-4196-9ac2-02c67b6afd31.png)    |
| marginStart/End to 8 boints   |        |    ![Screen Shot 2022-11-28 at 5 12 05 PM](https://user-images.githubusercontent.com/10593890/204395311-f00a3f47-1a4f-47c8-a0d5-057d93281a81.png)   |
| start alignment of Text   |   ![Screen Shot 2022-11-28 at 5 30 40 PM](https://user-images.githubusercontent.com/10593890/204395069-0af2d779-26bc-49b3-a294-6c4de84a557d.png) |    ![Screen Shot 2022-11-28 at 5 29 17 PM](https://user-images.githubusercontent.com/10593890/204395085-d4b52016-6734-4513-ad7d-d75479dd8b3e.png) |
| error icon size to 24 px   |   |    |

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4028)
- [TDD](https://paper.dropbox.com/doc/Gestalt-TDD-Toast--BqZRSpB7ziwSUFAwTIGjaPx2Ag-EC6LAr0uO808c6GrjH9FO)
- [Figma](http://localhost:8888/web/toast#Error)


