### PR TITLE
Masonry: replace the `Item` prop with the `renderItem` prop

### DIFF
--- a/docs/pages/visual-test/Masonry.js
+++ b/docs/pages/visual-test/Masonry.js
@@ -27,12 +27,13 @@ export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
       <Box color="default" display="inlineBlock" width={300} padding={1}>
+        {/* $FlowFixMe[prop-missing] */}
         <Masonry
           columnWidth={50}
           gutterWidth={3}
           items={dataObject}
           minCols={1}
-          renderItem={({ data }) => <GridComponent data={data} />}
+          renderITem={({ data }) => <GridComponent data={data} />}
         />
       </Box>
     </ColorSchemeProvider>

--- a/docs/pages/visual-test/Masonry.js
+++ b/docs/pages/visual-test/Masonry.js
@@ -27,13 +27,12 @@ export default function Snapshot(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
       <Box color="default" display="inlineBlock" width={300} padding={1}>
-        {/* $FlowFixMe[prop-missing] */}
         <Masonry
           columnWidth={50}
           gutterWidth={3}
           items={dataObject}
           minCols={1}
-          renderITem={({ data }) => <GridComponent data={data} />}
+          renderItem={({ data }) => <GridComponent data={data} />}
         />
       </Box>
     </ColorSchemeProvider>

--- a/docs/pages/visual-test/Masonry.js
+++ b/docs/pages/visual-test/Masonry.js
@@ -31,9 +31,9 @@ export default function Snapshot(): Node {
         <Masonry
           columnWidth={50}
           gutterWidth={3}
-          Item={GridComponent}
           items={dataObject}
           minCols={1}
+          renderITem={({ data }) => <GridComponent data={data} />}
         />
       </Box>
     </ColorSchemeProvider>

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -158,13 +158,13 @@ class ExampleMasonry extends Component<Props, State> {
             <Masonry
               columnWidth={170}
               gutterWidth={5}
-              Item={GridComponent}
               items={this.state.pins}
               layout={this.props.layout}
               minCols={1}
               ref={(ref) => {
                 this.grid = ref;
               }}
+              renderItem={({ data }) => <GridComponent data={data} />}
               scrollContainer={() => scrollContainer}
             />
           )}
@@ -189,10 +189,10 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
     ~~~jsx
     <Masonry
-      Item={Item}
       items={this.state.pins}
       loadItems={this.loadItems}
       minCols={1}
+      renderItem={({ data }) => <Item data={data} />}
     />
     ~~~
   `}
@@ -203,7 +203,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     When layout is set to \`flexible\`, the item width will shrink/grow to fill the container. This is great for responsive designs.
 
     ~~~jsx
-    <Masonry layout="flexible" Item={Item} items={items} minCols={1} />
+    <Masonry layout="flexible" items={items} minCols={1} renderItem={({ data }) => <Item data={data} />} />
     ~~~
     `}
         name="Flexible item width"
@@ -215,7 +215,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     When the \`flexible\` property is omitted, the item width will be fixed to \`columnWidth\`.
 
     ~~~jsx
-    <Masonry Item={Item} items={items} minCols={1} />
+    <Masonry items={items} minCols={1} renderItem={({ data }) => <Item data={data} />} />
     ~~~
   `}
         name="Non-flexible item width"
@@ -227,7 +227,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
     Using the \`uniformRow\` layout.
 
     ~~~jsx
-    <Masonry Item={Item} items={items} layout="uniformRow" />;
+    <Masonry items={items} layout="uniformRow" renderItem={({ data }) => <Item data={data} />} />;
     ~~~
   `}
         name="Uniform row heights"

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -192,14 +192,14 @@ export default function Collage(props: Props): Node {
   });
   return (
     <Collection
-      Item={({ idx: index }) =>
+      layout={positions}
+      renderItem={({ idx: index }) =>
         renderImage({
           index,
           width: positions[index].width,
           height: positions[index].height,
         })
       }
-      layout={positions}
     />
   );
 }

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -43,13 +43,14 @@ import { type Node } from 'react';
 import layoutStyles from './Layout.css';
 
 type Props = {|
-  Item: ({| idx: number |}) => Node,
+  Item?: ({| idx: number |}) => Node,
   layout: $ReadOnlyArray<{|
     top: number,
     left: number,
     width: number,
     height: number,
   |}>,
+  renderItem?: ({| idx: number |}) => Node,
   viewportTop?: number,
   viewportLeft?: number,
   viewportWidth?: number,
@@ -60,7 +61,7 @@ type Props = {|
  * https://gestalt.pinterest.systems/collection
  */
 export default function Collection(props: Props): Node {
-  const { Item, layout = [], viewportTop = 0, viewportLeft = 0 } = props;
+  const { Item, layout = [], renderItem, viewportTop = 0, viewportLeft = 0 } = props;
 
   // Calculate the full dimensions of the item layer
   const width = Math.max(...layout.map((item) => item.left + item.width));
@@ -87,7 +88,7 @@ export default function Collection(props: Props): Node {
     <div className={layoutStyles.relative} style={{ width, height }}>
       {items.map(({ idx, ...style }) => (
         <div key={idx} className={layoutStyles.absolute} style={style}>
-          <Item idx={idx} />
+          {renderItem ? renderItem({ idx }) : Item ? <Item idx={idx} /> : null}
         </div>
       ))}
     </div>

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -43,13 +43,14 @@ import { type Node } from 'react';
 import layoutStyles from './Layout.css';
 
 type Props = {|
+  Item?: ({| idx: number |}) => Node,
   layout: $ReadOnlyArray<{|
     top: number,
     left: number,
     width: number,
     height: number,
   |}>,
-  renderItem: ({| idx: number |}) => Node,
+  renderItem?: ({| idx: number |}) => Node,
   viewportTop?: number,
   viewportLeft?: number,
   viewportWidth?: number,
@@ -60,7 +61,7 @@ type Props = {|
  * https://gestalt.pinterest.systems/collection
  */
 export default function Collection(props: Props): Node {
-  const { layout = [], renderItem, viewportTop = 0, viewportLeft = 0 } = props;
+  const { Item, layout = [], renderItem, viewportTop = 0, viewportLeft = 0 } = props;
 
   // Calculate the full dimensions of the item layer
   const width = Math.max(...layout.map((item) => item.left + item.width));
@@ -87,7 +88,7 @@ export default function Collection(props: Props): Node {
     <div className={layoutStyles.relative} style={{ width, height }}>
       {items.map(({ idx, ...style }) => (
         <div key={idx} className={layoutStyles.absolute} style={style}>
-          {renderItem({ idx })}
+          {renderItem ? renderItem({ idx }) : Item && <Item idx={idx} />}
         </div>
       ))}
     </div>

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -43,14 +43,13 @@ import { type Node } from 'react';
 import layoutStyles from './Layout.css';
 
 type Props = {|
-  Item?: ({| idx: number |}) => Node,
   layout: $ReadOnlyArray<{|
     top: number,
     left: number,
     width: number,
     height: number,
   |}>,
-  renderItem?: ({| idx: number |}) => Node,
+  renderItem: ({| idx: number |}) => Node,
   viewportTop?: number,
   viewportLeft?: number,
   viewportWidth?: number,
@@ -61,7 +60,7 @@ type Props = {|
  * https://gestalt.pinterest.systems/collection
  */
 export default function Collection(props: Props): Node {
-  const { Item, layout = [], renderItem, viewportTop = 0, viewportLeft = 0 } = props;
+  const { layout = [], renderItem, viewportTop = 0, viewportLeft = 0 } = props;
 
   // Calculate the full dimensions of the item layer
   const width = Math.max(...layout.map((item) => item.left + item.width));
@@ -88,7 +87,7 @@ export default function Collection(props: Props): Node {
     <div className={layoutStyles.relative} style={{ width, height }}>
       {items.map(({ idx, ...style }) => (
         <div key={idx} className={layoutStyles.absolute} style={style}>
-          {renderItem ? renderItem({ idx }) : Item && <Item idx={idx} />}
+          {renderItem({ idx })}
         </div>
       ))}
     </div>

--- a/packages/gestalt/src/Collection.js
+++ b/packages/gestalt/src/Collection.js
@@ -88,7 +88,7 @@ export default function Collection(props: Props): Node {
     <div className={layoutStyles.relative} style={{ width, height }}>
       {items.map(({ idx, ...style }) => (
         <div key={idx} className={layoutStyles.absolute} style={style}>
-          {renderItem ? renderItem({ idx }) : Item ? <Item idx={idx} /> : null}
+          {renderItem ? renderItem({ idx }) : Item && <Item idx={idx} />}
         </div>
       ))}
     </div>

--- a/packages/gestalt/src/Collection.test.js
+++ b/packages/gestalt/src/Collection.test.js
@@ -5,11 +5,11 @@ import Collection from './Collection.js';
 test('Collection with default viewport', () => {
   const tree = create(
     <Collection
-      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
       ]}
+      renderItem={({ idx }) => <div>{idx}</div>}
     />,
   ).toJSON();
   expect(tree).toMatchSnapshot();
@@ -18,11 +18,11 @@ test('Collection with default viewport', () => {
 test('Collection with limited viewport', () => {
   const tree = create(
     <Collection
-      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
       ]}
+      renderItem={({ idx }) => <div>{idx}</div>}
       viewportTop={100}
       viewportLeft={100}
       viewportWidth={50}
@@ -35,13 +35,13 @@ test('Collection with limited viewport', () => {
 test('Collection with limited viewport and a few items', () => {
   const tree = create(
     <Collection
-      Item={({ idx }) => <div>{idx}</div>}
       layout={[
         { top: 0, left: 0, width: 100, height: 100 },
         { top: 0, left: 100, width: 100, height: 100 },
         { top: 100, left: 0, width: 100, height: 100 },
         { top: 100, left: 100, width: 100, height: 100 },
       ]}
+      renderItem={({ idx }) => <div>{idx}</div>}
       viewportTop={50}
       viewportLeft={50}
       viewportWidth={100}

--- a/packages/gestalt/src/Masonry.flowtest.js
+++ b/packages/gestalt/src/Masonry.flowtest.js
@@ -4,7 +4,7 @@ import Masonry from './Masonry.js';
 function Item() {
   return <div />;
 }
-const Valid = <Masonry items={[]} Item={Item} />;
+const Valid = <Masonry items={[]} renderItem={() => <Item />} />;
 
 // $FlowExpectedError[prop-missing]
 const MissingProp = <Masonry />;

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -32,7 +32,7 @@ type Props<T> = {|
   gutterWidth?: number,
   /**
    * A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item. *Note that this [must be a stable reference!](https://www.developerway.com/posts/react-re-renders-guide#part3.1)* If using a component declared within a parent function component, you must use [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback) to ensure a stable reference.
-   * This is deprecated in favor of the `renderItem` prop
+   * This is DEPRECATED and will be removed in the next major release. Please use `renderItem` prop instead.
    */
   Item?: ComponentType<{|
     data: T,
@@ -40,7 +40,7 @@ type Props<T> = {|
     isMeasuring: boolean,
   |}>,
   /**
-   * An array of items to display that contains the data to be rendered by `<Item />`.
+   * An array of items to display that contains the data to be rendered by `renderItem()` (fallback to the deprecated `<Item />` if `renderItem` is not passed).
    */
   items: $ReadOnlyArray<T>,
   /**

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type ComponentType, type Node, Component as ReactComponent } from 'react';
+import { type Node, Component as ReactComponent } from 'react';
 import debounce, { type DebounceReturn } from './debounce.js';
 import FetchItems from './FetchItems.js';
 import styles from './Masonry.css';
@@ -31,16 +31,7 @@ type Props<T> = {|
    */
   gutterWidth?: number,
   /**
-   * A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item. *Note that this [must be a stable reference!](https://www.developerway.com/posts/react-re-renders-guide#part3.1)* If using a component declared within a parent function component, you must use [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback) to ensure a stable reference.
-   * This is deprecated in favor of the `renderItem` prop
-   */
-  Item?: ComponentType<{|
-    data: T,
-    itemIdx: number,
-    isMeasuring: boolean,
-  |}>,
-  /**
-   * An array of items to display that contains the data to be rendered by `<Item />`.
+   * An array of items to display that contains the data to be rendered by `renderItem()`.
    */
   items: $ReadOnlyArray<T>,
   /**
@@ -76,7 +67,7 @@ type Props<T> = {|
   /**
    * A function that renders the item you would like displayed in the grid. This function is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item.
    */
-  renderItem?: ({|
+  renderItem: ({|
     +data: T,
     +itemIdx: number,
     +isMeasuring: boolean,
@@ -386,23 +377,13 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     this.forceUpdate();
   }
 
-  renderItem(item: {| +data: T, +itemIdx: number, +isMeasuring: boolean |}): Node {
-    const { Item, renderItem } = this.props;
-    if (renderItem) {
-      return renderItem(item);
-    }
-    if (Item) {
-      return <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />;
-    }
-    return null;
-  }
-
   renderMasonryComponent: (itemData: T, idx: number, position: Position) => Node = (
     itemData,
     idx,
     position,
   ) => {
     const {
+      renderItem,
       scrollContainer,
       virtualize,
       virtualBoundsTop,
@@ -447,7 +428,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
           height: layoutNumberToCssDimension(height),
         }}
       >
-        {this.renderItem({ data: itemData, itemIdx: idx, isMeasuring: false })}
+        {renderItem({ data: itemData, itemIdx: idx, isMeasuring: false })}
       </div>
     );
 
@@ -461,6 +442,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       items,
       layout,
       minCols,
+      renderItem,
       scrollContainer,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
@@ -533,7 +515,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
               }}
             >
-              {this.renderItem({ data: item, itemIdx: i, isMeasuring: false })}
+              {renderItem({ data: item, itemIdx: i, isMeasuring: false })}
             </div>
           ))}
         </div>
@@ -584,7 +566,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     }
                   }}
                 >
-                  {this.renderItem({ data, itemIdx: measurementIndex, isMeasuring: true })}
+                  {renderItem({ data, itemIdx: measurementIndex, isMeasuring: true })}
                 </div>
               );
             })}

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -388,13 +388,14 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
 
   renderItem(item: {| +data: T, +itemIdx: number, +isMeasuring: boolean |}): Node {
     const { Item, renderItem } = this.props;
-    if (renderItem) {
-      return renderItem(item);
+    if (!renderItem || !Item) {
+      throw new Error('Please add the required renderItem prop');
     }
-    if (Item) {
-      return <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />;
-    }
-    return null;
+    return renderItem ? (
+      renderItem(item)
+    ) : (
+      <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />
+    );
   }
 
   renderMasonryComponent: (itemData: T, idx: number, position: Position) => Node = (

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -388,14 +388,13 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
 
   renderItem(item: {| +data: T, +itemIdx: number, +isMeasuring: boolean |}): Node {
     const { Item, renderItem } = this.props;
-    if (!renderItem || !Item) {
-      throw new Error('Please add the required renderItem prop');
+    if (renderItem) {
+      return renderItem(item);
     }
-    return renderItem ? (
-      renderItem(item)
-    ) : (
-      <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />
-    );
+    if (Item) {
+      return <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />;
+    }
+    throw new Error('Please add the required renderItem prop.');
   }
 
   renderMasonryComponent: (itemData: T, idx: number, position: Position) => Node = (

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -32,8 +32,9 @@ type Props<T> = {|
   gutterWidth?: number,
   /**
    * A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item. *Note that this [must be a stable reference!](https://www.developerway.com/posts/react-re-renders-guide#part3.1)* If using a component declared within a parent function component, you must use [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback) to ensure a stable reference.
+   * This is deprecated in favor of the `renderItem` prop
    */
-  Item: ComponentType<{|
+  Item?: ComponentType<{|
     data: T,
     itemIdx: number,
     isMeasuring: boolean,
@@ -72,6 +73,14 @@ type Props<T> = {|
    * Minimum number of columns to display.
    */
   minCols: number,
+  /**
+   * A function that renders the item you would like displayed in the grid. This function is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item.
+   */
+  renderItem?: ({|
+    +data: T,
+    +itemIdx: number,
+    +isMeasuring: boolean,
+  |}) => Node,
   /**
    * A function that returns a DOM node that Masonry uses for on-scroll event subscription. This DOM node is intended to be the most immediate ancestor of Masonry in the DOM that will have a scroll bar; in most cases this will be the `window` itself, although sometimes Masonry is used inside containers that have `overflow: auto`. `scrollContainer` is optional, although it is required for features such as `virtualize` and `loadItems`.
    * This is required if the grid is expected to be scrollable.
@@ -377,13 +386,23 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     this.forceUpdate();
   }
 
+  renderItem(item: {| +data: T, +itemIdx: number, +isMeasuring: boolean |}): Node {
+    const { Item, renderItem } = this.props;
+    if (renderItem) {
+      return renderItem(item);
+    }
+    if (Item) {
+      return <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />;
+    }
+    return null;
+  }
+
   renderMasonryComponent: (itemData: T, idx: number, position: Position) => Node = (
     itemData,
     idx,
     position,
   ) => {
     const {
-      Item,
       scrollContainer,
       virtualize,
       virtualBoundsTop,
@@ -428,7 +447,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
           height: layoutNumberToCssDimension(height),
         }}
       >
-        <Item data={itemData} itemIdx={idx} isMeasuring={false} />
+        {this.renderItem({ data: itemData, itemIdx: idx, isMeasuring: false })}
       </div>
     );
 
@@ -439,7 +458,6 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     const {
       columnWidth,
       gutterWidth: gutter,
-      Item,
       items,
       layout,
       minCols,
@@ -515,7 +533,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
               }}
             >
-              <Item data={item} itemIdx={i} isMeasuring={false} />
+              {this.renderItem({ data: item, itemIdx: i, isMeasuring: false })}
             </div>
           ))}
         </div>
@@ -566,7 +584,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     }
                   }}
                 >
-                  <Item data={data} itemIdx={measurementIndex} isMeasuring />
+                  {this.renderItem({ data, itemIdx: measurementIndex, isMeasuring: true })}
                 </div>
               );
             })}


### PR DESCRIPTION
### Precursor to Breaking change

This PR adds a prop to the Masonry API. This prop is optional for now, but will eventually become required.

No changes are required now, but if you want to get a head start: run the following codemod to detect Masonry in your code base.

```
yarn codemod detectManualReplacement ~/path/to/your/code
--component=Masonry
```

You can also automate the renaming: 

```
yarn codemod modifyProp ~/path/to/your/code
--component=Masonry
--previousProp=Items
--nextProp=renderItems
```

but still need to change the value manually following the steps described below:

![Screenshot 2023-01-20 at 11 00 28 AM](https://user-images.githubusercontent.com/10593890/213745746-ef19a354-c612-4c71-a570-97cabe345daa.png)


### Summary

#### What changed?

In `Masonry`, deprecate the `Item` prop (which is expected to be a React component) in favor of `renderItem`, which can be any function that returns a React Node.

#### Why?

When React renders the `<App />` component here:
```ts
const MyGrid = ({ Item }) => <Item />;

const App = ({ foo }) => <MyGrid Item={() => <GridItem foo={foo} />} />;
```

The virtual DOM is `<App><MyGrid><Item><GridItem /></Item></MyGrid></App>`

When React re-renders `<App />`, [React reconciliation](https://reactjs.org/docs/reconciliation.html) algorithm sees that the `<Item>` element is an instance of a brand new React component, since the anonymous function `() => <GridItem />` is a new function for each render call. The reconciliation algorithm would unmount the old `<Item(old)><GridItem /></Item(old)>` subtree and mount the new `<Item(new)><GridItem /></Item(new)>` subtree. The `<GridItem />` gets unmounted as a result, since its parent is unmounted. This is a problem because we do not want the grid items to be unmounted when the parent is re-rendered.

Instead, consider we do this:
```ts
const MyGrid = ({ renderItem }) => renderItem();

const App = ({ foo }) => <MyGrid renderItem={() => <GridItem foo={foo} />} />;
```

The virtual DOM is `<App><MyGrid><GridItem /></MyGrid></App>`

When React re-renders `<App />`, each React component in the virtual DOM is unchanged. React reconciliation can keep the components mounted and `<GridItem />` does not get unmounted as a result.

See this example https://codesandbox.io/s/sandpack-project-forked-qmh0tf?file=/App.js for a simple demonstration
