### PR TITLE
Tag: fix background color and dark mode

### DIFF
--- a/packages/gestalt/src/Tag.css
+++ b/packages/gestalt/src/Tag.css
@@ -14,7 +14,7 @@ html:not([dir="rtl"]) .button {
 }
 
 .secondary {
-  composes: lightGrayBg from "./Colors.css";
+  composes: secondary from "./Colors.css";
 }
 
 .button.secondary:hover,
@@ -27,7 +27,7 @@ html:not([dir="rtl"]) .button {
 }
 
 .errorBase {
-  composes: redBg from "./Colors.css";
+  composes: errorBase from "./Colors.css";
 }
 
 .errorBase:hover,

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -9,7 +9,6 @@ import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import useFocusVisible from './useFocusVisible.js';
 import focusStyles from './Focus.css';
 import touchableStyles from './Touchable.css';
-import typographyStyles from './Typography.css';
 import styles from './Tag.css';
 
 type Props = {|
@@ -96,8 +95,8 @@ export default function Tag(props: Props): Node {
             />
           )}
         </Box>
-        <div className={typographyStyles.truncate} title={text}>
-          <Text color={fgColor} inline size="200">
+        <div title={text}>
+          <Text color={fgColor} inline size="200" lineClamp={1}>
             {text}
           </Text>
         </div>

--- a/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
@@ -128,11 +128,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="ey / em"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="ey / em"
                     >
                       ey / em
                     </span>
@@ -177,11 +177,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="he / him"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="he / him"
                     >
                       he / him
                     </span>
@@ -226,11 +226,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="ne / nem"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="ne / nem"
                     >
                       ne / nem
                     </span>
@@ -275,11 +275,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="she / her"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="she / her"
                     >
                       she / her
                     </span>
@@ -324,11 +324,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="they / them"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="they / them"
                     >
                       they / them
                     </span>
@@ -373,11 +373,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="ve / ver"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="ve / ver"
                     >
                       ve / ver
                     </span>
@@ -422,11 +422,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="xe / xem"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="xe / xem"
                     >
                       xe / xem
                     </span>
@@ -471,11 +471,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="xie / xem"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="xie / xem"
                     >
                       xie / xem
                     </span>
@@ -520,11 +520,11 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                     class="box marginEnd2 marginStart0"
                   />
                   <div
-                    class="truncate"
                     title="zie / zem"
                   >
                     <span
-                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                      class="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                      title="zie / zem"
                     >
                       zie / zem
                     </span>

--- a/packages/gestalt/src/__snapshots__/Tag.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tag.test.js.snap
@@ -23,11 +23,16 @@ exports[`Tag clips long strings 1`] = `
       className="box marginEnd2 marginStart0"
     />
     <div
-      className="truncate"
       title="The quick brown fox jumps over the lazy dog"
     >
       <span
-        className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+        className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+        style={
+          Object {
+            "WebkitLineClamp": 1,
+          }
+        }
+        title="The quick brown fox jumps over the lazy dog"
       >
         The quick brown fox jumps over the lazy dog
       </span>
@@ -82,11 +87,16 @@ exports[`Tag renders 1`] = `
       className="box marginEnd2 marginStart0"
     />
     <div
-      className="truncate"
       title="New"
     >
       <span
-        className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+        className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+        style={
+          Object {
+            "WebkitLineClamp": 1,
+          }
+        }
+        title="New"
       >
         New
       </span>
@@ -142,11 +152,16 @@ exports[`Tag renders a disabled tag 1`] = `
       className="box marginEnd2 marginStart0"
     />
     <div
-      className="truncate"
       title="New"
     >
       <span
-        className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal"
+        className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
+        style={
+          Object {
+            "WebkitLineClamp": 1,
+          }
+        }
+        title="New"
       >
         New
       </span>
@@ -195,11 +210,16 @@ exports[`Tag renders a tag with an error state 1`] = `
       </svg>
     </div>
     <div
-      className="truncate"
       title="New"
     >
       <span
-        className="Text fontSize200 inverseText alignStart breakWord fontWeightNormal"
+        className="Text fontSize200 inverseText alignStart breakWord fontWeightNormal lineClamp"
+        style={
+          Object {
+            "WebkitLineClamp": 1,
+          }
+        }
+        title="New"
       >
         New
       </span>

--- a/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
@@ -281,11 +281,16 @@ exports[`TextArea renders tags when supplied 1`] = `
             className="box marginEnd2 marginStart0"
           />
           <div
-            className="truncate"
             title="a@pinterest.com"
           >
             <span
-              className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+              className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+              style={
+                Object {
+                  "WebkitLineClamp": 1,
+                }
+              }
+              title="a@pinterest.com"
             >
               a@pinterest.com
             </span>
@@ -341,11 +346,16 @@ exports[`TextArea renders tags when supplied 1`] = `
             className="box marginEnd2 marginStart0"
           />
           <div
-            className="truncate"
             title="b@pinterest.com"
           >
             <span
-              className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+              className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+              style={
+                Object {
+                  "WebkitLineClamp": 1,
+                }
+              }
+              title="b@pinterest.com"
             >
               b@pinterest.com
             </span>
@@ -401,11 +411,16 @@ exports[`TextArea renders tags when supplied 1`] = `
             className="box marginEnd2 marginStart0"
           />
           <div
-            className="truncate"
             title="c@pinterest.com"
           >
             <span
-              className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+              className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+              style={
+                Object {
+                  "WebkitLineClamp": 1,
+                }
+              }
+              title="c@pinterest.com"
             >
               c@pinterest.com
             </span>

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -362,11 +362,16 @@ exports[`TextField TextField with tags 1`] = `
               className="box marginEnd2 marginStart0"
             />
             <div
-              className="truncate"
               title="a@pinterest.com"
             >
               <span
-                className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                style={
+                  Object {
+                    "WebkitLineClamp": 1,
+                  }
+                }
+                title="a@pinterest.com"
               >
                 a@pinterest.com
               </span>
@@ -422,11 +427,16 @@ exports[`TextField TextField with tags 1`] = `
               className="box marginEnd2 marginStart0"
             />
             <div
-              className="truncate"
               title="b@pinterest.com"
             >
               <span
-                className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                style={
+                  Object {
+                    "WebkitLineClamp": 1,
+                  }
+                }
+                title="b@pinterest.com"
               >
                 b@pinterest.com
               </span>
@@ -482,11 +492,16 @@ exports[`TextField TextField with tags 1`] = `
               className="box marginEnd2 marginStart0"
             />
             <div
-              className="truncate"
               title="c@pinterest.com"
             >
               <span
-                className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal"
+                className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                style={
+                  Object {
+                    "WebkitLineClamp": 1,
+                  }
+                }
+                title="c@pinterest.com"
               >
                 c@pinterest.com
               </span>


### PR DESCRIPTION
### Summary

#### What changed?

Fix color disparity and update truncated view in dark mode

Before

<img width="377" alt="Screen Shot 2022-11-22 at 5 06 03 PM" src="https://user-images.githubusercontent.com/5125094/203451203-ef4a5e79-a2c2-4409-a183-0eb785440e98.png">

After

<img width="427" alt="Screen Shot 2022-11-22 at 5 05 47 PM" src="https://user-images.githubusercontent.com/5125094/203451202-0eb5e310-9797-4d7f-a66b-66405b5bf406.png">
