### PR TITLE
Internal: add Flow declarations for Lottie JSON animations

### DIFF
--- a/docs/docs-components/YearInReviewBanner.js
+++ b/docs/docs-components/YearInReviewBanner.js
@@ -2,7 +2,6 @@
 import { type Node } from 'react';
 import { Box, Button, Text, TapArea, Flex, Heading, useReducedMotion } from 'gestalt';
 import Lottie from 'lottie-react';
-// $FlowExpectedError[untyped-import]
 import discoStars from '../graphics/year-in-review/lottie/discoStars.json';
 import DonutHalf from '../graphics/year-in-review/donutHalf.svg';
 import Asterisk from '../graphics/year-in-review/asteriskFilled.svg';

--- a/docs/graphics/year-in-review/lottie/discoStars.json.flow
+++ b/docs/graphics/year-in-review/lottie/discoStars.json.flow
@@ -1,0 +1,748 @@
+// @flow strict
+
+declare module.exports: {|
+  +v: string,
+  +meta: {|
+    +g: string,
+    +a: string,
+    +k: string,
+    +d: string,
+    +tc: string,
+  |},
+  +fr: number,
+  +ip: number,
+  +op: number,
+  +w: number,
+  +h: number,
+  +nm: string,
+  +ddd: number,
+  +assets: $ReadOnlyArray<{|
+    +id: string,
+    +layers: $ReadOnlyArray<{|
+      +ddd: number,
+      +ind: number,
+      +ty: number,
+      +nm: string,
+      +sr: number,
+      +ks: {|
+        +o: {|
+          +a: number,
+          +k: number,
+          +ix: number,
+        |},
+        +r: {|
+          +a: number,
+          +k: number,
+          +ix: number,
+        |},
+        +p: {|
+          +a: number,
+          +k: $ReadOnlyArray<number>,
+          +ix: number,
+        |},
+        +a: {|
+          +a: number,
+          +k: $ReadOnlyArray<number>,
+          +ix: number,
+        |},
+        +s: {|
+          +a: number,
+          +k: $ReadOnlyArray<number>,
+          +ix: number,
+        |},
+      |},
+      +ao: number,
+      +shapes: $ReadOnlyArray<{|
+        +ty: string,
+        +it: $ReadOnlyArray<{|
+          +ind: ?number,
+          +ty: string,
+          +ix: ?number,
+          +ks: ?{|
+            +a: number,
+            +k: $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<{|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |}>,
+            |}>,
+            +ix: number,
+          |},
+          +nm: string,
+          +mn: ?string,
+          +hd: ?boolean,
+          +c: ?{|
+            +a: number,
+            +k: $ReadOnlyArray<number>,
+            +ix: number,
+          |},
+          +o: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+          +w: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+          +lc: ?number,
+          +lj: ?number,
+          +bm: ?number,
+          +p: ?{|
+            +a: number,
+            +k: $ReadOnlyArray<number>,
+            +ix: number,
+          |},
+          +a: ?{|
+            +a: number,
+            +k: $ReadOnlyArray<number>,
+            +ix: number,
+          |},
+          +s: ?{|
+            +a: number,
+            +k: $ReadOnlyArray<number>,
+            +ix: number,
+          |},
+          +r: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+          +sk: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+          +sa: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+        |}>,
+        +nm: string,
+        +np: number,
+        +cix: number,
+        +bm: number,
+        +ix: number,
+        +mn: string,
+        +hd: boolean,
+      |}>,
+      +ip: number,
+      +op: number,
+      +st: number,
+      +bm: number,
+    |}>,
+  |}>,
+  +layers: $ReadOnlyArray<{|
+    +ddd: number,
+    +ind: number,
+    +ty: number,
+    +nm: string,
+    +sr: number,
+    +ks: {|
+      +o: {|
+        +a: number,
+        +k:
+          | number
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +r: {|
+        +a: number,
+        +k:
+          | number
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +p: {|
+        +a: number,
+        +k: $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+      +a: {|
+        +a: number,
+        +k: $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+      +s: {|
+        +a: number,
+        +k:
+          | $ReadOnlyArray<number>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+    |},
+    +ao: number,
+    +ip: number,
+    +op: number,
+    +st: number,
+    +bm: number,
+    +parent: ?number,
+    +shapes:
+      | ?$ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i:
+                  | $ReadOnlyArray<$ReadOnlyArray<number>>
+                  | $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o:
+                  | $ReadOnlyArray<$ReadOnlyArray<number>>
+                  | $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v:
+                  | $ReadOnlyArray<$ReadOnlyArray<number>>
+                  | $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +mm: ?number,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +r: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>,
+    +td: ?number,
+    +tt: ?number,
+    +refId: ?string,
+    +w: ?number,
+    +h: ?number,
+  |}>,
+  +markers: $ReadOnlyArray<mixed>,
+|};

--- a/docs/graphics/year-in-review/lottie/figma.json.flow
+++ b/docs/graphics/year-in-review/lottie/figma.json.flow
@@ -1,0 +1,582 @@
+// @flow strict
+
+declare module.exports: {|
+  +v: string,
+  +meta: {|
+    +g: string,
+    +a: string,
+    +k: string,
+    +d: string,
+    +tc: string,
+  |},
+  +fr: number,
+  +ip: number,
+  +op: number,
+  +w: number,
+  +h: number,
+  +nm: string,
+  +ddd: number,
+  +assets: $ReadOnlyArray<{|
+    +id: string,
+    +w: ?number,
+    +h: ?number,
+    +u: ?string,
+    +p: ?string,
+    +e: ?number,
+    +layers:
+      | ?$ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k:
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: number,
+                      +y: number,
+                    |},
+                    +o: ?{|
+                      +x: number,
+                      +y: number,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                    +to: ?$ReadOnlyArray<number>,
+                    +ti: ?$ReadOnlyArray<number>,
+                  |}>
+                | $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+          +parent: ?number,
+          +refId: ?string,
+        |}>
+      | $ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k:
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +o: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                  |}>
+                | number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k:
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: number,
+                      +y: number,
+                    |},
+                    +o: ?{|
+                      +x: number,
+                      +y: number,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                    +to: ?$ReadOnlyArray<number>,
+                    +ti: ?$ReadOnlyArray<number>,
+                  |}>
+                | $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k:
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +o: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                  |}>
+                | $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+          +parent: ?number,
+          +shapes: ?$ReadOnlyArray<{|
+            +ty: string,
+            +it: ?$ReadOnlyArray<{|
+              +ind: ?number,
+              +ty: string,
+              +ix: ?number,
+              +ks: ?{|
+                +a: number,
+                +k: {|
+                  +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +c: boolean,
+                |},
+                +ix: number,
+              |},
+              +nm: string,
+              +mn: ?string,
+              +hd: ?boolean,
+              +c: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +o: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +w: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +lc: ?number,
+              +lj: ?number,
+              +ml: ?number,
+              +bm: ?number,
+              +p: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +a: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +s: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +r: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +sk: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +sa: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+            |}>,
+            +nm: string,
+            +np: ?number,
+            +cix: ?number,
+            +bm: ?number,
+            +ix: number,
+            +mn: string,
+            +hd: boolean,
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<{|
+                +i: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +o: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +t: number,
+                +s: $ReadOnlyArray<number>,
+              |}>,
+              +ix: number,
+            |},
+            +e: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +m: ?number,
+          |}>,
+          +refId: ?string,
+        |}>,
+  |}>,
+  +layers: $ReadOnlyArray<{|
+    +ddd: number,
+    +ind: number,
+    +ty: number,
+    +nm: string,
+    +refId: ?string,
+    +sr: number,
+    +ks: {|
+      +o: {|
+        +a: number,
+        +k: number,
+        +ix: number,
+      |},
+      +r: {|
+        +a: number,
+        +k:
+          | number
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +p: {|
+        +a: number,
+        +k:
+          | $ReadOnlyArray<number>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +a: {|
+        +a: number,
+        +k: $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+      +s: {|
+        +a: number,
+        +k:
+          | $ReadOnlyArray<number>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+    |},
+    +ao: number,
+    +ip: number,
+    +op: number,
+    +st: number,
+    +bm: number,
+    +td: ?number,
+    +shapes:
+      | ?$ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ty: string,
+            +d: ?number,
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: ?$ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +r: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: ?number,
+          +cix: ?number,
+          +bm: ?number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+          +s: ?{|
+            +a: number,
+            +k: $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+            +ix: number,
+          |},
+          +e: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+          +o: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+          +m: ?number,
+        |}>,
+    +tt: ?number,
+    +w: ?number,
+    +h: ?number,
+    +parent: ?number,
+    +hasMask: ?boolean,
+    +masksProperties: ?$ReadOnlyArray<{|
+      +inv: boolean,
+      +mode: string,
+      +pt: {|
+        +a: number,
+        +k: {|
+          +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+          +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+          +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+          +c: boolean,
+        |},
+        +ix: number,
+      |},
+      +o: {|
+        +a: number,
+        +k: number,
+        +ix: number,
+      |},
+      +x: {|
+        +a: number,
+        +k: number,
+        +ix: number,
+      |},
+      +nm: string,
+    |}>,
+  |}>,
+  +markers: $ReadOnlyArray<mixed>,
+|};

--- a/docs/graphics/year-in-review/lottie/pencil.json.flow
+++ b/docs/graphics/year-in-review/lottie/pencil.json.flow
@@ -1,0 +1,472 @@
+// @flow strict
+
+declare module.exports: {|
+  +v: string,
+  +meta: {|
+    +g: string,
+    +a: string,
+    +k: string,
+    +d: string,
+    +tc: string,
+  |},
+  +fr: number,
+  +ip: number,
+  +op: number,
+  +w: number,
+  +h: number,
+  +nm: string,
+  +ddd: number,
+  +assets: $ReadOnlyArray<{|
+    +id: string,
+    +w: number,
+    +h: number,
+    +u: string,
+    +p: string,
+    +e: number,
+  |}>,
+  +layers: $ReadOnlyArray<{|
+    +ddd: number,
+    +ind: number,
+    +ty: number,
+    +nm: string,
+    +sr: number,
+    +ks: {|
+      +o: {|
+        +a: number,
+        +k:
+          | number
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +r: {|
+        +a: number,
+        +k:
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | number
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +p: {|
+        +a: number,
+        +k:
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+      +a: {|
+        +a: number,
+        +k: $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+      +s: {|
+        +a: number,
+        +k: $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+    |},
+    +ao: number,
+    +ip: number,
+    +op: number,
+    +st: number,
+    +bm: number,
+    +parent: ?number,
+    +refId: ?string,
+    +shapes:
+      | ?$ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +r: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +r: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: ?$ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +r: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: ?number,
+          +cix: ?number,
+          +bm: ?number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+          +s: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+          +e: ?{|
+            +a: number,
+            +k: $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+            +ix: number,
+          |},
+          +o: ?{|
+            +a: number,
+            +k: number,
+            +ix: number,
+          |},
+          +m: ?number,
+        |}>,
+  |}>,
+  +markers: $ReadOnlyArray<mixed>,
+|};

--- a/docs/graphics/year-in-review/lottie/steps.json.flow
+++ b/docs/graphics/year-in-review/lottie/steps.json.flow
@@ -1,0 +1,518 @@
+// @flow strict
+
+declare module.exports: {|
+  +v: string,
+  +meta: {|
+    +g: string,
+    +a: string,
+    +k: string,
+    +d: string,
+    +tc: string,
+  |},
+  +fr: number,
+  +ip: number,
+  +op: number,
+  +w: number,
+  +h: number,
+  +nm: string,
+  +ddd: number,
+  +assets: $ReadOnlyArray<{|
+    +id: string,
+    +w: ?number,
+    +h: ?number,
+    +u: ?string,
+    +p: ?string,
+    +e: ?number,
+    +layers:
+      | ?$ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +shapes: $ReadOnlyArray<{|
+            +ty: string,
+            +it: ?$ReadOnlyArray<{|
+              +ind: ?number,
+              +ty: string,
+              +ix: ?number,
+              +ks: ?{|
+                +a: number,
+                +k: {|
+                  +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +c: boolean,
+                |},
+                +ix: number,
+              |},
+              +nm: string,
+              +mn: ?string,
+              +hd: ?boolean,
+              +c: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +o: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +w: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +lc: ?number,
+              +lj: ?number,
+              +ml: ?number,
+              +bm: ?number,
+              +p: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +a: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +s: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +r: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +sk: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +sa: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+            |}>,
+            +nm: string,
+            +np: ?number,
+            +cix: ?number,
+            +bm: ?number,
+            +ix: number,
+            +mn: string,
+            +hd: boolean,
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<{|
+                +i: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +o: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +t: number,
+                +s: $ReadOnlyArray<number>,
+              |}>,
+              +ix: number,
+            |},
+            +e: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<{|
+                +i: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +o: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +t: number,
+                +s: $ReadOnlyArray<number>,
+              |}>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +m: ?number,
+          |}>,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+        |}>
+      | $ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +cl: string,
+          +refId: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+        |}>
+      | $ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +refId: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k:
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +o: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                  |}>
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +o: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                  |}>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+        |}>
+      | $ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +refId: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+        |}>,
+  |}>,
+  +layers: $ReadOnlyArray<{|
+    +ddd: number,
+    +ind: number,
+    +ty: number,
+    +nm: string,
+    +refId: ?string,
+    +sr: number,
+    +ks: {|
+      +o: {|
+        +a: number,
+        +k: number,
+        +ix: number,
+      |},
+      +r: {|
+        +a: number,
+        +k:
+          | number
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +p: {|
+        +a: number,
+        +k:
+          | $ReadOnlyArray<number>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +a: {|
+        +a: number,
+        +k: $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+      +s: {|
+        +a: number,
+        +k:
+          | $ReadOnlyArray<number>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+    |},
+    +ao: number,
+    +ip: number,
+    +op: number,
+    +st: number,
+    +bm: number,
+    +w: ?number,
+    +h: ?number,
+    +parent: ?number,
+    +hasMask: ?boolean,
+    +masksProperties: ?$ReadOnlyArray<{|
+      +inv: boolean,
+      +mode: string,
+      +pt: {|
+        +a: number,
+        +k: {|
+          +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+          +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+          +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+          +c: boolean,
+        |},
+        +ix: number,
+      |},
+      +o: {|
+        +a: number,
+        +k: number,
+        +ix: number,
+      |},
+      +x: {|
+        +a: number,
+        +k: number,
+        +ix: number,
+      |},
+      +nm: string,
+    |}>,
+  |}>,
+  +markers: $ReadOnlyArray<mixed>,
+|};

--- a/docs/graphics/year-in-review/lottie/vibes.json.flow
+++ b/docs/graphics/year-in-review/lottie/vibes.json.flow
@@ -1,0 +1,1439 @@
+// @flow strict
+
+declare module.exports: {|
+  +v: string,
+  +meta: {|
+    +g: string,
+    +a: string,
+    +k: string,
+    +d: string,
+    +tc: string,
+  |},
+  +fr: number,
+  +ip: number,
+  +op: number,
+  +w: number,
+  +h: number,
+  +nm: string,
+  +ddd: number,
+  +assets: $ReadOnlyArray<{|
+    +id: string,
+    +w: ?number,
+    +h: ?number,
+    +u: ?string,
+    +p: ?string,
+    +e: ?number,
+    +layers:
+      | ?$ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +shapes: $ReadOnlyArray<{|
+            +ty: string,
+            +it: ?$ReadOnlyArray<{|
+              +ind: ?number,
+              +ty: string,
+              +ix: ?number,
+              +ks: ?{|
+                +a: number,
+                +k: {|
+                  +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +c: boolean,
+                |},
+                +ix: number,
+              |},
+              +nm: string,
+              +mn: ?string,
+              +hd: ?boolean,
+              +c: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +o: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +w: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +lc: ?number,
+              +lj: ?number,
+              +ml: ?number,
+              +bm: ?number,
+              +p: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +a: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +s: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +r: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +sk: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +sa: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+            |}>,
+            +nm: string,
+            +np: ?number,
+            +cix: ?number,
+            +bm: ?number,
+            +ix: number,
+            +mn: string,
+            +hd: boolean,
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<{|
+                +i: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +o: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +t: number,
+                +s: $ReadOnlyArray<number>,
+              |}>,
+              +ix: number,
+            |},
+            +e: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<{|
+                +i: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +o: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +t: number,
+                +s: $ReadOnlyArray<number>,
+              |}>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +m: ?number,
+          |}>,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+        |}>
+      | $ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k:
+                | number
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +o: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                  |}>,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k:
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: number,
+                      +y: number,
+                    |},
+                    +o: ?{|
+                      +x: number,
+                      +y: number,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                    +to: ?$ReadOnlyArray<number>,
+                    +ti: ?$ReadOnlyArray<number>,
+                  |}>
+                | $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k:
+                | $ReadOnlyArray<number>
+                | $ReadOnlyArray<{|
+                    +i: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +o: ?{|
+                      +x: $ReadOnlyArray<number>,
+                      +y: $ReadOnlyArray<number>,
+                    |},
+                    +t: number,
+                    +s: $ReadOnlyArray<number>,
+                  |}>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+          +parent: ?number,
+          +shapes: ?$ReadOnlyArray<{|
+            +ty: string,
+            +it: ?$ReadOnlyArray<{|
+              +ind: ?number,
+              +ty: string,
+              +ix: ?number,
+              +ks: ?{|
+                +a: number,
+                +k: {|
+                  +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                  +c: boolean,
+                |},
+                +ix: number,
+              |},
+              +nm: string,
+              +mn: ?string,
+              +hd: ?boolean,
+              +c: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +o: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +w: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +lc: ?number,
+              +lj: ?number,
+              +ml: ?number,
+              +bm: ?number,
+              +p: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +a: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +s: ?{|
+                +a: number,
+                +k: $ReadOnlyArray<number>,
+                +ix: number,
+              |},
+              +r: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +sk: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+              +sa: ?{|
+                +a: number,
+                +k: number,
+                +ix: number,
+              |},
+            |}>,
+            +nm: string,
+            +np: ?number,
+            +cix: ?number,
+            +bm: ?number,
+            +ix: number,
+            +mn: string,
+            +hd: boolean,
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<{|
+                +i: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +o: ?{|
+                  +x: $ReadOnlyArray<number>,
+                  +y: $ReadOnlyArray<number>,
+                |},
+                +t: number,
+                +s: $ReadOnlyArray<number>,
+              |}>,
+              +ix: number,
+            |},
+            +e: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +m: ?number,
+          |}>,
+          +refId: ?string,
+        |}>
+      | $ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +refId: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +w: number,
+          +h: number,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+        |}>
+      | $ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +refId: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +w: number,
+          +h: number,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+        |}>
+      | $ReadOnlyArray<{|
+          +ddd: number,
+          +ind: number,
+          +ty: number,
+          +nm: string,
+          +sr: number,
+          +ks: {|
+            +o: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r: {|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +p: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: {|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+          |},
+          +ao: number,
+          +shapes:
+            | $ReadOnlyArray<{|
+                +ty: string,
+                +it: $ReadOnlyArray<{|
+                  +ind: ?number,
+                  +ty: string,
+                  +ix: ?number,
+                  +ks: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<{|
+                      +i: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +o: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +t: number,
+                      +s: $ReadOnlyArray<{|
+                        +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +c: boolean,
+                      |}>,
+                    |}>,
+                    +ix: number,
+                  |},
+                  +nm: string,
+                  +mn: ?string,
+                  +hd: ?boolean,
+                  +c: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +o: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +w: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +lc: ?number,
+                  +lj: ?number,
+                  +ml: ?number,
+                  +bm: ?number,
+                  +p: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +a: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +s: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +r: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sk: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sa: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                |}>,
+                +nm: string,
+                +np: number,
+                +cix: number,
+                +bm: number,
+                +ix: number,
+                +mn: string,
+                +hd: boolean,
+              |}>
+            | $ReadOnlyArray<{|
+                +ty: string,
+                +it: $ReadOnlyArray<{|
+                  +ind: ?number,
+                  +ty: string,
+                  +ix: ?number,
+                  +ks: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<{|
+                      +i: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +o: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +t: number,
+                      +s: $ReadOnlyArray<{|
+                        +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +c: boolean,
+                      |}>,
+                    |}>,
+                    +ix: number,
+                  |},
+                  +nm: string,
+                  +mn: ?string,
+                  +hd: ?boolean,
+                  +c: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +o: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +w: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +lc: ?number,
+                  +lj: ?number,
+                  +ml: ?number,
+                  +bm: ?number,
+                  +p: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +a: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +s: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +r: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sk: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sa: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                |}>,
+                +nm: string,
+                +np: number,
+                +cix: number,
+                +bm: number,
+                +ix: number,
+                +mn: string,
+                +hd: boolean,
+              |}>
+            | $ReadOnlyArray<{|
+                +ty: string,
+                +it: $ReadOnlyArray<{|
+                  +ind: ?number,
+                  +ty: string,
+                  +ix: ?number,
+                  +ks: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<{|
+                      +i: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +o: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +t: number,
+                      +s: $ReadOnlyArray<{|
+                        +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +c: boolean,
+                      |}>,
+                    |}>,
+                    +ix: number,
+                  |},
+                  +nm: string,
+                  +mn: ?string,
+                  +hd: ?boolean,
+                  +c: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +o: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +w: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +lc: ?number,
+                  +lj: ?number,
+                  +ml: ?number,
+                  +bm: ?number,
+                  +p: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +a: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +s: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +r: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sk: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sa: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                |}>,
+                +nm: string,
+                +np: number,
+                +cix: number,
+                +bm: number,
+                +ix: number,
+                +mn: string,
+                +hd: boolean,
+              |}>
+            | $ReadOnlyArray<{|
+                +ty: string,
+                +it: $ReadOnlyArray<{|
+                  +ind: ?number,
+                  +ty: string,
+                  +ix: ?number,
+                  +ks: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<{|
+                      +i: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +o: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +t: number,
+                      +s: $ReadOnlyArray<{|
+                        +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +c: boolean,
+                      |}>,
+                    |}>,
+                    +ix: number,
+                  |},
+                  +nm: string,
+                  +mn: ?string,
+                  +hd: ?boolean,
+                  +c: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +o: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +w: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +lc: ?number,
+                  +lj: ?number,
+                  +ml: ?number,
+                  +bm: ?number,
+                  +p: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +a: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +s: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +r: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sk: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sa: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                |}>,
+                +nm: string,
+                +np: number,
+                +cix: number,
+                +bm: number,
+                +ix: number,
+                +mn: string,
+                +hd: boolean,
+              |}>
+            | $ReadOnlyArray<{|
+                +ty: string,
+                +it: $ReadOnlyArray<{|
+                  +ind: ?number,
+                  +ty: string,
+                  +ix: ?number,
+                  +ks: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<{|
+                      +i: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +o: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +t: number,
+                      +s: $ReadOnlyArray<{|
+                        +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +c: boolean,
+                      |}>,
+                    |}>,
+                    +ix: number,
+                  |},
+                  +nm: string,
+                  +mn: ?string,
+                  +hd: ?boolean,
+                  +c: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +o: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +w: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +lc: ?number,
+                  +lj: ?number,
+                  +ml: ?number,
+                  +bm: ?number,
+                  +p: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +a: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +s: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +r: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sk: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sa: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                |}>,
+                +nm: string,
+                +np: number,
+                +cix: number,
+                +bm: number,
+                +ix: number,
+                +mn: string,
+                +hd: boolean,
+              |}>
+            | $ReadOnlyArray<{|
+                +ty: string,
+                +it: $ReadOnlyArray<{|
+                  +ind: ?number,
+                  +ty: string,
+                  +ix: ?number,
+                  +ks: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<{|
+                      +i: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +o: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +t: number,
+                      +s: $ReadOnlyArray<{|
+                        +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +c: boolean,
+                      |}>,
+                    |}>,
+                    +ix: number,
+                  |},
+                  +nm: string,
+                  +mn: ?string,
+                  +hd: ?boolean,
+                  +c: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +o: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +w: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +lc: ?number,
+                  +lj: ?number,
+                  +ml: ?number,
+                  +bm: ?number,
+                  +p: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +a: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +s: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +r: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sk: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sa: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                |}>,
+                +nm: string,
+                +np: number,
+                +cix: number,
+                +bm: number,
+                +ix: number,
+                +mn: string,
+                +hd: boolean,
+              |}>
+            | $ReadOnlyArray<{|
+                +ty: string,
+                +it: $ReadOnlyArray<{|
+                  +ind: ?number,
+                  +ty: string,
+                  +ix: ?number,
+                  +ks: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<{|
+                      +i: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +o: ?{|
+                        +x: number,
+                        +y: number,
+                      |},
+                      +t: number,
+                      +s: $ReadOnlyArray<{|
+                        +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                        +c: boolean,
+                      |}>,
+                    |}>,
+                    +ix: number,
+                  |},
+                  +nm: string,
+                  +mn: ?string,
+                  +hd: ?boolean,
+                  +c: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +o: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +w: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +lc: ?number,
+                  +lj: ?number,
+                  +ml: ?number,
+                  +bm: ?number,
+                  +p: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +a: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +s: ?{|
+                    +a: number,
+                    +k: $ReadOnlyArray<number>,
+                    +ix: number,
+                  |},
+                  +r: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sk: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                  +sa: ?{|
+                    +a: number,
+                    +k: number,
+                    +ix: number,
+                  |},
+                |}>,
+                +nm: string,
+                +np: number,
+                +cix: number,
+                +bm: number,
+                +ix: number,
+                +mn: string,
+                +hd: boolean,
+              |}>,
+          +ip: number,
+          +op: number,
+          +st: number,
+          +bm: number,
+        |}>,
+  |}>,
+  +layers: $ReadOnlyArray<{|
+    +ddd: number,
+    +ind: number,
+    +ty: number,
+    +nm: string,
+    +refId: ?string,
+    +sr: number,
+    +ks: {|
+      +o: {|
+        +a: number,
+        +k: number,
+        +ix: number,
+      |},
+      +r: {|
+        +a: number,
+        +k:
+          | number
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +o: ?{|
+                +x: $ReadOnlyArray<number>,
+                +y: $ReadOnlyArray<number>,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +p: {|
+        +a: number,
+        +k:
+          | $ReadOnlyArray<number>
+          | $ReadOnlyArray<{|
+              +i: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +o: ?{|
+                +x: number,
+                +y: number,
+              |},
+              +t: number,
+              +s: $ReadOnlyArray<number>,
+              +to: ?$ReadOnlyArray<number>,
+              +ti: ?$ReadOnlyArray<number>,
+            |}>,
+        +ix: number,
+      |},
+      +a: {|
+        +a: number,
+        +k: $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+      +s: {|
+        +a: number,
+        +k: $ReadOnlyArray<number>,
+        +ix: number,
+      |},
+    |},
+    +ao: number,
+    +w: ?number,
+    +h: ?number,
+    +ip: number,
+    +op: number,
+    +st: number,
+    +bm: number,
+    +td: ?number,
+    +shapes:
+      | ?$ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ty: string,
+            +d: ?number,
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +r:
+              | number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +bm: ?number,
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +d: ?number,
+            +ty: string,
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +bm: ?number,
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ind: ?number,
+            +ty: string,
+            +ix: ?number,
+            +ks: ?{|
+              +a: number,
+              +k: {|
+                +i: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +o: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +v: $ReadOnlyArray<$ReadOnlyArray<number>>,
+                +c: boolean,
+              |},
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +r:
+              | ?number
+              | {|
+                  +a: number,
+                  +k: number,
+                  +ix: number,
+                |},
+            +bm: ?number,
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>
+      | $ReadOnlyArray<{|
+          +ty: string,
+          +it: $ReadOnlyArray<{|
+            +ty: string,
+            +d: ?number,
+            +s: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +p: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +r: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +nm: string,
+            +mn: ?string,
+            +hd: ?boolean,
+            +c: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +o: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +w: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +lc: ?number,
+            +lj: ?number,
+            +ml: ?number,
+            +bm: ?number,
+            +a: ?{|
+              +a: number,
+              +k: $ReadOnlyArray<number>,
+              +ix: number,
+            |},
+            +sk: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+            +sa: ?{|
+              +a: number,
+              +k: number,
+              +ix: number,
+            |},
+          |}>,
+          +nm: string,
+          +np: number,
+          +cix: number,
+          +bm: number,
+          +ix: number,
+          +mn: string,
+          +hd: boolean,
+        |}>,
+    +tt: ?number,
+  |}>,
+  +markers: $ReadOnlyArray<mixed>,
+|};

--- a/docs/pages/year_in_review_2022.js
+++ b/docs/pages/year_in_review_2022.js
@@ -13,9 +13,10 @@ import {
   useReducedMotion,
   Link as GestaltLink,
 } from 'gestalt';
-import Lottie from 'lottie-react';
-
 import Link from 'next/link';
+import Lottie from 'lottie-react';
+import GestaltLogo from '../docs-components/GestaltLogo.js';
+// SVGs
 import AsteriskFilled from '../graphics/year-in-review/asteriskFilled.svg';
 import Circle from '../graphics/year-in-review/circle.svg';
 import CircleShadow from '../graphics/year-in-review/circleShadow.svg';
@@ -29,17 +30,11 @@ import KnobShadow from '../graphics/year-in-review/knobShadow.svg';
 import Sparkle from '../graphics/year-in-review/sparkle.svg';
 import SparkleShadow from '../graphics/year-in-review/sparkleShadow.svg';
 import Tokens from '../graphics/year-in-review/tokens.svg';
-
-// $FlowExpectedError[untyped-import]
+// Lottie animations
 import Pencil from '../graphics/year-in-review/lottie/pencil.json';
-// $FlowExpectedError[untyped-import]
 import Steps from '../graphics/year-in-review/lottie/steps.json';
-// $FlowExpectedError[untyped-import]
 import Vibes from '../graphics/year-in-review/lottie/vibes.json';
-// $FlowExpectedError[untyped-import]
 import Figma from '../graphics/year-in-review/lottie/figma.json';
-
-import GestaltLogo from '../docs-components/GestaltLogo.js';
 
 const INTRO_ZINDEX = new FixedZIndex(10);
 const BUTTON_ZINDEX = new CompositeZIndex([INTRO_ZINDEX]);
@@ -83,7 +78,6 @@ type AnimationProps = {|
 function DiscoAnimation({ shouldReduceMotion }: AnimationProps): Node {
   const [animationData, setAnimationData] = useState();
   useEffect(() => {
-    // $FlowExpectedError[untyped-import]
     import(`../graphics/year-in-review/lottie/discoStars.json`).then((res) =>
       setAnimationData(res.default),
     );


### PR DESCRIPTION
This PR uses [this tool](https://github.com/zth/json-to-flowtype-generator) to add Flow types for the Lottie animation JSON files using [declaration files](https://flow.org/en/docs/declarations/).