### PR TITLE
Table: fix unresponsive Table.Rowdrawer and Table.RowExpandable to wrapped children in React.Fragment

### DIFF
--- a/packages/gestalt/src/Table/getChildrenCount.js
+++ b/packages/gestalt/src/Table/getChildrenCount.js
@@ -1,0 +1,23 @@
+// @flow strict
+import { Fragment, Children, type Node } from 'react';
+
+function getChildrenCount(children: Node): number {
+  const topChildren = Children.toArray(children);
+  let nestedChildrenCount = 0;
+
+  topChildren.forEach((child) => {
+    // We need to check for Fragment first, so we can check for nested Table.Cell that don't get counted in Children.toArray
+    if (child?.type === Fragment) {
+      const nestedChildren = child.props.children.reduce(
+        (accumulator, currentValue) =>
+          currentValue?.type?.displayName === 'Table.Cell' ? 1 + accumulator : accumulator,
+        -1,
+      );
+      nestedChildrenCount += nestedChildren;
+    }
+  });
+
+  return topChildren.length + nestedChildrenCount;
+}
+
+export default getChildrenCount;

--- a/packages/gestalt/src/TableRowDrawer.js
+++ b/packages/gestalt/src/TableRowDrawer.js
@@ -3,6 +3,7 @@ import { type Node, Children, cloneElement, Fragment, useEffect, useRef, useStat
 import styles from './Table.css';
 import Box from './Box.js';
 import { useTableContext } from './contexts/TableContext.js';
+import getChildrenCount from './Table/getChildrenCount.js';
 
 type Props = {|
   /**
@@ -50,11 +51,12 @@ export default function TableRowDrawer({ children, drawerContents, id }: Props):
   return (
     <Fragment>
       <tr aria-details={drawerContents ? id : undefined} ref={rowRef}>
+        {/* This needs to be fixed for children wrapped in React.Fragment when sticky columns are present */}
         {Number(stickyColumns) > 0 ? Children.map(children, renderCellWithAdjustedIndex) : children}
       </tr>
       {drawerContents ? (
         <tr id={id}>
-          <td className={styles.drawer} colSpan={Children.count(children) + 1}>
+          <td className={styles.drawer} colSpan={getChildrenCount(children)}>
             <Box padding={2}>{drawerContents}</Box>
           </td>
         </tr>

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -5,6 +5,7 @@ import Box from './Box.js';
 import IconButton from './IconButton.js';
 import TableCell from './TableCell.js';
 import { useTableContext } from './contexts/TableContext.js';
+import getChildrenCount from './Table/getChildrenCount.js';
 
 type Props = {|
   /**
@@ -106,11 +107,13 @@ export default function TableRowExpandable({
             size="xs"
           />
         </TableCell>
+        {/* This needs to be fixed for children wrapped in React.Fragment when sticky columns are present */}
         {Number(stickyColumns) > 0 ? Children.map(children, renderCellWithAdjustedIndex) : children}
       </tr>
       {expanded && (
         <tr id={id}>
-          <td className={styles.drawer} colSpan={Children.count(children) + 1}>
+          {/* + 1 is added to colSpan to account for the icon button cell */}
+          <td className={styles.drawer} colSpan={getChildrenCount(children) + 1}>
             <Box padding={6}>{expandedContents}</Box>
           </td>
         </tr>

--- a/packages/gestalt/src/__snapshots__/TableRowDrawer.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableRowDrawer.test.js.snap
@@ -168,7 +168,7 @@ exports[`renders correctly with drawer 1`] = `
       >
         <td
           className="drawer"
-          colSpan={5}
+          colSpan={4}
         >
           <div
             className="box paddingX2 paddingY2"


### PR DESCRIPTION
Table: fix unresponsive Table.Rowdrawer and Table.RowExpandable to wrapped children in React.Fragment

### Summary

#### What changed?

BEFORE
![Screen Shot 2023-01-11 at 5 48 01 PM](https://user-images.githubusercontent.com/10593890/211934581-6a92afa0-a39b-42eb-9377-269f3a878743.png)

AFTER
![Screen Shot 2023-01-11 at 5 48 19 PM](https://user-images.githubusercontent.com/10593890/211934630-1f2e9c3c-4003-4371-9b56-0fefcc2d4408.png)


#### Why?

Under the hood, Table uses Children.count to estimate the amount of colSpan + 1 but React.Fragment is evaluated as the only children so Table sets colspan for Drawer to 2 incorrectly.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
