### PR TITLE
Table: implement controlled Table.RowExpanded with `expanded` prop

### DIFF
--- a/docs/examples/table/controlledExpandable.js
+++ b/docs/examples/table/controlledExpandable.js
@@ -1,0 +1,72 @@
+// @flow strict
+import { useState, type Node } from 'react';
+import { Table, Flex, Text, Box } from 'gestalt';
+
+export default function Example(): Node {
+  const [expandedRows, setExpandedRows] = useState(['row1']);
+
+  return (
+    <Box height="100%" width="100%" overflow="scroll">
+      <Flex alignItems="start" gap={4} height="100%" justifyContent="center" width="100%">
+        <Table accessibilityLabel="Table Row Expandable">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Box display="visuallyHidden">
+                  <Text weight="bold">Open/Close row</Text>
+                </Box>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Campaign</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Status</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Date</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            {[
+              { id: 'row1', campaign: 'Winter', status: 'Draft', date: 'December 25, 2023' },
+              { id: 'row2', campaign: 'Spring', status: 'Active', date: 'April 25, 2023' },
+              { id: 'row3', campaign: 'Fall', status: 'Finished', date: 'October 25, 2022' },
+            ].map(({ id, campaign, status, date }) => (
+              <Table.RowExpandable
+                key={id}
+                accessibilityExpandLabel="Expand"
+                accessibilityCollapseLabel="Collapse"
+                id={id}
+                expanded={expandedRows.includes(id)}
+                onExpand={({ expanded }) => {
+                  if (expanded) {
+                    setExpandedRows(expandedRows.filter((value) => value !== id));
+                  } else {
+                    setExpandedRows([...expandedRows, id]);
+                  }
+                }}
+                expandedContents={
+                  <Box width={100} padding={2}>
+                    <Text>Content</Text>
+                  </Box>
+                }
+              >
+                <Table.Cell>
+                  <Text>{campaign}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text>{status}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text>{date}</Text>
+                </Table.Cell>
+              </Table.RowExpandable>
+            ))}
+          </Table.Body>
+        </Table>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/table/main.js
+++ b/docs/examples/table/main.js
@@ -1,0 +1,52 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Flex, Text, Box } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box height="100%" width="100%" overflow="scroll">
+      <Flex alignItems="start" gap={4} height="100%" justifyContent="center" width="100%">
+        <Table accessibilityLabel="Main example table">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Box display="visuallyHidden">
+                  <Text weight="bold">Open/Close row</Text>
+                </Box>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Campaign</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Status</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Date</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            {[
+              { id: 'row1', campaign: 'Winter', status: 'Draft', date: 'December 25, 2023' },
+              { id: 'row2', campaign: 'Spring', status: 'Active', date: 'April 25, 2023' },
+              { id: 'row3', campaign: 'Fall', status: 'Finished', date: 'October 25, 2022' },
+            ].map(({ id, campaign, status, date }) => (
+              <Table.Row key={id}>
+                <Table.Cell>
+                  <Text>{campaign}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text>{status}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text>{date}</Text>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/table/uncontrolledExpandable.js
+++ b/docs/examples/table/uncontrolledExpandable.js
@@ -1,0 +1,63 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Flex, Text, Box } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box height="100%" width="100%" overflow="scroll">
+      <Flex alignItems="start" gap={4} height="100%" justifyContent="center" width="100%">
+        <Table accessibilityLabel="Table Row Expandable">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Box display="visuallyHidden">
+                  <Text weight="bold">Open/Close row</Text>
+                </Box>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Campaign</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Status</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Date</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            {[
+              { id: 'row1', campaign: 'Winter', status: 'Draft', date: 'December 25, 2023' },
+              { id: 'row2', campaign: 'Spring', status: 'Active', date: 'April 25, 2023' },
+              { id: 'row3', campaign: 'Fall', status: 'Finished', date: 'October 25, 2022' },
+            ].map(({ id, campaign, status, date }) => (
+              <Table.RowExpandable
+                key={id}
+                accessibilityExpandLabel="Expand"
+                accessibilityCollapseLabel="Collapse"
+                id={id}
+                onExpand={() => {}}
+                expandedContents={
+                  <Box width={100} padding={2}>
+                    <Text>Content</Text>
+                  </Box>
+                }
+              >
+                <Table.Cell>
+                  <Text>{campaign}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text>{status}</Text>
+                </Table.Cell>
+                <Table.Cell>
+                  <Text>{date}</Text>
+                </Table.Cell>
+              </Table.RowExpandable>
+            ))}
+          </Table.Body>
+        </Table>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/pages/web/table.js
+++ b/docs/pages/web/table.js
@@ -7,8 +7,12 @@ import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import controlledExpandable from '../../examples/table/controlledExpandable.js';
+import main from '../../examples/table/main.js';
+import uncontrolledExpandable from '../../examples/table/uncontrolledExpandable.js';
 
-export default function TablePage({
+export default function DocsPage({
   generatedDocGen,
 }: {|
   generatedDocGen: {| [string]: DocGen |},
@@ -18,70 +22,9 @@ export default function TablePage({
       <PageHeader
         name={generatedDocGen.Table?.displayName}
         description={generatedDocGen.Table?.description}
-        defaultCode={`
-<Table accessibilityLabel="Basic Table">
-  <Table.Header>
-    <Table.Row>
-      <Table.HeaderCell>
-        <Text weight="bold">Name</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">House</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">Birthday</Text>
-      </Table.HeaderCell>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Luna Lovegood</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Ravenclaw</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>June 25, 1993</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Draco Malfoy</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Slytherin</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>December 3, 1992</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Hermione Granger</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Gryffindor</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>September 19, 1979</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Neville Longbottom</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>Gryffindor</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>July 30, 1980</Text>
-      </Table.Cell>
-    </Table.Row>
-  </Table.Body>
-</Table>
-`}
-      />
+      >
+        <SandpackExample code={main} name="Main Table example" hideEditor />
+      </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen.Table} />
 
@@ -2066,220 +2009,39 @@ function Example() {
 `}
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
-          title="Table Row Expandable"
-          description="Expandable row that is able to hold content that will displayed depending on the clickable expand/collapse button icon."
+          title="Controlled/Uncontrolled Table.RowExpandable"
+          description={`To set Table.RowExpandable to be a controlled component, use the \`expanded\` prop. When \`expanded\` is not passed (\`expanded\` set to undefined), Table.RowExpandable stays uncontrolled. Use \`onExpand\` prop to have access to the internal state of the component via render props <code>({ event, expanded }) => { expanded }</code>"
+
+When Table.RowExpandable is uncontrolled, use the clickable expand/collapse icon button to hide/show the content.`}
+          columns={2}
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-    function Example() {
-      const [textShown, setTextShown] = React.useState(false);
-      const showTextOnExpand = () => {
-        return <Text>Row expanded</Text>;
-      };
+            sandpackExample={
+              <SandpackExample
+                code={controlledExpandable}
+                name="Controlled Table.RowExpandable example"
+                hideEditor
+              />
+            }
+          />
 
-      return(
-        <Table accessibilityLabel="Table Row Expandable">
-
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Box display="visuallyHidden">
-                  <Text weight="bold">Open/Close row</Text>
-                </Box>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Name</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">House</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Birthday</Text>
-              </Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-
-          <Table.Body>
-
-            <Table.RowExpandable
-              accessibilityExpandLabel="Expand"
-              accessibilityCollapseLabel="Collapse"
-              id="row1"
-              onExpand={() => setTextShown(!textShown)}
-              expandedContents={
-                <Box maxWidth={236} padding={2} column={12}>
-                  <WashAnimated
-                    image={
-                      <Avatar
-                        name="luna avatar"
-                        src="https://i.ibb.co/QY9qR7h/luna.png"
-                      />
-                    }
-                  >
-                    <Text align="center" weight="bold">
-                      <Link href="https://pinterest.com">
-                        <Box paddingX={3} paddingY={2}>
-                          Luna's Info
-                        </Box>
-                      </Link>
-                    </Text>
-                    {textShown && showTextOnExpand()}
-                  </WashAnimated>
-                </Box>
-              }
-            >
-              <Table.Cell>
-                <Text>Luna Lovegood</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Ravenclaw</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>June 25, 1993</Text>
-              </Table.Cell>
-            </Table.RowExpandable>
-
-            <Table.RowExpandable
-              accessibilityExpandLabel="Expand"
-              accessibilityCollapseLabel="Collapse"
-              id="row2"
-              expandedContents={
-                <Table maxWidth={800} maxHeight={500}>
-                  <Table.Header sticky>
-                    <Table.Row>
-                      <Table.HeaderCell>
-                        <Text weight="bold">Image</Text>
-                      </Table.HeaderCell>
-                      <Table.HeaderCell>
-                        <Text weight="bold">Name</Text>
-                      </Table.HeaderCell>
-                      <Table.HeaderCell>
-                        <Text weight="bold">House</Text>
-                      </Table.HeaderCell>
-                    </Table.Row>
-                  </Table.Header>
-                  <Table.Body>
-                    <Table.Row colSpan={10}>
-                      <Table.Cell>
-                        <Box width={50}>
-                          <Mask rounding="circle">
-                            <Image
-                              alt="Luna"
-                              src="https://i.ibb.co/QY9qR7h/luna.png"
-                              naturalHeight={50}
-                              naturalWidth={50}
-                            />
-                          </Mask>
-                        </Box>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Luna Lovegood</Text>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Ravenclaw</Text>
-                      </Table.Cell>
-                    </Table.Row>
-                    <Table.Row>
-                      <Table.Cell>
-                        <Box width={50}>
-                          <Mask rounding="circle">
-                            <Image
-                              alt="Draco"
-                              src="https://i.ibb.co/Hzcfxjt/draco.png"
-                              naturalHeight={50}
-                              naturalWidth={50}
-                            />
-                          </Mask>
-                        </Box>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Draco Malfoy</Text>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Slytherin</Text>
-                      </Table.Cell>
-                    </Table.Row>
-                    <Table.Row>
-                      <Table.Cell>
-                        <Box width={50}>
-                          <Mask rounding="circle">
-                            <Image
-                              alt="Neville"
-                              src="https://i.ibb.co/JvY9DKK/neville.png"
-                              naturalHeight={50}
-                              naturalWidth={50}
-                            />
-                          </Mask>
-                        </Box>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Neville Longbottom</Text>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Gryffindor</Text>
-                      </Table.Cell>
-                    </Table.Row>
-                  </Table.Body>
-                </Table>
-              }
-            >
-              <Table.Cell>
-                <Text>Draco Malfoy</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Slytherin</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>December 3, 1992</Text>
-              </Table.Cell>
-            </Table.RowExpandable>
-
-            <Table.RowExpandable
-              accessibilityExpandLabel="Expand"
-              accessibilityCollapseLabel="Collapse"
-              id="row3"
-              expandedContents={
-                <Box maxWidth={236} padding={2} column={12}>
-                  <WashAnimated
-                    image={
-                      <Avatar
-                        name="luna avatar"
-                        src="https://i.ibb.co/JvY9DKK/neville.png"
-                      />
-                    }
-                  >
-                    <Text align="center" weight="bold">
-                      <Link href="https://pinterest.com">
-                        <Box paddingX={3} paddingY={2}>
-                          Neville's Info
-                        </Box>
-                      </Link>
-                    </Text>
-                  </WashAnimated>
-                </Box>
-              }
-            >
-              <Table.Cell>
-                <Text>Neville Longbottom</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Gryffindor</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>July 30, 1980</Text>
-              </Table.Cell>
-            </Table.RowExpandable>
-
-          </Table.Body>
-        </Table>);
-    }
-    `}
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample
+                code={uncontrolledExpandable}
+                name="Uncontrolled Table.RowExpandable example"
+                hideEditor
+              />
+            }
           />
         </MainSection.Subsection>
+
         <MainSection.Subsection
-          title="Table Row Expandable with Sticky Columns"
+          title="Table.RowExpandable with Sticky Columns"
           description="When specifying `stickyColumns` with expandable rows, include the column of arrows in your count. This example sets `stickyColumns` to 3."
         >
           <MainSection.Card
@@ -2293,7 +2055,7 @@ function Example() {
 
       return(
       <Box width="60%">
-        <Table accessibilityLabel="Table Row Expandable with Sticky Columns" stickyColumns={3}>
+        <Table accessibilityLabel="Table.RowExpandable with Sticky Columns" stickyColumns={3}>
 
           <Table.Header>
             <Table.Row>
@@ -2504,7 +2266,7 @@ function Example() {
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          title="Table Row Drawer"
+          title="Table.RowDrawer implementation"
           description="Drawer row that is able to hold additional content."
         >
           <MainSection.Card
@@ -2515,7 +2277,7 @@ function Example() {
 
   return(
     <Box width="100%">
-      <Table accessibilityLabel="Table Row Drawer">
+      <Table accessibilityLabel="Table.RowDrawer example">
         <colgroup>
           <col span="1" style={{ width: "60%" }} />
           <col span="1" style={{ width: "15%" }} />

--- a/packages/gestalt/src/TableRowDrawer.js
+++ b/packages/gestalt/src/TableRowDrawer.js
@@ -11,7 +11,7 @@ type Props = {|
    */
   children: Node,
   /**
-   * The contents within the drawer.
+   * The contents within the drawer. See the [Table.RowDrawer implementation](https://gestalt.pinterest.systems/web/table#Table.RowDrawer-implementation) to learn more.
    */
   drawerContents: Node,
   /**


### PR DESCRIPTION
### Summary

#### What changed?

Table: implement controlled Table.RowExpanded

#### Why?

So engineers can leave some Table.RowExpanded open based on use case.