### PR TITLE
Box, Flex: remove responsive alignItems props from table

### DIFF
--- a/docs/pages/web/box.js
+++ b/docs/pages/web/box.js
@@ -28,6 +28,9 @@ import zIndex from '../../examples/box/zIndex.js';
 import visuallyHidden from '../../examples/box/visuallyHidden.js';
 
 const ignoredProps = [
+  'smAlignItems',
+  'mdAlignItems',
+  'lgAlignItems',
   'smColumn',
   'mdColumn',
   'lgColumn',

--- a/docs/pages/web/flex.js
+++ b/docs/pages/web/flex.js
@@ -17,6 +17,8 @@ import flexItem from '../../examples/flex/flexItem.js';
 import flexBasis from '../../examples/flex/flexBasis.js';
 import overflowing from '../../examples/flex/overflowing.js';
 
+const ignoredProps = ['smAlignItems', 'mdAlignItems', 'lgAlignItems'];
+
 export default function DocsPage({
   generatedDocGen,
 }: {|
@@ -31,7 +33,7 @@ export default function DocsPage({
         <SandpackExample code={main} name="Main example source" hideEditor previewHeight={150} />
       </PageHeader>
 
-      <GeneratedPropTable generatedDocGen={generatedDocGen.Flex} />
+      <GeneratedPropTable generatedDocGen={generatedDocGen.Flex} excludeProps={ignoredProps} />
 
       <AccessibilitySection name={generatedDocGen?.Flex?.displayName} />
 


### PR DESCRIPTION
We hide responsive props from the props table to reduce clutter. These recently-added props weren't added to GeneratedPropsTable's `excludeProps`, so this PR does that.

![Screen Shot 2022-12-07 at 11 58 02 AM](https://user-images.githubusercontent.com/12059539/206283574-3f7d3510-0094-4916-80ca-d845cbb476a1.png)
