### PR TITLE
OverlayPanel: remove from iOS/Android overview pages

### DIFF
--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -2166,7 +2166,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
       },
       badge: null,
       deprecated: false,
-      documentation: 'ready',
+      documentation: 'notAvailable',
       figma: null,
     },
     iOS: {
@@ -2179,7 +2179,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
       },
       badge: null,
       deprecated: false,
-      documentation: 'ready',
+      documentation: 'notAvailable',
       figma: null,
     },
   },


### PR DESCRIPTION
This needs to be replaced with a MobileSheet SVG when we have it