### PR TITLE
Link: replace `inline` prop with `display`

### DIFF
--- a/docs/docs-components/Page.js
+++ b/docs/docs-components/Page.js
@@ -63,7 +63,7 @@ export default function Page({
 
         {!hideEditLink && (
           <Box marginTop={12}>
-            <Link href={editPageUrl} target="blank" inline>
+            <Link href={editPageUrl} target="blank" display="inlineBlock">
               <Text underline>Edit page on GitHub</Text>
             </Link>
           </Box>

--- a/docs/examples/avatarGroup/sizing.js
+++ b/docs/examples/avatarGroup/sizing.js
@@ -31,7 +31,7 @@ export default function Example(): Node {
             <Text inline>The </Text>
             <Text inline weight="bold">
               <Link
-                inline
+                display="inlineBlock"
                 href="https://www.pinterest.com/search/boards/?q=quick%20vegan%20recipes&rs=typed&term_meta[]=quick%7Ctyped&term_meta[]=vegan%7Ctyped&term_meta[]=recipes%7Ctyped"
               >
                 Quick Vegan Recipes{' '}

--- a/docs/examples/combobox/labels.js
+++ b/docs/examples/combobox/labels.js
@@ -57,7 +57,7 @@ export default function Example(): Node {
             <Link
               accessibilityLabel="Learn how trends on Pinterest work"
               target="blank"
-              inline
+              display="inlineBlock"
               href="https://business.pinterest.com/content/pinterest-predicts/"
             >
               {' '}

--- a/docs/examples/iconbutton/keyboard.js
+++ b/docs/examples/iconbutton/keyboard.js
@@ -11,7 +11,7 @@ export default function Example(): Node {
           <Link
             accessibilityLabel="Open the settings page"
             target="blank"
-            inline
+            display="inlineBlock"
             underline="none"
             href="https://www.pinterest.com/settings/"
           >

--- a/docs/examples/link/inline.js
+++ b/docs/examples/link/inline.js
@@ -1,0 +1,56 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, Link, NumberField, Text } from 'gestalt';
+
+function TextExample({
+  linkDisplay,
+  maxWidth,
+}: {|
+  linkDisplay: 'inline' | 'inlineBlock',
+  maxWidth: number,
+|}): Node {
+  return (
+    <Box borderStyle="sm" maxWidth={maxWidth} padding={2} rounding={2}>
+      <Text>
+        To stop seeing content from an advertiser,{' '}
+        <Text weight="bold" inline>
+          <Link display={linkDisplay} href="/">
+            learn how to block accounts.
+          </Link>
+        </Text>{' '}
+        Note that you can also unblock accounts.
+      </Text>
+    </Box>
+  );
+}
+
+export default function Example(): Node {
+  const [containerWidth, setContainerWidth] = useState(250);
+
+  return (
+    <Box height="100%" padding={2} width="100%">
+      <Flex alignItems="center" direction="column" gap={6} height="100%" width="100%">
+        <NumberField
+          id="inlineExample"
+          label="Container width (px)"
+          onChange={({ value }) => {
+            setContainerWidth(value ?? 0);
+          }}
+          value={containerWidth}
+        />
+
+        <Flex gap={6}>
+          <Flex direction="column" gap={2}>
+            <Text>Inline</Text>
+            <TextExample linkDisplay="inline" maxWidth={containerWidth} />
+          </Flex>
+
+          <Flex direction="column" gap={2}>
+            <Text>Inline Block</Text>
+            <TextExample linkDisplay="inlineBlock" maxWidth={containerWidth} />
+          </Flex>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/modalalert/errorSingleAction.js
+++ b/docs/examples/modalalert/errorSingleAction.js
@@ -24,7 +24,7 @@ export default function ErrorSingleAction(): Node {
           Review our{' '}
           <Link
             underline="always"
-            inline
+            display="inlineBlock"
             href="https://policy.pinterest.com/en/community-guidelines"
           >
             content policy.

--- a/docs/pages/foundations/color/examples.js
+++ b/docs/pages/foundations/color/examples.js
@@ -39,7 +39,7 @@ export default function ColorExamplesPage(): Node {
                   Having a limited range of colors supports consistency, making our product easier
                   to interact with. Keep in mind that continuous use of high-contrast and saturated
                   colors can create fatigue and eye strain. See our{' '}
-                  <Link inline href="/foundations/color/usage">
+                  <Link display="inlineBlock" href="/foundations/color/usage">
                     <Text underline>color usage guidelines</Text>
                   </Link>{' '}
                   for more information about our color choices.
@@ -56,7 +56,7 @@ export default function ColorExamplesPage(): Node {
                   ways. For example, colors often change between light and dark modes to help
                   portray elevation and hierarchy, while ensuring proper contrast and legibility.
                   Any colors used should be consistent with the full{' '}
-                  <Link inline href="/foundations/color/palette#Extended-palette">
+                  <Link display="inlineBlock" href="/foundations/color/palette#Extended-palette">
                     <Text inline underline>
                       Pinterest color palette
                     </Text>
@@ -73,7 +73,7 @@ export default function ColorExamplesPage(): Node {
                 <Text>
                   All color pairings must pass WCAG&apos;s AA color contrast standards. Using our
                   color tokens properly ensures our colors meet legibility standards. Check out our{' '}
-                  <Link inline href="/foundations/accessibility">
+                  <Link display="inlineBlock" href="/foundations/accessibility">
                     <Text inline underline>
                       accessibility guidelines
                     </Text>

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -232,7 +232,7 @@ export default function IconPage(): Node {
       </Text>
       <Text>
         Need a new icon?{' '}
-        <Link inline href="/get_started/how_to_work_with_us#Slack-channels">
+        <Link display="inlineBlock" href="/get_started/how_to_work_with_us#Slack-channels">
           Reach out to us
         </Link>
         , and we can evaluate your request.

--- a/docs/pages/foundations/messaging/available_components.js
+++ b/docs/pages/foundations/messaging/available_components.js
@@ -114,7 +114,7 @@ export default function MessagingComponentsPage(): Node {
       <Text>
         Saved to{' '}
         <Text inline weight="bold">
-          <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor" underline="hover">
+          <Link display="inline" target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor" underline="hover">
             Home decor
           </Link>
         </Text>

--- a/docs/pages/foundations/messaging/priority_and_placement.js
+++ b/docs/pages/foundations/messaging/priority_and_placement.js
@@ -232,7 +232,7 @@ export default function MessagingPriorityAndPlacementPage(): Node {
                     <Text>
                       To acknowledge completion of a task that doesn’t require follow up, like
                       pinning to a board. Use{' '}
-                      <Link href="/web/toast" underline="always" inline>
+                      <Link href="/web/toast" underline="always" display="inlineBlock">
                         Toast
                       </Link>{' '}
                       instead.
@@ -247,7 +247,7 @@ export default function MessagingPriorityAndPlacementPage(): Node {
                   <Box padding={4} width="50%">
                     <Text>
                       To provide general information and recommendations. Use{' '}
-                      <Link href="/web/callout" underline="always" inline>
+                      <Link href="/web/callout" underline="always" display="inlineBlock">
                         Callout
                       </Link>{' '}
                       instead.

--- a/docs/pages/foundations/typography/guidelines.js
+++ b/docs/pages/foundations/typography/guidelines.js
@@ -504,7 +504,7 @@ Line height is automatically determined by a font’s size. For more info, refer
           <Box color="infoWeak" paddingX={6} paddingY={8}>
             <Text color="dark">
               This is a paragraph with a{' '}
-              <Link href="https://gestalt.pinterest.systems" underline="always" inline>
+              <Link href="https://gestalt.pinterest.systems" underline="always" display="inlineBlock">
                 link
               </Link>{' '}
               inside of it. Remember, the whole is different from the sum of its parts.

--- a/docs/pages/foundations/typography/guidelines.js
+++ b/docs/pages/foundations/typography/guidelines.js
@@ -504,7 +504,11 @@ Line height is automatically determined by a font’s size. For more info, refer
           <Box color="infoWeak" paddingX={6} paddingY={8}>
             <Text color="dark">
               This is a paragraph with a{' '}
-              <Link href="https://gestalt.pinterest.systems" underline="always" display="inlineBlock">
+              <Link
+                href="https://gestalt.pinterest.systems"
+                underline="always"
+                display="inlineBlock"
+              >
                 link
               </Link>{' '}
               inside of it. Remember, the whole is different from the sum of its parts.

--- a/docs/pages/get_started/developers/installation.js
+++ b/docs/pages/get_started/developers/installation.js
@@ -86,7 +86,11 @@ import 'gestalt-datepicker/dist/gestalt-datepicker.css';
         >
           <Text>
             Gestalt is a{' '}
-            <Link display="inlineBlock" href="https://yarnpkg.com/lang/en/docs/workspaces/" target="blank">
+            <Link
+              display="inlineBlock"
+              href="https://yarnpkg.com/lang/en/docs/workspaces/"
+              target="blank"
+            >
               <Text weight="bold"> multi-project monorepo.</Text>
             </Link>
             The docs and components are all organized as separate packages that share similar
@@ -131,7 +135,11 @@ yarn start
         >
           <Text>
             Install the{' '}
-            <Link display="inlineBlock" href="https://www.npmjs.com/package/@types/gestalt" target="blank">
+            <Link
+              display="inlineBlock"
+              href="https://www.npmjs.com/package/@types/gestalt"
+              target="blank"
+            >
               <Text weight="bold">DefinitelyTyped</Text>
             </Link>{' '}
             definitions.

--- a/docs/pages/get_started/developers/installation.js
+++ b/docs/pages/get_started/developers/installation.js
@@ -86,7 +86,7 @@ import 'gestalt-datepicker/dist/gestalt-datepicker.css';
         >
           <Text>
             Gestalt is a{' '}
-            <Link inline href="https://yarnpkg.com/lang/en/docs/workspaces/" target="blank">
+            <Link display="inlineBlock" href="https://yarnpkg.com/lang/en/docs/workspaces/" target="blank">
               <Text weight="bold"> multi-project monorepo.</Text>
             </Link>
             The docs and components are all organized as separate packages that share similar
@@ -112,7 +112,7 @@ yarn start
           />
           <Text>
             Visit{' '}
-            <Link inline href="http://localhost:8888/" target="blank">
+            <Link display="inlineBlock" href="http://localhost:8888/" target="blank">
               <Text weight="bold">http://localhost:8888</Text>
             </Link>{' '}
             and click on a component to view the docs.
@@ -131,7 +131,7 @@ yarn start
         >
           <Text>
             Install the{' '}
-            <Link inline href="https://www.npmjs.com/package/@types/gestalt" target="blank">
+            <Link display="inlineBlock" href="https://www.npmjs.com/package/@types/gestalt" target="blank">
               <Text weight="bold">DefinitelyTyped</Text>
             </Link>{' '}
             definitions.

--- a/docs/pages/get_started/developers/tooling/web.js
+++ b/docs/pages/get_started/developers/tooling/web.js
@@ -21,7 +21,7 @@ function ListElement({ text, href }: {| text: string, href: string |}) {
         <Link
           accessibilityLabel={`${text}, opens new window`}
           target="blank"
-          inline
+          display="inlineBlock"
           href={href}
           onClick={() => trackButtonClick(text)}
           externalLinkIcon="default"
@@ -295,7 +295,7 @@ Visit the [Releases](/get_started/developers/releases) guidance page to see all 
                   <Text inline>Drag this link: </Text>
                   {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                   <Link
-                    inline
+                    display="inlineBlock"
                     onClick={() => trackButtonClick('Gestalt Usage Visualizer')}
                     target="blank"
                     // eslint-disable-next-line no-script-url, no-template-curly-in-string

--- a/docs/pages/get_started/faq.js
+++ b/docs/pages/get_started/faq.js
@@ -10,7 +10,7 @@ function InlineLink({ children, href }: {| children: string, href: string |}) {
   return (
     <Fragment>
       {' '}
-      <Link inline href={href}>
+      <Link display="inlineBlock" href={href}>
         {children}
       </Link>{' '}
     </Fragment>

--- a/docs/pages/roadmap.js
+++ b/docs/pages/roadmap.js
@@ -105,7 +105,7 @@ export default function RoadmapPage(): Node {
         <Text>
           {`The following reflects all public-facing work the Gestalt team plans to ship in ${roadmapData.year}.`}{' '}
           For more details on our latest updates, visit the{' '}
-          <Link href="/whats_new" inline>
+          <Link href="/whats_new" display="inlineBlock">
             What&apos;s New page.
           </Link>
         </Text>
@@ -119,7 +119,7 @@ export default function RoadmapPage(): Node {
           <Text>
             <Link
               href="https://jira.pinadmin.com/secure/PortfolioPlanView.jspa?id=525&sid=530&vid=1684#plan/backlog"
-              inline
+              display="inlineBlock"
             >
               Visit our internal roadmap <InternalOnlyIconButton />
             </Link>

--- a/docs/pages/visual-test/Link-dark.js
+++ b/docs/pages/visual-test/Link-dark.js
@@ -15,14 +15,14 @@ export default function Screenshot(): Node {
         >
           <Text inline>
             Visit our{' '}
-            <Link inline href="https://pinterest.com">
+            <Link display="inlineBlock" href="https://pinterest.com">
               Business Help Center
             </Link>
           </Text>
           <Text inline size="400" color="success">
             <Link
               href="https://authy.com/download/"
-              inline
+              display="inlineBlock"
               externalLinkIcon={{ size: '400', color: 'success' }}
               target="blank"
               rel="nofollow"

--- a/docs/pages/visual-test/Link.js
+++ b/docs/pages/visual-test/Link.js
@@ -14,14 +14,14 @@ export default function Screenshot(): Node {
       >
         <Text inline>
           Visit our{' '}
-          <Link inline href="https://pinterest.com">
+          <Link display="inlineBlock" href="https://pinterest.com">
             Business Help Center
           </Link>
         </Text>
         <Text inline size="400" color="success">
           <Link
             href="https://authy.com/download/"
-            inline
+            display="inlineBlock"
             externalLinkIcon={{ size: '400', color: 'success' }}
             target="blank"
             rel="nofollow"

--- a/docs/pages/web/checkbox.js
+++ b/docs/pages/web/checkbox.js
@@ -546,7 +546,7 @@ function Example() {
             <Label htmlFor="sites2">
               Use sites you visit to improve which recommendations and ads you see on Pinterest.
             </Label>
-            <Link href="#" inline>
+            <Link href="#" display="inline">
               Learn more
             </Link>
           </Text>
@@ -562,7 +562,7 @@ function Example() {
             <Label htmlFor="partner2">
               Use partner info to improve which recommendations and ads you see on Pinterest.
             </Label>
-            <Link href="#" inline>
+            <Link href="#" display="inline">
               Learn more
             </Link>
           </Text>
@@ -579,7 +579,7 @@ function Example() {
               Use your activity to improve ads you see about Pinterest on other sites or apps you
               may visit.
             </Label>
-            <Link href="#" inline>
+            <Link href="#" display="inline">
               Learn more
             </Link>
           </Text>

--- a/docs/pages/web/component_status.js
+++ b/docs/pages/web/component_status.js
@@ -126,7 +126,7 @@ export default function ComponentStatus(): Node {
                             item?.path ??
                             `/web/${item.name.replace(/ /g, '_').replace(/'/g, '').toLowerCase()}`
                           }
-                          inline
+                          display="inlineBlock"
                         >
                           {item.name}
                           {badge ? (

--- a/docs/pages/web/fieldset.js
+++ b/docs/pages/web/fieldset.js
@@ -181,7 +181,7 @@ function CheckboxExample() {
         <Text size="200">
           Choose up to 3.
           <Text inline size="200" weight="bold">
-            <Link inline target="blank" href="https://www.pinterest.com/">
+            <Link display="inline" target="blank" href="https://www.pinterest.com/">
               Additional information
             </Link>
           </Text>

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -8,6 +8,8 @@ import Page from '../../docs-components/Page.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import inline from '../../examples/link/inline.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -18,7 +20,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         defaultCode={`
 <Text inline>
 To see how you can grow your business, visit
-  <Link href="https://business.pinterest.com/advertise" inline externalLinkIcon="default" target="blank">Pinterest Ads</Link>
+  <Link href="https://business.pinterest.com/advertise" display="inlineBlock" externalLinkIcon="default" target="blank">Pinterest Ads</Link>
 </Text>
         `}
       />
@@ -61,7 +63,7 @@ To see how you can grow your business, visit
     <Text weight="bold" align="center"> Product details </Text>
     <Text> Tennis-inspired retro sneaker by Pinterest, elevated with a stacked midsole for extra height and a chunky profile. </Text>
     <Text inline> Ships from and sold by
-      <Link href="http://www.pinterest.com" inline> pinterest.com </Link>
+      <Link href="http://www.pinterest.com" display="inline"> pinterest.com </Link>
     </Text>
   </Flex>
 </Box>
@@ -75,12 +77,12 @@ To see how you can grow your business, visit
   <Text weight="bold"> Need help? </Text>
   <Text inline> Find tips and best practices on the
     <Text weight="bold" inline>
-      <Link href="https://business.pinterest.com/" inline underline="hover"> Pinterest Business Site </Link>
+      <Link href="https://business.pinterest.com/" display="inline" underline="hover"> Pinterest Business Site </Link>
     </Text>
   </Text>
   <Text inline> Troubleshoot issues with the
     <Text weight="bold" inline>
-      <Link href="https://help.pinterest.com" inline underline="hover"> Pinterest Help Center </Link>
+      <Link href="https://help.pinterest.com" display="inline" underline="hover"> Pinterest Help Center </Link>
     </Text>
   </Text>
 </Flex>
@@ -103,11 +105,11 @@ To see how you can grow your business, visit
   </Box>
   <Text>
     <Text weight="bold" inline>
-      <Link href="https://www.pinterest.com" inline underline="hover"> Shanice Romero </Link>
+      <Link href="https://www.pinterest.com" display="inline" underline="hover"> Shanice Romero </Link>
     </Text>
     {" "}saved to
     <Text weight="bold" inline>
-      <Link href="https://www.pinterest.com" inline underline="hover"> Capoeira </Link>
+      <Link href="https://www.pinterest.com" display="inline" underline="hover"> Capoeira </Link>
     </Text>
     </Text>
 </Flex>
@@ -178,14 +180,14 @@ To see how you can grow your business, visit
   <Text size="100" align="center">
     By continuing, you agree to Pinterest's
     <Text size="100" inline>
-      <Link href="https://www.pinterest.com" inline>
+      <Link href="https://www.pinterest.com" display="inline">
         {' '}
         Business Terms of Service{' '}
       </Link>
     </Text>{' '}
     and acknowledge you've read our
     <Text size="100" inline>
-      <Link href="https://www.pinterest.com" inline>
+      <Link href="https://www.pinterest.com" display="inline">
         {' '}
         Privacy Policy{' '}
       </Link>
@@ -228,14 +230,14 @@ To see how you can grow your business, visit
   <Text size="100" align="center">
     By continuing, you agree to Pinterest's
     <Text size="100" inline weight="bold">
-      <Link href="https://www.pinterest.com" inline>
+      <Link href="https://www.pinterest.com" display="inline">
         {' '}
         Business Terms of Service{' '}
       </Link>
     </Text>{' '}
     and acknowledge you've read our
     <Text size="100" inline weight="bold">
-      <Link href="https://www.pinterest.com" inline>
+      <Link href="https://www.pinterest.com" display="inline">
         {' '}
         Privacy Policy{' '}
       </Link>
@@ -254,7 +256,7 @@ Display the external icon ("visit" icon) when the link text needs support to con
             defaultCode={`
 <Text inline>
   To receive push notifications instead of texts,
-  <Link href="https://authy.com/download/" inline externalLinkIcon="default" target="blank" rel="nofollow">download the Authy app</Link>.
+  <Link href="https://authy.com/download/" display="inline" externalLinkIcon="default" target="blank" rel="nofollow">download the Authy app</Link>.
 </Text>
 `}
           />
@@ -265,7 +267,7 @@ Display the external icon ("visit" icon) when the link text needs support to con
 <Flex gap={2} justifyContent="center" width="100%">
   <Text inline> Visit
     <Text inline>
-      <Link href="https://www.w3.org/WAI/standards-guidelines/" inline> WCAG accessibility resources</Link>
+      <Link href="https://www.w3.org/WAI/standards-guidelines/" display="inline"> WCAG accessibility resources</Link>
     </Text>
   </Text>
   <Icon icon="link" accessibilityLabel="" color="default" />
@@ -282,7 +284,7 @@ Add clarity to external links through explicit link text and predictable destina
             defaultCode={`
 <Text inline>
   Go to
-  <Link href="https://developers.pinterest.com/account-setup/" inline externalLinkIcon="default" target="blank">My Apps</Link>.
+  <Link href="https://developers.pinterest.com/account-setup/" display="inline" externalLinkIcon="default" target="blank">My Apps</Link>.
 </Text>
 `}
           />
@@ -295,17 +297,17 @@ Displaying multiple icons within the same text block can cause unnecessary visua
             defaultCode={`
 <Flex gap={2} direction="column" justifyContent="center" width="100%">
   <Text inline>- Comply with our
-    <Link href="https://policy.pinterest.com/en/developer-guidelines" inline externalLinkIcon="default"> Development guidelines</Link>{" "}
+    <Link href="https://policy.pinterest.com/en/developer-guidelines" display="inlineBlock" externalLinkIcon="default"> Development guidelines</Link>{" "}
     or ensure you are currently logged into an existing
-    <Link href="https://help.pinterest.com/en/business/article/get-a-business-account#section-8746" inline externalLinkIcon="default">business account.</Link>
+    <Link href="https://help.pinterest.com/en/business/article/get-a-business-account#section-8746" display="inlineBlock" externalLinkIcon="default">business account.</Link>
   </Text>
   <Text inline>-
-    <Link href="" inline externalLinkIcon="default">Create a Pinterest business account</Link>{" "}
+    <Link href="" display="inlineBlock" externalLinkIcon="default">Create a Pinterest business account</Link>{" "}
     or ensure you are currently logged into an existing
-    <Link href="https://help.pinterest.com/en/business/article/get-a-business-account#section-8746" inline externalLinkIcon="default">business account</Link>
+    <Link href="https://help.pinterest.com/en/business/article/get-a-business-account#section-8746" display="inlineBlock" externalLinkIcon="default">business account</Link>
   </Text>
   <Text inline>-
-    <Link href="https://developers.pinterest.com/account-setup/" inline externalLinkIcon="default">Go to My Apps</Link>
+    <Link href="https://developers.pinterest.com/account-setup/" display="inlineBlock" externalLinkIcon="default">Go to My Apps</Link>
   </Text>
 </Flex>
             `}
@@ -320,7 +322,7 @@ Provide a meaningful descriptive label to the link that clearly indicates the li
 <Text>
       Visit{' '}
       <Text inline>
-        <Link inline href="https://pinterest.com">
+        <Link display="inline" href="https://pinterest.com">
           Pinterest.com
         </Link>
       </Text>{' '}
@@ -335,7 +337,7 @@ Provide a meaningful descriptive label to the link that clearly indicates the li
 <Text>
   For more information,{' '}
   <Text inline>
-    <Link accessibilityLabel="visit https://pinterest.com" inline href="https://pinterest.com">
+    <Link accessibilityLabel="visit https://pinterest.com" display="inline" href="https://pinterest.com">
       click here
     </Link>
   </Text>
@@ -371,7 +373,7 @@ Accessible content is critical if we consider that assistive technology also pre
     <Label htmlFor="1">
       <Text>
         Use sites you visit to improve which recommendations and ads you see on Pinterest.{' '}
-        <Link accessibilityLabel="Learn more about personalization and data" inline href="https://pinterest.com/_/_/help/article/personalization-and-data#info-ad">
+        <Link accessibilityLabel="Learn more about personalization and data" display="inline" href="https://pinterest.com/_/_/help/article/personalization-and-data#info-ad">
           Learn more
         </Link>
       </Text>
@@ -387,7 +389,7 @@ Accessible content is critical if we consider that assistive technology also pre
     <Label htmlFor="2">
       <Text>
         Share activity for ads performance reporting.{' '}
-        <Link accessibilityLabel="Learn more about ads performance reporting" inline href="https://www.pinterest.com/_/_/help/article/ads-performance-reporting">
+        <Link accessibilityLabel="Learn more about ads performance reporting" display="inline" href="https://www.pinterest.com/_/_/help/article/ads-performance-reporting">
           Learn more
         </Link>
       </Text>
@@ -403,7 +405,7 @@ Accessible content is critical if we consider that assistive technology also pre
     <Label htmlFor="3">
       <Text>
         Use your activity to improve ads you see about Pinterest on other sites or apps you may visit.{' '}
-        <Link accessibilityLabel="Learn more about third-party analytics" inline href="https://www.pinterest.com/_/_/help/article/third-party-analytics-or-advertising-providers-pinterest-uses-or-allows">
+        <Link accessibilityLabel="Learn more about third-party analytics" display="inline" href="https://www.pinterest.com/_/_/help/article/third-party-analytics-or-advertising-providers-pinterest-uses-or-allows">
           Learn more
         </Link>
       </Text>
@@ -537,7 +539,7 @@ For external links where an external Gestalt Link doesn't apply, check out [Butt
     <Text color="inverse" weight="bold" size="600">Tips</Text>
       <Flex gap={{ row: 1, column: 0 }} alignItems="center">
         <Text color="inverse" size="400" align="center" weight="bold">
-          <Link href="https://pinterest.com" inline>Add a Pinterest widget</Link>{" "}
+          <Link href="https://pinterest.com" display="inline">Add a Pinterest widget</Link>{" "}
           and get inspired right from your phone's home screen.
         </Text>
       </Flex>
@@ -546,6 +548,7 @@ For external links where an external Gestalt Link doesn't apply, check out [Butt
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Link and color"
           description={`Link uses the typography color tokens. Keep in mind colors should be used purposefully and consistently as they convey meaning in multiple ways. See below how to use colors on links.
@@ -564,6 +567,7 @@ For external links where an external Gestalt Link doesn't apply, check out [Butt
     Reserved color for links within documentation and internal subsites when a color is needed to convey interactivity. Please note: This color shouldn't be used on links across Pinterest customer-facing UI.
           `}
         />
+
         <MainSection.Subsection
           title="Underline"
           columns={2}
@@ -573,7 +577,7 @@ We recommend showing the underline on the link, at least upon a hover behavior; 
 
 Don’t underline [Text](/web/text) that isn’t a Link, as underline has a strong link affordance.
 
-Link with \`inline={true}\` defaults the underline style to "always" to follow design guidelines while \`inline={false}\` defaults the underline style to "hover". On hover, \`underline="always"\` removes the underline, while \`underline="hover"\` adds it.
+Link with \`display="inline"\` or \`display="inlineBlock"\` sets the underline style to "always" to follow design guidelines while \`display="block"\` sets the underline style to "hover". On hover, \`underline="always"\` removes the underline, while \`underline="hover"\` adds it.
 
 However, Link's underline style can be overridden at any time using the \`underline\` prop.
 
@@ -585,7 +589,7 @@ However, Link's underline style can be overridden at any time using the \`underl
             defaultCode={`
 <Text inline>
   Find tips and best practices on the
-  <Link href="https://business.pinterest.com/" inline> Pinterest Business Site </Link>
+  <Link href="https://business.pinterest.com/" display="inline"> Pinterest Business Site </Link>
 </Text>
 `}
           />
@@ -633,11 +637,11 @@ However, Link's underline style can be overridden at any time using the \`underl
   </Box>
   <Text>
     <Text weight="bold" inline>
-      <Link href="https://www.pinterest.com" inline underline="hover"> Shanice Romero </Link>
+      <Link href="https://www.pinterest.com" display="inline" underline="hover"> Shanice Romero </Link>
     </Text>
     {" "}saved to
     <Text weight="bold" inline>
-      <Link href="https://www.pinterest.com" inline underline="hover"> Capoeira </Link>
+      <Link href="https://www.pinterest.com" display="inline" underline="hover"> Capoeira </Link>
     </Text>
     </Text>
 </Flex>
@@ -648,12 +652,30 @@ However, Link's underline style can be overridden at any time using the \`underl
             defaultCode={`
 <Flex gap={{ column: 2, row: 0 }} direction="column">
   <Text weight="bold">
-    <Link href="https://www.pinterest.com" inline underline="none">I'm a link with no underline</Link>
+    <Link href="https://www.pinterest.com" display="inline" underline="none">I'm a link with no underline</Link>
   </Text>
 </Flex>
 `}
           />
         </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="Inline"
+          description={`
+        By default, Link is a [block-level element](https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements). When Link needs to be displayed inline with the surrounding elements, you can use the \`display\` prop set to \`"inline"\` or \`"inlineBlock"\`. As shown below, the primary difference is how the words _within_ the Link wrap when width is restricted. \`"inline"\` will wrap by word, whereas \`"inlineBlock"\` will wrap the entire block of words.
+
+        Note that when \`display="inline"\` is used, \`tapStyle="compress"\` is _not_ respected.
+
+        Which should you choose? If you need inline Links, you most likely want \`display="inline"\`. Only choose \`display="inlineBlock"\` if you need the compress animation on click/tap.
+
+        Play around with the container width on the examples below and note how each responds to wrapping.
+        `}
+        >
+          <MainSection.Card
+            sandpackExample={<SandpackExample code={inline} name="Inline example" />}
+          />
+        </MainSection.Subsection>
+
         <MainSection.Subsection
           title="Target"
           description={`\`target\` is optional and defines the frame or window to open the anchor defined on \`href\`:
@@ -678,7 +700,7 @@ However, Link's underline style can be overridden at any time using the \`underl
             defaultCode={`
 <Text inline>
   Find tips and best practices on the
-  <Link href="https://business.pinterest.com/" inline> Pinterest Business Site</Link>
+  <Link href="https://business.pinterest.com/" display="inline"> Pinterest Business Site</Link>
 </Text>
 `}
           />
@@ -704,7 +726,7 @@ The "visit" icon should also match [Text](/web/text)'s \`size\` and \`color\`. \
           defaultCode={`
 <Text inline>
   To receive push notifications instead of texts,
-  <Link href="https://authy.com/download/" inline externalLinkIcon="default" target="blank" rel="nofollow">download the Authy app</Link>
+  <Link href="https://authy.com/download/" display="inline" externalLinkIcon="default" target="blank" rel="nofollow">download the Authy app</Link>
 </Text>
 `}
         />
@@ -713,13 +735,13 @@ The "visit" icon should also match [Text](/web/text)'s \`size\` and \`color\`. \
 <Flex direction="column" gap={{ column: 4, row: 0 }}>
   <Text inline size="100">
     Visit
-    <Link href="https://authy.com/download/" inline externalLinkIcon={{ size: "100" }} target="blank" rel="nofollow">
+    <Link href="https://authy.com/download/" display="inline" externalLinkIcon={{ size: "100" }} target="blank" rel="nofollow">
     MyBusiness.com
     </Link>{" "}
     for shipping details
   </Text>
   <Text inline size="400" color="success">
-    <Link href="https://authy.com/download/" inline externalLinkIcon={{ size: "400", color: "success" }} target="blank" rel="nofollow">
+    <Link href="https://authy.com/download/" display="inline" externalLinkIcon={{ size: "400", color: "success" }} target="blank" rel="nofollow">
       MyBusiness.com
     </Link>{" "}
     was successfully claimed

--- a/docs/pages/web/list.js
+++ b/docs/pages/web/list.js
@@ -89,7 +89,7 @@ export default function ListPage({
   <List label="With bulk actions, you can:" type="unordered">
     <List.Item text={
       <Text inline>Request an asynchronous bulk report on advertiser entities campaigns, ad groups, product groups, ads, keywords.
-        <Link inline accessibilityLabel="Learn more about async reports" href="#">Learn more</Link>
+        <Link display="inline" accessibilityLabel="Learn more about async reports" href="#">Learn more</Link>
       </Text>}
     />
     <List.Item text="Create/update ad-related entities" />

--- a/docs/pages/web/radiogroup.js
+++ b/docs/pages/web/radiogroup.js
@@ -754,7 +754,7 @@ function RadioButtonExample() {
         <Text size="200">
           Choose your primary goal for this account to help us better understand your needs
           <Text inline size="200" weight="bold">
-            <Link inline target="blank" href="https://www.pinterest.com/">
+            <Link display="inline" target="blank" href="https://www.pinterest.com/">
               Additional information
             </Link>
           </Text>

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -474,7 +474,7 @@ Due to localization constraints, the contents of \`message\` and \`helperLink\` 
 
   <SlimBanner
     type="recommendation"
-    message={<Text inline> The campaign <Text inline weight="bold">Back to School</Text> is regularly hitting its <Link inline href="">daily cap</Link>. Consider raising daily caps to increase scale for a similar CPC and CTR.</Text> }
+    message={<Text inline> The campaign <Text inline weight="bold">Back to School</Text> is regularly hitting its <Link display="inline" href="">daily cap</Link>. Consider raising daily caps to increase scale for a similar CPC and CTR.</Text> }
     primaryAction={{
       accessibilityLabel: 'Increase spend',
       label: 'Increase spend',

--- a/docs/pages/web/text.js
+++ b/docs/pages/web/text.js
@@ -485,7 +485,7 @@ function Example() {
             <Link
               accessibilityLabel="Visit our Help Site"
               href="#"
-              inline
+              display="inline"
             >
               Visit our Help Site
             </Link>
@@ -496,7 +496,7 @@ function Example() {
             <Link
               accessibilityLabel="Visit our Help Site"
               href="#"
-              inline
+              display="inline"
             >
             Visit our Help Site
             </Link>

--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -23,7 +23,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     primaryAction={{ accessibilityLabel: 'Test', label: 'Undo', size: 'lg' }}
     text={
       <Text inline> Saved to
-        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+        <Link display="inline" target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
           Home decor
         </Link>
       </Text>
@@ -120,7 +120,7 @@ function ToastExample() {
               text={
                 <Text inline>
                   Saved to{' '}
-                  <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+                  <Link display="inline" target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
                     Home decor
                   </Link>
                 </Text>
@@ -160,7 +160,7 @@ If  confirmation toast's text with more complex style is required, such as bold 
     text={
       <Text inline>
         Saved to{' '}
-        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+        <Link display="inline" target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
           Home decor
         </Link>
       </Text>
@@ -196,7 +196,7 @@ If  confirmation toast's text with more complex style is required, such as bold 
     text={
       <Text inline>
         Saved to{' '}
-        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+        <Link display="inline" target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
           Home decor
         </Link>
       </Text>
@@ -226,7 +226,7 @@ If  confirmation toast's text with more complex style is required, such as bold 
     text={
       <Text inline>
         Saved to{' '}
-        <Link inline target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
+        <Link display="inline" target="blank" href="https://www.pinterest.com/search/pins/?q=home%20decor">
           Home decor
         </Link>
       </Text>

--- a/docs/pages/year_in_review_2022.js
+++ b/docs/pages/year_in_review_2022.js
@@ -360,11 +360,11 @@ export default function YearInReview2022(): Node {
                   <Text size="400">
                     Gestalt shipped 38 component additions and updates this year, including some
                     game-changers like the new{' '}
-                    <GestaltLink href="/web/sidenavigation" inline>
+                    <GestaltLink href="/web/sidenavigation" display="inlineBlock">
                       SideNavigation
                     </GestaltLink>{' '}
                     and our big{' '}
-                    <GestaltLink href="/web/pageheader" inline>
+                    <GestaltLink href="/web/pageheader" display="inlineBlock">
                       PageHeader
                     </GestaltLink>{' '}
                     overhaul.
@@ -373,11 +373,11 @@ export default function YearInReview2022(): Node {
                     2022 saw a 11% bump in overall use of Gestalt instances in the Pinterest Web
                     codebase. We were most excited to see a 28% increase in our more complex
                     components (think something like{' '}
-                    <GestaltLink href="/web/slimbanner" inline>
+                    <GestaltLink href="/web/slimbanner" display="inlineBlock">
                       SlimBanner
                     </GestaltLink>{' '}
                     as opposed to{' '}
-                    <GestaltLink href="/web/text" inline>
+                    <GestaltLink href="/web/text" display="inlineBlock">
                       Text
                     </GestaltLink>
                     ).

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -74,6 +74,10 @@ type Props = {|
    */
   children?: Node,
   /**
+   * Determines how Link is positioned relative to surrounding elements, such as [Text](https://gestalt.pinterest.systems/web/text). See the [inline variant](https://gestalt.pinterest.systems/web/link#Inline) to learn more.
+   */
+  display?: 'inline' | 'inlineBlock' | 'block',
+  /**
    * When supplied, a "visit" icon is shown at the end of Link. See the [externalLinkIcon and rel variant](https://gestalt.pinterest.systems/web/link#externalLinkIcon-and-rel) to learn more.
    */
   externalLinkIcon?: ExternalLinkIcon,
@@ -85,10 +89,6 @@ type Props = {|
    * Unique id attribute of the anchor tag.
    */
   id?: string,
-  /**
-   * Properly positions Link relative to an inline element, such as [Text](https://gestalt.pinterest.systems/web/text), using the inline property. See the [underline variant](https://gestalt.pinterest.systems/web/link#Underline) to learn more.
-   */
-  inline?: boolean,
   /**
    * Callback triggered when when the element loses focus.
    */
@@ -149,10 +149,10 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
   {
     accessibilityLabel,
     children,
+    display = 'block',
     externalLinkIcon = 'none',
     href,
     id,
-    inline = false,
     onBlur,
     onClick,
     onFocus,
@@ -187,7 +187,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
 
   const { isFocusVisible } = useFocusVisible();
 
-  let underlineStyle = inline ? 'always' : 'hover';
+  let underlineStyle = ['inline', 'inlineBlock'].includes(display) ? 'always' : 'hover';
 
   if (underline && underline !== 'auto') {
     underlineStyle = underline;
@@ -198,9 +198,8 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
     focusStyles.hideOutline,
     touchableStyles.tapTransition,
     getRoundingClassName(rounding),
+    layoutStyles[display],
     {
-      [layoutStyles.inlineBlock]: inline,
-      [layoutStyles.block]: !inline,
       [textStyles.underline]: underlineStyle === 'always',
       [styles.hoverNoUnderline]: underlineStyle === 'always',
       [textStyles.noUnderline]: underlineStyle === 'hover' || underlineStyle === 'none',

--- a/packages/gestalt/src/Link.jsdom.test.js
+++ b/packages/gestalt/src/Link.jsdom.test.js
@@ -19,7 +19,7 @@ describe('Link', () => {
     render(
       <Link
         href="https://business.pinterest.com/advertise"
-        inline
+        display="inline"
         externalLinkIcon="default"
         target="blank"
       >
@@ -42,7 +42,7 @@ describe('Link', () => {
       <Link
         accessibilityLabel="Visit Pinterest"
         href="https://business.pinterest.com/advertise"
-        inline
+        display="inline"
         externalLinkIcon="default"
         target="blank"
       />,

--- a/packages/gestalt/src/Link.test.js
+++ b/packages/gestalt/src/Link.test.js
@@ -12,7 +12,7 @@ it('inline and auto underline', () =>
   expect(
     renderer
       .create(
-        <Link href="https://example.com" display="inline" underline="auto">
+        <Link href="https://example.com" display="inlineBlock" underline="auto">
           Link
         </Link>,
       )
@@ -23,7 +23,7 @@ it('inline and overriden underline="none"', () =>
   expect(
     renderer
       .create(
-        <Link href="https://example.com" display="inline" underline="none">
+        <Link href="https://example.com" display="inlineBlock" underline="none">
           Link
         </Link>,
       )
@@ -34,7 +34,7 @@ it('inline and overriden underline="hover"', () =>
   expect(
     renderer
       .create(
-        <Link href="https://example.com" display="inline" underline="hover">
+        <Link href="https://example.com" display="inlineBlock" underline="hover">
           Link
         </Link>,
       )

--- a/packages/gestalt/src/Link.test.js
+++ b/packages/gestalt/src/Link.test.js
@@ -12,7 +12,7 @@ it('inline and auto underline', () =>
   expect(
     renderer
       .create(
-        <Link href="https://example.com" inline underline="auto">
+        <Link href="https://example.com" display="inline" underline="auto">
           Link
         </Link>,
       )
@@ -23,7 +23,7 @@ it('inline and overriden underline="none"', () =>
   expect(
     renderer
       .create(
-        <Link href="https://example.com" inline underline="none">
+        <Link href="https://example.com" display="inline" underline="none">
           Link
         </Link>,
       )
@@ -34,7 +34,7 @@ it('inline and overriden underline="hover"', () =>
   expect(
     renderer
       .create(
-        <Link href="https://example.com" inline underline="hover">
+        <Link href="https://example.com" display="inline" underline="hover">
           Link
         </Link>,
       )

--- a/packages/gestalt/src/PageHeaderComponents.js
+++ b/packages/gestalt/src/PageHeaderComponents.js
@@ -150,7 +150,7 @@ export function PageHeaderSubtext({
                 href={helperLink.href}
                 onClick={helperLink.onClick}
                 target="blank"
-                inline
+                display="inlineBlock"
               >
                 {helperLink.text}
               </Link>

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -43,7 +43,7 @@ function HelperLink({ accessibilityLabel, href, onClick, target, text }: HelperL
       <Link
         accessibilityLabel={accessibilityLabel}
         href={href}
-        inline
+        display="inlineBlock"
         onClick={onClick}
         target={target}
       >

--- a/packages/gestalt/src/SlimBanner.test.js
+++ b/packages/gestalt/src/SlimBanner.test.js
@@ -57,7 +57,7 @@ describe('SlimBanner', () => {
               Back to School
             </Text>{' '}
             is regularly hitting its{' '}
-            <Link inline href="http://www.pinterest.com">
+            <Link display="inlineBlock" href="http://www.pinterest.com">
               daily cap
             </Link>
             . Consider raising daily caps to increase scale for a similar CPC and CTR.

--- a/packages/gestalt/src/Toast.test.js
+++ b/packages/gestalt/src/Toast.test.js
@@ -33,7 +33,7 @@ describe('<Toast />', () => {
           <Text inline weight="bold">
             Saved to{' '}
             <Link
-              inline
+              display="inlineBlock"
               href="https://www.pinterest.com/search/pins/?q=home%20decor"
               underline="hover"
             >
@@ -59,7 +59,7 @@ describe('<Toast />', () => {
           <Text inline weight="bold">
             Saved to{' '}
             <Link
-              inline
+              display="inlineBlock"
               href="https://www.pinterest.com/search/pins/?q=home%20decor"
               underline="hover"
             >
@@ -80,7 +80,7 @@ describe('<Toast />', () => {
           <Text inline weight="bold">
             Saved to{' '}
             <Link
-              inline
+              display="inlineBlock"
               href="https://www.pinterest.com/search/pins/?q=home%20decor"
               underline="hover"
             >


### PR DESCRIPTION
### Summary

#### What changed?

Currently Link's `inline` prop maps to `display: inline-block`, which doesn't wrap the contained text in an "inline" way — it wraps the entire block. This is not intuitive and interferes with common design patterns. This PR replaces `inline` with `display: 'inline' | 'inlineBlock' | 'block'`.

![Screen Shot 2023-01-03 at 5 29 23 PM](https://user-images.githubusercontent.com/12059539/210470649-383b3c8c-ecfd-4511-b286-b651351225b5.png)

#### Why?

Because inline-level elements ignore any height, width, or padding set on them, we must use `inline-block` for styles like our click/tap compress animation. However, we only set `tapStyle="compress` on 11 usages (out of 780 total Link usages), so it's not worth optimizing for this barely-used feature. Since we can't get rid of that feature completely, we have to accommodate by modifying `inline` to `display`. While the new prop is more complex, we can address this via docs updates.

### Codemod

Note that this codemod replaces all instances of `inline` with `display="inlineBlock"`, as this most faithfully reproduces the current behavior. However, most usages likely _should_ use `display="inline"`. I updated the usages on the Link docs page to use "inline", since they're easily verified and better convey the intended usage. We should revisit all other existing usages across our other docs pages and components and replace "inlineBlock" with "inline" where we can.

```bash
yarn codemod modifyPropValue ~/path/to/your/code \
  --component=Link \
  --previousProp=inline \
  --nextProp=display \
  --previousValue=true \
  --nextValue=inlineBlock
```

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5172)