### PR TITLE
Internal: update release.yml to use pinterest-gestalt account

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,8 @@ jobs:
           GITHUB_PERSONAL_TOKEN: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
         run: |
           echo "machine github.com" >> ~/.netrc
-          echo "login christianvuerings" >> ~/.netrc
-          echo "password $GITHUB_PERSONAL_TOKEN" >> ~/.netrc
+          echo "login pinterest-gestalt" >> ~/.netrc
+          echo "password $PINTEREST_GESTALT_PERSONAL_TOKEN" >> ~/.netrc
       - name: Release Steps
         id: release
         run: ./scripts/releaseSteps.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         run: yarn install
       - name: Setup GitHub access tokens
         env:
-          GITHUB_PERSONAL_TOKEN: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
+          PINTEREST_GESTALT_PERSONAL_TOKEN: ${{ secrets.PINTEREST_GESTALT_PERSONAL_TOKEN }}
         run: |
           echo "machine github.com" >> ~/.netrc
           echo "login pinterest-gestalt" >> ~/.netrc
@@ -94,7 +94,7 @@ jobs:
       - name: Trigger VSCode Gestalt release
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.GITHUB_PERSONAL_TOKEN }}
+          github-token: ${{ secrets.PINTEREST_GESTALT_PERSONAL_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'pinterest',


### PR DESCRIPTION
The release workflow previously used @christianvuerings's account, which isn't good. This PR updates the workflow to use the @pinterest-gestalt account that we use for other automated things.