### PR TITLE
Docs: fix manual prop table value on IconButton 

### DIFF
--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -103,7 +103,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           {
             name: 'size',
             type: `"xs" | "sm" | "md" | "lg" | "xl"`,
-            defaultValue: 'md',
+            defaultValue: 'lg',
             description:
               'The maximum height and width of IconButton. See the [size](#Size) variant to learn more.',
           },


### PR DESCRIPTION
Docs: fix manual prop table value on IconButton 
<img width="258" alt="Screen Shot 2023-01-03 at 6 54 21 PM" src="https://user-images.githubusercontent.com/10593890/210460604-1dc9bd0e-a980-454d-88bb-095c848e7835.png">
