### PR TITLE
Docs: improve 'See recent changes on GitHub" by including previous component names

### DIFF
--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -739,6 +739,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
     svg: <ComboBox />,
     name: 'ComboBox',
     aliases: ['Typeahead', 'Autocomplete', 'Autosuggest'],
+    previouslyNamed: ['Typeahead'],
     description:
       'ComboBox is the combination of a Textfield and an associated Dropdown that allows the user to filter a list when selecting an option.',
     category: 'Fields and forms',
@@ -3191,6 +3192,7 @@ const BUILDING_BLOCKS_LIST: $ReadOnlyArray<ListItemType> = [
   {
     svg: <ScrollBoundaryContainer />,
     name: 'ScrollBoundaryContainer',
+    previouslyNamed: ['ScrollableContainer'],
     path: '/web/utilities/scrollboundarycontainer',
     description:
       'ScrollBoundaryContainer is needed for proper positioning when Popover is anchored to an element that is located within a scrolling container.',

--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -130,6 +130,7 @@ export type ListItemType = {|
   iOS?: PlatformStatus,
   name: string,
   path?: string,
+  previouslyNamed?: $ReadOnlyArray<string>,
   status?: {| ...PlatformStatus, iOS: StatusType, android: StatusType, responsive: StatusType |}, // web status
   svg: Element<typeof Accessibility>,
 |};
@@ -1727,6 +1728,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
     svg: <Popover />,
     name: 'Popover',
     aliases: ['Flyout'],
+    previouslyNamed: ['Flyout'],
     description:
       'Popover is a floating view that contains a task related to the content on screen.',
     category: 'Overlays',
@@ -2024,6 +2026,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
     svg: <OverlayPanel />,
     name: 'OverlayPanel',
     aliases: ['Drawer', 'Panel', 'Tray', 'Sheet'],
+    previouslyNamed: ['Sheet'],
     description:
       'OverlayPanels are surfaces that allow users to view optional information or complete sub-tasks in a workflow while keeping the context of the current page.',
     category: 'Overlays',
@@ -3287,6 +3290,7 @@ const BUILDING_BLOCKS_LIST: $ReadOnlyArray<ListItemType> = [
     svg: <TapArea />,
     name: 'TapArea',
     aliases: ['Touchable'],
+    previouslyNamed: ['Touchable'],
     description: 'TapArea allows components to be clickable and touchable in an accessible way.',
     category: 'Building blocks',
     status: {

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -69,7 +69,8 @@ export default function PageHeader({
     sourceLink = sourceLink.replace(/\.js$/, '');
   }
 
-  const { aliases } = componentData.find((component) => component.name === name) ?? {};
+  const { aliases, previouslyNamed } =
+    componentData.find((component) => component.name === name) ?? {};
 
   const badgeMap = {
     pilot: {
@@ -120,25 +121,33 @@ export default function PageHeader({
             {/* Enable this when we have a consistent directory structure */}
             {['component' /* 'utility' */].includes(type) && (
               <Flex direction="column" gap={1}>
-                <Link
-                  href={sourceLink}
-                  onClick={() => trackButtonClick('View source on GitHub', sourcePathName)}
-                  target="blank"
-                  underline="always"
-                >
-                  <Text>View source on GitHub</Text>
-                </Link>
+                <Text>
+                  <Link
+                    href={sourceLink}
+                    onClick={() => trackButtonClick('View source on GitHub', sourcePathName)}
+                    target="blank"
+                    underline="always"
+                  >
+                    View source on GitHub
+                  </Link>
+                </Text>
 
-                <Link
-                  href={`https://github.com/pinterest/gestalt/releases?q=${name
-                    // Remove spaces and dashes
-                    .replaceAll(/[\s-]/g, '')}&expanded=true`}
-                  onClick={() => trackButtonClick('View recent changes on GitHub', sourcePathName)}
-                  target="blank"
-                  underline="always"
-                >
-                  <Text>See recent changes on GitHub</Text>
-                </Link>
+                <Text>
+                  <Link
+                    href={`https://github.com/pinterest/gestalt/releases?q=${name
+                      // Remove spaces and dashes
+                      .replaceAll(/[\s-]/g, '')}${
+                      previouslyNamed ? previouslyNamed.join('+OR+') : ''
+                    }&expanded=true`}
+                    onClick={() =>
+                      trackButtonClick('View recent changes on GitHub', sourcePathName)
+                    }
+                    target="blank"
+                    underline="always"
+                  >
+                    See recent changes on GitHub
+                  </Link>
+                </Text>
               </Flex>
             )}
           </Flex>

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -136,8 +136,8 @@ export default function PageHeader({
                   <Link
                     href={`https://github.com/pinterest/gestalt/releases?q=${name
                       // Remove spaces and dashes
-                      .replaceAll(/[\s-]/g, '')}${
-                      previouslyNamed ? previouslyNamed.join('+OR+') : ''
+                      .replaceAll(/[\s-]/g, '')}${previouslyNamed ? ' OR ' : ''}${
+                      previouslyNamed ? previouslyNamed.join(' OR ') : ''
                     }&expanded=true`}
                     onClick={() =>
                       trackButtonClick('View recent changes on GitHub', sourcePathName)


### PR DESCRIPTION
### Summary

#### What changed?

Docs: improve 'See recent changes on GitHub" by including previous component names


BEFORE

![Screenshot 2023-02-09 at 11 18 38 AM](https://user-images.githubusercontent.com/10593890/217871803-5835a230-26c1-4167-9a5a-c0c081952b77.png)

AFTER

![Screenshot 2023-02-09 at 11 20 11 AM](https://user-images.githubusercontent.com/10593890/217872198-ae29b9fd-5ab0-40f8-a6fd-1b682aea155a.png)


