### PR TITLE
IconButton: Add icon color option for Pinterest brand

### DIFF
--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -403,9 +403,11 @@ Follow these guidelines for \`iconColor\`
 2. Dark Gray ("darkGray"). Medium emphasis, used for secondary actions.
 3. Gray ("gray"). Low emphasis when placed on white backgrounds, used for tertiary actions. Medium emphasis when placed on dark backgrounds, used for secondary actions.
 4. White ("white"). Used in a dark mode scheme or over a dark-colored background creating better visibility.
+5. Brand primary ("brandPrimary"). Used to represent the Pinterest brand.
+
 `}
         >
-          <CombinationNew iconColor={['red', 'darkGray', 'gray', 'white']}>
+          <CombinationNew iconColor={['red', 'darkGray', 'gray', 'white', 'brandPrimary']}>
             {({ iconColor }) => (
               <IconButton
                 accessibilityLabel={`Example icon color ${iconColor}`}

--- a/docs/pages/web/pog.js
+++ b/docs/pages/web/pog.js
@@ -26,7 +26,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
       <Combination
         id="stateCombinations"
-        name="Combinations: State"
+        name="States"
         hovered={[false, true]}
         focused={[false, true]}
         active={[false, true]}
@@ -35,29 +35,31 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       </Combination>
       <Combination
         id="sizeCombinations"
-        name="Combinations: Size with default padding"
+        name="Sizes with default padding"
         size={['xs', 'sm', 'md', 'lg', 'xl']}
+        hasCheckerboard={false}
       >
-        {(props) => <Pog icon="heart" {...props} />}
+        {(props) => <Pog bgColor="lightGray" icon="heart" {...props} />}
       </Combination>
       <Combination
         id="paddingCombinations"
-        name="Combinations: Size with custom padding"
+        name="Sizes with custom padding"
         size={['xs', 'sm', 'md', 'lg', 'xl']}
         padding={[1, 2, 3, 4, 5]}
+        hasCheckerboard={false}
       >
-        {(props) => <Pog icon="heart" {...props} />}
+        {(props) => <Pog bgColor="lightGray" icon="heart" {...props} />}
       </Combination>
       <Combination
         id="iconColorCombinations"
-        name="Combinations: Icon Color"
-        iconColor={['darkGray', 'gray', 'red', 'white']}
+        name="Icon Colors"
+        iconColor={['darkGray', 'gray', 'red', 'white', 'brandPrimary']}
       >
         {(props) => <Pog icon="heart" {...props} />}
       </Combination>
       <Combination
         id="backgroundColorCombinations"
-        name="Combinations: Background Color"
+        name="Background Colors"
         bgColor={['transparent', 'transparentDarkGray', 'darkGray', 'white', 'lightGray', 'gray']}
       >
         {(props) => <Pog icon="heart" {...props} />}

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -42,7 +42,7 @@ type BaseIconButton = {|
     | SyntheticKeyboardEvent<HTMLAnchorElement>,
     {| dangerouslyDisableOnNavigation: () => void |},
   >,
-  iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary',
   padding?: 1 | 2 | 3 | 4 | 5,
   tabIndex?: -1 | 0,
   tooltip?: TooltipProps,

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -26,6 +26,7 @@ const OLD_TO_NEW_COLOR_MAP = {
   'gray': 'subtle',
   'darkGray': 'default',
   'red': 'error',
+  'brandPrimary': 'brandPrimary',
 };
 
 const defaultIconButtonIconColors = {
@@ -78,7 +79,7 @@ type Props = {|
   /**
    * Color applied to the [Icon](https://gestalt.pinterest.systems/web/icon). See [color combinations](https://gestalt.pinterest.systems/web/pog#iconColorCombinations) for more details.
    */
-  iconColor?: 'gray' | 'darkGray' | 'red' | 'white',
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary',
   /**
    * Padding in boints. If omitted, padding is derived from the \`size\` prop. See [padding combinations](https://gestalt.pinterest.systems/web/pog#paddingCombinations) for more details.
    */


### PR DESCRIPTION

### Summary

#### What changed?

Add an option for `iconColor` on IconButton to represent the Pinterest brand

#### Why?

Currently some IconButtons using the pinterest logo are not rendering the right shade of red

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5175)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
