### PR TITLE
Docs: remove extra TextField on Foundations forms

### DIFF
--- a/docs/pages/foundations/forms/available_components.js
+++ b/docs/pages/foundations/forms/available_components.js
@@ -129,46 +129,6 @@ export default function FormComponentsPage(): Node {
           </Text>
         </Flex>
       </MainSection>
-      <MainSection name="TextField2">
-        <Example
-          id="textfield-example-2"
-          name="TextField example"
-          showCode={false}
-          showHeading={false}
-          defaultCode={` function Example(props) {
-            const [value, setValue] = React.useState('');
-
-            return (
-              <Box width={500}>
-                <TextField
-                  autoComplete="username"
-                  id="header-example"
-                  label="Username"
-                  onChange={({ value }) => {
-                    setValue(value);
-                  }}
-                  placeholder="Please enter your username"
-                  type="text"
-                  value={value}
-                />
-              </Box>
-            );
-          }
-        `}
-        />
-        <Flex direction="column" gap={4}>
-          <Text>
-            TextField is used for single lines of text. It also allows for other types of inputs
-            like passwords and Tags.
-          </Text>
-
-          <Text>
-            <Link href="/web/textfield" underline="always">
-              Go to the TextField component
-            </Link>
-          </Text>
-        </Flex>
-      </MainSection>
       <MainSection name="DatePicker">
         <Example
           id="datepickerExample"


### PR DESCRIPTION
### Summary
There was an extra TextField example on the Available components page. It was removed.

#### What changed?
Removed TextField2.

#### Why?
 It's not needed. Was left over from copy and pasting examples.


### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
