### PR TITLE
Text: add forwardRef to component

### DIFF
--- a/docs/pages/web/text.js
+++ b/docs/pages/web/text.js
@@ -405,6 +405,111 @@ export default function TextPage({ generatedDocGen }: {| generatedDocGen: DocGen
 `}
           />
         </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="Refs"
+          description={`Don't use \`ref\` to manipulate the underlaying HTML div or span elements. Use \`ref\` to only read HTML attributes. For example, a valid use case can be detecting [truncation](#Overflow-and-truncation). The example below illustrates a case where detecting truncation allows rendering links contained within Text.`}
+        >
+          <MainSection.Card
+            defaultCode={`
+function Example() {
+  const [showLongText, setShowLongText] = React.useState(false);
+  const [applyTruncationDetection, setApplyTruncationDetection] = React.useState(false);
+
+
+  const text = "Tag brand partners in your Idea Pins with the paid partnership tool."
+
+  const veryLongText = "Tag brand partners in your Idea Pins with the paid partnership tool. Just make an Idea Pin in the app, add the paid partnership label and tag your partner brand. Once they approve the request, their brand name will show up on your Idea Pin. Brands can also choose to promote your Idea Pins as ads, boosting your reach to even more people. When you use the paid partnership tool, you work directly with brands to define the payment terms and process. Pinterest will not be directly involved in payment."
+
+  const textRef = React.useRef(null);
+  const [ellipsisActive, setEllipsisActive] = React.useState(false);
+
+  const isEllipsisActive = (element) =>
+    element.offsetHeight < element.scrollHeight || element.offsetWidth < element.scrollWidth;
+
+  const checkEllipsisActive = () => {
+    if (textRef.current && !ellipsisActive && isEllipsisActive(textRef.current)) {
+      setEllipsisActive(true);
+    } else if (textRef.current && ellipsisActive && !isEllipsisActive(textRef.current)) {
+      setEllipsisActive(false);
+    }
+  };
+
+  React.useEffect(() => {
+    checkEllipsisActive();
+    window.addEventListener('resize', checkEllipsisActive);
+    return () => {
+      window.removeEventListener('resize', checkEllipsisActive);
+    };
+  }, [checkEllipsisActive]);
+
+  return (
+    <Flex gap={8} direction="column" width="100%">
+      <Flex gap={2} direction="column">
+        <Box display="flex" alignItems="center">
+          <Box paddingX={2} WIDTH>
+            <Label htmlFor="longText">
+              <Text>Show long text</Text>
+            </Label>
+          </Box>
+          <Switch
+            onChange={() => setShowLongText(!showLongText)}
+            id="longText"
+            switched={showLongText}
+          />
+        </Box>
+        <Box display="flex" alignItems="center">
+          <Box paddingX={2}>
+            <Label htmlFor="truncation">
+              <Text>Apply truncation detection</Text>
+            </Label>
+          </Box>
+          <Switch
+            onChange={() => setApplyTruncationDetection(!applyTruncationDetection)}
+            id="truncation"
+            switched={applyTruncationDetection}
+          />
+        </Box>
+      </Flex >
+      <Flex direction="column">
+        <Text
+          inline
+          align="start"
+          lineClamp={2}
+          ref={textRef}
+          title={ellipsisActive && typeof veryLongText === 'string' ? veryLongText : undefined}
+        >
+          {showLongText ? veryLongText : text }
+          {' '}
+          <Text inline>
+            <Link
+              accessibilityLabel="Visit our Help Site"
+              href="#"
+              inline
+            >
+              Visit our Help Site
+            </Link>
+          </Text>
+        </Text>
+        {ellipsisActive && applyTruncationDetection? (
+          <Text>
+            <Link
+              accessibilityLabel="Visit our Help Site"
+              href="#"
+              inline
+            >
+            Visit our Help Site
+            </Link>
+          </Text>
+        ) : null}
+      </Flex>
+    </Flex>
+  );
+}
+`}
+          />
+        </MainSection.Subsection>
+
         <MainSection name="Writing">
           <MainSection.Subsection columns={2}>
             <MainSection.Card

--- a/packages/gestalt/src/Text.js
+++ b/packages/gestalt/src/Text.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node } from 'react';
+import { forwardRef, type AbstractComponent, type Element, type Node } from 'react';
 import cx from 'classnames';
 import colors from './Colors.css';
 import styles from './Text.css';
@@ -10,6 +10,7 @@ function isNotNullish(val): boolean {
   return val !== null && val !== undefined;
 }
 
+type As = 'span' | 'div';
 type Overflow = 'normal' | 'breakWord' | 'noWrap';
 type Size = '100' | '200' | '300' | '400' | '500' | '600';
 
@@ -53,6 +54,10 @@ type Props = {|
    */
   overflow?: Overflow,
   /**
+   * Ref that is forwarded to the underlying element. See the [ref variant](https://gestalt.pinterest.systems/web/text#Refs) for more details.
+   */
+  ref?: HTMLDivElement | HTMLSpanElement,
+  /**
    * The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [sizes variant](https://gestalt.pinterest.systems/web/text#Sizes) for more details.
    */
   size?: Size,
@@ -76,55 +81,61 @@ type Props = {|
  * ![Text light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Text.spec.mjs-snapshots/Text-chromium-darwin.png)
  * ![Text dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Text-dark.spec.mjs-snapshots/Text-dark-chromium-darwin.png)
  */
-function Text({
-  align = 'start',
-  children,
-  color = 'default',
-  inline = false,
-  italic = false,
-  lineClamp,
-  overflow = 'breakWord',
-  size = '300',
-  title,
-  underline = false,
-  weight = 'normal',
-}: Props): Node {
-  const colorClass = semanticColors.includes(color) && colors[`${color}Text`];
+const TextWithForwardRef: AbstractComponent<Props, HTMLElement> = forwardRef<Props, HTMLElement>(
+  function Text(
+    {
+      align = 'start',
+      children,
+      color = 'default',
+      inline = false,
+      italic = false,
+      lineClamp,
+      overflow = 'breakWord',
+      size = '300',
+      title,
+      underline = false,
+      weight = 'normal',
+    }: Props,
+    ref,
+  ): Element<As> {
+    const colorClass = semanticColors.includes(color) && colors[`${color}Text`];
 
-  const cs = cx(
-    styles.Text,
-    typography[`fontSize${size}`],
-    color && colorClass,
-    align === 'center' && typography.alignCenter,
-    align === 'justify' && typography.alignJustify,
-    align === 'start' && typography.alignStart,
-    align === 'end' && typography.alignEnd,
-    align === 'forceLeft' && typography.alignForceLeft,
-    align === 'forceRight' && typography.alignForceRight,
-    overflow === 'breakWord' && typography.breakWord,
-    overflow === 'noWrap' && typography.noWrap,
-    italic && typography.fontStyleItalic,
-    underline && typography.underline,
-    weight === 'bold' && typography.fontWeightSemiBold,
-    weight === 'normal' && typography.fontWeightNormal,
-    isNotNullish(lineClamp) && typography.lineClamp,
-  );
+    const cs = cx(
+      styles.Text,
+      typography[`fontSize${size}`],
+      color && colorClass,
+      align === 'center' && typography.alignCenter,
+      align === 'justify' && typography.alignJustify,
+      align === 'start' && typography.alignStart,
+      align === 'end' && typography.alignEnd,
+      align === 'forceLeft' && typography.alignForceLeft,
+      align === 'forceRight' && typography.alignForceRight,
+      overflow === 'breakWord' && typography.breakWord,
+      overflow === 'noWrap' && typography.noWrap,
+      italic && typography.fontStyleItalic,
+      underline && typography.underline,
+      weight === 'bold' && typography.fontWeightSemiBold,
+      weight === 'normal' && typography.fontWeightNormal,
+      isNotNullish(lineClamp) && typography.lineClamp,
+    );
 
-  const Tag = inline ? 'span' : 'div';
+    const Tag: As = inline ? 'span' : 'div';
 
-  return (
-    <Tag
-      className={cs}
-      title={
-        title ?? (isNotNullish(lineClamp) && typeof children === 'string' ? children : undefined)
-      }
-      {...(lineClamp ? { style: { WebkitLineClamp: lineClamp } } : {})}
-    >
-      {children}
-    </Tag>
-  );
-}
+    return (
+      <Tag
+        className={cs}
+        title={
+          title ?? (isNotNullish(lineClamp) && typeof children === 'string' ? children : undefined)
+        }
+        {...(lineClamp ? { style: { WebkitLineClamp: lineClamp } } : {})}
+        ref={ref}
+      >
+        {children}
+      </Tag>
+    );
+  },
+);
 
-Text.displayName = 'Text';
+TextWithForwardRef.displayName = 'Text';
 
-export default Text;
+export default TextWithForwardRef;


### PR DESCRIPTION

### Summary

#### What changed?

Text: add forwardRef to component

#### Why?

Accessing the ref can be helpful to detect if the text is being truncated. This can be helpful when the Text component is using text nodes rather than strings. If we detect truncation, we can manually set the title prop.

We need this change to detect truncation inside Toast (which remove the helperLink) and therefore we can stack the helperLink again back at the toast so not to lose functionality.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
