### PR TITLE
Pog, IconButton: bugfix for rotated icons on iPhone

### DIFF
--- a/packages/gestalt/src/Pog.css
+++ b/packages/gestalt/src/Pog.css
@@ -3,6 +3,10 @@
   composes: flex from "./Layout.css";
   composes: xsItemsCenter from "./Layout.css";
   composes: justifyCenter from "./Layout.css";
+
+  /* This fixes a mobile Safari bug (device only) that makes the icon disappear when rotated for RTL support
+  https://stackoverflow.com/a/28617071/5253702 */
+  perspective: 1px;
 }
 
 .focused {


### PR DESCRIPTION
This is a weird one. 

To support RTL languages, we rotate some icons by 180 rather than use a different SVG. On mobile Safari (device only!), this presents a problem:
![Arabic](https://user-images.githubusercontent.com/12059539/225174767-8e8b69fe-2b93-48fa-a61c-2336d41093fd.jpg)

Apparently this is a known bug on mobile Safari going back to at least 2015 (!) and still not fixed. Actually, it's kind of a combination of two bugs:
- [mobile Safari can't handle rotating SVGs in multiples of 90](https://9to5answer.com/svg-transform-rotate-by-90-180-or-270-degrees-not-working-on-circle-in-safari-ios-10)
- [mobile Safari can't handle rotating SVGs at all](https://stackoverflow.com/a/28617071/5253702)

Though it wouldn't be a shippable solution, I explored the "90° problem" by adjusting our rotation to 179°. The results are…not great:
![image0](https://user-images.githubusercontent.com/12059539/225175979-9f6f7974-e307-427e-8dcd-196e2ec70a4c.png)
![Screen Shot 2023-03-14 at 5 39 06 PM](https://user-images.githubusercontent.com/12059539/225176000-f4bebdbf-c0d1-4ac4-9df3-b37ee7317c9d.png)

It turns out the real solution is to add [the CSS property `perspective`](https://developer.mozilla.org/en-US/docs/Web/CSS/perspective) to the surrounding `div` — something usually used with 3-D objects ¯\_(ツ)_/¯ 
![image1](https://user-images.githubusercontent.com/12059539/225176482-bd5dbe95-c094-409a-aa29-881efefa1863.png)
![Screen Shot 2023-03-14 at 5 38 03 PM](https://user-images.githubusercontent.com/12059539/225176514-4de4cb31-db4f-471b-9215-a4c34483cf6e.png)

Therefore adding this property to Pog should solve this issue for IconButton and (hopefully) all other places where it might arise.

### Links

- [Jira](https://jira.pinadmin.com/browse/BUG-153866)
