### PR TITLE
SideNavigation: implemented `primaryAction` prop to allow actions on SideNavigation.TopItem and SideNavigation.Group

### DIFF
--- a/docs/examples/sidenavigation/localizationExample.js
+++ b/docs/examples/sidenavigation/localizationExample.js
@@ -38,7 +38,7 @@ export default function Example(): Node {
         onClick={({ event }) => event.preventDefault()}
         icon="add-layout"
         label="Optimieren Sie Ihren Home-Feed"
-        badge={{ text: 'New', type: 'info' }}
+        badge={{ text: 'Neu', type: 'info' }}
       />
     </SideNavigation>
   );

--- a/docs/examples/sidenavigation/primaryAction.js
+++ b/docs/examples/sidenavigation/primaryAction.js
@@ -1,0 +1,113 @@
+// @flow strict
+import { useState, type Node } from 'react';
+import { SideNavigation, Dropdown, Button, Box, DeviceTypeProvider, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  const [mobile, setMobile] = useState(false);
+
+  return (
+    <Box color="lightWash" padding={4} height="100%">
+      <Flex gap={12}>
+        <Button text="View mobile" onClick={() => setMobile(true)} color="red" />
+        <DeviceTypeProvider deviceType={mobile ? 'mobile' : 'desktop'}>
+          <Box position={mobile ? 'absolute' : undefined} top bottom left right id="sidenavigation">
+            <SideNavigation
+              accessibilityLabel="Notification example"
+              dismissButton={{ onDismiss: () => setMobile((value) => !value) }}
+            >
+              <SideNavigation.TopItem
+                href="#"
+                onClick={({ event }) => {
+                  event.preventDefault();
+                }}
+                label="Campaign z-168i"
+                primaryAction={{
+                  icon: 'edit',
+                  onClick: ({ event }) => {
+                    event.preventDefault();
+                  },
+                  tooltip: { text: 'Rename campaign' },
+                }}
+              />
+              <SideNavigation.TopItem
+                href="#"
+                onClick={({ event }) => {
+                  event.preventDefault();
+                }}
+                label="Campaign a-j6ki (inactive)"
+                primaryAction={{
+                  icon: 'trash-can',
+                  onClick: ({ event }) => {
+                    event.preventDefault();
+                  },
+                  tooltip: { text: 'Delete campaign' },
+                }}
+              />
+              <SideNavigation.Group
+                label="Campaign drafts"
+                counter={{ number: '12', accessibilityLabel: '12 campaign drafts' }}
+                primaryAction={{
+                  onClick: ({ event }) => {
+                    event.preventDefault();
+                  },
+                  tooltip: { text: 'More options' },
+                  dropdownItems: [
+                    <Dropdown.Item
+                      key="edit"
+                      option={{ value: 'Edit', label: 'Edit' }}
+                      onSelect={() => {}}
+                    />,
+                    <Dropdown.Item
+                      key="trash"
+                      option={{ value: 'Delete', label: 'Delete' }}
+                      onSelect={() => {}}
+                    />,
+                  ],
+                }}
+              >
+                <SideNavigation.NestedItem
+                  counter={{
+                    number: '10',
+                    accessibilityLabel: 'You have 10 messages in your inbox',
+                  }}
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="West Coast"
+                />
+                <SideNavigation.NestedItem
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="East Coast"
+                />
+              </SideNavigation.Group>
+              <SideNavigation.TopItem
+                href="#"
+                onClick={({ event }) => event.preventDefault()}
+                label="Archived campaigns"
+                primaryAction={{
+                  onClick: ({ event }) => {
+                    event.preventDefault();
+                  },
+                  tooltip: { text: 'More options' },
+                  dropdownItems: [
+                    <Dropdown.Item
+                      key="edit"
+                      option={{ value: 'Edit', label: 'Edit' }}
+                      onSelect={() => {}}
+                    />,
+                    <Dropdown.Item
+                      key="trash"
+                      option={{ value: 'Delete', label: 'Delete' }}
+                      onSelect={() => {}}
+                    />,
+                  ],
+                }}
+                counter={{ number: '87', accessibilityLabel: '87 archived campaings' }}
+              />
+            </SideNavigation>
+          </Box>
+        </DeviceTypeProvider>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -30,6 +30,7 @@ import nestedExample from '../../examples/sidenavigation/nestedExample.js';
 import notificationsExample from '../../examples/sidenavigation/notificationsExample.js';
 import mobileExample from '../../examples/sidenavigation/mobileExample.js';
 import subcomponent from '../../examples/sidenavigation/subcomponent.js';
+import primaryAction from '../../examples/sidenavigation/primaryAction.js';
 
 export default function SideNavigationPage({
   generatedDocGen,
@@ -200,7 +201,7 @@ export default function SideNavigationPage({
       <AccessibilitySection name={generatedDocGen.SideNavigation?.displayName}>
         <MainSection.Subsection
           title="Active item"
-          description={`SideNavigation.TopItem has an "active" state that visually identifies it. To set SideNavigation.TopItem to "active" set 'active="page"' (page redirect) or 'active="section"'. Use routing hooks from React.Router or other frameworks to identify the current route. For example, if the current pathname matches the SideNavigation.TopItem href, set SideNavigation.TopItem to "page". Use the example below as a reference.`}
+          description={`SideNavigation.TopItem and SideNavigation.NestedItem have an "active" state that visually identifies it. To set them to "active" set 'active="page"' (page redirect) or 'active="section"'. Use routing hooks from React.Router or other frameworks to identify the current route. For example, if the current pathname matches the SideNavigation.TopItem href, set SideNavigation.TopItem to "page". Use the example below as a reference.`}
         >
           <MainSection.Card
             sandpackExample={
@@ -414,6 +415,136 @@ To prevent visual overload, do not include counters in the parent if the childre
           />
         </MainSection.Subsection>
         <MainSection.Subsection
+          title="Primary action"
+          description={`SideNavigation.TopItem and SideNavigation.Group support an optional \`primaryAction\`.
+
+\`primaryAction\` can be a simple [IconButton](https://gestalt.pinterest.systems/web/iconbutton) or a [Dropdown](https://gestalt.pinterest.systems/web/dropdown). For the latter, set \`dropdownItems\` using an array of [Dropdown.Item](https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item).
+          `}
+        >
+          <MainSection.Card
+            defaultCode={`
+function Example() {
+  const anchorRef = React.useRef(null);
+  const [mobile, setMobile] = React.useState(false);
+
+  return (
+    <Box color="lightWash" padding={4} height={300} overflow="auto">
+      <Flex gap={12}>
+        <Button text="View mobile" onClick={() => setMobile(true)} color="red" />
+        <DeviceTypeProvider deviceType={mobile ? 'mobile' : 'desktop'}>
+          <Box position={mobile ? 'absolute' : undefined} top bottom left right id="sidenavigation">
+            <SideNavigation
+              accessibilityLabel="Notification example"
+              dismissButton={{ onDismiss: () => setMobile((value) => !value) }}
+            >
+              <SideNavigation.TopItem
+                href="#"
+                onClick={({ event }) => {
+                  event.preventDefault();
+                }}
+                label="Campaign z-168i"
+                primaryAction={{
+                  icon: 'edit',
+                  onClick: ({ event }) => {
+                    event.preventDefault();
+                  },
+                  tooltip: { text: 'Rename campaign' },
+                }}
+              />
+              <SideNavigation.TopItem
+                href="#"
+                onClick={({ event }) => {
+                  event.preventDefault();
+                }}
+                label="Campaign a-j6ki (inactive)"
+                primaryAction={{
+                  icon: 'trash-can',
+                  onClick: ({ event }) => {
+                    event.preventDefault();
+                  },
+                  tooltip: { text: 'Delete campaign' },
+                }}
+              />
+              <SideNavigation.Group
+                label="Campaign drafts"
+                counter={{ number: '12', accessibilityLabel: '12 campaign drafts' }}
+                primaryAction={{
+                  onClick: ({ event }) => {
+                    event.preventDefault();
+                  },
+                  tooltip: { text: 'More options' },
+                  dropdownItems: [
+                    <Dropdown.Item
+                      key="edit"
+                      option={{ value: 'Edit', label: 'Edit' }}
+                      onSelect={() => {}}
+                    />,
+                    <Dropdown.Item
+                      key="trash"
+                      option={{ value: 'Delete', label: 'Delete' }}
+                      onSelect={() => {}}
+                    />,
+                  ],
+                }}
+              >
+                <SideNavigation.NestedItem
+                  counter={{
+                    number: '10',
+                    accessibilityLabel: 'You have 10 messages in your inbox',
+                  }}
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="West Coast"
+                />
+                <SideNavigation.NestedItem
+                  href="#"
+                  onClick={({ event }) => event.preventDefault()}
+                  label="East Coast"
+                />
+              </SideNavigation.Group>
+              <SideNavigation.TopItem
+                href="#"
+                onClick={({ event }) => event.preventDefault()}
+                label="Archived campaigns"
+                primaryAction={{
+                  onClick: ({ event }) => {
+                    event.preventDefault();
+                  },
+                  tooltip: { text: 'More options' },
+                  dropdownItems: [
+                    <Dropdown.Item
+                      key="edit"
+                      option={{ value: 'Edit', label: 'Edit' }}
+                      onSelect={() => {}}
+                    />,
+                    <Dropdown.Item
+                      key="trash"
+                      option={{ value: 'Delete', label: 'Delete' }}
+                      onSelect={() => {}}
+                    />,
+                  ],
+                }}
+                counter={{ number: '87', accessibilityLabel: '87 archived campaings' }}
+              />
+            </SideNavigation>
+          </Box>
+        </DeviceTypeProvider>
+      </Flex>
+    </Box>
+  )
+}
+`}
+            sandpackExample={
+              <SandpackExample
+                code={primaryAction}
+                name="Primary action example"
+                previewHeight={500}
+              />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
           title="Nested directory"
           description="SideNavigation supports three navigation levels. The top level is composed of [SideNavigation.TopItem](#SideNavigation.TopItem) and [SideNavigation.Group](#SideNavigation.Group). The second nested level is composed of [SideNavigation.NestedGroup](#SideNavigation.NestedGroup) and [SideNavigation.Item](#SideNavigation.Item). The third nested level is composed of SideNavigation.Item"
         >
@@ -423,7 +554,6 @@ To prevent visual overload, do not include counters in the parent if the childre
             }
           />
         </MainSection.Subsection>
-
         <MainSection.Subsection
           title="Subcomponent composability"
           description={`SideNavigation requires its own subcomponents as children to build the list of navigation items.

--- a/packages/gestalt/src/OptionItem.js
+++ b/packages/gestalt/src/OptionItem.js
@@ -152,10 +152,15 @@ const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forward
       data-test-id={dataTestId}
       id={`${id}-item-${index}`}
       onClick={handleOnTap}
+      // These event.stopPropagation are important so interactive anchors don't receive the onFocus/onBlur event
+      onFocus={(event) => event.stopPropagation()}
+      onBlur={(event) => event.stopPropagation()}
       onKeyPress={(event) => {
         event.preventDefault();
       }}
+      // This event.stopPropagation is important so interactive anchors don't compress with the onMouseDown event
       onMouseDown={(event) => {
+        event.stopPropagation();
         event.preventDefault();
       }}
       onMouseEnter={() => setHoveredItemIndex(index)}

--- a/packages/gestalt/src/SideNavigation.js
+++ b/packages/gestalt/src/SideNavigation.js
@@ -8,6 +8,7 @@ import styles from './SideNavigation.css';
 import borderStyles from './Borders.css';
 import SideNavigationMobile from './SideNavigationMobile.js';
 import SideNavigationSection from './SideNavigationSection.js';
+import SideNavigationIconButton from './SideNavigationIconButton.js';
 import SideNavigationTopItem from './SideNavigationTopItem.js';
 import SideNavigationGroup from './SideNavigationGroup.js';
 import SideNavigationNestedItem from './SideNavigationNestedItem.js';

--- a/packages/gestalt/src/SideNavigation.js
+++ b/packages/gestalt/src/SideNavigation.js
@@ -2,13 +2,13 @@
 import { useId, type Node } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
+import ScrollBoundaryContainer from './ScrollBoundaryContainer.js';
 import Flex from './Flex.js';
 import Divider from './Divider.js';
 import styles from './SideNavigation.css';
 import borderStyles from './Borders.css';
 import SideNavigationMobile from './SideNavigationMobile.js';
 import SideNavigationSection from './SideNavigationSection.js';
-import SideNavigationIconButton from './SideNavigationIconButton.js';
 import SideNavigationTopItem from './SideNavigationTopItem.js';
 import SideNavigationGroup from './SideNavigationGroup.js';
 import SideNavigationNestedItem from './SideNavigationNestedItem.js';
@@ -82,53 +82,57 @@ export default function SideNavigation({
           id,
         }}
       >
-        <SideNavigationMobile
-          accessibilityLabel={accessibilityLabel}
-          footer={footer}
-          header={header}
-          dismissButton={dismissButton}
-          showBorder={showBorder}
-          title={title}
-          id={id}
-        >
-          {navigationChildren}
-        </SideNavigationMobile>
+        <ScrollBoundaryContainer>
+          <SideNavigationMobile
+            accessibilityLabel={accessibilityLabel}
+            footer={footer}
+            header={header}
+            dismissButton={dismissButton}
+            showBorder={showBorder}
+            title={title}
+            id={id}
+          >
+            {navigationChildren}
+          </SideNavigationMobile>
+        </ScrollBoundaryContainer>
       </SideNavigationProvider>
     );
   }
 
   return (
     <SideNavigationProvider>
-      <Box minWidth={280} width={280} height="100%" as="nav" aria-label={accessibilityLabel}>
-        <div
-          className={
-            showBorder ? classnames(borderStyles.borderRight, styles.fullHeight) : undefined
-          }
-        >
-          <Box
-            padding={2}
-            color="default"
-            dangerouslySetInlineStyle={{ __style: { paddingBottom: 24 } }}
-            height="100%"
+      <ScrollBoundaryContainer>
+        <Box minWidth={280} width={280} height="100%" as="nav" aria-label={accessibilityLabel}>
+          <div
+            className={
+              showBorder ? classnames(borderStyles.borderRight, styles.fullHeight) : undefined
+            }
           >
-            <Flex direction="column" gap={{ column: 4, row: 0 }}>
-              {header ? (
-                <Flex direction="column" gap={{ column: 4, row: 0 }}>
-                  <Box paddingX={4}>{header}</Box>
-                  <Divider />
-                </Flex>
-              ) : null}
-              <ul className={classnames(styles.ulItem)}>{navigationChildren}</ul>
-              {footer ? (
-                <Flex direction="column" gap={{ column: 4, row: 0 }}>
-                  <Divider />
-                  <Box paddingX={4}>{footer}</Box>
-                </Flex>
-              ) : null}
-            </Flex>
-          </Box>
-        </div>
-      </Box>
+            <Box
+              padding={2}
+              color="default"
+              dangerouslySetInlineStyle={{ __style: { paddingBottom: 24 } }}
+              height="100%"
+            >
+              <Flex direction="column" gap={{ column: 4, row: 0 }}>
+                {header ? (
+                  <Flex direction="column" gap={{ column: 4, row: 0 }}>
+                    <Box paddingX={4}>{header}</Box>
+                    <Divider />
+                  </Flex>
+                ) : null}
+                <ul className={classnames(styles.ulItem)}>{navigationChildren}</ul>
+                {footer ? (
+                  <Flex direction="column" gap={{ column: 4, row: 0 }}>
+                    <Divider />
+                    <Box paddingX={4}>{footer}</Box>
+                  </Flex>
+                ) : null}
+              </Flex>
+            </Box>
+          </div>
+        </Box>
+      </ScrollBoundaryContainer>
     </SideNavigationProvider>
   );
 }

--- a/packages/gestalt/src/SideNavigation.jsdom.test.js
+++ b/packages/gestalt/src/SideNavigation.jsdom.test.js
@@ -1,0 +1,452 @@
+// @flow strict
+import { fireEvent, screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Dropdown from './Dropdown.js';
+import SideNavigation from './SideNavigation.js';
+import DeviceTypeProvider from './contexts/DeviceTypeProvider.js';
+
+describe('SideNavigation desktop', () => {
+  function Component() {
+    return (
+      <SideNavigation accessibilityLabel="example1" dismissButton={{ onDismiss: () => {} }}>
+        <SideNavigation.Group
+          label="Group item"
+          counter={{ number: '123', accessibilityLabel: '123 counter' }}
+          primaryAction={{
+            onClick: ({ event }) => {
+              event.preventDefault();
+            },
+            tooltip: { text: 'More options', accessibilityLabel: 'More options label' },
+            dropdownItems: [
+              <Dropdown.Item
+                key="edit"
+                option={{ value: 'Edit', label: 'Edit' }}
+                onSelect={() => {}}
+              />,
+              <Dropdown.Item
+                key="trash"
+                option={{ value: 'Delete', label: 'Delete' }}
+                onSelect={() => {}}
+              />,
+            ],
+          }}
+        >
+          <SideNavigation.NestedItem
+            href="#"
+            onClick={({ event }) => event.preventDefault()}
+            label="test"
+          />
+        </SideNavigation.Group>
+        <SideNavigation.TopItem
+          href="#"
+          onClick={({ event }) => event.preventDefault()}
+          label="Top item"
+          primaryAction={{
+            onClick: ({ event }) => {
+              event.preventDefault();
+            },
+            tooltip: {
+              text: 'More options nested',
+              accessibilityLabel: 'More options nested label',
+            },
+            dropdownItems: [
+              <Dropdown.Item
+                key="edit"
+                option={{ value: 'Edit', label: 'Edit' }}
+                onSelect={() => {}}
+              />,
+              <Dropdown.Item
+                key="trash"
+                option={{ value: 'Delete', label: 'Delete' }}
+                onSelect={() => {}}
+              />,
+            ],
+          }}
+          counter={{ number: '321', accessibilityLabel: '321 counter' }}
+        />
+      </SideNavigation>
+    );
+  }
+
+  test('renders correctly on hover', () => {
+    render(<Component />);
+
+    // BEFORE HOVERING
+    expect(
+      screen.getByText('Group item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('123', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.queryByLabelText('More options label', {
+        exact: true,
+      }),
+    ).toBeNull();
+
+    expect(
+      screen.getByText('Top item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('321', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    // ON HOVER
+    fireEvent.mouseEnter(screen.getByText('Group item'));
+
+    expect(
+      screen.getByText('Group item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(screen.queryByText('123')).toBeNull();
+
+    expect(
+      screen.getByLabelText('More options label', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.queryByText('More options', {
+        exact: true,
+      }),
+    ).toBeNull();
+
+    expect(
+      screen.getByText('Top item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('321', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    fireEvent.mouseEnter(
+      screen.getByLabelText('More options label', {
+        exact: true,
+      }),
+    );
+
+    expect(
+      screen.getByText('More options', {
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
+  test('renders correctly on focus', async () => {
+    render(<Component />);
+
+    // BEFORE FOCUSING
+    expect(
+      screen.getByText('Group item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('123', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.queryByLabelText('More options label', {
+        exact: true,
+      }),
+    ).toBeNull();
+
+    expect(document.body).toHaveFocus();
+
+    // ON FOCUS
+    await userEvent.tab();
+
+    expect(
+      screen.getByRole('button', {
+        exact: true,
+      }),
+    ).toHaveFocus();
+
+    expect(
+      screen.getByText('Group item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(screen.queryByText('123')).toBeNull();
+
+    expect(
+      screen.getByLabelText('More options label', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.queryByText('More options', {
+        exact: true,
+      }),
+    ).toBeNull();
+
+    await userEvent.tab();
+
+    expect(
+      screen.queryByText('More options', {
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
+  test('renders primaryAction dropdown correctly on click', () => {
+    render(<Component />);
+
+    fireEvent.mouseEnter(screen.getByText('Group item'));
+
+    expect(screen.queryByText('Edit')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('More options label'));
+
+    expect(
+      screen.getByText('Edit', {
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
+  test('renders primaryAction dropdown correctly on enter', async () => {
+    render(<Component />);
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    await userEvent.tab();
+
+    expect(
+      screen.getByLabelText('More options label', {
+        exact: true,
+      }),
+    ).toHaveFocus();
+
+    expect(screen.queryByText('Edit')).toBeNull();
+
+    await userEvent.keyboard('[Enter]');
+
+    expect(
+      screen.getByText('Edit', {
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+});
+
+describe('SideNavigation mobile', () => {
+  function Component() {
+    return (
+      <DeviceTypeProvider deviceType="mobile">
+        <SideNavigation accessibilityLabel="example2" dismissButton={{ onDismiss: () => {} }}>
+          <SideNavigation.Group
+            label="Group item"
+            counter={{ number: '123', accessibilityLabel: '123 counter' }}
+            primaryAction={{
+              onClick: ({ event }) => {
+                event.preventDefault();
+              },
+              tooltip: { text: 'More options', accessibilityLabel: 'More options label' },
+              dropdownItems: [
+                <Dropdown.Item
+                  key="edit"
+                  option={{ value: 'Edit', label: 'Edit' }}
+                  onSelect={() => {}}
+                />,
+                <Dropdown.Item
+                  key="trash"
+                  option={{ value: 'Delete', label: 'Delete' }}
+                  onSelect={() => {}}
+                />,
+              ],
+            }}
+          >
+            <SideNavigation.NestedItem
+              href="#"
+              onClick={({ event }) => event.preventDefault()}
+              label="test"
+            />
+          </SideNavigation.Group>
+          <SideNavigation.TopItem
+            href="#"
+            onClick={({ event }) => event.preventDefault()}
+            label="Top item"
+            primaryAction={{
+              onClick: ({ event }) => {
+                event.preventDefault();
+              },
+              tooltip: {
+                text: 'More options nested',
+                accessibilityLabel: 'More options nested label',
+              },
+              dropdownItems: [
+                <Dropdown.Item
+                  key="edit"
+                  option={{ value: 'Edit', label: 'Edit' }}
+                  onSelect={() => {}}
+                />,
+                <Dropdown.Item
+                  key="trash"
+                  option={{ value: 'Delete', label: 'Delete' }}
+                  onSelect={() => {}}
+                />,
+              ],
+            }}
+            counter={{ number: '321', accessibilityLabel: '321 counter' }}
+          />
+        </SideNavigation>
+      </DeviceTypeProvider>
+    );
+  }
+
+  test('renders correctly on hover', () => {
+    render(<Component />);
+
+    expect(
+      screen.getByText('Group item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('123', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('Top item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('321', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(screen.queryByText('More options')).toBeNull();
+
+    fireEvent.mouseEnter(screen.getByText('Group item'));
+
+    expect(
+      screen.getByText('Group item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('123', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(screen.queryByText('More options')).toBeNull();
+
+    fireEvent.mouseEnter(screen.getByLabelText('More options label'));
+
+    expect(screen.getByText('More options')).toBeVisible();
+  });
+
+  test('renders correctly on focus', async () => {
+    render(<Component />);
+
+    expect(
+      screen.getByText('Group item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('123', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(screen.getByLabelText('More options label')).toBeVisible();
+
+    await userEvent.tab();
+
+    await userEvent.tab();
+
+    expect(
+      screen.getByText('Group item', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('123', {
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    expect(
+      screen.getByText('More options', {
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
+  test('renders primaryAction dropdown correctly on click', () => {
+    render(<Component />);
+
+    fireEvent.mouseEnter(screen.getByText('Group item'));
+
+    expect(screen.queryByText('Edit')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('More options label'));
+
+    expect(
+      screen.getByText('Edit', {
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
+  test('renders primaryAction dropdown correctly on enter', async () => {
+    render(<Component />);
+
+    await userEvent.tab();
+
+    await userEvent.tab();
+
+    expect(
+      screen.getByLabelText('More options label', {
+        exact: true,
+      }),
+    ).toHaveFocus();
+
+    expect(screen.queryByText('Edit')).toBeNull();
+
+    await userEvent.keyboard('[Enter]');
+
+    expect(
+      screen.getByText('Edit', {
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+});

--- a/packages/gestalt/src/SideNavigationGroupMobile.js
+++ b/packages/gestalt/src/SideNavigationGroupMobile.js
@@ -25,10 +25,15 @@ export default function SideNavigationGroupMobile({
   hasActiveChild = false,
   icon,
   label,
+  primaryAction,
   notificationAccessibilityLabel,
 }: SideNavigationGroupMobileProps): Node {
+  // Manages PrimaryAction
+  const [compression, setCompression] = useState<'compress' | 'none'>('compress');
   const [hovered, setHovered] = useState(false);
-  const [expanded, setExpanded] = useState(false);
+  const [focused, setFocused] = useState(false);
+
+  // Manages children
 
   const itemId = useId();
 
@@ -58,6 +63,8 @@ export default function SideNavigationGroupMobile({
     ),
     [itemId, childrenArray],
   );
+
+  const [expanded, setExpanded] = useState(false);
 
   const itemColor = hovered ? 'secondary' : undefined;
 
@@ -139,10 +146,10 @@ export default function SideNavigationGroupMobile({
           accessibilityExpanded={display === 'expandable' ? expanded : undefined}
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
-          onFocus={() => setHovered(true)}
-          onBlur={() => setHovered(false)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
           rounding={2}
-          tapStyle="compress"
+          tapStyle={compression}
           onTap={() => {
             if (isTopLevel) {
               elevateChildrenToParent();
@@ -166,6 +173,10 @@ export default function SideNavigationGroupMobile({
             notificationAccessibilityLabel={notificationAccessibilityLabel}
             counter={counter}
             display={display}
+            primaryAction={primaryAction}
+            setCompression={setCompression}
+            hovered={hovered}
+            focused={focused}
           />
         </TapArea>
         {expanded ? passedChildren : null}

--- a/packages/gestalt/src/SideNavigationIconButton.js
+++ b/packages/gestalt/src/SideNavigationIconButton.js
@@ -1,0 +1,78 @@
+/*
+
+InternalDismissIconButton aims to replace "dismiss" IconButtons in components that toggle on/off their visibility, p.ex. Modal, OverlayPanel, mobile SideNavigation. When visible, we require autofocus within the component in particular the dismiss IconButton. IconButton displays a Tooltip on focus, but for this particular usage the tooltip is not required as it creates a bad UX. InternalDismissIconButton is an IconButtons replacement without tooltip.
+
+*/
+
+// @flow strict
+import {
+  type Node,
+  type AbstractComponent,
+  type ElementConfig,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import IconButton from './IconButton.js';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import { type Indexable } from './zIndex.js';
+
+type Props = {|
+  accessibilityHaspopup?: boolean,
+  accessibilityControls?: string,
+  accessibilityExpanded?: boolean,
+  accessibilityPopupRole?: 'menu' | 'dialog',
+  icon: 'ellipsis' | 'edit' | 'trash-can',
+  onClick?: AbstractEventHandler<
+    | SyntheticMouseEvent<HTMLButtonElement>
+    | SyntheticKeyboardEvent<HTMLButtonElement>
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    {| dangerouslyDisableOnNavigation: () => void |},
+  >,
+  tooltip: {|
+    accessibilityLabel?: string,
+    inline?: boolean,
+    idealDirection?: 'up' | 'right' | 'down' | 'left',
+    text: string,
+    zIndex?: Indexable,
+  |},
+|};
+
+const SideNavigationIconButtonWithForwardRef: AbstractComponent<Props, HTMLButtonElement> =
+  forwardRef<Props, HTMLButtonElement>(function IconButton(
+    {
+      accessibilityHaspopup,
+      accessibilityExpanded,
+      accessibilityPopupRole,
+      accessibilityControls,
+      icon,
+      onClick,
+      tooltip,
+    }: Props,
+    ref,
+  ): Node {
+    const innerRef = useRef(null);
+
+    // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
+    // that renders <IconButton ref={inputRef} /> to call inputRef.current.focus()
+    useImperativeHandle(ref, () => innerRef.current);
+
+    return (
+      <IconButton
+        accessibilityHaspopup={accessibilityHaspopup}
+        accessibilityControls={accessibilityControls}
+        accessibilityExpanded={accessibilityExpanded}
+        accessibilityPopupRole={accessibilityPopupRole}
+        icon={icon}
+        onClick={onClick}
+        tooltip={tooltip}
+        ref={innerRef}
+        size="xs"
+      />
+    );
+  });
+
+export default SideNavigationIconButtonWithForwardRef;
+
+SideNavigationIconButtonWithForwardRef.displayName = 'SideNavigation.IconButton';

--- a/packages/gestalt/src/SideNavigationIconButton.js
+++ b/packages/gestalt/src/SideNavigationIconButton.js
@@ -1,78 +1,164 @@
-/*
-
-InternalDismissIconButton aims to replace "dismiss" IconButtons in components that toggle on/off their visibility, p.ex. Modal, OverlayPanel, mobile SideNavigation. When visible, we require autofocus within the component in particular the dismiss IconButton. IconButton displays a Tooltip on focus, but for this particular usage the tooltip is not required as it creates a bad UX. InternalDismissIconButton is an IconButtons replacement without tooltip.
-
-*/
-
 // @flow strict
-import {
-  type Node,
-  type AbstractComponent,
-  type ElementConfig,
-  forwardRef,
-  useImperativeHandle,
-  useRef,
-} from 'react';
-import IconButton from './IconButton.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
-import { type Indexable } from './zIndex.js';
+import { type Node, type Element, useRef, useState, useEffect, useId, cloneElement } from 'react';
+import TapArea from './TapArea.js';
+import Pog from './Pog.js';
+import Tooltip from './Tooltip.js';
+import Dropdown from './Dropdown.js';
+import { FixedZIndex, CompositeZIndex, type Indexable } from './zIndex.js';
 
 type Props = {|
-  accessibilityHaspopup?: boolean,
-  accessibilityControls?: string,
-  accessibilityExpanded?: boolean,
-  accessibilityPopupRole?: 'menu' | 'dialog',
-  icon: 'ellipsis' | 'edit' | 'trash-can',
-  onClick?: AbstractEventHandler<
-    | SyntheticMouseEvent<HTMLButtonElement>
-    | SyntheticKeyboardEvent<HTMLButtonElement>
-    | SyntheticMouseEvent<HTMLAnchorElement>
-    | SyntheticKeyboardEvent<HTMLAnchorElement>,
-    {| dangerouslyDisableOnNavigation: () => void |},
-  >,
+  icon?: 'ellipsis' | 'edit' | 'trash-can',
+  onClick?: ({|
+    event:
+      | SyntheticMouseEvent<HTMLDivElement>
+      | SyntheticKeyboardEvent<HTMLDivElement>
+      | SyntheticMouseEvent<HTMLAnchorElement>
+      | SyntheticKeyboardEvent<HTMLAnchorElement>,
+  |}) => void,
+  setCompression: ('compress' | 'none') => void,
+  forceIconButton: 'force' | 'default',
+  setForceIconButton: ('force' | 'default') => void,
+  setShowIconButton: ('show' | 'hide') => void,
+  isItemActive: boolean,
   tooltip: {|
     accessibilityLabel?: string,
-    inline?: boolean,
-    idealDirection?: 'up' | 'right' | 'down' | 'left',
     text: string,
     zIndex?: Indexable,
   |},
+  dropdownItems?: $ReadOnlyArray<Element<typeof Dropdown.Item>>,
 |};
 
-const SideNavigationIconButtonWithForwardRef: AbstractComponent<Props, HTMLButtonElement> =
-  forwardRef<Props, HTMLButtonElement>(function IconButton(
-    {
-      accessibilityHaspopup,
-      accessibilityExpanded,
-      accessibilityPopupRole,
-      accessibilityControls,
-      icon,
-      onClick,
-      tooltip,
-    }: Props,
-    ref,
-  ): Node {
-    const innerRef = useRef(null);
+function SideNavigationIconButton({
+  icon = 'ellipsis',
+  onClick,
+  tooltip,
+  dropdownItems,
+  isItemActive,
+  setShowIconButton,
+  forceIconButton,
+  setForceIconButton,
+  setCompression,
+}: Props): Node {
+  const id = useId();
 
-    // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
-    // that renders <IconButton ref={inputRef} /> to call inputRef.current.focus()
-    useImperativeHandle(ref, () => innerRef.current);
+  const innerRef = useRef(null);
 
-    return (
-      <IconButton
-        accessibilityHaspopup={accessibilityHaspopup}
-        accessibilityControls={accessibilityControls}
-        accessibilityExpanded={accessibilityExpanded}
-        accessibilityPopupRole={accessibilityPopupRole}
-        icon={icon}
-        onClick={onClick}
-        tooltip={tooltip}
+  const [selected, setSelected] = useState(dropdownItems ? false : undefined);
+  const [open, setOpen] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+
+  let bgColor = 'transparent';
+  let iconColor = 'darkGray';
+
+  if (!isItemActive && !hovered && !focused) {
+    bgColor = 'transparent';
+    iconColor = 'darkGray';
+  }
+
+  if (isItemActive && (hovered || focused)) {
+    bgColor = 'gray';
+    iconColor = 'white';
+  }
+
+  if (isItemActive && !hovered && !focused) {
+    iconColor = 'white';
+  }
+
+  if (isItemActive && selected) {
+    bgColor = 'white';
+    iconColor = 'darkGray';
+  }
+
+  useEffect(() => {
+    // As soon as Dropdown gets dismissed and unselects IconButton, we hide and stop forcing it
+    if (forceIconButton === 'force' && selected === false) {
+      setShowIconButton('hide');
+      setForceIconButton?.('default');
+    }
+  }, [selected, forceIconButton, setShowIconButton, setForceIconButton]);
+
+  const tooltipZIndex = tooltip?.zIndex
+    ? new CompositeZIndex([new FixedZIndex(1), tooltip?.zIndex].filter(Boolean))
+    : new FixedZIndex(1);
+  const dropdownZIndex = new CompositeZIndex([tooltipZIndex]);
+  return (
+    <Tooltip accessibilityLabel="" text={tooltip.text} zIndex={tooltipZIndex}>
+      {/* Interactive elements require an a11yLabel on them or their children. That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */}
+      <TapArea
+        accessibilityControls={id}
+        accessibilityExpanded={open}
+        accessibilityLabel={tooltip?.accessibilityLabel ?? tooltip.text}
+        onMouseEnter={() => {
+          setCompression('none');
+          setHovered(true);
+        }}
+        onMouseLeave={() => {
+          setCompression('compress');
+          setHovered(false);
+        }}
+        onFocus={() => {
+          setFocused(true);
+          setShowIconButton('show');
+        }}
+        onBlur={() => {
+          setFocused(false);
+          // With keyboard navigation, we want to hide IconButton if we keep tabbing without opening Dropdown
+          // However, Dropdown captures focus, therefore, as soon as it opens could hide IconButton and unmount itself, never displaying
+          // We prevent this by disabling this action until Dropdown gets dismissed and unselects IconButton
+          if (typeof selected === 'undefined' || forceIconButton === 'default') {
+            setShowIconButton('hide');
+          }
+        }}
+        onTap={({ event }) => {
+          // We need event.stopPropagation(); so the SideNavigation.TopItem's onClick doesn't get trigger as well
+          event.stopPropagation();
+          // As soon as IconButton gets clicked, we force its display, only if selected === false.
+          // We don't force if selected ===  undefined, which would indicate there's no Dropdown associated, just an action
+          if (selected === false) {
+            setForceIconButton?.('force');
+          }
+
+          if (selected !== undefined) {
+            setSelected((value) => !value);
+            setOpen((value) => !value);
+          }
+
+          onClick?.({ event });
+        }}
         ref={innerRef}
-        size="xs"
-      />
-    );
-  });
+        rounding="circle"
+        tapStyle="compress"
+      >
+        <Pog
+          accessibilityLabel=""
+          active={(hovered || focused) && !isItemActive}
+          selected={selected === true && !isItemActive}
+          size="xs"
+          icon={icon}
+          iconColor={iconColor}
+          bgColor={bgColor}
+        />
+        {open && (
+          <Dropdown
+            anchor={innerRef.current}
+            id={id}
+            onDismiss={() => {
+              setSelected(false);
+              setOpen(false);
+            }}
+            zIndex={dropdownZIndex}
+          >
+            {dropdownItems?.map((element, idx) =>
+              cloneElement(element, { key: `sidenavigation-dropdown-item-${idx}` }),
+            )}
+          </Dropdown>
+        )}
+      </TapArea>
+    </Tooltip>
+  );
+}
 
-export default SideNavigationIconButtonWithForwardRef;
+export default SideNavigationIconButton;
 
-SideNavigationIconButtonWithForwardRef.displayName = 'SideNavigation.IconButton';
+SideNavigationIconButton.displayName = 'SideNavigation.IconButton';

--- a/packages/gestalt/src/SideNavigationMobile.js
+++ b/packages/gestalt/src/SideNavigationMobile.js
@@ -37,18 +37,15 @@ export default function SideNavigationMobile({
   }, [dismissButtonRef]);
 
   return (
-    <Box
-      width="100%"
-      height="100%"
-      as="nav"
-      aria-label={accessibilityLabel}
-      color="default"
-      id={id}
-    >
+    <Box width="100%" height="100%" as="nav" aria-label={accessibilityLabel} id={id}>
       <div
         className={showBorder ? classnames(borderStyles.borderRight, styles.fullHeight) : undefined}
       >
-        <Box padding={2} dangerouslySetInlineStyle={{ __style: { paddingBottom: 24 } }}>
+        <Box
+          padding={2}
+          dangerouslySetInlineStyle={{ __style: { paddingBottom: 24 } }}
+          color="default"
+        >
           {selectedMobileChildren ?? (
             <Fragment>
               <Box height={64} paddingY={2}>

--- a/packages/gestalt/src/__snapshots__/SideNavigation.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SideNavigation.test.js.snap
@@ -1,1082 +1,867 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SideNavigation renders Header + Footer 1`] = `
-<nav
-  aria-label="label"
-  className="box"
+<div
+  className="box overflowAuto paddingX0 paddingY0 relative"
   style={
     Object {
       "height": "100%",
-      "minWidth": 280,
-      "width": 280,
     }
   }
 >
-  <div>
-    <div
-      className="box default paddingX2 paddingY2"
-      style={
-        Object {
-          "height": "100%",
-          "paddingBottom": 24,
-        }
+  <nav
+    aria-label="label"
+    className="box"
+    style={
+      Object {
+        "height": "100%",
+        "minWidth": 280,
+        "width": 280,
       }
-    >
+    }
+  >
+    <div>
       <div
-        className="Flex rowGap0 columnGap4 xsDirectionColumn"
+        className="box default paddingX2 paddingY2"
+        style={
+          Object {
+            "height": "100%",
+            "paddingBottom": 24,
+          }
+        }
       >
         <div
-          className="FlexItem"
+          className="Flex rowGap0 columnGap4 xsDirectionColumn"
         >
           <div
-            className="Flex rowGap0 columnGap4 xsDirectionColumn"
+            className="FlexItem"
           >
             <div
-              className="FlexItem"
+              className="Flex rowGap0 columnGap4 xsDirectionColumn"
             >
               <div
-                className="box paddingX4"
+                className="FlexItem"
               >
                 <div
-                  className="box default"
-                  style={
-                    Object {
-                      "height": 100,
-                      "width": "100%",
+                  className="box paddingX4"
+                >
+                  <div
+                    className="box default"
+                    style={
+                      Object {
+                        "height": 100,
+                        "width": "100%",
+                      }
                     }
-                  }
+                  />
+                </div>
+              </div>
+              <div
+                className="FlexItem"
+              >
+                <hr
+                  className="divider"
                 />
               </div>
             </div>
-            <div
-              className="FlexItem"
-            >
-              <hr
-                className="divider"
-              />
-            </div>
           </div>
-        </div>
-        <div
-          className="FlexItem"
-        >
-          <ul
-            className="ulItem"
+          <div
+            className="FlexItem"
           >
-            <li
-              className="liItem"
+            <ul
+              className="ulItem"
             >
-              <a
-                className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                href="#"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchCancel={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                rel=""
-                tabIndex={0}
-                target={null}
+              <li
+                className="liItem"
               >
-                <div
-                  className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
-                  style={
-                    Object {
-                      "minHeight": 44,
-                      "paddingInlineEnd": "16px",
-                      "paddingInlineStart": "16px",
-                    }
-                  }
+                <a
+                  className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  rel=""
+                  tabIndex={0}
+                  target={null}
                 >
                   <div
-                    className="Flex rowGap2 columnGap0 xsDirectionRow"
+                    className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
                     style={
                       Object {
-                        "height": "100%",
-                        "width": "100%",
+                        "minHeight": 44,
+                        "paddingInlineEnd": "16px",
+                        "paddingInlineStart": "16px",
                       }
                     }
                   >
                     <div
-                      className="FlexItem flexGrow selfCenter"
+                      className="Flex rowGap2 columnGap0 xsDirectionRow"
+                      style={
+                        Object {
+                          "height": "100%",
+                          "width": "100%",
+                        }
+                      }
                     >
-                      <span
-                        className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                      <div
+                        className="FlexItem flexGrow selfCenter"
                       >
-                        test
-                      </span>
+                        <span
+                          className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                        >
+                          test
+                        </span>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div
-          className="FlexItem"
-        >
+                </a>
+              </li>
+            </ul>
+          </div>
           <div
-            className="Flex rowGap0 columnGap4 xsDirectionColumn"
+            className="FlexItem"
           >
             <div
-              className="FlexItem"
-            >
-              <hr
-                className="divider"
-              />
-            </div>
-            <div
-              className="FlexItem"
+              className="Flex rowGap0 columnGap4 xsDirectionColumn"
             >
               <div
-                className="box paddingX4"
+                className="FlexItem"
+              >
+                <hr
+                  className="divider"
+                />
+              </div>
+              <div
+                className="FlexItem"
               >
                 <div
-                  className="box default"
-                  style={
-                    Object {
-                      "height": 100,
-                      "width": "100%",
+                  className="box paddingX4"
+                >
+                  <div
+                    className="box default"
+                    style={
+                      Object {
+                        "height": 100,
+                        "width": "100%",
+                      }
                     }
-                  }
-                />
+                  />
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;
 
 exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`] = `
-<nav
-  aria-label="label"
-  className="box"
+<div
+  className="box overflowAuto paddingX0 paddingY0 relative"
   style={
     Object {
       "height": "100%",
-      "minWidth": 280,
-      "width": 280,
     }
   }
 >
-  <div
-    className="borderRight fullHeight"
+  <nav
+    aria-label="label"
+    className="box"
+    style={
+      Object {
+        "height": "100%",
+        "minWidth": 280,
+        "width": 280,
+      }
+    }
   >
     <div
-      className="box default paddingX2 paddingY2"
-      style={
-        Object {
-          "height": "100%",
-          "paddingBottom": 24,
-        }
-      }
+      className="borderRight fullHeight"
     >
       <div
-        className="Flex rowGap0 columnGap4 xsDirectionColumn"
+        className="box default paddingX2 paddingY2"
+        style={
+          Object {
+            "height": "100%",
+            "paddingBottom": 24,
+          }
+        }
       >
         <div
-          className="FlexItem"
+          className="Flex rowGap0 columnGap4 xsDirectionColumn"
         >
-          <ul
-            className="ulItem"
+          <div
+            className="FlexItem"
           >
-            <li
-              className="liItem section"
+            <ul
+              className="ulItem"
             >
-              <div
-                className="box marginBottom2 paddingX4 xsDisplayFlex"
-                role="presentation"
+              <li
+                className="liItem section"
               >
                 <div
-                  className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold lineClamp"
-                  style={
-                    Object {
-                      "WebkitLineClamp": 2,
-                    }
-                  }
-                  title="section"
+                  className="box marginBottom2 paddingX4 xsDisplayFlex"
+                  role="presentation"
                 >
-                  section
-                </div>
-              </div>
-              <ul
-                className="ulItem"
-              >
-                <li
-                  className="liItem"
-                >
-                  <a
-                    className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                    href="#"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyPress={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchCancel={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    rel=""
-                    tabIndex={0}
-                    target={null}
-                  >
-                    <div
-                      className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
-                      style={
-                        Object {
-                          "minHeight": 44,
-                          "paddingInlineEnd": "16px",
-                          "paddingInlineStart": "16px",
-                        }
+                  <div
+                    className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 2,
                       }
+                    }
+                    title="section"
+                  >
+                    section
+                  </div>
+                </div>
+                <ul
+                  className="ulItem"
+                >
+                  <li
+                    className="liItem"
+                  >
+                    <a
+                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                      href="#"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyPress={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchCancel={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      rel=""
+                      tabIndex={0}
+                      target={null}
                     >
                       <div
-                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
                         style={
                           Object {
-                            "height": "100%",
-                            "width": "100%",
+                            "minHeight": 44,
+                            "paddingInlineEnd": "16px",
+                            "paddingInlineStart": "16px",
                           }
                         }
                       >
                         <div
-                          className="FlexItem selfCenter"
+                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          style={
+                            Object {
+                              "height": "100%",
+                              "width": "100%",
+                            }
+                          }
                         >
                           <div
-                            aria-hidden={true}
-                            className="box"
+                            className="FlexItem selfCenter"
                           >
-                            <svg
-                              aria-hidden={true}
-                              aria-label=""
-                              className="icon defaultIcon"
-                              height={16}
-                              role="img"
-                              viewBox="0 0 24 24"
-                              width={16}
-                            >
-                              <path
-                                d="test-file-stub"
-                              />
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="FlexItem flexGrow selfCenter"
-                        >
-                          <span
-                            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
-                          >
-                            test
                             <div
-                              className="box marginStart1 xsDisplayInlineBlock"
-                              style={
-                                Object {
-                                  "height": "100%",
-                                }
-                              }
+                              aria-hidden={true}
+                              className="box"
                             >
-                              <div
-                                className="box xsDisplayVisuallyHidden"
+                              <svg
+                                aria-hidden={true}
+                                aria-label=""
+                                className="icon defaultIcon"
+                                height={16}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={16}
                               >
-                                , 
-                              </div>
+                                <path
+                                  d="test-file-stub"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            className="FlexItem flexGrow selfCenter"
+                          >
+                            <span
+                              className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                            >
+                              test
                               <div
-                                className="Badge middle infoBase"
+                                className="box marginStart1 xsDisplayInlineBlock"
+                                style={
+                                  Object {
+                                    "height": "100%",
+                                  }
+                                }
                               >
                                 <div
-                                  className="Flex rowGap1 columnGap1 xsDirectionRow xsItemsCenter"
+                                  className="box xsDisplayVisuallyHidden"
+                                >
+                                  , 
+                                </div>
+                                <div
+                                  className="Badge middle infoBase"
                                 >
                                   <div
-                                    className="FlexItem"
+                                    className="Flex rowGap1 columnGap1 xsDirectionRow xsItemsCenter"
                                   >
                                     <div
-                                      className="box xsDisplayInlineBlock"
-                                      style={
-                                        Object {
-                                          "marginTop": "2px",
-                                        }
-                                      }
+                                      className="FlexItem"
                                     >
-                                      New
+                                      <div
+                                        className="box xsDisplayInlineBlock"
+                                        style={
+                                          Object {
+                                            "marginTop": "2px",
+                                          }
+                                        }
+                                      >
+                                        New
+                                      </div>
                                     </div>
                                   </div>
                                 </div>
                               </div>
-                            </div>
-                          </span>
-                        </div>
-                        <div
-                          className="FlexItem flexNone selfCenter"
-                        >
-                          <div
-                            className="box xsDisplayVisuallyHidden"
-                          >
-                            , 
+                            </span>
                           </div>
                           <div
-                            aria-label="You have 20 notifications"
-                            className="box marginEndN2"
-                            role="status"
+                            className="FlexItem flexNone selfCenter"
                           >
                             <div
-                              className="Text fontSize300 subtleText alignEnd breakWord fontWeightNormal"
+                              className="box xsDisplayVisuallyHidden"
                             >
-                              20
+                              , 
+                            </div>
+                            <div
+                              aria-label="You have 20 notifications"
+                              className="box marginEndN2"
+                            >
+                              <div
+                                className="Text fontSize300 subtleText alignEnd breakWord fontWeightNormal"
+                              >
+                                20
+                              </div>
                             </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-                <li
-                  className="liItem"
-                >
-                  <a
-                    className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                    href="#"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyPress={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchCancel={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    rel=""
-                    tabIndex={0}
-                    target={null}
+                    </a>
+                  </li>
+                  <li
+                    className="liItem"
                   >
-                    <div
-                      className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
-                      style={
-                        Object {
-                          "minHeight": 44,
-                          "paddingInlineEnd": "16px",
-                          "paddingInlineStart": "16px",
-                        }
-                      }
+                    <a
+                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                      href="#"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyPress={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchCancel={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      rel=""
+                      tabIndex={0}
+                      target={null}
                     >
                       <div
-                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
                         style={
                           Object {
-                            "height": "100%",
-                            "width": "100%",
+                            "minHeight": 44,
+                            "paddingInlineEnd": "16px",
+                            "paddingInlineStart": "16px",
                           }
                         }
                       >
                         <div
-                          className="FlexItem selfCenter"
+                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          style={
+                            Object {
+                              "height": "100%",
+                              "width": "100%",
+                            }
+                          }
                         >
                           <div
-                            aria-hidden={true}
-                            className="box"
+                            className="FlexItem selfCenter"
                           >
-                            <svg
-                              aria-hidden={true}
-                              aria-label=""
-                              className="icon defaultIcon"
-                              height={16}
-                              role="img"
-                              viewBox="0 0 24 24"
-                              width={16}
-                            >
-                              <path
-                                d="test-file-stub"
-                              />
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="FlexItem flexGrow selfCenter"
-                        >
-                          <span
-                            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
-                          >
-                            test
                             <div
-                              className="box marginStart1 xsDisplayInlineBlock"
-                              style={
-                                Object {
-                                  "height": "100%",
-                                }
-                              }
+                              aria-hidden={true}
+                              className="box"
                             >
-                              <div
-                                className="box xsDisplayVisuallyHidden"
+                              <svg
+                                aria-hidden={true}
+                                aria-label=""
+                                className="icon defaultIcon"
+                                height={16}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={16}
                               >
-                                , 
-                              </div>
+                                <path
+                                  d="test-file-stub"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            className="FlexItem flexGrow selfCenter"
+                          >
+                            <span
+                              className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                            >
+                              test
                               <div
-                                aria-label="You have new messages"
-                                className="box circle primary"
-                                role="status"
+                                className="box marginStart1 xsDisplayInlineBlock"
                                 style={
                                   Object {
-                                    "height": 8,
-                                    "width": 8,
+                                    "height": "100%",
                                   }
                                 }
-                              />
-                            </div>
-                          </span>
-                        </div>
-                        <div
-                          className="FlexItem flexNone selfCenter"
-                        >
-                          <div
-                            className="box xsDisplayVisuallyHidden"
-                          >
-                            , 
+                              >
+                                <div
+                                  className="box xsDisplayVisuallyHidden"
+                                >
+                                  , 
+                                </div>
+                                <div
+                                  aria-label="You have new messages"
+                                  className="box circle primary"
+                                  role="status"
+                                  style={
+                                    Object {
+                                      "height": 8,
+                                      "width": 8,
+                                    }
+                                  }
+                                />
+                              </div>
+                            </span>
                           </div>
                           <div
-                            aria-label="You have 20 notifications"
-                            className="box marginEndN2"
-                            role="status"
+                            className="FlexItem flexNone selfCenter"
                           >
                             <div
-                              className="Text fontSize300 subtleText alignEnd breakWord fontWeightNormal"
+                              className="box xsDisplayVisuallyHidden"
                             >
-                              20
+                              , 
+                            </div>
+                            <div
+                              aria-label="You have 20 notifications"
+                              className="box marginEndN2"
+                            >
+                              <div
+                                className="Text fontSize300 subtleText alignEnd breakWord fontWeightNormal"
+                              >
+                                20
+                              </div>
                             </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-            </li>
-          </ul>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;
 
 exports[`SideNavigation renders Sections 1`] = `
-<nav
-  aria-label="label"
-  className="box"
+<div
+  className="box overflowAuto paddingX0 paddingY0 relative"
   style={
     Object {
       "height": "100%",
-      "minWidth": 280,
-      "width": 280,
     }
   }
 >
-  <div>
-    <div
-      className="box default paddingX2 paddingY2"
-      style={
-        Object {
-          "height": "100%",
-          "paddingBottom": 24,
-        }
+  <nav
+    aria-label="label"
+    className="box"
+    style={
+      Object {
+        "height": "100%",
+        "minWidth": 280,
+        "width": 280,
       }
-    >
+    }
+  >
+    <div>
       <div
-        className="Flex rowGap0 columnGap4 xsDirectionColumn"
+        className="box default paddingX2 paddingY2"
+        style={
+          Object {
+            "height": "100%",
+            "paddingBottom": 24,
+          }
+        }
       >
         <div
-          className="FlexItem"
+          className="Flex rowGap0 columnGap4 xsDirectionColumn"
         >
-          <ul
-            className="ulItem"
+          <div
+            className="FlexItem"
           >
-            <li
-              className="liItem section"
+            <ul
+              className="ulItem"
             >
-              <div
-                className="box marginBottom2 paddingX4 xsDisplayFlex"
-                role="presentation"
+              <li
+                className="liItem section"
               >
                 <div
-                  className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold lineClamp"
-                  style={
-                    Object {
-                      "WebkitLineClamp": 2,
-                    }
-                  }
-                  title="section"
+                  className="box marginBottom2 paddingX4 xsDisplayFlex"
+                  role="presentation"
                 >
-                  section
-                </div>
-              </div>
-              <ul
-                className="ulItem"
-              >
-                <li
-                  className="liItem"
-                >
-                  <a
-                    className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                    href="#"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyPress={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchCancel={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    rel=""
-                    tabIndex={0}
-                    target={null}
-                  >
-                    <div
-                      className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
-                      style={
-                        Object {
-                          "minHeight": 44,
-                          "paddingInlineEnd": "16px",
-                          "paddingInlineStart": "16px",
-                        }
+                  <div
+                    className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 2,
                       }
+                    }
+                    title="section"
+                  >
+                    section
+                  </div>
+                </div>
+                <ul
+                  className="ulItem"
+                >
+                  <li
+                    className="liItem"
+                  >
+                    <a
+                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                      href="#"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyPress={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchCancel={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      rel=""
+                      tabIndex={0}
+                      target={null}
                     >
                       <div
-                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
                         style={
                           Object {
-                            "height": "100%",
-                            "width": "100%",
+                            "minHeight": 44,
+                            "paddingInlineEnd": "16px",
+                            "paddingInlineStart": "16px",
                           }
                         }
                       >
                         <div
-                          className="FlexItem flexGrow selfCenter"
+                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          style={
+                            Object {
+                              "height": "100%",
+                              "width": "100%",
+                            }
+                          }
                         >
-                          <span
-                            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                          <div
+                            className="FlexItem flexGrow selfCenter"
                           >
-                            test
-                          </span>
+                            <span
+                              className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                            >
+                              test
+                            </span>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-            </li>
-          </ul>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;
 
 exports[`SideNavigation renders basic Item 1`] = `
-<nav
-  aria-label="label"
-  className="box"
+<div
+  className="box overflowAuto paddingX0 paddingY0 relative"
   style={
     Object {
       "height": "100%",
-      "minWidth": 280,
-      "width": 280,
     }
   }
 >
-  <div>
-    <div
-      className="box default paddingX2 paddingY2"
-      style={
-        Object {
-          "height": "100%",
-          "paddingBottom": 24,
-        }
+  <nav
+    aria-label="label"
+    className="box"
+    style={
+      Object {
+        "height": "100%",
+        "minWidth": 280,
+        "width": 280,
       }
-    >
+    }
+  >
+    <div>
       <div
-        className="Flex rowGap0 columnGap4 xsDirectionColumn"
+        className="box default paddingX2 paddingY2"
+        style={
+          Object {
+            "height": "100%",
+            "paddingBottom": 24,
+          }
+        }
       >
         <div
-          className="FlexItem"
+          className="Flex rowGap0 columnGap4 xsDirectionColumn"
         >
-          <ul
-            className="ulItem"
+          <div
+            className="FlexItem"
           >
-            <li
-              className="liItem"
+            <ul
+              className="ulItem"
             >
-              <a
-                className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                href="#"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchCancel={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                rel=""
-                tabIndex={0}
-                target={null}
+              <li
+                className="liItem"
               >
-                <div
-                  className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
-                  style={
-                    Object {
-                      "minHeight": 44,
-                      "paddingInlineEnd": "16px",
-                      "paddingInlineStart": "16px",
-                    }
-                  }
+                <a
+                  className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  rel=""
+                  tabIndex={0}
+                  target={null}
                 >
                   <div
-                    className="Flex rowGap2 columnGap0 xsDirectionRow"
+                    className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
                     style={
                       Object {
-                        "height": "100%",
-                        "width": "100%",
+                        "minHeight": 44,
+                        "paddingInlineEnd": "16px",
+                        "paddingInlineStart": "16px",
                       }
                     }
                   >
                     <div
-                      className="FlexItem flexGrow selfCenter"
+                      className="Flex rowGap2 columnGap0 xsDirectionRow"
+                      style={
+                        Object {
+                          "height": "100%",
+                          "width": "100%",
+                        }
+                      }
                     >
-                      <span
-                        className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                      <div
+                        className="FlexItem flexGrow selfCenter"
                       >
-                        test
-                      </span>
+                        <span
+                          className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                        >
+                          test
+                        </span>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </a>
-            </li>
-          </ul>
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;
 
 exports[`SideNavigation renders nested directory 1`] = `
-<nav
-  aria-label="Nested items example"
-  className="box"
+<div
+  className="box overflowAuto paddingX0 paddingY0 relative"
   style={
     Object {
       "height": "100%",
-      "minWidth": 280,
-      "width": 280,
     }
   }
 >
-  <div>
-    <div
-      className="box default paddingX2 paddingY2"
-      style={
-        Object {
-          "height": "100%",
-          "paddingBottom": 24,
-        }
+  <nav
+    aria-label="Nested items example"
+    className="box"
+    style={
+      Object {
+        "height": "100%",
+        "minWidth": 280,
+        "width": 280,
       }
-    >
+    }
+  >
+    <div>
       <div
-        className="Flex rowGap0 columnGap4 xsDirectionColumn"
+        className="box default paddingX2 paddingY2"
+        style={
+          Object {
+            "height": "100%",
+            "paddingBottom": 24,
+          }
+        }
       >
         <div
-          className="FlexItem"
+          className="Flex rowGap0 columnGap4 xsDirectionColumn"
         >
-          <ul
-            className="ulItem"
+          <div
+            className="FlexItem"
           >
-            <li
-              className="liItem"
+            <ul
+              className="ulItem"
             >
-              <a
-                className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                href="#"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchCancel={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                rel=""
-                tabIndex={0}
-                target={null}
+              <li
+                className="liItem"
               >
-                <div
-                  className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
-                  style={
-                    Object {
-                      "minHeight": 44,
-                      "paddingInlineEnd": "16px",
-                      "paddingInlineStart": "16px",
-                    }
-                  }
+                <a
+                  className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  rel=""
+                  tabIndex={0}
+                  target={null}
                 >
                   <div
-                    className="Flex rowGap2 columnGap0 xsDirectionRow"
+                    className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
                     style={
                       Object {
-                        "height": "100%",
-                        "width": "100%",
+                        "minHeight": 44,
+                        "paddingInlineEnd": "16px",
+                        "paddingInlineStart": "16px",
                       }
                     }
                   >
                     <div
-                      className="FlexItem selfCenter"
-                    >
-                      <div
-                        aria-hidden={true}
-                        className="box"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          aria-label=""
-                          className="rtlSupport icon defaultIcon"
-                          height={16}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={16}
-                        >
-                          <path
-                            d="test-file-stub"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      className="FlexItem flexGrow selfCenter"
-                    >
-                      <span
-                        className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
-                      >
-                        Reporting
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </a>
-            </li>
-            <li
-              className="liItem"
-            >
-              <a
-                className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                href="#"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchCancel={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                rel=""
-                tabIndex={0}
-                target={null}
-              >
-                <div
-                  className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
-                  style={
-                    Object {
-                      "minHeight": 44,
-                      "paddingInlineEnd": "16px",
-                      "paddingInlineStart": "16px",
-                    }
-                  }
-                >
-                  <div
-                    className="Flex rowGap2 columnGap0 xsDirectionRow"
-                    style={
-                      Object {
-                        "height": "100%",
-                        "width": "100%",
-                      }
-                    }
-                  >
-                    <div
-                      className="FlexItem selfCenter"
-                    >
-                      <div
-                        aria-hidden={true}
-                        className="box"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          aria-label=""
-                          className="icon defaultIcon"
-                          height={16}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={16}
-                        >
-                          <path
-                            d="test-file-stub"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      className="FlexItem flexGrow selfCenter"
-                    >
-                      <span
-                        className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
-                      >
-                        Conversions
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </a>
-            </li>
-            <li
-              className="liItem section"
-            >
-              <div
-                className="box marginBottom2 paddingX4 xsDisplayFlex"
-                role="presentation"
-              >
-                <div
-                  className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold lineClamp"
-                  style={
-                    Object {
-                      "WebkitLineClamp": 2,
-                    }
-                  }
-                  title="Audiences"
-                >
-                  Audiences
-                </div>
-              </div>
-              <ul
-                className="ulItem"
-              >
-                <li
-                  className="liItem"
-                >
-                  <a
-                    className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                    href="#"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyPress={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchCancel={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    rel=""
-                    tabIndex={0}
-                    target={null}
-                  >
-                    <div
-                      className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
+                      className="Flex rowGap2 columnGap0 xsDirectionRow"
                       style={
                         Object {
-                          "minHeight": 44,
-                          "paddingInlineEnd": "16px",
-                          "paddingInlineStart": "16px",
+                          "height": "100%",
+                          "width": "100%",
                         }
                       }
                     >
                       <div
-                        className="Flex rowGap2 columnGap0 xsDirectionRow"
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
+                        className="FlexItem selfCenter"
                       >
                         <div
-                          className="FlexItem selfCenter"
+                          aria-hidden={true}
+                          className="box"
                         >
-                          <div
+                          <svg
                             aria-hidden={true}
-                            className="box"
+                            aria-label=""
+                            className="rtlSupport icon defaultIcon"
+                            height={16}
+                            role="img"
+                            viewBox="0 0 24 24"
+                            width={16}
                           >
-                            <svg
-                              aria-hidden={true}
-                              aria-label=""
-                              className="icon defaultIcon"
-                              height={16}
-                              role="img"
-                              viewBox="0 0 24 24"
-                              width={16}
-                            >
-                              <path
-                                d="test-file-stub"
-                              />
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="FlexItem flexGrow selfCenter"
-                        >
-                          <span
-                            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
-                          >
-                            Thanksgiving
-                          </span>
+                            <path
+                              d="test-file-stub"
+                            />
+                          </svg>
                         </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-                <li
-                  className="liItem"
-                >
-                  <div
-                    aria-controls=":rd:"
-                    aria-disabled={false}
-                    aria-expanded={false}
-                    className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyPress={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchCancel={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <div
-                      className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
-                      style={
-                        Object {
-                          "minHeight": 44,
-                          "paddingInlineEnd": "16px",
-                          "paddingInlineStart": "16px",
-                        }
-                      }
-                    >
                       <div
-                        className="Flex rowGap2 columnGap0 xsDirectionRow"
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
+                        className="FlexItem flexGrow selfCenter"
                       >
-                        <div
-                          className="FlexItem selfCenter"
+                        <span
+                          className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
                         >
-                          <div
-                            aria-hidden={true}
-                            className="box"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              aria-label=""
-                              className="icon defaultIcon"
-                              height={16}
-                              role="img"
-                              viewBox="0 0 24 24"
-                              width={16}
-                            >
-                              <path
-                                d="test-file-stub"
-                              />
-                            </svg>
-                          </div>
-                        </div>
-                        <div
-                          className="FlexItem flexGrow selfCenter"
-                        >
-                          <span
-                            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
-                          >
-                            Christmas
-                          </span>
-                        </div>
-                        <div
-                          className="FlexItem flexNone selfCenter"
-                        >
-                          <div
-                            aria-hidden={true}
-                            className="box circle marginEndN2 marginStart2"
-                            tabIndex={-1}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              aria-label=""
-                              className="icon defaultIcon iconBlock"
-                              height={12}
-                              role="img"
-                              viewBox="0 0 24 24"
-                              width={12}
-                            >
-                              <path
-                                d="test-file-stub"
-                              />
-                            </svg>
-                          </div>
-                        </div>
+                          Reporting
+                        </span>
                       </div>
                     </div>
                   </div>
-                </li>
-                <li
-                  className="liItem"
+                </a>
+              </li>
+              <li
+                className="liItem"
+              >
+                <a
+                  className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                  href="#"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  rel=""
+                  tabIndex={0}
+                  target={null}
                 >
                   <div
                     className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
@@ -1125,133 +910,391 @@ exports[`SideNavigation renders nested directory 1`] = `
                         <span
                           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
                         >
-                          Halloween
+                          Conversions
                         </span>
                       </div>
                     </div>
                   </div>
-                  <ul
-                    className="ulItem"
-                    id=":re:"
+                </a>
+              </li>
+              <li
+                className="liItem section"
+              >
+                <div
+                  className="box marginBottom2 paddingX4 xsDisplayFlex"
+                  role="presentation"
+                >
+                  <div
+                    className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold lineClamp"
+                    style={
+                      Object {
+                        "WebkitLineClamp": 2,
+                      }
+                    }
+                    title="Audiences"
                   >
-                    <li
-                      className="liItem"
+                    Audiences
+                  </div>
+                </div>
+                <ul
+                  className="ulItem"
+                >
+                  <li
+                    className="liItem"
+                  >
+                    <a
+                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                      href="#"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyPress={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchCancel={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      rel=""
+                      tabIndex={0}
+                      target={null}
                     >
-                      <a
-                        className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                        href="#"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyPress={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchCancel={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchMove={[Function]}
-                        onTouchStart={[Function]}
-                        rel=""
-                        tabIndex={0}
-                        target={null}
+                      <div
+                        className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
+                        style={
+                          Object {
+                            "minHeight": 44,
+                            "paddingInlineEnd": "16px",
+                            "paddingInlineStart": "16px",
+                          }
+                        }
                       >
                         <div
-                          className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
+                          className="Flex rowGap2 columnGap0 xsDirectionRow"
                           style={
                             Object {
-                              "minHeight": 44,
-                              "paddingInlineEnd": "16px",
-                              "paddingInlineStart": "48px",
+                              "height": "100%",
+                              "width": "100%",
                             }
                           }
                         >
                           <div
-                            className="Flex rowGap2 columnGap0 xsDirectionRow"
-                            style={
-                              Object {
-                                "height": "100%",
-                                "width": "100%",
-                              }
-                            }
+                            className="FlexItem selfCenter"
                           >
                             <div
-                              className="FlexItem flexGrow selfCenter"
+                              aria-hidden={true}
+                              className="box"
                             >
-                              <span
-                                className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                              <svg
+                                aria-hidden={true}
+                                aria-label=""
+                                className="icon defaultIcon"
+                                height={16}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={16}
                               >
-                                East Coast
-                              </span>
+                                <path
+                                  d="test-file-stub"
+                                />
+                              </svg>
                             </div>
                           </div>
+                          <div
+                            className="FlexItem flexGrow selfCenter"
+                          >
+                            <span
+                              className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                            >
+                              Thanksgiving
+                            </span>
+                          </div>
                         </div>
-                      </a>
-                    </li>
-                    <li
-                      className="liItem"
+                      </div>
+                    </a>
+                  </li>
+                  <li
+                    className="liItem"
+                  >
+                    <div
+                      aria-controls=":rd:"
+                      aria-disabled={false}
+                      aria-expanded={false}
+                      className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyPress={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchCancel={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      role="button"
+                      tabIndex={0}
                     >
-                      <a
-                        className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                        href="#"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyPress={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchCancel={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchMove={[Function]}
-                        onTouchStart={[Function]}
-                        rel=""
-                        tabIndex={0}
-                        target={null}
+                      <div
+                        className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
+                        style={
+                          Object {
+                            "minHeight": 44,
+                            "paddingInlineEnd": "16px",
+                            "paddingInlineStart": "16px",
+                          }
+                        }
                       >
                         <div
-                          className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
+                          className="Flex rowGap2 columnGap0 xsDirectionRow"
                           style={
                             Object {
-                              "minHeight": 44,
-                              "paddingInlineEnd": "16px",
-                              "paddingInlineStart": "48px",
+                              "height": "100%",
+                              "width": "100%",
                             }
                           }
                         >
                           <div
-                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            className="FlexItem selfCenter"
+                          >
+                            <div
+                              aria-hidden={true}
+                              className="box"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-label=""
+                                className="icon defaultIcon"
+                                height={16}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={16}
+                              >
+                                <path
+                                  d="test-file-stub"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            className="FlexItem flexGrow selfCenter"
+                          >
+                            <span
+                              className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                            >
+                              Christmas
+                            </span>
+                          </div>
+                          <div
+                            className="FlexItem flexNone selfCenter"
+                          >
+                            <div
+                              aria-hidden={true}
+                              className="box circle marginEndN2 marginStart2"
+                              tabIndex={-1}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-label=""
+                                className="icon defaultIcon iconBlock"
+                                height={12}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={12}
+                              >
+                                <path
+                                  d="test-file-stub"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li
+                    className="liItem"
+                  >
+                    <div
+                      className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
+                      style={
+                        Object {
+                          "minHeight": 44,
+                          "paddingInlineEnd": "16px",
+                          "paddingInlineStart": "16px",
+                        }
+                      }
+                    >
+                      <div
+                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <div
+                          className="FlexItem selfCenter"
+                        >
+                          <div
+                            aria-hidden={true}
+                            className="box"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              aria-label=""
+                              className="icon defaultIcon"
+                              height={16}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={16}
+                            >
+                              <path
+                                d="test-file-stub"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          className="FlexItem flexGrow selfCenter"
+                        >
+                          <span
+                            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                          >
+                            Halloween
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <ul
+                      className="ulItem"
+                      id=":re:"
+                    >
+                      <li
+                        className="liItem"
+                      >
+                        <a
+                          className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                          href="#"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyPress={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          rel=""
+                          tabIndex={0}
+                          target={null}
+                        >
+                          <div
+                            className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
                             style={
                               Object {
-                                "height": "100%",
-                                "width": "100%",
+                                "minHeight": 44,
+                                "paddingInlineEnd": "16px",
+                                "paddingInlineStart": "48px",
                               }
                             }
                           >
                             <div
-                              className="FlexItem flexGrow selfCenter"
+                              className="Flex rowGap2 columnGap0 xsDirectionRow"
+                              style={
+                                Object {
+                                  "height": "100%",
+                                  "width": "100%",
+                                }
+                              }
                             >
-                              <span
-                                className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                              <div
+                                className="FlexItem flexGrow selfCenter"
                               >
-                                West Coast
-                              </span>
+                                <span
+                                  className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                                >
+                                  East Coast
+                                </span>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-          </ul>
+                        </a>
+                      </li>
+                      <li
+                        className="liItem"
+                      >
+                        <a
+                          className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                          href="#"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyPress={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          rel=""
+                          tabIndex={0}
+                          target={null}
+                        >
+                          <div
+                            className="box paddingY2 rounding2 xsDisplayFlex xsItemsCenter"
+                            style={
+                              Object {
+                                "minHeight": 44,
+                                "paddingInlineEnd": "16px",
+                                "paddingInlineStart": "48px",
+                              }
+                            }
+                          >
+                            <div
+                              className="Flex rowGap2 columnGap0 xsDirectionRow"
+                              style={
+                                Object {
+                                  "height": "100%",
+                                  "width": "100%",
+                                }
+                              }
+                            >
+                              <div
+                                className="FlexItem flexGrow selfCenter"
+                              >
+                                <span
+                                  className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+                                >
+                                  West Coast
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;


### PR DESCRIPTION
### Summary

#### What changed?

SideNavigation: implemented `primaryAction` prop to allow actions on SideNavigation.TopItem and SideNavigation.Group

DESKTOP
![Brave Browser - SideNavigation - Gestalt 2023-02-21 at 5 59 27 PM](https://user-images.githubusercontent.com/10593890/220478168-be2c2bb7-1952-4da0-af78-ac16c31bc2cb.gif)

MOBILE
![Brave Browser - SideNavigation - Gestalt 2023-02-21 at 6 01 38 PM](https://user-images.githubusercontent.com/10593890/220478721-8cda3056-b742-41e7-a91e-dda7428b3db6.gif)

DESKTOP VOICEOVER
![Brave Browser - SideNavigation - Gestalt 2023-02-21 at 6 03 15 PM](https://user-images.githubusercontent.com/10593890/220478660-e21d6ca4-842e-4925-8591-17b99eb56d9d.gif)

FOLLOWUP to clean code: alphabetize, dry, etc

#### Why?

Add new features for m10n teams
### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
