### PR TITLE
Popover: Controlled height based on size of contents

### DIFF
--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -202,6 +202,25 @@ class Contents extends Component<Props, State> {
     }
   };
 
+  calcTopHeight() {
+    if (!window || !document) {
+      return { top: null, height: null };
+    }
+
+    const { scrollBoundaryContainerRef, positionRelativeToAnchor } = this.props;
+
+    // Define the height based the reference to render: ScrollBoundaryContainer or screen viewport
+    const height = scrollBoundaryContainerRef?.offsetHeight ?? window.innerHeight ?? 0;
+
+    // 5% of height available
+    const top = (height / 10) * 0.5;
+
+    // 90% of height available on container reference
+    const elementHeight = (height / 10) * 9;
+
+    return { top: !positionRelativeToAnchor ? top : null, height: elementHeight };
+  }
+
   render(): Node {
     const { accessibilityLabel, bgColor, border, caret, children, id, role, rounding, width } =
       this.props;
@@ -212,6 +231,10 @@ class Contents extends Component<Props, State> {
     const background = bgColor === 'white' ? `${bgColor}BgElevated` : `${bgColor}Bg`;
     const bgColorElevated = bgColor === 'white' ? 'whiteElevated' : bgColor;
     const isCaretVertical = ['down', 'up'].includes(popoverDir);
+
+    const { top, height } = this.calcTopHeight();
+    // Top value is used only when the current top value is negative
+    const topValue = top != null && (popoverOffset?.top ?? 0) < 0 ? { top } : {};
 
     return (
       <div
@@ -226,7 +249,7 @@ class Contents extends Component<Props, State> {
         ref={this.setPopoverRef}
         tabIndex={-1}
         // popoverOffset positions the Popover component
-        style={{ visibility, ...popoverOffset }}
+        style={{ visibility, ...popoverOffset, ...topValue }}
       >
         {caret && popoverDir && (
           <div
@@ -255,7 +278,7 @@ class Contents extends Component<Props, State> {
             styles.maxDimensions,
             width !== null && styles.minDimensions,
           )}
-          style={{ maxWidth: width }}
+          style={{ maxWidth: width, maxHeight: height }}
         >
           {children}
         </div>

--- a/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
@@ -39,6 +39,7 @@ exports[`Controller renders 1`] = `
       id=""
       style={
         Object {
+          "maxHeight": 691.1999999999999,
           "maxWidth": 230,
         }
       }

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -17,7 +17,7 @@ exports[`Dropdown renders a menu of 3 items conditionally 1`] = `
           class="border whiteBgElevated whiteElevated rounding4 innerContents maxDimensions minDimensions"
           id="ex-1"
           role="menu"
-          style="max-width: 360px;"
+          style="max-width: 360px; max-height: 691.1999999999999px;"
         >
           <div
             class="box flexGrow marginBottom2 marginEnd2 marginStart2 marginTop2 xsDirectionColumn xsDisplayFlex xsItemsCenter"
@@ -551,7 +551,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
           class="border whiteBgElevated whiteElevated rounding4 innerContents maxDimensions minDimensions"
           id="ex-1"
           role="menu"
-          style="max-width: 360px;"
+          style="max-width: 360px; max-height: 691.1999999999999px;"
         >
           <div
             class="box flexGrow marginBottom2 marginEnd2 marginStart2 marginTop2 xsDirectionColumn xsDisplayFlex xsItemsCenter"

--- a/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
@@ -21,6 +21,7 @@ exports[`Popover renders 1`] = `
       role="dialog"
       style={
         Object {
+          "maxHeight": 691.1999999999999,
           "maxWidth": 230,
         }
       }
@@ -48,6 +49,7 @@ exports[`Popover renders as blue 1`] = `
       role="dialog"
       style={
         Object {
+          "maxHeight": 691.1999999999999,
           "maxWidth": 230,
         }
       }
@@ -75,6 +77,7 @@ exports[`Popover renders as error 1`] = `
       role="dialog"
       style={
         Object {
+          "maxHeight": 691.1999999999999,
           "maxWidth": 230,
         }
       }


### PR DESCRIPTION
### Summary

This change handle and fix the following error, reported to us by [this thread](https://pinterest.slack.com/archives/C13KLG5P0/p1658953735281499):
"When we have more content inner dropdown children than the viewport height supports and the anchor is positioned on second half (bottom half) of screen, the initial elements is not accessible" 

The images below provide you the bug view:

<img width="1512" alt="Screen Shot 2022-07-27 at 1 28 10 PM" src="https://user-images.githubusercontent.com/16820917/207131941-a5291767-54b9-4a01-b4b3-99fdaeaa1a94.png">

BUG's reproduction: https://codesandbox.io/s/dropdown-size-error-3jo09u

## Gestalt component involved

- Popover
- Dropdown
- Content

## Solution

We fix the max height of children's Popover content to 90% of the viewport's vertical size. If the viewport contains a `ScrollBoundaryContainer` component, we use the height of this component to set the max height of popover content. In other words, the Popover max size is `90%  screen height` or `90% of ScrollBoundaryContainer height`.

The second solution part is "top positioning" If we have a negative top value, which means if the `Controller` sets the top with a negative value (< 0), the popover commonly will not allow access to part of its internal content. In front of this case, we set the top's value as `5%` of the height available (following the height decisions explained above).

_[More about Controller and Popover structure here](https://paper.dropbox.com/doc/Popovers-History--BuQSFUfQbWwCgcd5HWMlpQ3VAg-e5Yrz9jiksN0ce8c893EJ)_

To understand better each concept, please read the comments attached on code.

## How to test it?

1. Access our current branch deploy: https://deploy-preview-2562--gestalt.netlify.app/
2. Go to Dropdown page: `/web/dropdown`
3. Resizes your screen to position the first example button to the second half of screen, like the image below:
<img width="800" alt="Example of screen size" src="https://user-images.githubusercontent.com/16820917/207138264-5af0007b-5cdd-4466-9075-699ded3caca0.png">
4. Expand the code example;
5. Use one the following codes to test the solution:

#### Example 01
```js
function Example() {
  const [open, setOpen] = React.useState(false);
  const [selected, setSelected] = React.useState(null);
  const anchorRef = React.useRef(null);
  const onSelect = ({ item }) => setSelected(item);

  const items = new Array(100).fill({ name: "item" }).map((item, index) => (
    <Dropdown.Item
      key={item.name + index}
      onSelect={onSelect}
      option={{ value: 'item ' + index, label: 'Item ' + index }}
      selected={selected}
    />
  ));

  return (
    <Flex height="100%" justifyContent="center">
      <Button
        accessibilityControls="demo-dropdown-example"
        accessibilityExpanded={open}
        accessibilityHaspopup
        iconEnd="arrow-down"
        onClick={() => setOpen((prevVal) => !prevVal)}
        ref={anchorRef}
        selected={open}
        size="lg"
        text="Menu"
      />
      {open && (
        <Dropdown
          anchor={anchorRef.current}
          id="demo-dropdown-example"
          onDismiss={() => setOpen(false)}
        >
        {items}
        </Dropdown>
      )}
    </Flex>
  );
}
```

#### Example 02
```js
function Example() {
  const [open, setOpen] = React.useState(false);
  const [selected, setSelected] = React.useState(null);
  const anchorRef = React.useRef(null);
  const onSelect = ({ item }) => setSelected(item);

  const items = new Array(100).fill({ name: "item" }).map((item, index) => (
    <Dropdown.Item
      key={item.name + index}
      onSelect={onSelect}
      option={{ value: 'item ' + index, label: 'Item ' + index }}
      selected={selected}
    />
  ));

  return (
    <Flex height="100%" width="100%" justifyContent="center">
      <Box width="100%">
        <ScrollBoundaryContainer height={200}>
          <Button
            accessibilityControls="demo-dropdown-example"
            accessibilityExpanded={open}
            accessibilityHaspopup
            iconEnd="arrow-down"
            onClick={() => setOpen((prevVal) => !prevVal)}
            ref={anchorRef}
            selected={open}
            size="lg"
            text="Menu"
          />
            {open && (
              <Dropdown
                anchor={anchorRef.current}
                id="demo-dropdown-example"
                onDismiss={() => setOpen(false)}
              >
              {items}
              </Dropdown>
            )}
        </ScrollBoundaryContainer>
      </Box>
    </Flex>
  );
}
```

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4787)
