### PR TITLE
Internal: add first integration test for Masonry

### DIFF
--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -1,18 +1,25 @@
 // @flow strict
 import { type Node } from 'react';
 import { ColorSchemeProvider, Masonry } from 'gestalt';
+import { useRouter } from 'next/router';
 import MasonryContainer from '../../integration-test-helpers/masonry/MasonryContainer.js';
 import { generateExampleItems } from '../../integration-test-helpers/masonry/items-utils.js';
 
 const measurementStore = Masonry.createMeasurementStore();
 
 export default function TestPage(): Node {
+  const router = useRouter();
+  const { offsetTop, scrollContainer, virtualize } = router.query;
+
   return (
     <ColorSchemeProvider colorScheme="light">
       <MasonryContainer
+        initialItems={generateExampleItems({ name: 'InitialPin' })}
         MasonryComponent={Masonry}
         measurementStore={measurementStore}
-        initialItems={generateExampleItems({ name: 'InitialPin' })}
+        offsetTop={offsetTop}
+        scrollContainer={scrollContainer}
+        virtualize={virtualize}
       />
     </ColorSchemeProvider>
   );

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "lint:js": "eslint --max-warnings 0 .",
     "lint:sh": "shellcheck $(find . -type f -iname '*.sh' ! -path '*/node_modules/*' ! -path '*/.git/*')",
     "playwright:test": "npx playwright test playwright/accessibility/ --config=playwright/playwright.config.js",
+    "playwright:test-masonry": "npx playwright test playwright/masonry/ --config=playwright/playwright.config.js",
     "playwright:update-visual-test": "npx playwright test --config=playwright/playwright.config.js",
     "precommit": "lint-staged",
     "prettier": "prettier",

--- a/playwright/masonry/fetch-more.spec.mjs
+++ b/playwright/masonry/fetch-more.spec.mjs
@@ -1,0 +1,64 @@
+// @flow strict
+import { expect, test } from '@playwright/test';
+import getServerURL from './utils/getServerURL.mjs';
+import waitForRenderedItems from './utils/waitForRenderedItems.mjs';
+import selectors from './utils/selectors.mjs';
+
+test.describe('Masonry: fetch more', () => {
+  test('trigger a call to "fetchMore" when container resizes', async ({
+    page,
+  }) => {
+    // Start with a small screen.
+    await page.setViewportSize({ width: 400, height: 400 });
+    await page.goto(getServerURL());
+    await waitForRenderedItems(page, { targetItemsGTE: 20 });
+
+    const initialFetchCount = await page.evaluate(
+      () => window.TEST_FETCH_COUNTS
+    );
+    // TODO[@rjames]: re-enable this eventually (possibly needs better SSR support?)
+    // expect(initialFetchCount).toBe(0);
+
+    // Fetches more if the viewport is big enough.
+    await page.setViewportSize({ width: 2000, height: 1000 });
+    await waitForRenderedItems(page, { targetItemsGTE: 40 });
+
+    const newFetchCount = await page.evaluate(() => window.TEST_FETCH_COUNTS);
+    expect(newFetchCount).toBeGreaterThan(initialFetchCount);
+  });
+
+  // TODO[@rjames]: fix this test, currently timing out
+  // eslint-disable-next-line jest/no-disabled-tests
+  test.skip('trigger a call to "fetchMore" when scrolling far enough', async ({
+    page,
+  }) => {
+    // Start with a small screen.
+    await page.setViewportSize({ width: 800, height: 800 });
+    await page.goto(
+      getServerURL({ virtualize: true, scrollContainer: true, offsetTop: 800 })
+    );
+    await waitForRenderedItems(page, { targetItems: 0 });
+
+    let fetchCount = 0;
+
+    // Scroll a little bit. This should trigger the virtual bounds but not the
+    // fetch bounds.
+    const scrollContainer = await page.evaluateHandle(
+      (selector) => document.querySelector(selector),
+      selectors.scrollContainer
+    );
+
+    await scrollContainer.evaluate((node) => node.scrollBy(0, 600));
+    await waitForRenderedItems(page, { targetItems: 6 });
+
+    fetchCount = await page.evaluate(() => window.TEST_FETCH_COUNTS);
+    expect(fetchCount).toBe(0);
+
+    // Scroll a little more. This should finally trigger the fetch bounds.
+    await scrollContainer.evaluate((node) => node.scrollBy(0, 600));
+    await waitForRenderedItems(page, { targetItems: 15 });
+
+    fetchCount = await page.evaluate(() => window.TEST_FETCH_COUNTS);
+    expect(fetchCount).toBe(1);
+  });
+});

--- a/playwright/masonry/utils/getServerURL.mjs
+++ b/playwright/masonry/utils/getServerURL.mjs
@@ -1,0 +1,38 @@
+// @flow strict
+
+const BASE_DOMAIN = 'http://localhost:8888';
+const BASE_PATH = '/integration-test/masonry';
+
+const normalizeValue = (val) => {
+  if (typeof val === 'boolean') {
+    return val ? '1' : '0';
+  }
+  return String(val);
+};
+
+/*::
+type Options = ?{|
+  offsetTop?: number,
+  scrollContainer?: boolean,
+  virtualize?: boolean,
+|};
+*/
+
+const getServerURL = (options /*: Options */) /*: string */ => {
+  let serializedOptions = '';
+
+  if (options) {
+    serializedOptions = Object.keys(options ?? {})
+      .map((key) =>
+        typeof options[key] !== 'undefined'
+          ? `${key}=${normalizeValue(options[key])}`
+          : ''
+      )
+      .filter((item) => !!item)
+      .join('&');
+  }
+
+  return `${BASE_DOMAIN}/${BASE_PATH}?${serializedOptions}`;
+};
+
+export default getServerURL;

--- a/playwright/masonry/utils/resizeWidth.mjs
+++ b/playwright/masonry/utils/resizeWidth.mjs
@@ -5,7 +5,10 @@
 // widths at certain page sizes.
 
 // $FlowExpectedError[unclear-type] flow-typed def for playwright is…lacking
-export default async function resizeWidth(page /*: Object */, newWidth /*: number */) {
+export default async function resizeWidth(
+  page /*: Object */,
+  newWidth /*: number */
+) {
   await page.evaluate((_newWidth) => {
     // Mock out the window width for the next resize calculation.
     const gridWrapper = document.getElementById('gridWrapper');

--- a/playwright/masonry/utils/resizeWidth.mjs
+++ b/playwright/masonry/utils/resizeWidth.mjs
@@ -4,8 +4,8 @@
 // page because the page may have CSS breakpoints causing the grid to be fixed
 // widths at certain page sizes.
 
-// $FlowExpectedError[unclear-type] flow-typed def for playwright is…lacking
 export default async function resizeWidth(
+  // $FlowExpectedError[unclear-type] flow-typed def for playwright is…lacking
   page /*: Object */,
   newWidth /*: number */
 ) {

--- a/playwright/masonry/utils/resizeWidth.mjs
+++ b/playwright/masonry/utils/resizeWidth.mjs
@@ -1,0 +1,21 @@
+// @flow strict
+
+// Trigger a resize of the grid. This is more complicated than just resizing the
+// page because the page may have CSS breakpoints causing the grid to be fixed
+// widths at certain page sizes.
+
+// $FlowExpectedError[unclear-type] flow-typed def for playwright is…lacking
+export default async function resizeWidth(page /*: Object */, newWidth /*: number */) {
+  await page.evaluate((_newWidth) => {
+    // Mock out the window width for the next resize calculation.
+    const gridWrapper = document.getElementById('gridWrapper');
+
+    if (!gridWrapper) {
+      throw new Error("Couldn't find gridWrapper.");
+    }
+
+    gridWrapper.style.width = `${_newWidth}px`;
+
+    window.dispatchEvent(new Event('resize'));
+  }, newWidth);
+}

--- a/playwright/masonry/utils/selectors.mjs
+++ b/playwright/masonry/utils/selectors.mjs
@@ -1,0 +1,22 @@
+// @flow strict
+
+const selectors = {
+  afterGrid: '.afterGrid',
+  gridItem: '[data-grid-item], .Collection-Item',
+  addItems: '#add-items',
+  expandGridItems: '#expand-grid-items',
+  incrementItemCounter: (id /*: number */) /*: string */ => `#increment-counter-${id}`,
+  insertItem: '#insert-item',
+  insertNullItems: '#insert-null-items',
+  itemCounter: (id /*: number */) /*: string */ => `#item-counter-${id}`,
+  pushFirstItemDown: '#push-first-down',
+  pushGridDown: '#push-grid-down',
+  scrollContainer: '[data-scroll-container]',
+  shuffleItems: '#shuffle-items',
+  staticItem: '[data-grid-item].static, .Masonry-Premount .Collection-Item',
+  toggleMount: '#toggle-mount',
+  toggleScrollContainer: '#toggle-scroll-container',
+  updateGridItems: '#update-grid-items',
+};
+
+export default selectors;

--- a/playwright/masonry/utils/selectors.mjs
+++ b/playwright/masonry/utils/selectors.mjs
@@ -5,7 +5,8 @@ const selectors = {
   gridItem: '[data-grid-item], .Collection-Item',
   addItems: '#add-items',
   expandGridItems: '#expand-grid-items',
-  incrementItemCounter: (id /*: number */) /*: string */ => `#increment-counter-${id}`,
+  incrementItemCounter: (id /*: number */) /*: string */ =>
+    `#increment-counter-${id}`,
   insertItem: '#insert-item',
   insertNullItems: '#insert-null-items',
   itemCounter: (id /*: number */) /*: string */ => `#item-counter-${id}`,

--- a/playwright/masonry/utils/waitForRenderedItems.mjs
+++ b/playwright/masonry/utils/waitForRenderedItems.mjs
@@ -1,0 +1,183 @@
+// @flow strict
+import selectors from './selectors.mjs';
+
+// When Masonry is given a list of items, it uses dynamic rendering to measure
+// them offscreen in batches. Sometimes this takes many renders and happens
+// asyncronously. waitForRenderedItems waits for a specified number of items to
+// be added to the DOM with no others waiting for measurement.
+/*::
+type waitForRenderedItemsArgs = {|
+  scrollHeight?: number,
+  targetItems?: number,
+  targetItemsGT?: number,
+  targetItemsGTE?: number,
+  targetItemsLT?: number,
+  targetItemsLTE?: number,
+|};
+*/
+
+export default async function waitForRenderedItems(
+  // $FlowExpectedError[unclear-type] flow-typed def for playwright is…lacking
+  page /*: Object */,
+  args /*: waitForRenderedItemsArgs */,
+  timeout /*: number = 2000 */
+  // $FlowExpectedError[unclear-type] flow-typed def for playwright is…lacking
+) /*: Promise<any> */ {
+  return page
+    .waitForFunction(
+      ({
+        selector,
+        args: {
+          targetItems,
+          targetItemsLT,
+          targetItemsLTE,
+          targetItemsGT,
+          targetItemsGTE,
+          scrollHeight,
+        },
+      }) => {
+        const items = Array.from(document.querySelectorAll(selector));
+        const loadedItems = items.filter(
+          (item) => item.style.visibility !== 'hidden'
+        );
+        const loadingItems = items.filter(
+          (item) => item.style.visibility === 'hidden'
+        );
+
+        if (loadingItems.length > 0) {
+          return false;
+        }
+
+        if (
+          typeof targetItems !== 'undefined' &&
+          loadedItems.length !== targetItems
+        ) {
+          return false;
+        }
+        if (
+          typeof targetItemsLT !== 'undefined' &&
+          loadedItems.length >= targetItemsLT
+        ) {
+          return false;
+        }
+        if (
+          typeof targetItemsLTE !== 'undefined' &&
+          loadedItems.length > targetItemsLTE
+        ) {
+          return false;
+        }
+        if (
+          typeof targetItemsGT !== 'undefined' &&
+          loadedItems.length <= targetItemsGT
+        ) {
+          return false;
+        }
+        if (
+          typeof targetItemsGTE !== 'undefined' &&
+          loadedItems.length < targetItemsGTE
+        ) {
+          return false;
+        }
+
+        const { documentElement } = document;
+        if (
+          typeof scrollHeight !== 'undefined' &&
+          documentElement?.scrollHeight !== scrollHeight
+        ) {
+          return false;
+        }
+
+        return true;
+      },
+      { selector: selectors.gridItem, args },
+      { polling: 'raf', timeout }
+    )
+    .catch(async (err) => {
+      const {
+        targetItems,
+        targetItemsLT,
+        targetItemsLTE,
+        targetItemsGT,
+        targetItemsGTE,
+        scrollHeight,
+      } = args;
+
+      let error = '';
+
+      // Count the number of loading items.
+      const loadingItems = await page.evaluate(
+        (selector) =>
+          Array.from(document.querySelectorAll(selector)).filter(
+            (item) => item.style.visibility === 'hidden'
+          ).length,
+        selectors.gridItem
+      );
+
+      if (loadingItems > 0) {
+        error = `Grid items still loading (${loadingItems}).`;
+        return false;
+      }
+
+      // Count the number of rendered items.
+      const renderedItems = await page.evaluate(
+        (selector) =>
+          Array.from(document.querySelectorAll(selector)).filter(
+            (item) => item.style.visibility !== 'hidden'
+          ).length,
+        selectors.gridItem
+      );
+
+      if (typeof targetItems !== 'undefined' && renderedItems !== targetItems) {
+        error = `${renderedItems} items rendered -- expected ${targetItems}.`;
+        return false;
+      }
+      if (
+        typeof targetItemsLT !== 'undefined' &&
+        renderedItems >= targetItemsLT
+      ) {
+        error = `${renderedItems} items rendered -- expected < ${targetItemsLT}.`;
+        return false;
+      }
+      if (
+        typeof targetItemsLTE !== 'undefined' &&
+        renderedItems > targetItemsLTE
+      ) {
+        error = `${renderedItems} items rendered -- expected <= ${targetItemsLTE}.`;
+        return false;
+      }
+      if (
+        typeof targetItemsGT !== 'undefined' &&
+        renderedItems <= targetItemsGT
+      ) {
+        error = `${renderedItems} items rendered -- expected > ${targetItemsGT}.`;
+        return false;
+      }
+      if (
+        typeof targetItemsGTE !== 'undefined' &&
+        renderedItems < targetItemsGTE
+      ) {
+        error = `${renderedItems} items rendered -- expected >= ${targetItemsGTE}.`;
+        return false;
+      }
+
+      if (typeof scrollHeight !== 'undefined') {
+        // Get the actual content height.
+        const actualScrollHeight = await page.evaluate(() => {
+          const { documentElement } = document;
+          return documentElement?.scrollHeight;
+        });
+
+        error = `scrollHeight = ${actualScrollHeight} -- expected ${scrollHeight}.`;
+      }
+
+      await page.screenshot({ path: 'items-timeout.png' });
+
+      throw new Error(`
+waitForRenderedItems timed out. ${error}
+
+See items-timeout.png for a screenshot of the page.
+
+System error: ${err.message}
+`);
+    });
+}


### PR DESCRIPTION
Once upon a time there existed a suite of integration tests for Masonry. It first lived in this repo, then was migrated to Pinboard, then was turned off, then was deleted. womp womp.

This PR is the first of many adding this test suite back. The approach is fairly different, using a regular (but unlinked) route on our docs site instead of setting up a bespoke mini-app, and using Playwright instead of Puppeteer.

I started with a test that I thought looked pretty simple, but really had no idea. The test file has two tests. The first test now passes completely. The second test no longer throws any errors, but also times out without passing. I'm still trying to debug what's going on there, but I wanted to get this code checked in to get other 👀 on it, and I'll keep chipping away at the skipped test.