### PR TITLE
Internal: turn off `jsx-a11y/anchor-is-valid` for docs examples

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -108,9 +108,10 @@
       }
     },
     {
-      "files": ["docs/**/*.js"],
+      "files": ["docs/examples/**/*.js"],
       "rules": {
-        "import/no-relative-parent-imports": "off"
+        // Allows us to avoid directing the user off our docs site in examples
+        "jsx-a11y/anchor-is-valid": "off"
       }
     },
     {


### PR DESCRIPTION
This rule doesn't help us with our docs examples, where we want to avoid directing the user off our docs site.