### PR TITLE
Masonary: Update getDerivedStateFromProps  Flowtype

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -263,13 +263,13 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     window.removeEventListener('resize', this.handleResize);
   }
 
-  static getDerivedStateFromProps<T>(
-    props: Props<T>,
-    state: State<T>,
+  static getDerivedStateFromProps<K>(
+    props: Props<K>,
+    state: State<K>,
   ): null | {|
     hasPendingMeasurements: boolean,
     isFetching?: boolean,
-    items: $ReadOnlyArray<T>,
+    items: $ReadOnlyArray<K>,
   |} {
     const { items } = props;
     const { measurementStore } = state;

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -263,7 +263,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     window.removeEventListener('resize', this.handleResize);
   }
 
-  static getDerivedStateFromProps(
+  static getDerivedStateFromProps<T>(
     props: Props<T>,
     state: State<T>,
   ): null | {|


### PR DESCRIPTION
### Summary
When testing migration from Flow to Typescript I get an error saying: 

> File: Masonry.ts - Error: Parameter 'props' of public static method from exported class has or is using private name 'T'.

- It seems like the proper way to type Flow Generics is to declare the `private name T` after the function name `getDerivedStateFromProps<Private Name Here>`
- Also I renamed `T` to `K` because I got an eslint error saying that T was already used 

There's an [issue in the Typescript](https://github.com/microsoft/TypeScript/issues/23465#issuecomment-382077840) project that references how to probably type `getDerivedStateFromProps`

> Before the change, the type of props.items for getDerivedStateFromProps must be consistent with the one for componentDidUpdate. After the change, it no longer does? So the semantic is changed?
While it doesn’t seem ideal, it’s not a huge blocker because that’s really an internal API, not public API. I’m fine with this change even it turns out that it’s the only TypeScript-migration-friendly way. - Jack Hsu

#### What changed?

Just a tiny update to the Flow signature of the Masonry `getDerivedStateFromProps` method 

#### Why?

When converting from Flow to Typescript, Typescript is not able to determine where `T` is coming from


### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
