### PR TITLE
Internal: dev examples v2

### DIFF
--- a/docs/docs-components/DevelopmentEditor.js
+++ b/docs/docs-components/DevelopmentEditor.js
@@ -8,23 +8,62 @@ import theme from './atomDark.js';
 import ExampleCode from './ExampleCode.js';
 import { useDocsConfig } from './contexts/DocsConfigProvider.js';
 
+const reactImports = [
+  'Component',
+  'Children',
+  'Fragment',
+  'PureComponent',
+  'Profiler',
+  'StrictMode',
+  'Suspense',
+  'cloneElement',
+  'createContext',
+  'createElement',
+  'createFactory',
+  'createRef',
+  'forwardRef',
+  'isValidElement',
+  'lazy',
+  'memo',
+  'startTransition',
+  'useCallback',
+  'useContext',
+  'useDebugValue',
+  'useEffect',
+  'useImperativeHandle',
+  'useLayoutEffect',
+  'useMemo',
+  'useReducer',
+  'useRef',
+  'useState',
+  'version',
+];
+
+const reactRegex = new RegExp(`(${reactImports.join('|')})`, 'g');
+
+const importsToRemove = ['gestalt', 'gestalt-datepicker', 'react'];
+
+const importsToRemoveRegex = new RegExp(
+  `import (.|\n)*(${importsToRemove.map((item) => `'${item}'`).join('|')});`,
+  'g',
+);
+
 export default function DevelopmentEditor({ code }: {| code: ?string | (() => Node) |}): Node {
   const { showDevelopmentEditor } = useDocsConfig();
+  if (!showDevelopmentEditor) {
+    return null;
+  }
 
   const scope = { ...gestalt, DatePicker };
 
-  const regex = /import (.|\n)*('gestalt'|'react');/gi;
-
-  // Add more React API methods if needed
-  const regexReact = /(Fragment|useState|useRef|useEffect)/gi;
-
   const codeFileCleaned = code
     ?.toString()
-    .replace(regex, '')
+    // Remove imports
+    .replace(importsToRemoveRegex, '')
+    // Remove export statement
     .replace('export default', '')
-    .replace(regexReact, 'React.$&');
-
-  if (!showDevelopmentEditor) return null;
+    // Add React. to React imports
+    .replace(reactRegex, 'React.$&');
 
   return (
     <Box
@@ -55,7 +94,8 @@ export default function DevelopmentEditor({ code }: {| code: ?string | (() => No
                 <br />
                 <br />
                 To show the Sandpack preview during development, you can enable it on the site
-                settings dropdown in the page header. To render you local changes in Sandpack append
+                settings dropdown in the page header. To render your local changes in Sandpack
+                append
                 <br />
                 <code>?localFiles=true</code>
                 <br /> after the component name in the URL.{' '}

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -28,8 +28,14 @@ function SettingsDropdown({
 |}) {
   const { showDevelopmentEditor } = useDocsConfig();
 
-  const { colorScheme, setColorScheme, textDirection, setTextDirection, sandpack, setSandpack } =
-    useAppContext();
+  const {
+    colorScheme,
+    setColorScheme,
+    textDirection,
+    setTextDirection,
+    devExampleMode,
+    setDevExampleMode,
+  } = useAppContext();
 
   const colorSchemeCopy = colorScheme === 'light' ? 'Dark-Mode View' : 'Light-Mode View';
 
@@ -46,10 +52,10 @@ function SettingsDropdown({
     return setTextDirection(textDirection === 'rtl' ? 'ltr' : 'rtl');
   };
 
-  const onChangeSandpackVisibility = () => {
-    trackButtonClick('Toggle Sandpack visibility', sandpack);
+  const onChangeDevExampleMode = () => {
+    trackButtonClick('Toggle Sandpack visibility', devExampleMode);
     closeDropdown();
-    return setSandpack(sandpack === 'enabled' ? 'disabled' : 'enabled');
+    return setDevExampleMode(devExampleMode === 'sandpack' ? 'classic' : 'sandpack');
   };
 
   return (
@@ -62,17 +68,9 @@ function SettingsDropdown({
     >
       <Dropdown.Item
         onSelect={onChangeColorScheme}
-        option={{ value: 'isDarkMode', label: 'Custom link 1' }}
+        option={{ value: 'isDarkMode', label: 'Toggle dark mode' }}
       >
-        <Flex
-          alignItems="center"
-          justifyContent="between"
-          flex="grow"
-          gap={{
-            row: 8,
-            column: 0,
-          }}
-        >
+        <Flex alignItems="center" justifyContent="between" flex="grow" gap={8}>
           <Label htmlFor="darkMode-switch">
             <Text weight="bold">Dark mode</Text>
           </Label>
@@ -83,19 +81,12 @@ function SettingsDropdown({
           />
         </Flex>
       </Dropdown.Item>
+
       <Dropdown.Item
         onSelect={onChangeTextDirection}
-        option={{ value: 'isRTL', label: 'Custom link 1' }}
+        option={{ value: 'isRTL', label: 'Toggle text direction' }}
       >
-        <Flex
-          alignItems="center"
-          justifyContent="between"
-          flex="grow"
-          gap={{
-            row: 8,
-            column: 0,
-          }}
-        >
+        <Flex alignItems="center" justifyContent="between" flex="grow" gap={8}>
           <Label htmlFor="rtl-switch">
             <Text weight="bold">Right-to-left</Text>
           </Label>
@@ -106,27 +97,20 @@ function SettingsDropdown({
           />
         </Flex>
       </Dropdown.Item>
+
       {showDevelopmentEditor ? (
         <Dropdown.Item
-          onSelect={onChangeSandpackVisibility}
-          option={{ value: 'sandpack', label: 'sandpack' }}
+          onSelect={onChangeDevExampleMode}
+          option={{ value: 'sandpack', label: 'Toggle dev example mode' }}
         >
-          <Flex
-            alignItems="center"
-            justifyContent="between"
-            flex="grow"
-            gap={{
-              row: 8,
-              column: 0,
-            }}
-          >
-            <Label htmlFor="sandpack">
-              <Text weight="bold">Enable Sandpack</Text>
+          <Flex alignItems="center" justifyContent="between" flex="grow" gap={8}>
+            <Label htmlFor="devExampleMode-switch">
+              <Text weight="bold">Disable Sandpack</Text>
             </Label>
             <Switch
-              switched={sandpack === 'enabled'}
-              onChange={onChangeSandpackVisibility}
-              id="sandpack"
+              switched={devExampleMode === 'classic'}
+              onChange={onChangeDevExampleMode}
+              id="devExampleMode-switch"
             />
           </Flex>
         </Dropdown.Item>

--- a/docs/docs-components/SandpackExample.js
+++ b/docs/docs-components/SandpackExample.js
@@ -121,86 +121,83 @@ export default function SandpackExample({
 |}): Node {
   const { files } = useLocalFiles();
 
-  const { sandpack } = useAppContext();
+  const { devExampleMode } = useAppContext();
 
-  return (
-    <Fragment>
-      <DevelopmentEditor code={code} />
-      {/* Based on //
-      https://github.com/codesandbox/sandpack/blob/53811bb4fdfb66ea95b9881ff18c93307f12ce0d/sandpack-react/src/presets/Sandpack.tsx#L67 */}
-      {process.env.NODE_ENV === 'production' || sandpack === 'enabled' ? (
-        <SandpackProvider
-          template="react"
-          files={{
-            '/styles.css': {
-              code: `@import "gestalt/dist/gestalt.css";
+  return process.env.NODE_ENV === 'production' || devExampleMode === 'sandpack' ? (
+    <SandpackProvider
+      /* Based on //
+      https://github.com/codesandbox/sandpack/blob/53811bb4fdfb66ea95b9881ff18c93307f12ce0d/sandpack-react/src/presets/Sandpack.tsx#L67 */
+      template="react"
+      files={{
+        '/styles.css': {
+          code: `@import "gestalt/dist/gestalt.css";
           @import "gestalt-datepicker/dist/gestalt-datepicker.css";
           * { margin: 0; padding: 0;}
           body, html, #root { height: 100%; }`,
-              hidden: true,
-            },
-            ...(files
-              ? {
-                  // More info at https://twitter.com/CompuIves/status/1466464916441903116
-                  // Example: https://codesandbox.io/s/custom-library-in-sandpack-gq12p?file=/src/App.js:407-672
-                  '/node_modules/gestalt/package.json': {
-                    code: JSON.stringify({
-                      name: 'gestalt',
-                      main: './dist/gestalt.js',
-                      style: 'dist/gestalt.css',
-                    }),
-                    hidden: true,
-                  },
-                  '/node_modules/gestalt-datepicker/package.json': {
-                    code: JSON.stringify({
-                      name: 'gestalt-datepicker',
-                      main: './dist/gestalt-datepicker.js',
-                      style: 'dist/gestalt-datepicker.css',
-                    }),
-                    hidden: true,
-                  },
-                  '/node_modules/gestalt/dist/gestalt.js': {
-                    code: files.js,
-                    hidden: true,
-                  },
-                  '/node_modules/gestalt-datepicker/dist/gestalt-datepicker.js': {
-                    code: files.js,
-                    hidden: true,
-                  },
-                  '/node_modules/gestalt/dist/gestalt.css': {
-                    code: files.css,
-                    hidden: true,
-                  },
-                  '/node_modules/gestalt-datepicker/dist/gestalt-datepicker.css': {
-                    code: files.css,
-                    hidden: true,
-                  },
-                }
-              : {}),
-            '/App.js': {
-              code,
-            },
-          }}
-          theme="dark"
-          customSetup={{
-            dependencies: {
-              ...(files
-                ? { classnames: 'latest' }
-                : { gestalt: 'latest', 'gestalt-datepicker': 'latest' }),
-              react: '18.2.0',
-              'react-dom': '18.2.0',
-            },
-          }}
-        >
-          <SandpackContainer
-            layout={layout}
-            name={name}
-            previewHeight={previewHeight}
-            hideControls={hideControls}
-            hideEditor={hideEditor}
-          />
-        </SandpackProvider>
-      ) : null}
-    </Fragment>
+          hidden: true,
+        },
+        ...(files
+          ? {
+              // More info at https://twitter.com/CompuIves/status/1466464916441903116
+              // Example: https://codesandbox.io/s/custom-library-in-sandpack-gq12p?file=/src/App.js:407-672
+              '/node_modules/gestalt/package.json': {
+                code: JSON.stringify({
+                  name: 'gestalt',
+                  main: './dist/gestalt.js',
+                  style: 'dist/gestalt.css',
+                }),
+                hidden: true,
+              },
+              '/node_modules/gestalt-datepicker/package.json': {
+                code: JSON.stringify({
+                  name: 'gestalt-datepicker',
+                  main: './dist/gestalt-datepicker.js',
+                  style: 'dist/gestalt-datepicker.css',
+                }),
+                hidden: true,
+              },
+              '/node_modules/gestalt/dist/gestalt.js': {
+                code: files.js,
+                hidden: true,
+              },
+              '/node_modules/gestalt-datepicker/dist/gestalt-datepicker.js': {
+                code: files.js,
+                hidden: true,
+              },
+              '/node_modules/gestalt/dist/gestalt.css': {
+                code: files.css,
+                hidden: true,
+              },
+              '/node_modules/gestalt-datepicker/dist/gestalt-datepicker.css': {
+                code: files.css,
+                hidden: true,
+              },
+            }
+          : {}),
+        '/App.js': {
+          code,
+        },
+      }}
+      theme="dark"
+      customSetup={{
+        dependencies: {
+          ...(files
+            ? { classnames: 'latest' }
+            : { gestalt: 'latest', 'gestalt-datepicker': 'latest' }),
+          react: '18.2.0',
+          'react-dom': '18.2.0',
+        },
+      }}
+    >
+      <SandpackContainer
+        layout={layout}
+        name={name}
+        previewHeight={previewHeight}
+        hideControls={hideControls}
+        hideEditor={hideEditor}
+      />
+    </SandpackProvider>
+  ) : (
+    <DevelopmentEditor code={code} />
   );
 }

--- a/docs/docs-components/appContext.js
+++ b/docs/docs-components/appContext.js
@@ -7,13 +7,13 @@ const colorSchemeKey = 'gestalt-color-scheme';
 const propTableVariantKey = 'gestalt-propTable-variant';
 const textDirectionKey = 'gestalt-text-direction';
 const experimentsKey = 'gestalt-experiments';
-const sandpacksKey = 'gestalt-sandpack';
+const devExampleModeKey = 'gestalt-devExampleMode';
 
 type PropTableVariant = 'collapsed' | 'expanded';
 type ColorScheme = 'light' | 'dark';
 type DirectionScheme = 'ltr' | 'rtl';
 type Experiments = string;
-type Sandpack = 'enabled' | 'disabled';
+type DevExampleMode = 'classic' | 'sandpack';
 
 export type AppContextType = {|
   propTableVariant: PropTableVariant,
@@ -24,8 +24,8 @@ export type AppContextType = {|
   setTextDirection: (val: DirectionScheme) => void,
   experiments: Experiments,
   setExperiments: (val: Experiments) => void,
-  sandpack: Sandpack,
-  setSandpack: (val: Sandpack) => void,
+  devExampleMode: DevExampleMode,
+  setDevExampleMode: (val: DevExampleMode) => void,
 |};
 
 const {
@@ -40,7 +40,7 @@ function AppContextProvider({ children }: {| children?: Node |}): Node {
     propTableVariantKey,
     textDirectionKey,
     experimentsKey,
-    sandpacksKey,
+    devExampleModeKey,
   ]);
 
   const colorScheme: ColorScheme = cookies[colorSchemeKey] === 'dark' ? 'dark' : 'light';
@@ -49,7 +49,8 @@ function AppContextProvider({ children }: {| children?: Node |}): Node {
   const textDirection: DirectionScheme = cookies[textDirectionKey] === 'rtl' ? 'rtl' : 'ltr';
 
   const experiments: Experiments = cookies[experimentsKey] ?? [];
-  const sandpack: Sandpack = cookies[sandpacksKey] === 'enabled' ? 'enabled' : 'disabled';
+  const devExampleMode: DevExampleMode =
+    cookies[devExampleModeKey] === 'sandpack' ? 'sandpack' : 'classic';
 
   const setColorScheme = (newColorScheme) => setCookies(colorSchemeKey, newColorScheme);
   const setPropTableVariant = (variant) => setCookies(propTableVariantKey, variant);
@@ -57,7 +58,7 @@ function AppContextProvider({ children }: {| children?: Node |}): Node {
   const setExperiments = (component) => {
     setCookies(experimentsKey, component);
   };
-  const setSandpack = (state) => setCookies(sandpacksKey, state);
+  const setDevExampleMode = (state) => setCookies(devExampleModeKey, state);
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -76,8 +77,8 @@ function AppContextProvider({ children }: {| children?: Node |}): Node {
         setTextDirection,
         experiments,
         setExperiments,
-        sandpack,
-        setSandpack,
+        devExampleMode,
+        setDevExampleMode,
       }}
     >
       {children}


### PR DESCRIPTION
This fixes some issues with the Dev Preview changes implemented in #2754:
- Adds missing React imports
- Removes 'react-datepicker' import so examples using DatePicker work
- Rethinks the approach from adding Sandpack to toggling between Sandpack and "classic" (our old code editor). This keeps general dev docs usage clean and only introduces the dev preview when the user opts into it.