### PR TITLE
Docs: Fix typo in designer getting started

### DIFF
--- a/docs/pages/get_started/designers.js
+++ b/docs/pages/get_started/designers.js
@@ -85,7 +85,7 @@ Google Fonts
         <MainSection.Subsection
           title="Documentation"
           description={`
-Wondering how a component works? The dos and donts of its use?
+Wondering how a component works? The dos and dont's of its use?
 
 All of Gestalt’s documentation can be found right here at [gestalt.pinterest.systems](https://gestalt.pinterest.systems). This site is continuously updated and serves as the Gestalt source of truth. If you can’t find something or have ideas for our documentation, reach out or set up a meeting with the Gestalt team.
 


### PR DESCRIPTION
### Summary

#### What changed?

Fixed typo in designer getting started page (donts -> don'ts)

