### PR TITLE
Github Workflow: Auto-Format and Commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
     name: 'Format and Commit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.head_ref }
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   format:
     name: 'Format and Commit Changes'
+    if: ${{ github.event.pull_request.head.repo.full_name == 'pinterest/gestalt' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,37 @@ on:
   push:
     branches:
       - master
-
+permissions:
+  # Give the default GITHUB_TOKEN write permission to commit and push the
+  # added or changed files to the repository for the formatting changes
+  contents: write
 jobs:
+  format:
+    name: 'Format and Commit'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18.x'
+      - name: Install Prettier
+        run: npm install -g prettier@2.8.0
+      - name: Run Formatter
+        run: yarn format
+      - name: Set Author Details
+        run: |
+          git config --global user.email "pinterest-gestalt@gmail.com"
+          git config --global user.name "Pinterest-Gestalt"
+      - name: Commit Formatting Changes (if any)
+        run: |
+          git add -A && git commit -m "Applying Auto Formatting Changes" || echo "No changes to commit"
+          git push
   test:
     name: Tests
     runs-on: ubuntu-latest
+    needs: format
     strategy:
       matrix:
         node_version: [16, 18]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.head_ref }
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: '18.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 jobs:
   format:
-    name: 'Format and Commit'
+    name: 'Format and Commit Changes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/docs/pages/android/overview.js
+++ b/docs/pages/android/overview.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node } from 'react';
+import { type Node } from "react";
 import COMPONENT_DATA from '../../docs-components/COMPONENT_DATA.js';
 import Overview from '../../docs-components/Overview.js';
 

--- a/docs/pages/android/overview.js
+++ b/docs/pages/android/overview.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from "react";
-import COMPONENT_DATA from '../../docs-components/COMPONENT_DATA.js';
+import COMPONENT_DATA from "../../docs-components/COMPONENT_DATA.js";
 import Overview from '../../docs-components/Overview.js';
 
 export default function ComponentOverview(): Node {


### PR DESCRIPTION
See comments on https://github.com/pinterest/gestalt/pull/2705

### Summary
Run `yarn format` and commit the results if there are auto-fixes. 

This enables us to do simple changes from the browser, and not worry about linting. 

Since we already have a build preview in place, this should be a good addition to faster changes from the web.

The source for this workflow is derived from this blog post:
https://mskelton.medium.com/auto-formatting-code-using-prettier-and-github-actions-ed458f58b7df

#### What changed and Why?

For a PR as tiny as this one https://github.com/pinterest/gestalt/pull/2702. It's frustrating to pull the branch code, and do the changes on my machine, run it locally and blah, because of a tiny formatting issue. It's likely an extra space. 

Likewise, to make changes to a [file](https://github.com/pinterest/gestalt/blob/master/docs/pages/get_started/faq.js) like this (e.g. add a new section). It should be fairly easy to do by copy-pasting, and adding an answer from the web console, but formatting becomes a pain. 

Soo hoping this step makes these kind of changes faster

 