### PR TITLE
Internal: actually fix autogen props default values

### DIFF
--- a/docs/docs-components/GeneratedPropTable.js
+++ b/docs/docs-components/GeneratedPropTable.js
@@ -4,47 +4,50 @@ import { type DocGen } from './docgen.js';
 import PropTable from './PropTable.js';
 
 // Note if the prop has responsive versions (e.g. margin, smMargin, mdMargin, lgMargin)
-function getResponsive(description?: string): {|
+function getResponsive(description?: string): {
   description?: string,
   responsive?: boolean,
-|} {
+  ...
+} {
   const input = description ?? '';
   const match = input.match(/(?<main>Responsive: (?<responsive>.*))/);
   const groups = match?.groups ?? {};
 
   return {
     description: groups.main ? input.replace(groups.main, '') : description,
-    responsive: Boolean(groups.responsive?.replace(/'/g, '')),
+    ...(groups.responsive ? { responsive: Boolean(groups.responsive?.replace(/'/g, '')) } : {}),
   };
 }
 
 // Provide a different type to display when needed
-function getTypeOverrideValue(description?: string): {|
+function getTypeOverrideValue(description?: string): {
   description?: string,
   typeOverride?: string,
-|} {
+  ...
+} {
   const input = description ?? '';
   const match = input.match(/(?<main>Type: (?<typeOverride>.*))/);
   const groups = match?.groups ?? {};
 
   return {
     description: groups.main ? input.replace(groups.main, '') : description,
-    typeOverride: groups.typeOverride?.replace(/'/g, ''),
+    ...(groups.typeOverride ? { typeOverride: groups.typeOverride?.replace(/'/g, '') } : {}),
   };
 }
 
 // Provide a default value where the actual one can't be parsed, e.g. Box
-function getDefaultValue(description?: string): {|
+function getDefaultValue(description?: string): {
   description?: string,
   defaultValue?: string,
-|} {
+  ...
+} {
   const input = description ?? '';
   const match = input.match(/(?<main>Default: (?<defaultValue>.*))/);
   const groups = match?.groups ?? {};
 
   return {
     description: groups.main ? input.replace(groups.main, '') : description,
-    defaultValue: groups.defaultValue?.replace(/'/g, ''),
+    ...(groups.defaultValue ? { defaultValue: groups.defaultValue?.replace(/'/g, '') } : {}),
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4842,9 +4842,9 @@ bail@^2.0.0:
   integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 balanced-match@^2.0.0:
   version "2.0.0"
@@ -4961,7 +4961,7 @@ boxen@^5.0.0:
 
 brace-expansion@^1.1.7:
   version "1.1.11"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
@@ -5919,8 +5919,8 @@ compress-commons@^3.0.0:
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 concat-stream@^1.4.4:
   version "1.6.2"
@@ -12304,17 +12304,17 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^3.1.2:
+minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@~3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.8.tgz#5e6a59bd11e2ab0de1cfb843eb2d82e546c321c1"
+  integrity sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
This _actually_ fixes the broken autogen props defaults, introduced in #2504. This also reverts the revert of a dependabot patch, which wasn't the culprit (#2583).