### PR TITLE
Sheet: implement dismiss confirmation modal and `dismissConfirmation` prop

### DIFF
--- a/docs/examples/defaultlabelprovider/translations.js
+++ b/docs/examples/defaultlabelprovider/translations.js
@@ -19,6 +19,14 @@ const labels = {
   },
   Sheet: {
     accessibilityDismissButtonLabel: myI18nTranslator('Close sheet'),
+    dismissConfirmationMessage: myI18nTranslator('Are you sure you want to dismiss?'),
+    dismissConfirmationSubtext: myI18nTranslator(
+      'You will lose all of your changes. This cannot be undone.',
+    ),
+    dismissConfirmationPrimaryActionText: myI18nTranslator('Yes, dismiss.'),
+    dismissConfirmationPrimaryActionTextLabel: myI18nTranslator('Yes, dismiss the sheet.'),
+    dismissConfirmationSecondaryActionText: myI18nTranslator('No, go back.'),
+    dismissConfirmationSecondaryActionTextLabel: myI18nTranslator('No, go back to the sheet.'),
   },
   Tag: {
     accessibilityErrorIconLabel: myI18nTranslator('Error'),

--- a/docs/examples/sheet/defaultExample.js
+++ b/docs/examples/sheet/defaultExample.js
@@ -40,7 +40,7 @@ export default function AccessibilityExample(): Node {
             accessibilityDismissButtonLabel="Close audience creation sheet"
             accessibilitySheetLabel="Audience list creation for new campaign"
             heading="Create a new audience list"
-            onDismiss={() => {}}
+            onDismiss={() => setShouldShow(false)}
             footer={footer}
             size="md"
           >

--- a/docs/pages/web/sheet.js
+++ b/docs/pages/web/sheet.js
@@ -142,7 +142,7 @@ When Sheet opens, focus should be placed on the first interactive element within
       </AccessibilitySection>
       <MainSection
         name="Localization"
-        description={`Be sure to localize the \`heading\`, \`accessibilityDismissButtonLabel\`, \`accessibilitySheetLabel\` props and well as any custom string in \`dismissConfirmation\`. Note that localization can lengthen text by 20 to 30 percent.`}
+        description={`Be sure to localize the \`heading\`, \`accessibilityDismissButtonLabel\`, \`accessibilitySheetLabel\` props and well as any custom strings in \`dismissConfirmation\`. Note that localization can lengthen text by 20 to 30 percent.`}
       />
       <SlimBanner
         iconAccessibilityLabel="Localize the default label"
@@ -280,15 +280,15 @@ Sheet comes in 3 sizes: small (\`sm\`), medium (\`md\`), and large (\`lg\`).
 The three internally-controlled or component-controlled dismiss actions are:
 - when the \`ESC\` key is pressed
 - when the backdrop is clicked
-- when the dismiss IconButtons are clicked
+- when the dismiss IconButton is clicked
 
-The externally-controlled dismiss actions require implementing the callback \`onDismissStart\`. See the [animation variant](#Animation) to learn more.
+The externally-controlled dismiss actions (\`subHeading\`, \`children\`, and \`footer\`) require implementing the callback \`onDismissStart\`. See the [animation variant](#Animation) to learn more.
 
 Sheets can contain forms or be part of flows where the user is required to submit infomation. If a Sheet is dismissed involuntarily, the data entered by the user could not be saved and lost. This can create a bad user experience.
 
 To prevent dismissing Sheet involuntary, we can use \`dismissConfirmation\`. When provided, it will open a confirmation modal each time component-controlled dismiss actions are triggered.
 
-The confirmation modal has a flexible API. When the \`dismissConfirmation\` prop is set to "true", Sheet uses defauld texts and labels.
+The confirmation modal has a flexible API. When the \`dismissConfirmation\` prop is set to an empty object "dismissConfirmation={{}}", Sheet uses default texts and labels. See the default content below:
 
 - Message: "Are you sure you want to dismiss?"
 - Subtext: "You will lose all of your changes. This cannot be undone."
@@ -297,7 +297,7 @@ The confirmation modal has a flexible API. When the \`dismissConfirmation\` prop
 - Secondary action text: "No, go back."
 - Secondary action label: "No, go back to the sheet."
 
-All texts and labels can be customized using the \`dismissConfirmation\` prop. We can pass an object with custom strings. For any missing strings, Sheet uses the default ones.
+All texts and labels can be customized using the \`dismissConfirmation\` prop. We can pass an object with custom strings. For any missing strings, Sheet uses the default ones. See the \`dismissConfirmation\` prop Flow type to learn more about the optional texts and labels than can be customized.
 `}
         >
           <SlimBanner

--- a/docs/pages/web/sheet.js
+++ b/docs/pages/web/sheet.js
@@ -326,7 +326,7 @@ function AccessibilityExample() {
       {shouldShow && (
         <Layer zIndex={sheetZIndex}>
           <Sheet
-            dismissConfirmation
+            dismissConfirmation={{}}
             accessibilityDismissButtonLabel="Close audience creation sheet"
             accessibilitySheetLabel="Audience list creation for new campaign"
             heading="Create a new audience list"

--- a/docs/pages/web/sheet.js
+++ b/docs/pages/web/sheet.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
+import { SlimBanner } from 'gestalt';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -141,7 +142,18 @@ When Sheet opens, focus should be placed on the first interactive element within
       </AccessibilitySection>
       <MainSection
         name="Localization"
-        description={`Be sure to localize the \`heading\`, \`accessibilityDismissButtonLabel\` and \`accessibilitySheetLabel\` props. Note that localization can lengthen text by 20 to 30 percent.`}
+        description={`Be sure to localize the \`heading\`, \`accessibilityDismissButtonLabel\`, \`accessibilitySheetLabel\` props and well as any custom string in \`dismissConfirmation\`. Note that localization can lengthen text by 20 to 30 percent.`}
+      />
+      <SlimBanner
+        iconAccessibilityLabel="Localize the default label"
+        message="Sheet's dismiss IconButton and confirmation modal consume default text and labels from DefaultLabelProvider. Make sure to localize the default strings with DefaultLabelProvider."
+        type="recommendationBare"
+        helperLink={{
+          text: 'Learn more',
+          accessibilityLabel: 'Learn more about DefaultLabelProvider',
+          href: '/web/utilities/defaultlabelprovider',
+          onClick: () => {},
+        }}
       />
       <MainSection name="Variants">
         <MainSection.Subsection
@@ -259,6 +271,221 @@ Sheet comes in 3 sizes: small (\`sm\`), medium (\`md\`), and large (\`lg\`).
                 previewHeight={PREVIEW_HEIGHT}
               />
             }
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Dismiss confirmation"
+          description={`There are two ways Sheet can be dismissed: internally-controlled and externally-controlled dismiss actions.
+
+The three internally-controlled or component-controlled dismiss actions are:
+- when the \`ESC\` key is pressed
+- when the backdrop is clicked
+- when the dismiss IconButtons are clicked
+
+The externally-controlled dismiss actions require implementing the callback \`onDismissStart\`. See the [animation variant](#Animation) to learn more.
+
+Sheets can contain forms or be part of flows where the user is required to submit infomation. If a Sheet is dismissed involuntarily, the data entered by the user could not be saved and lost. This can create a bad user experience.
+
+To prevent dismissing Sheet involuntary, we can use \`dismissConfirmation\`. When provided, it will open a confirmation modal each time component-controlled dismiss actions are triggered.
+
+The confirmation modal has a flexible API. When the \`dismissConfirmation\` prop is set to "true", Sheet uses defauld texts and labels.
+
+- Message: "Are you sure you want to dismiss?"
+- Subtext: "You will lose all of your changes. This cannot be undone."
+- Primary action text: "Yes, dismiss."
+- Primary action label: "Yes, dismiss the sheet."
+- Secondary action text: "No, go back."
+- Secondary action label: "No, go back to the sheet."
+
+All texts and labels can be customized using the \`dismissConfirmation\` prop. We can pass an object with custom strings. For any missing strings, Sheet uses the default ones.
+`}
+        >
+          <SlimBanner
+            iconAccessibilityLabel="Recommendation"
+            message={`Sheet's confirmation Popover uses default texts and labels provided by DefaultLabelProvider when the "dismissConfirmation={true}". Don't forget to localize them.`}
+            type="recommendationBare"
+            helperLink={{
+              text: 'Learn more',
+              accessibilityLabel: 'Learn more about DefaultLabelProvider',
+              href: '/web/utilities/defaultlabelprovider',
+              onClick: () => {},
+            }}
+          />
+          <MainSection.Card
+            cardSize="lg"
+            defaultCode={`
+function AccessibilityExample() {
+  const [shouldShow, setShouldShow] = React.useState(false);
+  const HEADER_ZINDEX = new FixedZIndex(10);
+  const sheetZIndex = new CompositeZIndex([HEADER_ZINDEX]);
+  return (
+    <React.Fragment>
+      <Box padding={8}>
+        <Button text="View example Sheet" onClick={() => setShouldShow(true)} />
+      </Box>
+      {shouldShow && (
+        <Layer zIndex={sheetZIndex}>
+          <Sheet
+            dismissConfirmation
+            accessibilityDismissButtonLabel="Close audience creation sheet"
+            accessibilitySheetLabel="Audience list creation for new campaign"
+            heading="Create a new audience list"
+            onDismiss={() => setShouldShow(false)}
+            footer={({ onDismissStart }) => (
+              <Flex alignItems="center" justifyContent="end">
+                <Button color="red" text="Create" onClick={onDismissStart} />
+              </Flex>
+            )}
+            size="md"
+          >
+            <Flex
+              direction="column"
+              gap={{
+                row: 0,
+                column: 12,
+              }}
+            >
+              <Flex
+                direction="column"
+                gap={{
+                  row: 0,
+                  column: 4,
+                }}
+              >
+                <Box>
+                  <Text inline weight="bold">
+                    Step 1:
+                  </Text>
+                  <Text inline> Audience list details</Text>
+                </Box>
+                <TextField
+                  id="audience-name"
+                  label="Audience name"
+                  placeholder="Name your audience"
+                  onChange={() => {}}
+                />
+                <TextField
+                  id="desc"
+                  label="Audience description"
+                  placeholder="Describe your audience"
+                  onChange={() => {}}
+                />
+                <Fieldset legend="When adding this audience list to an ad group:">
+                  <Flex
+                    direction="column"
+                    gap={{
+                      row: 0,
+                      column: 3,
+                    }}
+                  >
+                    <RadioButton
+                      label="Include list"
+                      name="audience"
+                      value="include"
+                      onChange={() => {}}
+                      id="include"
+                    />
+                    <RadioButton
+                      label="Exclude list"
+                      name="audience"
+                      value="include"
+                      onChange={() => {}}
+                      id="exclude"
+                    />
+                  </Flex>
+                </Fieldset>
+              </Flex>
+              <Flex
+                direction="column"
+                gap={{
+                  row: 0,
+                  column: 4,
+                }}
+              >
+                <Box>
+                  <Text inline weight="bold">
+                    Step 2:
+                  </Text>
+                  <Text inline> Select conversion source</Text>
+                </Box>
+                <Text>
+                  To use a conversion source other than a Pinterest Tag, add a filter and configure
+                  the source of this event.
+                </Text>
+                <Fieldset legend="Select conversion source:" legendDisplay="hidden">
+                  <Flex
+                    direction="column"
+                    gap={{
+                      row: 0,
+                      column: 3,
+                    }}
+                  >
+                    <RadioButton
+                      label="Pinterest Tag"
+                      name="source"
+                      value="pin"
+                      onChange={() => {}}
+                      id="tag"
+                    />
+                    <RadioButton
+                      label="Mobile Measurement Partners (MMP)"
+                      name="source"
+                      value="mmp"
+                      onChange={() => {}}
+                      id="mmp"
+                    />
+                    <RadioButton
+                      label="Conversion Upload"
+                      name="source"
+                      value="conversion"
+                      onChange={() => {}}
+                      id="upload"
+                    />
+                    <RadioButton
+                      label="API"
+                      name="source"
+                      value="api"
+                      onChange={() => {}}
+                      id="api"
+                    />
+                  </Flex>
+                </Fieldset>
+              </Flex>
+              <Flex
+                direction="column"
+                gap={{
+                  row: 0,
+                  column: 4,
+                }}
+              >
+                <Box>
+                  <Text inline weight="bold">
+                    Step 3:
+                  </Text>
+                  <Text inline>Set a filter</Text>
+                </Box>
+                <TextField
+                  id="users"
+                  label="Users in the past few days"
+                  placeholder="Ex. 4"
+                  onChange={() => {}}
+                />
+                <Checkbox
+                  label="Include past traffic data"
+                  name="traffic"
+                  id="traffic"
+                  onChange={() => {}}
+                />
+              </Flex>
+            </Flex>
+          </Sheet>
+        </Layer>
+      )}
+    </React.Fragment>
+  );
+}
+
+      `}
           />
         </MainSection.Subsection>
       </MainSection>

--- a/packages/gestalt/src/InternalSheet.js
+++ b/packages/gestalt/src/InternalSheet.js
@@ -31,34 +31,32 @@ type InternalSheetProps = {|
   footer: NodeOrRenderProp,
   heading?: string,
   onAnimationEnd: ?({| animationState: 'in' | 'out' |}) => void,
-  dismissConfirmation?:
-    | boolean
-    | {|
-        message?: string,
-        subtext?: string,
-        primaryAction?: {|
-          accessibilityLabel?: string,
-          text?: string,
-          onClick?: ({|
-            event:
-              | SyntheticMouseEvent<HTMLButtonElement>
-              | SyntheticMouseEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLButtonElement>,
-          |}) => void,
-        |},
-        secondaryAction?: {|
-          accessibilityLabel?: string,
-          text?: string,
-          onClick?: ({|
-            event:
-              | SyntheticMouseEvent<HTMLButtonElement>
-              | SyntheticMouseEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLButtonElement>,
-          |}) => void,
-        |},
-      |},
+  dismissConfirmation?: {|
+    message?: string,
+    subtext?: string,
+    primaryAction?: {|
+      accessibilityLabel?: string,
+      text?: string,
+      onClick?: ({|
+        event:
+          | SyntheticMouseEvent<HTMLButtonElement>
+          | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLButtonElement>,
+      |}) => void,
+    |},
+    secondaryAction?: {|
+      accessibilityLabel?: string,
+      text?: string,
+      onClick?: ({|
+        event:
+          | SyntheticMouseEvent<HTMLButtonElement>
+          | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLButtonElement>,
+      |}) => void,
+    |},
+  |},
   size: 'sm' | 'md' | 'lg',
   subHeading: NodeOrRenderProp,
 |};
@@ -271,7 +269,9 @@ export default function InternalSheet({
                 {showPopover && (
                   <SheetConfirmationPopover
                     anchor={dismissButtonRef.current}
-                    dismissConfirmation={dismissConfirmation}
+                    dismissConfirmation={
+                      typeof dismissConfirmation === 'object' ? dismissConfirmation : {}
+                    }
                     onDismiss={() => {
                       setShowPopover(false);
                       dismissButtonRef?.current?.focus();

--- a/packages/gestalt/src/InternalSheet.js
+++ b/packages/gestalt/src/InternalSheet.js
@@ -72,10 +72,10 @@ export default function InternalSheet({
   accessibilitySheetLabel,
   children,
   closeOnOutsideClick,
+  dismissConfirmation,
   footer,
   heading,
   onAnimationEnd,
-  dismissConfirmation,
   size,
   subHeading,
 }: InternalSheetProps): Node {
@@ -96,7 +96,9 @@ export default function InternalSheet({
 
   const dismissButtonRef = useRef();
 
-  const enabledDismiss = !dismissConfirmation;
+  const enabledDismiss = typeof dismissConfirmation === 'undefined';
+
+  const { message, subtext, primaryAction, secondaryAction } = dismissConfirmation ?? {};
 
   useEffect(() => {
     if (dismissButtonRef.current) {
@@ -106,7 +108,7 @@ export default function InternalSheet({
 
   // Handle onDismiss triggering from ESC keyup event
   useEffect(() => {
-    function handleKeyDown(event: {| keyCode: number |}) {
+    function handleKeyDown(event) {
       if (event.keyCode === ESCAPE && enabledDismiss) {
         onAnimatedDismiss();
       }
@@ -269,9 +271,10 @@ export default function InternalSheet({
                 {showPopover && (
                   <SheetConfirmationPopover
                     anchor={dismissButtonRef.current}
-                    dismissConfirmation={
-                      typeof dismissConfirmation === 'object' ? dismissConfirmation : {}
-                    }
+                    message={message}
+                    subtext={subtext}
+                    primaryAction={primaryAction}
+                    secondaryAction={secondaryAction}
                     onDismiss={() => {
                       setShowPopover(false);
                       dismissButtonRef?.current?.focus();

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -8,33 +8,64 @@ type NodeOrRenderProp = Node | (({| onDismissStart: () => void |}) => Node);
 
 type Props = {|
   /**
-    Supply a short, descriptive label for screen-readers as a text alternative to the Dismiss button. See the [Accessibility section](#Accessibility) for more info.
+    Supply a short, descriptive label for screen-readers as a text alternative to the Dismiss button. See the [Accessibility section](https://gestalt.pinterest.systems/web/sheet#Accessibility) for more info.
    */
   accessibilityDismissButtonLabel?: string,
   /**
-   * Supply a short, descriptive label for screen-readers to contextualize the purpose of Sheet. See the [Accessibility section](#Accessibility) for more info.
+   * Supply a short, descriptive label for screen-readers to contextualize the purpose of Sheet. See the [Accessibility section](https://gestalt.pinterest.systems/web/sheet#Accessibility) for more info.
    */
   accessibilitySheetLabel: string,
   /**
-   * Supply the container element(s) or render prop that will be used as Sheet's main content. See the [animation variant](#Animation) for info on how to add exit animations to Sheet content..
+   * Supply the container element(s) or render prop that will be used as Sheet's main content. See the [animation variant](https://gestalt.pinterest.systems/web/sheet#Animation) for info on how to add exit animations to Sheet content..
    */
   children: NodeOrRenderProp,
   /**
-   * Indicate whether clicking on the backdrop (gray area) outside of Sheet will automatically close it. See the [outside click variant](#Preventing-close-on-outside-click) for more info.
+   * Indicate whether clicking on the backdrop (gray area) outside of Sheet will automatically close it. See the [outside click variant](https://gestalt.pinterest.systems/web/sheet#Preventing-close-on-outside-click) for more info.
    */
   closeOnOutsideClick?: boolean,
   /**
-   * Supply the container element(s) or render prop that will be used as Sheet's custom footer. See the [footer variant](#Footer) for more info..
+   * Supply the container element(s) or render prop that will be used as Sheet's custom footer. See the [footer variant](https://gestalt.pinterest.systems/web/sheet#Footer) for more info..
    */
   footer?: NodeOrRenderProp,
   /**
-   * The text used for Sheet's heading. Be sure to localize this text. See the [heading variant](#Heading) for more info.
+   * The text used for Sheet's heading. Be sure to localize this text. See the [heading variant](https://gestalt.pinterest.systems/web/sheet#Heading) for more info.
    */
   heading?: string,
   /**
-   * Callback fired when the Sheet in/out animations end. See the [animation](#Animation) variant to learn more.
+   * Callback fired when the Sheet in/out animations end. See the [animation](https://gestalt.pinterest.systems/web/sheet#Animation) variant to learn more.
    */
   onAnimationEnd?: ({| animationState: 'in' | 'out' |}) => void,
+  /**
+   * When supplied, it will disable component-controlled dismiss actions (ESC key press, backdrop click, or built-in dismiss IconButtons) and launch a confirmation Popover next to the dismiss IconButton requesting user confirmation before proceding. See the [dismiss confirmation](https://gestalt.pinterest.systems/web/sheet#Dismiss-confirmation) variant to learn more.
+   */
+  dismissConfirmation?:
+    | boolean
+    | {|
+        message?: string,
+        subtext?: string,
+        primaryAction?: {|
+          accessibilityLabel?: string,
+          text?: string,
+          onClick?: ({|
+            event:
+              | SyntheticMouseEvent<HTMLButtonElement>
+              | SyntheticMouseEvent<HTMLAnchorElement>
+              | SyntheticKeyboardEvent<HTMLAnchorElement>
+              | SyntheticKeyboardEvent<HTMLButtonElement>,
+          |}) => void,
+        |},
+        secondaryAction?: {|
+          accessibilityLabel?: string,
+          text?: string,
+          onClick?: ({|
+            event:
+              | SyntheticMouseEvent<HTMLButtonElement>
+              | SyntheticMouseEvent<HTMLAnchorElement>
+              | SyntheticKeyboardEvent<HTMLAnchorElement>
+              | SyntheticKeyboardEvent<HTMLButtonElement>,
+          |}) => void,
+        |},
+      |},
   /**
    * Callback fired when the Sheet is dismissed by clicking on the Dismiss button, pressing the ESC key, or clicking on the backdrop outside of the Sheet (if `closeOnOutsideClick` is true).
    */
@@ -63,6 +94,7 @@ function Sheet({
   footer,
   heading,
   onAnimationEnd,
+  dismissConfirmation = false,
   onDismiss,
   size = 'sm',
   subHeading,
@@ -73,6 +105,7 @@ function Sheet({
         accessibilityDismissButtonLabel={accessibilityDismissButtonLabel}
         accessibilitySheetLabel={accessibilitySheetLabel}
         closeOnOutsideClick={closeOnOutsideClick}
+        dismissConfirmation={dismissConfirmation}
         footer={footer}
         heading={heading}
         onAnimationEnd={onAnimationEnd}

--- a/packages/gestalt/src/Sheet.js
+++ b/packages/gestalt/src/Sheet.js
@@ -36,36 +36,34 @@ type Props = {|
    */
   onAnimationEnd?: ({| animationState: 'in' | 'out' |}) => void,
   /**
-   * When supplied, it will disable component-controlled dismiss actions (ESC key press, backdrop click, or built-in dismiss IconButtons) and launch a confirmation Popover next to the dismiss IconButton requesting user confirmation before proceding. See the [dismiss confirmation](https://gestalt.pinterest.systems/web/sheet#Dismiss-confirmation) variant to learn more.
+   * When supplied, it will disable component-controlled dismiss actions (ESC key press, backdrop click, or built-in dismiss IconButtons) and launch a confirmation Popover next to the dismiss IconButton requesting user confirmation before proceding. Pass an empty object to use the default text and labels. See the [dismiss confirmation](https://gestalt.pinterest.systems/web/sheet#Dismiss-confirmation) variant to learn more.
    */
-  dismissConfirmation?:
-    | boolean
-    | {|
-        message?: string,
-        subtext?: string,
-        primaryAction?: {|
-          accessibilityLabel?: string,
-          text?: string,
-          onClick?: ({|
-            event:
-              | SyntheticMouseEvent<HTMLButtonElement>
-              | SyntheticMouseEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLButtonElement>,
-          |}) => void,
-        |},
-        secondaryAction?: {|
-          accessibilityLabel?: string,
-          text?: string,
-          onClick?: ({|
-            event:
-              | SyntheticMouseEvent<HTMLButtonElement>
-              | SyntheticMouseEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLButtonElement>,
-          |}) => void,
-        |},
-      |},
+  dismissConfirmation?: {|
+    message?: string,
+    subtext?: string,
+    primaryAction?: {|
+      accessibilityLabel?: string,
+      text?: string,
+      onClick?: ({|
+        event:
+          | SyntheticMouseEvent<HTMLButtonElement>
+          | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLButtonElement>,
+      |}) => void,
+    |},
+    secondaryAction?: {|
+      accessibilityLabel?: string,
+      text?: string,
+      onClick?: ({|
+        event:
+          | SyntheticMouseEvent<HTMLButtonElement>
+          | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLButtonElement>,
+      |}) => void,
+    |},
+  |},
   /**
    * Callback fired when the Sheet is dismissed by clicking on the Dismiss button, pressing the ESC key, or clicking on the backdrop outside of the Sheet (if `closeOnOutsideClick` is true).
    */
@@ -94,7 +92,7 @@ function Sheet({
   footer,
   heading,
   onAnimationEnd,
-  dismissConfirmation = false,
+  dismissConfirmation,
   onDismiss,
   size = 'sm',
   subHeading,

--- a/packages/gestalt/src/Sheet.jsdom.test.js
+++ b/packages/gestalt/src/Sheet.jsdom.test.js
@@ -285,10 +285,7 @@ describe('Sheet', () => {
     );
     // eslint-disable-next-line testing-library/no-node-access -- Please fix the next time this file is touched!
     const backDrop = screen.getByRole('dialog').parentElement?.firstElementChild;
-    if (!(backDrop instanceof HTMLElement)) {
-      throw new Error('Backdrop should be an HTMLElement');
-    }
-    fireEvent.click(backDrop);
+    if (backDrop instanceof HTMLElement) fireEvent.click(backDrop);
 
     fireEvent.animationEnd(screen.getByRole('dialog'));
 
@@ -311,10 +308,7 @@ describe('Sheet', () => {
     );
     // eslint-disable-next-line testing-library/no-node-access -- Please fix the next time this file is touched!
     const backDrop = screen.getByRole('dialog').parentElement?.firstElementChild;
-    if (!(backDrop instanceof HTMLElement)) {
-      throw new Error('Backdrop should be an HTMLElement');
-    }
-    fireEvent.click(backDrop);
+    if (backDrop instanceof HTMLElement) fireEvent.click(backDrop);
 
     fireEvent.animationEnd(screen.getAllByRole('dialog')[0]);
 
@@ -386,10 +380,7 @@ describe('Sheet', () => {
     );
     // eslint-disable-next-line testing-library/no-node-access -- Please fix the next time this file is touched!
     const backDrop = screen.getByRole('dialog').parentElement?.firstElementChild;
-    if (!(backDrop instanceof HTMLElement)) {
-      throw new Error('Backdrop should be an HTMLElement');
-    }
-    fireEvent.click(backDrop);
+    if (backDrop instanceof HTMLElement) fireEvent.click(backDrop);
 
     fireEvent.animationEnd(screen.getAllByRole('dialog')[0]);
 
@@ -412,10 +403,7 @@ describe('Sheet', () => {
     );
     // eslint-disable-next-line testing-library/no-node-access -- Please fix the next time this file is touched!
     const backDrop = screen.getByRole('dialog').parentElement?.firstElementChild;
-    if (!(backDrop instanceof HTMLElement)) {
-      throw new Error('Backdrop should be an HTMLElement');
-    }
-    fireEvent.click(backDrop);
+    if (backDrop instanceof HTMLElement) fireEvent.click(backDrop);
 
     expect(
       screen.getByText('No, go back', {
@@ -482,10 +470,7 @@ describe('Sheet', () => {
     );
     // eslint-disable-next-line testing-library/no-node-access -- Please fix the next time this file is touched!
     const backDrop = screen.getByRole('dialog').parentElement?.firstElementChild;
-    if (!(backDrop instanceof HTMLElement)) {
-      throw new Error('Backdrop should be an HTMLElement');
-    }
-    fireEvent.click(backDrop);
+    if (backDrop instanceof HTMLElement) fireEvent.click(backDrop);
 
     expect(
       screen.getByText(secondaryAction, {

--- a/packages/gestalt/src/Sheet.jsdom.test.js
+++ b/packages/gestalt/src/Sheet.jsdom.test.js
@@ -181,10 +181,8 @@ describe('Sheet', () => {
     );
     // eslint-disable-next-line testing-library/no-node-access -- Please fix the next time this file is touched!
     const backDrop = screen.getByRole('dialog').parentElement?.firstElementChild;
-    if (!(backDrop instanceof HTMLElement)) {
-      throw new Error('Backdrop should be an HTMLElement');
-    }
-    fireEvent.click(backDrop);
+
+    if (backDrop instanceof HTMLElement) fireEvent.click(backDrop);
 
     fireEvent.animationEnd(screen.getByRole('dialog'));
 
@@ -302,7 +300,7 @@ describe('Sheet', () => {
 
     render(
       <Sheet
-        dismissConfirmation
+        dismissConfirmation={{}}
         accessibilityDismissButtonLabel="Dismiss"
         accessibilitySheetLabel="Test Sheet"
         closeOnOutsideClick
@@ -328,7 +326,7 @@ describe('Sheet', () => {
 
     render(
       <Sheet
-        dismissConfirmation
+        dismissConfirmation={{}}
         accessibilityDismissButtonLabel="Dismiss"
         accessibilitySheetLabel="Test Sheet"
         closeOnOutsideClick
@@ -351,7 +349,7 @@ describe('Sheet', () => {
 
     render(
       <Sheet
-        dismissConfirmation
+        dismissConfirmation={{}}
         accessibilityDismissButtonLabel="Dismiss"
         accessibilitySheetLabel="Test Sheet"
         closeOnOutsideClick
@@ -377,7 +375,7 @@ describe('Sheet', () => {
 
     const { container } = render(
       <Sheet
-        dismissConfirmation
+        dismissConfirmation={{}}
         accessibilityDismissButtonLabel="Dismiss"
         accessibilitySheetLabel="Test Sheet"
         closeOnOutsideClick
@@ -403,7 +401,7 @@ describe('Sheet', () => {
 
     render(
       <Sheet
-        dismissConfirmation
+        dismissConfirmation={{}}
         accessibilityDismissButtonLabel="Dismiss"
         accessibilitySheetLabel="Test Sheet"
         closeOnOutsideClick

--- a/packages/gestalt/src/SheetConfirmationPopover.js
+++ b/packages/gestalt/src/SheetConfirmationPopover.js
@@ -14,34 +14,32 @@ import { ESCAPE } from './keyCodes.js';
 type Props = {|
   onDismiss: () => void,
   anchor: ?HTMLElement,
-  dismissConfirmation?:
-    | boolean
-    | {|
-        message?: string,
-        subtext?: string,
-        primaryAction?: {|
-          accessibilityLabel?: string,
-          text?: string,
-          onClick?: ({|
-            event:
-              | SyntheticMouseEvent<HTMLButtonElement>
-              | SyntheticMouseEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLButtonElement>,
-          |}) => void,
-        |},
-        secondaryAction?: {|
-          accessibilityLabel?: string,
-          text?: string,
-          onClick?: ({|
-            event:
-              | SyntheticMouseEvent<HTMLButtonElement>
-              | SyntheticMouseEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLAnchorElement>
-              | SyntheticKeyboardEvent<HTMLButtonElement>,
-          |}) => void,
-        |},
-      |},
+  dismissConfirmation: {|
+    message?: string,
+    subtext?: string,
+    primaryAction?: {|
+      accessibilityLabel?: string,
+      text?: string,
+      onClick?: ({|
+        event:
+          | SyntheticMouseEvent<HTMLButtonElement>
+          | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLButtonElement>,
+      |}) => void,
+    |},
+    secondaryAction?: {|
+      accessibilityLabel?: string,
+      text?: string,
+      onClick?: ({|
+        event:
+          | SyntheticMouseEvent<HTMLButtonElement>
+          | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLButtonElement>,
+      |}) => void,
+    |},
+  |},
 |};
 
 export default function SheetConfirmationPopover({
@@ -49,6 +47,8 @@ export default function SheetConfirmationPopover({
   dismissConfirmation,
   onDismiss,
 }: Props): Node {
+  const confirmationButtonRef = useRef();
+
   const { onAnimatedDismiss } = useAnimation();
 
   const {
@@ -60,25 +60,21 @@ export default function SheetConfirmationPopover({
     dismissConfirmationSecondaryActionTextLabel: dismissConfirmationSecondaryActionTextLabelDefault,
   } = useDefaultLabelContext('Sheet');
 
-  const confirmationButtonRef = useRef();
-
   useEffect(() => {
-    if (confirmationButtonRef.current) {
-      confirmationButtonRef.current.focus();
-    }
+    confirmationButtonRef?.current?.focus();
   }, [confirmationButtonRef]);
 
   // Handle onDismiss triggering from ESC keyup event
   useEffect(() => {
-    function handleKeyDown(event: {| keyCode: number, stopPropagation: () => void |}) {
+    function handleKeyDown(event) {
       if (event.keyCode === ESCAPE) {
         event.stopPropagation();
       }
     }
+    window.addEventListener('keydown', handleKeyDown);
 
-    window.addEventListener('key', handleKeyDown);
     return function cleanup() {
-      window.removeEventListener('keyup', handleKeyDown);
+      window.removeEventListener('keydown', handleKeyDown);
     };
   }, []);
 
@@ -97,30 +93,20 @@ export default function SheetConfirmationPopover({
             <Box role="alert">
               <Flex direction="column" gap={2} alignItems="center" width="100%">
                 <Text weight="bold">
-                  {typeof dismissConfirmation === 'boolean'
-                    ? dismissConfirmationMessageDefault
-                    : dismissConfirmation?.message}
+                  {dismissConfirmation?.message ?? dismissConfirmationMessageDefault}
                 </Text>
-                <Text>
-                  {typeof dismissConfirmation === 'boolean'
-                    ? dismissConfirmationSubtextDefault
-                    : dismissConfirmation?.subtext}
-                </Text>
+                <Text>{dismissConfirmation?.subtext ?? dismissConfirmationSubtextDefault}</Text>
               </Flex>
             </Box>
             <Flex justifyContent="center" gap={2}>
               <Button
                 accessibilityLabel={
-                  (typeof dismissConfirmation === 'boolean'
-                    ? dismissConfirmationSecondaryActionTextLabelDefault
-                    : dismissConfirmation?.secondaryAction?.accessibilityLabel) ??
-                  dismissConfirmationSecondaryActionTextDefault
+                  dismissConfirmation?.secondaryAction?.accessibilityLabel ??
+                  dismissConfirmationSecondaryActionTextLabelDefault
                 }
                 color="gray"
                 text={
-                  (typeof dismissConfirmation === 'boolean'
-                    ? dismissConfirmationSecondaryActionTextDefault
-                    : dismissConfirmation?.secondaryAction?.text) ??
+                  dismissConfirmation?.secondaryAction?.text ??
                   dismissConfirmationSecondaryActionTextDefault
                 }
                 onClick={({ event }) => {
@@ -133,16 +119,12 @@ export default function SheetConfirmationPopover({
               <Button
                 color="red"
                 accessibilityLabel={
-                  typeof dismissConfirmation === 'boolean'
-                    ? dismissConfirmationPrimaryActionTextLabelDefault
-                    : dismissConfirmation?.primaryAction?.accessibilityLabel ??
-                      dismissConfirmationPrimaryActionTextDefault
+                  dismissConfirmation?.primaryAction?.accessibilityLabel ??
+                  dismissConfirmationPrimaryActionTextLabelDefault
                 }
                 text={
-                  typeof dismissConfirmation === 'boolean'
-                    ? dismissConfirmationPrimaryActionTextDefault
-                    : dismissConfirmation?.primaryAction?.text ??
-                      dismissConfirmationPrimaryActionTextDefault
+                  dismissConfirmation?.primaryAction?.text ??
+                  dismissConfirmationPrimaryActionTextDefault
                 }
                 onClick={({ event }) => {
                   if (typeof dismissConfirmation !== 'boolean') {

--- a/packages/gestalt/src/SheetConfirmationPopover.js
+++ b/packages/gestalt/src/SheetConfirmationPopover.js
@@ -1,0 +1,161 @@
+// @flow strict
+
+import { type Node, useEffect, useRef } from 'react';
+import { useAnimation } from './AnimationContext.js';
+import Box from './Box.js';
+import Flex from './Flex.js';
+import Popover from './Popover.js';
+import Button from './Button.js';
+import Text from './Text.js';
+import TrapFocusBehavior from './behaviors/TrapFocusBehavior.js';
+import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
+import { ESCAPE } from './keyCodes.js';
+
+type Props = {|
+  onDismiss: () => void,
+  anchor: ?HTMLElement,
+  dismissConfirmation?:
+    | boolean
+    | {|
+        message?: string,
+        subtext?: string,
+        primaryAction?: {|
+          accessibilityLabel?: string,
+          text?: string,
+          onClick?: ({|
+            event:
+              | SyntheticMouseEvent<HTMLButtonElement>
+              | SyntheticMouseEvent<HTMLAnchorElement>
+              | SyntheticKeyboardEvent<HTMLAnchorElement>
+              | SyntheticKeyboardEvent<HTMLButtonElement>,
+          |}) => void,
+        |},
+        secondaryAction?: {|
+          accessibilityLabel?: string,
+          text?: string,
+          onClick?: ({|
+            event:
+              | SyntheticMouseEvent<HTMLButtonElement>
+              | SyntheticMouseEvent<HTMLAnchorElement>
+              | SyntheticKeyboardEvent<HTMLAnchorElement>
+              | SyntheticKeyboardEvent<HTMLButtonElement>,
+          |}) => void,
+        |},
+      |},
+|};
+
+export default function SheetConfirmationPopover({
+  anchor,
+  dismissConfirmation,
+  onDismiss,
+}: Props): Node {
+  const { onAnimatedDismiss } = useAnimation();
+
+  const {
+    dismissConfirmationMessage: dismissConfirmationMessageDefault,
+    dismissConfirmationSubtext: dismissConfirmationSubtextDefault,
+    dismissConfirmationPrimaryActionText: dismissConfirmationPrimaryActionTextDefault,
+    dismissConfirmationSecondaryActionText: dismissConfirmationSecondaryActionTextDefault,
+    dismissConfirmationPrimaryActionTextLabel: dismissConfirmationPrimaryActionTextLabelDefault,
+    dismissConfirmationSecondaryActionTextLabel: dismissConfirmationSecondaryActionTextLabelDefault,
+  } = useDefaultLabelContext('Sheet');
+
+  const confirmationButtonRef = useRef();
+
+  useEffect(() => {
+    if (confirmationButtonRef.current) {
+      confirmationButtonRef.current.focus();
+    }
+  }, [confirmationButtonRef]);
+
+  // Handle onDismiss triggering from ESC keyup event
+  useEffect(() => {
+    function handleKeyDown(event: {| keyCode: number, stopPropagation: () => void |}) {
+      if (event.keyCode === ESCAPE) {
+        event.stopPropagation();
+      }
+    }
+
+    window.addEventListener('key', handleKeyDown);
+    return function cleanup() {
+      window.removeEventListener('keyup', handleKeyDown);
+    };
+  }, []);
+
+  return (
+    <Popover
+      anchor={anchor}
+      idealDirection="down"
+      onDismiss={() => onDismiss()}
+      positionRelativeToAnchor
+      role="dialog"
+      size="md"
+    >
+      <TrapFocusBehavior>
+        <Box padding={3} width="100%">
+          <Flex direction="column" gap={4}>
+            <Box role="alert">
+              <Flex direction="column" gap={2} alignItems="center" width="100%">
+                <Text weight="bold">
+                  {typeof dismissConfirmation === 'boolean'
+                    ? dismissConfirmationMessageDefault
+                    : dismissConfirmation?.message}
+                </Text>
+                <Text>
+                  {typeof dismissConfirmation === 'boolean'
+                    ? dismissConfirmationSubtextDefault
+                    : dismissConfirmation?.subtext}
+                </Text>
+              </Flex>
+            </Box>
+            <Flex justifyContent="center" gap={2}>
+              <Button
+                accessibilityLabel={
+                  (typeof dismissConfirmation === 'boolean'
+                    ? dismissConfirmationSecondaryActionTextLabelDefault
+                    : dismissConfirmation?.secondaryAction?.accessibilityLabel) ??
+                  dismissConfirmationSecondaryActionTextDefault
+                }
+                color="gray"
+                text={
+                  (typeof dismissConfirmation === 'boolean'
+                    ? dismissConfirmationSecondaryActionTextDefault
+                    : dismissConfirmation?.secondaryAction?.text) ??
+                  dismissConfirmationSecondaryActionTextDefault
+                }
+                onClick={({ event }) => {
+                  if (typeof dismissConfirmation !== 'boolean') {
+                    dismissConfirmation?.secondaryAction?.onClick?.({ event });
+                  }
+                  onDismiss();
+                }}
+              />
+              <Button
+                color="red"
+                accessibilityLabel={
+                  typeof dismissConfirmation === 'boolean'
+                    ? dismissConfirmationPrimaryActionTextLabelDefault
+                    : dismissConfirmation?.primaryAction?.accessibilityLabel ??
+                      dismissConfirmationPrimaryActionTextDefault
+                }
+                text={
+                  typeof dismissConfirmation === 'boolean'
+                    ? dismissConfirmationPrimaryActionTextDefault
+                    : dismissConfirmation?.primaryAction?.text ??
+                      dismissConfirmationPrimaryActionTextDefault
+                }
+                onClick={({ event }) => {
+                  if (typeof dismissConfirmation !== 'boolean') {
+                    dismissConfirmation?.primaryAction?.onClick?.({ event });
+                  }
+                  onAnimatedDismiss();
+                }}
+                ref={confirmationButtonRef}
+              />
+            </Flex>
+          </Flex>
+        </Box>
+      </TrapFocusBehavior>
+    </Popover>
+  );
+}

--- a/packages/gestalt/src/SheetConfirmationPopover.js
+++ b/packages/gestalt/src/SheetConfirmationPopover.js
@@ -12,39 +12,40 @@ import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import { ESCAPE } from './keyCodes.js';
 
 type Props = {|
-  onDismiss: () => void,
   anchor: ?HTMLElement,
-  dismissConfirmation: {|
-    message?: string,
-    subtext?: string,
-    primaryAction?: {|
-      accessibilityLabel?: string,
-      text?: string,
-      onClick?: ({|
-        event:
-          | SyntheticMouseEvent<HTMLButtonElement>
-          | SyntheticMouseEvent<HTMLAnchorElement>
-          | SyntheticKeyboardEvent<HTMLAnchorElement>
-          | SyntheticKeyboardEvent<HTMLButtonElement>,
-      |}) => void,
-    |},
-    secondaryAction?: {|
-      accessibilityLabel?: string,
-      text?: string,
-      onClick?: ({|
-        event:
-          | SyntheticMouseEvent<HTMLButtonElement>
-          | SyntheticMouseEvent<HTMLAnchorElement>
-          | SyntheticKeyboardEvent<HTMLAnchorElement>
-          | SyntheticKeyboardEvent<HTMLButtonElement>,
-      |}) => void,
-    |},
+  message?: string,
+  onDismiss: () => void,
+  primaryAction?: {|
+    accessibilityLabel?: string,
+    text?: string,
+    onClick?: ({|
+      event:
+        | SyntheticMouseEvent<HTMLButtonElement>
+        | SyntheticMouseEvent<HTMLAnchorElement>
+        | SyntheticKeyboardEvent<HTMLAnchorElement>
+        | SyntheticKeyboardEvent<HTMLButtonElement>,
+    |}) => void,
   |},
+  secondaryAction?: {|
+    accessibilityLabel?: string,
+    text?: string,
+    onClick?: ({|
+      event:
+        | SyntheticMouseEvent<HTMLButtonElement>
+        | SyntheticMouseEvent<HTMLAnchorElement>
+        | SyntheticKeyboardEvent<HTMLAnchorElement>
+        | SyntheticKeyboardEvent<HTMLButtonElement>,
+    |}) => void,
+  |},
+  subtext?: string,
 |};
 
 export default function SheetConfirmationPopover({
   anchor,
-  dismissConfirmation,
+  message,
+  subtext,
+  primaryAction,
+  secondaryAction,
   onDismiss,
 }: Props): Node {
   const confirmationButtonRef = useRef();
@@ -52,12 +53,12 @@ export default function SheetConfirmationPopover({
   const { onAnimatedDismiss } = useAnimation();
 
   const {
-    dismissConfirmationMessage: dismissConfirmationMessageDefault,
-    dismissConfirmationSubtext: dismissConfirmationSubtextDefault,
-    dismissConfirmationPrimaryActionText: dismissConfirmationPrimaryActionTextDefault,
-    dismissConfirmationSecondaryActionText: dismissConfirmationSecondaryActionTextDefault,
-    dismissConfirmationPrimaryActionTextLabel: dismissConfirmationPrimaryActionTextLabelDefault,
-    dismissConfirmationSecondaryActionTextLabel: dismissConfirmationSecondaryActionTextLabelDefault,
+    dismissConfirmationMessage: messageDefault,
+    dismissConfirmationSubtext: subtextDefault,
+    dismissConfirmationPrimaryActionText: primaryActionTextDefault,
+    dismissConfirmationSecondaryActionText: secondaryActionTextDefault,
+    dismissConfirmationPrimaryActionTextLabel: primaryActionTextLabelDefault,
+    dismissConfirmationSecondaryActionTextLabel: secondaryActionTextLabelDefault,
   } = useDefaultLabelContext('Sheet');
 
   useEffect(() => {
@@ -67,9 +68,7 @@ export default function SheetConfirmationPopover({
   // Handle onDismiss triggering from ESC keyup event
   useEffect(() => {
     function handleKeyDown(event) {
-      if (event.keyCode === ESCAPE) {
-        event.stopPropagation();
-      }
+      if (event.keyCode === ESCAPE) event.stopPropagation();
     }
     window.addEventListener('keydown', handleKeyDown);
 
@@ -92,44 +91,30 @@ export default function SheetConfirmationPopover({
           <Flex direction="column" gap={4}>
             <Box role="alert">
               <Flex direction="column" gap={2} alignItems="center" width="100%">
-                <Text weight="bold">
-                  {dismissConfirmation?.message ?? dismissConfirmationMessageDefault}
-                </Text>
-                <Text>{dismissConfirmation?.subtext ?? dismissConfirmationSubtextDefault}</Text>
+                <Text weight="bold">{message ?? messageDefault}</Text>
+                <Text>{subtext ?? subtextDefault}</Text>
               </Flex>
             </Box>
             <Flex justifyContent="center" gap={2}>
               <Button
                 accessibilityLabel={
-                  dismissConfirmation?.secondaryAction?.accessibilityLabel ??
-                  dismissConfirmationSecondaryActionTextLabelDefault
+                  secondaryAction?.accessibilityLabel ?? secondaryActionTextLabelDefault
                 }
                 color="gray"
-                text={
-                  dismissConfirmation?.secondaryAction?.text ??
-                  dismissConfirmationSecondaryActionTextDefault
-                }
+                text={secondaryAction?.text ?? secondaryActionTextDefault}
                 onClick={({ event }) => {
-                  if (typeof dismissConfirmation !== 'boolean') {
-                    dismissConfirmation?.secondaryAction?.onClick?.({ event });
-                  }
+                  secondaryAction?.onClick?.({ event });
                   onDismiss();
                 }}
               />
               <Button
                 color="red"
                 accessibilityLabel={
-                  dismissConfirmation?.primaryAction?.accessibilityLabel ??
-                  dismissConfirmationPrimaryActionTextLabelDefault
+                  primaryAction?.accessibilityLabel ?? primaryActionTextLabelDefault
                 }
-                text={
-                  dismissConfirmation?.primaryAction?.text ??
-                  dismissConfirmationPrimaryActionTextDefault
-                }
+                text={primaryAction?.text ?? primaryActionTextDefault}
                 onClick={({ event }) => {
-                  if (typeof dismissConfirmation !== 'boolean') {
-                    dismissConfirmation?.primaryAction?.onClick?.({ event });
-                  }
+                  primaryAction?.onClick?.({ event });
                   onAnimatedDismiss();
                 }}
                 ref={confirmationButtonRef}

--- a/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Sheet.jsdom.test.js.snap
@@ -1,5 +1,187 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Sheet renders Sheet with confirmation modal 1`] = `
+<div>
+  <div
+    name="trap-focus"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="backdrop zoomOut"
+      />
+      <div
+        aria-label="Test Sheet"
+        class="wrapper hideOutline"
+        id=":rg:"
+        role="dialog"
+        style="width: 540px;"
+        tabindex="-1"
+      >
+        <div
+          class="box flexGrow relative xsDirectionColumn xsDisplayFlex"
+          style="width: 100%;"
+        >
+          <div
+            class="box flexGrow justifyEnd marginBottom8 xsDisplayFlex"
+          >
+            <div
+              class="absolute box flexNone paddingX6 paddingY7"
+              style="z-index: 1;"
+            >
+              <button
+                aria-controls=":rg:"
+                aria-label="Dismiss"
+                class="parentButton"
+                type="button"
+              >
+                <div
+                  class="button tapTransition enabled"
+                >
+                  <div
+                    class="pog transparent"
+                    style="height: 40px; width: 40px;"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      aria-label=""
+                      class="icon defaultIcon iconBlock"
+                      height="18"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="18"
+                    >
+                      <path
+                        d="test-file-stub"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="box flexGrow overflowAuto paddingX6 paddingY6 relative"
+            style="height: 100%;"
+          >
+            <section />
+          </div>
+          <div>
+            <div
+              class="container rounding4 contents maxDimensions minDimensions"
+              style="visibility: visible; top: 8px; left: -10px;"
+              tabindex="-1"
+            >
+              <div
+                aria-label="Popover"
+                class="border whiteBgElevated whiteElevated rounding4 innerContents maxDimensions minDimensions"
+                role="dialog"
+                style="max-width: 284px; max-height: 691.1999999999999px;"
+              >
+                <div
+                  name="trap-focus"
+                >
+                  <div
+                    class="box paddingX3 paddingY3"
+                    style="width: 100%;"
+                  >
+                    <div
+                      class="Flex rowGap4 columnGap4 xsDirectionColumn"
+                    >
+                      <div
+                        class="FlexItem"
+                      >
+                        <div
+                          class="box"
+                          role="alert"
+                        >
+                          <div
+                            class="Flex rowGap2 columnGap2 xsDirectionColumn xsItemsCenter"
+                            style="width: 100%;"
+                          >
+                            <div
+                              class="FlexItem"
+                            >
+                              <div
+                                class="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+                              >
+                                Are you sure you want to dismiss?
+                              </div>
+                            </div>
+                            <div
+                              class="FlexItem"
+                            >
+                              <div
+                                class="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                              >
+                                You will lose all of your changes. This cannot be undone.
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="FlexItem"
+                      >
+                        <div
+                          class="Flex rowGap2 columnGap2 justifyCenter xsDirectionRow"
+                        >
+                          <div
+                            class="FlexItem"
+                          >
+                            <button
+                              aria-label="No, go back to the sheet."
+                              class="button hideOutline inline accessibilityOutline parentButton"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <div
+                                class="button hideOutline inline accessibilityOutline tapTransition md gray enabled childrenDiv"
+                              >
+                                <div
+                                  class="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+                                >
+                                  No, go back
+                                </div>
+                              </div>
+                            </button>
+                          </div>
+                          <div
+                            class="FlexItem"
+                          >
+                            <button
+                              aria-label="Yes, dismiss the sheet."
+                              class="button hideOutline inline accessibilityOutline parentButton"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <div
+                                class="button hideOutline inline accessibilityOutline tapTransition md red enabled childrenDiv"
+                              >
+                                <div
+                                  class="Text fontSize300 inverseText alignCenter fontWeightSemiBold"
+                                >
+                                  Yes, dismiss
+                                </div>
+                              </div>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Sheet should render all props with nodes 1`] = `
 <div>
   <div
@@ -51,7 +233,7 @@ exports[`Sheet should render all props with nodes 1`] = `
                     class="button tapTransition enabled"
                   >
                     <div
-                      class="pog transparent focused"
+                      class="pog transparent"
                       style="height: 40px; width: 40px;"
                     >
                       <svg
@@ -147,7 +329,7 @@ exports[`Sheet should render all props with render props 1`] = `
                     class="button tapTransition enabled"
                   >
                     <div
-                      class="pog transparent focused"
+                      class="pog transparent"
                       style="height: 40px; width: 40px;"
                     >
                       <svg

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.js
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.js
@@ -28,6 +28,12 @@ export type DefaultLabelContextType = {|
   |},
   Sheet: {|
     accessibilityDismissButtonLabel: string,
+    dismissConfirmationMessage: string,
+    dismissConfirmationSubtext: string,
+    dismissConfirmationPrimaryActionText: string,
+    dismissConfirmationPrimaryActionTextLabel: string,
+    dismissConfirmationSecondaryActionText: string,
+    dismissConfirmationSecondaryActionTextLabel: string,
   |},
   Tag: {|
     accessibilityErrorIconLabel: string,
@@ -55,6 +61,12 @@ export const fallbackLabels: DefaultLabelContextType = {
   },
   Sheet: {
     accessibilityDismissButtonLabel: 'Close sheet',
+    dismissConfirmationMessage: 'Are you sure you want to dismiss?',
+    dismissConfirmationSubtext: 'You will lose all of your changes. This cannot be undone.',
+    dismissConfirmationPrimaryActionText: 'Yes, dismiss',
+    dismissConfirmationPrimaryActionTextLabel: 'Yes, dismiss the sheet.',
+    dismissConfirmationSecondaryActionText: 'No, go back',
+    dismissConfirmationSecondaryActionTextLabel: 'No, go back to the sheet.',
   },
   Tag: {
     accessibilityErrorIconLabel: 'Error',

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.js
@@ -30,6 +30,12 @@ describe('useDefaultLabelContext', () => {
           },
           Sheet: {
             accessibilityDismissButtonLabel: 'Close sheet',
+            dismissConfirmationMessage: 'Are you sure you want to dismiss?',
+            dismissConfirmationSubtext: 'You will lose all of your changes. This cannot be undone.',
+            dismissConfirmationPrimaryActionText: 'Yes, dismiss.',
+            dismissConfirmationPrimaryActionTextLabel: 'Yes, dismiss the sheet.',
+            dismissConfirmationSecondaryActionText: 'No, go back.',
+            dismissConfirmationSecondaryActionTextLabel: 'No, go back to the sheet.',
           },
           Tag: {
             accessibilityErrorIconLabel: 'Error',


### PR DESCRIPTION
### Summary

#### What changed?

Sheet: implement dismiss confirmation modal and dismissConfirmation prop #2630

![Screenshot 2023-01-30 at 1 08 21 PM](https://user-images.githubusercontent.com/10593890/215559421-b9a42d8d-54a4-499d-8cb2-4bc5c40e26de.png)

#### Why?

It's been a long-time request from eng. Some Sheets have forms in them and dismissing the Sheet leads to losing the information entered. 

There are 6 action point for dismissing Sheet:

1. ESC key >> component controlled
2. Dismiss button >> component controlled
3. Backdrop click >> component controlled
4. onDismissStart render prop (subheading) >> Eng has access and control
5. onDismissStart render prop (content) >> Eng has access and control
6. onDismissStart render prop (footer) >> Eng has access and control

`dismissConfirmation` forces confirmation from user if it tries to dismiss Sheet via 1,2,3 action points.

It renders a Popover that alerts the user and request user action.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
![Kapture 2023-01-26 at 20 34 27](https://user-images.githubusercontent.com/10593890/214991268-5dc54701-2273-4048-9466-82a1ad2de7d1.gif)

- [ ] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
