### PR TITLE
Tokens: Update wash opacity

### DIFF
--- a/packages/gestalt-design-tokens/tokens/opacity/base.json
+++ b/packages/gestalt-design-tokens/tokens/opacity/base.json
@@ -5,8 +5,8 @@
       "comment": "Transparent - When a transparent alpha value is needed (without a background)"
     },
     "100": {
-      "value": "0.03",
-      "comment": "Pin wash - Permanent overlay used on Pin images to ensure a visual separation between the white background and any Pin images that have pure white peripheries. Note: iOS uses 4%"
+      "value": "0.04",
+      "comment": "Pin wash - Permanent overlay used on Pin images to ensure a visual separation between the white background and any Pin images that have pure white peripheries"
     },
     "200": {
       "value": "0.2",
@@ -22,7 +22,7 @@
     },
     "500": {
       "value": "0.9",
-      "comment": "Component wash applied on IconButton and other elements as needed (e.g. image overlays). In dark mode we recommend an inverse wash ($color-background-wash-light instead of $color-background-wash-dark)."
+      "comment": "Component wash applied on IconButton and other elements as needed (e.g. image overlays). In dark mode we recommend an inverse wash ($color-background-wash-light instead of $color-background-wash-dark)"
     }
   }
 }

--- a/packages/gestalt/src/Mask.css
+++ b/packages/gestalt/src/Mask.css
@@ -14,6 +14,6 @@
   composes: left0 from "./Layout.css";
   composes: right0 from "./Layout.css";
   composes: top0 from "./Layout.css";
-  background: rgb(0 0 0 / 0.04);
+  background: rgb(0 0 0 / var(--opacity-100));
   pointer-events: none;
 }


### PR DESCRIPTION
### Summary

#### What changed?

Update opacity-100 to be 0.04 instead of 0.03, ensure Mask uses the token

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5156)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
