### PR TITLE
Replace Flow React$AbstractComponent with React wrapper type AbstractComponent

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -1,5 +1,13 @@
 // @flow strict-local
-import { forwardRef, useEffect, useImperativeHandle, useState, useRef, type Element, type AbstractComponent } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+  useRef,
+  type Element,
+  type AbstractComponent,
+} from 'react';
 import ReactDatePicker, { registerLocale } from 'react-datepicker';
 import classnames from 'classnames';
 import { Icon, Box, Label, Text } from 'gestalt';

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import { forwardRef, useEffect, useImperativeHandle, useState, useRef, type Element } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useState, useRef, type Element, type AbstractComponent } from 'react';
 import ReactDatePicker, { registerLocale } from 'react-datepicker';
 import classnames from 'classnames';
 import { Icon, Box, Label, Text } from 'gestalt';
@@ -140,7 +140,7 @@ type Props = {|
  * ![DatePicker closed light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/DatePicker-closed.spec.mjs-snapshots/DatePicker-closed-chromium-darwin.png)
  * ![DatePicker closed dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/DatePicker-closed-dark.spec.mjs-snapshots/DatePicker-closed-dark-chromium-darwin.png)
  */
-const DatePickerWithForwardRef: React$AbstractComponent<Props, HTMLDivElement> = forwardRef<
+const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwardRef<
   Props,
   HTMLDivElement,
 >(function DatePicker(

--- a/packages/gestalt-datepicker/src/DatePickerTextField.js
+++ b/packages/gestalt-datepicker/src/DatePickerTextField.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type ElementRef } from 'react';
+import { forwardRef, type ElementRef, type AbstractComponent } from 'react';
 import { Box, Icon, Label, TextField } from 'gestalt';
 import classnames from 'classnames';
 import styles from './DatePicker.css';
@@ -92,7 +92,7 @@ function textFieldForwardRef(props, ref) {
 
 textFieldForwardRef.displayName = 'DatePickerTextFieldForwardRef';
 
-export default (forwardRef<Props, HTMLInputElement>(textFieldForwardRef): React$AbstractComponent<
+export default (forwardRef<Props, HTMLInputElement>(textFieldForwardRef): AbstractComponent<
   Props,
   HTMLInputElement,
 >);

--- a/packages/gestalt/src/AvatarGroup.js
+++ b/packages/gestalt/src/AvatarGroup.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node, useCallback, useState } from 'react';
+import { forwardRef, type Node, type AbstractComponent, useCallback, useState } from 'react';
 import Box from './Box.js';
 import TapArea, { type OnTapType } from './TapArea.js';
 import AddCollaboratorsButton from './AvatarGroupAddCollaboratorsButton.js';
@@ -74,7 +74,7 @@ type Props = {|
  * ![AvatarGroup light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/AvatarGroup.spec.mjs-snapshots/AvatarGroup-chromium-darwin.png)
  * ![AvatarGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/AvatarGroup-dark.spec.mjs-snapshots/AvatarGroup-dark-chromium-darwin.png)
  */
-const AvatarGroupWithForwardRef: React$AbstractComponent<Props, UnionRefs> = forwardRef<
+const AvatarGroupWithForwardRef: AbstractComponent<Props, UnionRefs> = forwardRef<
   Props,
   UnionRefs,
 >(function AvatarGroup(

--- a/packages/gestalt/src/AvatarGroup.js
+++ b/packages/gestalt/src/AvatarGroup.js
@@ -74,140 +74,140 @@ type Props = {|
  * ![AvatarGroup light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/AvatarGroup.spec.mjs-snapshots/AvatarGroup-chromium-darwin.png)
  * ![AvatarGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/AvatarGroup-dark.spec.mjs-snapshots/AvatarGroup-dark-chromium-darwin.png)
  */
-const AvatarGroupWithForwardRef: AbstractComponent<Props, UnionRefs> = forwardRef<
-  Props,
-  UnionRefs,
->(function AvatarGroup(
-  {
-    accessibilityLabel,
-    accessibilityControls,
-    accessibilityExpanded,
-    accessibilityHaspopup,
-    addCollaborators,
-    collaborators,
-    href,
-    onClick,
-    role,
-    size = 'fit',
-  }: Props,
-  ref,
-): Node {
-  const [hovered, setHovered] = useState(false);
+const AvatarGroupWithForwardRef: AbstractComponent<Props, UnionRefs> = forwardRef<Props, UnionRefs>(
+  function AvatarGroup(
+    {
+      accessibilityLabel,
+      accessibilityControls,
+      accessibilityExpanded,
+      accessibilityHaspopup,
+      addCollaborators,
+      collaborators,
+      href,
+      onClick,
+      role,
+      size = 'fit',
+    }: Props,
+    ref,
+  ): Node {
+    const [hovered, setHovered] = useState(false);
 
-  const isMdSize = size === 'md';
+    const isMdSize = size === 'md';
 
-  const isFitSize = size === 'fit';
+    const isFitSize = size === 'fit';
 
-  const isMdOrFitSize = isMdSize || isFitSize;
+    const isMdOrFitSize = isMdSize || isFitSize;
 
-  const isDisplayOnly = !role;
+    const isDisplayOnly = !role;
 
-  const isAboveMaxCollaborators = collaborators.length > MAX_COLLABORATOR_AVATARS;
+    const isAboveMaxCollaborators = collaborators.length > MAX_COLLABORATOR_AVATARS;
 
-  const showCollaboratorsCount = isMdOrFitSize && isAboveMaxCollaborators;
+    const showCollaboratorsCount = isMdOrFitSize && isAboveMaxCollaborators;
 
-  const showAddCollaboratorsButton = (isMdOrFitSize && !isDisplayOnly && addCollaborators) ?? false;
+    const showAddCollaboratorsButton =
+      (isMdOrFitSize && !isDisplayOnly && addCollaborators) ?? false;
 
-  const displayedCollaborators = collaborators.slice(
-    0,
-    isAboveMaxCollaborators && isMdOrFitSize ? 2 : MAX_COLLABORATOR_AVATARS,
-  );
+    const displayedCollaborators = collaborators.slice(
+      0,
+      isAboveMaxCollaborators && isMdOrFitSize ? 2 : MAX_COLLABORATOR_AVATARS,
+    );
 
-  const pileCount =
-    displayedCollaborators.length + showCollaboratorsCount + showAddCollaboratorsButton;
+    const pileCount =
+      displayedCollaborators.length + showCollaboratorsCount + showAddCollaboratorsButton;
 
-  const collaboratorStack = displayedCollaborators.map(({ src, name }, index) => (
-    <CollaboratorAvatar
-      hovered={hovered}
-      index={index}
-      // eslint-disable-next-line react/no-array-index-key
-      key={`collaboratorStack-${name}-${index}`}
-      name={name}
-      pileCount={pileCount}
-      size={size}
-      src={src || ''}
-    />
-  ));
-
-  if (showCollaboratorsCount) {
-    collaboratorStack.push(
-      <CollaboratorsCount
-        count={collaborators.length - 2}
-        showAddCollaboratorsButton={showAddCollaboratorsButton}
+    const collaboratorStack = displayedCollaborators.map(({ src, name }, index) => (
+      <CollaboratorAvatar
         hovered={hovered}
-        key={`collaboratorStack-count-${collaborators.length}`}
+        index={index}
+        // eslint-disable-next-line react/no-array-index-key
+        key={`collaboratorStack-${name}-${index}`}
+        name={name}
         pileCount={pileCount}
         size={size}
-      />,
+        src={src || ''}
+      />
+    ));
+
+    if (showCollaboratorsCount) {
+      collaboratorStack.push(
+        <CollaboratorsCount
+          count={collaborators.length - 2}
+          showAddCollaboratorsButton={showAddCollaboratorsButton}
+          hovered={hovered}
+          key={`collaboratorStack-count-${collaborators.length}`}
+          pileCount={pileCount}
+          size={size}
+        />,
+      );
+    }
+
+    if (showAddCollaboratorsButton) {
+      collaboratorStack.push(
+        <AddCollaboratorsButton
+          hovered={hovered}
+          key={`collaboratorStack-addButton-${collaborators.length}`}
+          pileCount={pileCount}
+          size={size}
+        />,
+      );
+    }
+
+    const AvatarGroupStack = useCallback(
+      () => (
+        <Box
+          aria-label={isDisplayOnly ? accessibilityLabel : undefined}
+          dangerouslySetInlineStyle={{ __style: { isolation: 'isolate' } }}
+          position={isFitSize ? 'relative' : 'static'}
+        >
+          {isFitSize ? collaboratorStack : <Flex>{collaboratorStack}</Flex>}
+        </Box>
+      ),
+      [accessibilityLabel, collaboratorStack, isDisplayOnly, isFitSize],
     );
-  }
 
-  if (showAddCollaboratorsButton) {
-    collaboratorStack.push(
-      <AddCollaboratorsButton
-        hovered={hovered}
-        key={`collaboratorStack-addButton-${collaborators.length}`}
-        pileCount={pileCount}
-        size={size}
-      />,
-    );
-  }
+    if (role === 'link' && href) {
+      return (
+        <TapArea
+          accessibilityLabel={accessibilityLabel}
+          href={href}
+          fullWidth={false}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          onTap={onClick}
+          ref={ref}
+          role="link"
+          rounding="pill"
+          tapStyle="compress"
+        >
+          <AvatarGroupStack />
+        </TapArea>
+      );
+    }
 
-  const AvatarGroupStack = useCallback(
-    () => (
-      <Box
-        aria-label={isDisplayOnly ? accessibilityLabel : undefined}
-        dangerouslySetInlineStyle={{ __style: { isolation: 'isolate' } }}
-        position={isFitSize ? 'relative' : 'static'}
-      >
-        {isFitSize ? collaboratorStack : <Flex>{collaboratorStack}</Flex>}
-      </Box>
-    ),
-    [accessibilityLabel, collaboratorStack, isDisplayOnly, isFitSize],
-  );
+    if (role === 'button' && onClick) {
+      return (
+        <TapArea
+          accessibilityLabel={accessibilityLabel}
+          accessibilityControls={accessibilityControls}
+          accessibilityExpanded={accessibilityExpanded}
+          accessibilityHaspopup={accessibilityHaspopup}
+          fullWidth={false}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          onTap={onClick}
+          ref={ref}
+          rounding="pill"
+          tapStyle="compress"
+        >
+          <AvatarGroupStack accessibilityLabel={accessibilityLabel} />
+        </TapArea>
+      );
+    }
 
-  if (role === 'link' && href) {
-    return (
-      <TapArea
-        accessibilityLabel={accessibilityLabel}
-        href={href}
-        fullWidth={false}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-        onTap={onClick}
-        ref={ref}
-        role="link"
-        rounding="pill"
-        tapStyle="compress"
-      >
-        <AvatarGroupStack />
-      </TapArea>
-    );
-  }
-
-  if (role === 'button' && onClick) {
-    return (
-      <TapArea
-        accessibilityLabel={accessibilityLabel}
-        accessibilityControls={accessibilityControls}
-        accessibilityExpanded={accessibilityExpanded}
-        accessibilityHaspopup={accessibilityHaspopup}
-        fullWidth={false}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-        onTap={onClick}
-        ref={ref}
-        rounding="pill"
-        tapStyle="compress"
-      >
-        <AvatarGroupStack accessibilityLabel={accessibilityLabel} />
-      </TapArea>
-    );
-  }
-
-  // Display-only role
-  return <AvatarGroupStack />;
-});
+    // Display-only role
+    return <AvatarGroupStack />;
+  },
+);
 
 AvatarGroupWithForwardRef.displayName = 'AvatarGroup';
 

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Fragment, forwardRef, useImperativeHandle, useRef, type Node } from 'react';
+import { Fragment, forwardRef, useImperativeHandle, useRef, type Node, type AbstractComponent } from 'react';
 import classnames from 'classnames';
 import Flex from './Flex.js';
 import focusStyles from './Focus.css';
@@ -124,7 +124,7 @@ function InternalButtonContent({
  * ![Button dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Button-dark.spec.mjs-snapshots/Button-dark-chromium-darwin.png)
  *
  */
-const ButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
+const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,
   unionRefs,
 >(function Button(props: unionProps, ref): Node {

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -1,5 +1,12 @@
 // @flow strict
-import { Fragment, forwardRef, useImperativeHandle, useRef, type Node, type AbstractComponent } from 'react';
+import {
+  Fragment,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type Node,
+  type AbstractComponent,
+} from 'react';
 import classnames from 'classnames';
 import Flex from './Flex.js';
 import focusStyles from './Focus.css';

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node, useImperativeHandle, useEffect, useRef, useState } from 'react';
+import { forwardRef, type Node, type AbstractComponent, useImperativeHandle, useEffect, useRef, useState } from 'react';
 import classnames from 'classnames';
 import colors from './Colors.css';
 import styles from './Checkbox.css';
@@ -79,7 +79,7 @@ type Props = {|
  * ![Checkbox dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Checkbox-dark.spec.mjs-snapshots/Checkbox-dark-chromium-darwin.png)
  *
  */
-const CheckboxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
+const CheckboxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
 >(function Checkbox(

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -1,5 +1,13 @@
 // @flow strict
-import { forwardRef, type Node, type AbstractComponent, useImperativeHandle, useEffect, useRef, useState } from 'react';
+import {
+  forwardRef,
+  type Node,
+  type AbstractComponent,
+  useImperativeHandle,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import classnames from 'classnames';
 import colors from './Colors.css';
 import styles from './Checkbox.css';

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -12,6 +12,7 @@ import {
   type Ref,
   type Element,
   type Node,
+  type AbstractComponent,
 } from 'react';
 import Box from './Box.js';
 import ComboBoxItem from './ComboBoxItem.js';
@@ -161,7 +162,7 @@ type Props = {|
  * ![Combobox open dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ComboBox-open-dark.spec.mjs-snapshots/ComboBox-open-dark-chromium-darwin.png)
  *
  */
-const ComboBoxWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
+const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
 >(function ComboBox(

--- a/packages/gestalt/src/ComboBoxItem.js
+++ b/packages/gestalt/src/ComboBoxItem.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node } from 'react';
+import { forwardRef, type Node, type AbstractComponent } from 'react';
 import classnames from 'classnames';
 import Text from './Text.js';
 import Icon from './Icon.js';
@@ -32,7 +32,7 @@ type Props = {|
   value: string,
 |};
 
-const ComboBoxItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = forwardRef<
+const ComboBoxItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forwardRef<
   Props,
   ?HTMLElement,
 >(function OptionItem(

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -1,5 +1,12 @@
 // @flow strict
-import { type Node, type AbstractComponent, forwardRef, useImperativeHandle, useState, useRef } from 'react';
+import {
+  type Node,
+  type AbstractComponent,
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  useRef,
+} from 'react';
 import classnames from 'classnames';
 import icons from './icons/index.js';
 import InternalLink from './InternalLink.js';

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, forwardRef, useImperativeHandle, useState, useRef } from 'react';
+import { type Node, type AbstractComponent, forwardRef, useImperativeHandle, useState, useRef } from 'react';
 import classnames from 'classnames';
 import icons from './icons/index.js';
 import InternalLink from './InternalLink.js';
@@ -80,7 +80,7 @@ type unionRefs = HTMLButtonElement | HTMLAnchorElement;
  * ![IconButton dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/IconButton-dark.spec.mjs-snapshots/IconButton-dark-chromium-darwin.png)
  *
  */
-const IconButtonWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
+const IconButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,
   unionRefs,
 >(function IconButton(props: unionProps, ref): Node {

--- a/packages/gestalt/src/IconButtonFloating.js
+++ b/packages/gestalt/src/IconButtonFloating.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node } from 'react';
+import { forwardRef, type Node, type AbstractComponent } from 'react';
 import Box from './Box.js';
 import IconButton from './IconButton.js';
 import icons from './icons/index.js';
@@ -55,7 +55,7 @@ type unionRefs = HTMLButtonElement | HTMLAnchorElement;
  * ![IconButtonFloating dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/IconButtonFloating-dark.spec.mjs-snapshots/IconButtonFloating-dark-chromium-darwin.png)
  *
  */
-const IconButtonFloatingWithForwardRef: React$AbstractComponent<Props, unionRefs> = forwardRef<
+const IconButtonFloatingWithForwardRef: AbstractComponent<Props, unionRefs> = forwardRef<
   Props,
   unionRefs,
 >(function IconButtonFloating(

--- a/packages/gestalt/src/InternalDismissButton.js
+++ b/packages/gestalt/src/InternalDismissButton.js
@@ -5,7 +5,14 @@ InternalDismissIconButton aims to replace "dismiss" IconButtons in components th
 */
 
 // @flow strict
-import { type Node, type AbstractComponent, forwardRef, useImperativeHandle, useState, useRef } from 'react';
+import {
+  type Node,
+  type AbstractComponent,
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  useRef,
+} from 'react';
 import classnames from 'classnames';
 import Pog from './Pog.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';

--- a/packages/gestalt/src/InternalDismissButton.js
+++ b/packages/gestalt/src/InternalDismissButton.js
@@ -5,7 +5,7 @@ InternalDismissIconButton aims to replace "dismiss" IconButtons in components th
 */
 
 // @flow strict
-import { type Node, forwardRef, useImperativeHandle, useState, useRef } from 'react';
+import { type Node, type AbstractComponent, forwardRef, useImperativeHandle, useState, useRef } from 'react';
 import classnames from 'classnames';
 import Pog from './Pog.js';
 import { type AbstractEventHandler } from './AbstractEventHandler.js';
@@ -24,7 +24,7 @@ type Props = {|
   size?: $ElementType<React$ElementConfig<typeof Pog>, 'size'>,
 |};
 
-const InternalDismissIconButtonWithForwardRef: React$AbstractComponent<Props, HTMLButtonElement> =
+const InternalDismissIconButtonWithForwardRef: AbstractComponent<Props, HTMLButtonElement> =
   forwardRef<Props, HTMLButtonElement>(function IconButton(
     {
       accessibilityLabel,

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -1,5 +1,13 @@
 // @flow strict
-import { useImperativeHandle, useRef, forwardRef, type Element, type Node, type AbstractComponent, useState } from 'react';
+import {
+  useImperativeHandle,
+  useRef,
+  forwardRef,
+  type Element,
+  type Node,
+  type AbstractComponent,
+  useState,
+} from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
 import { type MaxLength } from './TextField.js';
@@ -62,188 +70,190 @@ type Props = {|
   value?: string,
 |};
 
-const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> =
-  forwardRef<Props, HTMLInputElement>(function TextField(
+const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwardRef<
+  Props,
+  HTMLInputElement,
+>(function TextField(
+  {
+    accessibilityControls,
+    accessibilityActiveDescendant,
+    autoComplete,
+    disabled = false,
+    errorMessage,
+    enterKeyHint,
+    hasError = false,
+    helperText,
+    id,
+    iconButton,
+    label,
+    labelDisplay,
+    max,
+    maxLength,
+    min,
+    name,
+    onBlur,
+    onChange,
+    onClick,
+    onFocus,
+    onKeyDown,
+    placeholder,
+    readOnly,
+    size = 'md',
+    step,
+    tags,
+    type = 'text',
+    value,
+  }: Props,
+  ref,
+): Node {
+  // ==== REFS ====
+  const innerRef = useRef(null);
+  // When using both forwardRef and innerRefs, useimperativehandle() allows to externally set focus via the ref prop: textfieldRef.current.focus()
+  // $FlowFixMe[incompatible-call]
+  useImperativeHandle(ref, () => innerRef.current);
+
+  // ==== STATE ====
+  const [focused, setFocused] = useState(false);
+  const [currentLength, setCurrentLength] = useState(value?.length ?? 0);
+
+  // ==== HANDLERS ====
+  const handleBlur = (event: SyntheticFocusEvent<HTMLInputElement>) => {
+    setFocused(false);
+    onBlur?.({ event, value: event.currentTarget.value });
+  };
+
+  const handleClick = (event: SyntheticInputEvent<HTMLInputElement>) =>
+    onClick?.({ event, value: event.currentTarget.value });
+
+  const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
+    setCurrentLength(event.currentTarget.value?.length ?? 0);
+    onChange({ event, value: event.currentTarget.value });
+  };
+
+  const handleFocus = (event: SyntheticFocusEvent<HTMLInputElement>) => {
+    setFocused(true);
+    onFocus?.({ event, value: event.currentTarget.value });
+  };
+
+  const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) =>
+    onKeyDown?.({ event, value: event.currentTarget.value });
+
+  // ==== STYLING ====
+  const hasErrorMessage = Boolean(errorMessage);
+
+  const styledClasses = classnames(
+    styles.textField,
+    formElement.base,
+    disabled ? formElement.disabled : formElement.enabled,
+    (hasError || hasErrorMessage) && !focused ? formElement.errored : formElement.normal,
     {
-      accessibilityControls,
-      accessibilityActiveDescendant,
-      autoComplete,
-      disabled = false,
-      errorMessage,
-      enterKeyHint,
-      hasError = false,
-      helperText,
-      id,
-      iconButton,
-      label,
-      labelDisplay,
-      max,
-      maxLength,
-      min,
-      name,
-      onBlur,
-      onChange,
-      onClick,
-      onFocus,
-      onKeyDown,
-      placeholder,
-      readOnly,
-      size = 'md',
-      step,
-      tags,
-      type = 'text',
-      value,
-    }: Props,
-    ref,
-  ): Node {
-    // ==== REFS ====
-    const innerRef = useRef(null);
-    // When using both forwardRef and innerRefs, useimperativehandle() allows to externally set focus via the ref prop: textfieldRef.current.focus()
-    // $FlowFixMe[incompatible-call]
-    useImperativeHandle(ref, () => innerRef.current);
+      [layout.medium]: !tags && size === 'md',
+      [layout.large]: tags || size === 'lg',
+      [styles.actionButton]: iconButton,
+    },
+    tags
+      ? {
+          [focusStyles.accessibilityOutlineFocus]: focused,
+          [styles.textFieldWrapper]: true,
+        }
+      : { [typography.truncate]: true },
+  );
 
-    // ==== STATE ====
-    const [focused, setFocused] = useState(false);
-    const [currentLength, setCurrentLength] = useState(value?.length ?? 0);
+  const unstyledClasses = classnames(styles.unstyledTextField);
 
-    // ==== HANDLERS ====
-    const handleBlur = (event: SyntheticFocusEvent<HTMLInputElement>) => {
-      setFocused(false);
-      onBlur?.({ event, value: event.currentTarget.value });
-    };
+  if (maxLength && maxLength.characterCount < 0) {
+    throw new Error('`maxLength` must be an integer value 0 or higher.');
+  }
 
-    const handleClick = (event: SyntheticInputEvent<HTMLInputElement>) =>
-      onClick?.({ event, value: event.currentTarget.value });
+  let ariaDescribedby;
 
-    const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
-      setCurrentLength(event.currentTarget.value?.length ?? 0);
-      onChange({ event, value: event.currentTarget.value });
-    };
+  if (hasErrorMessage) {
+    ariaDescribedby = `${id}-error`;
+  }
 
-    const handleFocus = (event: SyntheticFocusEvent<HTMLInputElement>) => {
-      setFocused(true);
-      onFocus?.({ event, value: event.currentTarget.value });
-    };
+  if (helperText || maxLength) {
+    ariaDescribedby = `${id}-helperText`;
+  }
 
-    const handleKeyDown = (event: SyntheticKeyboardEvent<HTMLInputElement>) =>
-      onKeyDown?.({ event, value: event.currentTarget.value });
+  const inputElement = (
+    <input
+      aria-activedescendant={accessibilityActiveDescendant}
+      aria-controls={accessibilityControls}
+      // checking for "focused" is not required by screenreaders but it prevents a11y integration tests to complain about missing label, as aria-describedby seems to shadow label in tests though it's a W3 accepeted pattern https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html
+      aria-describedby={focused ? ariaDescribedby : undefined}
+      aria-invalid={hasErrorMessage || hasError ? 'true' : 'false'}
+      autoComplete={autoComplete}
+      className={tags ? unstyledClasses : styledClasses}
+      disabled={disabled}
+      enterKeyHint={enterKeyHint}
+      id={id}
+      maxLength={maxLength?.characterCount}
+      max={type === 'number' ? max : undefined}
+      min={type === 'number' ? min : undefined}
+      name={name}
+      onBlur={handleBlur}
+      onChange={handleChange}
+      onClick={handleClick}
+      onFocus={handleFocus}
+      onKeyDown={handleKeyDown}
+      // type='number' doesn't work on ios safari without a pattern
+      // https://stackoverflow.com/questions/14447668/input-type-number-is-not-showing-a-number-keypad-on-ios
+      pattern={type === 'number' ? '\\d*' : undefined}
+      placeholder={placeholder}
+      readOnly={readOnly}
+      // This config is required to prevent exposing passwords and usernames to spell-checking servers during login processes. More info here: https://www.androidpolice.com/google-chrome-servers-get-passwords-enhanced-spell-check/
+      spellCheck={['email', 'password'].includes(type) ? false : undefined}
+      step={type === 'number' ? step : undefined}
+      {...(tags ? {} : { ref: innerRef })}
+      type={type}
+      value={value}
+    />
+  );
 
-    // ==== STYLING ====
-    const hasErrorMessage = Boolean(errorMessage);
+  return (
+    <span>
+      {label ? <FormLabel id={id} label={label} labelDisplay={labelDisplay} /> : null}
 
-    const styledClasses = classnames(
-      styles.textField,
-      formElement.base,
-      disabled ? formElement.disabled : formElement.enabled,
-      (hasError || hasErrorMessage) && !focused ? formElement.errored : formElement.normal,
-      {
-        [layout.medium]: !tags && size === 'md',
-        [layout.large]: tags || size === 'lg',
-        [styles.actionButton]: iconButton,
-      },
-      tags
-        ? {
-            [focusStyles.accessibilityOutlineFocus]: focused,
-            [styles.textFieldWrapper]: true,
-          }
-        : { [typography.truncate]: true },
-    );
-
-    const unstyledClasses = classnames(styles.unstyledTextField);
-
-    if (maxLength && maxLength.characterCount < 0) {
-      throw new Error('`maxLength` must be an integer value 0 or higher.');
-    }
-
-    let ariaDescribedby;
-
-    if (hasErrorMessage) {
-      ariaDescribedby = `${id}-error`;
-    }
-
-    if (helperText || maxLength) {
-      ariaDescribedby = `${id}-helperText`;
-    }
-
-    const inputElement = (
-      <input
-        aria-activedescendant={accessibilityActiveDescendant}
-        aria-controls={accessibilityControls}
-        // checking for "focused" is not required by screenreaders but it prevents a11y integration tests to complain about missing label, as aria-describedby seems to shadow label in tests though it's a W3 accepeted pattern https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html
-        aria-describedby={focused ? ariaDescribedby : undefined}
-        aria-invalid={hasErrorMessage || hasError ? 'true' : 'false'}
-        autoComplete={autoComplete}
-        className={tags ? unstyledClasses : styledClasses}
-        disabled={disabled}
-        enterKeyHint={enterKeyHint}
-        id={id}
-        maxLength={maxLength?.characterCount}
-        max={type === 'number' ? max : undefined}
-        min={type === 'number' ? min : undefined}
-        name={name}
-        onBlur={handleBlur}
-        onChange={handleChange}
-        onClick={handleClick}
-        onFocus={handleFocus}
-        onKeyDown={handleKeyDown}
-        // type='number' doesn't work on ios safari without a pattern
-        // https://stackoverflow.com/questions/14447668/input-type-number-is-not-showing-a-number-keypad-on-ios
-        pattern={type === 'number' ? '\\d*' : undefined}
-        placeholder={placeholder}
-        readOnly={readOnly}
-        // This config is required to prevent exposing passwords and usernames to spell-checking servers during login processes. More info here: https://www.androidpolice.com/google-chrome-servers-get-passwords-enhanced-spell-check/
-        spellCheck={['email', 'password'].includes(type) ? false : undefined}
-        step={type === 'number' ? step : undefined}
-        {...(tags ? {} : { ref: innerRef })}
-        type={type}
-        value={value}
-      />
-    );
-
-    return (
-      <span>
-        {label ? <FormLabel id={id} label={label} labelDisplay={labelDisplay} /> : null}
-
-        <Box position="relative">
-          {tags ? (
-            <div className={styledClasses} {...(tags ? { ref: innerRef } : {})}>
-              {tags.map((tag, tagIndex) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <Box key={tagIndex} marginEnd={1} marginBottom={1}>
-                  {tag}
-                </Box>
-              ))}
-              <Box flex="grow" marginEnd={2} maxWidth="100%" position="relative">
-                {/* This is an invisible spacer div which mirrors the input's
-                 * content. We use it to implement the flex wrapping behavior
-                 * which is not supported by inputs, by having the actual input
-                 * track it with absolute positioning. */}
-                <div aria-hidden className={styles.textFieldSpacer}>
-                  {value}
-                </div>
-                {inputElement}
+      <Box position="relative">
+        {tags ? (
+          <div className={styledClasses} {...(tags ? { ref: innerRef } : {})}>
+            {tags.map((tag, tagIndex) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <Box key={tagIndex} marginEnd={1} marginBottom={1}>
+                {tag}
               </Box>
-            </div>
-          ) : (
-            inputElement
-          )}
+            ))}
+            <Box flex="grow" marginEnd={2} maxWidth="100%" position="relative">
+              {/* This is an invisible spacer div which mirrors the input's
+               * content. We use it to implement the flex wrapping behavior
+               * which is not supported by inputs, by having the actual input
+               * track it with absolute positioning. */}
+              <div aria-hidden className={styles.textFieldSpacer}>
+                {value}
+              </div>
+              {inputElement}
+            </Box>
+          </div>
+        ) : (
+          inputElement
+        )}
 
-          {!disabled && iconButton}
-        </Box>
+        {!disabled && iconButton}
+      </Box>
 
-        {(helperText || maxLength) && !errorMessage ? (
-          <FormHelperText
-            id={`${id}-helperText`}
-            text={helperText}
-            maxLength={maxLength}
-            currentLength={currentLength}
-          />
-        ) : null}
+      {(helperText || maxLength) && !errorMessage ? (
+        <FormHelperText
+          id={`${id}-helperText`}
+          text={helperText}
+          maxLength={maxLength}
+          currentLength={currentLength}
+        />
+      ) : null}
 
-        {hasErrorMessage ? <FormErrorMessage id={`${id}-error`} text={errorMessage} /> : null}
-      </span>
-    );
-  });
+      {hasErrorMessage ? <FormErrorMessage id={`${id}-error`} text={errorMessage} /> : null}
+    </span>
+  );
+});
 
 InternalTextFieldWithForwardRef.displayName = 'InternalTextField';
 

--- a/packages/gestalt/src/InternalTextField.js
+++ b/packages/gestalt/src/InternalTextField.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { useImperativeHandle, useRef, forwardRef, type Element, type Node, useState } from 'react';
+import { useImperativeHandle, useRef, forwardRef, type Element, type Node, type AbstractComponent, useState } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
 import { type MaxLength } from './TextField.js';
@@ -62,7 +62,7 @@ type Props = {|
   value?: string,
 |};
 
-const InternalTextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> =
+const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> =
   forwardRef<Props, HTMLInputElement>(function TextField(
     {
       accessibilityControls,

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node } from 'react';
+import { forwardRef, type Node, type AbstractComponent } from 'react';
 import InternalTextField from './InternalTextField.js';
 
 // <input> deals with strings, but we only want numbers for this component.
@@ -113,7 +113,7 @@ type Props = {|
  * ![NumberField dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/NumberField-dark.spec.mjs-snapshots/NumberField-dark-chromium-darwin.png)
  *
  */
-const NumberFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
+const NumberFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
 >(function NumberField(

--- a/packages/gestalt/src/OptionItem.js
+++ b/packages/gestalt/src/OptionItem.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, Fragment, type Node } from 'react';
+import { forwardRef, Fragment, type Node, type AbstractComponent } from 'react';
 import classnames from 'classnames';
 import Badge from './Badge.js';
 import Box from './Box.js';
@@ -48,7 +48,7 @@ type Props = {|
   textWeight?: FontWeight,
 |};
 
-const OptionItemWithForwardRef: React$AbstractComponent<Props, ?HTMLElement> = forwardRef<
+const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forwardRef<
   Props,
   ?HTMLElement,
 >(function OptionItem(

--- a/packages/gestalt/src/RadioButton.js
+++ b/packages/gestalt/src/RadioButton.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node, useState } from 'react';
+import { forwardRef, type Node, type AbstractComponent, useState } from 'react';
 import classnames from 'classnames';
 import controlStyles from './RadioButtonCheckbox.css';
 import styles from './RadioButton.css';
@@ -60,7 +60,7 @@ type Props = {|
 /**
  * **NOTE** The standalone RadioButton is soon to be deprecated, use [RadioGroup](https://gestalt.pinterest.systems/web/radiogroup) and RadioGroup.RadioButton instead.**NOTE**
  */
-const RadioButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
+const RadioButtonWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
 >(function RadioButton(

--- a/packages/gestalt/src/RadioGroupButton.js
+++ b/packages/gestalt/src/RadioGroupButton.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node, useState } from 'react';
+import { forwardRef, type Node, type AbstractComponent, useState } from 'react';
 import classnames from 'classnames';
 import controlStyles from './RadioButtonCheckbox.css';
 import styles from './RadioButton.css';
@@ -66,7 +66,7 @@ type Props = {|
  * ![RadioGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/RadioGroup-dark.spec.mjs-snapshots/RadioGroup-dark-chromium-darwin.png)
  *
  */
-const RadioGroupButtonWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
+const RadioGroupButtonWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
 >(function RadioButton(

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node, useState, useRef, useImperativeHandle } from 'react';
+import { forwardRef, type Node, type AbstractComponent, useState, useRef, useImperativeHandle } from 'react';
 import classnames from 'classnames';
 import layout from './Layout.css';
 import styles from './SearchField.css';
@@ -87,7 +87,7 @@ type Props = {|
  * ![SearchField dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/SearchField-dark.spec.mjs-snapshots/SearchField-dark-chromium-darwin.png)
  *
  */
-const SearchFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
+const SearchFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
 >(function SearchField(

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -1,5 +1,12 @@
 // @flow strict
-import { forwardRef, type Node, type AbstractComponent, useState, useRef, useImperativeHandle } from 'react';
+import {
+  forwardRef,
+  type Node,
+  type AbstractComponent,
+  useState,
+  useRef,
+  useImperativeHandle,
+} from 'react';
 import classnames from 'classnames';
 import layout from './Layout.css';
 import styles from './SearchField.css';

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Node, useImperativeHandle, useRef } from 'react';
+import { forwardRef, type Node, type AbstractComponent, useImperativeHandle, useRef } from 'react';
 import classnames from 'classnames';
 import styles from './TapArea.css';
 import InternalLink from './InternalLink.js';
@@ -80,7 +80,7 @@ type unionRefs = HTMLDivElement | HTMLAnchorElement;
  * ![TapArea](https://raw.githubusercontent.com/pinterest/gestalt/master/docs/graphics/building-blocks/TapArea.svg)
  *
  */
-const TapAreaWithForwardRef: React$AbstractComponent<unionProps, unionRefs> = forwardRef<
+const TapAreaWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRef<
   unionProps,
   unionRefs,
 >(function TapArea(props: unionProps, ref): Node {

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Element, type Node, useState } from 'react';
+import { forwardRef, type Element, type Node, type AbstractComponent, useState } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
 import focusStyles from './Focus.css';
@@ -114,7 +114,7 @@ type Props = {|
  * ![TextArea dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TextArea-dark.spec.mjs-snapshots/TextArea-dark-chromium-darwin.png)
  *
  */
-const TextAreaWithForwardRef: React$AbstractComponent<Props, HTMLTextAreaElement> = forwardRef<
+const TextAreaWithForwardRef: AbstractComponent<Props, HTMLTextAreaElement> = forwardRef<
   Props,
   HTMLTextAreaElement,
 >(function TextArea(

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { forwardRef, type Element, type Node, useEffect, useState } from 'react';
+import { forwardRef, type Element, type Node, type AbstractComponent, useEffect, useState } from 'react';
 import InternalTextField from './InternalTextField.js';
 import InternalTextFieldIconButton from './InternalTextFieldIconButton.js';
 import Tag from './Tag.js';
@@ -122,7 +122,7 @@ type Props = {|
  * ![TextField dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TextField-dark.spec.mjs-snapshots/TextField-dark-chromium-darwin.png)
  *
  */
-const TextFieldWithForwardRef: React$AbstractComponent<Props, HTMLInputElement> = forwardRef<
+const TextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwardRef<
   Props,
   HTMLInputElement,
 >(function TextField(

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -1,5 +1,12 @@
 // @flow strict
-import { forwardRef, type Element, type Node, type AbstractComponent, useEffect, useState } from 'react';
+import {
+  forwardRef,
+  type Element,
+  type Node,
+  type AbstractComponent,
+  useEffect,
+  useState,
+} from 'react';
 import InternalTextField from './InternalTextField.js';
 import InternalTextFieldIconButton from './InternalTextFieldIconButton.js';
 import Tag from './Tag.js';


### PR DESCRIPTION
### Summary

Replace usage of `React$AbstractComponent` with react's built in type `AbstractComponent`. 

They are pretty much the same thing 
If you option-click (also called hyber-click?) the AbstractComponent, you would see this:
```
  declare export type AbstractComponent<
    -Config,
    +Instance = mixed,
  > = React$AbstractComponent<Config, Instance>;
```

From @dangerismycat 
> The React$SomeType types are considered “internal”, so changes to them aren’t necessarily considered “breaking”. I’ve heard of folks recommending not using them, but I also see them being used everywhere, so functionally I don’t think the React team can make unannounced breaking changes to them without alienating a large part of their users.

#### What changed?

Updated 19 files, for example: 

![image](https://user-images.githubusercontent.com/5871660/211446142-2ee79fd0-1314-48f7-92a8-72635a487839.png)
![image](https://user-images.githubusercontent.com/5871660/211446157-fa6b03f7-efc1-4def-841b-21cfa6628041.png)


#### Why?

- More future proof to use the react implementation 
- I'm working on another PR which generates Typescript types from Flow and it's complaining about flow's React$AbstractTypes


### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
