### PR TITLE
DatePicker: added Year/Month dropdown options, removed virtual keyboard, upgraded react-datepicker to 4.0.0

### DIFF
--- a/docs/examples/datepicker/main.js
+++ b/docs/examples/datepicker/main.js
@@ -6,12 +6,7 @@ import DatePicker from 'gestalt-datepicker';
 export default function Example(): Node {
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <DatePicker
-        id="example-page-header"
-        label="Select a date"
-        onChange={() => {}}
-        idealDirection="down"
-      />
+      <DatePicker id="example-page-header" label="Select a date" onChange={() => {}} />
     </Flex>
   );
 }

--- a/docs/examples/datepicker/selectLists.js
+++ b/docs/examples/datepicker/selectLists.js
@@ -1,0 +1,27 @@
+// @flow strict
+import { useState, type Node } from 'react';
+import { Flex, SegmentedControl } from 'gestalt';
+import DatePicker from 'gestalt-datepicker';
+
+export default function Example(): Node {
+  const mapOptions = { '0': ['month'], '1': ['year'], '2': ['year', 'month'] };
+  const items = ['Month', 'Year', 'Month & Year'];
+  const [itemIndex, setItemIndex] = useState(0);
+
+  return (
+    <Flex direction="column" gap={4} width="100%">
+      <SegmentedControl
+        items={items}
+        selectedItemIndex={itemIndex}
+        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
+      />
+      <DatePicker
+        id="selectLists"
+        label="Alberto's birth date"
+        onChange={() => {}}
+        value={new Date(1985, 6, 4)}
+        selectLists={mapOptions[itemIndex.toString()]}
+      />
+    </Flex>
+  );
+}

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -51,6 +51,7 @@ import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
 import main from '../../examples/datepicker/main.js';
+import selectLists from '../../examples/datepicker/selectLists.js';
 
 const localeMap = {
   'af': { localeData: af, lang: 'Afrikaans' },
@@ -338,26 +339,17 @@ function DatePickerExample() {
 }
 `}
         />
-        <Example
-          description="Provide select lists for quickly changing year and month."
-          id="showMonthYearDropdown_example"
-          name="showMonthYearDropdown"
-          defaultCode={`
-function DatePickerExample() {
-  const handleChange = (value) => value;
+        <MainSection.Subsection
+          columns={2}
+          title="selectLists"
+          description="Provide select lists for quickly changing year and month"
+        >
+          <MainSection.Card
+            cardSize="md"
+            sandpackExample={<SandpackExample code={selectLists} name="selectLists example." />}
+          />
+        </MainSection.Subsection>
 
-  return (
-    <DatePicker
-      id="showMonthYearDropdown"
-      label="Alberto's birth date"
-      onChange={({value}) => handleChange(value)}
-      value={new Date(1985,6,4)}
-      showMonthYearDropdown
-    />
-  )
-}
-`}
-        />
         <Combination
           id="idealDirection"
           name="Ideal Direction"
@@ -402,7 +394,7 @@ import { it } from 'date-fns/locale';
                   onChange={({ value }) => setDate(value)}
                   value={date}
                   localeData={localeMap[localeDataCode].localeData}
-                  showMonthYearDropdown
+                  selectLists={['month']}
                 />
               </Box>
             );

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -338,6 +338,27 @@ function DatePickerExample() {
 }
 `}
         />
+        <Example
+          description="Provide select lists for quickly changing year and month."
+          id="showMonthYearDropdown_example"
+          name="showMonthYearDropdown"
+          defaultCode={`
+function DatePickerExample() {
+  const handleChange = (value) => value;
+
+  return (
+    <DatePicker
+      id="showMonthYearDropdown"
+      idealDirection="down"
+      label="Alberto's birth date"
+      onChange={({value}) => handleChange(value)}
+      value={new Date(1985,6,4)}
+      showMonthYearDropdown
+    />
+  )
+}
+`}
+        />
         <Combination
           id="idealDirection"
           name="Ideal Direction"
@@ -382,6 +403,7 @@ import { it } from 'date-fns/locale';
                   onChange={({ value }) => setDate(value)}
                   value={date}
                   localeData={localeMap[localeDataCode].localeData}
+                  showMonthYearDropdown
                 />
               </Box>
             );

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -349,7 +349,6 @@ function DatePickerExample() {
   return (
     <DatePicker
       id="showMonthYearDropdown"
-      idealDirection="down"
       label="Alberto's birth date"
       onChange={({value}) => handleChange(value)}
       value={new Date(1985,6,4)}

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "classnames": "^2.2.6",
-    "react-datepicker": "4.0.0"
+    "react-datepicker": "4.11.0"
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "classnames": "^2.2.6",
-    "react-datepicker": "4.11.0"
+    "react-datepicker": "4.0.0"
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "classnames": "^2.2.6",
-    "react-datepicker": "2.16.0"
+    "react-datepicker": "4.0.0"
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -377,6 +377,43 @@ html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--next {
   margin-right: 8px;
 }
 
+/* Year / Month dropdown  */
+
+:global ._gestalt .react-datepicker__month-select,
+:global ._gestalt .react-datepicker__year-select {
+  background-color: var(--g-colorGray0);
+  border-color: var(--color-border-container);
+  border-radius: 16px;
+  border-style: solid;
+  border-width: 2px;
+  color: var(--color-text-subtle);
+  cursor: pointer;
+  font-family: var(--font-family-default-latin);
+  font-size: var(--font-size-200);
+  height: 40px;
+  margin-bottom: 10px;
+  margin-top: 10px;
+  padding: 5px 16px; /* right padding prevents it from running into arrow */
+  position: relative;
+  width: 100%;
+}
+
+:global ._gestalt .react-datepicker__month-select:focus,
+:global ._gestalt .react-datepicker__year-select:focus {
+  box-shadow: 0 0 0 4px rgb(0 132 255 / 0.5);
+  outline: 0;
+}
+
+:global ._gestalt .react-datepicker__year-dropdown-container--select,
+:global ._gestalt .react-datepicker__month-dropdown-container--select,
+:global ._gestalt .react-datepicker__month-year-dropdown-container--select,
+:global ._gestalt .react-datepicker__year-dropdown-container--scroll,
+:global ._gestalt .react-datepicker__month-dropdown-container--scroll,
+:global ._gestalt .react-datepicker__month-year-dropdown-container--scroll {
+  display: inline-block;
+  margin: 0 10px;
+}
+
 /* Override the textfield container since gestalt has block not inline block */
 
 :global ._gestalt .reactDatepickerWrapper {

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -375,7 +375,7 @@ html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--next {
   height: 40px;
   margin-bottom: 10px;
   margin-top: 10px;
-  padding: 5px 16px; /* right padding prevents it from running into arrow */
+  padding: 5px 16px; /* horizontal padding prevents it from running into arrow */
   position: relative;
   width: 100%;
 }

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -359,24 +359,6 @@ html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--next {
   z-index: 1;
 }
 
-.react-datepicker-popper[data-placement^="bottom"] {
-  margin-top: 6px;
-}
-
-.react-datepicker-popper[data-placement^="top"] {
-  /* !important is required to keep same distance from Textfield
-     when popper flips from top to bottom */
-  top: -2px !important; /* stylelint-disable-line declaration-no-important */
-}
-
-.react-datepicker-popper[data-placement^="right"] {
-  margin-left: 8px;
-}
-
-.react-datepicker-popper[data-placement^="left"] {
-  margin-right: 8px;
-}
-
 /* Year / Month dropdown  */
 
 :global ._gestalt .react-datepicker__month-select,

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -132,9 +132,9 @@ type Props = {|
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
-   * Show a select list for quick selection of year and month. See the [showMonthYearDropdown example](https://gestalt.pinterest.systems/web/datepicker#showMonthYearDropdown) to learn more.
+   * Show a select list for quick selection of year and/or month. See the [selectLists variant](https://gestalt.pinterest.systems/web/datepicker#selectLists) to learn more.
    */
-  showMonthYearDropdown?: boolean,
+  selectLists?: $ReadOnlyArray<'month' | 'year'>,
   /**
    * Pre-selected date value. See the [preselected date example](https://gestalt.pinterest.systems/web/datepicker#preselectedValue) to learn more.
    */
@@ -174,7 +174,7 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
     rangeEndDate,
     rangeSelector,
     rangeStartDate,
-    showMonthYearDropdown,
+    selectLists,
     value: dateValue,
   }: Props,
   ref,
@@ -255,7 +255,7 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
         dateFormat={format}
         dayClassName={() => classnames(styles['react-datepicker__days'])}
         disabled={disabled}
-        dropdownMode={showMonthYearDropdown ? 'select' : undefined}
+        dropdownMode="select"
         endDate={rangeEndDate}
         excludeDates={excludeDates && [...excludeDates]}
         highlightDates={initRangeHighlight ? [initRangeHighlight] : []}
@@ -302,8 +302,8 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
         selectsEnd={rangeSelector === 'end'}
         selectsStart={rangeSelector === 'start'}
         showPopperArrow={false}
-        showMonthDropdown={showMonthYearDropdown}
-        showYearDropdown={showMonthYearDropdown}
+        showMonthDropdown={selectLists?.includes('month')}
+        showYearDropdown={selectLists?.includes('year')}
         startDate={rangeStartDate}
       />
     </div>

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -132,7 +132,7 @@ type Props = {|
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
-   * Show a select list for quick selection of year and monnth. See the [showMonthYearDropdown example](https://gestalt.pinterest.systems/web/datepicker#showMonthYearDropdown) to learn more.
+   * Show a select list for quick selection of year and month. See the [showMonthYearDropdown example](https://gestalt.pinterest.systems/web/datepicker#showMonthYearDropdown) to learn more.
    */
   showMonthYearDropdown?: boolean,
   /**
@@ -275,20 +275,16 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
         onKeyDown={(event) => updateNextRef(event.key === 'Enter')}
         onMonthChange={(newMonth: Date) => setMonth(newMonth.getMonth())}
         placeholderText={placeholder ?? format?.toUpperCase()}
-        popperClassName={classnames(
-          styles['react-datepicker-popper'],
-          // styles[`react-datepicker-popper-${popperPlacement[idealDirection]}`],
-        )}
+        popperClassName={classnames(styles['react-datepicker-popper'])}
         popperModifiers={[
           {
-            name: 'flip',
+            name: 'offset',
             options: {
-              fallbackPlacements: [],
+              offset: [0, 20],
             },
           },
         ]}
-        popperPlacement="bottom"
-        // popperPlacement={popperPlacement[idealDirection]}
+        popperPlacement={popperPlacement[idealDirection]}
         previousMonthButtonLabel={
           <Icon accessibilityLabel="" color="default" icon="arrow-back" size={16} />
         }

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -277,9 +277,18 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
         placeholderText={placeholder ?? format?.toUpperCase()}
         popperClassName={classnames(
           styles['react-datepicker-popper'],
-          styles[`react-datepicker-popper-${popperPlacement[idealDirection]}`],
+          // styles[`react-datepicker-popper-${popperPlacement[idealDirection]}`],
         )}
-        popperPlacement={popperPlacement[idealDirection]}
+        popperModifiers={[
+          {
+            name: 'flip',
+            options: {
+              fallbackPlacements: [],
+            },
+          },
+        ]}
+        popperPlacement="bottom"
+        // popperPlacement={popperPlacement[idealDirection]}
         previousMonthButtonLabel={
           <Icon accessibilityLabel="" color="default" icon="arrow-back" size={16} />
         }

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -132,6 +132,10 @@ type Props = {|
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
+   * Show a select list for quick selection of year and monnth. See the [showMonthYearDropdown example](https://gestalt.pinterest.systems/web/datepicker#showMonthYearDropdown) to learn more.
+   */
+  showMonthYearDropdown?: boolean,
+  /**
    * Pre-selected date value. See the [preselected date example](https://gestalt.pinterest.systems/web/datepicker#preselectedValue) to learn more.
    */
   value?: Date,
@@ -170,6 +174,7 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
     rangeEndDate,
     rangeSelector,
     rangeStartDate,
+    showMonthYearDropdown,
     value: dateValue,
   }: Props,
   ref,
@@ -250,6 +255,7 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
         dateFormat={format}
         dayClassName={() => classnames(styles['react-datepicker__days'])}
         disabled={disabled}
+        dropdownMode={showMonthYearDropdown ? 'select' : undefined}
         endDate={rangeEndDate}
         excludeDates={excludeDates && [...excludeDates]}
         highlightDates={initRangeHighlight ? [initRangeHighlight] : []}
@@ -291,6 +297,8 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
         selectsEnd={rangeSelector === 'end'}
         selectsStart={rangeSelector === 'start'}
         showPopperArrow={false}
+        showMonthDropdown={showMonthYearDropdown}
+        showYearDropdown={showMonthYearDropdown}
         startDate={rangeStartDate}
       />
     </div>

--- a/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
+++ b/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
@@ -5,7 +5,7 @@ import DatePicker from './DatePicker.js';
 
 const initialDate = new Date(2018, 11, 14);
 
-function DatePickerWrap(showMonthYearDropdown) {
+function DatePickerWrap({ showMonthYearDropdown }: {| showMonthYearDropdown?: boolean |}) {
   const [date, setDate] = useState(initialDate);
 
   return (
@@ -13,7 +13,7 @@ function DatePickerWrap(showMonthYearDropdown) {
       id="fake_id"
       onChange={(e) => setDate(e.value)}
       value={date}
-      showMonthYearDropdown={!!showMonthYearDropdown}
+      selectLists={showMonthYearDropdown ? ['year', 'month'] : undefined}
     />
   );
 }
@@ -128,7 +128,6 @@ describe('DatePicker', () => {
     await act(async () => {
       fireEvent.focus(screen.getByDisplayValue('12/14/2018'));
     });
-
     expect(screen.queryAllByRole('option', { name: 'January' })).toHaveLength(1);
     expect(screen.queryAllByRole('option', { name: '2017' })).toHaveLength(1);
   });

--- a/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
+++ b/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
@@ -5,10 +5,17 @@ import DatePicker from './DatePicker.js';
 
 const initialDate = new Date(2018, 11, 14);
 
-function DatePickerWrap() {
+function DatePickerWrap(showMonthYearDropdown) {
   const [date, setDate] = useState(initialDate);
 
-  return <DatePicker id="fake_id" onChange={(e) => setDate(e.value)} value={date} />;
+  return (
+    <DatePicker
+      id="fake_id"
+      onChange={(e) => setDate(e.value)}
+      value={date}
+      showMonthYearDropdown={!!showMonthYearDropdown}
+    />
+  );
 }
 
 describe('DatePicker', () => {
@@ -112,5 +119,17 @@ describe('DatePicker', () => {
     expect(screen.getByText('13')).toHaveClass(
       'react-datepicker__day react-datepicker__day--013 react-datepicker__day--selected',
     );
+  });
+
+  test('has year and month select list options', async () => {
+    render(<DatePickerWrap showMonthYearDropdown />);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
+    await act(async () => {
+      fireEvent.focus(screen.getByDisplayValue('12/14/2018'));
+    });
+
+    expect(screen.queryAllByRole('option', { name: 'January' })).toHaveLength(1);
+    expect(screen.queryAllByRole('option', { name: '2017' })).toHaveLength(1);
   });
 });

--- a/packages/gestalt-datepicker/src/DatePickerTextField.js
+++ b/packages/gestalt-datepicker/src/DatePickerTextField.js
@@ -60,6 +60,7 @@ function DatePickerTextField(props: Props) {
             autoComplete="off"
             disabled={disabled}
             id={id}
+            inputMode="none"
             onBlur={(data) => onBlur?.(data.event)}
             onFocus={(data) => {
               onFocus?.(data.event);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6502,15 +6502,15 @@ data-urls@^3.0.1:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-date-fns@^2.0.1:
-  version "2.14.0"
-  resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz"
-  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
-
 date-fns@^2.16.1:
   version "2.16.1"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
+date-fns@^2.24.0:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 date-time@^2.1.0:
   version "2.1.0"
@@ -14750,17 +14750,17 @@ react-cookie@^4.1.1:
     hoist-non-react-statics "^3.0.0"
     universal-cookie "^4.0.0"
 
-react-datepicker@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.0.0.tgz#e2cbd8e7068b9a62bda9085410c85926a65e25f6"
-  integrity sha512-dk3+qQFBKdS/cZLr8rbm1Lya97xcBiLxyrmm8EVCxTSHCYFjcuMMMSNbk7J9SxS1nxyy8ptbnuaKlub9xtjy0g==
+react-datepicker@4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.11.0.tgz#40e73b4729a284ed206fdb322b8e84eb566e11a3"
+  integrity sha512-50n93o7mQwBEhg05tbopjFKgs8qgi8VBCAOMC4VqrKut72eAjESc/wXS/k5hRtnP0oe2FCGw7MJuIwh37wuXOw==
   dependencies:
     "@popperjs/core" "^2.9.2"
     classnames "^2.2.6"
-    date-fns "^2.0.1"
+    date-fns "^2.24.0"
     prop-types "^15.7.2"
-    react-onclickoutside "^6.10.0"
-    react-popper "^2.2.5"
+    react-onclickoutside "^6.12.2"
+    react-popper "^2.3.0"
 
 react-devtools-inline@4.4.0:
   version "4.4.0"
@@ -14841,12 +14841,12 @@ react-live@^2.3.0:
     react-simple-code-editor "^0.11.0"
     unescape "^1.0.1"
 
-react-onclickoutside@^6.10.0:
+react-onclickoutside@^6.12.2:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz#e165ea4e5157f3da94f4376a3ab3e22a565f4ffc"
   integrity sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==
 
-react-popper@^2.2.5:
+react-popper@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
   integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6502,15 +6502,15 @@ data-urls@^3.0.1:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
+date-fns@^2.0.1:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 date-fns@^2.16.1:
   version "2.16.1"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
-
-date-fns@^2.24.0:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 date-time@^2.1.0:
   version "2.1.0"
@@ -14750,17 +14750,17 @@ react-cookie@^4.1.1:
     hoist-non-react-statics "^3.0.0"
     universal-cookie "^4.0.0"
 
-react-datepicker@4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.11.0.tgz#40e73b4729a284ed206fdb322b8e84eb566e11a3"
-  integrity sha512-50n93o7mQwBEhg05tbopjFKgs8qgi8VBCAOMC4VqrKut72eAjESc/wXS/k5hRtnP0oe2FCGw7MJuIwh37wuXOw==
+react-datepicker@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.0.0.tgz#e2cbd8e7068b9a62bda9085410c85926a65e25f6"
+  integrity sha512-dk3+qQFBKdS/cZLr8rbm1Lya97xcBiLxyrmm8EVCxTSHCYFjcuMMMSNbk7J9SxS1nxyy8ptbnuaKlub9xtjy0g==
   dependencies:
     "@popperjs/core" "^2.9.2"
     classnames "^2.2.6"
-    date-fns "^2.24.0"
+    date-fns "^2.0.1"
     prop-types "^15.7.2"
-    react-onclickoutside "^6.12.2"
-    react-popper "^2.3.0"
+    react-onclickoutside "^6.10.0"
+    react-popper "^2.2.5"
 
 react-devtools-inline@4.4.0:
   version "4.4.0"
@@ -14841,12 +14841,12 @@ react-live@^2.3.0:
     react-simple-code-editor "^0.11.0"
     unescape "^1.0.1"
 
-react-onclickoutside@^6.12.2:
+react-onclickoutside@^6.10.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz#e165ea4e5157f3da94f4376a3ab3e22a565f4ffc"
   integrity sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==
 
-react-popper@^2.3.0:
+react-popper@^2.2.5:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
   integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,7 +1702,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz"
   integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
@@ -3514,6 +3514,11 @@
   dependencies:
     "@types/node" "*"
     playwright-core "1.30.0"
+
+"@popperjs/core@^2.9.2":
+  version "2.11.7"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.7.tgz#ccab5c8f7dc557a52ca3288c10075c9ccd37fff7"
+  integrity sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==
 
 "@react-hook/intersection-observer@^3.1.1":
   version "3.1.1"
@@ -6194,14 +6199,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz"
-  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
-  dependencies:
-    gud "^1.0.0"
-    warning "^4.0.3"
-
 crelt@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
@@ -6644,18 +6641,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
-
-deep-equal@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz"
-  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
-  dependencies:
-    is-arguments "^1.0.4"
-    is-date-object "^1.0.1"
-    is-regex "^1.0.4"
-    object-is "^1.0.1"
-    object-keys "^1.1.1"
-    regexp.prototype.flags "^1.2.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -8930,11 +8915,6 @@ gray-matter@^4.0.3:
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
 
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
-
 h3@^0.8.1:
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/h3/-/h3-0.8.6.tgz#8095ef998fe14769b87170b7c8b68ba9c54973d5"
@@ -9625,11 +9605,6 @@ is-alphanumerical@^2.0.0:
     is-alphabetical "^2.0.0"
     is-decimal "^2.0.0"
 
-is-arguments@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz"
-  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
@@ -9988,7 +9963,7 @@ is-reference@^3.0.0:
   dependencies:
     "@types/estree" "*"
 
-is-regex@^1.0.4, is-regex@^1.0.5:
+is-regex@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz"
   integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
@@ -13000,14 +12975,6 @@ object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
-object-is@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz"
-  integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
@@ -13767,11 +13734,6 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
-
-popper.js@^1.14.4:
-  version "1.16.1"
-  resolved "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz"
-  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -14588,7 +14550,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.1, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -14788,16 +14750,17 @@ react-cookie@^4.1.1:
     hoist-non-react-statics "^3.0.0"
     universal-cookie "^4.0.0"
 
-react-datepicker@2.16.0:
-  version "2.16.0"
-  resolved "https://registry.npmjs.org/react-datepicker/-/react-datepicker-2.16.0.tgz"
-  integrity sha512-TvcmSY27rn0JKvuJuIXNNS+niGQNdgtuG/CsBttVYhPOA9KmSw7c2PvQBPVEvzkyV+QPNJ8jN/KVJNj9uvopqA==
+react-datepicker@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.0.0.tgz#e2cbd8e7068b9a62bda9085410c85926a65e25f6"
+  integrity sha512-dk3+qQFBKdS/cZLr8rbm1Lya97xcBiLxyrmm8EVCxTSHCYFjcuMMMSNbk7J9SxS1nxyy8ptbnuaKlub9xtjy0g==
   dependencies:
+    "@popperjs/core" "^2.9.2"
     classnames "^2.2.6"
     date-fns "^2.0.1"
     prop-types "^15.7.2"
-    react-onclickoutside "^6.9.0"
-    react-popper "^1.3.4"
+    react-onclickoutside "^6.10.0"
+    react-popper "^2.2.5"
 
 react-devtools-inline@4.4.0:
   version "4.4.0"
@@ -14837,6 +14800,11 @@ react-error-boundary@^3.1.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+react-fast-compare@^3.0.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.1.tgz#53933d9e14f364281d6cba24bfed7a4afb808b5f"
+  integrity sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==
+
 react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -14873,22 +14841,17 @@ react-live@^2.3.0:
     react-simple-code-editor "^0.11.0"
     unescape "^1.0.1"
 
-react-onclickoutside@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz"
-  integrity sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A==
+react-onclickoutside@^6.10.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz#e165ea4e5157f3da94f4376a3ab3e22a565f4ffc"
+  integrity sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==
 
-react-popper@^1.3.4:
-  version "1.3.7"
-  resolved "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz"
-  integrity sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==
+react-popper@^2.2.5:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
+  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    create-react-context "^0.3.0"
-    deep-equal "^1.1.1"
-    popper.js "^1.14.4"
-    prop-types "^15.6.1"
-    typed-styles "^0.0.7"
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-shallow-renderer@^16.15.0:
@@ -15086,14 +15049,6 @@ regexp-tree@^0.1.24:
   version "0.1.24"
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.24.tgz#3d6fa238450a4d66e5bc9c4c14bb720e2196829d"
   integrity sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==
-
-regexp.prototype.flags@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz"
-  integrity sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
 
 regexp.prototype.flags@^1.3.1:
   version "1.3.1"
@@ -17049,11 +17004,6 @@ type@^2.5.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f"
   integrity sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==
 
-typed-styles@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz"
-  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
-
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz"
@@ -17651,7 +17601,7 @@ walker@^1.0.7:
   dependencies:
     makeerror "1.0.x"
 
-warning@^4.0.2, warning@^4.0.3:
+warning@^4.0.2:
   version "4.0.3"
   resolved "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
#### BREAKING CHANGE

No codemod needed. We are removing virtual keyboard support for DatePicker so they don't conflict with each other. Also, upgrading react-datepicker to 4.0.0

### Summary

#### What changed?

DatePicker: added Year/Month dropdown options + DatePicker:  remove virtual keyboard on mobile

https://user-images.githubusercontent.com/10593890/229939820-76c3a6c0-d38b-477d-96a8-0dfd9f75f889.MP4

![Brave Browser - DatePicker - Gestalt 2023-04-04 at 3 08 21 PM](https://user-images.githubusercontent.com/10593890/229895542-dce6514a-c910-40f1-a8d0-edb252122562.gif)



Also, 

Upgraded library to 4.0.0. to get latest Popper v2. utils.

#### Why?

What is the purpose of this PR? Please include the context around these changes for Future Us. In addition to _what_ is changing, we need to know _why_ these changes are needed. Imagine someone is looking at these changes a year from now and needs to know why they were made.


DatePicker: add 'inputMode' = none to internal TextField to only show calendar, and don't display virtual keyboard


![image](https://user-images.githubusercontent.com/10593890/229245141-6a84db56-6ed2-486d-9118-17952295506d.png)


https://user-images.githubusercontent.com/10593890/229680720-c440d4cd-2546-4170-8861-b63deb1755da.MP4


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
