### PR TITLE
ScrollBoundaryContainer: add 'visible' to `overflow` prop type, documented case, and move editor to Sandpack

### DIFF
--- a/docs/examples/scrollboundarycontainer/autoOverflowExample.js
+++ b/docs/examples/scrollboundarycontainer/autoOverflowExample.js
@@ -1,0 +1,164 @@
+// @flow strict
+import { useState, type Node } from 'react';
+import {
+  Flex,
+  Box,
+  ScrollBoundaryContainer,
+  Text,
+  Tooltip,
+  TapArea,
+  Icon,
+  RadioGroup,
+} from 'gestalt';
+
+export default function Example(): Node {
+  const [content, setContent] = useState(null);
+  const [claimed, setClaimed] = useState(null);
+  const [device, setDevice] = useState(null);
+
+  return (
+    <Box padding={4} color="secondary" height="100%">
+      <ScrollBoundaryContainer overflow="auto" height={200}>
+        <Box color="light" padding={3}>
+          <Flex width={300} direction="column" gap={{ column: 4, row: 0 }}>
+            <Flex direction="column" gap={{ column: 2, row: 0 }}>
+              <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
+                <Text weight="bold">Content type</Text>
+                <Tooltip
+                  idealDirection="right"
+                  text="See stats about different types of content created by you and/or others on Pinterest. Filter to get more details on your organic (not an ad) and paid (promoted as an ad) content."
+                >
+                  <TapArea>
+                    <Icon icon="info-circle" accessibilityLabel="Information" color="default" />
+                  </TapArea>
+                </Tooltip>
+              </Flex>
+              <Flex direction="column">
+                <RadioGroup id="content-type" legend="Select content type" legendDisplay="hidden">
+                  <RadioGroup.RadioButton
+                    checked={content === 'all'}
+                    id="allcontent"
+                    label="All"
+                    name="content"
+                    onChange={() => setContent('all')}
+                    value="all"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={content === 'organic'}
+                    id="organic"
+                    label="Organic"
+                    name="content"
+                    onChange={() => setContent('organic')}
+                    value="organic"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={content === 'paid'}
+                    id="paid"
+                    label="Paid and earned"
+                    name="content"
+                    onChange={() => setContent('paid')}
+                    value="paid"
+                  />
+                </RadioGroup>
+              </Flex>
+            </Flex>
+            <Flex direction="column" gap={{ column: 2, row: 0 }}>
+              <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
+                <Text weight="bold">Claimed account</Text>
+                <Tooltip
+                  idealDirection="right"
+                  text="See stats for Pins linked to your claimed accounts like websites, Etsy, Instagram or Youtube. The Other Pins category includes Pins you’ve published or saved that don’t link to any of your claimed accounts."
+                >
+                  <TapArea>
+                    <Icon icon="info-circle" accessibilityLabel="Information" color="default" />
+                  </TapArea>
+                </Tooltip>
+              </Flex>
+              <Flex direction="column">
+                <RadioGroup
+                  id="claimed-account"
+                  legend="Select claimed account"
+                  legendDisplay="hidden"
+                >
+                  <RadioGroup.RadioButton
+                    checked={claimed === 'all'}
+                    id="allclaimed"
+                    label="All Pins"
+                    name="claimed"
+                    onChange={() => setClaimed('all')}
+                    value="all"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={claimed === 'instagram'}
+                    id="instagram"
+                    label="Instagram"
+                    name="claimed"
+                    onChange={() => setClaimed('instagram')}
+                    value="instagram"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={claimed === 'other'}
+                    id="other"
+                    label="Other pins"
+                    name="claimed"
+                    onChange={() => setClaimed('other')}
+                    value="other"
+                  />
+                </RadioGroup>
+              </Flex>
+            </Flex>
+            <Flex direction="column" gap={{ column: 2, row: 0 }}>
+              <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
+                <Text weight="bold">Device</Text>
+                <Tooltip
+                  idealDirection="right"
+                  text="See stats for the different devices your Pinterest traffic is coming from."
+                >
+                  <TapArea>
+                    <Icon icon="info-circle" accessibilityLabel="Information" color="default" />
+                  </TapArea>
+                </Tooltip>
+              </Flex>
+              <Flex direction="column">
+                <RadioGroup id="device-type" legend="Select a device" legendDisplay="hidden">
+                  <RadioGroup.RadioButton
+                    checked={device === 'all'}
+                    id="alldevices"
+                    label="All"
+                    name="device"
+                    onChange={() => setDevice('all')}
+                    value="all"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={device === 'mobile'}
+                    id="mobile"
+                    label="Mobile"
+                    name="device"
+                    onChange={() => setDevice('mobile')}
+                    value="mobile"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={device === 'desktop'}
+                    id="desktop"
+                    label="Desktop"
+                    name="device"
+                    onChange={() => setDevice('desktop')}
+                    value="desktop"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={device === 'tablet'}
+                    id="tablet"
+                    label="Tablet"
+                    name="device"
+                    onChange={() => setDevice('tablet')}
+                    value="tablet"
+                  />
+                </RadioGroup>
+              </Flex>
+            </Flex>
+          </Flex>
+        </Box>
+      </ScrollBoundaryContainer>
+    </Box>
+  );
+}

--- a/docs/examples/scrollboundarycontainer/modalExample.js
+++ b/docs/examples/scrollboundarycontainer/modalExample.js
@@ -1,0 +1,232 @@
+// @flow strict
+import { useState, useRef, type Node } from 'react';
+import {
+  Flex,
+  Box,
+  Button,
+  Layer,
+  ComboBox,
+  TextField,
+  Heading,
+  RadioGroup,
+  FixedZIndex,
+  CompositeZIndex,
+  Modal,
+  OverlayPanel,
+  Dropdown,
+} from 'gestalt';
+
+export default function ScrollBoundaryContainerExample(): Node {
+  const [showModal, setShowModal] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState(null);
+  const [parentComponent, setParentComponent] = useState('modal');
+  const anchorDropdownRef = useRef(null);
+
+  const handleSelect = ({ item }) => setSelected(item);
+
+  const MODAL_Z_INDEX = new FixedZIndex(11);
+
+  const ANCHORED_Z_INDEX = new CompositeZIndex([MODAL_Z_INDEX]);
+
+  const footer = (
+    <Box flex="grow" paddingX={3} paddingY={3}>
+      <Box
+        justifyContent="end"
+        marginStart={-1}
+        marginEnd={-1}
+        marginTop={-1}
+        marginBottom={-1}
+        display="flex"
+        wrap
+      >
+        <Box paddingX={1} paddingY={1}>
+          <Button text="Cancel" size="lg" onClick={() => setShowModal(false)} />
+        </Box>
+        <Box paddingX={1} paddingY={1}>
+          <Button
+            text="Save"
+            color="red"
+            size="lg"
+            type="submit"
+            onClick={() => setShowModal(false)}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+
+  const children = (
+    <Flex justifyContent="center">
+      <Box
+        direction="column"
+        display="flex"
+        marginStart={-3}
+        marginEnd={-3}
+        marginBottom={-3}
+        marginTop={-3}
+        maxWidth={800}
+        width="100%"
+        wrap
+      >
+        <Box display="flex" justifyContent="start" padding={3}>
+          <Button
+            accessibilityControls="subtext-dropdown-example"
+            accessibilityHaspopup
+            accessibilityExpanded={open}
+            accessibilityLabel="Select Previous Address"
+            selected={open}
+            iconEnd="arrow-down"
+            text="Select Previous Address"
+            onClick={() => setOpen((prevVal) => !prevVal)}
+            ref={anchorDropdownRef}
+          />
+          {open && (
+            <Dropdown
+              anchor={anchorDropdownRef.current}
+              id="subtext-dropdown-example"
+              onDismiss={() => {
+                setOpen(false);
+              }}
+              zIndex={ANCHORED_Z_INDEX}
+            >
+              <Dropdown.Item
+                onSelect={handleSelect}
+                option={{
+                  value: 'Headquarters San Francisco',
+                  label: 'Headquarters San Francisco',
+                  subtext: '321 Inspiration Street, Suite # 12',
+                }}
+                selected={selected}
+              />
+              <Dropdown.Item
+                onSelect={handleSelect}
+                option={{
+                  value: 'Headquarters Seattle',
+                  label: 'Headquarters Seattle',
+                  subtext: '123 Creativity Street, Suite # 21',
+                }}
+                selected={selected}
+              />
+            </Dropdown>
+          )}
+        </Box>
+        <Box flex="grow" paddingX={3} paddingY={3}>
+          <Heading accessibilityLevel={2} size="400">
+            Billing Address
+          </Heading>
+        </Box>
+        <Box flex="grow" paddingX={3} paddingY={3}>
+          <TextField id="Address_Name" label="Address Name" onChange={() => {}} />
+        </Box>
+        <Box flex="grow" paddingX={3} paddingY={3}>
+          <TextField id="Business_Name" label="Business Name" onChange={() => {}} />
+        </Box>
+        <Box flex="grow" paddingX={3} paddingY={3}>
+          <TextField id="Address_Line_1" label="Address Line 1" onChange={() => {}} />
+        </Box>
+        <Box flex="grow" paddingX={3} paddingY={3}>
+          <TextField id="Address_Line_2" label="Address Line 2" onChange={() => {}} />
+        </Box>
+        <Box flex="grow" paddingX={3} paddingY={3}>
+          <Box display="flex" marginStart={-3} marginEnd={-3} marginBottom={-3} marginTop={-3} wrap>
+            <Box flex="grow" paddingX={3} paddingY={3}>
+              <TextField id="City" label="City" onChange={() => {}} />
+            </Box>
+            <Box flex="grow" paddingX={3} paddingY={3}>
+              <TextField
+                id="State_Province_Region"
+                label="State/Province/Region"
+                onChange={() => {}}
+              />
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+      <Box flex="grow" paddingX={3} paddingY={3}>
+        <ComboBox
+          id="Country"
+          accessibilityClearButtonLabel="Clear countries"
+          options={[
+            {
+              value: 'United States',
+              label: 'United States',
+            },
+            {
+              value: 'Canada',
+              label: 'Canada',
+            },
+            {
+              value: 'United Kingdom',
+              label: 'United Kingdom',
+            },
+            {
+              value: 'Brazil',
+              label: 'Brazil',
+            },
+            {
+              value: 'Japan',
+              label: 'Japan',
+            },
+          ]}
+          onChange={() => {}}
+          onSelect={() => {}}
+          placeholder="Select a Country"
+          noResultText="No Results"
+          label="Country"
+          inputValue="United States"
+        />
+      </Box>
+    </Flex>
+  );
+
+  return (
+    <Box padding={4} height="100%">
+      <RadioGroup id="example" legend="Select Modal or OverlayPanel">
+        <RadioGroup.RadioButton
+          checked={parentComponent === 'modal'}
+          id="modal"
+          label="Open Modal"
+          name="parentComponent"
+          onChange={() => setParentComponent('modal')}
+          value="modal"
+        />
+        <RadioGroup.RadioButton
+          checked={parentComponent === 'overlaypanel'}
+          id="overlaypanel"
+          label="Open OverlayPanel"
+          name="parentComponent"
+          onChange={() => setParentComponent('overlaypanel')}
+          value="overlaypanel"
+        />
+        <Button text="Update Billing Address" onClick={() => setShowModal(true)} />
+      </RadioGroup>
+      {showModal && (
+        <Layer zIndex={MODAL_Z_INDEX}>
+          {parentComponent === 'modal' ? (
+            <Modal
+              accessibilityModalLabel=""
+              heading="Billing Information"
+              footer={footer}
+              onDismiss={() => setShowModal(false)}
+              size="lg"
+            >
+              {children}
+            </Modal>
+          ) : (
+            <OverlayPanel
+              accessibilityDismissButtonLabel="Dismiss Billing Information OverlayPanel"
+              accessibilityLabel=""
+              heading="Billing Information"
+              footer={footer}
+              onDismiss={() => setShowModal(false)}
+              size="lg"
+            >
+              {children}
+            </OverlayPanel>
+          )}
+        </Layer>
+      )}
+    </Box>
+  );
+}

--- a/docs/examples/scrollboundarycontainer/popoverExample.js
+++ b/docs/examples/scrollboundarycontainer/popoverExample.js
@@ -1,0 +1,68 @@
+// @flow strict
+import { useState, useEffect, useRef, type Node } from 'react';
+import { Flex, Box, ScrollBoundaryContainer, Text, Button, Layer, Popover } from 'gestalt';
+
+export default function Example(): Node {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef();
+
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  return (
+    <Box padding={4} color="secondary" height="100%">
+      <ScrollBoundaryContainer height={200}>
+        <Box padding={4} width={600} color="light">
+          <Flex gap={{ column: 0, row: 4 }}>
+            <Box width={200}>
+              <Text>
+                You need to add your data source URL to Pinterest so we can access your data source
+                file and create Pins for your products. Before you do this, make sure you have
+                prepared your data source and that you have claimed your website. If there are any
+                errors with your data source file, you can learn how to troubleshoot them below.
+                After you click Create Pins, you will land back at the main data source page while
+                your feed is being processed. Wait for a confirmation email from Pinterest about the
+                status of your data source submission.
+              </Text>
+            </Box>
+            <Button
+              ref={anchorRef}
+              href="https://help.pinterest.com/en/business/article/data-source-ingestion"
+              iconEnd="visit"
+              onClick={() => setOpen(false)}
+              role="link"
+              target="blank"
+              text="Help"
+            />
+            {open && (
+              <Layer>
+                <Popover
+                  anchor={anchorRef.current}
+                  color="blue"
+                  idealDirection="right"
+                  onDismiss={() => {}}
+                  positionRelativeToAnchor={false}
+                  showCaret
+                  size="xs"
+                >
+                  <Box
+                    padding={3}
+                    display="flex"
+                    alignItems="center"
+                    direction="column"
+                    column={12}
+                  >
+                    <Text color="inverse" align="center">
+                      Need help with something? Check out our Help Center.
+                    </Text>
+                  </Box>
+                </Popover>
+              </Layer>
+            )}
+          </Flex>
+        </Box>
+      </ScrollBoundaryContainer>
+    </Box>
+  );
+}

--- a/docs/examples/scrollboundarycontainer/visibleOverflowExample.js
+++ b/docs/examples/scrollboundarycontainer/visibleOverflowExample.js
@@ -1,0 +1,170 @@
+// @flow strict
+import { useState, type Node } from 'react';
+import {
+  Flex,
+  Box,
+  ScrollBoundaryContainer,
+  Text,
+  Tooltip,
+  TapArea,
+  Icon,
+  RadioGroup,
+} from 'gestalt';
+
+export default function Example(): Node {
+  const [content, setContent] = useState(null);
+  const [claimed, setClaimed] = useState(null);
+  const [device, setDevice] = useState(null);
+
+  return (
+    <Box padding={4} color="secondary" height="100%">
+      <Box color="light" height={200} overflow="auto" padding={3}>
+        <Flex width={300} direction="column" gap={{ column: 4, row: 0 }}>
+          <ScrollBoundaryContainer overflow="visible">
+            <Flex direction="column" gap={{ column: 2, row: 0 }}>
+              <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
+                <Text weight="bold">Content type</Text>
+                <Tooltip
+                  idealDirection="right"
+                  text="See stats about different types of content created by you and/or others on Pinterest. Filter to get more details on your organic (not an ad) and paid (promoted as an ad) content."
+                >
+                  <TapArea>
+                    <Icon icon="info-circle" accessibilityLabel="Information" color="default" />
+                  </TapArea>
+                </Tooltip>
+              </Flex>
+              <Flex direction="column">
+                <RadioGroup id="content-type" legend="Select content type" legendDisplay="hidden">
+                  <RadioGroup.RadioButton
+                    checked={content === 'all'}
+                    id="allcontent"
+                    label="All"
+                    name="content"
+                    onChange={() => setContent('all')}
+                    value="all"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={content === 'organic'}
+                    id="organic"
+                    label="Organic"
+                    name="content"
+                    onChange={() => setContent('organic')}
+                    value="organic"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={content === 'paid'}
+                    id="paid"
+                    label="Paid and earned"
+                    name="content"
+                    onChange={() => setContent('paid')}
+                    value="paid"
+                  />
+                </RadioGroup>
+              </Flex>
+            </Flex>
+          </ScrollBoundaryContainer>
+
+          <ScrollBoundaryContainer overflow="visible">
+            <Flex direction="column" gap={{ column: 2, row: 0 }}>
+              <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
+                <Text weight="bold">Claimed account</Text>
+                <Tooltip
+                  idealDirection="right"
+                  text="See stats for Pins linked to your claimed accounts like websites, Etsy, Instagram or Youtube. The Other Pins category includes Pins you’ve published or saved that don’t link to any of your claimed accounts."
+                >
+                  <TapArea>
+                    <Icon icon="info-circle" accessibilityLabel="Information" color="default" />
+                  </TapArea>
+                </Tooltip>
+              </Flex>
+              <Flex direction="column">
+                <RadioGroup
+                  id="claimed-account"
+                  legend="Select claimed account"
+                  legendDisplay="hidden"
+                >
+                  <RadioGroup.RadioButton
+                    checked={claimed === 'all'}
+                    id="allclaimed"
+                    label="All Pins"
+                    name="claimed"
+                    onChange={() => setClaimed('all')}
+                    value="all"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={claimed === 'instagram'}
+                    id="instagram"
+                    label="Instagram"
+                    name="claimed"
+                    onChange={() => setClaimed('instagram')}
+                    value="instagram"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={claimed === 'other'}
+                    id="other"
+                    label="Other pins"
+                    name="claimed"
+                    onChange={() => setClaimed('other')}
+                    value="other"
+                  />
+                </RadioGroup>
+              </Flex>
+            </Flex>
+          </ScrollBoundaryContainer>
+
+          <ScrollBoundaryContainer overflow="visible">
+            <Flex direction="column" gap={{ column: 2, row: 0 }}>
+              <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
+                <Text weight="bold">Device</Text>
+                <Tooltip
+                  idealDirection="right"
+                  text="See stats for the different devices your Pinterest traffic is coming from."
+                >
+                  <TapArea>
+                    <Icon icon="info-circle" accessibilityLabel="Information" color="default" />
+                  </TapArea>
+                </Tooltip>
+              </Flex>
+              <Flex direction="column">
+                <RadioGroup id="device-type" legend="Select a device" legendDisplay="hidden">
+                  <RadioGroup.RadioButton
+                    checked={device === 'all'}
+                    id="alldevices"
+                    label="All"
+                    name="device"
+                    onChange={() => setDevice('all')}
+                    value="all"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={device === 'mobile'}
+                    id="mobile"
+                    label="Mobile"
+                    name="device"
+                    onChange={() => setDevice('mobile')}
+                    value="mobile"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={device === 'desktop'}
+                    id="desktop"
+                    label="Desktop"
+                    name="device"
+                    onChange={() => setDevice('desktop')}
+                    value="desktop"
+                  />
+                  <RadioGroup.RadioButton
+                    checked={device === 'tablet'}
+                    id="tablet"
+                    label="Tablet"
+                    name="device"
+                    onChange={() => setDevice('tablet')}
+                    value="tablet"
+                  />
+                </RadioGroup>
+              </Flex>
+            </Flex>
+          </ScrollBoundaryContainer>
+        </Flex>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/pages/web/utilities/scrollboundarycontainer.js
+++ b/docs/pages/web/utilities/scrollboundarycontainer.js
@@ -3,10 +3,15 @@ import { type Node } from 'react';
 import PageHeader from '../../../docs-components/PageHeader.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
+import SandpackExample from '../../../docs-components/SandpackExample.js';
 import docgen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
 import QualityChecklist from '../../../docs-components/QualityChecklist.js';
 import AccessibilitySection from '../../../docs-components/AccessibilitySection.js';
+import popoverExample from '../../../examples/scrollboundarycontainer/popoverExample.js';
+import autoOverflowExample from '../../../examples/scrollboundarycontainer/autoOverflowExample.js';
+import visibleOverflowExample from '../../../examples/scrollboundarycontainer/visibleOverflowExample.js';
+import modalExample from '../../../examples/scrollboundarycontainer/modalExample.js';
 
 export default function ScrollBoundaryContainerPage({
   generatedDocGen,
@@ -30,236 +35,42 @@ When scrolling is desired, we must explicitly set a height. Unless a height is s
 In ScrollBoundaryContainer, height is an optional prop with a default value of \`100%\`. If ScrollBoundaryContainer’s immediate parent is a component with a fixed height, do not pass a height to ScrollBoundaryContainer as seen in first example below. On the other hand, if there isn’t an immediate parent fixing the height, you must specify the ScrollBoundaryContainer height as seen in the  second example below.`}
         >
           <MainSection.Card
-            title="Popover within ScrollBoundaryContainer"
             cardSize="lg"
-            defaultCode={`
-function Example() {
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef();
-
-  React.useEffect(() => {
-    setOpen(true)
-  }, []);
-
-  return (
-    <ScrollBoundaryContainer height={200}>
-      <Box padding={4} width={600}>
-        <Flex gap={{ column: 0, row: 4 }}>
-          <Box width={200}>
-            <Text>
-              You need to add your data source URL to Pinterest so we can access your data source file and create Pins for your products. Before you do this, make sure you have prepared your data source and that you have claimed your website. If there are any errors with your data source file, you can learn how to troubleshoot them below. After you click Create Pins, you'll land back at the main data source page while your feed is being processed. Wait for a confirmation email from Pinterest about the status of your data source submission.
-            </Text>
-          </Box>
-          <Button
-            ref={anchorRef}
-            href="https://help.pinterest.com/en/business/article/data-source-ingestion"
-            iconEnd="visit"
-            onClick={() => setOpen(false)}
-            role="link"
-            target="blank"
-            text="Help"
-          />
-          {open && (
-            <Layer>
-              <Popover
-                anchor={anchorRef.current}
-                color="blue"
-                idealDirection="right"
-                onDismiss={() => {}}
-                positionRelativeToAnchor={false}
-                showCaret
-                size="xs"
-              >
-                <Box
-                  padding={3}
-                  display="flex"
-                  alignItems="center"
-                  direction="column"
-                  column={12}
-                >
-                  <Text color="inverse" align="center">
-                    Need help with something? Check out our Help Center.
-                  </Text>
-                </Box>
-              </Popover>
-            </Layer>
-          )}
-        </Flex>
-      </Box>
-    </ScrollBoundaryContainer>
-)}`}
+            sandpackExample={
+              <SandpackExample
+                code={popoverExample}
+                name="Popover within ScrollBoundaryContainer"
+              />
+            }
           />
         </MainSection.Subsection>
-        <MainSection.Card
-          title="Tooltips within ScrollBoundaryContainer"
-          cardSize="lg"
-          defaultCode={`
-function ScrollBoundaryContainerExample() {
-  const [content, setContent] = React.useState(null);
-  const [claimed, setClaimed] = React.useState(null);
-  const [device, setDevice] = React.useState(null);
 
-  return (
-    <ScrollBoundaryContainer overflow="scrollY" height={200}>
-      <Flex width={300} direction="column" gap={{ column: 4, row: 0 }}>
-        <Flex direction="column" gap={{ column: 2, row: 0 }}>
-          <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
-            <Text weight="bold" size="lg">
-              Content type
-            </Text>
-            <Tooltip
-              idealDirection="right"
-              text="See stats about different types of content created by you and/or others on Pinterest. Filter to get more details on your organic (not an ad) and paid (promoted as an ad) content."
-            >
-              <TapArea>
-                <Icon
-                  icon="info-circle"
-                  accessibilityLabel="Information"
-                  color="default"
-                />
-              </TapArea>
-            </Tooltip>
-          </Flex>
-          <Flex direction="column">
-            <Fieldset legend="Select content type" legendDisplay="hidden">
-              <Flex direction="column" gap={{ column: 2, row: 0 }}>
-                <RadioButton
-                  checked={content === "all"}
-                  id="allcontent"
-                  label="All"
-                  name="content"
-                  onChange={() => setContent( "all" )}
-                  value="all"
-                />
-                <RadioButton
-                  checked={content === "organic"}
-                  id="organic"
-                  label="Organic"
-                  name="content"
-                  onChange={() => setContent( "organic" )}
-                  value="organic"
-                />
-                <RadioButton
-                  checked={content === "paid"}
-                  id="paid"
-                  label="Paid and earned"
-                  name="content"
-                  onChange={() => setContent( "paid" )}
-                  value="paid"
-                />
-              </Flex>
-            </Fieldset>
-          </Flex>
-        </Flex>
-        <Flex direction="column" gap={{ column: 2, row: 0 }}>
-          <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
-            <Text weight="bold" size="lg">
-              Claimed account
-            </Text>
-            <Tooltip
-              idealDirection="right"
-              text="See stats for Pins linked to your claimed accounts like websites, Etsy, Instagram or Youtube. The Other Pins category includes Pins you’ve published or saved that don’t link to any of your claimed accounts."
-            >
-              <TapArea>
-                <Icon
-                  icon="info-circle"
-                  accessibilityLabel="Information"
-                  color="default"
-                />
-              </TapArea>
-            </Tooltip>
-          </Flex>
-          <Flex direction="column">
-          <Fieldset legend="Select claimed account" legendDisplay="hidden">
-            <Flex direction="column" gap={{ column: 2, row: 0 }}>
-              <RadioButton
-                checked={claimed === "all"}
-                id="allclaimed"
-                label="All Pins"
-                name="claimed"
-                onChange={() => setClaimed( "all" )}
-                value="all"
-              />
-              <RadioButton
-                checked={claimed === "instagram"}
-                id="instagram"
-                label="Instagram"
-                name="claimed"
-                onChange={() => setClaimed( "instagram" )}
-                value="instagram"
-              />
-              <RadioButton
-                checked={claimed === "other"}
-                id="other"
-                label="Other pins"
-                name="claimed"
-                onChange={() => setClaimed( "other" )}
-                value="other"
-              />
-              </Flex>
-            </Fieldset>
-          </Flex>
-        </Flex>
-        <Flex direction="column" gap={{ column: 2, row: 0 }}>
-          <Flex alignItems="center" gap={{ row: 1, column: 0 }}>
-            <Text weight="bold" size="lg">
-              Device
-            </Text>
-            <Tooltip
-              idealDirection="right"
-              text="See stats for the different devices your Pinterest traffic is coming from.">
-                <TapArea>
-                  <Icon
-                    icon="info-circle"
-                    accessibilityLabel="Information"
-                    color="default"
-                  />
-                </TapArea>
-            </Tooltip>
-          </Flex>
-          <Flex direction="column">
-          <Fieldset legend="Select a device" legendDisplay="hidden">
-            <Flex direction="column" gap={{ column: 2, row: 0 }}>
-              <RadioButton
-                checked={device === "all"}
-                id="alldevices"
-                label="All"
-                name="device"
-                onChange={() => setDevice( "all" )}
-                value="all"
-              />
-              <RadioButton
-                checked={device === "mobile"}
-                id="mobile"
-                label="Mobile"
-                name="device"
-                onChange={() => setDevice( "mobile" )}
-                value="mobile"
-              />
-              <RadioButton
-                checked={device === "desktop"}
-                id="desktop"
-                label="Desktop"
-                name="device"
-                onChange={() => setDevice( "desktop" )}
-                value="desktop"
-              />
-              <RadioButton
-                checked={device === "tablet"}
-                id="tablet"
-                label="Tablet"
-                name="device"
-                onChange={() => setDevice( "tablet" )}
-                value="tablet"
-              />
-              </Flex>
-            </Fieldset>
-          </Flex>
-        </Flex>
-      </Flex>
-    </ScrollBoundaryContainer>
-)}`}
-        />
+        <MainSection.Subsection
+          title="Overflow"
+          description={`
+In most cases, \`overflow\` set to "auto" is the expected behavior for most containers. If the scrolling container is large enough, Popover-based components are displayed without problems.
+
+However, if ScrollBoundaryContainer is small and hides Popover-based components within its boundaries, \`overflow\` set to "visible" displays Popover-based components above ScrollBoundaryContainer. This approach should only be used when there is no chance that the content within ScrollBoundaryContainer can overflow outside of it and, therefore, require scroll.
+
+Use this approach if implementing ScrollBoundaryContainer in a higher parent container doesn't fix your Popover-based components positioning issues as expected.
+
+See the examples below to compare the implementation in both circumnstances.`}
+        >
+          <MainSection.Card
+            title={`Overflow="auto"`}
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample code={autoOverflowExample} name="Overflow prop set to auto" />
+            }
+          />{' '}
+          <MainSection.Card
+            title={`Overflow="visible"`}
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample code={visibleOverflowExample} name="Overflow prop set to visible" />
+            }
+          />
+        </MainSection.Subsection>
         <MainSection.Subsection
           title="Built-in component"
           description={`
@@ -269,289 +80,14 @@ The following example shows the internal ScrollBoundaryContainer in action. The 
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ScrollBoundaryContainerExample() {
-  const [showModal, setShowModal] = React.useState(false);
-  const [open, setOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState(null);
-  const [parentComponent, setParentComponent] = React.useState('modal');
-  const anchorDropdownRef = React.useRef(null);
-  const handleSelect = ({ item }) => {
-    setSelected(item);
-  };
-
-  const MODAL_Z_INDEX = new FixedZIndex(11)
-  const ANCHORED_Z_INDEX = new CompositeZIndex([MODAL_Z_INDEX])
-  const ParentComponent = parentComponent === 'modal' ? Modal : OverlayPanel
-  const props =
-    parentComponent === 'modal'
-      ? { accessibilityModalLabel: '' }
-      : {
-          accessibilityDismissButtonLabel: 'Dismiss Billing Information OverlayPanel',
-          accessibilitySheetLabel: '',
-        };
-
-  return (
-    <React.Fragment>
-      <Flex alignItems="center" gap={{ row: 3, column: 0 }}>
-        <RadioButton
-          checked={parentComponent === 'modal'}
-          id="modal"
-          label="Open Modal"
-          name="parentComponent"
-          onChange={() => setParentComponent('modal')}
-          value="modal"
-        />
-        <RadioButton
-          checked={parentComponent === 'overlaypanel'}
-          id="overlaypanel"
-          label="Open OverlayPanel"
-          name="parentComponent"
-          onChange={() => setParentComponent('overlaypanel')}
-          value="overlaypanel"
-        />
-        <Button
-          text="Update Billing Address"
-          onClick={() => setShowModal(true)}
-        />
-      </Flex>
-      {showModal && (
-        <Layer zIndex={MODAL_Z_INDEX}>
-          <ParentComponent
-            {...props}
-            heading="Billing Information"
-            footer={
-              <Box
-                flex="grow"
-                paddingX={3}
-                paddingY={3}
-              >
-                <Box
-                  justifyContent="end"
-                  marginStart={-1}
-                  marginEnd={-1}
-                  marginTop={-1}
-                  marginBottom={-1}
-                  display="flex"
-                  wrap
-                >
-                  <Box
-                    paddingX={1}
-                    paddingY={1}
-                  >
-                    <Button
-                      text="Cancel"
-                      size="lg"
-                      onClick={() => setShowModal(false)}
-                    />
-                  </Box>
-                  <Box
-                    paddingX={1}
-                    paddingY={1}
-                  >
-                    <Button
-                      text="Save"
-                      color="red"
-                      size="lg"
-                      type="submit"
-                      onClick={() => setShowModal(false)}
-                    />
-                  </Box>
-                </Box>
-              </Box>
+            sandpackExample={
+              <SandpackExample
+                previewHeight={600}
+                layout="column"
+                code={modalExample}
+                name="Built-in component"
+              />
             }
-            onDismiss={() => setShowModal(false)}
-            size="lg"
-          >
-            <Flex justifyContent="center">
-              <Box
-                direction="column"
-                display="flex"
-                marginStart={-3}
-                marginEnd={-3}
-                marginBottom={-3}
-                marginTop={-3}
-                maxWidth={800}
-                width="100%"
-                wrap
-              >
-                <Box
-                  display="flex"
-                  justifyContent="start"
-                  padding={3}
-                >
-                  <Button
-                    accessibilityControls="subtext-dropdown-example"
-                    accessibilityHaspopup
-                    accessibilityExpanded={open}
-                    accessibilityLabel="Select Previous Address"
-                    selected={open}
-                    iconEnd="arrow-down"
-                    text="Select Previous Address"
-                    onClick={ () => setOpen((prevVal) => !prevVal) }
-                    ref={anchorDropdownRef}
-                  />
-                  {open && (
-                    <Dropdown
-                      anchor={anchorDropdownRef.current}
-                      id="subtext-dropdown-example"
-                      onDismiss={() => {setOpen(false)}}
-                      zIndex={ANCHORED_Z_INDEX}
-                    >
-                      <Dropdown.Item
-                        handleSelect={handleSelect}
-                        option={{
-                          value: "Headquarters San Francisco",
-                          label: "Headquarters San Francisco",
-                          subtext: "321 Inspiration Street, Suite # 12" }}
-                        selected={selected}
-                      />
-                      <Dropdown.Item
-                        handleSelect={handleSelect}
-                        option={{
-                          value: "Headquarters Seattle",
-                          label: "Headquarters Seattle",
-                          subtext: "123 Creativity Street, Suite # 21" }}
-                        selected={selected}
-                      />
-                    </Dropdown>
-                  )}
-                </Box>
-                <Box
-                  flex="grow"
-                  paddingX={3}
-                  paddingY={3}
-                >
-                  <Heading
-                    accessibilityLevel={2}
-                    size="400"
-                  >
-                    Billing Address
-                  </Heading>
-                </Box>
-                <Box
-                  flex="grow"
-                  paddingX={3}
-                  paddingY={3}
-                >
-                  <TextField
-                    id="Address_Name"
-                    label="Address Name"
-                    onChange={() => {}}
-                  />
-                </Box>
-                <Box
-                  flex="grow"
-                  paddingX={3}
-                  paddingY={3}
-                >
-                  <TextField
-                    id="Business_Name"
-                    label="Business Name"
-                    onChange={() => {}}
-                  />
-                </Box>
-                <Box
-                  flex="grow"
-                  paddingX={3}
-                  paddingY={3}
-                >
-                  <TextField
-                    id="Address_Line_1"
-                    label="Address Line 1"
-                    onChange={() => {}}
-                  />
-                </Box>
-                <Box
-                  flex="grow"
-                  paddingX={3}
-                  paddingY={3}
-                >
-                  <TextField
-                    id="Address_Line_2"
-                    label="Address Line 2"
-                    onChange={() => {}}
-                  />
-                </Box>
-                <Box
-                  flex="grow"
-                  paddingX={3}
-                  paddingY={3}
-                >
-                  <Box
-                    display="flex"
-                    marginStart={-3}
-                    marginEnd={-3}
-                    marginBottom={-3}
-                    marginTop={-3}
-                    wrap
-                  >
-                    <Box
-                      flex="grow"
-                      paddingX={3}
-                      paddingY={3}
-                    >
-                      <TextField
-                        id="City"
-                        label="City"
-                        onChange={() => {}}
-                      />
-                    </Box>
-                    <Box
-                      flex="grow"
-                      paddingX={3}
-                      paddingY={3}
-                    >
-                      <TextField
-                        id="State_Province_Region"
-                        label="State/Province/Region"
-                        onChange={() => {}}
-                      />
-                    </Box>
-                  </Box>
-                </Box>
-              </Box>
-              <Box
-                flex="grow"
-                paddingX={3}
-                paddingY={3}
-              >
-                <ComboBox
-                  id="Country"
-                  accessibilityClearButtonLabel="Clear countries"
-                  options={[
-                    {
-                      value: "United States",
-                      label: "United States" ,
-                    },{
-                      value: "Canada",
-                      label: "Canada" ,
-                    },{
-                      value: "United Kingdom",
-                      label: "United Kingdom" ,
-                    },{
-                      value: "Brazil",
-                      label: "Brazil" ,
-                    },{
-                      value: "Japan",
-                      label: "Japan" ,
-                    }
-                  ]}
-                  onChange={() => {}}
-                  onSelect={() => {}}
-                  placeholder="Select a Country"
-                  noResultText="No Results"
-                  label="Country"
-                  value="United States"
-                />
-              </Box>
-            </Flex>
-          </ParentComponent>
-        </Layer>
-      )}
-    </React.Fragment>
-  )
-}`}
           />
         </MainSection.Subsection>
       </MainSection>
@@ -567,7 +103,7 @@ function ScrollBoundaryContainerExample() {
       **[Modal](/web/modal)** / **[OverlayPanel](/web/overlaypanel)**
       Modal and OverlayPanel come with ScrollBoundaryContainer built-in, so any anchored components used in their children tree should work out-of-the-box. Passing an additional ScrollBoundaryContainer will break the existing styling on scroll.
 
-      **[Tooltip](/web/tooltip)** / **[Popover](/web/popover)** / **[Dropdown](/web/dropdown)** / **[ComboBox](/web/combobox)**
+      **[Tooltip](/web/tooltip)** / **[Popover](/web/popover)** / **[Dropdown](/web/dropdown)** / **[ComboBox](/web/combobox) ** **
       ScrollBoundaryContainer must be used around any of these components if they are used within a container that could possibly scroll. This is necessary to ensure the component remains attached to its anchor on scroll. If they are located within scrolling Modal or OverlayPanel components, ScrollBoundaryContainer isn't needed as it's already built-in.
     `}
         />

--- a/packages/gestalt/src/ScrollBoundaryContainer.js
+++ b/packages/gestalt/src/ScrollBoundaryContainer.js
@@ -16,7 +16,7 @@ import { type Node } from 'react';
 import { ScrollBoundaryContainerProvider } from './contexts/ScrollBoundaryContainerProvider.js';
 import ScrollBoundaryContainerWithForwardRef from './ScrollBoundaryContainerWithForwardRef.js';
 
-type ScrollBoundaryContainerOverflow = 'scroll' | 'scrollX' | 'scrollY' | 'auto';
+type ScrollBoundaryContainerOverflow = 'scroll' | 'scrollX' | 'scrollY' | 'auto' | 'visible';
 
 type Props = {|
   children: Node,

--- a/packages/gestalt/src/ScrollBoundaryContainerWithForwardRef.js
+++ b/packages/gestalt/src/ScrollBoundaryContainerWithForwardRef.js
@@ -11,7 +11,7 @@ import { useScrollBoundaryContainer } from './contexts/ScrollBoundaryContainerPr
 import Box from './Box.js';
 import { type Dimension, type Padding } from './boxTypes.js';
 
-type ScrollBoundaryContainerOverflow = 'scroll' | 'scrollX' | 'scrollY' | 'auto';
+type ScrollBoundaryContainerOverflow = 'scroll' | 'scrollX' | 'scrollY' | 'auto' | 'visible';
 
 type InternalProps = {|
   children?: Node,


### PR DESCRIPTION
### Summary

#### What changed?

ScrollBoundaryContainer: add 'visible' to `overflow` prop type, documented case, and move editor to Sandpack

#### Why?

In some cases, we might want to anchor Popover to a small container that will never overflow/scroll, when the parent container does scroll. Visible allows Popover to not hide within the small container. We've experienced some complex implementations where ScrollBoundaryContainer at higher prents doesn't fix floating issues, so moving ScrollBoundaryContainer closer to Popover is needed.

<img width="1499" alt="Screenshot 2023-02-21 at 10 32 55 PM" src="https://user-images.githubusercontent.com/10593890/220972851-fdf02bba-5ef9-4095-af01-6f51ffae3bba.png">

https://user-images.githubusercontent.com/10593890/220972873-f6aec12d-cd25-42c7-98dd-e280467cec89.mov




### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
