### PR TITLE
Internal: fix lint errors in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Visit [http://localhost:8888/](http://localhost:8888) and click on a component t
 
 When a release will cause breaking changes — in usage or in typing — we provide a codemod to ease the upgrade process. Codemods are organized by release in `/packages/gestalt-codemods`.
 
-### Usage
+### Codemod Usage
 
 Clone the Gestalt repo locally if you haven't already. Run the relevant codemod(s) in the relevant directory of your repo (not the Gestalt repo): anywhere the component to be updated is used. Example usage for a codebase using Flow:
 
@@ -78,7 +78,7 @@ Example PR title: `Avatar: Add outline prop`
 
 Install the [DefinitelyTyped](https://www.npmjs.com/package/@types/gestalt) definitions.
 
-### Installation
+### DefinitelyTyped Installation
 
 Install via npm:
 


### PR DESCRIPTION
This PR really does fix a couple of lint errors, but I'm mostly trying to kick the releases workflow back into order. As such, this is a "minor" release though it's really a patch