### PR TITLE
Icons: Add keywords to icon search page

### DIFF
--- a/docs/pages/foundations/iconography/ICON_DATA.json
+++ b/docs/pages/foundations/iconography/ICON_DATA.json
@@ -3,7 +3,7 @@
     {
       "name": "360",
       "categories": ["Utility and tools"],
-      "keywords": ["label-360", "view"]
+      "keywords": ["label", "view"]
     },
     {
       "name": "accessibility",
@@ -33,25 +33,25 @@
       "name": "add-circle",
       "categories": ["Add"],
       "description": "Indicates the ability to display more content or additional information",
-      "keywords": ["plus-circle", "create", "new"]
+      "keywords": ["plus circle", "create", "new"]
     },
     {
       "name": "add-layout",
       "categories": ["Add"],
       "description": "Indicates the ability to choose a new file and create a layout",
-      "keywords": ["plus-layout", "create", "new"]
+      "keywords": ["plus layout", "create", "new"]
     },
     {
       "name": "add-person",
       "categories": ["Add"],
       "description": "Indicates the ability to add a new person/collaborator",
-      "keywords": ["plus-person", "collaborator", "create", "new", "share"]
+      "keywords": ["plus person", "collaborator", "create", "new", "share"]
     },
     {
       "name": "add-pin",
       "categories": ["Add"],
       "description": "Indicates the ability to send a Pin",
-      "keywords": ["plus-pin", "create", "new"]
+      "keywords": ["plus pin", "create", "new"]
     },
     {
       "name": "ads-overview",

--- a/docs/pages/foundations/iconography/ICON_DATA.json
+++ b/docs/pages/foundations/iconography/ICON_DATA.json
@@ -1,1032 +1,1273 @@
 {
   "icons": [
     {
-      "name": "add",
-      "categories": ["Add"],
-      "description": "Indicates the ability to create or add content"
-    },
-    {
-      "name": "add-circle",
-      "categories": ["Add"],
-      "description": "Indicates the ability to display more content or additional information"
-    },
-    {
-      "name": "add-layout",
-      "categories": ["Add"],
-      "description": "Indicates the ability to choose a new file and create a layout"
-    },
-    {
-      "name": "add-person",
-      "categories": ["Add"],
-      "description": "Indicates the ability to add a new person/collaborator"
-    },
-    {
-      "name": "add-pin",
-      "categories": ["Add"],
-      "description": "Indicates the ability to send a Pin"
-    },
-    {
-      "name": "ad",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates an ad type"
-    },
-    {
-      "name": "ad-group",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates a group of ads accounts"
-    },
-    {
-      "name": "ads-overview",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates ads overview"
-    },
-    {
-      "name": "ads-stats",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates ads stats"
-    },
-    {
-      "name": "graph-bar",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates a graph-bar data format"
-    },
-    {
-      "name": "graph-pie",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates a graph-pie data format"
-    },
-    {
-      "name": "insights-audience",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates insights from the audience"
-    },
-    {
-      "name": "insights-conversions",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates insights conversion data"
-    },
-    {
-      "name": "overview",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates a dashboard overview"
-    },
-    {
-      "name": "target",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates the target audience"
-    },
-    {
-      "name": "trending",
-      "categories": ["Ads and measurements"],
-      "description": "Indicates trends"
-    },
-    {
-      "name": "align-bottom",
-      "categories": ["Alignment"],
-      "description": "Indicates a bottom alignment"
-    },
-    {
-      "name": "align-bottom-center",
-      "categories": ["Alignment"],
-      "description": "Indicates a bottom-center alignment"
-    },
-    {
-      "name": "align-bottom-left",
-      "categories": ["Alignment"],
-      "description": "Indicates a bottom-left alignment"
-    },
-    {
-      "name": "align-bottom-right",
-      "categories": ["Alignment"],
-      "description": "Indicates a bottom-right alignment"
-    },
-    {
-      "name": "align-middle",
-      "categories": ["Alignment"],
-      "description": "Indicates a middle alignment"
-    },
-    {
-      "name": "align-top",
-      "categories": ["Alignment"],
-      "description": "Indicates a top alignment"
-    },
-    {
-      "name": "align-top-center",
-      "categories": ["Alignment"],
-      "description": "Indicates a top-center alignment"
-    },
-    {
-      "name": "align-top-left",
-      "categories": ["Alignment"],
-      "description": "Indicates a top-left alignment"
-    },
-    {
-      "name": "align-top-right",
-      "categories": ["Alignment"],
-      "description": "Indicates a top-right alignment"
-    },
-    {
-      "name": "arrow-back",
-      "categories": ["Arrows", "Platform specific"],
-      "description": "On iOS, indicates backward movement"
-    },
-    {
-      "name": "arrow-circle-down",
-      "categories": ["Arrows"]
-    },
-    {
-      "name": "arrow-circle-forward",
-      "categories": ["Arrows"],
-      "description": "Indicates a forward movement"
-    },
-    {
-      "name": "arrow-circle-left",
-      "categories": ["Arrows"],
-      "description": "Indicates a backward movement"
-    },
-    {
-      "name": "arrow-circle-up",
-      "categories": ["Arrows"],
-      "description": "Indicates the ability to choose a file to upload"
-    },
-    {
-      "name": "arrow-counter-clockwise",
-      "categories": ["Arrows"],
-      "description": "Indicates a backward action"
-    },
-    {
-      "name": "arrow-down",
-      "categories": ["Arrows"],
-      "description": "Indicates a list or more content available to view/expand"
-    },
-    {
-      "name": "arrow-end",
-      "categories": ["Arrows"],
-      "description": "Indicates the end of a sequence in a list of items or pages"
-    },
-    {
-      "name": "arrow-forward",
-      "categories": ["Arrows"],
-      "description": "Indicates the ability to move forward"
-    },
-    {
-      "name": "arrow-start",
-      "categories": ["Arrows"],
-      "description": "Indicates the beginning of a sequence in a list of items or pages"
-    },
-    {
-      "name": "arrow-up",
-      "categories": ["Arrows"],
-      "description": "Indicates an expanded content is being displayed"
-    },
-    {
-      "name": "arrow-up-left",
-      "categories": ["Arrows"],
-      "description": "Indicates going to a previous content/page"
-    },
-    {
-      "name": "arrow-up-right",
-      "categories": ["Arrows"],
-      "description": "Indicates going to a different content/page when inside of a dropdown list"
-    },
-    {
-      "name": "scale",
-      "categories": ["Arrows", "Utility and tools"],
-      "description": "Indicates the ability to scale an image"
-    },
-    {
-      "name": "switch-account",
-      "categories": ["Arrows"],
-      "description": "Indicates the ability to reorder pages"
-    },
-    {
-      "name": "minimize",
-      "categories": ["Arrows", "Utility and tools"],
-      "description": "Indicates the ability to minimize the view"
-    },
-    {
-      "name": "maximize",
-      "categories": ["Arrows", "Utility and tools"],
-      "description": "Indicates the ability to maximize the view"
-    },
-    {
-      "name": "chevron-up-circle",
-      "categories": ["Arrows"],
-      "description": "Indicates an expanded content is being displayed. Background is needed to emphasize visibility"
-    },
-    {
-      "name": "directional-arrow-left",
-      "categories": ["Arrows", "Platform specific"],
-      "description": "On Android, indicates backward movement. Also used on web to indicate backward movement"
-    },
-    {
-      "name": "directional-arrow-right",
-      "categories": ["Arrows"],
-      "description": "Indicates forward movement"
-    },
-    {
-      "name": "sort-ascending",
-      "categories": ["Arrows"],
-      "description": "Indicates the ability to sort a list in an ascending format"
-    },
-    {
-      "name": "sort-descending",
-      "categories": ["Arrows"],
-      "description": "Indicates the ability to sort a list in a descending format"
-    },
-    {
-      "name": "camera",
-      "categories": ["Media controls"],
-      "description": "Indicates the ability to open the camera settings"
-    },
-    {
-      "name": "camera-roll",
-      "categories": ["Media controls"],
-      "description": "Indicates the camera-roll content"
-    },
-    {
-      "name": "captions",
-      "categories": ["Media controls"],
-      "description": "Indicates the ability to show or hide captions in a video context"
-    },
-    {
-      "name": "forward",
-      "categories": ["Media controls"],
-      "description": "Indicates a forward movement in a video context"
-    },
-    {
-      "name": "flash",
-      "categories": ["Media controls"],
-      "description": "Indicates the ability to enable a flash feature"
-    },
-    {
-      "name": "mute",
-      "categories": ["Media controls", "Toggle"],
-      "description": "Indicates the ability to mute the audio"
-    },
-    {
-      "name": "music-off",
-      "categories": ["Media controls", "Toggle"],
-      "description": "Indicates the ability to turn the music off"
-    },
-    {
-      "name": "music-on",
-      "categories": ["Media controls", "Toggle"],
-      "description": "Indicates the ability to turn the music on"
-    },
-    {
-      "name": "pause",
-      "categories": ["Media controls"],
-      "description": "Indicates the ability to pause video or audio"
-    },
-    {
-      "name": "play",
-      "categories": ["Media controls"],
-      "description": "Indicates the ability to play a video"
-    },
-    {
-      "name": "rewind",
-      "categories": ["Media controls"],
-      "description": "Indicates the ability to rewind a video content"
-    },
-    {
-      "name": "sound",
-      "categories": ["Media controls", "Toggle"],
-      "description": "Indicates the ability to turn the audio on"
-    },
-    {
-      "name": "video-camera",
-      "categories": ["Media controls"],
-      "description": "Indicates the ability to use a video camera"
-    },
-    {
-      "name": "android-share",
-      "categories": ["Platform specific"],
-      "description": "On Android, indicates the ability to share an element"
-    },
-    {
-      "name": "check",
-      "categories": ["Platform specific"],
-      "description": "Instead of a radio button on iOS, use the check icon"
-    },
-    {
-      "name": "hand-pointing",
-      "categories": ["Platform specific"],
-      "description": "Indicates a hand point gesture"
-    },
-    {
-      "name": "share",
-      "categories": ["Platform specific"],
-      "description": "On iOS, indicates the ability to share an element"
-    },
-    {
-      "name": "send",
-      "categories": ["Platform specific"],
-      "description": "Indicates the ability to send a message"
-    },
-    {
-      "name": "face-happy",
-      "categories": ["Reactions and ratings"],
-      "description": "Indicates a super happy feeling or satisfied opinion"
-    },
-    {
-      "name": "face-neutral",
-      "categories": ["Reactions and ratings"],
-      "description": "Indicates a neutral feeling or opinion"
-    },
-    {
-      "name": "face-sad",
-      "categories": ["Reactions and ratings"],
-      "description": "Indicates a sad/unsatisfied feeling or opinion"
-    },
-    {
-      "name": "face-smiley",
-      "categories": ["Reactions and ratings"],
-      "description": "Indicates a mild happy feeling or opinion"
-    },
-    {
-      "name": "heart",
-      "categories": ["Reactions and ratings", "Toggle"],
-      "description": "Indicates a loved feedback"
-    },
-    {
-      "name": "heart-outline",
-      "categories": ["Reactions and ratings", "Toggle"],
-      "description": "Indicates an unselected love reaction"
-    },
-    {
-      "name": "heart-broken",
-      "categories": ["Reactions and ratings", "Toggle"],
-      "description": "Indicates a heart-broken reaction"
-    },
-    {
-      "name": "star",
-      "categories": ["Reactions and ratings"],
-      "description": "Indicates the ability to add to favorites, or to represent a review rating"
-    },
-    {
-      "name": "star-half",
-      "categories": ["Reactions and ratings"],
-      "description": "Indicates a half-star review rating"
-    },
-    {
-      "name": "smiley",
-      "categories": ["Reactions and ratings"],
-      "description": "Indicates a mild happy reaction"
-    },
-    {
-      "name": "smiley-outline",
-      "categories": ["Reactions and ratings"],
-      "description": "Indicates an unselected mild happy reaction"
-    },
-    {
-      "name": "facebook",
-      "categories": ["Social"],
-      "description": "Indicates a Facebook service"
-    },
-    {
-      "name": "gmail",
-      "categories": ["Social"],
-      "description": "Indicates a Gmail service"
-    },
-    {
-      "name": "google-plus",
-      "categories": ["Social"],
-      "description": "Indicates a Google Plus service"
-    },
-    {
-      "name": "twitter",
-      "categories": ["Social"],
-      "description": "Indicates a Twitter service"
-    },
-    {
-      "name": "pinterest",
-      "categories": ["Social", "Utility and tools"],
-      "description": "Indicates the Pinterest logo"
-    },
-    {
-      "name": "workflow-status-all",
-      "categories": ["Status"],
-      "description": "Indicates the workflow status all"
-    },
-    {
-      "name": "workflow-status-canceled",
-      "categories": ["Status"],
-      "description": "Indicates an element's state as canceled"
-    },
-    {
-      "name": "workflow-status-halted",
-      "categories": ["Status"],
-      "description": "Indicates an element's state as halted"
-    },
-    {
-      "name": "workflow-status-in-progress",
-      "categories": ["Status"],
-      "description": "Indicates an element's state as in progress"
-    },
-    {
-      "name": "workflow-status-ok",
-      "categories": ["Status"],
-      "description": "Indicates an element's state as completed or a success"
-    },
-    {
-      "name": "workflow-status-problem",
-      "categories": ["Status"],
-      "description": "Indicates an element's state as a problem or to convey an error"
-    },
-    {
-      "name": "workflow-status-unstarted",
-      "categories": ["Status"],
-      "description": "Indicates an element's state as unstarted"
-    },
-    {
-      "name": "workflow-status-warning",
-      "categories": ["Status"],
-      "description": "Indicates an element's state as warning"
-    },
-    {
-      "name": "alphabetical",
-      "categories": ["Text"],
-      "description": "Indicates an alphabetical list"
-    },
-    {
-      "name": "text-align-center",
-      "categories": ["Text"],
-      "description": "Indicates a text centered-alignment"
-    },
-    {
-      "name": "text-align-left",
-      "categories": ["Text"],
-      "description": "Indicates a text left-alignment"
-    },
-    {
-      "name": "text-align-right",
-      "categories": ["Text"],
-      "description": "Indicates a text right-alignment"
-    },
-    {
-      "name": "text-all-caps",
-      "categories": ["Text"],
-      "description": "Indicates all caps text format"
-    },
-    {
-      "name": "text-extra-small",
-      "categories": ["Text"],
-      "description": "Indicates an extra-small text size"
-    },
-    {
-      "name": "text-large",
-      "categories": ["Text"],
-      "description": "Indicates a large text size"
-    },
-    {
-      "name": "text-line-height",
-      "categories": ["Text"],
-      "description": "Indicates the ability to change a text line-height"
-    },
-    {
-      "name": "text-medium",
-      "categories": ["Text"],
-      "description": "Indicates a medium text size"
-    },
-    {
-      "name": "overlay-text",
-      "categories": ["Text"],
-      "description": "Indicates text overlay settings"
-    },
-    {
-      "name": "text-sentence-case",
-      "categories": ["Text"],
-      "description": "Indicates text sentence case format"
-    },
-    {
-      "name": "text-size",
-      "categories": ["Text"],
-      "description": "Indicates the ability to change the text size settings"
-    },
-    {
-      "name": "text-small",
-      "categories": ["Text"],
-      "description": "Indicates a small text size"
-    },
-    {
-      "name": "text-spacing",
-      "categories": ["Text"],
-      "description": "Indicates the ability to change text spacing between characters"
-    },
-    {
-      "name": "calendar",
-      "categories": ["Time"],
-      "description": "Indicates date selection"
-    },
-    {
-      "name": "clock",
-      "categories": ["Time"],
-      "description": "Indicates time"
-    },
-    {
-      "name": "history",
-      "categories": ["Time"],
-      "description": "Indicates history view"
-    },
-    {
-      "name": "eye",
-      "categories": ["Toggle"],
-      "description": "Indicates the ability to view data, or convey a number of views"
-    },
-    {
-      "name": "eye-hide",
-      "categories": ["Toggle"],
-      "description": "Indicates the ability to hide items, such as passwords or confidential information"
-    },
-    {
-      "name": "globe",
-      "categories": ["Toggle"],
-      "description": "Indicates the ability to claim a website account"
-    },
-    {
-      "name": "globe-checked",
-      "categories": ["Toggle"],
-      "description": "Indicates a profile-verified URL"
-    },
-    {
       "name": "360",
-      "categories": ["Utility and tools"]
+      "categories": ["Utility and tools"],
+      "keywords": ["label-360", "view"]
     },
     {
       "name": "accessibility",
       "categories": ["Utility and tools"],
-      "description": "Indicates accessibility features or adjustments"
+      "description": "Indicates accessibility features or adjustments",
+      "keywords": ["a11y", "ally"]
     },
     {
-      "name": "apps",
-      "categories": ["Utility and tools"],
-      "description": "Indicates a collection of apps"
+      "name": "ad",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates an ad type",
+      "keywords": ["promotion", "campaign"]
+    },
+    {
+      "name": "ad-group",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates a group of ads accounts",
+      "keywords": ["ads", "promotions", "campaigns"]
+    },
+    {
+      "name": "add",
+      "categories": ["Add"],
+      "description": "Indicates the ability to create or add content",
+      "keywords": ["plus", "create", "new"]
+    },
+    {
+      "name": "add-circle",
+      "categories": ["Add"],
+      "description": "Indicates the ability to display more content or additional information",
+      "keywords": ["plus-circle", "create", "new"]
+    },
+    {
+      "name": "add-layout",
+      "categories": ["Add"],
+      "description": "Indicates the ability to choose a new file and create a layout",
+      "keywords": ["plus-layout", "create", "new"]
+    },
+    {
+      "name": "add-person",
+      "categories": ["Add"],
+      "description": "Indicates the ability to add a new person/collaborator",
+      "keywords": ["plus-person", "collaborator", "create", "new", "share"]
+    },
+    {
+      "name": "add-pin",
+      "categories": ["Add"],
+      "description": "Indicates the ability to send a Pin",
+      "keywords": ["plus-pin", "create", "new"]
+    },
+    {
+      "name": "ads-overview",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates ads overview",
+      "keywords": ["dashboard", "summary", "measurement"]
+    },
+    {
+      "name": "ads-stats",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates ads stats",
+      "keywords": ["data", "metrics"]
     },
     {
       "name": "alert",
       "categories": ["Utility and tools"],
-      "description": "Indicates an alert message bringing awareness to an important content"
+      "description": "Indicates an alert message bringing awareness to an important content",
+      "keywords": ["exclamation", "awareness", "warning", "error"]
+    },
+    {
+      "name": "align-bottom",
+      "categories": ["Alignment"],
+      "description": "Indicates a bottom alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "align-bottom-center",
+      "categories": ["Alignment"],
+      "description": "Indicates a bottom-center alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "align-bottom-left",
+      "categories": ["Alignment"],
+      "description": "Indicates a bottom-left alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "align-bottom-right",
+      "categories": ["Alignment"],
+      "description": "Indicates a bottom-right alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "align-middle",
+      "categories": ["Alignment"],
+      "description": "Indicates a middle alignment",
+      "keywords": ["formatting", "center"]
+    },
+    {
+      "name": "align-top",
+      "categories": ["Alignment"],
+      "description": "Indicates a top alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "align-top-center",
+      "categories": ["Alignment"],
+      "description": "Indicates a top-center alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "align-top-left",
+      "categories": ["Alignment"],
+      "description": "Indicates a top-left alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "align-top-right",
+      "categories": ["Alignment"],
+      "description": "Indicates a top-right alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "alphabetical",
+      "categories": ["Text"],
+      "description": "Indicates an alphabetical list",
+      "keywords": ["text", "sequence", "letter", "formatting"]
+    },
+    {
+      "name": "android-share",
+      "categories": ["Platform specific"],
+      "description": "On Android, indicates the ability to share an element",
+      "keywords": ["send"]
     },
     {
       "name": "angled-pin",
       "categories": ["Utility and tools"],
-      "description": "Indicates the number of times a Pin was saved to a board"
+      "description": "Indicates the number of times a Pin was saved to a board",
+      "keywords": ["diagonal"]
+    },
+    {
+      "name": "apps",
+      "categories": ["Utility and tools"],
+      "description": "Indicates a collection of apps",
+      "keywords": ["list", "waffle", "grid"]
+    },
+    {
+      "name": "arrow-back",
+      "categories": ["Arrows", "Platform specific"],
+      "description": "On iOS, indicates backward movement",
+      "keywords": ["previous", "left", "chevron"]
+    },
+    {
+      "name": "arrow-circle-down",
+      "categories": ["Arrows"],
+      "keywords": []
+    },
+    {
+      "name": "arrow-circle-forward",
+      "categories": ["Arrows"],
+      "description": "Indicates a forward movement",
+      "keywords": ["next", "go"]
+    },
+    {
+      "name": "arrow-circle-left",
+      "categories": ["Arrows"],
+      "description": "Indicates a backward movement",
+      "keywords": ["previous", "back"]
+    },
+    {
+      "name": "arrow-circle-up",
+      "categories": ["Arrows"],
+      "description": "Indicates the ability to choose a file to upload",
+      "keywords": ["import", "upload"]
+    },
+    {
+      "name": "arrow-counter-clockwise",
+      "categories": ["Arrows"],
+      "description": "Indicates a backward action",
+      "keywords": ["reset", "refresh"]
+    },
+    {
+      "name": "arrow-down",
+      "categories": ["Arrows"],
+      "description": "Indicates a list or more content available to view/expand",
+      "keywords": ["chevron", "expand"]
+    },
+    {
+      "name": "arrow-end",
+      "categories": ["Arrows"],
+      "description": "Indicates the end of a sequence in a list of items or pages",
+      "keywords": ["last", "skip", "end", "forward"]
+    },
+    {
+      "name": "arrow-forward",
+      "categories": ["Arrows"],
+      "description": "Indicates the ability to move forward",
+      "keywords": ["next", "chevron", "right"]
+    },
+    {
+      "name": "arrow-start",
+      "categories": ["Arrows"],
+      "description": "Indicates the beginning of a sequence in a list of items or pages",
+      "keywords": ["first", "start", "beginning", "rewind", "back", "skip"]
+    },
+    {
+      "name": "arrow-up",
+      "categories": ["Arrows"],
+      "description": "Indicates an expanded content is being displayed",
+      "keywords": ["collapse", "chevron"]
+    },
+    {
+      "name": "arrow-up-left",
+      "categories": ["Arrows"],
+      "description": "Indicates going to a previous content/page",
+      "keywords": ["angled"]
+    },
+    {
+      "name": "arrow-up-right",
+      "categories": ["Arrows"],
+      "description": "Indicates going to a different content/page when inside of a dropdown list",
+      "keywords": ["angled"]
     },
     {
       "name": "bell",
       "categories": ["Utility and tools"],
-      "description": "Indicates notifications"
+      "description": "Indicates notifications",
+      "keywords": ["notifications"]
+    },
+    {
+      "name": "calendar",
+      "categories": ["Time"],
+      "description": "Indicates date selection",
+      "keywords": ["date", "schedule", "time"]
+    },
+    {
+      "name": "camera",
+      "categories": ["Media controls"],
+      "description": "Indicates the ability to open the camera settings",
+      "keywords": ["photo", "thumbnail", "picture", "image"]
+    },
+    {
+      "name": "camera-roll",
+      "categories": ["Media controls"],
+      "description": "Indicates the camera-roll content",
+      "keywords": ["image", "photo", "picture", "image"]
     },
     {
       "name": "cancel",
       "categories": ["Utility and tools"],
-      "description": "Indicates closing or dismissing a message"
+      "description": "Indicates closing or dismissing a message",
+      "keywords": ["close", "dismiss", "back", "x"]
     },
     {
       "name": "canonical-pin",
       "categories": ["Utility and tools"],
-      "description": "Indicates a list/sequence of saved Pins"
+      "description": "Indicates a list/sequence of saved Pins",
+      "keywords": []
+    },
+    {
+      "name": "captions",
+      "categories": ["Media controls"],
+      "description": "Indicates the ability to show or hide captions in a video context",
+      "keywords": ["subtitles"]
+    },
+    {
+      "name": "check",
+      "categories": ["Platform specific"],
+      "description": "Instead of a radio button on iOS, use the check icon",
+      "keywords": ["done", "completed", "success", "selected"]
     },
     {
       "name": "check-circle",
       "categories": ["Utility and tools"],
-      "description": "Indicates a to-do list"
+      "description": "Indicates a to-do list",
+      "keywords": ["done", "completed", "success", "selected"]
+    },
+    {
+      "name": "chevron-up-circle",
+      "categories": ["Arrows"],
+      "description": "Indicates an expanded content is being displayed. Background is needed to emphasize visibility",
+      "keywords": ["arrow"]
     },
     {
       "name": "clear",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to clear the entered text in form elements"
+      "description": "Indicates the ability to clear the entered text in form elements",
+      "keywords": ["erase", "x", "delete"]
+    },
+    {
+      "name": "clock",
+      "categories": ["Time"],
+      "description": "Indicates time",
+      "keywords": ["time", "schedule"]
     },
     {
       "name": "code",
       "categories": ["Utility and tools"],
-      "description": "Indicates a code view or connection"
+      "description": "Indicates a code view or connection",
+      "keywords": ["insert", "tag", "developer", "development"]
     },
     {
       "name": "cog",
       "categories": ["Utility and tools"],
-      "description": "Indicates setting options are available"
+      "description": "Indicates setting options are available",
+      "keywords": ["settings", "gear", "nut"]
     },
     {
       "name": "color-picker",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to pick a specific color"
+      "description": "Indicates the ability to pick a specific color",
+      "keywords": ["eyedropper"]
     },
     {
       "name": "color-solid",
       "categories": ["Utility and tools"],
-      "description": "Indicates a solid color"
+      "description": "Indicates a solid color",
+      "keywords": ["swatch"]
     },
     {
       "name": "color-split",
       "categories": ["Utility and tools"],
-      "description": "Indicates color split"
+      "description": "Indicates color split",
+      "keywords": ["dual"]
     },
     {
       "name": "compass",
       "categories": ["Utility and tools"],
-      "description": "Indicates directions"
+      "description": "Indicates directions",
+      "keywords": ["direction", "explore"]
     },
     {
       "name": "compose",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to compose a new content"
+      "description": "Indicates the ability to compose a new content",
+      "keywords": ["new", "note", "write", "edit", "pencil"]
     },
     {
       "name": "conversion-tag",
       "categories": ["Utility and tools"],
-      "description": "Indicates code sources or API references"
+      "description": "Indicates code sources or API references",
+      "keywords": ["code", "api"]
     },
     {
       "name": "copy-to-clipboard",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to copy items to clipboard"
+      "description": "Indicates the ability to copy items to clipboard",
+      "keywords": ["duplicate"]
     },
     {
       "name": "credit-card",
       "categories": ["Utility and tools"],
-      "description": "Indicates a credit card option is available as a payment method"
+      "description": "Indicates a credit card option is available as a payment method",
+      "keywords": ["payment"]
     },
     {
       "name": "crop",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to crop an image"
+      "description": "Indicates the ability to crop an image",
+      "keywords": ["cut", "edit"]
     },
     {
       "name": "dash",
       "categories": ["Utility and tools"],
-      "description": "Indicates there isn't data/numbers to show"
+      "description": "Indicates there isn't data/numbers to show",
+      "keywords": ["minus", "empty", "remove"]
+    },
+    {
+      "name": "directional-arrow-left",
+      "categories": ["Arrows", "Platform specific"],
+      "description": "On Android, indicates backward movement. Also used on web to indicate backward movement",
+      "keywords": ["previous", "backward"]
+    },
+    {
+      "name": "directional-arrow-right",
+      "categories": ["Arrows"],
+      "description": "Indicates forward movement",
+      "keywords": ["next", "forward"]
     },
     {
       "name": "download",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to download items"
+      "description": "Indicates the ability to download items",
+      "keywords": ["save"]
     },
     {
       "name": "drag-drop",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to drag and drop items"
+      "description": "Indicates the ability to drag and drop items",
+      "keywords": ["move", "drag and drop"]
     },
     {
       "name": "duplicate",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to duplicate an element or asset"
+      "description": "Indicates the ability to duplicate an element or asset",
+      "keywords": ["copy", "add"]
     },
     {
       "name": "edit",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to edit something"
+      "description": "Indicates the ability to edit something",
+      "keywords": ["pencil", "write"]
     },
     {
       "name": "ellipsis",
       "categories": ["Utility and tools"],
-      "description": "Indicates an overflow menu"
+      "description": "Indicates an overflow menu",
+      "keywords": ["kebab", "more", "overflow", "menu", "meatballs"]
     },
     {
       "name": "ellipsis-circle-outline",
       "categories": ["Utility and tools"],
-      "description": "Indicates an overflow menu"
+      "description": "Indicates an overflow menu",
+      "keywords": ["kebab", "more", "overflow", "menu", "meatballs"]
     },
     {
       "name": "envelope",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to send content"
+      "description": "Indicates the ability to send content",
+      "keywords": ["mail", "send"]
+    },
+    {
+      "name": "eye",
+      "categories": ["Toggle"],
+      "description": "Indicates the ability to view data, or convey a number of views",
+      "keywords": ["view", "preview"]
+    },
+    {
+      "name": "eye-hide",
+      "categories": ["Toggle"],
+      "description": "Indicates the ability to hide items, such as passwords or confidential information",
+      "keywords": ["hide", "view", "privacy"]
+    },
+    {
+      "name": "face-happy",
+      "categories": ["Reactions and ratings"],
+      "description": "Indicates a super happy feeling or satisfied opinion",
+      "keywords": ["laugh", "excited", "smile"]
+    },
+    {
+      "name": "face-neutral",
+      "categories": ["Reactions and ratings"],
+      "description": "Indicates a neutral feeling or opinion",
+      "keywords": ["reaction", "impartial"]
+    },
+    {
+      "name": "face-sad",
+      "categories": ["Reactions and ratings"],
+      "description": "Indicates a sad/unsatisfied feeling or opinion",
+      "keywords": ["unhappy", "disappointed"]
+    },
+    {
+      "name": "face-smiley",
+      "categories": ["Reactions and ratings"],
+      "description": "Indicates a mild happy feeling or opinion",
+      "keywords": ["happy"]
+    },
+    {
+      "name": "facebook",
+      "categories": ["Social"],
+      "description": "Indicates a Facebook service",
+      "keywords": ["logo", "social media"]
     },
     {
       "name": "file-box",
       "categories": ["Utility and tools"],
-      "description": "Indicates a file box collection"
+      "description": "Indicates a file box collection",
+      "keywords": ["folder", "document", "archive"]
     },
     {
       "name": "file-unknown",
       "categories": ["Utility and tools"],
-      "description": "Indicates an unknown file"
+      "description": "Indicates an unknown file",
+      "keywords": ["document"]
     },
     {
       "name": "fill-opaque",
       "categories": ["Utility and tools"],
-      "description": "Indicates an opaque fill"
+      "description": "Indicates an opaque fill",
+      "keywords": ["solid"]
     },
     {
       "name": "fill-transparent",
       "categories": ["Utility and tools"],
-      "description": "Indicates a transparent fill"
+      "description": "Indicates a transparent fill",
+      "keywords": ["sheer", "opacity"]
     },
     {
       "name": "filter",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to filter options"
-    },
-    {
-      "name": "folder",
-      "categories": ["Utility and tools"],
-      "description": "Indicates a folder storage"
+      "description": "Indicates the ability to filter options",
+      "keywords": ["refine"]
     },
     {
       "name": "flag",
       "categories": ["Utility and tools"],
-      "description": "Indicates a flagged item"
+      "description": "Indicates a flagged item",
+      "keywords": ["priority", "highlight"]
+    },
+    {
+      "name": "flash",
+      "categories": ["Media controls"],
+      "description": "Indicates the ability to enable a flash feature",
+      "keywords": ["lightning", "bolt", "activity", "lightening"]
     },
     {
       "name": "flashlight",
       "categories": ["Utility and tools"],
-      "description": "Indicates a visual search feature"
+      "description": "Indicates a visual search feature",
+      "keywords": ["search", "visual", "magnifier"]
     },
     {
       "name": "flipHorizontal",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to flip an image horizontally"
+      "description": "Indicates the ability to flip an image horizontally",
+      "keywords": ["orientation"]
     },
     {
       "name": "flipVertical",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to flip an image vertically"
+      "description": "Indicates the ability to flip an image vertically",
+      "keywords": ["orientation"]
+    },
+    {
+      "name": "folder",
+      "categories": ["Utility and tools"],
+      "description": "Indicates a folder storage",
+      "keywords": ["files", "projects"]
+    },
+    {
+      "name": "forward",
+      "categories": ["Media controls"],
+      "description": "Indicates a forward movement in a video context",
+      "keywords": ["advance"]
     },
     {
       "name": "gif",
       "categories": ["Utility and tools"],
-      "description": "Indicates a GIF media"
+      "description": "Indicates a GIF media",
+      "keywords": ["media", "animated", "image"]
+    },
+    {
+      "name": "globe",
+      "categories": ["Toggle"],
+      "description": "Indicates the ability to claim a website account",
+      "keywords": [
+        "URL",
+        "profile",
+        "merchant",
+        "global",
+        "internet",
+        "website",
+        "world",
+        "sphere"
+      ]
+    },
+    {
+      "name": "globe-checked",
+      "categories": ["Toggle"],
+      "description": "Indicates a profile-verified URL",
+      "keywords": [
+        "URL",
+        "profile",
+        "merchant",
+        "success",
+        "done",
+        "completed",
+        "global",
+        "internet",
+        "website",
+        "world",
+        "sphere"
+      ]
+    },
+    {
+      "name": "gmail",
+      "categories": ["Social"],
+      "description": "Indicates a Gmail service",
+      "keywords": ["logo", "share", "email", "send"]
+    },
+    {
+      "name": "google-plus",
+      "categories": ["Social"],
+      "description": "Indicates a Google Plus service",
+      "keywords": []
+    },
+    {
+      "name": "graph-bar",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates a graph-bar data format",
+      "keywords": [
+        "chart",
+        "column",
+        "bar",
+        "metrics",
+        "analytics",
+        "measurement"
+      ]
+    },
+    {
+      "name": "graph-pie",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates a graph-pie data format",
+      "keywords": [
+        "chart",
+        "wedge",
+        "pie",
+        "metrics",
+        "analytics",
+        "measurement"
+      ]
+    },
+    {
+      "name": "hand-pointing",
+      "categories": ["Platform specific"],
+      "description": "Indicates a hand point gesture",
+      "keywords": ["gesture", "cursor"]
     },
     {
       "name": "handle",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to reorder elements"
+      "description": "Indicates the ability to reorder elements",
+      "keywords": ["move", "drag", "organize", "rearrange"]
+    },
+    {
+      "name": "heart",
+      "categories": ["Reactions and ratings", "Toggle"],
+      "description": "Indicates a loved feedback",
+      "keywords": ["love", "like"]
+    },
+    {
+      "name": "heart-broken",
+      "categories": ["Reactions and ratings", "Toggle"],
+      "description": "Indicates a heart-broken reaction",
+      "keywords": ["love", "dislike"]
+    },
+    {
+      "name": "heart-outline",
+      "categories": ["Reactions and ratings", "Toggle"],
+      "description": "Indicates an unselected love reaction",
+      "keywords": ["love", "like"]
+    },
+    {
+      "name": "history",
+      "categories": ["Time"],
+      "description": "Indicates history view",
+      "keywords": ["viewed", "versions", "time"]
     },
     {
       "name": "home",
       "categories": ["Utility and tools"],
-      "description": "Indicates a home screen or feed"
+      "description": "Indicates a home screen or feed",
+      "keywords": ["main", "house"]
     },
     {
       "name": "idea-pin",
       "categories": ["Utility and tools"],
-      "description": "Indicates IdeaPin format"
+      "description": "Indicates IdeaPin format",
+      "keywords": ["stories"]
     },
     {
       "name": "impressum",
       "categories": ["Utility and tools"],
-      "description": "Indicates a legal statement of ownership/authorship"
+      "description": "Indicates a legal statement of ownership/authorship",
+      "keywords": []
     },
     {
       "name": "info-circle",
       "categories": ["Utility and tools"],
-      "description": "Indicates more information is available"
+      "description": "Indicates more information is available",
+      "keywords": ["assistance", "help", "more", "tooltip"]
+    },
+    {
+      "name": "insights-audience",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates insights from the audience",
+      "keywords": ["metrics", "users", "audience", "measurement"]
+    },
+    {
+      "name": "insights-conversions",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates insights conversion data",
+      "keywords": ["metrics", "measurement"]
     },
     {
       "name": "key",
       "categories": ["Utility and tools"],
-      "description": "Indicates keywords"
+      "description": "Indicates keywords",
+      "keywords": ["password", "confidential", "access"]
     },
     {
       "name": "knoop",
       "categories": ["Utility and tools"],
-      "description": "Indicates a loading behavior"
+      "description": "Indicates a loading behavior",
+      "keywords": ["loading", "button", "spinner"]
     },
     {
       "name": "layout",
       "categories": ["Utility and tools"],
-      "description": "Indicates a layout setting"
+      "description": "Indicates a layout setting",
+      "keywords": ["structure", "page", "grid"]
     },
     {
       "name": "lightbulb",
       "categories": ["Utility and tools"],
-      "description": "Indicates insights or educational content such as trends"
+      "description": "Indicates insights or educational content such as trends",
+      "keywords": ["idea", "lamp", "insight"]
     },
     {
       "name": "lightning-bolt-circle",
       "categories": ["Utility and tools"],
-      "description": "Indicates service-amp is available"
-    },
-    {
-      "name": "lips",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to try a lipstick color"
+      "description": "Indicates service-amp is available",
+      "keywords": ["flash", "service", "bolt", "lightening"]
     },
     {
       "name": "link",
       "categories": ["Utility and tools"],
-      "description": "Indicates a link source, to copy a link to clipboard, or to jump into a new page section"
+      "description": "Indicates a link source, to copy a link to clipboard, or to jump into a new page section",
+      "keywords": ["chain", "section"]
+    },
+    {
+      "name": "lips",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to try a lipstick color",
+      "keywords": ["mouth", "lipstick"]
     },
     {
       "name": "location",
       "categories": ["Utility and tools"],
-      "description": "Indicates a location orientation"
+      "description": "Indicates a location orientation",
+      "keywords": ["map", "marker"]
     },
     {
       "name": "lock",
       "categories": ["Utility and tools"],
-      "description": "Indicates private content"
+      "description": "Indicates private content",
+      "keywords": ["private", "safe", "privacy"]
     },
     {
       "name": "logo-large",
       "categories": ["Utility and tools"],
-      "description": "Indicates a large logo size"
+      "description": "Indicates a large logo size",
+      "keywords": ["size"]
     },
     {
       "name": "logo-small",
       "categories": ["Utility and tools"],
-      "description": "Indicates a small logo size"
+      "description": "Indicates a small logo size",
+      "keywords": ["size"]
     },
     {
       "name": "logout",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to end access to a session"
-    },
-    {
-      "name": "megaphone",
-      "categories": ["Utility and tools"],
-      "description": "Indicates engagement or announcement"
-    },
-    {
-      "name": "menu",
-      "categories": ["Utility and tools"],
-      "description": "Indicates a condensed menu"
-    },
-    {
-      "name": "move",
-      "categories": ["Arrows", "Utility and tools"],
-      "description": "Indicates an ability to move an object"
-    },
-    {
-      "name": "people",
-      "categories": ["Utility and tools"],
-      "description": "Indicates users"
-    },
-    {
-      "name": "person",
-      "categories": ["Utility and tools"],
-      "description": "Indicates profile or a person"
-    },
-    {
-      "name": "phone",
-      "categories": ["Utility and tools"],
-      "description": "Indicates a phone service or number"
-    },
-    {
-      "name": "pin",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to save Pins"
-    },
-    {
-      "name": "pin-hide",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to hide a pin"
-    },
-    {
-      "name": "pincode",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to scan and open a Pincode"
-    },
-    {
-      "name": "protect",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the data or content is protected, or privacy"
-    },
-    {
-      "name": "publish",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to move Pins within sections/boards"
-    },
-    {
-      "name": "question-mark",
-      "categories": ["Utility and tools"],
-      "description": "Indicates help is available"
-    },
-    {
-      "name": "refresh",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to refresh content"
-    },
-    {
-      "name": "reorder-images",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to reorder images"
-    },
-    {
-      "name": "replace",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to replace an item, usually an image"
-    },
-    {
-      "name": "report",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to report an inappropriate content"
-    },
-    {
-      "name": "remove",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to remove an item"
-    },
-    {
-      "name": "rotate",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to rotate an element"
-    },
-    {
-      "name": "search",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to reorder images"
-    },
-    {
-      "name": "security",
-      "categories": ["Utility and tools"],
-      "description": "Indicates security standards"
-    },
-    {
-      "name": "shopping-bag",
-      "categories": ["Utility and tools"],
-      "description": "Indicates a shopping bag on shopping experience"
-    },
-    {
-      "name": "skintone",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to select skintones"
-    },
-    {
-      "name": "sparkle",
-      "categories": ["Utility and tools"],
-      "description": "Indicates more ideas and recommendations"
-    },
-    {
-      "name": "speech",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to comment"
-    },
-    {
-      "name": "speech-ellipsis",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the messages inbox"
-    },
-    {
-      "name": "speech-exclamation-point",
-      "categories": ["Utility and tools"],
-      "description": "Indicates an alert message"
-    },
-    {
-      "name": "story-pin",
-      "categories": ["Utility and tools"],
-      "description": "Indicates a Story Pin"
-    },
-    {
-      "name": "tag",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to view products and shop"
-    },
-    {
-      "name": "terms",
-      "categories": ["Utility and tools"],
-      "description": "Indicates terms and services"
-    },
-    {
-      "name": "trash-can",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to delete items"
-    },
-    {
-      "name": "upload-feed",
-      "categories": ["Utility and tools"],
-      "description": "Indicates the ability to upload the feed"
-    },
-    {
-      "name": "visit",
-      "categories": ["Utility and tools"],
-      "description": "Indicates an external link or domain"
+      "description": "Indicates the ability to end access to a session",
+      "keywords": ["power", "end"]
     },
     {
       "name": "margins-large",
       "categories": ["Utility and tools"],
-      "description": "Indicates a large margin configuration"
+      "description": "Indicates a large margin configuration",
+      "keywords": ["space", "page", "layout"]
     },
     {
       "name": "margins-medium",
       "categories": ["Utility and tools"],
-      "description": "Indicates a medium margin configuration"
+      "description": "Indicates a medium margin configuration",
+      "keywords": ["space", "page", "layout"]
     },
     {
       "name": "margins-small",
       "categories": ["Utility and tools"],
-      "description": "Indicates a small margin configuration"
+      "description": "Indicates a small margin configuration",
+      "keywords": ["space", "page", "layout"]
+    },
+    {
+      "name": "maximize",
+      "categories": ["Arrows", "Utility and tools"],
+      "description": "Indicates the ability to maximize the view",
+      "keywords": ["increase", "expand"]
+    },
+    {
+      "name": "megaphone",
+      "categories": ["Utility and tools"],
+      "description": "Indicates engagement or announcement",
+      "keywords": ["announcements", "engagement", "new", "speaker"]
+    },
+    {
+      "name": "menu",
+      "categories": ["Utility and tools"],
+      "description": "Indicates a condensed menu",
+      "keywords": ["hamburger", "overflow", "more"]
+    },
+    {
+      "name": "minimize",
+      "categories": ["Arrows", "Utility and tools"],
+      "description": "Indicates the ability to minimize the view",
+      "keywords": ["decrease", "shrink"]
+    },
+    {
+      "name": "move",
+      "categories": ["Arrows", "Utility and tools"],
+      "description": "Indicates an ability to move an object",
+      "keywords": ["arrange", "shift", "drag"]
+    },
+    {
+      "name": "music-off",
+      "categories": ["Media controls", "Toggle"],
+      "description": "Indicates the ability to turn the music off",
+      "keywords": ["sound", "off", "mute", "audio", "volume"]
+    },
+    {
+      "name": "music-on",
+      "categories": ["Media controls", "Toggle"],
+      "description": "Indicates the ability to turn the music on",
+      "keywords": ["sound", "on", "mute", "audio", "volume"]
+    },
+    {
+      "name": "mute",
+      "categories": ["Media controls", "Toggle"],
+      "description": "Indicates the ability to mute the audio",
+      "keywords": ["sound", "off", "audio", "volume"]
+    },
+    {
+      "name": "overlay-text",
+      "categories": ["Text"],
+      "description": "Indicates text overlay settings",
+      "keywords": []
+    },
+    {
+      "name": "overview",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates a dashboard overview",
+      "keywords": ["summary", "layout", "grid", "square"]
+    },
+    {
+      "name": "pause",
+      "categories": ["Media controls"],
+      "description": "Indicates the ability to pause video or audio",
+      "keywords": ["halt", "hold"]
+    },
+    {
+      "name": "people",
+      "categories": ["Utility and tools"],
+      "description": "Indicates users",
+      "keywords": ["users", "shared", "audience"]
+    },
+    {
+      "name": "person",
+      "categories": ["Utility and tools"],
+      "description": "Indicates profile or a person",
+      "keywords": ["user", "avatar", "profile", "audience"]
+    },
+    {
+      "name": "phone",
+      "categories": ["Utility and tools"],
+      "description": "Indicates a phone service or number",
+      "keywords": ["call"]
+    },
+    {
+      "name": "pin",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to save Pins",
+      "keywords": []
+    },
+    {
+      "name": "pin-hide",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to hide a pin",
+      "keywords": []
+    },
+    {
+      "name": "pincode",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to scan and open a Pincode",
+      "keywords": ["scan", "code"]
+    },
+    {
+      "name": "pinterest",
+      "categories": ["Social", "Utility and tools"],
+      "description": "Indicates the Pinterest logo",
+      "keywords": ["logo"]
+    },
+    {
+      "name": "play",
+      "categories": ["Media controls"],
+      "description": "Indicates the ability to play a video",
+      "keywords": ["start"]
+    },
+    {
+      "name": "protect",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the data or content is protected, or privacy",
+      "keywords": ["shield", "safe"]
+    },
+    {
+      "name": "publish",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to move Pins within sections/boards",
+      "keywords": ["move", "reorganize"]
+    },
+    {
+      "name": "question-mark",
+      "categories": ["Utility and tools"],
+      "description": "Indicates help is available",
+      "keywords": ["help", "support"]
+    },
+    {
+      "name": "refresh",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to refresh content",
+      "keywords": ["reload", "restart"]
+    },
+    {
+      "name": "remove",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to remove an item",
+      "keywords": ["delete"]
+    },
+    {
+      "name": "reorder-images",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to reorder images",
+      "keywords": ["reorganize"]
+    },
+    {
+      "name": "replace",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to replace an item, usually an image",
+      "keywords": ["change", "swap"]
+    },
+    {
+      "name": "report",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to report an inappropriate content",
+      "keywords": ["block", "disclose"]
+    },
+    {
+      "name": "rewind",
+      "categories": ["Media controls"],
+      "description": "Indicates the ability to rewind a video content",
+      "keywords": ["backwards", "beginning"]
+    },
+    {
+      "name": "rotate",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to rotate an element",
+      "keywords": ["turn", "orientation"]
+    },
+    {
+      "name": "scale",
+      "categories": ["Arrows", "Utility and tools"],
+      "description": "Indicates the ability to scale an image",
+      "keywords": ["enlarge", "amplify", "grow", "full size"]
+    },
+    {
+      "name": "search",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to reorder images",
+      "keywords": ["find", "magnifying glass"]
+    },
+    {
+      "name": "security",
+      "categories": ["Utility and tools"],
+      "description": "Indicates security standards",
+      "keywords": ["shield", "safe", "secure"]
+    },
+    {
+      "name": "send",
+      "categories": ["Platform specific"],
+      "description": "Indicates the ability to send a message",
+      "keywords": ["direct", "paper airplane", "share"]
+    },
+    {
+      "name": "share",
+      "categories": ["Platform specific"],
+      "description": "On iOS, indicates the ability to share an element",
+      "keywords": ["send"]
+    },
+    {
+      "name": "shopping-bag",
+      "categories": ["Utility and tools"],
+      "description": "Indicates a shopping bag on shopping experience",
+      "keywords": ["cart", "buying"]
+    },
+    {
+      "name": "skintone",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to select skintones",
+      "keywords": []
+    },
+    {
+      "name": "smiley",
+      "categories": ["Reactions and ratings"],
+      "description": "Indicates a mild happy reaction",
+      "keywords": ["happy"]
+    },
+    {
+      "name": "smiley-outline",
+      "categories": ["Reactions and ratings"],
+      "description": "Indicates an unselected mild happy reaction",
+      "keywords": ["happy"]
+    },
+    {
+      "name": "sort-ascending",
+      "categories": ["Arrows"],
+      "description": "Indicates the ability to sort a list in an ascending format",
+      "keywords": ["arrow", "order"]
+    },
+    {
+      "name": "sort-descending",
+      "categories": ["Arrows"],
+      "description": "Indicates the ability to sort a list in a descending format",
+      "keywords": ["arrow", "order"]
+    },
+    {
+      "name": "sound",
+      "categories": ["Media controls", "Toggle"],
+      "description": "Indicates the ability to turn the audio on",
+      "keywords": ["audio", "volume"]
+    },
+    {
+      "name": "sparkle",
+      "categories": ["Utility and tools"],
+      "description": "Indicates more ideas and recommendations",
+      "keywords": ["shine", "recommendation", "idea"]
+    },
+    {
+      "name": "speech",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to comment",
+      "keywords": ["chat", "message"]
+    },
+    {
+      "name": "speech-ellipsis",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the messages inbox",
+      "keywords": ["chat", "message", "inbox"]
+    },
+    {
+      "name": "speech-exclamation-point",
+      "categories": ["Utility and tools"],
+      "description": "Indicates an alert message",
+      "keywords": ["chat", "message", "alert"]
+    },
+    {
+      "name": "star",
+      "categories": ["Reactions and ratings"],
+      "description": "Indicates the ability to add to favorites, or to represent a review rating",
+      "keywords": ["favorite", "rating", "review"]
+    },
+    {
+      "name": "star-half",
+      "categories": ["Reactions and ratings"],
+      "description": "Indicates a half-star review rating",
+      "keywords": ["rating", "review"]
+    },
+    {
+      "name": "story-pin",
+      "categories": ["Utility and tools"],
+      "description": "Indicates a Story Pin",
+      "keywords": []
+    },
+    {
+      "name": "switch-account",
+      "categories": ["Arrows"],
+      "description": "Indicates the ability to reorder pages",
+      "keywords": ["reorder", "arrows"]
+    },
+    {
+      "name": "tag",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to view products and shop",
+      "keywords": ["label", "shopping"]
+    },
+    {
+      "name": "target",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates the target audience",
+      "keywords": ["bullseye"]
+    },
+    {
+      "name": "terms",
+      "categories": ["Utility and tools"],
+      "description": "Indicates terms and services",
+      "keywords": ["list", "bullet points"]
+    },
+    {
+      "name": "text-align-center",
+      "categories": ["Text"],
+      "description": "Indicates a text centered-alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "text-align-left",
+      "categories": ["Text"],
+      "description": "Indicates a text left-alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "text-align-right",
+      "categories": ["Text"],
+      "description": "Indicates a text right-alignment",
+      "keywords": ["formatting"]
+    },
+    {
+      "name": "text-all-caps",
+      "categories": ["Text"],
+      "description": "Indicates all caps text format",
+      "keywords": ["uppercase"]
+    },
+    {
+      "name": "text-extra-small",
+      "categories": ["Text"],
+      "description": "Indicates an extra-small text size",
+      "keywords": ["font size", "typography"]
+    },
+    {
+      "name": "text-large",
+      "categories": ["Text"],
+      "description": "Indicates a large text size",
+      "keywords": ["font size", "typography"]
+    },
+    {
+      "name": "text-line-height",
+      "categories": ["Text"],
+      "description": "Indicates the ability to change a text line-height",
+      "keywords": ["typography"]
+    },
+    {
+      "name": "text-medium",
+      "categories": ["Text"],
+      "description": "Indicates a medium text size",
+      "keywords": ["font size", "typography"]
+    },
+    {
+      "name": "text-sentence-case",
+      "categories": ["Text"],
+      "description": "Indicates text sentence case format",
+      "keywords": ["mixed case"]
+    },
+    {
+      "name": "text-size",
+      "categories": ["Text"],
+      "description": "Indicates the ability to change the text size settings",
+      "keywords": ["font size", "typography"]
+    },
+    {
+      "name": "text-small",
+      "categories": ["Text"],
+      "description": "Indicates a small text size",
+      "keywords": ["font size", "typography"]
+    },
+    {
+      "name": "text-spacing",
+      "categories": ["Text"],
+      "description": "Indicates the ability to change text spacing between characters",
+      "keywords": ["kerning"]
+    },
+    {
+      "name": "trash-can",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to delete items",
+      "keywords": ["delete", "remove", "bin"]
+    },
+    {
+      "name": "trending",
+      "categories": ["Ads and measurements"],
+      "description": "Indicates trends",
+      "keywords": ["arrow up"]
+    },
+    {
+      "name": "twitter",
+      "categories": ["Social"],
+      "description": "Indicates a Twitter service",
+      "keywords": ["logo"]
+    },
+    {
+      "name": "upload-feed",
+      "categories": ["Utility and tools"],
+      "description": "Indicates the ability to upload the feed",
+      "keywords": []
+    },
+    {
+      "name": "video-camera",
+      "categories": ["Media controls"],
+      "description": "Indicates the ability to use a video camera",
+      "keywords": ["record"]
     },
     {
       "name": "view-type-default",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to change the view type to default"
+      "description": "Indicates the ability to change the view type to default",
+      "keywords": ["square", "grid"]
     },
     {
       "name": "view-type-dense",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to change the view type to dense"
+      "description": "Indicates the ability to change the view type to dense",
+      "keywords": ["square", "grid"]
     },
     {
       "name": "view-type-list",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to change the view type to a list"
+      "description": "Indicates the ability to change the view type to a list",
+      "keywords": []
     },
     {
       "name": "view-type-space",
       "categories": ["Utility and tools"],
-      "description": "Indicates the ability to change the view type to space"
+      "description": "Indicates the ability to change the view type to space",
+      "keywords": ["square"]
+    },
+    {
+      "name": "visit",
+      "categories": ["Utility and tools"],
+      "description": "Indicates an external link or domain",
+      "keywords": ["external", "link", "new window"]
+    },
+    {
+      "name": "workflow-status-all",
+      "categories": ["Status"],
+      "description": "Indicates the workflow status all",
+      "keywords": []
+    },
+    {
+      "name": "workflow-status-canceled",
+      "categories": ["Status"],
+      "description": "Indicates an element's state as canceled",
+      "keywords": ["abandon"]
+    },
+    {
+      "name": "workflow-status-halted",
+      "categories": ["Status"],
+      "description": "Indicates an element's state as halted",
+      "keywords": ["paused"]
+    },
+    {
+      "name": "workflow-status-in-progress",
+      "categories": ["Status"],
+      "description": "Indicates an element's state as in progress",
+      "keywords": ["processing"]
+    },
+    {
+      "name": "workflow-status-ok",
+      "categories": ["Status"],
+      "description": "Indicates an element's state as completed or a success",
+      "keywords": ["completed", "done", "success"]
+    },
+    {
+      "name": "workflow-status-problem",
+      "categories": ["Status"],
+      "description": "Indicates an element's state as a problem or to convey an error",
+      "keywords": ["error", "alert"]
+    },
+    {
+      "name": "workflow-status-unstarted",
+      "categories": ["Status"],
+      "description": "Indicates an element's state as unstarted",
+      "keywords": []
+    },
+    {
+      "name": "workflow-status-warning",
+      "categories": ["Status"],
+      "description": "Indicates an element's state as warning",
+      "keywords": ["error", "alert", "exclamation", "awareness"]
     }
   ]
 }

--- a/docs/pages/foundations/iconography/ICON_DATA.json.flow
+++ b/docs/pages/foundations/iconography/ICON_DATA.json.flow
@@ -21,5 +21,6 @@ declare module.exports: {|
       | 'Utility and tools'
     >,
     +description: ?string,
+    +keywords: Array<string>,
   |}>,
 |};

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -116,6 +116,15 @@ function findIconByCategory(icon?: string, category: string) {
   );
 }
 
+function iconHasKeyword(iconName?: string, searchTerm: string) {
+  return (
+    iconCategoryData.icons.find(
+      ({ name, keywords }) =>
+        name === iconName && keywords?.find((word) => word.includes(searchTerm)),
+    ) !== undefined
+  );
+}
+
 export default function IconPage(): Node {
   const [showToastText, setShowToastText] = useState(false);
 
@@ -138,7 +147,10 @@ export default function IconPage(): Node {
     setInputValue(value);
     setSuggestedOptions(
       value
-        ? iconOptions.filter(({ label }) => label.toLowerCase().includes(value.toLowerCase()))
+        ? iconOptions.filter(
+            ({ label }) =>
+              label.toLowerCase().includes(value.toLowerCase()) || iconHasKeyword(label, value),
+          )
         : iconOptions,
     );
   };


### PR DESCRIPTION
### Summary

#### What changed?

Add keywords to make a better search experience for the Icon library page 

#### Why?

Find icons by keywords instead of just exact icon name

<img width="891" alt="Screen Shot 2023-01-06 at 4 45 24 PM" src="https://user-images.githubusercontent.com/5125094/211106113-183b6b34-c0ca-4076-9e48-f88ae3b2d2c2.png">


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5001)
- [Figma](https://www.figma.com/file/RBlfOYmL123whCtlglXIsG/Iconography-page-redesign?node-id=442%3A3384&t=U2cj3eIDMKoIpsEg-0)

