### PR TITLE
ModalAlert: make sure docs examples are open without user interaction

### DIFF
--- a/docs/examples/modalalert/doClearCommunicate.js
+++ b/docs/examples/modalalert/doClearCommunicate.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DoClearCommunicate(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/doExplainWhy.js
+++ b/docs/examples/modalalert/doExplainWhy.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DoClearCommunicate(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/doLimitContent.js
+++ b/docs/examples/modalalert/doLimitContent.js
@@ -2,11 +2,11 @@
 import { Fragment, type Node, useState } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DoLimitContent(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/doProvideAction.js
+++ b/docs/examples/modalalert/doProvideAction.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DoClearCommunicate(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/dontDoubleOverlay.js
+++ b/docs/examples/modalalert/dontDoubleOverlay.js
@@ -2,12 +2,12 @@
 import { type Node, useState } from 'react';
 import { ModalAlert, Box, Button, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DoOverlayPage(): Node {
-  const [showCmpA, setShowComponentA] = useState(false);
-  const [showCmpB, setShowComponentB] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showCmpA, setShowComponentA] = useState(true);
+  const [showCmpB, setShowComponentB] = useState(true);
 
   return (
     <Box padding={3}>

--- a/docs/examples/modalalert/dontHardLanguage.js
+++ b/docs/examples/modalalert/dontHardLanguage.js
@@ -2,10 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DontHardLanguage(): Node {
-  const [showComponent, setShowComponent] = useState(false);
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/dontLeaveOutAction.js
+++ b/docs/examples/modalalert/dontLeaveOutAction.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DoClearCommunicate(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/dontLeaveOutExplanation.js
+++ b/docs/examples/modalalert/dontLeaveOutExplanation.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DoClearCommunicate(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/dontLongContent.js
+++ b/docs/examples/modalalert/dontLongContent.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, Flex, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DoLimitContent(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/errorMultiAction.js
+++ b/docs/examples/modalalert/errorMultiAction.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function ErrorMultiAction(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/errorSingleAction.js
+++ b/docs/examples/modalalert/errorSingleAction.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Link, Text } from 'gestalt';
 
-export default function ErrorSingleAction(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/main.js
+++ b/docs/examples/modalalert/main.js
@@ -2,11 +2,11 @@
 import { type Node, useState } from 'react';
 import { ModalAlert, Box, Button, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function DefaultExample(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function DefaultExample(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Box padding={3}>

--- a/docs/examples/modalalert/mobileExample.js
+++ b/docs/examples/modalalert/mobileExample.js
@@ -3,7 +3,7 @@ import { useState, type Node } from 'react';
 import { Layer, ModalAlert, Box, Text, DeviceTypeProvider, Button } from 'gestalt';
 
 export default function Example(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <DeviceTypeProvider deviceType="mobile">

--- a/docs/examples/modalalert/multipleActions.js
+++ b/docs/examples/modalalert/multipleActions.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function MultipleActions(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/singleAction.js
+++ b/docs/examples/modalalert/singleAction.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function SingleAction(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/warningMultiAction.js
+++ b/docs/examples/modalalert/warningMultiAction.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function WarningMultiAction(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/warningSingleAction.js
+++ b/docs/examples/modalalert/warningSingleAction.js
@@ -2,11 +2,11 @@
 import { Fragment, useState, type Node } from 'react';
 import { Box, Button, ModalAlert, CompositeZIndex, FixedZIndex, Layer, Text } from 'gestalt';
 
-export default function WarningSingleAction(): Node {
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
 
   return (
     <Fragment>

--- a/docs/examples/modalalert/withCheckbox.js
+++ b/docs/examples/modalalert/withCheckbox.js
@@ -12,12 +12,12 @@ import {
   Text,
 } from 'gestalt';
 
-export default function WithCheckbox(): Node {
-  const [checked1, setChecked1] = useState(false);
-  const [showComponent, setShowComponent] = useState(false);
+const HEADER_ZINDEX = new FixedZIndex(10);
+const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
 
-  const HEADER_ZINDEX = new FixedZIndex(10);
-  const zIndex = new CompositeZIndex([HEADER_ZINDEX]);
+export default function Example(): Node {
+  const [showComponent, setShowComponent] = useState(true);
+  const [checked1, setChecked1] = useState(false);
 
   return (
     <Fragment>


### PR DESCRIPTION
#2787 introduced changes that caused ModalAlert examples to require user interaction to be visible, degrading the UX. This PR makes sure that the examples are visible as the user scrolls through the page.