### PR TITLE
Popover, Dropdown: revert https://github.com/pinterest/gestalt/pull/2562 and add maxheight 30vh to Dropdown

### DIFF
--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -202,25 +202,6 @@ class Contents extends Component<Props, State> {
     }
   };
 
-  calcTopHeight() {
-    if (!window || !document) {
-      return { top: null, height: null };
-    }
-
-    const { scrollBoundaryContainerRef, positionRelativeToAnchor } = this.props;
-
-    // Define the height based the reference to render: ScrollBoundaryContainer or screen viewport
-    const height = scrollBoundaryContainerRef?.offsetHeight ?? window.innerHeight ?? 0;
-
-    // 5% of height available
-    const top = (height / 10) * 0.5;
-
-    // 90% of height available on container reference
-    const elementHeight = (height / 10) * 9;
-
-    return { top: !positionRelativeToAnchor ? top : null, height: elementHeight };
-  }
-
   render(): Node {
     const { accessibilityLabel, bgColor, border, caret, children, id, role, rounding, width } =
       this.props;
@@ -231,10 +212,6 @@ class Contents extends Component<Props, State> {
     const background = bgColor === 'white' ? `${bgColor}BgElevated` : `${bgColor}Bg`;
     const bgColorElevated = bgColor === 'white' ? 'whiteElevated' : bgColor;
     const isCaretVertical = ['down', 'up'].includes(popoverDir);
-
-    const { top, height } = this.calcTopHeight();
-    // Top value is used only when the current top value is negative
-    const topValue = top != null && (popoverOffset?.top ?? 0) < 0 ? { top } : {};
 
     return (
       <div
@@ -249,7 +226,7 @@ class Contents extends Component<Props, State> {
         ref={this.setPopoverRef}
         tabIndex={-1}
         // popoverOffset positions the Popover component
-        style={{ visibility, ...popoverOffset, ...topValue }}
+        style={{ visibility, ...popoverOffset }}
       >
         {caret && popoverDir && (
           <div
@@ -278,7 +255,7 @@ class Contents extends Component<Props, State> {
             styles.maxDimensions,
             width !== null && styles.minDimensions,
           )}
-          style={{ maxWidth: width, maxHeight: height }}
+          style={{ maxWidth: width }}
         >
           {children}
         </div>

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -221,7 +221,14 @@ export default function Dropdown({
       shouldFocus
       size="xl"
     >
-      <Box alignItems="center" direction="column" display="flex" flex="grow" margin={2}>
+      <Box
+        alignItems="center"
+        direction="column"
+        display="flex"
+        flex="grow"
+        margin={2}
+        maxHeight="30vh"
+      >
         {Boolean(headerContent) && <Box padding={2}>{headerContent}</Box>}
 
         <DropdownContextProvider value={{ id, hoveredItem, setHoveredItem, setOptionRef }}>

--- a/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Controller.jsdom.test.js.snap
@@ -39,7 +39,6 @@ exports[`Controller renders 1`] = `
       id=""
       style={
         Object {
-          "maxHeight": 691.1999999999999,
           "maxWidth": 230,
         }
       }

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -17,7 +17,7 @@ exports[`Dropdown renders a menu of 3 items conditionally 1`] = `
           class="border whiteBgElevated whiteElevated rounding4 innerContents maxDimensions minDimensions"
           id="ex-1"
           role="menu"
-          style="max-width: 360px; max-height: 691.1999999999999px;"
+          style="max-width: 360px;"
         >
           <div
             class="box flexGrow marginBottom2 marginEnd2 marginStart2 marginTop2 xsDirectionColumn xsDisplayFlex xsItemsCenter"
@@ -551,7 +551,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
           class="border whiteBgElevated whiteElevated rounding4 innerContents maxDimensions minDimensions"
           id="ex-1"
           role="menu"
-          style="max-width: 360px; max-height: 691.1999999999999px;"
+          style="max-width: 360px;"
         >
           <div
             class="box flexGrow marginBottom2 marginEnd2 marginStart2 marginTop2 xsDirectionColumn xsDisplayFlex xsItemsCenter"

--- a/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
@@ -21,7 +21,6 @@ exports[`Popover renders 1`] = `
       role="dialog"
       style={
         Object {
-          "maxHeight": 691.1999999999999,
           "maxWidth": 230,
         }
       }
@@ -49,7 +48,6 @@ exports[`Popover renders as blue 1`] = `
       role="dialog"
       style={
         Object {
-          "maxHeight": 691.1999999999999,
           "maxWidth": 230,
         }
       }
@@ -77,7 +75,6 @@ exports[`Popover renders as error 1`] = `
       role="dialog"
       style={
         Object {
-          "maxHeight": 691.1999999999999,
           "maxWidth": 230,
         }
       }


### PR DESCRIPTION
### Summary

#### What changed?

Popover, Dropdown: revert https://github.com/pinterest/gestalt/pull/2562 and add `maxheight="30vh"` to Dropdown

BEFORE
<img width="531" alt="Screenshot 2023-02-24 at 3 52 49 PM" src="https://user-images.githubusercontent.com/10593890/221289556-eedce68c-7978-4bdf-a98b-afbbd1f98f24.png">

AFTER
<img width="659" alt="Screenshot 2023-02-24 at 3 54 39 PM" src="https://user-images.githubusercontent.com/10593890/221290074-01a63a41-3402-4e94-8f61-eaa2820851ae.png">

#### Why?

The solution in https://github.com/pinterest/gestalt/pull/2562 does not work with small height ScrollBoundaryContainers. An overengineered solution that wasn't scalable to future problems.

Reducing the logic like we do in other components implementations, `maxHeight="30vh"` that is just so simple we can all understand how it works in most use cases and implementations.

More context here https://paper.dropbox.com/doc/Popovers-History--BzXlCWDyIuGRkiRJ0Nt_TEc5Ag-e5Yrz9jiksN0ce8c893EJ