### PR TITLE
Internal: fix "open in codesandbox" dependencies

### DIFF
--- a/docs/docs-components/handleCodeSandbox.js
+++ b/docs/docs-components/handleCodeSandbox.js
@@ -61,11 +61,8 @@ const handleCodeSandbox = async ({ code, title }: {| code: string, title: string
           dependencies: {
             react: 'latest',
             'react-dom': 'latest',
-            // $FlowIssue[exponential-spread]
-            ...(baseComponents.length > 0 ? { gestalt: 'latest' } : {}),
-            ...(additionalComponents.includes('DatePicker')
-              ? { 'gestalt-datepicker': 'latest' }
-              : {}),
+            gestalt: 'latest',
+            'gestalt-datepicker': 'latest',
           },
           devDependencies: {
             'react-scripts': 'latest',


### PR DESCRIPTION
### Summary


#### What changed?

Internal: fix "open in codesandbox" dependencies
Fixes a bug when opening codesandbox from example in Datepicker

<img width="1433" alt="Screenshot 2023-02-08 at 11 45 08 PM" src="https://user-images.githubusercontent.com/10593890/217720144-acf6160f-e00f-42a6-99ff-d3bfa7ed1869.png">


