### PR TITLE
Internal: add Masonry `flexible-resize` integration test

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -316,8 +316,8 @@ export default class MasonryContainer extends Component<Props, State> {
           <MasonryComponent
             ref={this.gridRef}
             renderItem={this.renderItem}
-            flexible={flexible}
             items={items}
+            layout={flexible ? 'flexible' : undefined}
             measurementStore={externalCache ? measurementStore : undefined}
             virtualize={virtualize}
             columnWidth={columnWidth}

--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { Component, createRef, type Element, type Node } from 'react';
+import { Masonry } from 'gestalt';
 import ExampleGridItem from './ExampleGridItem.js';
 import getClassicGridServerStyles from './getClassicGridServerStyles.js';
 import getFlexibleGridServerStyles from './getFlexibleGridServerStyles.js';
@@ -15,10 +16,9 @@ import { getRandomNumberGenerator, generateExampleItems } from './items-utils.js
 // Masonry works, MasonryContainer also supports certain SSR functionality such
 // as generating styles that affect pre-hydration Masonry content.
 
-type Props = {
+type Props = {|
   // The actual Masonry component to be used (if using an experimental version of Masonry).
-  // $FlowFixMe[unclear-type]
-  MasonryComponent: any,
+  MasonryComponent: typeof Masonry,
   // Sets up props to display a collage layout.
   collage?: boolean,
   // Constrains the width of the grid rendering.
@@ -49,18 +49,16 @@ type Props = {
   virtualBoundsTop?: number,
   // The relative amount in pixel to extend the virtualized viewport bottom value.
   virtualBoundsBottom?: number,
-  ...
-};
+|};
 
-type State = {
+type State = {|
   expanded: boolean,
   hasScrollContainer: boolean,
   // $FlowFixMe[unclear-type]
-  items: $ReadOnlyArray<?Object>,
+  items: $ReadOnlyArray<Object>,
   mountGrid: boolean,
   mounted: boolean,
-  ...
-};
+|};
 
 export default class MasonryContainer extends Component<Props, State> {
   state: State = {
@@ -238,7 +236,10 @@ export default class MasonryContainer extends Component<Props, State> {
   };
 
   // $FlowFixMe[unclear-type]
-  renderItem: ({| data: any, itemIdx: number |}) => Node = ({ data, itemIdx }) => {
+  renderItem: ({| +data: any, +itemIdx: number, +isMeasuring: boolean |}) => Node = ({
+    data,
+    itemIdx,
+  }) => {
     const { expanded } = this.state;
     return <ExampleGridItem expanded={expanded} data={data} itemIdx={itemIdx} />;
   };
@@ -311,6 +312,7 @@ export default class MasonryContainer extends Component<Props, State> {
       <div id="gridWrapper" className="gridCentered" style={gridStyle}>
         <div id="top-sibling" />
         {mountGrid && (
+          // $FlowFixMe[incompatible-exact]
           <MasonryComponent
             ref={this.gridRef}
             renderItem={this.renderItem}

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -8,18 +8,24 @@ import { generateExampleItems } from '../../integration-test-helpers/masonry/ite
 const measurementStore = Masonry.createMeasurementStore();
 
 // This is the counterpart to `normalizeValue` in `playwright/masonry/utils/getServerURL.mjs`
-// This will likely need to be updated in the near future
-function booleanize(value: '1' | '0'): boolean {
-  return Boolean(Number(value));
+function booleanize(value: string): boolean {
+  if (['false', '0'].includes(value)) {
+    return false;
+  }
+  if (['true', '1'].includes(value)) {
+    return true;
+  }
+  return Boolean(value);
 }
 
 export default function TestPage(): Node {
   const router = useRouter();
-  const { offsetTop, scrollContainer, virtualize } = router.query;
+  const { flexible, offsetTop, scrollContainer, virtualize } = router.query;
 
   return (
     <ColorSchemeProvider colorScheme="light">
       <MasonryContainer
+        flexible={booleanize(flexible)}
         initialItems={generateExampleItems({ name: 'InitialPin' })}
         MasonryComponent={Masonry}
         measurementStore={measurementStore}

--- a/playwright/masonry/flexible-resize.spec.mjs
+++ b/playwright/masonry/flexible-resize.spec.mjs
@@ -57,7 +57,6 @@ test.describe('Masonry: flexible resize', () => {
     await page.waitForFunction(
       ({ selector, previousItemWidth }) => {
         const gridItem = document.querySelector(selector);
-        console.log(gridItem, gridItem?.getBoundingClientRect());
 
         const rect = gridItem?.getBoundingClientRect();
         return rect?.width !== previousItemWidth;

--- a/playwright/masonry/flexible-resize.spec.mjs
+++ b/playwright/masonry/flexible-resize.spec.mjs
@@ -1,0 +1,101 @@
+// @flow strict
+import { expect, test } from '@playwright/test';
+import selectors from './utils/selectors.mjs';
+import getGridItems from './utils/getGridItems.mjs';
+import getServerURL from './utils/getServerURL.mjs';
+import resizeWidth from './utils/resizeWidth.mjs';
+import waitForRenderedItems from './utils/waitForRenderedItems.mjs';
+
+async function getItemColumnMap(gridItems) {
+  const itemLeftMap = {};
+  for (let i = 0; i < gridItems.length; i += 1) {
+    const boundingBox = await gridItems[i].boundingBox();
+    if (boundingBox) {
+      itemLeftMap[boundingBox.x] = itemLeftMap[boundingBox.x] || [];
+      itemLeftMap[boundingBox.x].push({
+        ...boundingBox,
+        itemIndex: i,
+        text: await gridItems[i].innerText(),
+      });
+    }
+  }
+
+  return itemLeftMap;
+}
+
+test.describe('Masonry: flexible resize', () => {
+  test('should resize item width and height on window resize', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 800, height: 800 });
+    await page.goto(getServerURL({ flexible: true }));
+    await waitForRenderedItems(page, { targetItems: 40 });
+
+    // Test item size.
+    const gridItemsBefore = await getGridItems(page);
+    expect(gridItemsBefore.length).toBe(40);
+
+    const itemRectsBefore = await Promise.all(
+      gridItemsBefore.map((gridItemBefore) => gridItemBefore.boundingBox())
+    );
+    // expect(itemRectsBefore[0].width).toBe(266);
+    expect(itemRectsBefore[0].height).toBe(216);
+
+    // Check size of initial grid items.
+    const originalItemMap = await getItemColumnMap(gridItemsBefore);
+    const originalColumns = Object.keys(originalItemMap);
+
+    // Trigger slight resize -- enough to resize, but not reflow columns. Mock
+    // out the window width for the next resize calculation. Wait for debounce.
+    await resizeWidth(page, 820);
+
+    // Masonry will re-layout after the resize. Unfortunately, using
+    // waitForRenderedItems doesn't work because we're not adding or removing
+    // any items and waitForRenderedItems could return before the actual
+    // re-layout happens. Instead, we wait for the first item to actually change
+    // size.
+    await page.waitForFunction(
+      ({ selector, previousItemWidth }) => {
+        const gridItem = document.querySelector(selector);
+        console.log(gridItem, gridItem?.getBoundingClientRect());
+
+        const rect = gridItem?.getBoundingClientRect();
+        return rect?.width !== previousItemWidth;
+      },
+      {
+        selector: selectors.gridItem,
+        previousItemWidth: itemRectsBefore[0].width,
+      },
+      { polling: 'raf' }
+    );
+
+    // After resize, Masonry will remeasure/layout.
+    await waitForRenderedItems(page, { targetItems: 40 });
+
+    // Test item size.
+    const gridItemsAfter = await getGridItems(page);
+    expect(gridItemsAfter.length).toBe(40);
+
+    const itemRectsAfter = await Promise.all(
+      gridItemsAfter.map((gridItemAfter) => gridItemAfter.boundingBox())
+    );
+    expect(itemRectsAfter[0].width).toBe(273);
+    expect(itemRectsAfter[0].height).toBe(216);
+
+    // Get new sizes of grid items.
+    const newItemMap = await getItemColumnMap(gridItemsAfter);
+    const newColumns = Object.keys(newItemMap);
+
+    for (let i = 0; i < originalColumns.length; i += 1) {
+      const originalCol = originalItemMap[originalColumns[i]];
+      const newCol = newItemMap[newColumns[i]];
+      originalCol.forEach((item, row) => {
+        const newItem = newCol[row];
+        expect(newItem).not.toBeUndefined();
+        expect(item.text).toEqual(newItem.text);
+        expect(item.height).toEqual(newItem.height);
+        expect(item.width).not.toEqual(newItem.width);
+      });
+    }
+  });
+});

--- a/playwright/masonry/handle-item-updates.spec.mjs
+++ b/playwright/masonry/handle-item-updates.spec.mjs
@@ -1,12 +1,9 @@
 // @flow strict
 import { expect, test } from '@playwright/test';
 import selectors from './utils/selectors.mjs';
+import getGridItems from './utils/getGridItems.mjs';
 import getServerURL from './utils/getServerURL.mjs';
 import waitForRenderedItems from './utils/waitForRenderedItems.mjs';
-
-async function getGridItems(page) {
-  return page.locator(selectors.gridItem).all();
-}
 
 test.describe('Masonry: handle item updates', () => {
   test('should correctly update grid item heights', async ({ page }) => {

--- a/playwright/masonry/handle-position-update.spec.mjs
+++ b/playwright/masonry/handle-position-update.spec.mjs
@@ -1,12 +1,9 @@
 // @flow strict
 import { expect, test } from '@playwright/test';
 import selectors from './utils/selectors.mjs';
+import getGridItems from './utils/getGridItems.mjs';
 import getServerURL from './utils/getServerURL.mjs';
 import waitForRenderedItems from './utils/waitForRenderedItems.mjs';
-
-async function getGridItems(page) {
-  return page.locator(selectors.gridItem).all();
-}
 
 test.describe('Masonry: handle offset update', () => {
   test('should correctly account for relative position changes', async ({

--- a/playwright/masonry/utils/getGridItems.mjs
+++ b/playwright/masonry/utils/getGridItems.mjs
@@ -1,0 +1,7 @@
+// @flow strict
+import selectors from './selectors.mjs';
+
+// $FlowExpectedError[unclear-type] flow-typed def for playwright is…lacking
+export default function getGridItems(page /*: Object */) /*: Promise<any> */ {
+  return page.locator(selectors.gridItem).all();
+}

--- a/playwright/masonry/utils/getServerURL.mjs
+++ b/playwright/masonry/utils/getServerURL.mjs
@@ -12,6 +12,7 @@ const normalizeValue = (val) => {
 
 /*::
 type Options = ?{|
+  flexible?: boolean,
   offsetTop?: number,
   scrollContainer?: boolean,
   virtualize?: boolean,


### PR DESCRIPTION
- Fixed up some Flow types, which uncovered a prop error
- Added support for `flexible` query param to Masonry integration test route
- Pulled out `getGridItems` as a util
- Added `flexible-resize` integration test