### PR TITLE
Masonry: remove `Item` prop

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type ComponentType, type Node, Component as ReactComponent } from 'react';
+import { type Node, Component as ReactComponent } from 'react';
 import debounce, { type DebounceReturn } from './debounce.js';
 import FetchItems from './FetchItems.js';
 import styles from './Masonry.css';
@@ -30,15 +30,6 @@ type Props<T> = {|
    * The amount of vertical and horizontal space between each item, specified in pixels.
    */
   gutterWidth?: number,
-  /**
-   * A React component (or stateless functional component) that renders the item you would like displayed in the grid. This component is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item. *Note that this [must be a stable reference!](https://www.developerway.com/posts/react-re-renders-guide#part3.1)* If using a component declared within a parent function component, you must use [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback) to ensure a stable reference.
-   * This is DEPRECATED and will be removed in the next major release. Please use `renderItem` prop instead.
-   */
-  Item?: ComponentType<{|
-    data: T,
-    itemIdx: number,
-    isMeasuring: boolean,
-  |}>,
   /**
    * An array of items to display that contains the data to be rendered by `renderItem()` (fallback to the deprecated `<Item />` if `renderItem` is not passed).
    */
@@ -76,7 +67,7 @@ type Props<T> = {|
   /**
    * A function that renders the item you would like displayed in the grid. This function is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item.
    */
-  renderItem?: ({|
+  renderItem: ({|
     +data: T,
     +itemIdx: number,
     +isMeasuring: boolean,
@@ -386,16 +377,16 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     this.forceUpdate();
   }
 
-  renderItem(item: {| +data: T, +itemIdx: number, +isMeasuring: boolean |}): Node {
-    const { Item, renderItem } = this.props;
-    if (renderItem) {
-      return renderItem(item);
-    }
-    if (Item) {
-      return <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />;
-    }
-    throw new Error('Please add the required renderItem prop.');
-  }
+  // renderItem(item: {| +data: T, +itemIdx: number, +isMeasuring: boolean |}): Node {
+  //   const { Item, renderItem } = this.props;
+  //   if (renderItem) {
+  //     return renderItem(item);
+  //   }
+  //   if (Item) {
+  //     return <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />;
+  //   }
+  //   throw new Error('Please add the required renderItem prop.');
+  // }
 
   renderMasonryComponent: (itemData: T, idx: number, position: Position) => Node = (
     itemData,
@@ -403,6 +394,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     position,
   ) => {
     const {
+      renderItem,
       scrollContainer,
       virtualize,
       virtualBoundsTop,
@@ -447,7 +439,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
           height: layoutNumberToCssDimension(height),
         }}
       >
-        {this.renderItem({ data: itemData, itemIdx: idx, isMeasuring: false })}
+        {renderItem({ data: itemData, itemIdx: idx, isMeasuring: false })}
       </div>
     );
 
@@ -461,6 +453,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       items,
       layout,
       minCols,
+      renderItem,
       scrollContainer,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
@@ -533,7 +526,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     : layoutNumberToCssDimension(columnWidth), // we can't set a width for server rendered flexible items
               }}
             >
-              {this.renderItem({ data: item, itemIdx: i, isMeasuring: false })}
+              {renderItem({ data: item, itemIdx: i, isMeasuring: false })}
             </div>
           ))}
         </div>
@@ -584,7 +577,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                     }
                   }}
                 >
-                  {this.renderItem({ data, itemIdx: measurementIndex, isMeasuring: true })}
+                  {renderItem({ data, itemIdx: measurementIndex, isMeasuring: true })}
                 </div>
               );
             })}

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -377,17 +377,6 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     this.forceUpdate();
   }
 
-  // renderItem(item: {| +data: T, +itemIdx: number, +isMeasuring: boolean |}): Node {
-  //   const { Item, renderItem } = this.props;
-  //   if (renderItem) {
-  //     return renderItem(item);
-  //   }
-  //   if (Item) {
-  //     return <Item data={item.data} itemIdx={item.itemIdx} isMeasuring={item.isMeasuring} />;
-  //   }
-  //   throw new Error('Please add the required renderItem prop.');
-  // }
-
   renderMasonryComponent: (itemData: T, idx: number, position: Position) => Node = (
     itemData,
     idx,


### PR DESCRIPTION
In [a previous PR](https://github.com/pinterest/gestalt/pull/2616), @jackhsu978 introduced `renderItem` to replace Masonry's `Item` prop. Now that we've refactored all usages in Pinboard, this PR removes `Item` and makes `renderItem` required.

** CODEMOD

I recommend manually updating:
```bash
yarn codemod detectManualReplacement ~/path/to/your/code
--component=Masonry
```