### PR TITLE
Internal: improve Masonry a11y test route, refactor docs example

### DIFF
--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -15,7 +15,7 @@ import YearInReviewBanner from './YearInReviewBanner.js';
 export const CONTENT_MAX_WIDTH_PX = 1200;
 const HEADER_HEIGHT_PX = 75;
 const fullWidthPages = ['home', 'whats_new', 'roadmap'];
-const fullBleedNoNavigationPages = ['/year_in_review_2022'];
+const fullBleedNoNavigationPages = ['/year_in_review_2022', 'integration-test'];
 
 type Props = {|
   children?: Node,
@@ -30,7 +30,7 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
   const [shouldHideSideNav, setShouldHideSideNav] = useState(true);
 
   const isHomePage = router?.route === '/home';
-  const isFullBleedLayout = fullBleedNoNavigationPages.includes(router?.route);
+  const isFullBleedLayout = fullBleedNoNavigationPages.some((page) => router?.route.includes(page));
 
   const footerColor =
     colorScheme === 'dark' ? 'var(--color-gray-roboflow-700)' : 'var(--color-orange-firetini-0)';

--- a/docs/integration-test-helpers/masonry/ExampleGridItem.js
+++ b/docs/integration-test-helpers/masonry/ExampleGridItem.js
@@ -1,0 +1,49 @@
+// @flow strict
+import { type Element, useEffect, useState } from 'react';
+
+type Props = {
+  // $FlowFixMe[unclear-type]
+  data: Object,
+  expanded: boolean,
+  itemIdx: number,
+  ...
+};
+
+export default function ExampleGridItem({ data = {}, itemIdx, expanded }: Props): Element<'div'> {
+  const [counter, setCounter] = useState<number>(0);
+
+  useEffect(() => {
+    const mountCount = window.ITEM_MOUNT_COUNT || 0;
+    window.ITEM_MOUNT_COUNT = mountCount + 1;
+  }, []);
+
+  function incrementStateCounter() {
+    setCounter((prevCounter) => prevCounter + 1);
+  }
+
+  return (
+    <div
+      style={{
+        padding: '0 7px 14px',
+      }}
+    >
+      <div
+        style={{
+          height: expanded ? data.height + 100 : data.height,
+          border: '1px solid #ff0000',
+          background: data.color,
+        }}
+      >
+        <div>{data.name}</div>
+        <div>Slot Index: {itemIdx}</div>
+        <div>
+          <button id={`increment-counter-${itemIdx}`} onClick={incrementStateCounter} type="button">
+            Increment counter:
+          </button>
+          {'(Current '}
+          <span id={`item-counter-${itemIdx}`}>{counter}</span>)
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -1,0 +1,400 @@
+// @flow strict
+import { Component, createRef, type Element, type Node } from 'react';
+import ExampleGridItem from './ExampleGridItem.js';
+import getClassicGridServerStyles from './getClassicGridServerStyles.js';
+import getFlexibleGridServerStyles from './getFlexibleGridServerStyles.js';
+import { getRandomNumberGenerator, generateExampleItems } from './items-utils.js';
+
+// MasonryContainer is a simulation of a web page that contains a Masonry grid
+// on it. It allows for a ton of configuration and also has a number of buttons
+// rendered at the top, all of which change the behavior of the page and the
+// grid. This is intended to simulate all possible scenarios a Masonry grid
+// could be rendered; it's a gauntlet!
+//
+// Note: While most of the behavior of this component is meant to test how
+// Masonry works, MasonryContainer also supports certain SSR functionality such
+// as generating styles that affect pre-hydration Masonry content.
+
+type Props = {
+  // The actual Masonry component to be used (if using an experimental version of Masonry).
+  // $FlowFixMe[unclear-type]
+  MasonryComponent: any,
+  // Sets up props to display a collage layout.
+  collage?: boolean,
+  // Constrains the width of the grid rendering.
+  constrained?: boolean,
+  // Grid items should have flexible width.
+  flexible?: boolean,
+  // Whether or not to use an external cache
+  externalCache?: boolean,
+  // Whether or not to require tests to trigger fetch completion manually.
+  manualFetch?: boolean,
+  // Does not allow infinite scroll.
+  finiteLength?: boolean,
+  // The initial data from the server side render.
+  // $FlowFixMe[unclear-type]
+  initialItems?: $ReadOnlyArray<?Object>,
+  // External measurement store.
+  // $FlowFixMe[unclear-type]
+  measurementStore: Object,
+  // Prevent scrolling on Masonry
+  noScroll?: boolean,
+  // Positions the element inside of a relative container, offset from the top.
+  offsetTop?: number,
+  // If we should position the grid within a scrollContainer besides the window.
+  scrollContainer?: boolean,
+  // If we should virtualize the grid
+  virtualize?: boolean,
+  // The relative amount in pixel to extend the virtualized viewport top value.
+  virtualBoundsTop?: number,
+  // The relative amount in pixel to extend the virtualized viewport bottom value.
+  virtualBoundsBottom?: number,
+  ...
+};
+
+type State = {
+  expanded: boolean,
+  hasScrollContainer: boolean,
+  // $FlowFixMe[unclear-type]
+  items: $ReadOnlyArray<?Object>,
+  mountGrid: boolean,
+  mounted: boolean,
+  ...
+};
+
+export default class MasonryContainer extends Component<Props, State> {
+  state: State = {
+    expanded: false,
+    hasScrollContainer: !!this.props.scrollContainer,
+    items: this.props.initialItems || [],
+    mountGrid: true,
+    mounted: false, // eslint-disable-line react/no-unused-state
+  };
+
+  // $FlowFixMe[unclear-type]
+  gridRef: {| current: any | null |} = createRef();
+
+  randomNumberSeed: number = 0;
+
+  componentDidMount() {
+    window.TEST_FETCH_COUNTS = 0;
+
+    window.addEventListener('trigger-reflow', () => {
+      if (this.gridRef.current) {
+        this.gridRef.current.reflow();
+        this.forceUpdate();
+      }
+    });
+
+    window.addEventListener('set-masonry-items', (e) => {
+      this.setState({
+        items: e.detail.items,
+      });
+    });
+
+    window.ERROR_COUNT = window.ERROR_COUNT || 0;
+    window.addEventListener('error', () => {
+      window.ERROR_COUNT += 1;
+    });
+
+    // Trigger a re-render in case we need to render /w scrollContainer.
+    setTimeout(() => {
+      this.setState({ mounted: true }); // eslint-disable-line react/no-unused-state
+    });
+  }
+
+  handleToggleScrollContainer: () => void = () => {
+    this.setState((prevState) => ({
+      hasScrollContainer: !prevState.hasScrollContainer,
+    }));
+  };
+
+  handlePushGridDown: () => void = () => {
+    const topSibling = document.getElementById('top-sibling');
+    if (!topSibling) {
+      throw new Error('Cannot find top-sibling.');
+    }
+    topSibling.style.height = '1000px';
+
+    if (this.gridRef.current && this.gridRef.current.updatePosition) {
+      this.gridRef.current.updatePosition();
+    }
+  };
+
+  handleAddItems: () => void = () => {
+    const { items } = this.state;
+    this.loadItems({ name: 'Manual Fetch Pin', from: items.length, force: true });
+  };
+
+  handleShuffleItems: () => void = () => {
+    this.randomNumberSeed += 1;
+    const pseudoRandom = getRandomNumberGenerator(this.randomNumberSeed);
+
+    this.setState((prevState) => ({
+      items: [...prevState.items]
+        .map((item) => ({
+          ...item,
+        }))
+        .sort(() => 0.5 - pseudoRandom()),
+    }));
+  };
+
+  handleInsertNullItems: () => void = () => {
+    this.setState((prevState) => ({
+      items: [...prevState.items, null, null, null],
+    }));
+  };
+
+  handleExpandGridItems: () => void = () => {
+    this.setState(
+      (prevState) => ({
+        expanded: !prevState.expanded,
+      }),
+      () => {
+        if (this.gridRef.current) {
+          this.gridRef.current.reflow();
+        }
+      },
+    );
+  };
+
+  handleUpdateGridItems: () => void = () => {
+    this.setState(
+      (prevState) => ({
+        mountGrid: !prevState.mountGrid,
+      }),
+      () => {
+        this.setState((prevState) => ({
+          mountGrid: !prevState.mountGrid,
+        }));
+      },
+    );
+
+    setTimeout(() => {
+      this.setState((prevState) => ({
+        items: prevState.items.map((item) =>
+          item
+            ? {
+                ...item,
+                height: item.height * 2,
+              }
+            : item,
+        ),
+      }));
+    });
+  };
+
+  toggleMount: () => void = () => {
+    window.ITEM_MOUNT_COUNT = 0;
+    this.setState((prevState) => ({
+      mountGrid: !prevState.mountGrid,
+    }));
+  };
+
+  pushFirstItemDown: () => void = () => {
+    const { measurementStore } = this.props;
+    measurementStore.setItemPosition(measurementStore.getGridCell(0, 0), { top: 100, row: 1 });
+    this.forceUpdate();
+  };
+
+  loadItems: ({ force: boolean, from?: number, name?: string, ... }) => void = ({
+    name,
+    from = 0,
+    force = false,
+  }: {
+    name?: string,
+    from?: number,
+    force: boolean,
+    ...
+  }) => {
+    const { collage, manualFetch } = this.props;
+
+    if (manualFetch && !force) {
+      return;
+    }
+
+    window.TEST_FETCH_COUNTS += 1;
+
+    let until = from + 20;
+    let baseHeight = 200;
+
+    if (collage) {
+      until = 5;
+      baseHeight = 40;
+    }
+
+    this.randomNumberSeed += 1;
+    const newItems = generateExampleItems({
+      name,
+      total: until - from,
+      from,
+      baseHeight,
+      randomNumberSeed: this.randomNumberSeed,
+    });
+
+    this.setState(({ items }) => ({
+      items: [...items, ...newItems],
+    }));
+  };
+
+  // $FlowFixMe[unclear-type]
+  renderItem: ({| data: any |}) => Node = ({ data }) => {
+    const { expanded } = this.state;
+    return <ExampleGridItem expanded={expanded} {...data} />;
+  };
+
+  render(): Element<'div'> {
+    const {
+      MasonryComponent,
+      finiteLength,
+      flexible,
+      collage,
+      constrained,
+      externalCache,
+      measurementStore,
+      noScroll,
+      offsetTop,
+      virtualize,
+      virtualBoundsTop,
+      virtualBoundsBottom,
+    } = this.props;
+
+    const { hasScrollContainer, mountGrid, items } = this.state;
+
+    const dynamicGridProps = {};
+
+    const gridStyle = {};
+
+    if (constrained) {
+      gridStyle.margin = '0px 200px';
+    }
+
+    // One example of a collage layout w/o scrolling.
+    if (collage) {
+      dynamicGridProps.minCols = 1;
+      dynamicGridProps.gutterWidth = 5;
+      gridStyle.width = 500;
+    }
+
+    if (flexible) {
+      gridStyle.width = '100%';
+      dynamicGridProps.gutterWidth = 0;
+    }
+
+    // Allow for infinite scroll if the test does not opt out with the finiteLength prop.
+    if (!finiteLength) {
+      dynamicGridProps.loadItems = this.loadItems;
+    }
+
+    if (virtualBoundsTop) {
+      dynamicGridProps.virtualBoundsTop = virtualBoundsTop;
+    }
+
+    if (virtualBoundsBottom) {
+      dynamicGridProps.virtualBoundsBottom = virtualBoundsBottom;
+    }
+
+    if (noScroll) {
+      dynamicGridProps.scrollContainer = () => undefined;
+    } else if (hasScrollContainer) {
+      dynamicGridProps.scrollContainer = () =>
+        typeof document === 'undefined'
+          ? undefined
+          : document.querySelector('[data-scroll-container]');
+    } else {
+      dynamicGridProps.scrollContainer = () => (typeof window === 'undefined' ? undefined : window);
+    }
+
+    const columnWidth = flexible ? 300 : 240;
+
+    let gridWrapper = (
+      <div id="gridWrapper" className="gridCentered" style={gridStyle}>
+        <div id="top-sibling" />
+        {mountGrid && (
+          <MasonryComponent
+            ref={this.gridRef}
+            renderItem={this.renderItem}
+            flexible={flexible}
+            items={items}
+            measurementStore={externalCache ? measurementStore : undefined}
+            virtualize={virtualize}
+            columnWidth={columnWidth}
+            gutterWidth={0}
+            {...dynamicGridProps}
+          />
+        )}
+        <div className="afterGrid" />
+      </div>
+    );
+
+    // Render multiple relative ancestors to verify virtual bound calculation.
+    if (offsetTop) {
+      const top = parseInt(offsetTop / 2, 10);
+      gridWrapper = (
+        <div style={{ top, position: 'relative' }}>
+          <div style={{ top, position: 'relative' }}>{gridWrapper}</div>
+        </div>
+      );
+    }
+
+    const containerStyle = hasScrollContainer ? { height: 400, overflowY: 'scroll' } : {};
+
+    return (
+      <div>
+        <div style={{ paddingTop: 8, paddingBottom: 8 }}>
+          <button id="add-items" onClick={this.handleAddItems} type="submit">
+            Add items
+          </button>
+          <button id="shuffle-items" onClick={this.handleShuffleItems} type="submit">
+            Shuffle items
+          </button>
+          <button id="toggle-mount" onClick={this.toggleMount} type="submit">
+            Toggle mount
+          </button>
+          <button id="insert-null-items" onClick={this.handleInsertNullItems} type="submit">
+            Insert null items
+          </button>
+          {externalCache && (
+            <button id="push-first-down" onClick={this.pushFirstItemDown} type="submit">
+              Push first item down
+            </button>
+          )}
+          <button id="push-grid-down" onClick={this.handlePushGridDown} type="submit">
+            Push grid down
+          </button>
+          <button id="update-grid-items" onClick={this.handleUpdateGridItems} type="submit">
+            Update grid items
+          </button>
+          {!flexible && (
+            <button id="expand-grid-items" onClick={this.handleExpandGridItems} type="submit">
+              Expand grid items
+            </button>
+          )}
+          <button
+            id="toggle-scroll-container"
+            onClick={this.handleToggleScrollContainer}
+            type="submit"
+          >
+            Toggle scroll container
+          </button>
+        </div>
+        <div data-scroll-container style={containerStyle}>
+          {gridWrapper}
+        </div>
+        <style>
+          {flexible
+            ? getFlexibleGridServerStyles({
+                maxItemWidth: columnWidth,
+                maxColumns: 10,
+                minColumns: 3,
+              })
+            : getClassicGridServerStyles({
+                itemWidth: columnWidth,
+                maxColumns: 10,
+                minColumns: 3,
+              })}
+        </style>
+      </div>
+    );
+  }
+}

--- a/docs/integration-test-helpers/masonry/getClassicGridServerStyles.js
+++ b/docs/integration-test-helpers/masonry/getClassicGridServerStyles.js
@@ -1,0 +1,47 @@
+// @flow strict
+
+// USE WITH CAUTION
+// This file needs to be migrated from Pinboard: app/packages/gestaltExtensions/Masonry/styles/getClassicGridServerStyles.js
+// For now, make sure that it stays in sync with the original file
+
+export default function getClassicGridServerStyles({
+  isRTL = false,
+  itemWidth = 236,
+  maxColumns = 16,
+  minColumns = 2,
+}: {|
+  isRTL?: boolean,
+  itemWidth: number,
+  maxColumns: number,
+  minColumns: number,
+|}): string {
+  let styles = `
+.gridCentered {
+  margin-left: auto;
+  margin-right: auto;
+}
+.gridCentered .static {
+  position: absolute;
+  visibility: hidden;
+}
+`;
+
+  for (let i = minColumns; i < maxColumns + 1; i += 1) {
+    const minWidth = i === minColumns ? 0 : i * itemWidth;
+    styles += `
+@media (min-width: ${minWidth}px) and (max-width: ${(i + 1) * itemWidth - 1}px) {
+  .gridCentered {
+    width: ${i * itemWidth}px;
+  }
+  .gridCentered .static:nth-child(-n+${i}) {
+    position: static !important;
+    visibility: visible !important;
+    float: ${isRTL ? 'right' : 'left'};
+    display: block;
+  }
+}
+`;
+  }
+
+  return styles;
+}

--- a/docs/integration-test-helpers/masonry/getFlexibleGridServerStyles.js
+++ b/docs/integration-test-helpers/masonry/getFlexibleGridServerStyles.js
@@ -1,0 +1,70 @@
+// @flow strict
+
+// USE WITH CAUTION
+// This file needs to be migrated from Pinboard: app/packages/gestaltExtensions/Masonry/styles/getFlexibleGridServerStyles.js
+// For now, make sure that it stays in sync with the original file
+
+export default function getFlexibleGridServerStyles({
+  isRTL = false,
+  maxItemWidth = 300,
+  maxColumns = 16,
+  minColumns = 2,
+}: {|
+  isRTL?: boolean,
+  maxItemWidth: number,
+  maxColumns: number,
+  minColumns: number,
+|}): string {
+  let styles = `
+.gridCentered {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: ${maxColumns * maxItemWidth}
+}
+
+.gridCentered .static {
+  position: absolute !important;
+  visibility: hidden !important;
+}
+
+@media (min-width: ${maxColumns * maxItemWidth}px) {
+  .gridCentered .static:nth-child(-n+${maxColumns}) {
+    position: static !important;
+    visibility: visible !important;
+    float: ${isRTL ? 'right' : 'left'};
+    display: block;
+  }
+
+  .gridCentered .static:nth-child(-n+${maxColumns}) {
+    position: static !important;
+    visibility: visible !important;
+    float: ${isRTL ? 'right' : 'left'};
+    display: block;
+  }
+
+  .gridCentered .static {
+    width: ${maxItemWidth}px !important;
+  }
+}
+`;
+
+  for (let i = minColumns; i < maxColumns + 1; i += 1) {
+    const minWidth = i === minColumns ? 0 : (i - 1) * maxItemWidth;
+    styles += `
+@media (min-width: ${minWidth}px) and (max-width: ${i * maxItemWidth - 1}px) {
+  .gridCentered .static:nth-child(-n+${i}) {
+    position: static !important;
+    visibility: visible !important;
+    float: ${isRTL ? 'right' : 'left'};
+    display: block;
+  }
+
+  .gridCentered .static {
+    width: calc(100% / ${i}) !important;
+  }
+}
+`;
+  }
+
+  return styles;
+}

--- a/docs/integration-test-helpers/masonry/items-utils.js
+++ b/docs/integration-test-helpers/masonry/items-utils.js
@@ -1,0 +1,51 @@
+// @flow strict
+
+export const getRandomColor = (getRandomNumber?: () => number = Math.random): string => {
+  const letters = '0123456789ABCDEF';
+  let color = '#';
+  for (let i = 0; i < 6; i += 1) {
+    color += letters[Math.floor(getRandomNumber() * 16)];
+  }
+  return color;
+};
+
+export const getRandomNumberGenerator = (seed: number): (() => number) => {
+  let localSeed = seed;
+
+  return () => {
+    localSeed += 1;
+    const rnd = Math.sin(localSeed);
+    return rnd - Math.floor(rnd);
+  };
+};
+
+type generateExampleItemProps = {
+  name?: string,
+  total?: number,
+  from?: number,
+  baseHeight?: number,
+  randomNumberSeed?: number,
+  ...
+};
+
+type ExampleItem = {
+  name: string,
+  height: number,
+  color: string,
+  ...
+};
+
+export const generateExampleItems = ({
+  name = 'Pin',
+  total = 20,
+  from = 0,
+  baseHeight = 200,
+  randomNumberSeed = 0,
+}: generateExampleItemProps): $ReadOnlyArray<ExampleItem> => {
+  const getRandomNumber = getRandomNumberGenerator(randomNumberSeed);
+  return Array.from({ length: total }).map((_, i) => ({
+    name: `${name} ${i + from}`,
+    height: baseHeight + from + i,
+    color: getRandomColor(getRandomNumber),
+  }));
+};

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -1,124 +1,19 @@
 // @flow strict
-import { type ElementProps, type Node, useEffect, useRef, useState } from 'react';
-import { Box, ColorSchemeProvider, Flex, Image, Masonry, Text } from 'gestalt';
+import { type Node } from 'react';
+import { ColorSchemeProvider, Masonry } from 'gestalt';
+import MasonryContainer from '../../integration-test-helpers/masonry/MasonryContainer.js';
+import { generateExampleItems } from '../../integration-test-helpers/masonry/items-utils.js';
 
-const getPins = () => {
-  const pins = [
-    {
-      color: '#2b3938',
-      height: 316,
-      src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
-      width: 474,
-      name: 'the Hang Son Doong cave in Vietnam',
-    },
-    {
-      color: '#8e7439',
-      height: 1081,
-      src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
-      width: 474,
-      name: 'La Gran Muralla, Pekín, China',
-    },
-    {
-      color: '#698157',
-      height: 711,
-      src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
-      width: 474,
-      name: 'Plitvice Lakes National Park, Croatia',
-    },
-    {
-      color: '#4e5d50',
-      height: 632,
-      src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
-      width: 474,
-      name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
-    },
-    {
-      color: '#6d6368',
-      height: 710,
-      src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
-      width: 474,
-      name: 'Border of China and Vietnam',
-    },
-  ];
-
-  const pinList = [...new Array(3)].map(() => [...pins]).flat();
-  return Promise.resolve(pinList);
-};
-
-type Pin = {|
-  color: string,
-  height: number,
-  name: string,
-  src: string,
-  width: number,
-|};
-
-function GridComponent({ data }: { data: Pin, ... }) {
-  return (
-    <Flex direction="column">
-      <Image
-        alt={data.name}
-        color={data.color}
-        naturalHeight={data.height}
-        naturalWidth={data.width}
-        src={data.src}
-      />
-      <Text>{data.name}</Text>
-    </Flex>
-  );
-}
-
-type Props = {|
-  layout?: $ElementType<ElementProps<typeof Masonry>, 'layout'>,
-|};
-
-function ExampleMasonry({ layout }: Props): Node {
-  const [pins, setPins] = useState<$ReadOnlyArray<Pin>>([]);
-  const scrollContainerRef = useRef();
-
-  useEffect(() => {
-    getPins().then((startPins) => {
-      setPins(startPins);
-    });
-  }, []);
-
-  return (
-    <div
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      tabIndex={0}
-      ref={(el) => {
-        scrollContainerRef.current = el;
-      }}
-      style={{
-        height: '300px',
-        margin: '0 auto',
-        outline: '3px solid #ddd',
-        overflowY: 'scroll',
-        width: `700px`,
-      }}
-    >
-      {scrollContainerRef.current && (
-        <Masonry
-          columnWidth={170}
-          gutterWidth={5}
-          items={pins}
-          layout={layout}
-          minCols={1}
-          renderItem={({ data }) => <GridComponent data={data} />}
-          // $FlowFixMe[incompatible-type]
-          scrollContainer={() => scrollContainerRef.current}
-        />
-      )}
-    </div>
-  );
-}
+const measurementStore = Masonry.createMeasurementStore();
 
 export default function TestPage(): Node {
   return (
     <ColorSchemeProvider colorScheme="light">
-      <Box color="default" display="inlineBlock" width={300} padding={1}>
-        <ExampleMasonry layout="flexible" />
-      </Box>
+      <MasonryContainer
+        MasonryComponent={Masonry}
+        measurementStore={measurementStore}
+        initialItems={generateExampleItems({ name: 'InitialPin' })}
+      />
     </ColorSchemeProvider>
   );
 }


### PR DESCRIPTION
The component I'll need for the Masonry integration test route is considerably more complex than the simple one I'd copied over from the docs page. However, I'd also refactored and cleaned up that docs example when I migrated it over, which I don't want to lose.

This PR does two things:
- Replaces the previous `/integration-test/masonry` view with a much more complex one, migrated from Pinboard
- Updates the docs Masonry example with the refactored one