### PR TITLE
Docs: Remove Year in Review banner

### DIFF
--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -50,7 +50,6 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
     <Box minHeight="100vh" color="default">
       <SkipToContent />
       <Header />
-      {isHomePage}
       {isSidebarOpen && (
         <Fragment>
           {/* The <div> element has a child <button> element that allows keyboard interaction */}

--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -10,7 +10,6 @@ import ResourcesFooter from './ResourcesFooter.js';
 import { useNavigationContext } from './navigationContext.js';
 import { useDocsDeviceType, DocsDeviceTypeProvider } from './contexts/DocsDeviceTypeProvider.js';
 import { ABOVE_PAGE_HEADER_ZINDEX } from './z-indices.js';
-import YearInReviewBanner from './YearInReviewBanner.js';
 
 export const CONTENT_MAX_WIDTH_PX = 1200;
 const HEADER_HEIGHT_PX = 75;
@@ -51,7 +50,7 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
     <Box minHeight="100vh" color="default">
       <SkipToContent />
       <Header />
-      {isHomePage && <YearInReviewBanner />}
+      {isHomePage}
       {isSidebarOpen && (
         <Fragment>
           {/* The <div> element has a child <button> element that allows keyboard interaction */}


### PR DESCRIPTION
Given it's nearly March, it seems appropriate to remove the 2022 year in review banner.