### PR TITLE
TextField, NumberField: prefix 'mobile' to mobile only props: inputMode & enterKeyHint

### DIFF
--- a/docs/examples/numberfield/enterKeyHint.js
+++ b/docs/examples/numberfield/enterKeyHint.js
@@ -9,7 +9,7 @@ export default function Example(): React$Node {
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">
       <Box width={300}>
         <NumberField
-          enterKeyHint="next"
+          mobileEnterKeyHint="next"
           id="enterKeyHint"
           label="Age"
           onChange={({ value }) => {

--- a/packages/gestalt-datepicker/src/DatePickerTextField.js
+++ b/packages/gestalt-datepicker/src/DatePickerTextField.js
@@ -60,7 +60,7 @@ function DatePickerTextField(props: Props) {
             autoComplete="off"
             disabled={disabled}
             id={id}
-            inputMode="none"
+            mobileInputMode="none"
             onBlur={(data) => onBlur?.(data.event)}
             onFocus={(data) => {
               onFocus?.(data.event);

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -25,10 +25,6 @@ type Props = {|
    */
   disabled?: boolean,
   /**
-   *  Optionally specify the action label to present for the enter key on virtual keyboards. See the [enterKeyHint variant](https://gestalt.pinterest.systems/web/numberfield#EnterKeyHint) for more info.
-   *
-   */ enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
-  /**
    * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/web/link) or [TapArea](https://gestalt.pinterest.systems/web/taparea).
    */
   errorMessage?: Node,
@@ -52,6 +48,11 @@ type Props = {|
    * The lower bound of valid input, inclusive.
    */
   min?: number,
+  /**
+   *  Mobile only prop. Optionally specify the action label to present for the enter key on virtual keyboards. See the [enterKeyHint variant](https://gestalt.pinterest.systems/web/numberfield#EnterKeyHint) for more info.
+   *
+   */
+  mobileEnterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
   /**
    * A unique name for the input.
    */
@@ -120,7 +121,7 @@ const NumberFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = fo
   {
     autoComplete,
     disabled = false,
-    enterKeyHint,
+    mobileEnterKeyHint,
     errorMessage,
     helperText,
     id,
@@ -143,7 +144,7 @@ const NumberFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = fo
     <InternalTextField
       autoComplete={autoComplete}
       disabled={disabled}
-      enterKeyHint={enterKeyHint}
+      mobileEnterKeyHint={mobileEnterKeyHint}
       errorMessage={errorMessage}
       helperText={helperText}
       id={id}

--- a/packages/gestalt/src/NumberField.test.js
+++ b/packages/gestalt/src/NumberField.test.js
@@ -38,7 +38,7 @@ describe('NumberField', () => {
   it('NumberField with enterKeyHint', () => {
     const tree = create(
       <NumberField
-        enterKeyHint="go"
+        mobileEnterKeyHint="go"
         id="test"
         onChange={jest.fn()}
         onFocus={jest.fn()}

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -29,10 +29,6 @@ type Props = {|
    */
   disabled?: boolean,
   /**
-   *  Optionally specify the action label to present for the enter key on virtual keyboards. See the [enterKeyHint variant](https://gestalt.pinterest.systems/web/textfield#EnterKeyHint) for more info.
-   */
-  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
-  /**
    * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/web/link) or [TapArea](https://gestalt.pinterest.systems/web/taparea).
    */
   errorMessage?: Node,
@@ -49,10 +45,6 @@ type Props = {|
    */
   id: string,
   /**
-   * Optionally specify the type of data that might be entered by the user while editing the element or its contents. This allows mobile browsers to display an appropriate virtual keyboard. See the [enterKeyHint variant](https://gestalt.pinterest.systems/web/textfield#EnterKeyHint) for more info.
-   */
-  inputMode?: 'none' | 'text' | 'decimal' | 'numeric',
-  /**
    * The label for the input. Be sure to localize the text.
    */
   label?: string,
@@ -64,6 +56,14 @@ type Props = {|
    * The maximum number of characters allowed in Textfield. `maxLength` must be an integer value 0 or higher. See the [maximum length variant](https://gestalt.pinterest.systems/web/textfield#Maximum-length) for more details.
    */
   maxLength?: MaxLength,
+  /**
+   * Mobile only prop. Optionally specify the action label to present for the enter key on virtual keyboards. See the [enterKeyHint variant](https://gestalt.pinterest.systems/web/textfield#EnterKeyHint) for more info.
+   */
+  mobileEnterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
+  /**
+   * Mobile only prop. Optionally specify the type of data that might be entered by the user while editing the element or its contents. This allows mobile browsers to display an appropriate virtual keyboard. See the [enterKeyHint variant](https://gestalt.pinterest.systems/web/textfield#EnterKeyHint) for more info.
+   */
+  mobileInputMode?: 'none' | 'text' | 'decimal' | 'numeric',
   /**
    * A unique name for the input.
    */
@@ -140,15 +140,15 @@ const TextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forw
   {
     autoComplete,
     disabled = false,
-    enterKeyHint,
     errorMessage,
     hasError = false,
     helperText,
     id,
-    inputMode,
     label,
     labelDisplay = 'visible',
     maxLength,
+    mobileEnterKeyHint,
+    mobileInputMode,
     name,
     onBlur,
     onChange,
@@ -203,16 +203,16 @@ const TextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forw
     <InternalTextField
       autoComplete={autoComplete}
       disabled={disabled}
-      enterKeyHint={enterKeyHint}
       errorMessage={errorMessage}
       hasError={hasError}
       helperText={helperText}
       iconButton={iconButton}
       id={id}
-      inputMode={inputMode}
       label={label}
       labelDisplay={labelDisplay}
       maxLength={maxLength}
+      mobileEnterKeyHint={mobileEnterKeyHint}
+      mobileInputMode={mobileInputMode}
       name={name}
       onBlur={onBlur}
       onChange={onChange}

--- a/packages/gestalt/src/TextField.test.js
+++ b/packages/gestalt/src/TextField.test.js
@@ -40,7 +40,7 @@ describe('TextField', () => {
     const tree = create(
       <TextField
         id="test"
-        enterKeyHint="go"
+        mobileEnterKeyHint="go"
         onChange={jest.fn()}
         onFocus={jest.fn()}
         onBlur={jest.fn()}

--- a/packages/gestalt/src/TextField/InternalTextField.js
+++ b/packages/gestalt/src/TextField/InternalTextField.js
@@ -34,17 +34,17 @@ type Props = {|
   accessibilityActiveDescendant?: string,
   autoComplete?: 'bday' | 'current-password' | 'email' | 'new-password' | 'on' | 'off' | 'username',
   disabled?: boolean,
-  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
   errorMessage?: Node,
   hasError?: boolean,
   helperText?: string,
   iconButton?: Element<typeof InternalTextFieldIconButton>,
-  inputMode?: 'none' | 'text' | 'decimal' | 'numeric',
   label?: string,
   labelDisplay?: 'visible' | 'hidden',
   max?: number,
   maxLength?: ?MaxLength,
   min?: number,
+  mobileEnterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send',
+  mobileInputMode?: 'none' | 'text' | 'decimal' | 'numeric',
   name?: string,
   onBlur?: ({|
     event: SyntheticFocusEvent<HTMLInputElement>,
@@ -81,16 +81,16 @@ const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement
     autoComplete,
     disabled = false,
     errorMessage,
-    enterKeyHint,
     hasError = false,
     helperText,
     id,
     iconButton,
-    inputMode,
     label,
     labelDisplay,
     max,
     maxLength,
+    mobileEnterKeyHint,
+    mobileInputMode,
     min,
     name,
     onBlur,
@@ -187,9 +187,9 @@ const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement
       autoComplete={autoComplete}
       className={tags ? unstyledClasses : styledClasses}
       disabled={disabled}
-      enterKeyHint={enterKeyHint}
+      enterKeyHint={mobileEnterKeyHint}
       id={id}
-      inputMode={inputMode}
+      inputMode={mobileInputMode}
       maxLength={maxLength?.characterCount}
       max={type === 'number' ? max : undefined}
       min={type === 'number' ? min : undefined}


### PR DESCRIPTION
### BREAKING CHANGE

```
yarn codemod modifyProp ~/path/to/your/code
--component=TextField
--previousProp=inputMode
--nextProp=mobileInputMode
```

```
yarn codemod modifyProp ~/path/to/your/code
--component=TextField
--previousProp=enterKeyHint
--nextProp=mobileEnterKeyHint
```

```
yarn codemod modifyProp ~/path/to/your/code
--component=NumberField
--previousProp=enterKeyHint
--nextProp=mobileEnterKeyHint
```

### Summary

#### What changed?

TextField, NumberField: prefix 'mobile' to mobile only props: inputMode & enterKeyHint

#### Why?

Provide clarity to API. These props are only to be used in mobile web experiences.
