### PR TITLE
Docs: Update site layout

### DIFF
--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -12,7 +12,7 @@ import { useDocsDeviceType, DocsDeviceTypeProvider } from './contexts/DocsDevice
 import { ABOVE_PAGE_HEADER_ZINDEX } from './z-indices.js';
 import YearInReviewBanner from './YearInReviewBanner.js';
 
-const CONTENT_MAX_WIDTH_PX = 1200;
+export const CONTENT_MAX_WIDTH_PX = 1200;
 const HEADER_HEIGHT_PX = 75;
 const fullWidthPages = ['home', 'whats_new', 'roadmap'];
 const fullBleedNoNavigationPages = ['/year_in_review_2022'];

--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -12,7 +12,8 @@ import { useDocsDeviceType, DocsDeviceTypeProvider } from './contexts/DocsDevice
 import { ABOVE_PAGE_HEADER_ZINDEX } from './z-indices.js';
 import YearInReviewBanner from './YearInReviewBanner.js';
 
-const CONTENT_MAX_WIDTH_PX = 1546;
+const CONTENT_MAX_WIDTH_PX = 894;
+const HOME_PAGE_CONTENT_MAX_WIDTH_PX = 1200;
 const HEADER_HEIGHT_PX = 75;
 const fullWidthPages = ['home', 'whats_new', 'roadmap'];
 const fullBleedNoNavigationPages = ['/year_in_review_2022'];
@@ -104,6 +105,7 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
         <Box width="100%" minWidth={0}>
           <Box
             padding={4}
+            mdPaddingY={12}
             mdPadding={8}
             marginBottom={12}
             width="100%"
@@ -111,7 +113,10 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
             mdDisplay="flex"
             justifyContent="center"
           >
-            <Box width="100%" maxWidth={CONTENT_MAX_WIDTH_PX}>
+            <Box
+              width="100%"
+              maxWidth={isHomePage ? HOME_PAGE_CONTENT_MAX_WIDTH_PX : CONTENT_MAX_WIDTH_PX}
+            >
               {children}
             </Box>
           </Box>

--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { useEffect, useState, Fragment, type Node } from 'react';
-import { Box, Divider, DeviceTypeProvider } from 'gestalt';
+import { Box, Divider, DeviceTypeProvider, Flex } from 'gestalt';
 import { useRouter } from 'next/router';
 import Header from './Header.js';
 import SkipToContent from './SkipToContent.js';
@@ -12,8 +12,7 @@ import { useDocsDeviceType, DocsDeviceTypeProvider } from './contexts/DocsDevice
 import { ABOVE_PAGE_HEADER_ZINDEX } from './z-indices.js';
 import YearInReviewBanner from './YearInReviewBanner.js';
 
-const CONTENT_MAX_WIDTH_PX = 894;
-const HOME_PAGE_CONTENT_MAX_WIDTH_PX = 1200;
+const CONTENT_MAX_WIDTH_PX = 1200;
 const HEADER_HEIGHT_PX = 75;
 const fullWidthPages = ['home', 'whats_new', 'roadmap'];
 const fullBleedNoNavigationPages = ['/year_in_review_2022'];
@@ -113,12 +112,14 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
             mdDisplay="flex"
             justifyContent="center"
           >
-            <Box
+            <Flex
               width="100%"
-              maxWidth={isHomePage ? HOME_PAGE_CONTENT_MAX_WIDTH_PX : CONTENT_MAX_WIDTH_PX}
+              maxWidth={CONTENT_MAX_WIDTH_PX}
+              alignItems="center"
+              direction="column"
             >
               {children}
-            </Box>
+            </Flex>
           </Box>
           <Box
             role="contentinfo"

--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -117,6 +117,7 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
               maxWidth={CONTENT_MAX_WIDTH_PX}
               alignItems="center"
               direction="column"
+              flex="none"
             >
               {children}
             </Flex>

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -150,7 +150,7 @@ function Header() {
 
   return (
     <Box
-      paddingY={2}
+      paddingY={3}
       paddingX={4}
       color="default"
       borderStyle="raisedTopShadow"

--- a/docs/docs-components/IllustrationCard.js
+++ b/docs/docs-components/IllustrationCard.js
@@ -28,7 +28,7 @@ function IllustrationCard({
 
   return (
     <TapArea href={href} role="link" accessibilityLabel={`${title} page`}>
-      <Box minWidth={280}>
+      <Box minWidth={245}>
         <Card>
           <Flex direction="column" height={320}>
             <Box

--- a/docs/docs-components/IllustrationCard.js
+++ b/docs/docs-components/IllustrationCard.js
@@ -2,6 +2,7 @@
 import { Badge, Box, Card, Flex, Heading, TapArea, Text } from 'gestalt';
 import { type Node } from 'react';
 import illustrations, { type IllustrationTypes } from '../graphics/index.js';
+import { MIN_SVG_ILLUSTRATION_WIDTH } from './IllustrationSection.js';
 
 export type IllustrationCardProps = {|
   headingLevel: 2 | 3,
@@ -28,7 +29,7 @@ function IllustrationCard({
 
   return (
     <TapArea href={href} role="link" accessibilityLabel={`${title} page`}>
-      <Box minWidth={245}>
+      <Box minWidth={MIN_SVG_ILLUSTRATION_WIDTH}>
         <Card>
           <Flex direction="column" height={320}>
             <Box

--- a/docs/docs-components/IllustrationContainer.js
+++ b/docs/docs-components/IllustrationContainer.js
@@ -10,8 +10,6 @@ type Props = {|
 function IllustrationContainer({ children, justifyContent = 'center' }: Props): Node {
   return (
     <Box
-      marginStart={-8}
-      marginEnd={-8}
       smMarginEnd={0}
       smMarginStart={0}
       paddingX={12}

--- a/docs/docs-components/IllustrationSection.js
+++ b/docs/docs-components/IllustrationSection.js
@@ -4,7 +4,7 @@ import { type Node } from 'react';
 import IllustrationContainer from './IllustrationContainer.js';
 
 // Matches minWidth in IllustrationCard
-const MIN_SVG_ILLUSTRATION_WIDTH = 245;
+export const MIN_SVG_ILLUSTRATION_WIDTH = 245;
 
 type Props = {|
   title?: string,

--- a/docs/docs-components/IllustrationSection.js
+++ b/docs/docs-components/IllustrationSection.js
@@ -3,7 +3,8 @@ import { Box, Flex, Heading } from 'gestalt';
 import { type Node } from 'react';
 import IllustrationContainer from './IllustrationContainer.js';
 
-const MIN_SVG_ILLUSTRATION_WIDTH = 285;
+// Matches minWidth in IllustrationCard
+const MIN_SVG_ILLUSTRATION_WIDTH = 245;
 
 type Props = {|
   title?: string,

--- a/docs/docs-components/Page.js
+++ b/docs/docs-components/Page.js
@@ -4,7 +4,7 @@ import { Box, Flex, Link, Text } from 'gestalt';
 import SearchContent from './SearchContent.js';
 import Toc from './Toc.js';
 
-const DETAIL_PAGE_MAX_WIDTH = 1314;
+const DETAIL_PAGE_MAX_WIDTH = 672;
 
 type Props = {|
   children: Node,

--- a/docs/docs-components/Page.js
+++ b/docs/docs-components/Page.js
@@ -4,13 +4,15 @@ import { Box, Flex, Link, Text } from 'gestalt';
 import SearchContent from './SearchContent.js';
 import Toc from './Toc.js';
 
-const DETAIL_PAGE_MAX_WIDTH = 672;
+const DETAIL_PAGE_MAX_WIDTH = 894;
+const FULL_WIDTH_MAX_WIDTH = 1200;
 
 type Props = {|
   children: Node,
   title: string,
   hideSideNav?: boolean,
   hideEditLink?: boolean,
+  isFullWidth?: boolean,
   pageSourceUrl?: string,
 |};
 
@@ -19,6 +21,7 @@ export default function Page({
   children,
   hideSideNav = false,
   hideEditLink = false,
+  isFullWidth = false,
   pageSourceUrl,
 }: Props): Node {
   const sections = Children.toArray(children);
@@ -35,7 +38,7 @@ export default function Page({
 
   return (
     <Flex>
-      <Box flex="grow" maxWidth={hideSideNav ? '100%' : DETAIL_PAGE_MAX_WIDTH}>
+      <Box flex="grow" maxWidth={isFullWidth ? FULL_WIDTH_MAX_WIDTH : DETAIL_PAGE_MAX_WIDTH}>
         <SearchContent>
           <Flex
             gap={{

--- a/docs/docs-components/Page.js
+++ b/docs/docs-components/Page.js
@@ -12,7 +12,6 @@ type Props = {|
   title: string,
   hideSideNav?: boolean,
   hideEditLink?: boolean,
-  isFullWidth?: boolean,
   pageSourceUrl?: string,
 |};
 
@@ -21,7 +20,6 @@ export default function Page({
   children,
   hideSideNav = false,
   hideEditLink = false,
-  isFullWidth = false,
   pageSourceUrl,
 }: Props): Node {
   const sections = Children.toArray(children);
@@ -37,8 +35,8 @@ export default function Page({
   }, [page]);
 
   return (
-    <Flex>
-      <Box flex="grow" maxWidth={isFullWidth ? FULL_WIDTH_MAX_WIDTH : DETAIL_PAGE_MAX_WIDTH}>
+    <Flex width="100%">
+      <Box flex="grow" maxWidth={hideSideNav ? FULL_WIDTH_MAX_WIDTH : DETAIL_PAGE_MAX_WIDTH}>
         <SearchContent>
           <Flex
             gap={{

--- a/docs/docs-components/Page.js
+++ b/docs/docs-components/Page.js
@@ -3,9 +3,9 @@ import { type Node, useEffect, Children } from 'react';
 import { Box, Flex, Link, Text } from 'gestalt';
 import SearchContent from './SearchContent.js';
 import Toc from './Toc.js';
+import { CONTENT_MAX_WIDTH_PX } from './AppLayout.js';
 
 const DETAIL_PAGE_MAX_WIDTH = 894;
-const FULL_WIDTH_MAX_WIDTH = 1200;
 
 type Props = {|
   children: Node,
@@ -36,7 +36,7 @@ export default function Page({
 
   return (
     <Flex width="100%">
-      <Box flex="grow" maxWidth={hideSideNav ? FULL_WIDTH_MAX_WIDTH : DETAIL_PAGE_MAX_WIDTH}>
+      <Box flex="grow" maxWidth={hideSideNav ? CONTENT_MAX_WIDTH_PX : DETAIL_PAGE_MAX_WIDTH}>
         <SearchContent>
           <Flex
             gap={{

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -142,16 +142,20 @@ export default function PageHeader({
             </Flex>
             {slimBanner}
             {type === 'component' ? <PageHeaderQualitySummary name={name} /> : null}
+
             {defaultCode && (
-              <MainSection.Card
-                cardSize="lg"
-                defaultCode={defaultCode}
-                shaded={shadedCodeExample}
-                showCode={showCode}
-                hideCodePreview
-              />
+              <Box marginTop={2}>
+                <MainSection.Card
+                  cardSize="lg"
+                  defaultCode={defaultCode}
+                  shaded={shadedCodeExample}
+                  showCode={showCode}
+                  hideCodePreview
+                />
+              </Box>
             )}
-            {children}
+
+            {children ? <Box marginTop={2}>{children}</Box> : null}
           </Flex>
         </Flex>
       </Flex>

--- a/docs/docs-components/Toc.js
+++ b/docs/docs-components/Toc.js
@@ -161,11 +161,11 @@ export default function Toc({ cards }: Props): Node {
       mdMarginTop={-6}
       lgMarginTop={-8}
       maxHeight={`calc(100% - ${HEADER_HEIGHT_PX}px - ${FOOTER_HEIGHT_PX}px)`}
-      minWidth={240}
       overflow="auto"
       paddingY={8} // re-apply just the padding we need
       position="fixed"
       role="navigation"
+      width={240}
     >
       {anchors.map((anchor) => {
         const isActive = activeState === anchor.id;

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -232,7 +232,7 @@ export default function IconPage(): Node {
   );
 
   return (
-    <Page title="Icon library">
+    <Page title="Icon library" hideSideNav>
       <PageHeader
         name="Icon library"
         folderName="icons"

--- a/docs/pages/home.js
+++ b/docs/pages/home.js
@@ -14,7 +14,7 @@ import Roadmap from '../graphics/home-page/roadmap.svg';
 
 export default function HomePage(): Node {
   return (
-    <Page title="Welcome to Gestalt" hideSideNav hideEditLink>
+    <Page title="Welcome to Gestalt" hideSideNav hideEditLink isFullWidth>
       <Box width="100%">
         <Flex direction="column">
           {/* Hero */}

--- a/docs/pages/home.js
+++ b/docs/pages/home.js
@@ -14,7 +14,7 @@ import Roadmap from '../graphics/home-page/roadmap.svg';
 
 export default function HomePage(): Node {
   return (
-    <Page title="Welcome to Gestalt" hideSideNav hideEditLink isFullWidth>
+    <Page title="Welcome to Gestalt" hideSideNav hideEditLink>
       <Box width="100%">
         <Flex direction="column">
           {/* Hero */}


### PR DESCRIPTION
### Summary

#### What changed?

Update layout of Roadmap and Whats New page, fix mobile layout on home screen

Before
<img width="1439" alt="Screen Shot 2023-01-09 at 5 55 55 PM" src="https://user-images.githubusercontent.com/5125094/211630198-29660915-aded-445f-bdec-7092a707428c.png">

After
<img width="1439" alt="Screen Shot 2023-01-10 at 1 14 03 PM" src="https://user-images.githubusercontent.com/5125094/211630191-8c8df39c-e755-42f6-908a-ecedda6c43be.png">
<img width="1434" alt="Screen Shot 2023-01-10 at 1 23 23 PM" src="https://user-images.githubusercontent.com/5125094/211631860-72110231-5e28-4afe-922e-f614e8cc78ca.png">





### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4810)
- [Figma](https://www.figma.com/file/ZNDhPw1tHNgpLtaQploUSm/Docs-style-guide?node-id=208%3A11629&t=wNdtShZa74IcNA7x-0)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
