### PR TITLE
Internal: `copyProp` codemod

### DIFF
--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectObject.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectObject.input.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good="test" />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectObject.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectObject.output.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good="test" test={{ text: "test" }} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectObject.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectObject.output.js
@@ -1,7 +1,5 @@
 import { IconButton } from 'gestalt';
 
 export default function TestComp() {
-  return (
-    <IconButton good="test" test={{ text: "test" }} />
-  );
+  return <IconButton good="test" test={{ text: "test" }} />;
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectObject.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectObject.output.js
@@ -1,5 +1,11 @@
 import { IconButton } from 'gestalt';
 
 export default function TestComp() {
-  return <IconButton good="test" test={{ text: "test" }} />;
+  return (
+    <IconButton
+      good="test"
+      test={{
+        text: "test"
+      }} />
+  );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectBoolean.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectBoolean.input.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good={false} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectBoolean.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectBoolean.output.js
@@ -1,7 +1,5 @@
 import { IconButton } from 'gestalt';
 
 export default function TestComp() {
-  return (
-    <IconButton good={false} test={false} />
-  );
+  return <IconButton good={false} test={false} />;
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectBoolean.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectBoolean.output.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good={false} test={false} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectNumber.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectNumber.input.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good={1} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectNumber.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectNumber.output.js
@@ -1,7 +1,5 @@
 import { IconButton } from 'gestalt';
 
 export default function TestComp() {
-  return (
-    <IconButton good={1} test={1} />
-  );
+  return <IconButton good={1} test={1} />;
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectNumber.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectNumber.output.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good={1} test={1} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectText.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectText.input.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good="good" />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectText.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectText.output.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good="good" test="good" />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectText.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/noObjectnoObjectText.output.js
@@ -1,7 +1,5 @@
 import { IconButton } from 'gestalt';
 
 export default function TestComp() {
-  return (
-    <IconButton good="good" test="good" />
-  );
+  return <IconButton good="good" test="good" />;
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectNoObject.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectNoObject.input.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good={{ test: 1 }} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectNoObject.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectNoObject.output.js
@@ -1,7 +1,5 @@
 import { IconButton } from 'gestalt';
 
 export default function TestComp() {
-  return (
-    <IconButton good={{ test: 1 }} test={1} />
-  );
+  return <IconButton good={{ test: 1 }} test={1} />;
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectNoObject.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectNoObject.output.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good={{ test: 1 }} test={1} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectObject.input.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectObject.input.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good={{ test: 1 }} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectObject.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectObject.output.js
@@ -1,5 +1,13 @@
 import { IconButton } from 'gestalt';
 
 export default function TestComp() {
-  return <IconButton good={{ test: 1 }} test={{ text: 1 }} />;
+  return (
+    <IconButton
+      good={{
+        test: 1
+      }}
+      test={{
+        text: 1
+      }} />
+  );
 }

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectObject.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectObject.output.js
@@ -1,0 +1,7 @@
+import { IconButton } from 'gestalt';
+
+export default function TestComp() {
+  return (
+    <IconButton good={{ test: 1 }} test={{ text: 1 }} />
+  );
+}

--- a/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectObject.output.js
+++ b/packages/gestalt-codemods/generic-codemods/__testfixtures__/copyProp/objectObject.output.js
@@ -1,7 +1,5 @@
 import { IconButton } from 'gestalt';
 
 export default function TestComp() {
-  return (
-    <IconButton good={{ test: 1 }} test={{ text: 1 }} />
-  );
+  return <IconButton good={{ test: 1 }} test={{ text: 1 }} />;
 }

--- a/packages/gestalt-codemods/generic-codemods/__tests__/copyProp.test.js
+++ b/packages/gestalt-codemods/generic-codemods/__tests__/copyProp.test.js
@@ -1,0 +1,83 @@
+import { defineTest } from 'jscodeshift/dist/testUtils.js';
+
+jest.mock('../copyProp', () =>
+  Object.assign(jest.requireActual('../copyProp'), {
+    parser: 'flow',
+  }),
+);
+
+describe('copyProp: noObjectnoObject', () => {
+  [
+    'copyProp/noObjectnoObjectBoolean',
+    'copyProp/noObjectnoObjectText',
+    'copyProp/noObjectnoObjectNumber',
+  ].forEach((test) => {
+    defineTest(
+      __dirname,
+      'copyProp',
+      {
+        quote: 'single',
+        component: 'IconButton',
+        previousProp: 'good',
+        nextProp: 'test',
+      },
+      test,
+      {},
+    );
+  });
+});
+
+describe('copyProp: noObjectObject', () => {
+  ['copyProp/noObjectObject'].forEach((test) => {
+    defineTest(
+      __dirname,
+      'copyProp',
+      {
+        quote: 'single',
+        component: 'IconButton',
+        previousProp: 'good',
+        nextProp: 'test',
+        nextPropNode: 'text',
+      },
+      test,
+      {},
+    );
+  });
+});
+
+describe('copyProp: ObjectNoObject', () => {
+  ['copyProp/ObjectNoObject'].forEach((test) => {
+    defineTest(
+      __dirname,
+      'copyProp',
+      {
+        quote: 'single',
+        component: 'IconButton',
+        previousProp: 'good',
+        previousPropNode: 'test',
+        nextProp: 'test',
+      },
+      test,
+      {},
+    );
+  });
+});
+
+describe('copyProp: ObjectObject', () => {
+  ['copyProp/ObjectObject'].forEach((test) => {
+    defineTest(
+      __dirname,
+      'copyProp',
+      {
+        quote: 'single',
+        component: 'IconButton',
+        previousProp: 'good',
+        previousPropNode: 'test',
+        nextProp: 'test',
+        nextPropNode: 'text',
+      },
+      test,
+      {},
+    );
+  });
+});

--- a/packages/gestalt-codemods/generic-codemods/__tests__/copyProp.test.js
+++ b/packages/gestalt-codemods/generic-codemods/__tests__/copyProp.test.js
@@ -46,7 +46,7 @@ describe('copyProp: noObjectObject', () => {
 });
 
 describe('copyProp: ObjectNoObject', () => {
-  ['copyProp/ObjectNoObject'].forEach((test) => {
+  ['copyProp/objectNoObject'].forEach((test) => {
     defineTest(
       __dirname,
       'copyProp',
@@ -64,7 +64,7 @@ describe('copyProp: ObjectNoObject', () => {
 });
 
 describe('copyProp: ObjectObject', () => {
-  ['copyProp/ObjectObject'].forEach((test) => {
+  ['copyProp/objectObject'].forEach((test) => {
     defineTest(
       __dirname,
       'copyProp',

--- a/packages/gestalt-codemods/generic-codemods/copyProp.js
+++ b/packages/gestalt-codemods/generic-codemods/copyProp.js
@@ -1,0 +1,181 @@
+// @flow strict
+
+/**
+ * CODEMOD to COPY (COPY VALUE TO NEW PROP) PROP-VALUE COMBINATIONS in GESTALT COMPONENT
+ * Supports string, number, and boolean values
+ * Ex. <Box variant="error" /> to <Box variant="error" newProp="error" />
+ * Ex. <IconButton accessibilityLabel="test" /> to <IconButton accessibilityLabel="test" tooltip={{ text: 'test' }} />
+ *
+ * OPTIONS:
+ * --component: component to which copy props
+ * --previousProp: current prop name to be copied
+ * --previousPropNode: node of object to copy the current prop if the previousProp is an object [Not required]
+ * --nextProp: new prop name to paste
+ * --nextPropNode: node of object to paste the new prop if the newProp is an object [Not required]
+ *
+ * TO RUN THIS CODEMOD
+ * yarn codemod copyProp ~/path/to/your/code \
+ * --component=string \
+ * --previousProp=string \
+ * --previousPropNode=string \
+ * --nextProp=string \
+ * --nextPropNode=string
+ *
+ * If all options passed, previous+next combination are copied and paste between object props (OBJECT/OBJECT)
+ * In the absence of previousPropNode, the codemod will apply the same `value` on the nextPropNode of the previousProp (NoOBJECT/OBJECT)
+ * In the absence of previousPropNode & nextPropNode, the codemod will apply the the same `value` on the nextProp of the previousProp (NoOBJECT/NoOBJECT)
+ * In the absence of nextPropNode, the codemod will apply the the same `value` on the nextProp of the previousPropNode (OBJECT/NoOBJECT)
+ *
+ * OBJECT/OBJECT E.g. yarn codemod copyProp ~/code/pinboard/webapp --component=IconButton --previousProp=dangerouslySetSvgPath --previousPropNode=__path --nextProp=tooltip --nextPropNode=text
+ *
+ * NoOBJECT/OBJECT E.g. yarn codemod copyProp ~/code/pinboard/webapp --component=IconButton --previousProp=accessibilityLabel --nextProp=tooltip --nextPropNode=text
+ *
+ * NoOBJECT/NoOBJECT E.g. yarn codemod copyProp ~/code/pinboard/webapp --component=Box --previousProp=variant --nextProp=color
+ *
+ * OBJECT/NoOBJECT E.g. yarn codemod copyProp ~/code/pinboard/webapp --component=IconButton --previousProp=dangerouslySetSvgPath --previousPropNode=__path --nextProp=accessibilityLabel
+ */
+
+import {
+  getGestaltImport,
+  getComponentIdentifierByName,
+  getLocalImportedName,
+  filterJSXByTargetLocalName,
+  filterJSXByAttribute,
+  initialize,
+  isNullOrUndefined,
+  saveToSource,
+  deepCloneNode,
+  throwErrorIfSpreadProps,
+  JSCSObjectExpression,
+} from './utils.js';
+import { type FileType, type ApiType } from './flowtypes.js';
+
+type OptionsType = {|
+  component: string,
+  subcomponent?: string,
+  previousProp: string,
+  previousPropNode?: string,
+  nextProp: string,
+  nextPropNode?: string,
+|};
+
+function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?string | null {
+  const { component, subcomponent, previousProp, previousPropNode, nextProp, nextPropNode } =
+    options;
+
+  const { j, src } = initialize({ api, fileInfo });
+
+  const gestaltImportCollection = getGestaltImport({ src, j });
+
+  if (gestaltImportCollection.size() === 0) return null;
+
+  // Getting component
+  const componentIdentifierCollection = getComponentIdentifierByName({
+    j,
+    gestaltImportCollection,
+    componentName: component,
+  });
+
+  if (componentIdentifierCollection.size() === 0) return null;
+
+  const targetLocalName = getLocalImportedName({
+    importSpecifierCollection: componentIdentifierCollection,
+  });
+
+  const matchedJSXCollection = filterJSXByTargetLocalName({
+    src,
+    j,
+    targetLocalName,
+    subcomponent,
+  });
+
+  throwErrorIfSpreadProps({
+    fileInfo,
+    j,
+    jSXCollection: matchedJSXCollection,
+    componentName: targetLocalName,
+    subcomponentName: subcomponent,
+  });
+
+  const nextjSXWithMatchingAttributesCollection = filterJSXByAttribute({
+    j,
+    jSXCollection: matchedJSXCollection,
+    componentName: targetLocalName,
+    subcomponentName: subcomponent,
+    prop: nextProp,
+  });
+
+  if (nextjSXWithMatchingAttributesCollection.size() > 0) return null;
+
+  // Copying & pasting values
+  for (let idx = matchedJSXCollection.size() - 1; idx >= 0; idx -= 1) {
+    matchedJSXCollection.at(idx).replaceWith((node) => {
+      const jSXWithMatchingAttributesCollection = filterJSXByAttribute({
+        j,
+        jSXCollection: matchedJSXCollection.at(idx),
+        componentName: targetLocalName,
+        subcomponentName: subcomponent,
+        prop: previousProp,
+      });
+
+      let previousValue;
+
+      // NoOBJECT/NoOBJECT
+      if (isNullOrUndefined(previousPropNode) && isNullOrUndefined(nextPropNode)) {
+        console.log('NoOBJECT/NoOBJECT');
+        jSXWithMatchingAttributesCollection.forEach((previousNode) => {
+          previousValue = previousNode.get().value.value;
+        });
+      }
+
+      // OBJECT/NoOBJECT
+      if (!isNullOrUndefined(previousPropNode) && isNullOrUndefined(nextPropNode)) {
+        console.log('OBJECT/NoOBJECT');
+        jSXWithMatchingAttributesCollection.forEach((previousNode) => {
+          const tmpValue = previousNode.get().value.value;
+          const { properties } = tmpValue.expression;
+          const prop = properties.find((item) => item.key.name === previousPropNode);
+          previousValue = j.stringLiteral(prop.value.value);
+        });
+      }
+
+      // NoOBJECT/OBJECT
+      if (isNullOrUndefined(previousPropNode) && !isNullOrUndefined(nextPropNode)) {
+        console.log('NoOBJECT/OBJECT');
+        jSXWithMatchingAttributesCollection.forEach((previousNode) => {
+          const { value } =
+            previousNode.get().value.value.expression ?? previousNode.get().value.value;
+          console.log(value);
+          const newObject = new JSCSObjectExpression({ [nextPropNode ?? '']: value }, j);
+          previousValue = j.jsxExpressionContainer(newObject);
+        });
+      }
+
+      // OBJECT/OBJECT
+      if (!isNullOrUndefined(previousPropNode) && !isNullOrUndefined(nextPropNode)) {
+        console.log('OBJECT/OBJECT');
+        jSXWithMatchingAttributesCollection.forEach((previousNode) => {
+          const { properties } = previousNode.get().value.value.expression;
+          const previousPropValue = properties?.find((item) => item.key.name === previousPropNode)
+            .value.value;
+          const newObject = new JSCSObjectExpression(
+            { [nextPropNode ?? '']: previousPropValue },
+            j,
+          );
+          previousValue = j.jsxExpressionContainer(newObject);
+        });
+      }
+
+      const newAttribute = j.jsxAttribute(j.jsxIdentifier(nextProp), previousValue);
+      const newNode = deepCloneNode({ node: node.get().node });
+      newNode.openingElement.attributes.push(newAttribute);
+      return newNode;
+    });
+  }
+
+  src.modified = true;
+
+  return saveToSource({ src });
+}
+
+export default transform;

--- a/packages/gestalt-codemods/generic-codemods/copyProp.js
+++ b/packages/gestalt-codemods/generic-codemods/copyProp.js
@@ -133,7 +133,7 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
           const tmpValue = previousNode.get().value.value;
           const { properties } = tmpValue.expression;
           const prop = properties.find((item) => item.key.name === previousPropNode);
-          previousValue = j.stringLiteral(prop.value.value);
+          previousValue = prop.value.value;
         });
       }
 

--- a/packages/gestalt-codemods/generic-codemods/copyProp.js
+++ b/packages/gestalt-codemods/generic-codemods/copyProp.js
@@ -122,7 +122,6 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
 
       // NoOBJECT/NoOBJECT
       if (isNullOrUndefined(previousPropNode) && isNullOrUndefined(nextPropNode)) {
-        console.log('NoOBJECT/NoOBJECT');
         jSXWithMatchingAttributesCollection.forEach((previousNode) => {
           previousValue = previousNode.get().value.value;
         });
@@ -130,7 +129,6 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
 
       // OBJECT/NoOBJECT
       if (!isNullOrUndefined(previousPropNode) && isNullOrUndefined(nextPropNode)) {
-        console.log('OBJECT/NoOBJECT');
         jSXWithMatchingAttributesCollection.forEach((previousNode) => {
           const tmpValue = previousNode.get().value.value;
           const { properties } = tmpValue.expression;
@@ -141,11 +139,9 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
 
       // NoOBJECT/OBJECT
       if (isNullOrUndefined(previousPropNode) && !isNullOrUndefined(nextPropNode)) {
-        console.log('NoOBJECT/OBJECT');
         jSXWithMatchingAttributesCollection.forEach((previousNode) => {
           const { value } =
             previousNode.get().value.value.expression ?? previousNode.get().value.value;
-          console.log(value);
           const newObject = new JSCSObjectExpression({ [nextPropNode ?? '']: value }, j);
           previousValue = j.jsxExpressionContainer(newObject);
         });
@@ -153,7 +149,6 @@ function transform(fileInfo: FileType, api: ApiType, options: OptionsType): ?str
 
       // OBJECT/OBJECT
       if (!isNullOrUndefined(previousPropNode) && !isNullOrUndefined(nextPropNode)) {
-        console.log('OBJECT/OBJECT');
         jSXWithMatchingAttributesCollection.forEach((previousNode) => {
           const { properties } = previousNode.get().value.value.expression;
           const previousPropValue = properties?.find((item) => item.key.name === previousPropNode)


### PR DESCRIPTION
### Summary

Codemod to copy the current prop value to a new prop. Supporting 4 kind of copies:
1. to **OBJECT/OBJECT**: `<Box dangerouslySetInlineStyle={{ color: "error" }} />` to `<Box dangerouslySetInlineStyle={{ color: "error" }} variant={{ color: "error" }} />`;
Please, run:
```
yarn codemod copyProp ~/path/to/your/code \ 
--component=Box \
--previousProp=dangerouslySetInlineStyle \
--previousPropNode=color \
--nextProp=variant \
--nextPropNode=color
```

2. to **NoOBJECT/OBJECT**:  `<Box color="error" />` to `<Box color="error" variant={{ example: "error" }}/>`;
Please, run:
```
yarn codemod copyProp ~/path/to/your/code \ 
--component=Box \
--previousProp=color \
--nextProp=variant \
--nextPropNode=example
```

3. to **NoOBJECT/NoOBJECT**: `<Box color="error" />` to `<Box color="error" variant="error" />`;
Please, run:
```
yarn codemod copyProp ~/path/to/your/code \ 
--component=Box \
--previousProp=color \
--nextProp=variant 
```

4. to **OBJECT/NoOBJECT**: `<Box dangerouslySetInlineStyle={{ color: "error" }} />` to `<Box dangerouslySetInlineStyle={{ color: "error" }} variant="error" />`;
Please, run:
```
yarn codemod copyProp ~/path/to/your/code \ 
--component=Box \
--previousProp=dangerouslySetInlineStyle \
--previousPropNode=color \
--nextProp=variant 
```

*The entire docs was adding to the  `packages/gestalt-codemods/generic-codemods/copyProp.js` file header*

#### What changed?

The command below was added to the source code:

``` 
yarn codemod copyProp ~/path/to/your/code \
  --component=string \
  --previousProp=string \
  --previousPropNode=string \
  --nextProp=string \
  --nextPropNode=string
```

Which: 
 - `--component`: Is the component name to copy props
 - `--previousProp`: Is the current prop name to be copied
 - `--previousPropNode`: Is the node of object to copy the current prop if the previousProp is an object [Is not required]
 - `--nextProp`: New prop name to paste
 - `--nextPropNode`: Is the node of object to paste the new prop if the newProp is an object [Is not required]

_Attention_: If the prop has exists the copy won't work, the copy and paste prop is only workable if the component doesn't has the `--newProp` assigned on you scope.

#### Why?

Based on [this task](https://jira.pinadmin.com/browse/GESTALT-4663) requirements, this codemod is requested to copy the previous value if `accessibiltyLabel` of `IconButton` and paste to  the `tooltip` prop of the same component.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4663)

### Checklist

- [ ] Checked stakeholder feedback (e.g. ??)
