### PR TITLE
IconButtonFloating: add required `tooltip` prop

### DIFF
--- a/docs/examples/iconbuttonfloating/doForScroll.js
+++ b/docs/examples/iconbuttonfloating/doForScroll.js
@@ -64,6 +64,9 @@ export default function Example(): Node {
           icon="question-mark"
           onClick={() => setOpen((prevVal) => !prevVal)}
           selected={open}
+          tooltip={{
+            text: 'Help & Resources Menu',
+          }}
         />
       </Box>
       {open && (

--- a/docs/examples/iconbuttonfloating/dontNegative.js
+++ b/docs/examples/iconbuttonfloating/dontNegative.js
@@ -26,6 +26,9 @@ export default function Example(): Node {
         onClick={() => setOpen((prevVal) => !prevVal)}
         ref={anchorRef}
         selected={open}
+        tooltip={{
+          text: 'Deletion Menu',
+        }}
       />
       {open && (
         <Dropdown

--- a/docs/examples/iconbuttonfloating/dontNotification.js
+++ b/docs/examples/iconbuttonfloating/dontNotification.js
@@ -26,6 +26,9 @@ export default function Example(): Node {
           icon="add"
           onClick={() => {}}
           ref={anchorRef}
+          tooltip={{
+            text: 'Create Pin Menu',
+          }}
         />
       </Box>
     </Flex>

--- a/docs/examples/iconbuttonfloating/variantsA11y.js
+++ b/docs/examples/iconbuttonfloating/variantsA11y.js
@@ -97,6 +97,7 @@ export default function Example(): Node {
           icon="add"
           onClick={() => setOpen((prevVal) => !prevVal)}
           selected={open}
+          tooltip={{ text: 'Create Pin Menu' }}
         />
       </Box>
       {open && (

--- a/docs/examples/iconbuttonfloating/variantsWithTooltip.js
+++ b/docs/examples/iconbuttonfloating/variantsWithTooltip.js
@@ -32,6 +32,7 @@ export default function Example(): Node {
           }}
         />
       </Box>
+
       {open && (
         <Dropdown
           anchor={anchorRef.current}

--- a/docs/pages/visual-test/IconButtonFloating-dark.js
+++ b/docs/pages/visual-test/IconButtonFloating-dark.js
@@ -11,6 +11,9 @@ export default function Snapshot(): Node {
           accessibilityLabel="test"
           icon="add"
           onClick={() => {}}
+          tooltip={{
+            text: 'test',
+          }}
         />
       </Box>
     </ColorSchemeProvider>

--- a/docs/pages/visual-test/IconButtonFloating.js
+++ b/docs/pages/visual-test/IconButtonFloating.js
@@ -11,6 +11,9 @@ export default function Snapshot(): Node {
           accessibilityLabel="test"
           icon="add"
           onClick={() => {}}
+          tooltip={{
+            text: 'test',
+          }}
         />
       </Box>
     </ColorSchemeProvider>

--- a/docs/pages/web/iconbuttonfloating.js
+++ b/docs/pages/web/iconbuttonfloating.js
@@ -8,19 +8,22 @@ import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
-import a11y from '../../examples/iconbuttonfloating/a11y.js';
 import doForScroll from '../../examples/iconbuttonfloating/doForScroll.js';
 import dontNegative from '../../examples/iconbuttonfloating/dontNegative.js';
 import dontNotification from '../../examples/iconbuttonfloating/dontNotification.js';
 import main from '../../examples/iconbuttonfloating/main.js';
+import variantsA11y from '../../examples/iconbuttonfloating/variantsA11y.js';
+import variantsWithTooltip from '../../examples/iconbuttonfloating/variantsWithTooltip.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
       <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
-        <SandpackExample code={main} name="Main example" hideEditor />
+        <SandpackExample code={main} name="Main IconButtonFloating example" hideEditor />
       </PageHeader>
+
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
+
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -44,6 +47,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           />
         </MainSection.Subsection>
       </MainSection>
+
       <MainSection name="Best practices">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -68,12 +72,15 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             }
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection columns={2}>
           <MainSection.Card
             cardSize="md"
             type="do"
             description="Use IconButtonFloating for positive and supportive actions like Create, Help or Maximize."
-            sandpackExample={<SandpackExample code={a11y} name="Center example" hideEditor />}
+            sandpackExample={
+              <SandpackExample code={variantsA11y} name="Center example" hideEditor />
+            }
           />
           <MainSection.Card
             cardSize="md"
@@ -90,6 +97,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           />
         </MainSection.Subsection>
       </MainSection>
+
       <AccessibilitySection name={generatedDocGen?.displayName}>
         <MainSection.Subsection
           title="ARIA attributes"
@@ -110,11 +118,13 @@ IconButtonFloating should be contained within the \`role="contentinfo"\` contain
           />
           <MainSection.Card
             cardSize="lg"
-            sandpackExample={<SandpackExample code={a11y} name="A11Y example" />}
+            sandpackExample={<SandpackExample code={variantsA11y} name="A11Y example" />}
           />
         </MainSection.Subsection>
       </AccessibilitySection>
+
       <MainSection name="Localization" description="Be sure to localize `accessibilityLabel`." />
+
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Size"
@@ -123,9 +133,10 @@ IconButtonFloating should be contained within the \`role="contentinfo"\` contain
         >
           <MainSection.Card
             cardSize="lg"
-            sandpackExample={<SandpackExample code={doForScroll} name="Scroll Placement example" />}
+            sandpackExample={<SandpackExample code={doForScroll} name="Variants - Size" />}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
           columns={2}
           title="Placement"
@@ -142,15 +153,32 @@ IconButtonFloating should be contained within the \`role="contentinfo"\` contain
           <MainSection.Card
             title="Bottom edge placement"
             cardSize="md"
-            sandpackExample={<SandpackExample code={doForScroll} name="Scroll Placement example" />}
+            sandpackExample={
+              <SandpackExample code={doForScroll} name="Variants - Scroll Placement - Bottom" />
+            }
           />
           <MainSection.Card
             title="Centered placement"
             cardSize="md"
-            sandpackExample={<SandpackExample code={a11y} name="A11Y Placement example" />}
+            sandpackExample={
+              <SandpackExample code={variantsA11y} name="Variants - Scroll Placement - Centered" />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="With tooltip"
+          description="IconButtonFloating requires a [tooltip](/web/tooltip) to provide additional context to the user about the action."
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample code={variantsWithTooltip} name="Variants - With tooltip" />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
+
       <MainSection name="Writing">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -166,7 +194,9 @@ IconButtonFloating should be contained within the \`role="contentinfo"\` contain
           />
         </MainSection.Subsection>
       </MainSection>
+
       <QualityChecklist component={generatedDocGen?.displayName} />
+
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
@@ -177,13 +207,13 @@ Use IconButton when only an icon is needed instead of text, and the action does 
 Button allows users to take actions and make choices using text labels to express what action will occur when the user interacts with it.
 
 **[Icon](/web/icon)**
-IconButtonFloating uses icons instead of text to convey available actions on a screen. Use an existing Icon from the [Gestalt Icon library](/foundations/iconography/library).
+IconButtonFloating uses icons instead of text to convey available actions on a screen. Use an existing icon from the [Gestalt icon library](/foundations/iconography/library).
 
 **[Dropdown](/web/dropdown)**
 IconButtonFloating is commonly paired with Dropdown to display a menu of options or actions.
       `}
         />
-      </MainSection>{' '}
+      </MainSection>
     </Page>
   );
 }

--- a/packages/gestalt/src/IconButtonFloating.js
+++ b/packages/gestalt/src/IconButtonFloating.js
@@ -2,19 +2,20 @@
 import { forwardRef, type Node, type AbstractComponent } from 'react';
 import Box from './Box.js';
 import IconButton from './IconButton.js';
+import { type Indexable } from './zIndex.js';
 import icons from './icons/index.js';
 
 type Props = {|
   /**
-   * Specifies the `id` of an associated element (or elements) whose contents or visibility are controlled by IconButtonFloating so that screen reader users can identify the relationship between elements. See the [Accessibility](#ARIA-attributes) guidelines for details on proper usage.
+   * Specifies the `id` of an associated element (or elements) whose contents or visibility are controlled by IconButtonFloating so that screen reader users can identify the relationship between elements. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/iconbuttonfloating#ARIA-attributes) for details on proper usage.
    */
   accessibilityControls?: string,
   /**
-   * Used to indicates that IconButtonFloating hides or exposes a Dropdown and details whether it is currently open or closed. See the [Accessibility](#ARIA-attributes) guidelines for details on proper usage.
+   * Used to indicates that IconButtonFloating hides or exposes a Dropdown and details whether it is currently open or closed. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/iconbuttonfloating#ARIA-attributes) for details on proper usage.
    */
   accessibilityExpanded?: boolean,
   /**
-   * Indicates whether this component displays a menu, such as Dropdown, or a dialog, like Popover, Modal or ModalAlert. See the [Accessibility](#ARIA-attributes) guidelines for details on proper usage.
+   * Indicates whether this component displays a menu, such as Dropdown, or a dialog, like Popover, Modal or ModalAlert. See the [Accessibility guidelines](https://gestalt.pinterest.systems/web/iconbuttonfloating#ARIA-attributes) for details on proper usage.
    */
   accessibilityPopupRole: 'menu' | 'dialog',
   /**
@@ -22,15 +23,15 @@ type Props = {|
    */
   accessibilityLabel: string,
   /**
-   * Defines a new icon different from the built-in Gestalt icons. See [custom icon](#Custom-icon) variant to learn more.
+   * Defines a new icon different from the built-in Gestalt icons. See [custom icon](https://gestalt.pinterest.systems/web/iconbuttonfloating#Custom-icon) variant to learn more.
    */
   dangerouslySetSvgPath?: {| __path: string |},
   /**
-   * When disabled, IconButtonFloating looks inactive and cannot be interacted with
+   * When disabled, IconButtonFloating looks inactive and cannot be interacted with.
    */
   disabled?: boolean,
   /**
-   * Icon displayed in IconButtonFloating to convey the behavior of the component. Refer to the [iconography](/foundations/iconography/library) guidelines regarding the available icon options.
+   * Icon displayed in IconButtonFloating to convey the behavior of the component. Refer to our [iconography library](https://gestalt.pinterest.systems/foundations/iconography/library) to see available icons.
    */
   icon: $Keys<typeof icons>,
   /**
@@ -45,9 +46,19 @@ type Props = {|
     dangerouslyDisableOnNavigation: () => void,
   |}) => void,
   /**
-   * Indicates whether the associated Dropdown is open or closed. Not used when IconButtonFloating opens a dialog.
+   * Indicates whether the associated dropdown is open or closed. Not used when IconButtonFloating opens a dialog.
    */
   selected?: boolean,
+  /**
+   * Adds a [Tooltip](https://gestalt.pinterest.systems/web/tooltip) on hover/focus of the IconButtonFloating. See the [With Tooltip](https://gestalt.pinterest.systems/web/iconbuttonfloating#With-Tooltip) variant to learn more.
+   */
+  tooltip: {|
+    accessibilityLabel?: string,
+    inline?: boolean,
+    idealDirection?: 'up' | 'right' | 'down' | 'left',
+    text: string,
+    zIndex?: Indexable,
+  |},
 |};
 
 type unionRefs = HTMLButtonElement | HTMLAnchorElement;
@@ -77,6 +88,7 @@ const IconButtonFloatingWithForwardRef: AbstractComponent<Props, unionRefs> = fo
     icon,
     onClick,
     selected,
+    tooltip,
   }: Props,
   ref,
 ): Node {
@@ -96,6 +108,7 @@ const IconButtonFloatingWithForwardRef: AbstractComponent<Props, unionRefs> = fo
         role="button"
         selected={selected}
         size="xl"
+        tooltip={tooltip}
       />
     </Box>
   );


### PR DESCRIPTION
### Summary

#### What changed?

This PR adds a required `tooltip` prop to IconButtonFloating. The prop value is identical to IconButton's.

#### Why?

For the same reason we added `tooltip` to IconButton: icon meaning is not always obvious to the user, and providing a tooltip gives the user more context so they know what to expect when interacting with the button.

IconButtonFloating usage is still very low (2 instances in Pinboard currently), so jumping straight to a required prop isn't a big lift.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6028)