### PR TITLE
Toast: Updates to iOS images in Docs

### DIFF
--- a/docs/markdown/ios/toast.md
+++ b/docs/markdown/ios/toast.md
@@ -4,7 +4,7 @@ description: Toasts are brief and small messages that overlay content, but do no
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/27/32/0d/27320d8b7731c7cea23fbf917e7d2160.jpg" noPadding alt="an example of toast"/>
+<ImgContainer src="https://i.pinimg.com/originals/8e/6e/e2/8e6ee211ccfa215645f98e7538f3c76b.jpg" noPadding alt="an example of toast"/>
 
 ## Usage guidelines
 
@@ -29,32 +29,32 @@ fullwidth: true
 ## Best practices
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/b5/86/15/b5861579a1c5f7b958c6b7a7099ee9f4.jpg" alt="example with toast with unblocking placement"/>
+    <ImgContainer src="https://i.pinimg.com/originals/77/09/34/77093471a8c08670bb416a742ac13ace.jpg" alt="example with toast with unblocking placement"/>
     <Do title="Do" />
-    Place Toasts out of the way so that a user can still navigate and complete tasks. Keep a bottom margin that is the same size as the left and right margins.
+    Place Toasts out of the way so that a user can still navigate and complete tasks. Keep a top or bottom margin that is the same size as the left and right margins.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/f1/9c/d1/f19cd161c8cc6112a450fb58e0dc03d2.jpg" alt="example of with blocking placement"/>
+    <ImgContainer src="https://i.pinimg.com/originals/fb/8b/8c/fb8b8c73d9103201cac4b8e366bfd627.jpg" alt="example of with blocking placement"/>
     <Dont title="Don't" />
     Block navigation controls with Toasts or align too close to the edge of a navigation bar.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/5b/49/ce/5b49ce5d555fdd56b3b555fb62fcaaea.jpg" alt="example of showing one toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/7f/af/f0/7faff01d9c493be15ffb8742735c9b15.jpg" alt="example of showing one toast"/>
     <Do title="Do" />
-    Show one Toast at a time, with errors and Acknowledgements taking priority.
+    Show one Toast at a time, with errors and acknowledgements taking priority.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/e2/c7/4e/e2c74eed170be2f7029a673ef4b8512e.jpg" alt="example of showing multiple toasts"/>
+    <ImgContainer src="https://i.pinimg.com/originals/b7/b5/e4/b7b5e40bdedd672f127c0ee625d5ff1c.jpg" alt="example of showing multiple toasts"/>
     <Dont title="Don't" />
     Stack multiple toasts as that will block the user.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/36/0a/c3/360ac34d4f9b31c22058a056abd89e21.jpg" alt="example of a dismissible toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/ee/2d/1a/ee2d1acda7fb690b4a6de04ae2fc3d23.jpg" alt="example of a dismissible toast"/>
     <Do title="Do" />
-    Include a way to dismiss the toast when it is actionable or contains multiple lines of text. Mobile toasts can be dismissed via swiping on the toast in any direction.
+    Include a way to dismiss the toast when it is actionable or contains multiple lines of text. Mobile toasts can be dismissed via swiping up on the toast if it is placed on top or down if placed on the bottom.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/c8/ea/51/c8ea51c06c88110bde0f2854e9103980.jpg" alt="example of leaving a toast on screen"/>
+    <ImgContainer src="https://i.pinimg.com/originals/46/66/2c/46662cf86e721af0d755f27100b05771.jpg" alt="example of leaving a toast on screen"/>
     <Dont title="Don't" />
     Leave toasts on screen for a long time without a way to dismiss. Exceptions are blocking error toasts where a user can’t take any action until the error is resolved.
   </Group>
@@ -79,13 +79,13 @@ Some people may take longer to read toasts than others due to aging, low vision,
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/d9/eb/56/d9eb56243a337584cebbb57e293b3d7f.jpg" noPadding alt="default toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/77/b6/1b/77b61ba14fa3aa95d8124994a387fc51.jpg" noPadding alt="default toast"/>
     
     **Default**
     A generic acknowledgment after an action is taken.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/7f/c3/0d/7fc30d26a72b1c23f71f685f5bfbfc51.jpg" noPadding alt="error toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/1d/e0/04/1de004b81b15d909062a2f6d055137d5.jpg" noPadding alt="error toast"/>
    
     **Error**
     Used rarely for connection issues or unknown errors where we don’t want to completely block the users flow, but want the message to persist if the user goes to another surface. Providing a way to solve the error or get help is recommended.
@@ -97,13 +97,13 @@ Some people may take longer to read toasts than others due to aging, low vision,
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/d9/eb/56/d9eb56243a337584cebbb57e293b3d7f.jpg" noPadding alt="text only toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/fd/30/62/fd30629c36b5a2a799689e1fa33d9add.jpg" noPadding alt="text only toast"/>
     
     **Text only**
     A simple, generic acknowledgment after an action is taken These should not be actionable.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/02/40/85/024085af164541554f69c18368d7078e.jpg" noPadding alt="toast with image"/>
+    <ImgContainer src="https://i.pinimg.com/originals/77/b6/1b/77b61ba14fa3aa95d8124994a387fc51.jpg" noPadding alt="toast with image"/>
     
     **Image**
     With an image for Pin or Board actions.
@@ -111,7 +111,7 @@ Some people may take longer to read toasts than others due to aging, low vision,
 </TwoCol>
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/fa/1d/e5/fa1de5fbe15b0a3ee774f40c0a46b66c.jpg" noPadding alt="toast with avatar"/>
+    <ImgContainer src="https://i.pinimg.com/originals/17/68/e3/1768e3b164a4a67f163b6ec216b0a680.jpg" noPadding alt="toast with avatar"/>
     
     **Avatar**
     With an Avatar for Profile or Pinner-related messaging. An optional link can be included. When there’s a link on mWeb, the entire toast is tappable, using TapArea.
@@ -125,13 +125,13 @@ Some people may take longer to read toasts than others due to aging, low vision,
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/d3/05/0c/d3050c666e8b7a03b2d45873a218c9f7.jpg" noPadding alt="toast with button"/>
+    <ImgContainer src="https://i.pinimg.com/originals/d1/6d/53/d16d5368753bb66ed4b43768cec1673f.jpg" noPadding alt="toast with button"/>
     
     **Button**
     As a secondary element, to drive users to another surface, or change a recently completed action.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/02/40/85/024085af164541554f69c18368d7078e.jpg" noPadding alt="toast with link"/>
+    <ImgContainer src="https://i.pinimg.com/originals/be/96/f2/be96f2a755e144ef7554135f6c166b56.jpg" noPadding alt="toast with link"/>
     
     **Link**
     As a secondary element, to drive users to another surface.
@@ -140,7 +140,7 @@ Some people may take longer to read toasts than others due to aging, low vision,
 
 ### Placement
 
-Placement is always centered at the top of the screen and not blocking any navigation or important buttons.
+Placement is always centered at the top or bottom of the screen and not blocking any navigation or important buttons.
 
 ## Writing
 

--- a/docs/markdown/ios/toast.md
+++ b/docs/markdown/ios/toast.md
@@ -44,7 +44,7 @@ fullwidth: true
     Show one Toast at a time, with errors and acknowledgements taking priority.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/b7/b5/e4/b7b5e40bdedd672f127c0ee625d5ff1c.jpg" alt="example of showing multiple toasts"/>
+    <ImgContainer src="https://i.pinimg.com/originals/00/c4/96/00c49608baafa2cd3eb0cd3f4bd5086a.jpg" alt="example of showing multiple toasts"/>
     <Dont title="Don't" />
     Stack multiple toasts as that will block the user.
   </Group>

--- a/docs/markdown/ios/toast.md
+++ b/docs/markdown/ios/toast.md
@@ -100,7 +100,7 @@ Some people may take longer to read toasts than others due to aging, low vision,
     <ImgContainer src="https://i.pinimg.com/originals/fd/30/62/fd30629c36b5a2a799689e1fa33d9add.jpg" noPadding alt="text only toast"/>
     
     **Text only**
-    A simple, generic acknowledgment after an action is taken These should not be actionable.
+    A simple, generic acknowledgment after an action is taken. These should not be actionable.
   </Group>
   <Group>
     <ImgContainer src="https://i.pinimg.com/originals/77/b6/1b/77b61ba14fa3aa95d8124994a387fc51.jpg" noPadding alt="toast with image"/>


### PR DESCRIPTION
Updated iOS toast images to represent upcoming work and added/fixed text to clarify.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [Figma](link to Figma file)
