### PR TITLE
Upsell: Remove with limit to content and add `height` property to images

### DIFF
--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -76,6 +76,7 @@ type Props = {|
       wash?: boolean,
     |},
     width?: number,
+    height?: number,
   |},
   /**
    * Main content of Upsell, explains what is being offered or recommended. Content should be [localized](https://gestalt.pinterest.systems/web/upsell#Localization). See the [Message variant](https://gestalt.pinterest.systems/web/upsell#Message) to learn more.
@@ -208,6 +209,7 @@ export default function Upsell({
               marginBottom={4}
               smMarginBottom={0}
               width={isImage ? Math.min(imageData.width || 128, 128) : undefined}
+              height={isImage ? Math.min(imageData.height || 128, 128) : undefined}
             >
               <Mask rounding={imageData.mask?.rounding || 0} wash={imageData.mask?.wash || false}>
                 {imageData.component}
@@ -227,7 +229,7 @@ export default function Upsell({
             smMarginEnd={6}
             smMarginStart={imageData ? 6 : 0}
           >
-            <Box maxWidth={648}>
+            <Box>
               {title && (
                 <Box marginBottom={2}>
                   <Text

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -20,11 +20,6 @@ exports[`<Upsell /> Basic Upsell 1`] = `
       >
         <div
           className="box"
-          style={
-            Object {
-              "maxWidth": 648,
-            }
-          }
         >
           <div
             className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -57,6 +52,7 @@ exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
         className="box flexNone marginBottom4 smMarginBottom0"
         style={
           Object {
+            "height": undefined,
             "width": undefined,
           }
         }
@@ -90,11 +86,6 @@ exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
       >
         <div
           className="box"
-          style={
-            Object {
-              "maxWidth": 648,
-            }
-          }
         >
           <div
             className="box marginBottom2"
@@ -268,6 +259,7 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] 
         className="box flexNone marginBottom4 smMarginBottom0"
         style={
           Object {
+            "height": undefined,
             "width": undefined,
           }
         }
@@ -301,11 +293,6 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] 
       >
         <div
           className="box"
-          style={
-            Object {
-              "maxWidth": 648,
-            }
-          }
         >
           <div
             className="box marginBottom2"
@@ -440,11 +427,6 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton 1`] = `
       >
         <div
           className="box"
-          style={
-            Object {
-              "maxWidth": 648,
-            }
-          }
         >
           <div
             className="box marginBottom2"
@@ -579,11 +561,6 @@ exports[`<Upsell /> message + title + primaryAction + secondaryAction 1`] = `
       >
         <div
           className="box"
-          style={
-            Object {
-              "maxWidth": 648,
-            }
-          }
         >
           <div
             className="box marginBottom2"
@@ -708,11 +685,6 @@ exports[`<Upsell /> message + title + primaryAction with href 1`] = `
       >
         <div
           className="box"
-          style={
-            Object {
-              "maxWidth": 648,
-            }
-          }
         >
           <div
             className="box marginBottom2"
@@ -798,11 +770,6 @@ exports[`<Upsell /> message + title + primaryAction without href 1`] = `
       >
         <div
           className="box"
-          style={
-            Object {
-              "maxWidth": 648,
-            }
-          }
         >
           <div
             className="box marginBottom2"
@@ -878,11 +845,6 @@ exports[`<Upsell /> message + title 1`] = `
       >
         <div
           className="box"
-          style={
-            Object {
-              "maxWidth": 648,
-            }
-          }
         >
           <div
             className="box marginBottom2"


### PR DESCRIPTION
### Summary

#### Motivation

1. With limit of upsell content, as you can see on image below, when we working with large width viewports the upsell content is limited to `648px`, so this PR is removing this limitation to enable more flexibility  to our users.

![Content with maxWidth="648px"](https://user-images.githubusercontent.com/16820917/224427165-e23d2d20-92f3-49a3-a1ce-b72463794fb8.png)

2. Other case is if we add a image to the Upsell and only set the `width` the image is not rendered as you can see on the image below:

![Image is not rendered](https://user-images.githubusercontent.com/16820917/224427451-a49236a6-a596-4acf-a618-f5eeb74eee19.png)

Code example to see this problems:
```js
<Box width={1240}>
      <Upsell
        dismissButton={{
          accessibilityLabel: 'Dissmiss text',
          onDismiss: () => {},
        }}
        imageData={{
          component: (
             <Image
              alt="Alt image"
              naturalHeight={204}
              naturalWidth={177}
              src="https://i.pinimg.com/originals/88/3f/0f/883f0f0a59468be758f8e67774e00600.png"
              fit="contain"
            />
          ),
          width: 64
        }}
        primaryAction={{
          href: 'https://pinterest.com',
          onClick: () => {},
          target: 'blank',
          label: 'Click here',
          accessibilityLabel: 'Click here',
        }}
        title='Good title'
        message='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed enim ante, ultricies sollicitudin mauris sed, porttitor mollis orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus in iaculis odio. Ut in risus quam. Nunc gravida enim at nulla iaculis fermentum id a magna. Aenean pulvinar enim orci, a sodales est aliquet a.'
      />
    </Box>
```

#### What change?

The limitation of content was removed, so the container now show a full width `message` prop content. And was added a new property called height to  `imageData` object to set the height of image rendered.

### Checklist

- [x] Added unit and Flow Tests
- [x] Update snapshots
