### PR TITLE
DatePicker:  remove virtual keyboard on mobile

### DIFF
--- a/packages/gestalt-datepicker/src/DatePickerTextField.js
+++ b/packages/gestalt-datepicker/src/DatePickerTextField.js
@@ -67,6 +67,7 @@ function DatePickerTextField(props: Props) {
             }}
             errorMessage={errorMessage}
             helperText={helperText}
+            inputMode="none"
             name={name}
             onChange={(data) => onChange?.(data.event)}
             onKeyDown={(data) => onKeyDown?.(data.event)}


### PR DESCRIPTION
### Summary

#### BREAKING CHANGE

No codemod needed. We are removing virtual keyboard support for DatePicker so they don't conflict with each other.

#### What changed?

DatePicker:  remove virtual keyboard on mobile

#### Why?

DatePicker: add 'inputMode' = none to internal TextField to only show calendar, and don't display virtual keyboard


![image](https://user-images.githubusercontent.com/10593890/229245141-6a84db56-6ed2-486d-9118-17952295506d.png)


https://user-images.githubusercontent.com/10593890/229680720-c440d4cd-2546-4170-8861-b63deb1755da.MP4

