### PR TITLE
Replace React$ElementConfig for type Element config

### DIFF
--- a/packages/gestalt/src/InternalDismissButton.js
+++ b/packages/gestalt/src/InternalDismissButton.js
@@ -8,6 +8,7 @@ InternalDismissIconButton aims to replace "dismiss" IconButtons in components th
 import {
   type Node,
   type AbstractComponent,
+  type ElementConfig,
   forwardRef,
   useImperativeHandle,
   useState,
@@ -24,11 +25,11 @@ import useTapFeedback from './useTapFeedback.js';
 type Props = {|
   accessibilityLabel: string,
   accessibilityControls?: string,
-  iconColor?: $ElementType<React$ElementConfig<typeof Pog>, 'iconColor'>,
+  iconColor?: $ElementType<ElementConfig<typeof Pog>, 'iconColor'>,
   onClick?: AbstractEventHandler<
     SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>,
   >,
-  size?: $ElementType<React$ElementConfig<typeof Pog>, 'size'>,
+  size?: $ElementType<ElementConfig<typeof Pog>, 'size'>,
 |};
 
 const InternalDismissIconButtonWithForwardRef: AbstractComponent<Props, HTMLButtonElement> =

--- a/packages/gestalt/src/InternalTextFieldIconButton.js
+++ b/packages/gestalt/src/InternalTextFieldIconButton.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useState } from 'react';
+import { type Node, type ElementConfig, useState } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
 import Pog from './Pog.js';
@@ -17,7 +17,7 @@ type Props = {|
   onClick: () => void,
   pogPadding?: 1 | 2,
   role?: 'switch',
-  tapStyle?: $ElementType<React$ElementConfig<typeof TapArea>, 'tapStyle'>,
+  tapStyle?: $ElementType<ElementConfig<typeof TapArea>, 'tapStyle'>,
   tooltipText?: string,
 |};
 

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -7,6 +7,7 @@ import {
   type Node,
   type Element,
   type Ref,
+  type ElementConfig,
 } from 'react';
 import classnames from 'classnames';
 import { useOnLinkNavigation } from './contexts/OnLinkNavigationProvider.js';
@@ -40,8 +41,8 @@ type ExternalLinkIcon =
   | 'none'
   | 'default'
   | {|
-      color: $ElementType<React$ElementConfig<typeof Icon>, 'color'>,
-      size: $ElementType<React$ElementConfig<typeof Text>, 'size'>,
+      color: $ElementType<ElementConfig<typeof Icon>, 'color'>,
+      size: $ElementType<ElementConfig<typeof Text>, 'size'>,
     |};
 
 function ExternalIcon({ externalLinkIcon }: {| externalLinkIcon: ExternalLinkIcon |}): Node {

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Children, isValidElement, type Element, type Node } from 'react';
+import { Children, isValidElement, type Element, type Node, type ElementConfig } from 'react';
 import Box from './Box.js';
 import Icon from './Icon.js';
 import Flex from './Flex.js';
@@ -31,10 +31,10 @@ type Props = {|
     accessibilityLabel: string,
     href?: string,
     label: string,
-    onClick?: $ElementType<React$ElementConfig<typeof Button>, 'onClick'>,
-    rel?: $ElementType<React$ElementConfig<typeof Link>, 'rel'>,
-    size?: $ElementType<React$ElementConfig<typeof Button>, 'size'>,
-    target?: $ElementType<React$ElementConfig<typeof Link>, 'target'>,
+    onClick?: $ElementType<ElementConfig<typeof Button>, 'onClick'>,
+    rel?: $ElementType<ElementConfig<typeof Link>, 'rel'>,
+    size?: $ElementType<ElementConfig<typeof Button>, 'size'>,
+    target?: $ElementType<ElementConfig<typeof Link>, 'target'>,
   |},
 
   /**

--- a/packages/gestalt/src/ToastPrimaryAction.js
+++ b/packages/gestalt/src/ToastPrimaryAction.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node } from 'react';
+import { type Node, type ElementConfig } from 'react';
 import Button from './Button.js';
 import Link from './Link.js';
 
@@ -7,10 +7,10 @@ type Props = {|
   accessibilityLabel: string,
   href?: string,
   label: string,
-  onClick?: $ElementType<React$ElementConfig<typeof Button>, 'onClick'>,
-  rel?: $ElementType<React$ElementConfig<typeof Link>, 'rel'>,
-  size?: $ElementType<React$ElementConfig<typeof Button>, 'size'>,
-  target?: $ElementType<React$ElementConfig<typeof Link>, 'target'>,
+  onClick?: $ElementType<ElementConfig<typeof Button>, 'onClick'>,
+  rel?: $ElementType<ElementConfig<typeof Link>, 'rel'>,
+  size?: $ElementType<ElementConfig<typeof Button>, 'size'>,
+  target?: $ElementType<ElementConfig<typeof Link>, 'target'>,
 |};
 
 export default function ToastPrimaryAction({


### PR DESCRIPTION
### Summary

Replace usage of `React$ElementConfig` with react's built in type `ElementConfig`. 

They are pretty much the same thing: 

![image](https://user-images.githubusercontent.com/5871660/211686177-a180a412-03e7-4309-8909-f45522dab58c.png)


From @dangerismycat 
> The React$SomeType types are considered “internal”, so changes to them aren’t necessarily considered “breaking”. I’ve heard of folks recommending not using them, but I also see them being used everywhere, so functionally I don’t think the React team can make unannounced breaking changes to them without alienating a large part of their users.

#### What changed?

Updated 5 files like this: 

![image](https://user-images.githubusercontent.com/5871660/211686363-2d454071-318a-4934-9131-03766466cb3b.png)



#### Why?

- More future proof to use the react implementation 
- I'm working on another PR which generates Typescript types from Flow and it's complaining about flow's React$AbstractTypes


### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
