### PR TITLE
Internal: turn off `import/no-relative-parent-imports` lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,7 @@
     "import/no-anonymous-default-export": "error",
     "import/no-extraneous-dependencies": "off",
     "import/no-namespace": "error",
-    "import/no-relative-parent-imports": "error",
+    "import/no-relative-parent-imports": "off",
     "import/no-unresolved": "off",
     "jsx-a11y/label-has-associated-control": [
       "error",

--- a/packages/gestalt-datepicker/rollup.config.js
+++ b/packages/gestalt-datepicker/rollup.config.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line flowtype/require-valid-file-annotation, import/no-relative-parent-imports, import/no-relative-packages
+// eslint-disable-next-line flowtype/require-valid-file-annotation, import/no-relative-packages
 import plugins from '../gestalt-core/build.js';
 
 const rollupConfig = {

--- a/packages/gestalt/rollup.config.js
+++ b/packages/gestalt/rollup.config.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line flowtype/require-valid-file-annotation, import/no-relative-parent-imports, import/no-relative-packages
+// eslint-disable-next-line flowtype/require-valid-file-annotation, import/no-relative-packages
 import plugins from '../gestalt-core/build.js';
 
 const rollupConfig = {

--- a/packages/gestalt/src/contexts/__mocks__/DefaultLabelProvider.js
+++ b/packages/gestalt/src/contexts/__mocks__/DefaultLabelProvider.js
@@ -1,10 +1,6 @@
 // @flow strict
 import { createContext, type Context, type Node, useContext } from 'react';
-import {
-  fallbackLabels,
-  type DefaultLabelContextType,
-  // eslint-disable-next-line import/no-relative-parent-imports
-} from '../DefaultLabelProvider.js';
+import { fallbackLabels, type DefaultLabelContextType } from '../DefaultLabelProvider.js';
 
 const MockContext: Context<?DefaultLabelContextType> =
   createContext<?DefaultLabelContextType>(fallbackLabels);


### PR DESCRIPTION
This rule is preventing us from keeping our main directory clean by moving child components into directories. Eventually we should add a webpack resolver to allow us to use absolute paths for all imports.