### PR TITLE
Docs: fix mobile examples display

### DIFF
--- a/docs/docs-components/SandpackExample.js
+++ b/docs/docs-components/SandpackExample.js
@@ -17,7 +17,8 @@ import ShowHideEditorButton from './buttons/ShowHideEditorButton.js';
 import { useLocalFiles } from './contexts/LocalFilesProvider.js';
 
 const MIN_EDITOR_HEIGHT = 350;
-const MAX_EDITOR_MOBILE_WIDTH = 390;
+const MAX_EDITOR_IPHONE_SE_MOBILE_WIDTH = 375;
+const MAX_EDITOR_IPHONE_SE_MOBILE_HEIGHT = 667;
 
 async function copyCode({ code }: {| code: ?string |}) {
   try {
@@ -35,7 +36,7 @@ function SandpackContainer({
   hideControls = false,
   hideEditor = false,
 }: {|
-  layout: 'row' | 'column' | 'mobileRow',
+  layout: 'row' | 'column' | 'mobileRow' | 'mobileColumn',
   name: string,
   previewHeight?: number,
   hideControls?: boolean,
@@ -43,15 +44,35 @@ function SandpackContainer({
 |}) {
   const [editorShown, setEditorShown] = useState(!hideEditor);
   const { sandpack } = useSandpack();
+  const isMobileRowLayout = layout === 'mobileRow';
+  const isMobileColumnLayout = layout === 'mobileColumn';
+  let codeEditorHeight = MIN_EDITOR_HEIGHT;
+
+  if (!!previewHeight && previewHeight > MIN_EDITOR_HEIGHT) {
+    codeEditorHeight = previewHeight;
+  }
+
+  if (isMobileRowLayout) {
+    codeEditorHeight = MAX_EDITOR_IPHONE_SE_MOBILE_HEIGHT;
+  }
 
   return (
     <Fragment>
-      <Box borderStyle="sm" rounding={2}>
+      <Box
+        borderStyle="sm"
+        rounding={2}
+        color="darkWash"
+        display={isMobileRowLayout ? 'flex' : undefined}
+        justifyContent="center"
+      >
         <SandpackLayout>
           <SandpackPreview
             style={{
-              maxWidth: layout === 'mobileRow' ? MAX_EDITOR_MOBILE_WIDTH : undefined,
-              height: previewHeight,
+              width: isMobileRowLayout ? MAX_EDITOR_IPHONE_SE_MOBILE_WIDTH : undefined,
+              height:
+                isMobileRowLayout || isMobileColumnLayout
+                  ? MAX_EDITOR_IPHONE_SE_MOBILE_HEIGHT
+                  : previewHeight,
             }}
             showRefreshButton={false}
             showOpenInCodeSandbox={false}
@@ -60,9 +81,9 @@ function SandpackContainer({
             <SandpackCodeEditor
               wrapContent
               style={{
-                height:
-                  (previewHeight ?? 0) > MIN_EDITOR_HEIGHT ? previewHeight : MIN_EDITOR_HEIGHT,
-                flex: layout === 'column' ? 'none' : null,
+                height: codeEditorHeight,
+                width: '100%',
+                flex: ['mobileColumn', 'column'].includes(layout) ? 'none' : null,
               }}
             />
           )}
@@ -113,7 +134,7 @@ export default function SandpackExample({
   hideEditor,
 }: {|
   code: ?string | (() => Node),
-  layout?: 'row' | 'column' | 'mobileRow',
+  layout?: 'row' | 'column' | 'mobileRow' | 'mobileColumn',
   name: string,
   previewHeight?: number,
   hideControls?: boolean,

--- a/docs/pages/web/modal.js
+++ b/docs/pages/web/modal.js
@@ -255,7 +255,7 @@ For mobile, all \`sizes\` are unified into a full mobile viewport Modal. Notice 
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample code={mobileExample} name="Mobile example" previewHeight={500} />
+              <SandpackExample code={mobileExample} name="Mobile example" layout="mobileRow" />
             }
           />
         </MainSection>

--- a/docs/pages/web/modalalert.js
+++ b/docs/pages/web/modalalert.js
@@ -303,7 +303,7 @@ export default function ModalAlertPage({ generatedDocGen }: {| generatedDocGen: 
         <MainSection.Card
           cardSize="lg"
           sandpackExample={
-            <SandpackExample code={mobileExample} name="Mobile example" previewHeight={500} />
+            <SandpackExample code={mobileExample} name="Mobile example" layout="mobileRow" />
           }
         />
       </MainSection>

--- a/docs/pages/web/sheetmobile.js
+++ b/docs/pages/web/sheetmobile.js
@@ -40,7 +40,12 @@ export default function SheetMobilePage({
           />
         }
       >
-        <SandpackExample code={main} hideEditor name="Main SheetMobile example" />
+        <SandpackExample
+          code={main}
+          hideEditor
+          name="Main SheetMobile example"
+          layout="mobileRow"
+        />
       </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen?.SheetMobile} />
@@ -147,7 +152,7 @@ There is one size variant for full Sheets: "full". See examples below for more d
 
 `}
             sandpackExample={
-              <SandpackExample code={defaultSize} name="Heading example" layout="column" />
+              <SandpackExample code={defaultSize} name="Heading example" layout="mobileColumn" />
             }
           />
           <MainSection.Card
@@ -155,7 +160,7 @@ There is one size variant for full Sheets: "full". See examples below for more d
             title="Auto"
             description={`A partial SheetMobile with a max of 90% and a min of 30% screen height. When \`size\` is set to "auto", SheetMobile doesn't require a visible dismiss IconButton.`}
             sandpackExample={
-              <SandpackExample code={autoSize} name="Heading example" layout="column" />
+              <SandpackExample code={autoSize} name="Heading example" layout="mobileColumn" />
             }
           />
           <MainSection.Card
@@ -163,7 +168,7 @@ There is one size variant for full Sheets: "full". See examples below for more d
             title="Full"
             description={`A full SheetMobile fully fills the page. It completely covers the primary screen. When \`size\` is set to "full", SheetMobile requires a visible dismiss IconButton.`}
             sandpackExample={
-              <SandpackExample code={fullSize} name="Heading example" layout="column" />
+              <SandpackExample code={fullSize} name="Heading example" layout="mobileColumn" />
             }
           />
         </MainSection.Subsection>
@@ -187,7 +192,7 @@ See the following cases for reference.
               <SandpackExample
                 code={textOnlyHeader}
                 name="Heading with only text example"
-                layout="column"
+                layout="mobileColumn"
               />
             }
           />
@@ -198,7 +203,7 @@ See the following cases for reference.
               <SandpackExample
                 code={withPrimaryActionHeader}
                 name="Heading with primary action example"
-                layout="column"
+                layout="mobileColumn"
               />
             }
           />
@@ -210,7 +215,7 @@ See the following cases for reference.
               <SandpackExample
                 code={dismissButtonHeader}
                 name="Dismiss button example"
-                layout="column"
+                layout="mobileColumn"
               />
             }
           />
@@ -222,7 +227,7 @@ See the following cases for reference.
               <SandpackExample
                 code={navigationHeader}
                 name="Back and forward navigation example"
-                layout="column"
+                layout="mobileColumn"
               />
             }
           />
@@ -233,9 +238,8 @@ See the following cases for reference.
           description={`SheetMobile's footer has a flexible configuration. \`footer\` prop accepts any kind of node. The footer can have up to two Buttons and another two IconButtons as shown in the example.`}
         >
           <MainSection.Card
-            cardSize="lg"
             sandpackExample={
-              <SandpackExample code={footer} name="Footer example" layout="column" />
+              <SandpackExample code={footer} name="Footer example" layout="mobileRow" />
             }
           />
         </MainSection.Subsection>
@@ -266,7 +270,11 @@ When using these render props, just pass the argument \`onDismissStart\` to your
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample code={animation} name="Dismiss animation example" layout="column" />
+              <SandpackExample
+                code={animation}
+                name="Dismiss animation example"
+                layout="mobileRow"
+              />
             }
           />
         </MainSection.Subsection>
@@ -282,7 +290,7 @@ When using these render props, just pass the argument \`onDismissStart\` to your
               <SandpackExample
                 code={outsideClick}
                 name="Preventing outside click dismissal example"
-                layout="column"
+                layout="mobileRow"
               />
             }
           />

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -421,118 +421,6 @@ To prevent visual overload, do not include counters in the parent if the childre
           `}
         >
           <MainSection.Card
-            defaultCode={`
-function Example() {
-  const anchorRef = React.useRef(null);
-  const [mobile, setMobile] = React.useState(false);
-
-  return (
-    <Box color="lightWash" padding={4} height={300} overflow="auto">
-      <Flex gap={12}>
-        <Button text="View mobile" onClick={() => setMobile(true)} color="red" />
-        <DeviceTypeProvider deviceType={mobile ? 'mobile' : 'desktop'}>
-          <Box position={mobile ? 'absolute' : undefined} top bottom left right id="sidenavigation">
-            <SideNavigation
-              accessibilityLabel="Notification example"
-              dismissButton={{ onDismiss: () => setMobile((value) => !value) }}
-            >
-              <SideNavigation.TopItem
-                href="#"
-                onClick={({ event }) => {
-                  event.preventDefault();
-                }}
-                label="Campaign z-168i"
-                primaryAction={{
-                  icon: 'edit',
-                  onClick: ({ event }) => {
-                    event.preventDefault();
-                  },
-                  tooltip: { text: 'Rename campaign' },
-                }}
-              />
-              <SideNavigation.TopItem
-                href="#"
-                onClick={({ event }) => {
-                  event.preventDefault();
-                }}
-                label="Campaign a-j6ki (inactive)"
-                primaryAction={{
-                  icon: 'trash-can',
-                  onClick: ({ event }) => {
-                    event.preventDefault();
-                  },
-                  tooltip: { text: 'Delete campaign' },
-                }}
-              />
-              <SideNavigation.Group
-                label="Campaign drafts"
-                counter={{ number: '12', accessibilityLabel: '12 campaign drafts' }}
-                primaryAction={{
-                  onClick: ({ event }) => {
-                    event.preventDefault();
-                  },
-                  tooltip: { text: 'More options' },
-                  dropdownItems: [
-                    <Dropdown.Item
-                      key="edit"
-                      option={{ value: 'Edit', label: 'Edit' }}
-                      onSelect={() => {}}
-                    />,
-                    <Dropdown.Item
-                      key="trash"
-                      option={{ value: 'Delete', label: 'Delete' }}
-                      onSelect={() => {}}
-                    />,
-                  ],
-                }}
-              >
-                <SideNavigation.NestedItem
-                  counter={{
-                    number: '10',
-                    accessibilityLabel: 'You have 10 messages in your inbox',
-                  }}
-                  href="#"
-                  onClick={({ event }) => event.preventDefault()}
-                  label="West Coast"
-                />
-                <SideNavigation.NestedItem
-                  href="#"
-                  onClick={({ event }) => event.preventDefault()}
-                  label="East Coast"
-                />
-              </SideNavigation.Group>
-              <SideNavigation.TopItem
-                href="#"
-                onClick={({ event }) => event.preventDefault()}
-                label="Archived campaigns"
-                primaryAction={{
-                  onClick: ({ event }) => {
-                    event.preventDefault();
-                  },
-                  tooltip: { text: 'More options' },
-                  dropdownItems: [
-                    <Dropdown.Item
-                      key="edit"
-                      option={{ value: 'Edit', label: 'Edit' }}
-                      onSelect={() => {}}
-                    />,
-                    <Dropdown.Item
-                      key="trash"
-                      option={{ value: 'Delete', label: 'Delete' }}
-                      onSelect={() => {}}
-                    />,
-                  ],
-                }}
-                counter={{ number: '87', accessibilityLabel: '87 archived campaings' }}
-              />
-            </SideNavigation>
-          </Box>
-        </DeviceTypeProvider>
-      </Flex>
-    </Box>
-  )
-}
-`}
             sandpackExample={
               <SandpackExample
                 code={primaryAction}
@@ -584,7 +472,7 @@ Notice that the mobile UI requires logic to hide and show SideNavigation full wi
       >
         <MainSection.Card
           sandpackExample={
-            <SandpackExample code={mobileExample} name="Mobile example" previewHeight={500} />
+            <SandpackExample code={mobileExample} name="Mobile example" layout="mobileRow" />
           }
         />
       </MainSection>


### PR DESCRIPTION
Docs: fix mobile examples display

### BEFORE
<img width="992" alt="Screenshot by Dropbox Capture" src="https://user-images.githubusercontent.com/10593890/230505775-4867a110-d47f-4b31-81f2-9285313be6ed.png">
<img width="915" alt="Screenshot by Dropbox Capture" src="https://user-images.githubusercontent.com/10593890/230505806-e72e3a98-fd94-4597-bd47-5fd150e034a0.png">
<img width="849" alt="Screenshot by Dropbox Capture" src="https://user-images.githubusercontent.com/10593890/230505818-2647eb6d-cb9e-40c4-a549-1ca154548f59.png">


### AFTER
<img width="878" alt="Screenshot by Dropbox Capture" src="https://user-images.githubusercontent.com/10593890/230505869-43ab9a1c-a950-4f37-ac72-18a2c5da9f97.png">
<img width="881" alt="Screenshot 2023-04-06 at 6 34 19 PM" src="https://user-images.githubusercontent.com/10593890/230505933-9dc518a1-c0d7-4866-b4d4-ab5ab71bb618.png">
<img width="954" alt="Screenshot 2023-04-06 at 6 34 29 PM" src="https://user-images.githubusercontent.com/10593890/230505965-90d8f1de-8a8d-4ca4-8229-6dbc2200c03b.png">
