### PR TITLE
List: fix style issue replacing uncompiling `padding-inline-start` with `padding-right/left`

### DIFF
--- a/packages/gestalt/src/List.css
+++ b/packages/gestalt/src/List.css
@@ -1,7 +1,3 @@
-.bareList:first-child {
-  padding-inline-start: 0;
-}
-
 .parentList {
   margin: 0;
 }
@@ -9,7 +5,22 @@
 .list {
   margin-left: 0;
   margin-right: 0;
-  padding-inline-start: 16px;
+}
+
+html:not([dir="rtl"]) .list {
+  padding-left: var(--space-300);
+}
+
+html[dir="rtl"] .list {
+  padding-right: var(--space-300);
+}
+
+html:not([dir="rtl"]) .bareList:first-child {
+  padding-left: var(--space-0);
+}
+
+html[dir="rtl"] .bareList:first-child {
+  padding-right: var(--space-0);
 }
 
 .listItem {


### PR DESCRIPTION
### Summary

#### What changed?

Replaced `padding-inline-start` with `padding-start ` & `padding-left` with RTL logic in CSS files.

BEFORE
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/218643485-30529810-53b9-46df-bbdb-ea625e4e9f92.png)
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/218643830-115ad6e8-b839-49bd-8037-1e4b6f8de1a6.png)

AFTER
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/218643682-28350031-b060-4c97-a1e5-face6df37e01.png)
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/218643997-18ddb1fb-22ef-4ff4-a10e-4631fe37db5c.png)


#### Why?

`padding-inline-start` was first use in List. It seems it was being lost after CSS compilation in Sandpack code editor and pinterest.developers.com

Seems related to https://github.com/csstools/postcss-preset-env/issues/210

