### PR TITLE
IconButtonFloating - Add `dangerouslySetSvgPath` prop

### DIFF
--- a/packages/gestalt/src/IconButtonFloating.js
+++ b/packages/gestalt/src/IconButtonFloating.js
@@ -22,6 +22,10 @@ type Props = {|
    */
   accessibilityLabel: string,
   /**
+   * Defines a new icon different from the built-in Gestalt icons. See [custom icon](#Custom-icon) variant to learn more.
+   */
+  dangerouslySetSvgPath?: {| __path: string |},
+  /**
    * When disabled, IconButtonFloating looks inactive and cannot be interacted with
    */
   disabled?: boolean,
@@ -68,6 +72,7 @@ const IconButtonFloatingWithForwardRef: AbstractComponent<Props, unionRefs> = fo
     accessibilityExpanded,
     accessibilityPopupRole,
     accessibilityLabel,
+    dangerouslySetSvgPath,
     disabled,
     icon,
     onClick,
@@ -83,6 +88,7 @@ const IconButtonFloatingWithForwardRef: AbstractComponent<Props, unionRefs> = fo
         accessibilityPopupRole={accessibilityPopupRole}
         accessibilityLabel={accessibilityLabel}
         bgColor="transparent"
+        dangerouslySetSvgPath={dangerouslySetSvgPath}
         disabled={disabled}
         icon={icon}
         onClick={onClick}


### PR DESCRIPTION
### Summary

#### What changed?

This PR is adding a property `dangerouslySetSvgPath` to IconButtonFloating.

#### Why?

[This deprecation ticket](https://jira.pinadmin.com/browse/GESTALT-5478) is changing a Pinboard code based which has two icons out of our library but is in review of our Design System team.

The current solution is to keep the icons until their added to our code base;

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5478)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [X] Checked stakeholder feedback (e.g. @hectoid e @ponori )
