### PR TITLE
Dropdown, Popover: Add `maxHeight` prop

### DIFF
--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -45,6 +45,7 @@ type OwnProps = {|
   shouldFocus?: boolean,
   triggerRect: ?ClientRect,
   width: ?number,
+  __dangerouslyIgnoreScrollBoundaryContainerSize?: boolean,
 |};
 
 type HookProps = {|
@@ -207,10 +208,16 @@ class Contents extends Component<Props, State> {
       return { top: null, height: null };
     }
 
-    const { positionRelativeToAnchor } = this.props;
+    const {
+      __dangerouslyIgnoreScrollBoundaryContainerSize,
+      scrollBoundaryContainerRef,
+      positionRelativeToAnchor,
+    } = this.props;
 
     // Define the height based the reference to render: ScrollBoundaryContainer or screen viewport
-    const height = window.innerHeight ?? 0;
+    let height = window.innerHeight ?? 0;
+    if (__dangerouslyIgnoreScrollBoundaryContainerSize) height = window.innerHeight ?? 0;
+    else height = scrollBoundaryContainerRef?.offsetHeight ?? window.innerHeight ?? 0;
 
     // 5% of height available
     const top = (height / 10) * 0.5;

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -216,8 +216,9 @@ class Contents extends Component<Props, State> {
 
     // Define the height based the reference to render: ScrollBoundaryContainer or screen viewport
     let height = window.innerHeight ?? 0;
-    if (__dangerouslyIgnoreScrollBoundaryContainerSize) height = window.innerHeight ?? 0;
-    else height = scrollBoundaryContainerRef?.offsetHeight ?? window.innerHeight ?? 0;
+    if (!__dangerouslyIgnoreScrollBoundaryContainerSize) {
+      height = scrollBoundaryContainerRef?.offsetHeight ?? window.innerHeight ?? 0;
+    }
 
     // 5% of height available
     const top = (height / 10) * 0.5;

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -216,8 +216,8 @@ class Contents extends Component<Props, State> {
 
     // Define the height based the reference to render: ScrollBoundaryContainer or screen viewport
     let height = window.innerHeight ?? 0;
-    if (!__dangerouslyIgnoreScrollBoundaryContainerSize) {
-      height = scrollBoundaryContainerRef?.offsetHeight ?? window.innerHeight ?? 0;
+    if (!__dangerouslyIgnoreScrollBoundaryContainerSize && scrollBoundaryContainerRef) {
+      height = scrollBoundaryContainerRef.offsetHeight;
     }
 
     // 5% of height available

--- a/packages/gestalt/src/Contents.js
+++ b/packages/gestalt/src/Contents.js
@@ -207,10 +207,10 @@ class Contents extends Component<Props, State> {
       return { top: null, height: null };
     }
 
-    const { scrollBoundaryContainerRef, positionRelativeToAnchor } = this.props;
+    const { positionRelativeToAnchor } = this.props;
 
     // Define the height based the reference to render: ScrollBoundaryContainer or screen viewport
-    const height = scrollBoundaryContainerRef?.offsetHeight ?? window.innerHeight ?? 0;
+    const height = window.innerHeight ?? 0;
 
     // 5% of height available
     const top = (height / 10) * 0.5;

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -30,6 +30,7 @@ type OwnProps = {|
   rounding?: 2 | 4,
   shouldFocus?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | null,
+  __dangerouslyIgnoreScrollBoundaryContainerSize?: boolean,
 |};
 
 type HookProps = {|
@@ -150,6 +151,10 @@ class Controller extends Component<Props, State> {
           shouldFocus={shouldFocus}
           triggerRect={triggerBoundingRect}
           width={width}
+          __dangerouslyIgnoreScrollBoundaryContainerSize={
+            // eslint-disable-next-line no-underscore-dangle
+            this.props.__dangerouslyIgnoreScrollBoundaryContainerSize
+          }
         >
           {children}
         </Contents>

--- a/packages/gestalt/src/Controller.js
+++ b/packages/gestalt/src/Controller.js
@@ -127,6 +127,7 @@ class Controller extends Component<Props, State> {
       rounding,
       shouldFocus,
       size,
+      __dangerouslyIgnoreScrollBoundaryContainerSize,
     } = this.props;
     const { relativeOffset, triggerBoundingRect } = this.state;
 
@@ -152,8 +153,7 @@ class Controller extends Component<Props, State> {
           triggerRect={triggerBoundingRect}
           width={width}
           __dangerouslyIgnoreScrollBoundaryContainerSize={
-            // eslint-disable-next-line no-underscore-dangle
-            this.props.__dangerouslyIgnoreScrollBoundaryContainerSize
+            __dangerouslyIgnoreScrollBoundaryContainerSize
           }
         >
           {children}

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -116,6 +116,10 @@ type Props = {|
    */
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   /**
+   *  Define a controlled size to dropdown's Popover.
+   */
+  maxHeight?: '30vh',
+  /**
    * Callback fired when the menu is closed.
    */
   onDismiss: () => void,
@@ -123,7 +127,6 @@ type Props = {|
    * An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](https://gestalt.pinterest.systems/web/zindex_classes)
    */
   zIndex?: Indexable,
-  __dangerouslyIgnoreScrollBoundaryContainerSize?: boolean,
 |};
 
 /**
@@ -142,7 +145,7 @@ export default function Dropdown({
   idealDirection = 'down',
   onDismiss,
   zIndex,
-  __dangerouslyIgnoreScrollBoundaryContainerSize = false,
+  maxHeight,
 }: Props): Node {
   const [hoveredItem, setHoveredItem] = useState<number>(0);
 
@@ -222,9 +225,7 @@ export default function Dropdown({
       role="menu"
       shouldFocus
       size="xl"
-      __dangerouslyIgnoreScrollBoundaryContainerSize={
-        __dangerouslyIgnoreScrollBoundaryContainerSize
-      }
+      __dangerouslySetMaxHeight={maxHeight}
     >
       <Box
         alignItems="center"
@@ -232,7 +233,7 @@ export default function Dropdown({
         display="flex"
         flex="grow"
         margin={2}
-        maxHeight={__dangerouslyIgnoreScrollBoundaryContainerSize ? '30vh' : 'auto'}
+        maxHeight={maxHeight}
       >
         {Boolean(headerContent) && <Box padding={2}>{headerContent}</Box>}
 

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -123,6 +123,7 @@ type Props = {|
    * An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](https://gestalt.pinterest.systems/web/zindex_classes)
    */
   zIndex?: Indexable,
+  __dangerouslyIgnoreScrollBoundaryContainerSize?: boolean,
 |};
 
 /**
@@ -141,6 +142,7 @@ export default function Dropdown({
   idealDirection = 'down',
   onDismiss,
   zIndex,
+  __dangerouslyIgnoreScrollBoundaryContainerSize = false,
 }: Props): Node {
   const [hoveredItem, setHoveredItem] = useState<number>(0);
 
@@ -220,8 +222,18 @@ export default function Dropdown({
       role="menu"
       shouldFocus
       size="xl"
+      __dangerouslyIgnoreScrollBoundaryContainerSize={
+        __dangerouslyIgnoreScrollBoundaryContainerSize
+      }
     >
-      <Box alignItems="center" direction="column" display="flex" flex="grow" margin={2}>
+      <Box
+        alignItems="center"
+        direction="column"
+        display="flex"
+        flex="grow"
+        margin={2}
+        maxHeight={__dangerouslyIgnoreScrollBoundaryContainerSize ? '30vh' : 'auto'}
+      >
         {Boolean(headerContent) && <Box padding={2}>{headerContent}</Box>}
 
         <DropdownContextProvider value={{ id, hoveredItem, setHoveredItem, setOptionRef }}>

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -72,7 +72,8 @@ type Props = {|
    * The maximum width of Popover. See the [size](https://gestalt.pinterest.systems/web/popover#Size) variant to learn more.
    */
   size?: Size,
-  __dangerouslyIgnoreScrollBoundaryContainerSize?: boolean,
+  // This property can be set when `ScrollBoundaryContainer` is set to `overflow="visible"` but therefore limits the height of the Popover-based component. Some cases require
+  __dangerouslySetMaxHeight?: '30vh',
 |};
 
 /**
@@ -100,7 +101,7 @@ export default function Popover({
   shouldFocus = true,
   showCaret = false,
   size = 'sm',
-  __dangerouslyIgnoreScrollBoundaryContainerSize,
+  __dangerouslySetMaxHeight,
 }: Props): null | Node {
   const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
     useDefaultLabelContext('Popover');
@@ -131,9 +132,7 @@ export default function Popover({
       rounding={4}
       shouldFocus={shouldFocus}
       size={size === 'flexible' ? null : size}
-      __dangerouslyIgnoreScrollBoundaryContainerSize={
-        __dangerouslyIgnoreScrollBoundaryContainerSize
-      }
+      __dangerouslyIgnoreScrollBoundaryContainerSize={__dangerouslySetMaxHeight === '30vh'}
     >
       {showDismissButton ? (
         <Flex direction="column">

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -72,6 +72,7 @@ type Props = {|
    * The maximum width of Popover. See the [size](https://gestalt.pinterest.systems/web/popover#Size) variant to learn more.
    */
   size?: Size,
+  __dangerouslyIgnoreScrollBoundaryContainerSize?: boolean,
 |};
 
 /**
@@ -99,6 +100,7 @@ export default function Popover({
   shouldFocus = true,
   showCaret = false,
   size = 'sm',
+  __dangerouslyIgnoreScrollBoundaryContainerSize,
 }: Props): null | Node {
   const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
     useDefaultLabelContext('Popover');
@@ -129,6 +131,9 @@ export default function Popover({
       rounding={4}
       shouldFocus={shouldFocus}
       size={size === 'flexible' ? null : size}
+      __dangerouslyIgnoreScrollBoundaryContainerSize={
+        __dangerouslyIgnoreScrollBoundaryContainerSize
+      }
     >
       {showDismissButton ? (
         <Flex direction="column">


### PR DESCRIPTION
### Summary

#### What changed?

We add the new property `maxHeight` to Dropdown component to control the size of Popover container and  removing `ScrollBoundaryContainer` calculation when this property is defined.

#### Why?

To understand better, please read the thread: https://pinterest.slack.com/archives/C13KLG5P0/p1676662974832019

### Explanation

https://capture.dropbox.com/tCVVMlf5LTJoLY7q