### PR TITLE
Internal: add markdown lint config file, ease some rules

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD034": false
+}


### PR DESCRIPTION
While linting markdown files can be useful (and we should fix our existing errors), [some of the rules](https://github.com/DavidAnson/vscode-markdownlint#rules) don't make sense with MDX. This PR adds a config file for `markdownlint` and eases a few rules:
- [MD013](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013) line-length - Line length, not applicable
- [MD033](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033) no-inline-html - Inline HTML, kinda the whole point of MDX
- [MD034](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md034) no-bare-urls - Causes this error:
![Screen Shot 2022-12-12 at 11 12 44 AM](https://user-images.githubusercontent.com/12059539/207134101-105e7d22-6035-468e-836f-91a3475f2ac7.png)
