### PR TITLE
Internal: tweak generic codemods for easier copy/paste-ability

### DIFF
--- a/packages/gestalt-codemods/generic-codemods/detectManualReplacement.js
+++ b/packages/gestalt-codemods/generic-codemods/detectManualReplacement.js
@@ -12,11 +12,11 @@
  *
  *
  * TO RUN THIS CODEMOD
- * yarn codemod detectManualReplacement ~/path/to/your/code
- * --component=string
- * --subcomponent=string
- * --prop=string
- * --value=string|number|boolean
+yarn codemod detectManualReplacement ~/path/to/your/code \
+  --component=string \
+  --subcomponent=string \
+  --prop=string \
+  --value=string|number|boolean
  *
  * E.g. yarn codemod detectManualReplacement ~/code/pinboard/webapp --component=Box --prop=color value=error
  *

--- a/packages/gestalt-codemods/generic-codemods/modifyProp.js
+++ b/packages/gestalt-codemods/generic-codemods/modifyProp.js
@@ -15,7 +15,10 @@
  *
  *
  * TO RUN THIS CODEMOD
- * yarn codemod modifyProp ~/path/to/your/code --component=<value> --previousProp=<value> --nextProp=<value>
+ yarn codemod modifyProp ~/path/to/your/code \
+  --component=string \
+  --previousProp=string \
+  --nextProp=string
  *
  *
  * If all options passed, previous prop is replaced with next prop value (REPLACE)

--- a/packages/gestalt-codemods/generic-codemods/modifyPropValue.js
+++ b/packages/gestalt-codemods/generic-codemods/modifyPropValue.js
@@ -18,13 +18,13 @@
  *
  *
  * TO RUN THIS CODEMOD
- * yarn codemod modifyPropValue ~/path/to/your/code
- * --component=string
- * --subcomponent=string
- * --previousProp=string
- * --nextProp=string
- * --previousValue=string|number|boolean
- * --nextValue=string|number|boolean
+ yarn codemod modifyPropValue ~/path/to/your/code \
+  --component=string \
+  --subcomponent=string \
+  --previousProp=string \
+  --nextProp=string \
+  --previousValue=string|number|boolean \
+  --nextValue=string|number|boolean
  *
  *
  * If all options passed, prop+value combination are replaced with new prop+value combination (REPLACE)

--- a/packages/gestalt-codemods/generic-codemods/renameComponent.js
+++ b/packages/gestalt-codemods/generic-codemods/renameComponent.js
@@ -5,7 +5,9 @@
  * Ex. <Flyout /> to <Popover />
  *
  * TO RUN THIS CODEMOD
- * yarn codemod renameComponent ~/path/to/your/code --componentName=<value> --nextComponentName=<value>
+yarn codemod renameComponent ~/path/to/your/code \
+  --componentName=string \
+  --nextComponentName=string
  * E.g. yarn codemod renameComponent ~/code/pinboard/webapp --componentName=Box --nextComponentName=RenamedBox
  *
  * OPTIONS:


### PR DESCRIPTION
Make it a bit easier on ourselves when copy-pasting the script examples into the terminal