### PR TITLE
IconButtonFloating: Add `disabled` prop

### DIFF
--- a/packages/gestalt/src/IconButtonFloating.js
+++ b/packages/gestalt/src/IconButtonFloating.js
@@ -22,6 +22,10 @@ type Props = {|
    */
   accessibilityLabel: string,
   /**
+   * When disabled, IconButtonFloating looks inactive and cannot be interacted with
+   */
+  disabled?: boolean,
+  /**
    * Icon displayed in IconButtonFloating to convey the behavior of the component. Refer to the [iconography](/foundations/iconography/library) guidelines regarding the available icon options.
    */
   icon: $Keys<typeof icons>,
@@ -64,6 +68,7 @@ const IconButtonFloatingWithForwardRef: AbstractComponent<Props, unionRefs> = fo
     accessibilityExpanded,
     accessibilityPopupRole,
     accessibilityLabel,
+    disabled,
     icon,
     onClick,
     selected,
@@ -78,6 +83,7 @@ const IconButtonFloatingWithForwardRef: AbstractComponent<Props, unionRefs> = fo
         accessibilityPopupRole={accessibilityPopupRole}
         accessibilityLabel={accessibilityLabel}
         bgColor="transparent"
+        disabled={disabled}
         icon={icon}
         onClick={onClick}
         ref={ref}


### PR DESCRIPTION
### Summary

#### What changed?

This PR is adding a property `disabled` to IconButtonFloating.

#### Why?

[This deprecation ticket](https://jira.pinadmin.com/browse/GESTALT-5478) is changing a Pinboard code based which has the follow behaviour:

1. While the user not select one of pins on organize screen, the IconButtonFloating, on footer of screen, should be disabled;
2. After one of pins is selected the IconButtonFloating should be enabled;

To get more context, please look at [this video](https://capture.dropbox.com/8RzrpABsVStH5XpS)

The video above was sent to @hectoid and @ponori and both of them understanding the `disabled` prop should be present on this component.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5478)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [X] Checked stakeholder feedback (e.g. @hectoid e @ponori )
