### PR TITLE
Popover: Deprecating 'orange' color

### DIFF
--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -6,7 +6,7 @@ import Flex from './Flex.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import InternalDismissButton from './shared/InternalDismissButton.js';
 
-type Color = 'blue' | 'orange' | 'red' | 'white' | 'darkGray';
+type Color = 'blue' | 'red' | 'white' | 'darkGray';
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number;
 type IdealDirection = 'up' | 'right' | 'down' | 'left';
 type Role = 'dialog' | 'listbox' | 'menu' | 'tooltip';


### PR DESCRIPTION
# Breaking change
Removing prop value color=**orange**

Run the following codemod to replace orange with red

```
yarn codemod modifyPropValue ~/path/to/your/code
  --component=Popover
  --previousProp=color
  --previousValue=orange
  --nextValue=red
```

Run the following codemod to locate orange values for manual changes

```
yarn codemod detectManualReplacement ~/path/to/your/code
 --component=Popover
 --prop=color
 --value=orange
```

### Summary
#### What changed?
Popover: deprecating color='orange'

#### Why?
New redesigns deprecate this option. Cleaning up API to facilitate next changes

### Links
* [JIRA](https://jira.pinadmin.com/browse/GESTALT-6020)

### Checklist
- [ N/A ] Changed unit and Flow Tests
- [ Yes ] Changed documentation + accessibility tests
- [ N/A ] Verified accessibility: keyboard & screen reader interaction
- [ N/A ] Checked dark mode, responsiveness, and right-to-left support
- [ Yes ] Checked stakeholder feedback (e.g. Gestalt designers)
