### PR TITLE
Docs: Add white bg to darkmode images, remove padding

### DIFF
--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -236,14 +236,14 @@ const components = {
             alignItems="center"
             justifyContent="center"
           >
-              <Image
-                src={src}
-                alt={alt}
-                width={layout === 'fill' ? undefined : width || '100%'}
-                height={layout === 'fill' ? undefined : height || '100%'}
-                layout={layout}
-                objectFit="contain"
-              />
+            <Image
+              src={src}
+              alt={alt}
+              width={layout === 'fill' ? undefined : width || '100%'}
+              height={layout === 'fill' ? undefined : height || '100%'}
+              layout={layout}
+              objectFit="contain"
+            />
           </Box>
         </Box>
         {caption && (

--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -4,7 +4,7 @@
 
 import { type Node } from 'react';
 import { MDXProvider } from '@mdx-js/react';
-import { Text, Box, Link, Flex, Icon, List, Button, Mask } from 'gestalt';
+import { Text, Box, Link, Flex, Icon, List, Button } from 'gestalt';
 import Image from 'next/image';
 import Highlighter from './highlight.js';
 import IllustrationCard from './IllustrationCard.js';

--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -236,16 +236,14 @@ const components = {
             alignItems="center"
             justifyContent="center"
           >
-          <Mask rounding={2} height={"250px"}>
-            <Image
-              src={src}
-              alt={alt}
-              width={layout === 'fill' ? undefined : width || '100%'}
-              height={layout === 'fill' ? undefined : height || '100%'}
-              layout={layout}
-              objectFit="contain"
-            />
-            </Mask>
+              <Image
+                src={src}
+                alt={alt}
+                width={layout === 'fill' ? undefined : width || '100%'}
+                height={layout === 'fill' ? undefined : height || '100%'}
+                layout={layout}
+                objectFit="contain"
+              />
           </Box>
         </Box>
         {caption && (

--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -4,7 +4,7 @@
 
 import { type Node } from 'react';
 import { MDXProvider } from '@mdx-js/react';
-import { Text, Box, Link, Flex, Icon, List, Button } from 'gestalt';
+import { Text, Box, Link, Flex, Icon, List, Button, Mask } from 'gestalt';
 import Image from 'next/image';
 import Highlighter from './highlight.js';
 import IllustrationCard from './IllustrationCard.js';
@@ -198,25 +198,35 @@ const components = {
     alt,
     width,
     height,
-    addPadding,
+    padding,
+    color,
   }: {|
     src: string,
     caption?: string,
     alt?: string,
     width?: number,
     height?: number,
-    addPadding?: boolean,
+    padding?: 'standard' | 'none',
+    color?: string,
   |}) => {
     const layout = width || height ? 'fixed' : 'fill';
+
+    const colorStyle = {
+      __style: {
+        backgroundColor: color ? `var(--color-${color})` : 'white',
+      },
+    };
+
+    const defaultPadding = padding || 'none';
 
     return (
       <Box>
         <Box
-          padding={addPadding ? 8 : 0}
+          padding={defaultPadding === 'standard' ? 8 : 0}
           rounding={2}
           borderStyle="sm"
           height="250px"
-          color="light"
+          dangerouslySetInlineStyle={colorStyle}
         >
           <Box
             position="relative"
@@ -226,6 +236,7 @@ const components = {
             alignItems="center"
             justifyContent="center"
           >
+          <Mask rounding={2} height={"250px"}>
             <Image
               src={src}
               alt={alt}
@@ -234,6 +245,7 @@ const components = {
               layout={layout}
               objectFit="contain"
             />
+            </Mask>
           </Box>
         </Box>
         {caption && (

--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -198,20 +198,21 @@ const components = {
     alt,
     width,
     height,
-    noPadding,
+    addPadding,
   }: {|
     src: string,
     caption?: string,
     alt?: string,
     width?: number,
     height?: number,
-    noPadding?: boolean,
+    addPadding?: boolean,
   |}) => {
-    const layout = width || height ? 'fixed' : 'fill';
+    const layout = (width || height) ? 'fixed' : 'fill';
 
+   
     return (
       <Box>
-        <Box padding={noPadding ? 0 : 8} rounding={2} borderStyle="sm" height="250px">
+        <Box padding={addPadding ? 8 : 0} rounding={2} borderStyle="sm" height="250px" color="light">
           <Box
             position="relative"
             width="100%"

--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -207,12 +207,17 @@ const components = {
     height?: number,
     addPadding?: boolean,
   |}) => {
-    const layout = (width || height) ? 'fixed' : 'fill';
+    const layout = width || height ? 'fixed' : 'fill';
 
-   
     return (
       <Box>
-        <Box padding={addPadding ? 8 : 0} rounding={2} borderStyle="sm" height="250px" color="light">
+        <Box
+          padding={addPadding ? 8 : 0}
+          rounding={2}
+          borderStyle="sm"
+          height="250px"
+          color="light"
+        >
           <Box
             position="relative"
             width="100%"

--- a/docs/markdown/android/avatar.md
+++ b/docs/markdown/android/avatar.md
@@ -4,7 +4,7 @@ description: Avatar is used to represent a user. Every Avatar image has a subtle
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/af/75/6f/af756f3ad767857e5695d6cb626c1a12.png" alt="all variations of the avatar component"/>
+<ImgContainer padding="standard" src="https://i.pinimg.com/originals/af/75/6f/af756f3ad767857e5695d6cb626c1a12.png" alt="all variations of the avatar component"/>
 
 ## Usage guidelines
 

--- a/docs/markdown/android/checkbox.md
+++ b/docs/markdown/android/checkbox.md
@@ -4,7 +4,7 @@ description: Checkbox is used for multiple choice selection.
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/d3/66/fb/d366fb0a6b4bc150779c149aea472a24.jpg" addPadding alt="Primary example of Checkbox component" />
+<ImgContainer src="https://i.pinimg.com/originals/d3/66/fb/d366fb0a6b4bc150779c149aea472a24.jpg" alt="Primary example of Checkbox component" />
 
 ## Usage guidelines
 

--- a/docs/markdown/android/checkbox.md
+++ b/docs/markdown/android/checkbox.md
@@ -4,7 +4,7 @@ description: Checkbox is used for multiple choice selection.
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/d3/66/fb/d366fb0a6b4bc150779c149aea472a24.jpg" noPadding alt="Primary example of Checkbox component" />
+<ImgContainer src="https://i.pinimg.com/originals/d3/66/fb/d366fb0a6b4bc150779c149aea472a24.jpg" addPadding alt="Primary example of Checkbox component" />
 
 ## Usage guidelines
 

--- a/docs/markdown/android/switch.md
+++ b/docs/markdown/android/switch.md
@@ -4,7 +4,7 @@ description: Use Switch for single-cell options that can be turned on and off on
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/d3/90/ad/d390ad2e3fa4c1c8319d7baa7508cb0a.jpg" noPadding alt="Primary example of Switch component" />
+<ImgContainer src="https://i.pinimg.com/originals/d3/90/ad/d390ad2e3fa4c1c8319d7baa7508cb0a.jpg"  alt="Primary example of Switch component" />
 
 ## Usage guidelines
 
@@ -24,13 +24,13 @@ fullwidth: true
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/2c/19/f6/2c19f61a4901d6f77069c3ed9f266de4.jpg" noPadding alt="Example of Switch with label and subtext" />
+    <ImgContainer src="https://i.pinimg.com/originals/2c/19/f6/2c19f61a4901d6f77069c3ed9f266de4.jpg"  alt="Example of Switch with label and subtext" />
     <Do title="Do" />
     Use a label and subtext to give Switch context when possible.
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/d4/ea/4d/d4ea4d12eb9ec8235bd773b363cddc97.jpg" noPadding alt="Example of Switch with truncated text" />
+    <ImgContainer src="https://i.pinimg.com/originals/d4/ea/4d/d4ea4d12eb9ec8235bd773b363cddc97.jpg"  alt="Example of Switch with truncated text" />
     <Dont title="Don't" />
     Truncate label text. Instead, allow it to wrap to form another line.
   </Group>
@@ -38,13 +38,13 @@ fullwidth: true
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/da/30/95/da309504c6a99dc3b989099a2bfde060.jpg" noPadding alt="Example of disabled Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/da/30/95/da309504c6a99dc3b989099a2bfde060.jpg"  alt="Example of disabled Switch" />
     <Do title="Do" />
     Communicate why a switch is disabled and how to enable it if possible.
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/66/ef/07/66ef0701a9d3d0927c1198d0d8bc9651.jpg" noPadding alt="Example of incorrect switch usage" />
+    <ImgContainer src="https://i.pinimg.com/originals/66/ef/07/66ef0701a9d3d0927c1198d0d8bc9651.jpg"  alt="Example of incorrect switch usage" />
     <Dont title="Don't" />
     Use checkboxes or radio buttons to replace the functionality of a switch. If the functionality is a binary on or off, use Switch instead.
   </Group>
@@ -99,22 +99,22 @@ People use Apple and Android’s accessibility features, such as VoiceOver and T
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/7f/6b/5a/7f6b5a6438b9331f9172d346715cdd0c.jpg" noPadding alt="Example of default inactive state of Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/7f/6b/5a/7f6b5a6438b9331f9172d346715cdd0c.jpg"  alt="Example of default inactive state of Switch" />
     **Default | Inactive state**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/80/29/45/802945dd6c7a4dcf2eb43bc4d1cc9f3f.jpg" noPadding alt="Example of default active state of Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/80/29/45/802945dd6c7a4dcf2eb43bc4d1cc9f3f.jpg"  alt="Example of default active state of Switch" />
     **Default | Active state**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/c0/4c/97/c04c970f0d926842cf4ef89ad42b9347.jpg" noPadding alt="Example of disabled inactive state of Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/c0/4c/97/c04c970f0d926842cf4ef89ad42b9347.jpg"  alt="Example of disabled inactive state of Switch" />
     **Disabled | Inactive state**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/e2/12/af/e212aff2d4ff881e3246bdbe2396a058.jpg" noPadding alt="Example of disabled active state of Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/e2/12/af/e212aff2d4ff881e3246bdbe2396a058.jpg"  alt="Example of disabled active state of Switch" />
     **Disabled | Active state**
   </Group>
 </TwoCol>

--- a/docs/markdown/android/toast.md
+++ b/docs/markdown/android/toast.md
@@ -4,7 +4,7 @@ description: Toasts are brief and small messages that overlay content, but do no
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/db/49/55/db4955bf701fc8d8b02df5db1b629553.jpg" noPadding alt="an example of toast"/>
+<ImgContainer src="https://i.pinimg.com/originals/db/49/55/db4955bf701fc8d8b02df5db1b629553.jpg"  alt="an example of toast"/>
 
 ## Usage guidelines
 
@@ -49,7 +49,7 @@ fullwidth: true
     Stack multiple toasts as that will block the user.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/ee/2d/1a/ee2d1acda7fb690b4a6de04ae2fc3d23.jpg" alt="example of a dismissible toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/ee/2d/1a/ee2d1acda7fb690b4a6de04ae2fc3d23.jpg"  alt="example of a dismissible toast"/>
     <Do title="Do" />
     Include a way to dismiss the toast when it is actionable or contains multiple lines of text. Mobile toasts can be dismissed via swiping up if placed on the top or down if placed on the bottom.
   </Group>
@@ -93,7 +93,7 @@ Use these tokens for applying size and color styles to Toast.
 A generic acknowledgment after an action is taken.
 <TwoCol>
 <Group>
-<ImgContainer src="https://i.pinimg.com/originals/ed/6c/59/ed6c59cc39e64ae6244cf1a3a4158d44.jpg" noPadding alt="default toast"/>
+<ImgContainer src="https://i.pinimg.com/originals/ed/6c/59/ed6c59cc39e64ae6244cf1a3a4158d44.jpg"  alt="default toast"/>
 </Group>
 <Group>
 <iframe style={{border:0}} width="100%" height="300" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FVespNbaZGqiY7M0PMSIipE%2FMobile-Specs%3Fnode-id%3D1400%253A9903%26t%3Dwu4xHZXGRwObOjKp-1" allowFullScreen></iframe>
@@ -104,7 +104,7 @@ A generic acknowledgment after an action is taken.
 Used rarely for connection issues or unknown errors where we don’t want to completely block the users flow, but want the message to persist if the user goes to another surface. Providing a way to solve the error or get help is recommended.
 <TwoCol>
 <Group>
-<ImgContainer src="https://i.pinimg.com/originals/04/6f/e8/046fe8c42fbf51d4065515f793865205.jpg" noPadding alt="error toast"/>
+<ImgContainer src="https://i.pinimg.com/originals/04/6f/e8/046fe8c42fbf51d4065515f793865205.jpg"  alt="error toast"/>
 </Group>
 <Group>
 <iframe style={{border:0}} width="100%" height="300" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FVespNbaZGqiY7M0PMSIipE%2FMobile-Specs%3Fnode-id%3D1400%253A9978%26t%3Dwu4xHZXGRwObOjKp-1" allowFullScreen></iframe>
@@ -116,7 +116,7 @@ Used rarely for connection issues or unknown errors where we don’t want to com
 A simple, generic acknowledgment after an action is taken. These should not be actionable.
 <TwoCol>
 <Group>
-<ImgContainer src="https://i.pinimg.com/originals/ed/6c/59/ed6c59cc39e64ae6244cf1a3a4158d44.jpg" noPadding alt="text only toast"/>
+<ImgContainer src="https://i.pinimg.com/originals/ed/6c/59/ed6c59cc39e64ae6244cf1a3a4158d44.jpg"  alt="text only toast"/>
 </Group>
 <Group>
 <iframe style={{border:0}} width="100%" height="300" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FVespNbaZGqiY7M0PMSIipE%2FMobile-Specs%3Fnode-id%3D1400%253A9903%26t%3Dwu4xHZXGRwObOjKp-1" allowFullScreen></iframe>
@@ -127,7 +127,7 @@ A simple, generic acknowledgment after an action is taken. These should not be a
 With an image for Pin or Board actions.
 <TwoCol>
 <Group>
-<ImgContainer src="https://i.pinimg.com/originals/31/44/83/31448327246692115b4eb3546a2a26f4.jpg" noPadding alt="toast with image"/>
+<ImgContainer src="https://i.pinimg.com/originals/31/44/83/31448327246692115b4eb3546a2a26f4.jpg"  alt="toast with image"/>
 </Group>
 <Group>
 <iframe style={{border:0}} width="100%" height="300" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FVespNbaZGqiY7M0PMSIipE%2FMobile-Specs%3Fnode-id%3D1400%253A9600%26t%3Dwu4xHZXGRwObOjKp-1" allowFullScreen></iframe>
@@ -138,7 +138,7 @@ With an image for Pin or Board actions.
 With an Avatar for Profile or Pinner-related messaging. An optional link can be included. When there’s a link on mWeb, the entire toast is tappable, using TapArea.
 <TwoCol>
 <Group>
-<ImgContainer src="https://i.pinimg.com/originals/7b/03/89/7b038920b2ff477c2b60935dccb87fbc.jpg" noPadding alt="toast with avatar"/>
+<ImgContainer src="https://i.pinimg.com/originals/7b/03/89/7b038920b2ff477c2b60935dccb87fbc.jpg"  alt="toast with avatar"/>
 </Group>
 <Group>
 <iframe style={{border:0}} width="100%" height="300" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FVespNbaZGqiY7M0PMSIipE%2FMobile-Specs%3Fnode-id%3D1400%253A9677%26t%3Dwu4xHZXGRwObOjKp-1" allowFullScreen></iframe>
@@ -149,7 +149,7 @@ With an Avatar for Profile or Pinner-related messaging. An optional link can be 
 As a secondary element, to drive users to another surface, or change a recently completed action.
 <TwoCol>
 <Group>
-<ImgContainer src="https://i.pinimg.com/originals/79/dd/04/79dd04506e8e3f17b4ecae1398ab2720.jpg" noPadding alt="toast with button"/>
+<ImgContainer src="https://i.pinimg.com/originals/79/dd/04/79dd04506e8e3f17b4ecae1398ab2720.jpg"  alt="toast with button"/>
 </Group>
 <Group>
 <iframe style={{border:0}} width="100%" height="300" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FVespNbaZGqiY7M0PMSIipE%2FMobile-Specs%3Fnode-id%3D1400%253A9522%26t%3Dwu4xHZXGRwObOjKp-1" allowFullScreen></iframe>
@@ -160,7 +160,7 @@ As a secondary element, to drive users to another surface, or change a recently 
 As a secondary element, to drive users to another surface.
 <TwoCol>
 <Group>
-<ImgContainer src="https://i.pinimg.com/originals/31/44/83/31448327246692115b4eb3546a2a26f4.jpg" noPadding alt="toast with link"/>
+<ImgContainer src="https://i.pinimg.com/originals/31/44/83/31448327246692115b4eb3546a2a26f4.jpg"  alt="toast with link"/>
 </Group>
 <Group>
 <iframe style={{border:0}} width="100%" height="300" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FVespNbaZGqiY7M0PMSIipE%2FMobile-Specs%3Fnode-id%3D1400%253A9751%26t%3Dwu4xHZXGRwObOjKp-1" allowFullScreen></iframe>

--- a/docs/markdown/ios/avatar.md
+++ b/docs/markdown/ios/avatar.md
@@ -4,7 +4,7 @@ description: Avatar is used to represent a user. Every Avatar image has a subtle
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/30/7a/de/307adebcacf4fca359de788e6a077329.png" alt="all variations of the avatar component"/>
+<ImgContainer padding="standard" src="https://i.pinimg.com/originals/30/7a/de/307adebcacf4fca359de788e6a077329.png" alt="all variations of the avatar component"/>
 
 ## Usage guidelines
 

--- a/docs/markdown/ios/checkbox.md
+++ b/docs/markdown/ios/checkbox.md
@@ -4,7 +4,7 @@ description: Checkbox is used for multiple choice selection.
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/d3/66/fb/d366fb0a6b4bc150779c149aea472a24.jpg" noPadding alt="Primary example of Checkbox component" />
+<ImgContainer src="https://i.pinimg.com/originals/d3/66/fb/d366fb0a6b4bc150779c149aea472a24.jpg"  alt="Primary example of Checkbox component" />
 
 ## Usage guidelines
 
@@ -28,13 +28,13 @@ fullwidth: true
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/32/33/bb/3233bb3a92c57dd29f2b5f2fd2a417f7.jpg" noPadding alt="Example of correct multi-select use" />
+    <ImgContainer src="https://i.pinimg.com/originals/32/33/bb/3233bb3a92c57dd29f2b5f2fd2a417f7.jpg"  alt="Example of correct multi-select use" />
     <Do title="Do" />
     Use checkboxes for multi-selection of related list items
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/1e/14/24/1e14245a26f12cf014028d24b00a6317.jpg" noPadding alt="Example of incorrect single-select use" />
+    <ImgContainer src="https://i.pinimg.com/originals/1e/14/24/1e14245a26f12cf014028d24b00a6317.jpg"  alt="Example of incorrect single-select use" />
     <Dont title="Don't" />
     Use checkboxes for one selection. Use [RadioGroup](https://gestalt.pinterest.systems/web/radiogroup) instead.
   </Group>
@@ -42,13 +42,13 @@ fullwidth: true
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/b2/20/93/b2209377241895d0471bde7340ee85c2.jpg" noPadding alt="Example of correct single checkbox use" />
+    <ImgContainer src="https://i.pinimg.com/originals/b2/20/93/b2209377241895d0471bde7340ee85c2.jpg"  alt="Example of correct single checkbox use" />
     <Do title="Do" />
     Use a single Checkbox in forms where the selection only takes effect after submitting the form
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/e7/07/02/e70702e40416c5f4f89e92eca2bbb490.jpg" noPadding alt="Example of incorrect immediate effect use" />
+    <ImgContainer src="https://i.pinimg.com/originals/e7/07/02/e70702e40416c5f4f89e92eca2bbb490.jpg"  alt="Example of incorrect immediate effect use" />
     <Dont title="Don't" />
     Use a Checkbox to turn a state on and off with immediate effect. Use [Switch](https://gestalt.pinterest.systems/ios/switch) instead.
   </Group>
@@ -95,27 +95,27 @@ People use Apple and Android’s accessibility features, such as VoiceOver and T
 
 <ThreeCol spacing="expanded">
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/45/01/9f/45019f108f27c0d3aa9480fcf001b115.jpg" noPadding alt="Example of unchecked checkbox" />
+    <ImgContainer src="https://i.pinimg.com/originals/45/01/9f/45019f108f27c0d3aa9480fcf001b115.jpg"  alt="Example of unchecked checkbox" />
     **Unchecked**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/fd/06/05/fd06051095a0d1c76122ec282ec54bea.jpg" noPadding alt="Example of checked checkbox" />
+    <ImgContainer src="https://i.pinimg.com/originals/fd/06/05/fd06051095a0d1c76122ec282ec54bea.jpg"  alt="Example of checked checkbox" />
     **Checked**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/60/60/48/60604885afd2ee2e8b9cad4c1efdbb0a.jpg" noPadding alt="Example of checkbox with an error" />
+    <ImgContainer src="https://i.pinimg.com/originals/60/60/48/60604885afd2ee2e8b9cad4c1efdbb0a.jpg"  alt="Example of checkbox with an error" />
     **Error**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/e0/ab/e1/e0abe172b2dfe56166d33b5d8a8175f2.jpg" noPadding alt="Example of checkbox with an indeterminate state" />
+    <ImgContainer src="https://i.pinimg.com/originals/e0/ab/e1/e0abe172b2dfe56166d33b5d8a8175f2.jpg"  alt="Example of checkbox with an indeterminate state" />
     **Indeterminate**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/82/50/5c/82505c5eb557f3b85049965ccbe14435.jpg" noPadding alt="Example of checkbox with a disabled state" />
+    <ImgContainer src="https://i.pinimg.com/originals/82/50/5c/82505c5eb557f3b85049965ccbe14435.jpg"  alt="Example of checkbox with a disabled state" />
     **Disabled**
   </Group>
 </ThreeCol>
@@ -123,7 +123,7 @@ People use Apple and Android’s accessibility features, such as VoiceOver and T
 **With helper text**
 Checkbox supports helper text to provide more detail about an option.
 
-<ImgContainer src="https://i.pinimg.com/originals/dd/12/5a/dd125a30d6fb4cdd8c44c002f363dd56.jpg" noPadding alt="Example of checkbox with helper text" />
+<ImgContainer src="https://i.pinimg.com/originals/dd/12/5a/dd125a30d6fb4cdd8c44c002f363dd56.jpg"  alt="Example of checkbox with helper text" />
 
 ## Related
 

--- a/docs/markdown/ios/icon.md
+++ b/docs/markdown/ios/icon.md
@@ -88,7 +88,7 @@ Used sparingly to draw attention to an icon that might otherwise be missed
 
 <TwoCol>
 <Group>
-<ImgContainer src="https://i.pinimg.com/originals/81/ca/d0/81cad0e1aa26025955806c587f135f47.jpg" alt="The Pinterest homepage with a 16 pixel TV icon." />
+<ImgContainer src="https://i.pinimg.com/originals/81/ca/d0/81cad0e1aa26025955806c587f135f47.jpg"  alt="The Pinterest homepage with a 16 pixel TV icon." />
 16px Icon example
 </Group>
 <Group>

--- a/docs/markdown/ios/switch.md
+++ b/docs/markdown/ios/switch.md
@@ -4,7 +4,7 @@ description: Use Switch for single-cell options that can be turned on and off on
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/d3/90/ad/d390ad2e3fa4c1c8319d7baa7508cb0a.jpg" noPadding alt="Primary example of Switch component" />
+<ImgContainer src="https://i.pinimg.com/originals/d3/90/ad/d390ad2e3fa4c1c8319d7baa7508cb0a.jpg"  alt="Primary example of Switch component" />
 
 ## Usage guidelines
 
@@ -24,13 +24,13 @@ fullwidth: true
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/2c/19/f6/2c19f61a4901d6f77069c3ed9f266de4.jpg" noPadding alt="Example of Switch with label and subtext" />
+    <ImgContainer src="https://i.pinimg.com/originals/2c/19/f6/2c19f61a4901d6f77069c3ed9f266de4.jpg"  alt="Example of Switch with label and subtext" />
     <Do title="Do" />
     Use a label and subtext to give Switch context when possible.
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/d4/ea/4d/d4ea4d12eb9ec8235bd773b363cddc97.jpg" noPadding alt="Example of Switch with truncated text" />
+    <ImgContainer src="https://i.pinimg.com/originals/d4/ea/4d/d4ea4d12eb9ec8235bd773b363cddc97.jpg"  alt="Example of Switch with truncated text" />
     <Dont title="Don't" />
     Truncate label text. Instead, allow it to wrap to form another line.
   </Group>
@@ -38,13 +38,13 @@ fullwidth: true
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/da/30/95/da309504c6a99dc3b989099a2bfde060.jpg" noPadding alt="Example of disabled Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/da/30/95/da309504c6a99dc3b989099a2bfde060.jpg"  alt="Example of disabled Switch" />
     <Do title="Do" />
     Communicate why a switch is disabled and how to enable it if possible.
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/66/ef/07/66ef0701a9d3d0927c1198d0d8bc9651.jpg" noPadding alt="Example of incorrect switch usage" />
+    <ImgContainer src="https://i.pinimg.com/originals/66/ef/07/66ef0701a9d3d0927c1198d0d8bc9651.jpg"  alt="Example of incorrect switch usage" />
     <Dont title="Don't" />
     Use checkboxes or radio buttons to replace the functionality of a switch. If the functionality is a binary on or off, use Switch instead.
   </Group>
@@ -99,22 +99,22 @@ People use Apple and Android’s accessibility features, such as VoiceOver and T
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/7f/6b/5a/7f6b5a6438b9331f9172d346715cdd0c.jpg" noPadding alt="Example of default inactive state of Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/7f/6b/5a/7f6b5a6438b9331f9172d346715cdd0c.jpg"  alt="Example of default inactive state of Switch" />
     **Default | Inactive state**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/80/29/45/802945dd6c7a4dcf2eb43bc4d1cc9f3f.jpg" noPadding alt="Example of default active state of Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/80/29/45/802945dd6c7a4dcf2eb43bc4d1cc9f3f.jpg"  alt="Example of default active state of Switch" />
     **Default | Active state**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/c0/4c/97/c04c970f0d926842cf4ef89ad42b9347.jpg" noPadding alt="Example of disabled inactive state of Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/c0/4c/97/c04c970f0d926842cf4ef89ad42b9347.jpg"  alt="Example of disabled inactive state of Switch" />
     **Disabled | Inactive state**
   </Group>
 
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/e2/12/af/e212aff2d4ff881e3246bdbe2396a058.jpg" noPadding alt="Example of disabled active state of Switch" />
+    <ImgContainer src="https://i.pinimg.com/originals/e2/12/af/e212aff2d4ff881e3246bdbe2396a058.jpg"  alt="Example of disabled active state of Switch" />
     **Disabled | Active state**
   </Group>
 </TwoCol>

--- a/docs/markdown/ios/toast.md
+++ b/docs/markdown/ios/toast.md
@@ -4,7 +4,7 @@ description: Toasts are brief and small messages that overlay content, but do no
 fullwidth: true
 ---
 
-<ImgContainer src="https://i.pinimg.com/originals/8e/6e/e2/8e6ee211ccfa215645f98e7538f3c76b.jpg" noPadding alt="an example of toast"/>
+<ImgContainer src="https://i.pinimg.com/originals/8e/6e/e2/8e6ee211ccfa215645f98e7538f3c76b.jpg"  alt="an example of toast"/>
 
 ## Usage guidelines
 
@@ -79,13 +79,13 @@ Some people may take longer to read toasts than others due to low vision or cogn
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/77/b6/1b/77b61ba14fa3aa95d8124994a387fc51.jpg" noPadding alt="default toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/77/b6/1b/77b61ba14fa3aa95d8124994a387fc51.jpg"  alt="default toast"/>
     
     **Default**
     A generic acknowledgment after an action is taken.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/1d/e0/04/1de004b81b15d909062a2f6d055137d5.jpg" noPadding alt="error toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/1d/e0/04/1de004b81b15d909062a2f6d055137d5.jpg"  alt="error toast"/>
    
     **Error**
     Used rarely for connection issues or unknown errors where we don’t want to completely block the users flow, but want the message to persist if the user goes to another surface. Providing a way to solve the error or get help is recommended.
@@ -97,13 +97,13 @@ Some people may take longer to read toasts than others due to low vision or cogn
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/fd/30/62/fd30629c36b5a2a799689e1fa33d9add.jpg" noPadding alt="text only toast"/>
+    <ImgContainer src="https://i.pinimg.com/originals/fd/30/62/fd30629c36b5a2a799689e1fa33d9add.jpg"  alt="text only toast"/>
     
     **Text only**
     A simple, generic acknowledgment after an action is taken. These should not be actionable.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/77/b6/1b/77b61ba14fa3aa95d8124994a387fc51.jpg" noPadding alt="toast with image"/>
+    <ImgContainer src="https://i.pinimg.com/originals/77/b6/1b/77b61ba14fa3aa95d8124994a387fc51.jpg"  alt="toast with image"/>
     
     **Image**
     With an image for Pin or Board actions.
@@ -111,7 +111,7 @@ Some people may take longer to read toasts than others due to low vision or cogn
 </TwoCol>
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/17/68/e3/1768e3b164a4a67f163b6ec216b0a680.jpg" noPadding alt="toast with avatar"/>
+    <ImgContainer src="https://i.pinimg.com/originals/17/68/e3/1768e3b164a4a67f163b6ec216b0a680.jpg"  alt="toast with avatar"/>
     
     **Avatar**
     With an Avatar for Profile or Pinner-related messaging. An optional link can be included. When there’s a link on mWeb, the entire toast is tappable, using TapArea.
@@ -125,13 +125,13 @@ Some people may take longer to read toasts than others due to low vision or cogn
 
 <TwoCol>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/d1/6d/53/d16d5368753bb66ed4b43768cec1673f.jpg" noPadding alt="toast with button"/>
+    <ImgContainer src="https://i.pinimg.com/originals/d1/6d/53/d16d5368753bb66ed4b43768cec1673f.jpg"  alt="toast with button"/>
     
     **Button**
     As a secondary element, to drive users to another surface, or change a recently completed action.
   </Group>
   <Group>
-    <ImgContainer src="https://i.pinimg.com/originals/be/96/f2/be96f2a755e144ef7554135f6c166b56.jpg" noPadding alt="toast with link"/>
+    <ImgContainer src="https://i.pinimg.com/originals/be/96/f2/be96f2a755e144ef7554135f6c166b56.jpg"  alt="toast with link"/>
     
     **Link**
     As a secondary element, to drive users to another surface.

--- a/docs/pages/BlogPosts.json
+++ b/docs/pages/BlogPosts.json
@@ -48,7 +48,7 @@
           {
             "title": "Team support resources + Component request/updates process",
             "audience": ["Design", "Engineering"],
-            "imageColor":"blue-skycicle-450",
+            "imageColor": "blue-skycicle-450",
             "imageSrc": "https://i.pinimg.com/originals/e1/08/c6/e108c63132adda654d78f72f7fad90be.png",
             "imageAltText": "illustration of glasses clinking",
             "content": "We know the design system is all about collaboration and service. And, to improve our collaboration process, we just published a set of resources and guidelines to help you build consistent product surfaces and collaborate with us!\n\nWe defined a straightforward process to receive, centralize and manage your component’s requests and updates, making it easier for you to follow your request’s progress and understand how it fits in our roadmap. Yay! \n\n[**Check it out!**](https://gestalt.pinterest.systems/team_support/overview)"
@@ -64,7 +64,7 @@
             "title": "Figma Popover caret positioning and new PopoverEducational",
             "audience": ["Design"],
             "imageSrc": "https://i.pinimg.com/originals/cf/ea/a5/cfeaa5cc8a88fc2af25921c25ede15b6.png",
-            "imageColor":"blue-skycicle-100",
+            "imageColor": "blue-skycicle-100",
             "imageAltText": "example of popovereducational component",
             "content": "We finally added [PopoverEducational](https://gestalt.pinterest.systems/web/popovereducational) to our Figma Web library which should speed up designing education or onboarding experiences moving forward. We _also_ added the ability to position the caret on all sides in our Popover and PopoverEducational Figma components. Note, these updates are only for our Web library at the moment, but we plan to make the same changes to Android and iOS shortly. Rejoice!"
           }
@@ -77,7 +77,7 @@
           {
             "title": "Illustration guidelines",
             "audience": ["Design", "Engineering"],
-            "imageColor":"blue-skycicle-100",
+            "imageColor": "blue-skycicle-100",
             "imageSrc": "https://i.pinimg.com/originals/e3/19/4f/e3194f7a84cddaac993cc37c780441e0.png",
             "imageAltText": "examples of gestalt illustrations",
             "content": "We're super excited to announce our newly-published [Illustration guidelines](https://gestalt.pinterest.systems/foundations/illustration). We shipped our first set of official Gestalt illustrations in late 2022 and this update is another step towards a richer Pinterest product experience. "

--- a/docs/pages/BlogPosts.json
+++ b/docs/pages/BlogPosts.json
@@ -48,6 +48,7 @@
           {
             "title": "Team support resources + Component request/updates process",
             "audience": ["Design", "Engineering"],
+            "imageColor":"blue-skycicle-450",
             "imageSrc": "https://i.pinimg.com/originals/e1/08/c6/e108c63132adda654d78f72f7fad90be.png",
             "imageAltText": "illustration of glasses clinking",
             "content": "We know the design system is all about collaboration and service. And, to improve our collaboration process, we just published a set of resources and guidelines to help you build consistent product surfaces and collaborate with us!\n\nWe defined a straightforward process to receive, centralize and manage your component’s requests and updates, making it easier for you to follow your request’s progress and understand how it fits in our roadmap. Yay! \n\n[**Check it out!**](https://gestalt.pinterest.systems/team_support/overview)"
@@ -63,6 +64,7 @@
             "title": "Figma Popover caret positioning and new PopoverEducational",
             "audience": ["Design"],
             "imageSrc": "https://i.pinimg.com/originals/cf/ea/a5/cfeaa5cc8a88fc2af25921c25ede15b6.png",
+            "imageColor":"blue-skycicle-100",
             "imageAltText": "example of popovereducational component",
             "content": "We finally added [PopoverEducational](https://gestalt.pinterest.systems/web/popovereducational) to our Figma Web library which should speed up designing education or onboarding experiences moving forward. We _also_ added the ability to position the caret on all sides in our Popover and PopoverEducational Figma components. Note, these updates are only for our Web library at the moment, but we plan to make the same changes to Android and iOS shortly. Rejoice!"
           }
@@ -75,6 +77,7 @@
           {
             "title": "Illustration guidelines",
             "audience": ["Design", "Engineering"],
+            "imageColor":"blue-skycicle-100",
             "imageSrc": "https://i.pinimg.com/originals/e3/19/4f/e3194f7a84cddaac993cc37c780441e0.png",
             "imageAltText": "examples of gestalt illustrations",
             "content": "We're super excited to announce our newly-published [Illustration guidelines](https://gestalt.pinterest.systems/foundations/illustration). We shipped our first set of official Gestalt illustrations in late 2022 and this update is another step towards a richer Pinterest product experience. "

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -21,9 +21,18 @@ export type Post = {|
   +imageSrc: string,
   +imageAltText: string,
   +content: string,
+  imageColor?: string,
 |};
 
-function PostLayout({ audience, content, imageAltText, imageSrc, title }: Post): Node {
+function PostLayout({ audience, content, imageAltText, imageSrc, title, imageColor }: Post): Node {
+
+
+  const colorStyle = {
+    __style: {
+      backgroundColor: imageColor ? `var(--color-${imageColor})` : 'white',
+    },
+  };
+  
   return (
     <Flex direction="column" gap={2}>
       <Flex direction="column" gap={1}>
@@ -41,6 +50,7 @@ function PostLayout({ audience, content, imageAltText, imageSrc, title }: Post):
           lgMarginBottom={0}
           borderStyle="sm"
           rounding={2}
+          dangerouslySetInlineStyle={colorStyle}
         >
           <Mask rounding={2} height={POST_IMAGE_HEIGHT_PX - 2}>
             <Image

--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -25,14 +25,12 @@ export type Post = {|
 |};
 
 function PostLayout({ audience, content, imageAltText, imageSrc, title, imageColor }: Post): Node {
-
-
   const colorStyle = {
     __style: {
       backgroundColor: imageColor ? `var(--color-${imageColor})` : 'white',
     },
   };
-  
+
   return (
     <Flex direction="column" gap={2}>
       <Flex direction="column" gap={1}>


### PR DESCRIPTION
Change image container so that the darkmode bg is white

Remove padding by default on all images. Can be added again with `addPadding` flag

![image](https://user-images.githubusercontent.com/5509813/230233035-06cdbbd1-f354-4365-9e03-f03dd8540b36.png)


![image](https://user-images.githubusercontent.com/5509813/230233059-5542d729-4bff-43a8-983f-1be65f610cec.png)
