### PR TITLE
Internal: Add resolution for `nth-check` to address vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "node-fetch": "^2.6.7",
     "node-forge": "^1.0.0",
     "normalize-url": "4.5.1",
+    "nth-check": "2.1.1",
     "serialize-javascript": "3.1.0",
     "trim-newlines": "3.0.1",
     "ws": "7.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12959,10 +12959,10 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-nth-check@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz"
-  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
+nth-check@2.1.1, nth-check@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
 


### PR DESCRIPTION
Addressing [this vulnerability](https://github.com/pinterest/gestalt/security/dependabot/73). The [Dependabot PR](https://github.com/pinterest/gestalt/pull/2763) is failing lots of tests, likely due to the `cssnano` major version bump.

Tracing how this sub-sub-sub-dependency is used:
nth-check
- css-select
  - svgo
    - postcss-svgo
      - cssnano-preset-default
        - cssnano *
    - babel-plugin-inline-react-svg *

* = dependency in package.json