### PR TITLE
SideNavigation: support counter prop in all subcomponents

### DIFF
--- a/docs/examples/sidenavigation/counterExample.js
+++ b/docs/examples/sidenavigation/counterExample.js
@@ -5,24 +5,56 @@ import { SideNavigation } from 'gestalt';
 export default function Example(): Node {
   return (
     <SideNavigation accessibilityLabel="Counters example">
-      <SideNavigation.TopItem
-        href="#"
-        onClick={({ event }) => event.preventDefault()}
-        label="Under review"
-        counter={{ number: '20', accessibilityLabel: 'You have 20 Idea Pins under review' }}
-      />
-      <SideNavigation.TopItem
-        href="#"
-        onClick={({ event }) => event.preventDefault()}
-        label="Drafts"
-        counter={{ number: '5', accessibilityLabel: 'You have 5 Idea Pins drafts' }}
-      />
-      <SideNavigation.TopItem
-        href="#"
-        onClick={({ event }) => event.preventDefault()}
-        label="Published"
-        counter={{ number: '200', accessibilityLabel: 'You have published 200 Idea Pins' }}
-      />
+      <SideNavigation.Section label="Ads">
+        <SideNavigation.TopItem
+          href="#"
+          onClick={({ event }) => event.preventDefault()}
+          label="Campaigns"
+          counter={{ number: '2', accessibilityLabel: 'You have 2 campaigns' }}
+        />
+        <SideNavigation.Group label="Catalogues">
+          <SideNavigation.NestedGroup label="Christmas">
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="Data sources"
+              counter={{ number: '20', accessibilityLabel: 'You have 20 data sources' }}
+            />
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="Product groups"
+              counter={{ number: '5', accessibilityLabel: 'You have 5 product groups' }}
+            />
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="Listings"
+              counter={{ number: '200', accessibilityLabel: 'You have 200 listings' }}
+            />
+          </SideNavigation.NestedGroup>
+          <SideNavigation.NestedGroup label="Thanksgiving">
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="Data sources"
+              counter={{ number: '15', accessibilityLabel: 'You have 15 data sources' }}
+            />
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="Product groups"
+              counter={{ number: '3', accessibilityLabel: 'You have 3 product groups' }}
+            />
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="Listings"
+              counter={{ number: '100', accessibilityLabel: 'You have 100 listings' }}
+            />
+          </SideNavigation.NestedGroup>
+        </SideNavigation.Group>
+      </SideNavigation.Section>
     </SideNavigation>
   );
 }

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -402,7 +402,12 @@ export default function SideNavigationPage({
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Counters"
-          description="Counters can be included as indicators of the number of items on a page or section. Only include counters if it’s information that’s useful to the user to know before clicking on a menu item. Only supported in SideNavigation.TopItem and SideNavigation.Group."
+          description="Counters can be included as indicators of the number of items on a page or section.
+
+Only include counters if the information is useful for the user to know before clicking on a menu item.
+
+To prevent visual overload, do not include counters in the parent if the children have counters.
+"
         >
           <MainSection.Card
             sandpackExample={<SandpackExample code={counterExample} name="Counters example" />}

--- a/packages/gestalt/src/SideNavigationGroupContent.js
+++ b/packages/gestalt/src/SideNavigationGroupContent.js
@@ -111,7 +111,7 @@ export default function SideNavigationGroupContent({
               role="status"
               marginEnd={display === 'static' ? -2 : undefined}
             >
-              <Text align="end" color="default">
+              <Text align="end" color="subtle">
                 {counter.number}
               </Text>
             </Box>

--- a/packages/gestalt/src/SideNavigationNestedGroup.js
+++ b/packages/gestalt/src/SideNavigationNestedGroup.js
@@ -8,6 +8,10 @@ type Props = {|
    */
   children: Node,
   /**
+   * When supplied, will display a counter. See the [Counter](https://gestalt.pinterest.systems/web/sidenavigation#Counter) variant to learn more.
+   */
+  counter?: {| number: string, accessibilityLabel: string |},
+  /**
    * Nested directories can be static or expandable. See [nested directory](#Nested-directory) variant for more information.
    */
   display?: 'expandable' | 'static',
@@ -22,11 +26,12 @@ type Props = {|
  */
 export default function SideNavigationNestedGroup({
   children,
+  counter,
   display = 'expandable',
   label,
 }: Props): Node {
   return (
-    <SideNavigationGroup label={label} display={display}>
+    <SideNavigationGroup counter={counter} label={label} display={display}>
       {children}
     </SideNavigationGroup>
   );

--- a/packages/gestalt/src/SideNavigationNestedItem.js
+++ b/packages/gestalt/src/SideNavigationNestedItem.js
@@ -8,6 +8,10 @@ type Props = {|
    */
   active?: 'page' | 'section',
   /**
+   * When supplied, will display a counter. See the [Counter](https://gestalt.pinterest.systems/web/sidenavigation#Counter) variant to learn more.
+   */
+  counter?: {| number: string, accessibilityLabel: string |},
+  /**
    * Directs users to the url when item is selected.
    */
   href: string,
@@ -31,8 +35,22 @@ type Props = {|
 /**
  * Use [SideNavigation.NestedItem](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem) to redirect the user to a different page or section. SideNavigation.NestedItem must be used in second and third nested levels.
  */
-export default function SideNavigationNestedItem({ active, href, label, onClick }: Props): Node {
-  return <SideNavigationTopItem active={active} href={href} label={label} onClick={onClick} />;
+export default function SideNavigationNestedItem({
+  active,
+  counter,
+  href,
+  label,
+  onClick,
+}: Props): Node {
+  return (
+    <SideNavigationTopItem
+      active={active}
+      counter={counter}
+      href={href}
+      label={label}
+      onClick={onClick}
+    />
+  );
 }
 
 SideNavigationNestedItem.displayName = 'SideNavigation.NestedItem';

--- a/packages/gestalt/src/SideNavigationTopItem.js
+++ b/packages/gestalt/src/SideNavigationTopItem.js
@@ -179,7 +179,7 @@ export default function SideNavigationTopItem({
                 <Box display="visuallyHidden">{`, `}</Box>
                 {/* marginEnd={-2} is a hack to correctly position the counter as Flex + gap + width="100%" doean't expand to full width */}
                 <Box aria-label={counter.accessibilityLabel} role="status" marginEnd={-2}>
-                  <Text align="end" color={textColor}>
+                  <Text align="end" color="subtle">
                     {counter.number}
                   </Text>
                 </Box>

--- a/packages/gestalt/src/__snapshots__/SideNavigation.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SideNavigation.test.js.snap
@@ -319,7 +319,7 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
                             role="status"
                           >
                             <div
-                              className="Text fontSize300 defaultText alignEnd breakWord fontWeightNormal"
+                              className="Text fontSize300 subtleText alignEnd breakWord fontWeightNormal"
                             >
                               20
                             </div>
@@ -441,7 +441,7 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
                             role="status"
                           >
                             <div
-                              className="Text fontSize300 defaultText alignEnd breakWord fontWeightNormal"
+                              className="Text fontSize300 subtleText alignEnd breakWord fontWeightNormal"
                             >
                               20
                             </div>


### PR DESCRIPTION
### Summary

#### What changed?

SideNavigation: support counters in all subcomponents

#### Why?

To support use cases like the one below needed in monetization

![Screen Shot 2022-12-08 at 3 59 59 PM](https://user-images.githubusercontent.com/10593890/206566788-01bc3958-3f47-44f0-af4b-9f8a32028512.png)

Best practices for this new feature to come soon.
