### PR TITLE
Docs: Removing Paragraph BG Color for MD documents

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -83,7 +83,7 @@ pre {
 }
 
 .Markdown p {
-  background-color: var(--g-colorGray0);
+  background-color: transparent;
   margin: 0;
 }
 


### PR DESCRIPTION
Thanks for creating a PR! Please follow this template and delete items/sections that are not relevant to your changes, including these instructions.


### Summary

Dark mode shows a paragraph highlight.

![image](https://user-images.githubusercontent.com/5509813/229880465-b95edc4e-2970-486f-8fb3-ace7b04f4cba.png)

<img width="688" alt="image" src="https://user-images.githubusercontent.com/5509813/229881478-4f8acd1d-0e4f-4fb2-a7f3-ba954c11fe7b.png">


#### What changed?

Changing paragraphs to a transparent background. Didn't find instances of where a fixed bg color was needed. Turns out for most MD pages w/ paragraphs, this seems like an issue.




