### PR TITLE
Modal: add default padding to main content and heading and padding prop

### DIFF
--- a/docs/examples/modal/accessibilityExample.js
+++ b/docs/examples/modal/accessibilityExample.js
@@ -1,7 +1,6 @@
 // @flow strict
 import React, { type Node } from 'react';
 import {
-  Box,
   Button,
   CompositeZIndex,
   FixedZIndex,
@@ -26,21 +25,19 @@ export default function AccessibilityExample(): Node {
         accessibilityModalLabel="Choose how to claim site"
         align="start"
         heading={
-          <Box padding={6}>
-            <Flex justifyContent="between">
-              <Heading size="500" accessibilityLevel={1}>
-                Pick claim option
-              </Heading>
-              <IconButton
-                accessibilityLabel="Dismiss modal"
-                bgColor="white"
-                icon="cancel"
-                iconColor="darkGray"
-                onClick={() => {}}
-                size="sm"
-              />
-            </Flex>
-          </Box>
+          <Flex justifyContent="between">
+            <Heading size="500" accessibilityLevel={1}>
+              Pick claim option
+            </Heading>
+            <IconButton
+              accessibilityLabel="Dismiss modal"
+              bgColor="white"
+              icon="cancel"
+              iconColor="darkGray"
+              onClick={() => {}}
+              size="sm"
+            />
+          </Flex>
         }
         onDismiss={() => {
           setShowModal(!showModal);
@@ -53,28 +50,26 @@ export default function AccessibilityExample(): Node {
         }
         size="sm"
       >
-        <Box padding={6}>
-          <RadioGroup id="claim-option" legend="Claim options" legendDisplay="hidden">
-            <RadioGroup.RadioButton
-              checked={claim === 'tag'}
-              id="claimTag"
-              label="Add HTML tag"
-              helperText="Paste this tag into the <head> section of your site's index.html file"
-              name="claim-type"
-              onChange={() => setClaim('tag')}
-              value="tag"
-            />
-            <RadioGroup.RadioButton
-              checked={claim === 'file'}
-              id="claimFile"
-              label="Upload HTML file"
-              helperText="Download this file and upload it to your website's root directory"
-              name="claim-type"
-              onChange={() => setClaim('file')}
-              value="file"
-            />
-          </RadioGroup>
-        </Box>
+        <RadioGroup id="claim-option" legend="Claim options" legendDisplay="hidden">
+          <RadioGroup.RadioButton
+            checked={claim === 'tag'}
+            id="claimTag"
+            label="Add HTML tag"
+            helperText="Paste this tag into the <head> section of your site's index.html file"
+            name="claim-type"
+            onChange={() => setClaim('tag')}
+            value="tag"
+          />
+          <RadioGroup.RadioButton
+            checked={claim === 'file'}
+            id="claimFile"
+            label="Upload HTML file"
+            helperText="Download this file and upload it to your website's root directory"
+            name="claim-type"
+            onChange={() => setClaim('file')}
+            value="file"
+          />
+        </RadioGroup>
       </Modal>
     </Layer>
   );

--- a/docs/examples/modal/createBoardExample.js
+++ b/docs/examples/modal/createBoardExample.js
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { type Node } from 'react';
+import React, { Fragment, type Node } from 'react';
 import {
   Box,
   Button,
@@ -26,7 +26,7 @@ function ModalWithHeading({ onDismiss }: {| onDismiss: () => void |}) {
       }
       size="sm"
     >
-      <Box paddingX={6}>
+      <Fragment>
         <Box marginBottom={6}>
           <TextField
             id="name"
@@ -44,7 +44,7 @@ function ModalWithHeading({ onDismiss }: {| onDismiss: () => void |}) {
           name="languages"
           onChange={() => {}}
         />
-      </Box>
+      </Fragment>
     </Modal>
   );
 }

--- a/docs/examples/modal/limitActionsExample.js
+++ b/docs/examples/modal/limitActionsExample.js
@@ -18,12 +18,10 @@ function ModalWithSubHeading({ onDismiss }: {| onDismiss: () => void |}) {
       }
       size="sm"
     >
-      <Box paddingX={6}>
-        <Text>
-          Want to continue where you left off? Click &quot;Resume&quot; to continue creating your
-          account or &quot;Cancel&quot; to start over.
-        </Text>
-      </Box>
+      <Text>
+        Want to continue where you left off? Click &quot;Resume&quot; to continue creating your
+        account or &quot;Cancel&quot; to start over.
+      </Text>
     </Modal>
   );
 }

--- a/docs/examples/modal/preventCloseExample.js
+++ b/docs/examples/modal/preventCloseExample.js
@@ -37,9 +37,7 @@ export default function PreventCloseExample(): Node {
               </Flex>
             }
           >
-            <Box padding={6}>
-              <Text align="start">Click on the button to close the modal</Text>
-            </Box>
+            <Text align="start">Click on the button to close the modal</Text>
           </Modal>
         </Layer>
       )}

--- a/docs/examples/modal/sizesExample.js
+++ b/docs/examples/modal/sizesExample.js
@@ -43,9 +43,7 @@ export default function SizesExample(): Node {
               footer={<Heading size="500">Footer</Heading>}
               size="sm"
             >
-              <Box padding={6}>
-                <Heading size="500">Children</Heading>
-              </Box>
+              <Heading size="500">Children</Heading>
             </Modal>
           </Layer>
         )}

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -40,10 +40,6 @@ type Props = {|
    */
   footer?: Node,
   /**
-   * The main Modal content has a default padding. For those cases where full bleed is needed, set `fullBleed` to "false".
-   */
-  fullBleed?: boolean,
-  /**
    * The text used for Modal's heading. See the [Heading variant](https://gestalt.pinterest.systems/web/modal#Heading) for more info.
    */
   heading?: Node,
@@ -51,6 +47,10 @@ type Props = {|
    * Callback fired when Modal is dismissed by clicking on the backdrop outside of the Modal (if `closeOnOutsideClick` is true).
    */
   onDismiss: () => void,
+  /**
+   * The main Modal content has a "default" padding. For those cases where full bleed is needed, set `padding` to "none".
+   */
+  padding?: 'default' | 'none',
   /**
    * The underlying ARIA role for the Modal. See the [Accessibility Role section](https://gestalt.pinterest.systems/web/modal#Role) for more info.
    */
@@ -107,7 +107,7 @@ export default function Modal({
   closeOnOutsideClick = true,
   onDismiss,
   footer,
-  fullBleed = false,
+  padding = 'default',
   heading,
   role = 'dialog',
   size = 'sm',
@@ -196,7 +196,7 @@ export default function Modal({
                     <InternalScrollBoundaryContainer
                       onScroll={updateShadows}
                       ref={contentRef}
-                      padding={fullBleed ? 0 : 6}
+                      padding={padding === 'none' ? 0 : 6}
                     >
                       {children}
                     </InternalScrollBoundaryContainer>

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -40,6 +40,10 @@ type Props = {|
    */
   footer?: Node,
   /**
+   * The main Modal content has a default padding. For those cases where full bleed is needed, set `fullBleed` to "false".
+   */
+  fullBleed?: boolean,
+  /**
    * The text used for Modal's heading. See the [Heading variant](https://gestalt.pinterest.systems/web/modal#Heading) for more info.
    */
   heading?: Node,
@@ -103,6 +107,7 @@ export default function Modal({
   closeOnOutsideClick = true,
   onDismiss,
   footer,
+  fullBleed = false,
   heading,
   role = 'dialog',
   size = 'sm',
@@ -177,7 +182,7 @@ export default function Modal({
                     {typeof heading === 'string' ? (
                       <Header align={align} heading={heading} subHeading={subHeading} />
                     ) : (
-                      heading
+                      <Box padding={6}>{heading}</Box>
                     )}
                   </Box>
                 )}
@@ -188,7 +193,11 @@ export default function Modal({
                   </Box>
                 ) : (
                   <ScrollBoundaryContainerProvider>
-                    <InternalScrollBoundaryContainer onScroll={updateShadows} ref={contentRef}>
+                    <InternalScrollBoundaryContainer
+                      onScroll={updateShadows}
+                      ref={contentRef}
+                      padding={fullBleed ? 0 : 6}
+                    >
                       {children}
                     </InternalScrollBoundaryContainer>
                   </ScrollBoundaryContainerProvider>

--- a/packages/gestalt/src/ModalAlert.js
+++ b/packages/gestalt/src/ModalAlert.js
@@ -88,37 +88,35 @@ function Header({
   onDismiss: () => void,
 |}) {
   return (
-    <Box padding={6}>
-      <Flex flex="grow" alignItems="center" gap={4}>
-        {type !== 'default' && (
-          <Box>
-            <Icon
-              size="20"
-              accessibilityLabel={type}
-              icon={ICON_COLOR_MAP[type].icon}
-              color={ICON_COLOR_MAP[type].color}
-            />
-          </Box>
-        )}
-        <Flex.Item flex="grow">
-          <Heading size="400" accessibilityLevel={1}>
-            {heading}
-          </Heading>
-        </Flex.Item>
-        {type === 'default' && (
-          <Box marginStart={2}>
-            <IconButton
-              accessibilityLabel={accessibilityDismissButtonLabel}
-              bgColor="white"
-              icon="cancel"
-              iconColor="darkGray"
-              onClick={onDismiss}
-              size="sm"
-            />
-          </Box>
-        )}
-      </Flex>
-    </Box>
+    <Flex flex="grow" alignItems="center" gap={4}>
+      {type !== 'default' && (
+        <Box>
+          <Icon
+            size="20"
+            accessibilityLabel={type}
+            icon={ICON_COLOR_MAP[type].icon}
+            color={ICON_COLOR_MAP[type].color}
+          />
+        </Box>
+      )}
+      <Flex.Item flex="grow">
+        <Heading size="400" accessibilityLevel={1}>
+          {heading}
+        </Heading>
+      </Flex.Item>
+      {type === 'default' && (
+        <Box marginStart={2}>
+          <IconButton
+            accessibilityLabel={accessibilityDismissButtonLabel}
+            bgColor="white"
+            icon="cancel"
+            iconColor="darkGray"
+            onClick={onDismiss}
+            size="sm"
+          />
+        </Box>
+      )}
+    </Flex>
   );
 }
 
@@ -204,7 +202,7 @@ export default function ModalAlert({
       role="alertdialog"
       size="sm"
     >
-      <Box paddingX={6}>{children}</Box>
+      {children}
     </Modal>
   );
 }

--- a/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Modal.jsdom.test.js.snap
@@ -28,7 +28,7 @@ Object {
               style="width: 100%;"
             >
               <div
-                class="box flexGrow overflowAuto paddingX0 paddingY0 relative"
+                class="box flexGrow overflowAuto paddingX6 paddingY6 relative"
                 style="height: 100%;"
               >
                 Modal content
@@ -61,7 +61,7 @@ Object {
             style="width: 100%;"
           >
             <div
-              class="box flexGrow overflowAuto paddingX0 paddingY0 relative"
+              class="box flexGrow overflowAuto paddingX6 paddingY6 relative"
               style="height: 100%;"
             >
               Modal content

--- a/packages/gestalt/src/__snapshots__/ModalAlert.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModalAlert.jsdom.test.js.snap
@@ -85,14 +85,10 @@ exports[`Modal Modal renders 1`] = `
               </div>
             </div>
             <div
-              class="box flexGrow overflowAuto paddingX0 paddingY0 relative"
+              class="box flexGrow overflowAuto paddingX6 paddingY6 relative"
               style="height: 100%;"
             >
-              <div
-                class="box paddingX6"
-              >
-                Modal content
-              </div>
+              Modal content
             </div>
             <div
               class="box fit relative"


### PR DESCRIPTION
# Breaking change

We are changing internal padding. To prevent styling inside Modal breaking, we should set padding="default" into all Modals to keep the same style logic as before.

We also have to remove any padding in custom headings


Run the following codemod to locate Modals in the codebase and update them manually

`yarn codemod detectManualReplacement ~/path/to/your/code --component=Modal
`

**Codebase impact magnitude**
![Screen Shot 2022-12-02 at 2 47 20 PM](https://user-images.githubusercontent.com/10593890/205374329-16323d73-5a0c-4340-b7ec-bdf6df6fe13d.png)

app/packages/gestaltExtensions/Modal/DesktopModal.js
app/packages/gestaltExtensions/Modal/MobileModal.js

# Summary

#### What changed?

Modal: add default padding to main content and heading and padding prop

Adding padding = {6} (24 px) in header and main content (footer already had). padding="none" removes padding = {6}  on main content

#### Why?

Style unification between Modal/Sheet

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5098) 
- [Figma](https://www.figma.com/file/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-web?node-id=2508%3A17900&t=y3qTRUfavn0IBoXJ-1)
