### PR TITLE
Internal: do not autolaunch browser in dev

### DIFF
--- a/docs/markdown/get_started/developers/contributing/development_process.md
+++ b/docs/markdown/get_started/developers/contributing/development_process.md
@@ -65,8 +65,7 @@ git remote -v
 
 Whenever you make changes to Gestalt, please test them out locally before making a PR.
 
-To start the documentation server, run `yarn start`, which will automatically open the docs in a new browser tab.
-If that tab doesn't launch automatically, navigate to <ins>http://localhost:8888</ins>
+To start the documentation server, run `yarn start`. In your favorite browser, navigate to <ins>http://localhost:8888</ins>.
 
 ## Create a pull request
 

--- a/docs/markdown/get_started/developers/contributing/development_process.md
+++ b/docs/markdown/get_started/developers/contributing/development_process.md
@@ -104,7 +104,6 @@ yarn generate ComponentName
 
   - Run [Playwright visual diff snapshot tests](https://playwright.dev/docs/test-snapshots). If any component changes are expected to visually modify your component, you must update the snapshot tests. Make sure your macOS version matches the one set in [Playwright's config file](https://github.com/pinterest/gestalt/blob/master/.github/workflows/playwright.yml#L13)
 
-
   ```bash
   # Update all Gestalt packages builds running rollup
   yarn build
@@ -166,7 +165,6 @@ A Gestalt Core maintainer will add a semver label (patch release / minor release
 ### Scope of work
 
 When pushing new changes to GitHub, your PR title should be aligned with the scope of your work. If your goal was to change the default color of a component, keep the scope of changes to that specific task and word the title to exactly reflect those changes.
-
 
 ### Changes not allowed
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   targetPort = 3000
   port = 8888
   framework = "#custom"
-  autoLaunch = true
+  autoLaunch = false
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
The typical dev process across the team involves leaving a browser tab open to the dev site constantly, making it annoying to restart the dev server as it launches a new tab that needs to be closed. This PR removes that autolaunch feature.