### PR TITLE
PopoverEducational: move examples to Sandpack + added `shouldFocus` to props

### DIFF
--- a/docs/examples/popovereducational/customContent.js
+++ b/docs/examples/popovereducational/customContent.js
@@ -3,11 +3,11 @@ import { type Node, useRef, useEffect, useState } from 'react';
 import { Box, Flex, IconButton, Button, Text, PopoverEducational } from 'gestalt';
 
 export default function Example(): Node {
-  const [openA, setOpenA] = useState(false);
+  const [open, setOpen] = useState(false);
   const anchorRefA = useRef();
 
   useEffect(() => {
-    setOpenA(true);
+    setOpen(true);
   }, []);
 
   return (
@@ -20,7 +20,7 @@ export default function Example(): Node {
         ref={anchorRefA}
         size="lg"
       />
-      {openA && (
+      {open && (
         <PopoverEducational
           accessibilityLabel={`Description of new "More ideas" feature`}
           anchor={anchorRefA.current}

--- a/docs/examples/popovereducational/customContent.js
+++ b/docs/examples/popovereducational/customContent.js
@@ -1,0 +1,44 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { Box, Flex, IconButton, Button, Text, PopoverEducational } from 'gestalt';
+
+export default function Example(): Node {
+  const [openA, setOpenA] = useState(false);
+  const anchorRefA = useRef();
+
+  useEffect(() => {
+    setOpenA(true);
+  }, []);
+
+  return (
+    <Flex alignItems="center" justifyContent="center" height="100%" width="100%">
+      <IconButton
+        accessibilityLabel="This IconButton represents a new feature"
+        iconColor="darkGray"
+        icon="pin"
+        onClick={() => {}}
+        ref={anchorRefA}
+        size="lg"
+      />
+      {openA && (
+        <PopoverEducational
+          accessibilityLabel={`Description of new "More ideas" feature`}
+          anchor={anchorRefA.current}
+          idealDirection="down"
+          onDismiss={() => {}}
+        >
+          <Box padding={3}>
+            <Flex direction="column" gap={3}>
+              <Text color="light">
+                Tap to tag a product or press and hold to see product details
+              </Text>
+              <Flex.Item alignSelf="end">
+                <Button color="white" text="Next" />
+              </Flex.Item>
+            </Flex>
+          </Box>
+        </PopoverEducational>
+      )}
+    </Flex>
+  );
+}

--- a/docs/examples/popovereducational/doEducate.js
+++ b/docs/examples/popovereducational/doEducate.js
@@ -1,0 +1,112 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { TapArea, Box, Flex, Mask, Image, Text, PopoverEducational, Icon } from 'gestalt';
+
+export default function Example(): Node {
+  const [openA, setOpenA] = useState(false);
+  const [openB, setOpenB] = useState(false);
+
+  const anchorRefA = useRef();
+  const anchorRefB = useRef();
+
+  useEffect(() => {
+    setOpenA(true);
+    setOpenB(false);
+  }, []);
+
+  return (
+    <Box width="100%" height="100%" padding={12}>
+      <Flex direction="column" justifyContent="between" alignItems="start" height="100%">
+        <Box>
+          <TapArea ref={anchorRefA} rounding={3} fullWidth={false}>
+            <Box padding={3} color="secondary" height={75} width={200} rounding={3}>
+              <Flex gap={2}>
+                <Box aria-hidden width={50}>
+                  <Mask rounding={3} wash>
+                    <Image
+                      alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
+                      color="rgb(231, 186, 176)"
+                      loading="lazy"
+                      naturalHeight={1}
+                      naturalWidth={1}
+                      src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
+                    />
+                  </Mask>
+                </Box>
+                <Flex direction="column">
+                  <Text size="100">More ideas for</Text>
+                  <Text weight="bold">Food, Drinks, Snacks</Text>
+                </Flex>
+              </Flex>
+            </Box>
+          </TapArea>
+          {openA && (
+            <PopoverEducational
+              accessibilityLabel={`Description of new "More ideas" feature`}
+              idealDirection="right"
+              anchor={anchorRefA.current}
+              onDismiss={() => {}}
+              message="Tap to tag a product to see product details"
+              primaryAction={{
+                text: 'Next',
+                onClick: () => {
+                  setOpenA(false);
+                  setOpenB(true);
+                },
+              }}
+            />
+          )}
+        </Box>
+
+        <Box>
+          <TapArea fullWidth={false} rounding={3}>
+            <Box borderStyle="shadow" padding={3} rounding={3} width={350}>
+              <Flex direction="column" gap={3}>
+                <Flex>
+                  <Flex.Item flex="grow">
+                    <Flex direction="column" gap={1}>
+                      <Text size="100">Ideas for you</Text>
+                      <Box display="flex">
+                        <Text ref={anchorRefB} inline weight="bold">
+                          <Box marginEnd={2}>Small tattoos</Box>
+                        </Text>
+                      </Box>
+                    </Flex>
+                  </Flex.Item>
+                  <Flex.Item flex="none">
+                    <Icon accessibilityLabel="" icon="arrow-forward" />
+                  </Flex.Item>
+                </Flex>
+                <Box width="100%" aria-hidden>
+                  <Mask rounding={1} wash>
+                    <Image
+                      alt=""
+                      color="rgb(231, 186, 176)"
+                      loading="lazy"
+                      naturalHeight={181}
+                      naturalWidth={698}
+                      src="https://i.ibb.co/DWJFWkV/Screenshot-2023-02-24-at-2-27-59-PM.png"
+                    />
+                  </Mask>
+                </Box>
+              </Flex>
+            </Box>
+          </TapArea>
+          {openB && (
+            <PopoverEducational
+              accessibilityLabel={`Description of new "Ideas for you" feature`}
+              anchor={anchorRefB.current}
+              idealDirection="right"
+              message="Explore your recent searches in more details"
+              onDismiss={() => {
+                setOpenA(true);
+                setOpenB(false);
+              }}
+              shouldFocus
+            />
+          )}
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/popovereducational/doReference.js
+++ b/docs/examples/popovereducational/doReference.js
@@ -1,0 +1,59 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { TapArea, Box, Flex, Mask, Image, Text, PopoverEducational, Icon } from 'gestalt';
+
+export default function Example(): Node {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef();
+
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  return (
+    <Flex width="100%" height="100%" justifyContent="center" alignItems="center">
+      <TapArea fullWidth={false} rounding={3}>
+        <Box borderStyle="shadow" padding={3} rounding={3} width={400}>
+          <Flex direction="column" gap={3}>
+            <Flex>
+              <Flex.Item flex="grow">
+                <Flex direction="column" gap={1}>
+                  <Text size="100">Ideas for you</Text>
+                  <Box display="flex">
+                    <Text ref={anchorRef} inline weight="bold">
+                      <Box marginEnd={2}>Small tattoos</Box>
+                    </Text>
+                  </Box>
+                </Flex>
+              </Flex.Item>
+              <Flex.Item flex="none">
+                <Icon accessibilityLabel="" icon="arrow-forward" />
+              </Flex.Item>
+            </Flex>
+            <Box width="100%" aria-hidden>
+              <Mask rounding={1} wash>
+                <Image
+                  alt=""
+                  color="rgb(231, 186, 176)"
+                  loading="lazy"
+                  naturalHeight={181}
+                  naturalWidth={698}
+                  src="https://i.ibb.co/DWJFWkV/Screenshot-2023-02-24-at-2-27-59-PM.png"
+                />
+              </Mask>
+            </Box>
+          </Flex>
+        </Box>
+      </TapArea>
+      {open && (
+        <PopoverEducational
+          accessibilityLabel={`Description of new "More ideas" feature`}
+          idealDirection="right"
+          anchor={anchorRef.current}
+          onDismiss={() => {}}
+          message="Explore your recent searches in more details"
+        />
+      )}
+    </Flex>
+  );
+}

--- a/docs/examples/popovereducational/dontDouble.js
+++ b/docs/examples/popovereducational/dontDouble.js
@@ -1,0 +1,101 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { TapArea, Box, Flex, Mask, Image, Text, PopoverEducational, Icon } from 'gestalt';
+
+export default function Example(): Node {
+  const [openA, setOpenA] = useState(false);
+  const [openB, setOpenB] = useState(false);
+
+  const anchorRefA = useRef();
+  const anchorRefB = useRef();
+
+  useEffect(() => {
+    setOpenA(true);
+    setOpenB(true);
+  }, []);
+
+  return (
+    <Box width="100%" height="100%" padding={12}>
+      <Flex direction="column" justifyContent="between" alignItems="start" height="100%">
+        <Box>
+          <TapArea ref={anchorRefA} rounding={3} fullWidth={false}>
+            <Box padding={3} color="secondary" height={75} width={200} rounding={3}>
+              <Flex gap={2}>
+                <Box aria-hidden width={50}>
+                  <Mask rounding={3} wash>
+                    <Image
+                      alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
+                      color="rgb(231, 186, 176)"
+                      loading="lazy"
+                      naturalHeight={1}
+                      naturalWidth={1}
+                      src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
+                    />
+                  </Mask>
+                </Box>
+                <Flex direction="column">
+                  <Text size="100">More ideas for</Text>
+                  <Text weight="bold">Food, Drinks, Snacks</Text>
+                </Flex>
+              </Flex>
+            </Box>
+          </TapArea>
+          {openA && (
+            <PopoverEducational
+              accessibilityLabel={`Description of new "More ideas" feature`}
+              idealDirection="right"
+              anchor={anchorRefA.current}
+              onDismiss={() => {}}
+              message="Tap to tag a product to see product details"
+            />
+          )}
+        </Box>
+
+        <Box>
+          <TapArea fullWidth={false} rounding={3}>
+            <Box borderStyle="shadow" padding={3} rounding={3} width={350}>
+              <Flex direction="column" gap={3}>
+                <Flex>
+                  <Flex.Item flex="grow">
+                    <Flex direction="column" gap={1}>
+                      <Text size="100">Ideas for you</Text>
+                      <Box display="flex">
+                        <Text ref={anchorRefB} inline weight="bold">
+                          <Box marginEnd={2}>Small tattoos</Box>
+                        </Text>
+                      </Box>
+                    </Flex>
+                  </Flex.Item>
+                  <Flex.Item flex="none">
+                    <Icon accessibilityLabel="" icon="arrow-forward" />
+                  </Flex.Item>
+                </Flex>
+                <Box width="100%" aria-hidden>
+                  <Mask rounding={1} wash>
+                    <Image
+                      alt=""
+                      color="rgb(231, 186, 176)"
+                      loading="lazy"
+                      naturalHeight={181}
+                      naturalWidth={698}
+                      src="https://i.ibb.co/DWJFWkV/Screenshot-2023-02-24-at-2-27-59-PM.png"
+                    />
+                  </Mask>
+                </Box>
+              </Flex>
+            </Box>
+          </TapArea>
+          {openB && (
+            <PopoverEducational
+              accessibilityLabel={`Description of new "Ideas for you" feature`}
+              anchor={anchorRefB.current}
+              idealDirection="right"
+              message="Explore your recent searches in more details"
+              onDismiss={() => {}}
+            />
+          )}
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/popovereducational/main.js
+++ b/docs/examples/popovereducational/main.js
@@ -1,0 +1,50 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { TapArea, Box, Flex, Mask, Image, Text, PopoverEducational } from 'gestalt';
+
+export default function Example(): Node {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef();
+
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  return (
+    <Box width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
+      <TapArea ref={anchorRef} rounding={3} fullWidth={false}>
+        <Box padding={3} color="secondary" height={75} width={200} rounding={3}>
+          <Flex gap={2}>
+            <Box aria-hidden width={50}>
+              <Mask rounding={3} wash>
+                <Image
+                  alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
+                  color="rgb(231, 186, 176)"
+                  loading="lazy"
+                  naturalHeight={1}
+                  naturalWidth={1}
+                  src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
+                />
+              </Mask>
+            </Box>
+            <Flex direction="column">
+              <Text size="100">More ideas for</Text>
+              <Text weight="bold">Food, Drinks, Snacks</Text>
+            </Flex>
+          </Flex>
+        </Box>
+        {open && (
+          <PopoverEducational
+            accessibilityLabel={`Description of new "More ideas" feature`}
+            id="popover-primary-action"
+            idealDirection="right"
+            anchor={anchorRef.current}
+            onDismiss={() => {}}
+            message="Tap to tag a product or press and hold to see product details"
+            primaryAction={{ text: 'Next' }}
+          />
+        )}
+      </TapArea>
+    </Box>
+  );
+}

--- a/docs/examples/popovereducational/message.js
+++ b/docs/examples/popovereducational/message.js
@@ -1,0 +1,65 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { Box, Flex, IconButton, Text, PopoverEducational } from 'gestalt';
+
+export default function Example(): Node {
+  const [openA, setOpenA] = useState(false);
+  const [openB, setOpenB] = useState(false);
+  const anchorRefA = useRef();
+  const anchorRefB = useRef();
+
+  useEffect(() => {
+    setOpenA(true);
+    setOpenB(true);
+  }, []);
+
+  return (
+    <Flex alignItems="center" justifyContent="between" height="100%" width="100%">
+      <Box>
+        <IconButton
+          accessibilityLabel="This IconButton represents a new feature"
+          iconColor="darkGray"
+          icon="pin"
+          onClick={() => {}}
+          ref={anchorRefA}
+          size="lg"
+        />
+        {openA && (
+          <PopoverEducational
+            accessibilityLabel="Simple message string"
+            anchor={anchorRefA.current}
+            idealDirection="right"
+            onDismiss={() => {}}
+            message="Simple message string"
+          />
+        )}
+      </Box>
+      <Box>
+        <IconButton
+          accessibilityLabel="This IconButton represents a new feature"
+          iconColor="darkGray"
+          icon="pin"
+          onClick={() => {}}
+          ref={anchorRefB}
+          size="lg"
+        />
+        {openB && (
+          <PopoverEducational
+            accessibilityLabel="Rich message with Text component and bold text"
+            anchor={anchorRefB.current}
+            idealDirection="right"
+            onDismiss={() => {}}
+            message={
+              <Text inline>
+                Rich message with Text component and{' '}
+                <Text inline weight="bold">
+                  bold text
+                </Text>
+              </Text>
+            }
+          />
+        )}
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/popovereducational/primaryAction.js
+++ b/docs/examples/popovereducational/primaryAction.js
@@ -1,0 +1,50 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { TapArea, Box, Flex, Text, Mask, Image, PopoverEducational } from 'gestalt';
+
+export default function Example(): Node {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef();
+
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  return (
+    <Flex alignItems="center" justifyContent="center" height="100%" width="100%">
+      <TapArea ref={anchorRef} rounding={3} fullWidth={false}>
+        <Box padding={3} color="secondary" height={75} width={200} rounding={3}>
+          <Flex gap={2}>
+            <Box aria-hidden width={50}>
+              <Mask rounding={3} wash>
+                <Image
+                  alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
+                  color="rgb(231, 186, 176)"
+                  loading="lazy"
+                  naturalHeight={1}
+                  naturalWidth={1}
+                  src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
+                />
+              </Mask>
+            </Box>
+            <Flex direction="column">
+              <Text size="100">More ideas for</Text>
+              <Text weight="bold">Food, Drinks, Snacks</Text>
+            </Flex>
+          </Flex>
+        </Box>
+      </TapArea>
+      {open && (
+        <PopoverEducational
+          accessibilityLabel={`Description of new "More ideas" feature`}
+          id="popover-primary-action"
+          idealDirection="down"
+          anchor={anchorRef.current}
+          onDismiss={() => {}}
+          message="Tap to tag a product or press and hold to see product details"
+          primaryAction={{ text: 'Next' }}
+        />
+      )}
+    </Flex>
+  );
+}

--- a/docs/examples/popovereducational/size.js
+++ b/docs/examples/popovereducational/size.js
@@ -1,0 +1,61 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { Box, Flex, IconButton, PopoverEducational } from 'gestalt';
+
+export default function Example(): Node {
+  const [openA, setOpenA] = useState(false);
+  const [openB, setOpenB] = useState(false);
+  const anchorRefA = useRef();
+  const anchorRefB = useRef();
+
+  useEffect(() => {
+    setOpenA(true);
+    setOpenB(true);
+  }, []);
+
+  return (
+    <Box width="100%" height="100%" padding={4}>
+      <Flex direction="column" width="100%" height="100%" justifyContent="between">
+        <Box>
+          <IconButton
+            accessibilityLabel="This IconButton represents a new feature"
+            iconColor="darkGray"
+            icon="pin"
+            onClick={() => {}}
+            ref={anchorRefA}
+            size="lg"
+          />
+        </Box>
+        {openA && (
+          <PopoverEducational
+            accessibilityLabel="Description of new feature"
+            size="flexible"
+            anchor={anchorRefA.current}
+            idealDirection="right"
+            onDismiss={() => {}}
+            message="Ads allow you to reach more people who matter to you. When audiences engage with your ad, you'll be able to track performance here."
+          />
+        )}
+        <Box>
+          <IconButton
+            accessibilityLabel="This IconButton represents a new feature"
+            iconColor="darkGray"
+            icon="pin"
+            onClick={() => {}}
+            ref={anchorRefB}
+            size="lg"
+          />
+        </Box>
+        {openB && (
+          <PopoverEducational
+            accessibilityLabel="Description of new feature"
+            anchor={anchorRefB.current}
+            idealDirection="right"
+            onDismiss={() => {}}
+            message="Ads allow you to reach more people who matter to you. When audiences engage with your ad, you'll be able to track performance here."
+          />
+        )}
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/popovereducational/visibility.js
+++ b/docs/examples/popovereducational/visibility.js
@@ -1,0 +1,34 @@
+// @flow strict
+import { type Node, useRef, useEffect, useState } from 'react';
+import { IconButton, Flex, PopoverEducational } from 'gestalt';
+
+export default function Example(): Node {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef();
+
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  return (
+    <Flex alignItems="center" justifyContent="center" height="100%" width="100%">
+      <IconButton
+        accessibilityLabel="This IconButton represents a new feature"
+        iconColor="darkGray"
+        icon="pin"
+        onClick={() => {}}
+        ref={anchorRef}
+        size="lg"
+      />
+      {open && (
+        <PopoverEducational
+          accessibilityLabel="Popover visible on initial page load"
+          anchor={anchorRef.current}
+          idealDirection="right"
+          onDismiss={() => {}}
+          message="This PopoverEducational is visible on initial page load"
+        />
+      )}
+    </Flex>
+  );
+}

--- a/docs/pages/web/popovereducational.js
+++ b/docs/pages/web/popovereducational.js
@@ -101,8 +101,6 @@ PopoverEducational doesn't behave like regular popovers where they are open/clos
 In most cases, PopoverEducational might be already visible on page load. See [visible on page load](#Visibility-on-page-load) to learn more. However, popover-based components rely on the component opening/dismissing event to capture focus.
 
 If PopoverEducational is already visible, we need its content to be keyboard accessible in sequential order. Don't use Layer to wrap PopoverEducational as it would move PopoverEducational outside the DOM hierarchy of the parent component and it will lose contextual sequencial order. The content will placed last in the keyboard navigations sequence, becoming unreachable in its content context. Moreover, make sure PopoverEducational is implemented right after the code of the anchor element so that it navigates the popover right after the anchor.
-
-If PopoverEducational
 `}
         />
         <MainSection.Subsection

--- a/docs/pages/web/popovereducational.js
+++ b/docs/pages/web/popovereducational.js
@@ -7,59 +7,23 @@ import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import main from '../../examples/popovereducational/main.js';
+import doEducate from '../../examples/popovereducational/doEducate.js';
+import dontDouble from '../../examples/popovereducational/dontDouble.js';
+import doReference from '../../examples/popovereducational/doReference.js';
+import message from '../../examples/popovereducational/message.js';
+import primaryAction from '../../examples/popovereducational/primaryAction.js';
+import customContent from '../../examples/popovereducational/customContent.js';
+import size from '../../examples/popovereducational/size.js';
+import visibility from '../../examples/popovereducational/visibility.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader
-        name={generatedDocGen?.displayName}
-        description={generatedDocGen?.description}
-        defaultCode={`
-function Example() {
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef();
-
-  React.useEffect(() => {
-    setOpen(true)
-  }, []);
-
-  return (
-    <Box height="100%" width="60%" display="flex" justifyContent="start">
-      <TapArea ref={anchorRef} rounding={3} fullWidth={false}>
-        <Box padding={3} color="secondary" height={75} width={200} rounding={3}>
-          <Flex gap={2}>
-            <Box aria-hidden height={500} width={50}>
-              <Mask rounding={3} wash>
-                <Image
-                  alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
-                  color="rgb(231, 186, 176)"
-                  loading="lazy"
-                  naturalHeight={1}
-                  naturalWidth={1}
-                  src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
-                />
-              </Mask>
-            </Box>
-            <Flex direction="column">
-              <Text size="100">More ideas for</Text>
-              <Text weight="bold">Food, Drinks, Snacks</Text>
-            </Flex>
-          </Flex>
-        </Box>
-      </TapArea>
-      {open && (
-        <PopoverEducational
-          id="popover-primary-action"
-          idealDirection="right"
-          anchor={anchorRef.current}
-          onDismiss={() => {}}
-          message="Tap to tag a product or press and hold to see product details"
-          primaryAction={{ text: "Next"}}
-        />
-      )}
-    </Box>
-)}`}
-      />
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+        <SandpackExample code={main} hideEditor name="Main PopoverEducational example" />
+      </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
@@ -88,276 +52,42 @@ function Example() {
       </MainSection>
 
       <MainSection name="Best practices">
-        <MainSection.Subsection columns={2}>
+        <MainSection.Subsection>
           <MainSection.Card
-            cardSize="md"
             type="do"
             description="Use the PopoverEducational to educate users on a new or existing feature. Be sure to use a caret pointing to the feature. If there is more than one item, use a CTA button to move the user to the next popover."
-            defaultCode={`
-            function Example() {
-  const [openA, setOpenA] = React.useState(false);
-  const [openB, setOpenB] = React.useState(false);
-
-  const anchorRefA = React.useRef();
-  const anchorRefB = React.useRef();
-
-  React.useEffect(() => {
-    setOpenA(true)
-    setOpenB(false)
-  }, []);
-
-  return (
-    <Box width="100%" height="100%">
-      <Flex direction="column" alignItems="start" height="100%">
-        <Flex.Item flex="grow">
-          <Box padding={3} color="secondary" height={75} width={175} ref={anchorRefA} rounding={3}>
-            <Flex gap={2}>
-              <Box height={500} width={50}>
-                <Mask rounding={3} wash>
-                  <Image
-                    alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
-                    color="rgb(231, 186, 176)"
-                    loading="lazy"
-                    naturalHeight={1}
-                    naturalWidth={1}
-                    src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
-                  />
-                </Mask>
-              </Box>
-              <Flex direction="column">
-                <Text size="100">More ideas for</Text>
-                <Text weight="bold">Food & Drinks</Text>
-              </Flex>
-            </Flex>
-          </Box>
-        </Flex.Item>
-        <TapArea fullWidth={false} rounding={3}>
-          <Box borderStyle="shadow" padding={3} rounding={3} width={350}>
-            <Flex direction="column" gap={3}>
-              <Flex>
-                <Flex.Item flex="grow">
-                  <Flex direction="column" gap={1}>
-                    <Text size="100">Ideas for you</Text>
-                    <Box display="flex">
-                      <Text ref={anchorRefB} inline weight="bold">
-                        <Box marginEnd={2}>Small tattoos</Box>
-                      </Text>
-                    </Box>
-                  </Flex>
-                </Flex.Item>
-                <Flex.Item flex="none">
-                  <Icon
-                    accessibilityLabel=""
-                    icon="arrow-forward"
-                  />
-                </Flex.Item>
-              </Flex>
-              <Box width="100%" aria-hidden>
-                <Mask rounding={1} wash>
-                  <Image
-                    alt=""
-                    color="rgb(231, 186, 176)"
-                    loading="lazy"
-                    naturalHeight={181}
-                    naturalWidth={698}
-                    src="https://i.ibb.co/DWJFWkV/Screenshot-2023-02-24-at-2-27-59-PM.png"
-                  />
-                </Mask>
-              </Box>
-            </Flex>
-          </Box>
-        </TapArea>
-
-        {openA && (
-            <PopoverEducational
-              idealDirection="right"
-              anchor={anchorRefA.current}
-              onDismiss={() => {}}
-              message="Tap to tag a product to see product details"
-              primaryAction={{ text: "Next", onClick: () => {
-                setOpenA(false)
-                setOpenB(true)
-              }}}
-            />
-        )}
-        {openB && (
-          <PopoverEducational
-            idealDirection="right"
-            anchor={anchorRefB.current}
-            onDismiss={() => {}}
-            message="Explore your recent searches in more details"
+            sandpackExample={
+              <SandpackExample
+                code={doEducate}
+                hideEditor
+                name="Do - Educate"
+                previewHeight={400}
+              />
+            }
           />
-        )}
-      </Flex>
-    </Box>
-)}
-`}
-          />
+
           <MainSection.Card
-            cardSize="md"
             type="don't"
             description="Show more than one PopoverEducational at a time. If used for onboarding, show a next button instead, to launch the next popover."
-            defaultCode={`
-            function Example() {
-  const [openA, setOpenA] = React.useState(false);
-  const [openB, setOpenB] = React.useState(false);
-
-  const anchorRefA = React.useRef();
-  const anchorRefB = React.useRef();
-
-  React.useEffect(() => {
-    setOpenA(true)
-    setOpenB(true)
-  }, []);
-
-  return (
-    <Box width="100%" height="100%">
-      <Flex direction="column" alignItems="start" height="100%">
-        <Flex.Item flex="grow">
-          <Box padding={3} color="secondary" height={75} width={175} ref={anchorRefA} rounding={3}>
-            <Flex gap={2}>
-              <Box height={500} width={50}>
-                <Mask rounding={3} wash>
-                  <Image
-                    alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
-                    color="rgb(231, 186, 176)"
-                    loading="lazy"
-                    naturalHeight={1}
-                    naturalWidth={1}
-                    src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
-                  />
-                </Mask>
-              </Box>
-              <Flex direction="column">
-                <Text size="100">More ideas for</Text>
-                <Text weight="bold">Food & Drinks</Text>
-              </Flex>
-            </Flex>
-          </Box>
-        </Flex.Item>
-        <TapArea fullWidth={false} rounding={3}>
-          <Box borderStyle="shadow" padding={3} rounding={3} width={350}>
-            <Flex direction="column" gap={3}>
-              <Flex>
-                <Flex.Item flex="grow">
-                  <Flex direction="column" gap={1}>
-                    <Text size="100">Ideas for you</Text>
-                    <Box display="flex">
-                      <Text ref={anchorRefB} inline weight="bold">
-                        <Box marginEnd={2}>Small tattoos</Box>
-                      </Text>
-                    </Box>
-                  </Flex>
-                </Flex.Item>
-                <Flex.Item flex="none">
-                  <Icon
-                    accessibilityLabel=""
-                    icon="arrow-forward"
-                  />
-                </Flex.Item>
-              </Flex>
-              <Box width="100%" aria-hidden>
-                <Mask rounding={1} wash>
-                  <Image
-                    alt=""
-                    color="rgb(231, 186, 176)"
-                    loading="lazy"
-                    naturalHeight={181}
-                    naturalWidth={698}
-                    src="https://i.ibb.co/DWJFWkV/Screenshot-2023-02-24-at-2-27-59-PM.png"
-                  />
-                </Mask>
-              </Box>
-            </Flex>
-          </Box>
-        </TapArea>
-
-        {openA && (
-            <PopoverEducational
-              idealDirection="right"
-              anchor={anchorRefA.current}
-              onDismiss={() => {}}
-              message="Tap to tag a product to see product details"
-            />
-        )}
-        {openB && (
-          <PopoverEducational
-            idealDirection="right"
-            anchor={anchorRefB.current}
-            onDismiss={() => {}}
-            message="Explore your recent searches in more details"
-          />
-        )}
-      </Flex>
-    </Box>
-)}
-`}
+            sandpackExample={
+              <SandpackExample
+                code={dontDouble}
+                hideEditor
+                hideControls
+                name="Don't - Double"
+                previewHeight={400}
+              />
+            }
           />
         </MainSection.Subsection>
 
-        <MainSection.Subsection columns={2}>
+        <MainSection.Subsection>
           <MainSection.Card
-            cardSize="md"
             type="do"
             description="Position PopoverEducational appropriately on the screen. Make sure the arrow points directly to the element it is referencing."
-            defaultCode={`
-function Example() {
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef();
-
-  React.useEffect(() => {
-    setOpen(true)
-  }, []);
-
-  return (
-    <React.Fragment>
-      <TapArea fullWidth={false} rounding={3}>
-        <Box borderStyle="shadow" padding={3} rounding={3} width={400}>
-          <Flex direction="column" gap={3}>
-            <Flex>
-              <Flex.Item flex="grow">
-                <Flex direction="column" gap={1}>
-                  <Text size="100">Ideas for you</Text>
-                  <Box display="flex">
-                    <Text ref={anchorRef} inline weight="bold">
-                      <Box marginEnd={2}>Small tattoos</Box>
-                    </Text>
-                  </Box>
-                </Flex>
-              </Flex.Item>
-              <Flex.Item flex="none">
-                <Icon
-                  accessibilityLabel=""
-                  icon="arrow-forward"
-                />
-              </Flex.Item>
-            </Flex>
-            <Box width="100%" aria-hidden>
-              <Mask rounding={1} wash>
-                <Image
-                  alt=""
-                  color="rgb(231, 186, 176)"
-                  loading="lazy"
-                  naturalHeight={181}
-                  naturalWidth={698}
-                  src="https://i.ibb.co/DWJFWkV/Screenshot-2023-02-24-at-2-27-59-PM.png"
-                />
-              </Mask>
-            </Box>
-          </Flex>
-        </Box>
-      </TapArea>
-      {open && (
-        <PopoverEducational
-          id="popover-do-educate"
-          idealDirection="right"
-          anchor={anchorRef.current}
-          onDismiss={() => {}}
-          message="Explore your recent searches in more details"
-        />
-      )}
-    </React.Fragment>
-)}`}
+            sandpackExample={
+              <SandpackExample code={doReference} hideEditor name="Do - Reference" />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -368,9 +98,11 @@ function Example() {
           description={`
 PopoverEducational doesn't behave like regular popovers where they are open/closed upon user interaction, i.e. Tooltip, Dropdown, or ComboBox. PopoverEducational visibility is not directly controlled by the user; instead, its visibility is defined as part of a broader user experience and the user interaction engagement with this experience.
 
-In most cases, PopoverEducational might be already visible on page load. See [visible on page load](#Visibility-on-page-load) to learn more. However, popover-based components rely on the opening/closing action to capture focus.
+In most cases, PopoverEducational might be already visible on page load. See [visible on page load](#Visibility-on-page-load) to learn more. However, popover-based components rely on the component opening/dismissing event to capture focus.
 
-If PopoverEducational is already visible, we need its content to be keyboard accessible in sequential order. Don't use Layer to wrap PopoverEducational as it would move PopoverEducational outside the DOM hierarchy of the parent component and it will lose contextual sequencial order. The content will placed last in the keyboard navigations sequence, becoming unreachable in its content context.
+If PopoverEducational is already visible, we need its content to be keyboard accessible in sequential order. Don't use Layer to wrap PopoverEducational as it would move PopoverEducational outside the DOM hierarchy of the parent component and it will lose contextual sequencial order. The content will placed last in the keyboard navigations sequence, becoming unreachable in its content context. Moreover, make sure PopoverEducational is implemented right after the code of the anchor element so that it navigates the popover right after the anchor.
+
+If PopoverEducational
 `}
         />
         <MainSection.Subsection
@@ -411,56 +143,7 @@ The \`message\` prop accepts either a string or [Text](/web/text). Use a string 
         >
           <MainSection.Card
             cardSize="md"
-            defaultCode={`
-function Example() {
-  const [openA, setOpenA] = React.useState(false);
-  const [openB, setOpenB] = React.useState(false);
-  const anchorRefA = React.useRef();
-  const anchorRefB = React.useRef();
-
-  React.useEffect(() => {
-    setOpenA(true);
-    setOpenB(true);
-  }, []);
-
-  return (
-    <Flex alignItems="center" justifyContent="between" height="100%" width="100%">
-      <IconButton
-        accessibilityLabel="This IconButton represents a new feature"
-        iconColor="darkGray"
-        icon="pin"
-        onClick={() => {}}
-        ref={anchorRefA}
-        size="lg"
-      />
-      <IconButton
-        accessibilityLabel="This IconButton represents a new feature"
-        iconColor="darkGray"
-        icon="pin"
-        onClick={() => {}}
-        ref={anchorRefB}
-        size="lg"
-      />
-      {openA && (
-        <PopoverEducational
-          anchor={anchorRefA.current}
-          idealDirection="right"
-          onDismiss={() => {}}
-          message="Simple message string"
-        />
-      )}
-      {openB && (
-        <PopoverEducational
-          anchor={anchorRefB.current}
-          idealDirection="right"
-          onDismiss={() => {}}
-          message={<Text inline>Rich message with Text component and <Text inline weight="bold">bold text</Text></Text>}
-        />
-      )}
-    </Flex>
-  );
-}
-`}
+            sandpackExample={<SandpackExample code={message} hideEditor name="Message variant" />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -473,51 +156,9 @@ function Example() {
         >
           <MainSection.Card
             cardSize="md"
-            defaultCode={`
-function Example() {
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef();
-
-  React.useEffect(() => {
-    setOpen(true)
-  }, []);
-
-  return (
-    <Box height="100%">
-      <TapArea ref={anchorRef} rounding={3}>
-        <Box padding={3} color="secondary" height={75} width={200} rounding={3}>
-          <Flex gap={2}>
-            <Box aria-hidden height={500} width={50}>
-              <Mask rounding={3} wash>
-                <Image
-                  alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
-                  color="rgb(231, 186, 176)"
-                  loading="lazy"
-                  naturalHeight={1}
-                  naturalWidth={1}
-                  src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
-                />
-              </Mask>
-            </Box>
-            <Flex direction="column">
-              <Text size="100">More ideas for</Text>
-              <Text weight="bold">Food, Drinks, Snacks</Text>
-            </Flex>
-          </Flex>
-        </Box>
-      </TapArea>
-      {open && (
-        <PopoverEducational
-          id="popover-primary-action"
-          idealDirection="down"
-          anchor={anchorRef.current}
-          onDismiss={() => {}}
-          message="Tap to tag a product or press and hold to see product details"
-          primaryAction={{ text: "Next"}}
-        />
-      )}
-    </Box>
-)}`}
+            sandpackExample={
+              <SandpackExample code={primaryAction} hideEditor name="Primary action variant" />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -528,43 +169,9 @@ PopoverEducational doesn't overwrite style in children or set any padding or mar
         >
           <MainSection.Card
             cardSize="md"
-            defaultCode={`
-function Example() {
-  const [openA, setOpenA] = React.useState(false);
-  const anchorRefA = React.useRef();
-
-  React.useEffect(() => {
-    setOpenA(true);
-  }, []);
-
-  return (
-    <Flex alignItems="center" justifyContent="center" height="100%" width="100%">
-      <IconButton
-        accessibilityLabel="This IconButton represents a new feature"
-        iconColor="darkGray"
-        icon="pin"
-        onClick={() => {}}
-        ref={anchorRefA}
-        size="lg"
-      />
-      {openA && (
-        <PopoverEducational
-          anchor={anchorRefA.current}
-          idealDirection="down"
-          onDismiss={() => {}}
-        >
-          <Box padding={3}>
-            <Flex direction="column" gap={3}>
-              <Text color="light">Tap to tag a product or press and hold to see product details</Text>
-              <Flex.Item alignSelf="end"><Button color="white" text="Next"/></Flex.Item>
-            </Flex>
-          </Box>
-        </PopoverEducational>
-      )}
-    </Flex>
-  )
-}
-`}
+            sandpackExample={
+              <SandpackExample code={customContent} hideEditor name="Custom content variant" />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -577,65 +184,9 @@ The maximum width of PopoverEducational. PopoverEducational has different size c
         >
           <MainSection.Card
             cardSize="md"
-            defaultCode={`
-function Example() {
-  const [openA, setOpenA] = React.useState(false);
-  const [openB, setOpenB] = React.useState(false);
-  const anchorRefA = React.useRef();
-  const anchorRefB = React.useRef();
-
-  React.useEffect(() => {
-    setOpenA(true);
-    setOpenB(true);
-  }, []);
-
-  return (
-    <React.Fragment>
-      <Flex direction="column" width="100%" height="100%">
-        <Flex.Item flex="grow">
-          <IconButton
-            accessibilityLabel="This IconButton represents a new feature"
-            iconColor="darkGray"
-            icon="pin"
-            onClick={() => {}}
-            ref={anchorRefA}
-            size="lg"
-        />
-        </Flex.Item>
-        <Flex.Item flex="grow">
-          <IconButton
-            accessibilityLabel="This IconButton represents a new feature"
-            iconColor="darkGray"
-            icon="pin"
-            onClick={() => {}}
-            ref={anchorRefB}
-            size="lg"
-          />
-        </Flex.Item>
-
-        </Flex>
-        {openA && (
-          <PopoverEducational
-            size="flexible"
-            anchor={anchorRefA.current}
-            idealDirection="right"
-            onDismiss={() => {}}
-            message="Ads allow you to reach more people who matter to you. When audiences engage with your ad, you'll be able to track performance here."
-          />
-        )}
-        {openB && (
-          <PopoverEducational
-            anchor={anchorRefB.current}
-            idealDirection="right"
-            onDismiss={() => {}}
-            message="Ads allow you to reach more people who matter to you. When audiences engage with your ad, you'll be able to track performance here."
-
-          />
-        )}
-    </React.Fragment>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample code={size} hideEditor name="Size variant" previewHeight={400} />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -646,37 +197,9 @@ PopoverEducational's positioning algorithm requires that the anchor element rend
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example() {
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef();
-
-  React.useEffect(() => {
-    setOpen(true);
-  }, []);
-
-  return (
-    <Flex alignItems="center" justifyContent="center" height="100%" width="100%">
-      <IconButton
-        accessibilityLabel="This IconButton represents a new feature"
-        iconColor="darkGray"
-        icon="pin"
-        onClick={() => {}}
-        ref={anchorRef}
-        size="lg"
-      />
-      {open && (
-        <PopoverEducational
-          anchor={anchorRef.current}
-          idealDirection="right"
-          onDismiss={() => {}}
-          message="This PopoverEducational is visible on initial page load"
-        />
-      )}
-    </Flex>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample code={visibility} hideEditor name="Visibility variant" />
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -175,17 +175,17 @@ export default function PopoverEducational({
         role={primaryAction && !children ? 'dialog' : role}
         size={size}
       >
-        {!children && message ? (
-          <Box padding={4} tabIndex={0}>
-            <Flex direction="column" gap={3}>
-              {textElement}
-              <Flex.Item flex="grow" alignSelf="end">
-                {primaryAction ? <PrimaryAction {...primaryAction} /> : null}
-              </Flex.Item>
-            </Flex>
-          </Box>
-        ) : null}
-        {children ?? null}
+        {children ??
+          (message ? (
+            <Box padding={4} tabIndex={0}>
+              <Flex direction="column" gap={3}>
+                {textElement}
+                <Flex.Item flex="grow" alignSelf="end">
+                  {primaryAction ? <PrimaryAction {...primaryAction} /> : null}
+                </Flex.Item>
+              </Flex>
+            </Box>
+          ) : null)}
       </Popover>
     </Box>
   );

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -98,9 +98,13 @@ type Props = {|
    */
   message?: string | Element<typeof Text>,
   /**
-   * The underlying ARIA role for PopoverEducational. See the [role sectionin Accessibility](https://gestalt.pinterest.systems/web/popovereducational#Role) for more info.
+   * The underlying ARIA role for PopoverEducational. See the [role section in Accessibility](https://gestalt.pinterest.systems/web/popovereducational#Role) for more info.
    */
   role?: Role,
+  /**
+   * Puts the focus on PopoverEducational when it’s triggered. See the [keyboard navigation section in Accessibility](https://gestalt.pinterest.systems/web/popovereducational#Keyboard-navigation) to learn more.
+   */
+  shouldFocus?: boolean,
   /**
    * The maximum width of PopoverEducational. See the [size variant](https://gestalt.pinterest.systems/web/popovereducational#Size) to learn more.
    */
@@ -126,6 +130,7 @@ export default function PopoverEducational({
   onDismiss,
   primaryAction,
   role = 'tooltip',
+  shouldFocus = false,
   size = 'sm',
   zIndex,
 }: Props): Node {
@@ -166,10 +171,11 @@ export default function PopoverEducational({
         onDismiss={onDismiss}
         positionRelativeToAnchor
         showCaret
+        shouldFocus={shouldFocus ?? false}
         role={primaryAction && !children ? 'dialog' : role}
         size={size}
       >
-        {children ?? message ? (
+        {!children && message ? (
           <Box padding={4} tabIndex={0}>
             <Flex direction="column" gap={3}>
               {textElement}

--- a/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
@@ -151,18 +151,6 @@ exports[`PopoverEducational renders correctly with custom children 1`] = `
         }
       >
         <div
-          className="box paddingX4 paddingY4"
-          tabIndex={0}
-        >
-          <div
-            className="Flex rowGap3 columnGap3 xsDirectionColumn"
-          >
-            <div
-              className="FlexItem flexGrow selfEnd"
-            />
-          </div>
-        </div>
-        <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
         >
           Custom children


### PR DESCRIPTION
### Summary

#### What changed?

PopoverEducational: move examples to Sandpack + added `shouldFocus` to props