### PR TITLE
Docs: Add Icon descriptions to library page

### DIFF
--- a/docs/pages/foundations/iconography/ICON_DATA.json
+++ b/docs/pages/foundations/iconography/ICON_DATA.json
@@ -2,11 +2,13 @@
   "icons": [
     {
       "name": "add",
-      "categories": "Add"
+      "categories": "Add",
+      "description": "Use this icon to indicate the ability to create or add content"
     },
     {
       "name": "add-circle",
-      "categories": "Add"
+      "categories": "Add",
+      "description": "Use this icon to indicate the ability to display more content or additional information"
     },
     {
       "name": "add-layout",
@@ -22,11 +24,13 @@
     },
     {
       "name": "ad",
-      "categories": "Ads and measurements"
+      "categories": "Ads and measurements",
+      "description": "Use this icon to indicate an ad type"
     },
     {
       "name": "ad-group",
-      "categories": "Ads and measurements"
+      "categories": "Ads and measurements",
+      "description": "Use this icon to indicate a group of ads accounts"
     },
     {
       "name": "ads-overview",
@@ -438,7 +442,8 @@
     },
     {
       "name": "accessibility",
-      "categories": "Utility and tools"
+      "categories": "Utility and tools",
+      "description": "Use this icon to indicate accessibility features or adjustments"
     },
     {
       "name": "apps",

--- a/docs/pages/foundations/iconography/ICON_DATA.json
+++ b/docs/pages/foundations/iconography/ICON_DATA.json
@@ -3,12 +3,12 @@
     {
       "name": "add",
       "categories": "Add",
-      "description": "Use this icon to indicate the ability to create or add content"
+      "description": "Indicates the ability to create or add content"
     },
     {
       "name": "add-circle",
       "categories": "Add",
-      "description": "Use this icon to indicate the ability to display more content or additional information"
+      "description": "Indicates the ability to display more content or additional information"
     },
     {
       "name": "add-layout",
@@ -25,12 +25,12 @@
     {
       "name": "ad",
       "categories": "Ads and measurements",
-      "description": "Use this icon to indicate an ad type"
+      "description": "Indicates an ad type"
     },
     {
       "name": "ad-group",
       "categories": "Ads and measurements",
-      "description": "Use this icon to indicate a group of ads accounts"
+      "description": "Indicates a group of ads accounts"
     },
     {
       "name": "ads-overview",

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -13,6 +13,7 @@ import {
   TapArea,
   Text,
   Toast,
+  Tooltip,
 } from 'gestalt';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
@@ -53,70 +54,77 @@ type IconData = {|
     | 'Time'
     | 'Toggle'
     | 'Utility and tools',
+  description: string,
 |};
 
-function IconTile({ iconName, onTap }: {| iconName: IconName, onTap: () => void |}) {
+function IconTile({
+  iconName,
+  iconDescription = 'Description coming soon',
+  onTap,
+}: {|
+  iconName: IconName,
+  iconDescription: string,
+  onTap: () => void,
+|}) {
   const [hovered, setHovered] = useState();
 
   return (
-    <TapArea
-      rounding={2}
-      tapStyle="compress"
-      onTap={onTap}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      onFocus={() => setHovered(true)}
-      onBlur={() => setHovered(false)}
-    >
-      <Box
-        borderStyle="sm"
+    <Tooltip text={iconDescription} accessibilityLabel={iconDescription} idealDirection="down">
+      <TapArea
         rounding={2}
-        padding={2}
-        width={150}
-        height={110}
-        color={hovered ? 'inverse' : 'default'}
-        position="relative"
+        tapStyle="compress"
+        onTap={onTap}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onFocus={() => setHovered(true)}
+        onBlur={() => setHovered(false)}
       >
-        <Flex
-          height="100%"
-          flex="grow"
-          direction="column"
-          gap={2}
-          alignItems="center"
-          justifyContent="center"
-        >
-          <Icon
-            color={hovered ? 'inverse' : 'default'}
-            accessibilityLabel={iconName}
-            icon={iconName}
-            size="24"
-          />
-          <Text color={hovered ? 'inverse' : 'default'} size="100">
-            {iconName}
-          </Text>
-        </Flex>
         <Box
-          position="absolute"
-          bottom
-          right
-          display={hovered ? 'block' : 'none'}
-          dangerouslySetInlineStyle={{ __style: { bottom: '8px', right: '8px' } }}
+          borderStyle="sm"
+          rounding={2}
+          padding={2}
+          width={150}
+          height={110}
+          color={hovered ? 'inverse' : 'default'}
+          position="relative"
         >
-          <Pog
-            icon="copy-to-clipboard"
-            size="xs"
-            iconColor="darkGray"
-            bgColor="lightGray"
-            padding={1}
-          />
+          <Flex
+            height="100%"
+            flex="grow"
+            direction="column"
+            gap={2}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Icon
+              color={hovered ? 'inverse' : 'default'}
+              accessibilityLabel=""
+              icon={iconName}
+              size="24"
+            />
+            <Text color={hovered ? 'inverse' : 'default'} size="100">
+              {iconName}
+            </Text>
+          </Flex>
+          <Box
+            position="absolute"
+            bottom
+            right
+            display={hovered ? 'block' : 'none'}
+            dangerouslySetInlineStyle={{ __style: { bottom: '8px', right: '8px' } }}
+          >
+            <Pog
+              icon="copy-to-clipboard"
+              size="xs"
+              iconColor="darkGray"
+              bgColor="lightGray"
+              padding={1}
+            />
+          </Box>
         </Box>
-      </Box>
-    </TapArea>
+      </TapArea>{' '}
+    </Tooltip>
   );
-}
-
-function findIcon(icon?: string): ?IconName {
-  return icons.find((name) => name === icon);
 }
 
 function findIconByCategory(icon?: string, category: string): IconData {
@@ -164,10 +172,15 @@ export default function IconPage(): Node {
     sortedAlphabetical ? (
       <Flex gap={3} wrap>
         {(suggestedOptions || iconOptions).map(({ label: iconName }) => {
-          const icon = findIcon(iconName);
-          return icon ? (
-            <IconTile key={iconName} iconName={icon} onTap={buildHandleIconClick(icon)} />
-          ) : null;
+          const filteredIconData = iconCategoryData.icons.find((icon) => icon.name === iconName);
+          return (
+            <IconTile
+              key={iconName}
+              iconName={iconName}
+              onTap={buildHandleIconClick(iconName)}
+              iconDescription={filteredIconData?.description}
+            />
+          );
         })}
       </Flex>
     ) : (
@@ -179,6 +192,7 @@ export default function IconPage(): Node {
               <IconTile
                 key={iconName}
                 iconName={iconData.name}
+                iconDescription={iconData.description}
                 onTap={buildHandleIconClick(iconData.name)}
               />
             ) : null;


### PR DESCRIPTION
### Summary

#### What changed?

Add a tooltip for descriptions of Icons on the Icon Library page

![Screen Shot 2022-11-30 at 3 49 28 PM](https://user-images.githubusercontent.com/5125094/204932540-3c8511ce-f600-4d0e-80f9-a31581ed3d79.png)


#### Why?

Give designers and developers an example of when to use each icon

Note: Layla will be adding the rest of the descriptions in a follow up PR 

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [Figma](https://www.figma.com/file/RBlfOYmL123whCtlglXIsG/Iconography-page-redesign?node-id=360%3A3389&t=Ndz6EXOsnEahAIjm-0)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
