### PR TITLE
TextField: Ship password visibility experiment

### DIFF
--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -11,7 +11,6 @@ import { useAppContext } from '../appContext.js';
 
 const enabledExperiments = {
   Badge: ['web_gestalt_redesigned_badge', 'mweb_gestalt_redesigned_badge'],
-  TextField: ['web_unauth_show_password_button', 'mweb_unauth_show_password_button'],
   Toast: ['web_gestalt_redesigned_toast', 'mweb_gestalt_redesigned_toast'],
 };
 

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -544,7 +544,7 @@ function Example(props) {
 
         <MainSection.Subsection
           title="Password"
-          description={`TextField with \`type="password"\` shows obfuscated characters by default. Add \`showPasswordVisibilityToggle\` to provide an icon button that allows the user to toggle password visibility. This creates a more accessible experience by allowing the user to confirm what they have entered before submitting the form.`}
+          description={`TextField with \`type="password"\` shows obfuscated characters by default. An icon button at the end of the field allows the user to toggle password visibility. This creates a more accessible experience by allowing the user to confirm what they have entered before submitting the form.`}
         >
           <MainSection.Card
             defaultCode={`
@@ -557,7 +557,6 @@ function Example(props) {
                 label="Account password"
                 onChange={({ value }) => setPassword(value)}
                 placeholder="Password"
-                showPasswordVisibilityToggle
                 type="password"
                 value={password}
               />

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -7,10 +7,6 @@ import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import {
-  BareSlimBannerExperiment,
-  SlimBannerExperiment,
-} from '../../docs-components/SlimBannerExperiment.js';
 
 export default function TextFieldPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -39,14 +35,6 @@ function Example(props) {
   );
 }
 `}
-        slimBanner={
-          <SlimBannerExperiment
-            componentName={generatedDocGen?.displayName}
-            description="is under an experiment to improve its password typing UI: adds an 'show/hide password' icon button for type='password'."
-            pullRequest={1995}
-            section="#Password"
-          />
-        }
       />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
@@ -554,25 +542,28 @@ function Example(props) {
           />
         </MainSection.Subsection>
 
-        <MainSection.Subsection title="Password">
-          <BareSlimBannerExperiment componentName={generatedDocGen?.displayName} />
+        <MainSection.Subsection
+          title="Password"
+          description={`TextField with \`type="password"\` shows obfuscated characters by default. Add \`showPasswordVisibilityToggle\` to provide an icon button that allows the user to toggle password visibility. This creates a more accessible experience by allowing the user to confirm what they have entered before submitting the form.`}
+        >
           <MainSection.Card
             defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState();
+          function Example(props) {
+            const [password, setPassword] = React.useState();
 
-  return (
-    <TextField
-      id="enter-password"
-      label="Account password"
-      onChange={({ value }) => setValue(value)}
-      placeholder="Password"
-      value={value}
-      type="password"
-    />
-  );
-}
-`}
+            return (
+              <TextField
+                id="enter-password"
+                label="Account password"
+                onChange={({ value }) => setPassword(value)}
+                placeholder="Password"
+                showPasswordVisibilityToggle
+                type="password"
+                value={password}
+              />
+            );
+          }
+          `}
           />
         </MainSection.Subsection>
 

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -3,9 +3,7 @@ import { forwardRef, type Element, type Node, useEffect, useState } from 'react'
 import InternalTextField from './InternalTextField.js';
 import InternalTextFieldIconButton from './InternalTextFieldIconButton.js';
 import Tag from './Tag.js';
-import { useExperimentContext } from './contexts/ExperimentProvider.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
-import { useDeviceType } from './contexts/DeviceTypeProvider.js';
 
 type Type = 'date' | 'email' | 'password' | 'tel' | 'text' | 'url';
 
@@ -100,6 +98,10 @@ type Props = {|
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
+   * For `type="password"`, show an icon button to allow the user to toggle the visibility of their password. Passwords are obfuscated by default but can be shown in plain text for better user feedback.
+   */
+  showPasswordVisibilityToggle?: boolean,
+  /**
    * List of tags to display in the component.
    */
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
@@ -146,6 +148,7 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     onKeyDown,
     placeholder,
     readOnly = false,
+    showPasswordVisibilityToggle,
     size = 'md',
     tags,
     type: typeProp = 'text',
@@ -153,8 +156,6 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   }: Props,
   ref,
 ): Node {
-  const deviceType = useDeviceType();
-
   /**
    * Yes, this is initializing a state variable with a prop value and then disregarding the prop value — often a code smell, I know. This is necessary to internalize the effective input type (password vs text) and not force the user to handle responding to clicks on the button
    */
@@ -167,26 +168,11 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const isPasswordField = typeProp === 'password';
   const isCurrentlyPasswordType = type === 'password';
 
-  const { anyEnabled: inWebShowPasswordExp } = useExperimentContext(
-    'web_unauth_show_password_button',
-  );
-  const { anyEnabled: inMwebShowPasswordExp } = useExperimentContext(
-    'mweb_unauth_show_password_button',
-  );
-  let inShowPasswordExp = false;
-
-  if (deviceType) {
-    if (deviceType === 'desktop') {
-      inShowPasswordExp = inWebShowPasswordExp;
-    } else {
-      inShowPasswordExp = inMwebShowPasswordExp;
-    }
-  }
   const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
     useDefaultLabelContext('TextField');
 
   const iconButton =
-    inShowPasswordExp && isPasswordField ? (
+    showPasswordVisibilityToggle && isPasswordField ? (
       <InternalTextFieldIconButton
         accessibilityChecked={!isCurrentlyPasswordType}
         accessibilityLabel={

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -98,10 +98,6 @@ type Props = {|
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
-   * For `type="password"`, show an icon button to allow the user to toggle the visibility of their password. Passwords are obfuscated by default but can be shown in plain text for better user feedback.
-   */
-  showPasswordVisibilityToggle?: boolean,
-  /**
    * List of tags to display in the component.
    */
   tags?: $ReadOnlyArray<Element<typeof Tag>>,
@@ -148,7 +144,6 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
     onKeyDown,
     placeholder,
     readOnly = false,
-    showPasswordVisibilityToggle,
     size = 'md',
     tags,
     type: typeProp = 'text',
@@ -171,27 +166,26 @@ const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> 
   const { accessibilityHidePasswordLabel, accessibilityShowPasswordLabel } =
     useDefaultLabelContext('TextField');
 
-  const iconButton =
-    showPasswordVisibilityToggle && isPasswordField ? (
-      <InternalTextFieldIconButton
-        accessibilityChecked={!isCurrentlyPasswordType}
-        accessibilityLabel={
-          isCurrentlyPasswordType
-            ? accessibilityShowPasswordLabel ?? ''
-            : accessibilityHidePasswordLabel ?? ''
-        }
-        icon={isCurrentlyPasswordType ? 'eye' : 'eye-hide'}
-        onClick={() => {
-          setType(isCurrentlyPasswordType ? 'text' : 'password');
-        }}
-        role="switch"
-        tooltipText={
-          isCurrentlyPasswordType
-            ? accessibilityShowPasswordLabel ?? ''
-            : accessibilityHidePasswordLabel ?? ''
-        }
-      />
-    ) : undefined;
+  const iconButton = isPasswordField ? (
+    <InternalTextFieldIconButton
+      accessibilityChecked={!isCurrentlyPasswordType}
+      accessibilityLabel={
+        isCurrentlyPasswordType
+          ? accessibilityShowPasswordLabel ?? ''
+          : accessibilityHidePasswordLabel ?? ''
+      }
+      icon={isCurrentlyPasswordType ? 'eye' : 'eye-hide'}
+      onClick={() => {
+        setType(isCurrentlyPasswordType ? 'text' : 'password');
+      }}
+      role="switch"
+      tooltipText={
+        isCurrentlyPasswordType
+          ? accessibilityShowPasswordLabel ?? ''
+          : accessibilityHidePasswordLabel ?? ''
+      }
+    />
+  ) : undefined;
 
   return (
     <InternalTextField


### PR DESCRIPTION
### Summary

#### What changed?

This PR ships the password visibility toggle experiments, ensuring that every `<TextField type="password">` shows a visibility icon button.

#### Why?

This makes for a more accessible and enjoyable UX, as the user confirm what they've entered before submitting the form.

We originally intended to run this as an experiment (in spirit with Project Ignite). Implementation ran into a number of issues with ExperimentProvider, and so never actually launched. However, we also discovered that other teams had implemented hacky versions of this feature on the primary login surfaces, so it's unlikely that we would have seen significant changes in user behavior in our experiment. Therefore we're shipping this feature and will replace the hacky versions as part of bumping the Pinboard version.

Note that this PR will not be merged/bumped until January 2023, after code freeze is lifted.