### PR TITLE
Internal: update release.yml to use dangerismycat account

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,11 @@ jobs:
         run: yarn install
       - name: Setup GitHub access tokens
         env:
-          PINTEREST_GESTALT_PERSONAL_TOKEN: ${{ secrets.PINTEREST_GESTALT_PERSONAL_TOKEN }}
+          RYAN_GITHUB_PERSONAL_TOKEN: ${{ secrets.RYAN_GITHUB_PERSONAL_TOKEN }}
         run: |
           echo "machine github.com" >> ~/.netrc
-          echo "login pinterest-gestalt" >> ~/.netrc
-          echo "password $PINTEREST_GESTALT_PERSONAL_TOKEN" >> ~/.netrc
+          echo "login dangerismycat" >> ~/.netrc
+          echo "password $RYAN_GITHUB_PERSONAL_TOKEN" >> ~/.netrc
       - name: Release Steps
         id: release
         run: ./scripts/releaseSteps.js
@@ -94,7 +94,7 @@ jobs:
       - name: Trigger VSCode Gestalt release
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.PINTEREST_GESTALT_PERSONAL_TOKEN }}
+          github-token: ${{ secrets.RYAN_GITHUB_PERSONAL_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'pinterest',


### PR DESCRIPTION
#2603 didn't seem to work. Given these lines in the logs:

_before #2603_
```
remote: Permission to pinterest/gestalt.git denied to christianvuerings.
fatal: unable to access 'https://github.com/pinterest/gestalt/': The requested URL returned error: 403
```

_after #2603_
```
remote: Permission to pinterest/gestalt.git denied to pinterest-gestalt.
fatal: unable to access 'https://github.com/pinterest/gestalt/': The requested URL returned error: 403
```

This may be a permissions error. I know that my account definitely has permissions, so let's see if that works.