### PR TITLE
Revert "Masonry: deprecate Item prop in favor of renderItem prop"

### DIFF
--- a/docs/pages/visual-test/Masonry.js
+++ b/docs/pages/visual-test/Masonry.js
@@ -31,9 +31,9 @@ export default function Snapshot(): Node {
         <Masonry
           columnWidth={50}
           gutterWidth={3}
+          Item={GridComponent}
           items={dataObject}
           minCols={1}
-          renderITem={({ data }) => <GridComponent data={data} />}
         />
       </Box>
     </ColorSchemeProvider>

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -158,13 +158,13 @@ class ExampleMasonry extends Component<Props, State> {
             <Masonry
               columnWidth={170}
               gutterWidth={5}
+              Item={GridComponent}
               items={this.state.pins}
               layout={this.props.layout}
               minCols={1}
               ref={(ref) => {
                 this.grid = ref;
               }}
-              renderItem={({ data }) => <GridComponent data={data} />}
               scrollContainer={() => scrollContainer}
             />
           )}
@@ -189,10 +189,10 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
     ~~~jsx
     <Masonry
+      Item={Item}
       items={this.state.pins}
       loadItems={this.loadItems}
       minCols={1}
-      renderItem={({ data }) => <Item data={data} />}
     />
     ~~~
   `}
@@ -203,7 +203,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     When layout is set to \`flexible\`, the item width will shrink/grow to fill the container. This is great for responsive designs.
 
     ~~~jsx
-    <Masonry layout="flexible" items={items} minCols={1} renderItem={({ data }) => <Item data={data} />} />
+    <Masonry layout="flexible" Item={Item} items={items} minCols={1} />
     ~~~
     `}
         name="Flexible item width"
@@ -215,7 +215,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     When the \`flexible\` property is omitted, the item width will be fixed to \`columnWidth\`.
 
     ~~~jsx
-    <Masonry items={items} minCols={1} renderItem={({ data }) => <Item data={data} />} />
+    <Masonry Item={Item} items={items} minCols={1} />
     ~~~
   `}
         name="Non-flexible item width"
@@ -227,7 +227,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     Using the \`uniformRow\` layout.
 
     ~~~jsx
-    <Masonry items={items} layout="uniformRow" renderItem={({ data }) => <Item data={data} />} />;
+    <Masonry Item={Item} items={items} layout="uniformRow" />;
     ~~~
   `}
         name="Uniform row heights"

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -192,14 +192,14 @@ export default function Collage(props: Props): Node {
   });
   return (
     <Collection
-      layout={positions}
-      renderItem={({ idx: index }) =>
+      Item={({ idx: index }) =>
         renderImage({
           index,
           width: positions[index].width,
           height: positions[index].height,
         })
       }
+      layout={positions}
     />
   );
 }

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -43,14 +43,13 @@ import { type Node } from 'react';
 import layoutStyles from './Layout.css';
 
 type Props = {|
-  Item?: ({| idx: number |}) => Node,
+  Item: ({| idx: number |}) => Node,
   layout: $ReadOnlyArray<{|
     top: number,
     left: number,
     width: number,
     height: number,
   |}>,
-  renderItem?: ({| idx: number |}) => Node,
   viewportTop?: number,
   viewportLeft?: number,
   viewportWidth?: number,
@@ -61,7 +60,7 @@ type Props = {|
  * https://gestalt.pinterest.systems/collection
  */
 export default function Collection(props: Props): Node {
-  const { Item, layout = [], renderItem, viewportTop = 0, viewportLeft = 0 } = props;
+  const { Item, layout = [], viewportTop = 0, viewportLeft = 0 } = props;
 
   // Calculate the full dimensions of the item layer
   const width = Math.max(...layout.map((item) => item.left + item.width));
@@ -88,7 +87,7 @@ export default function Collection(props: Props): Node {
     <div className={layoutStyles.relative} style={{ width, height }}>
       {items.map(({ idx, ...style }) => (
         <div key={idx} className={layoutStyles.absolute} style={style}>
-          {renderItem ? renderItem({ idx }) : Item ? <Item idx={idx} /> : null}
+          <Item idx={idx} />
         </div>
       ))}
     </div>

--- a/packages/gestalt/src/Collection.test.js
+++ b/packages/gestalt/src/Collection.test.js
@@ -5,11 +5,11 @@ import Collection from './Collection.js';
 test('Collection with default viewport', () => {
   const tree = create(
     <Collection
+      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
       ]}
-      renderItem={({ idx }) => <div>{idx}</div>}
     />,
   ).toJSON();
   expect(tree).toMatchSnapshot();
@@ -18,11 +18,11 @@ test('Collection with default viewport', () => {
 test('Collection with limited viewport', () => {
   const tree = create(
     <Collection
+      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
       ]}
-      renderItem={({ idx }) => <div>{idx}</div>}
       viewportTop={100}
       viewportLeft={100}
       viewportWidth={50}
@@ -35,13 +35,13 @@ test('Collection with limited viewport', () => {
 test('Collection with limited viewport and a few items', () => {
   const tree = create(
     <Collection
+      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 0, left: 100, width: 100, height: 100 },
         { top: 100, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
       ]}
-      renderItem={({ idx }) => <div>{idx}</div>}
       viewportTop={50}
       viewportLeft={50}
       viewportWidth={100}

--- a/packages/gestalt/src/Masonry.flowtest.js
+++ b/packages/gestalt/src/Masonry.flowtest.js
@@ -4,7 +4,7 @@ import Masonry from './Masonry.js';
 function Item() {
   return <div />;
 }
-const Valid = <Masonry items={[]} renderItem={() => <Item />} />;
+const Valid = <Masonry items={[]} Item={Item} />;
 
 // $FlowExpectedError[prop-missing]
 const MissingProp = <Masonry />;

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -32,9 +32,8 @@ type Props<T> = {|
   gutterWidth?: number,
   /**
    * A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item. *Note that this [must be a stable reference!](https://www.developerway.com/posts/react-re-renders-guide#part3.1)* If using a component declared within a parent function component, you must use [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback) to ensure a stable reference.
-   * This is deprecated in favor of the `renderItem` prop
    */
-  Item?: ComponentType<{|
+  Item: ComponentType<{|
     data: T,
     itemIdx: number,
     isMeasuring: boolean,
@@ -73,14 +72,6 @@ type Props<T> = {|
    * Minimum number of columns to display.
    */
   minCols: number,
-  /**
-   * A function that renders the item you would like displayed in the grid. This function is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item.
-   */
-  renderItem?: ({|
-    +data: T,
-    +itemIdx: number,
-    +isMeasuring: boolean,
-  |}) => Node,
   /**
    * A function that returns a DOM node that Masonry uses for on-scroll event subscription. This DOM node is intended to be the most immediate ancestor of Masonry in the DOM that will have a scroll bar; in most cases this will be the `window` itself, although sometimes Masonry is used inside containers that have `overflow: auto`. `scrollContainer` is optional, although it is required for features such as `virtualize` and `loadItems`.
    * This is required if the grid is expected to be scrollable.
@@ -386,17 +377,6 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     this.forceUpdate();
   }
 
-  renderItem(item: {| +data: T, +itemIdx: number, +isMeasuring: boolean |}): Node {
-    const { Item, renderItem } = this.props;
-    if (renderItem) {
-      return renderItem(item);
-    }
-    if (Item) {
-      return <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />;
-    }
-    return null;
-  }
-
   renderMasonryComponent: (itemData: T, idx: number, position: Position) => Node = (
     itemData,
     idx,
@@ -404,7 +384,6 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
   ) => {
     const {
       Item,
-      renderItem,
       scrollContainer,
       virtualize,
       virtualBoundsTop,
@@ -449,7 +428,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
           height: layoutNumberToCssDimension(height),
         }}
       >
-        {this.renderItem({ data: itemData, itemIdx: idx, isMeasuring: false })}
+        <Item data={itemData} itemIdx={idx} isMeasuring={false} />
       </div>
     );
 
@@ -536,7 +515,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
               }}
             >
-              {this.renderItem({ data: item, itemIdx: i, isMeasuring: false })}
+              <Item data={item} itemIdx={i} isMeasuring={false} />
             </div>
           ))}
         </div>
@@ -587,7 +566,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     }
                   }}
                 >
-                  {this.renderItem({ data, itemIdx: measurementIndex, isMeasuring: true })}
+                  <Item data={data} itemIdx={measurementIndex} isMeasuring />
                 </div>
               );
             })}


### PR DESCRIPTION
This reverts commit d41bdf7e37c38b8f4de8125880f0016033a8f450, which was accidentally merged without CI and code review
