### PR TITLE
ModalAlert, Button: add dataTestId

### DIFF
--- a/docs/docs-components/docgen.js
+++ b/docs/docs-components/docgen.js
@@ -23,6 +23,10 @@ export type DocGen = {|
   |},
 |};
 
+export type DocType = {|
+  generatedDocGen: DocGen,
+|};
+
 export default function docgen({ componentName }: {| componentName: string |}): DocGen {
   return metadata[componentName];
 }

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -1,15 +1,16 @@
 // @flow strict
 import { type Node } from 'react';
 import { Button, SlimBanner } from 'gestalt';
-import PropTable from '../../docs-components/PropTable.js';
-import CombinationNew from '../../docs-components/CombinationNew.js';
-import PageHeader from '../../docs-components/PageHeader.js';
-import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
+import CombinationNew from '../../docs-components/CombinationNew.js';
+import docgen, { type DocGen, type DocType } from '../../docs-components/docgen.js';
 import MainSection from '../../docs-components/MainSection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
 import Page from '../../docs-components/Page.js';
+import PageHeader from '../../docs-components/PageHeader.js';
+import PropTable from '../../docs-components/PropTable.js';
+import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
+
 import main from '../../examples/button/main.js';
 import placePrimaryButtonDo from '../../examples/button/placePrimaryButtonDo.js';
 import placePrimaryButtonDont from '../../examples/button/placePrimaryButtonDont.js';
@@ -33,11 +34,7 @@ import buttonPopoverExample from '../../examples/button/buttonPopoverExample.js'
 
 const PREVIEW_HEIGHT = 300;
 
-type DocType = {|
-  generatedDocGen: DocGen,
-|};
-
-export default function ButtonPage({ generatedDocGen }: DocType): Node {
+export default function DocsPage({ generatedDocGen }: DocType): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
       <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
@@ -85,6 +82,14 @@ export default function ButtonPage({ generatedDocGen }: DocType): Node {
             required: false,
             defaultValue: 'gray',
             description: ['The background color of Button.'],
+          },
+          {
+            name: 'dataTestId',
+            type: 'string',
+            required: false,
+            description: [
+              'Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.',
+            ],
           },
           {
             name: 'disabled',

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -8,20 +8,20 @@ import {
   type AbstractComponent,
 } from 'react';
 import classnames from 'classnames';
+import { type AbstractEventHandler } from './AbstractEventHandler.js';
+import { useColorScheme } from './contexts/ColorSchemeProvider.js';
+import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import Flex from './Flex.js';
 import focusStyles from './Focus.css';
+import Icon, { type IconColor } from './Icon.js';
 import icons from './icons/index.js';
+import InternalLink from './InternalLink.js';
+import NewTabAccessibilityLabel, { getAriaLabel } from './NewTabAccessibilityLabel.js';
 import styles from './Button.css';
 import Text from './Text.js';
 import touchableStyles from './TapArea.css';
 import useFocusVisible from './useFocusVisible.js';
 import useTapFeedback from './useTapFeedback.js';
-import InternalLink from './InternalLink.js';
-import Icon, { type IconColor } from './Icon.js';
-import { useColorScheme } from './contexts/ColorSchemeProvider.js';
-import { type AbstractEventHandler } from './AbstractEventHandler.js';
-import NewTabAccessibilityLabel, { getAriaLabel } from './NewTabAccessibilityLabel.js';
-import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 
 const DEFAULT_TEXT_COLORS = {
   blue: 'inverse',
@@ -39,6 +39,8 @@ const SIZE_NAME_TO_PIXEL = {
   lg: 12,
 };
 
+type Target = null | 'self' | 'blank';
+
 type BaseButton = {|
   accessibilityLabel?: string,
   color?:
@@ -49,6 +51,7 @@ type BaseButton = {|
     | 'semiTransparentWhite'
     | 'transparentWhiteText'
     | 'white',
+  dataTestId?: string,
   disabled?: boolean,
   iconEnd?: $Keys<typeof icons>,
   fullWidth?: boolean,
@@ -86,7 +89,7 @@ type LinkButtonType = {|
   href: string,
   rel?: 'none' | 'nofollow',
   role: 'link',
-  target?: null | 'self' | 'blank',
+  target?: Target,
 |};
 
 type unionProps = ButtonType | SubmitButtonType | LinkButtonType;
@@ -100,7 +103,7 @@ function InternalButtonContent({
   icon,
   size,
 }: {|
-  target?: null | 'self' | 'blank',
+  target?: Target,
   text: Node,
   textColor: IconColor,
   icon?: $Keys<typeof icons>,
@@ -138,6 +141,7 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
   const {
     accessibilityLabel,
     color = 'gray',
+    dataTestId,
     disabled = false,
     fullWidth = false,
     iconEnd,
@@ -237,6 +241,7 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
       <InternalLink
         accessibilityLabel={ariaLabel}
         colorClass={colorClass}
+        dataTestId={dataTestId}
         disabled={disabled}
         fullWidth={fullWidth}
         href={href}
@@ -267,6 +272,7 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
       <button
         aria-label={accessibilityLabel}
         className={baseTypeClasses}
+        data-test-id={dataTestId}
         disabled={disabled}
         name={name}
         onBlur={handleBlur}
@@ -296,6 +302,7 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
       aria-haspopup={accessibilityHaspopup}
       aria-label={accessibilityLabel}
       className={parentButtonClasses}
+      data-test-id={dataTestId}
       disabled={disabled}
       name={name}
       onBlur={handleBlur}

--- a/packages/gestalt/src/InternalLink.js
+++ b/packages/gestalt/src/InternalLink.js
@@ -27,6 +27,7 @@ type Props = {|
   accessibilityLabel?: string,
   children?: Node,
   colorClass?: string,
+  dataTestId?: string,
   disabled?: boolean,
   fullHeight?: boolean,
   fullWidth?: boolean,
@@ -63,6 +64,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
     accessibilityLabel,
     children,
     colorClass,
+    dataTestId,
     disabled,
     fullHeight,
     fullWidth,
@@ -181,6 +183,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
       aria-selected={accessibilityCurrent === 'section' ? accessibilityCurrent : undefined}
       aria-label={accessibilityLabel}
       className={className}
+      data-test-id={dataTestId}
       href={disabled ? undefined : href}
       id={id}
       onBlur={(event) => {

--- a/packages/gestalt/src/ModalAlert.js
+++ b/packages/gestalt/src/ModalAlert.js
@@ -1,17 +1,15 @@
 // @flow strict
 import { type Node } from 'react';
-import Box from './Box.js';
-import Button from './Button.js';
 import Flex from './Flex.js';
-import Heading from './Heading.js';
-import Icon from './Icon.js';
-import IconButton from './IconButton.js';
 import Modal from './Modal.js';
+import ModalAlertAction from './ModalAlert/ModalAlertAction.js';
+import ModalAlertHeader from './ModalAlert/ModalAlertHeader.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import DeviceTypeProvider from './contexts/DeviceTypeProvider.js';
 
-type ActionDataType = {|
+export type ActionDataType = {|
   accessibilityLabel: string,
+  dataTestId?: string,
   disabled?: boolean,
   href?: string,
   label: string,
@@ -66,93 +64,6 @@ type Props = {|
   secondaryAction?: ActionDataType,
 |};
 
-const ICON_COLOR_MAP = {
-  error: {
-    icon: 'workflow-status-problem',
-    color: 'error',
-  },
-  warning: {
-    icon: 'workflow-status-warning',
-    color: 'warning',
-  },
-};
-
-function Header({
-  accessibilityDismissButtonLabel,
-  type,
-  heading,
-  onDismiss,
-}: {|
-  accessibilityDismissButtonLabel: string,
-  type: 'default' | 'warning' | 'error',
-  heading: string,
-  onDismiss: () => void,
-|}) {
-  return (
-    <Flex flex="grow" alignItems="center" gap={4}>
-      {type !== 'default' && (
-        <Box>
-          <Icon
-            size="20"
-            accessibilityLabel={type}
-            icon={ICON_COLOR_MAP[type].icon}
-            color={ICON_COLOR_MAP[type].color}
-          />
-        </Box>
-      )}
-      <Flex.Item flex="grow">
-        <Heading size="400" accessibilityLevel={1}>
-          {heading}
-        </Heading>
-      </Flex.Item>
-      {type === 'default' && (
-        <Box marginStart={2}>
-          <IconButton
-            accessibilityLabel={accessibilityDismissButtonLabel}
-            bgColor="white"
-            icon="cancel"
-            iconColor="darkGray"
-            onClick={onDismiss}
-            size="sm"
-          />
-        </Box>
-      )}
-    </Flex>
-  );
-}
-
-function ModalAlertAction({ data, type }: {| data: ActionDataType, type: string |}): Node {
-  const color = type === 'primary' ? 'red' : 'gray';
-  const { accessibilityLabel, disabled, label, onClick, href, rel, target } = data;
-  return href ? (
-    <Button
-      accessibilityLabel={accessibilityLabel}
-      color={color}
-      disabled={disabled}
-      href={href}
-      fullWidth
-      onClick={onClick}
-      iconEnd="visit"
-      rel={rel}
-      role="link"
-      size="lg"
-      target={target}
-      text={label}
-    />
-  ) : (
-    <Button
-      accessibilityLabel={accessibilityLabel}
-      disabled={disabled}
-      color={color}
-      onClick={onClick}
-      fullWidth
-      role="button"
-      size="lg"
-      text={label}
-    />
-  );
-}
-
 /**
  * A [ModalAlert](https://gestalt.pinterest.systems/web/modalalert) is a simple modal dialog used to alert a user of an issue, or to request confirmation after a user-triggered action. ModalAlert overlays and blocks page content until it is dismissed by the user.
  *
@@ -195,12 +106,12 @@ export default function ModalAlert({
         closeOnOutsideClick={type === 'default'}
         footer={
           <Flex justifyContent="end" gap={2}>
-            {secondaryAction && <ModalAlertAction type="secondary" data={secondaryAction} />}
-            {primaryAction && <ModalAlertAction type="primary" data={primaryAction} />}
+            {secondaryAction && <ModalAlertAction type="secondary" {...secondaryAction} />}
+            {primaryAction && <ModalAlertAction type="primary" {...primaryAction} />}
           </Flex>
         }
         heading={
-          <Header
+          <ModalAlertHeader
             type={type}
             heading={heading}
             onDismiss={onDismiss}

--- a/packages/gestalt/src/ModalAlert/ModalAlertAction.js
+++ b/packages/gestalt/src/ModalAlert/ModalAlertAction.js
@@ -1,0 +1,50 @@
+// @flow strict
+import { type Node } from 'react';
+import Button from '../Button.js';
+import { type ActionDataType } from '../ModalAlert.js';
+
+type Props = {| ...ActionDataType, type: string |};
+
+export default function ModalAlertAction({
+  accessibilityLabel,
+  dataTestId,
+  disabled,
+  label,
+  onClick,
+  href,
+  rel,
+  target,
+  type,
+}: Props): Node {
+  const color = type === 'primary' ? 'red' : 'gray';
+
+  return href ? (
+    <Button
+      accessibilityLabel={accessibilityLabel}
+      color={color}
+      dataTestId={dataTestId}
+      disabled={disabled}
+      href={href}
+      fullWidth
+      onClick={onClick}
+      iconEnd="visit"
+      rel={rel}
+      role="link"
+      size="lg"
+      target={target}
+      text={label}
+    />
+  ) : (
+    <Button
+      accessibilityLabel={accessibilityLabel}
+      dataTestId={dataTestId}
+      disabled={disabled}
+      color={color}
+      onClick={onClick}
+      fullWidth
+      role="button"
+      size="lg"
+      text={label}
+    />
+  );
+}

--- a/packages/gestalt/src/ModalAlert/ModalAlertHeader.js
+++ b/packages/gestalt/src/ModalAlert/ModalAlertHeader.js
@@ -1,0 +1,64 @@
+// @flow strict
+import { type Node } from 'react';
+import Box from '../Box.js';
+import Flex from '../Flex.js';
+import Heading from '../Heading.js';
+import Icon from '../Icon.js';
+import IconButton from '../IconButton.js';
+
+const ICON_COLOR_MAP = {
+  error: {
+    icon: 'workflow-status-problem',
+    color: 'error',
+  },
+  warning: {
+    icon: 'workflow-status-warning',
+    color: 'warning',
+  },
+};
+
+type Props = {|
+  accessibilityDismissButtonLabel: string,
+  type: 'default' | 'warning' | 'error',
+  heading: string,
+  onDismiss: () => void,
+|};
+
+export default function Header({
+  accessibilityDismissButtonLabel,
+  type,
+  heading,
+  onDismiss,
+}: Props): Node {
+  return (
+    <Flex flex="grow" alignItems="center" gap={4}>
+      {type !== 'default' && (
+        <Box>
+          <Icon
+            size="20"
+            accessibilityLabel={type}
+            icon={ICON_COLOR_MAP[type].icon}
+            color={ICON_COLOR_MAP[type].color}
+          />
+        </Box>
+      )}
+      <Flex.Item flex="grow">
+        <Heading size="400" accessibilityLevel={1}>
+          {heading}
+        </Heading>
+      </Flex.Item>
+      {type === 'default' && (
+        <Box marginStart={2}>
+          <IconButton
+            accessibilityLabel={accessibilityDismissButtonLabel}
+            bgColor="white"
+            icon="cancel"
+            iconColor="darkGray"
+            onClick={onDismiss}
+            size="sm"
+          />
+        </Box>
+      )}
+    </Flex>
+  );
+}

--- a/packages/gestalt/src/ModalAlert/ModalAlertHeader.js
+++ b/packages/gestalt/src/ModalAlert/ModalAlertHeader.js
@@ -24,7 +24,7 @@ type Props = {|
   onDismiss: () => void,
 |};
 
-export default function Header({
+export default function ModalAlertHeader({
   accessibilityDismissButtonLabel,
   type,
   heading,


### PR DESCRIPTION
### Summary

#### What changed?

Adding `dataTestId` to the actions on ModalAlert, which necessitates also adding that prop to Button.

_(note the URL, linking to RTL docs trying to convince people not to use dataTestIds for unit tests)_
![Screen Shot 2023-03-13 at 6 56 50 PM](https://user-images.githubusercontent.com/12059539/224873299-9f1abbcc-f6aa-47cb-92b7-1b421a177471.png)

![Screen Shot 2023-03-13 at 6 57 12 PM](https://user-images.githubusercontent.com/12059539/224873302-aa54d473-4c87-460e-bad9-cee59da92c64.png)


#### Why?

Request from a team refactoring a custom modal to use ModalAlert. Needed for integration tests, where we prefer to use stable test ids rather than labels that may change.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5886)