### PR TITLE
Internal: match peer dependencies to actual usage

### DIFF
--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -18,8 +18,8 @@
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",
-    "react": "^16.13.1 || ^17.0 || ^18.0",
-    "react-dom": "^16.13.1 || ^17.0 || ^18.0"
+    "react": "^18.0",
+    "react-dom": "^18.0"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -17,8 +17,8 @@
     "gestalt-design-tokens": ">0.0.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0 || ^18.0",
-    "react-dom": "^16.13.1 || ^17.0 || ^18.0"
+    "react": "^18.0",
+    "react-dom": "^18.0"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",


### PR DESCRIPTION
We upgraded to React 18 back in #2104, but didn't start using any new features until the introduction of SideNavigation in #2185. While the `react` dependency in `package.json` was correct, the `react` and `react-dom` peer dependencies in `/packages/gestalt/package.json` and `/packages/gestalt-datepicker/package.json` still indicated that React 16 & 17 were supported. We now have multiple components that use React 18-only features, so we need to officially remove 16 & 17 as acceptable peer dependencies.

This PR does not add specific documentation around this, as we don't specifically call out any of our dependencies in the docs. If we keep getting questions about it in the future, we can add documentation as needed.