### PR TITLE
Internal: add TypeScript declaration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,10 @@ packages/gestalt-datepicker/dist/*
 packages/eslint-plugin-gestalt/dist/*
 packages/gestalt-design-tokens/dist
 
-# the flow export file as it's maintained by hand
+# the following files as they are maintained by hand
 !packages/gestalt/dist/gestalt.js.flow
 !packages/gestalt/dist/gestalt-datepicker.js.flow
+!packages/gestalt/dist/index.d.ts
 
 playwright/test-results
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ packages/gestalt-design-tokens/dist
 
 # the following files as they are maintained by hand
 !packages/gestalt/dist/gestalt.js.flow
-!packages/gestalt/dist/gestalt-datepicker.js.flow
 !packages/gestalt/dist/index.d.ts
+!packages/gestalt/dist/gestalt-datepicker.js.flow
+!packages/gestalt-datepicker/dist/index.d.ts
 
 playwright/test-results
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,7 +2,7 @@
   "singleQuote": true,
   "overrides": [
     {
-      "files": "*.js",
+      "files": ["*.js", "*.d.ts"],
       "options": {
         "arrowParens": "always",
         "printWidth": 100,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,5 @@
   "grunt.autoDetect": "off",
   "javascript.validate.enable": false,
   "npm.packageManager": "yarn",
-  "typescript.validate.enable": false
+  "typescript.validate.enable": true
 }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Example PR title: `Avatar: Add outline prop`
 
 ## Typescript Support
 
-Install the [DefinitelyTyped](https://www.npmjs.com/package/@types/gestalt) definitions.
+Gestalt officiallty supports and maintains Typescript declarations files.
 
 ### DefinitelyTyped Installation
 

--- a/docs/pages/get_started/developers/installation.js
+++ b/docs/pages/get_started/developers/installation.js
@@ -123,40 +123,6 @@ yarn start
           </Text>
         </Flex>
       </Card>
-
-      <Card name="Typescript Support">
-        <Flex
-          alignItems="start"
-          direction="column"
-          gap={{
-            row: 0,
-            column: 4,
-          }}
-        >
-          <Text>
-            Install the{' '}
-            <Link
-              display="inlineBlock"
-              href="https://www.npmjs.com/package/@types/gestalt"
-              target="blank"
-            >
-              <Text weight="bold">DefinitelyTyped</Text>
-            </Link>{' '}
-            definitions.
-          </Text>
-          <Heading size="400">Usage</Heading>
-          <Markdown
-            text="
-~~~jsx
-npm i --save @types/gestalt
-~~~
-or
-~~~jsx
-yarn add @types/gestalt
-~~~"
-          />
-        </Flex>
-      </Card>
     </Page>
   );
 }

--- a/docs/pages/get_started/developers/installation.js
+++ b/docs/pages/get_started/developers/installation.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Flex, Heading, Link, Text } from 'gestalt';
+import { Flex, Link, Text } from 'gestalt';
 import Card from '../../../docs-components/Card.js';
 import Markdown from '../../../docs-components/Markdown.js';
 import Page from '../../../docs-components/Page.js';

--- a/docs/pages/get_started/faq.js
+++ b/docs/pages/get_started/faq.js
@@ -104,13 +104,8 @@ $ElementType<React$ElementConfig<typeof ComponentName>, 'propName'>
 
           <Heading size="400">Does Gestalt have TypeScript support?</Heading>
           <Text>
-            Not officially. However, a group of dedicated engineers who work on internal tools at
-            Pinterest created
-            <InlineLink href="https://www.npmjs.com/package/@types/gestalt">
-              this package
-            </InlineLink>
-            with TypeScript definitions. We hope to offer better official TypeScript support in the
-            future, but currently lack the resources for proper support.
+            Yes. Gestalt officially supports and maintains TypeScript declaration files for our
+            gestalt and gestalt-datepicker packages.
           </Text>
         </Flex>
       </Card>

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "stylelint-config-prettier": "^9.0.4",
     "stylelint-config-standard": "^23.0.0",
     "stylelint-order": "^5.0.0",
-    "xml2js": "^0.5.0"
+    "xml2js": "^0.5.0",
+    "typescript": "^5.0.2"
   },
   "resolutions": {
     "ansi-regex": "5.0.1",

--- a/packages/gestalt-datepicker/dist/index.d.ts
+++ b/packages/gestalt-datepicker/dist/index.d.ts
@@ -1,0 +1,440 @@
+import React = require('react');
+
+/**
+ * =========================================================
+ * ====================== SHARED UTILS =====================
+ * =========================================================
+ */
+
+type Node = React.ReactNode;
+
+type AbstractEventHandler<T extends React.SyntheticEvent<HTMLElement> | Event, U = {}> = (
+  arg: U & {
+    readonly event: T;
+  },
+) => void;
+
+type ReactForwardRef<T, P> = React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<P> & React.RefAttributes<T>
+>;
+
+/**
+ * =========================================================
+ * ====================== SHARED TYPED =====================
+ * =========================================================
+ */
+
+// All these types are copies form https://github.com/date-fns/date-fns
+
+type Era = 0 | 1;
+
+type Quarter = 1 | 2 | 3 | 4;
+
+type Day = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+type Month = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+
+type Unit =
+  | 'second'
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'dayOfYear'
+  | 'date'
+  | 'week'
+  | 'month'
+  | 'quarter'
+  | 'year';
+
+type FirstWeekContainsDate = 1 | 4;
+
+interface LocaleOptions {
+  weekStartsOn?: Day;
+  firstWeekContainsDate?: FirstWeekContainsDate;
+}
+
+type FormatDistanceToken =
+  | 'lessThanXSeconds'
+  | 'xSeconds'
+  | 'halfAMinute'
+  | 'lessThanXMinutes'
+  | 'xMinutes'
+  | 'aboutXHours'
+  | 'xHours'
+  | 'xDays'
+  | 'aboutXWeeks'
+  | 'xWeeks'
+  | 'aboutXMonths'
+  | 'xMonths'
+  | 'aboutXYears'
+  | 'xYears'
+  | 'overXYears'
+  | 'almostXYears';
+
+type FormatDistanceLocale<Value> = {
+  [token in FormatDistanceToken]: Value;
+};
+
+interface FormatDistanceFnOptions {
+  addSuffix?: boolean;
+  comparison?: -1 | 0 | 1;
+}
+
+type FormatDistanceTokenFn = (count: number, options?: FormatDistanceFnOptions) => string;
+
+interface FormatDistanceFnOptions {
+  addSuffix?: boolean;
+  comparison?: -1 | 0 | 1;
+}
+
+type FormatDistanceFn = (
+  token: FormatDistanceToken,
+  count: number,
+  options?: FormatDistanceFnOptions,
+) => string;
+
+type FormatRelativeTokenFn = <DateType extends Date>(
+  date: DateType | number,
+  baseDate: DateType | number,
+  options?: { weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6 },
+) => string;
+
+type FormatRelativeToken = 'lastWeek' | 'yesterday' | 'today' | 'tomorrow' | 'nextWeek' | 'other';
+
+interface FormatRelativeFnOptions {
+  weekStartsOn?: Day;
+  locale?: LocaleData;
+}
+
+type FormatRelativeFn = <DateType extends Date>(
+  token: FormatRelativeToken,
+  date: DateType,
+  baseDate: DateType,
+  options?: FormatRelativeFnOptions,
+) => string;
+
+// TODO: You're real champion if you're actually get back to it. Proud of you!
+// Try to get rid of this and (especially) ArgCallback types because the only
+// case when it's helpful is when using quarter. Maybe.
+type LocalizeUnitIndex<Unit extends LocaleUnit | number> = Unit extends LocaleUnit
+  ? LocalizeUnitValuesIndex<LocalizeUnitValues<Unit>>
+  : number;
+
+type LocalizeFn<
+  Result extends LocaleUnit | number,
+  ArgCallback extends BuildLocalizeFnArgCallback<Result> | undefined = undefined,
+> = (
+  value: ArgCallback extends undefined
+    ? Result
+    : Result extends Quarter
+    ? Quarter
+    : LocalizeUnitIndex<Result>,
+  options?: {
+    width?: LocalePatternWidth;
+    context?: 'formatting' | 'standalone';
+    unit?: Unit;
+  },
+) => string;
+
+interface Localize {
+  ordinalNumber: LocalizeFn<number, BuildLocalizeFnArgCallback<number> | undefined>;
+  era: LocalizeFn<Era, undefined>;
+  quarter: LocalizeFn<Quarter, BuildLocalizeFnArgCallback<Quarter>>;
+  month: LocalizeFn<Month, undefined>;
+  day: LocalizeFn<Day, undefined>;
+  dayPeriod: LocalizeFn<LocaleDayPeriod, undefined>;
+}
+
+interface BuildMatchFnArgs<
+  Result extends LocaleUnit,
+  DefaultMatchWidth extends LocalePatternWidth,
+  DefaultParseWidth extends LocalePatternWidth,
+> {
+  matchPatterns: MatchPatterns<DefaultMatchWidth>;
+  defaultMatchWidth: DefaultMatchWidth;
+  parsePatterns: ParsePatterns<Result, DefaultParseWidth>;
+  defaultParseWidth: DefaultParseWidth;
+  valueCallback?: MatchValueCallback<Result extends LocaleDayPeriod ? string : number, Result>;
+}
+
+type MatchPatterns<DefaultWidth extends LocalePatternWidth> = {
+  [pattern in LocalePatternWidth]?: RegExp;
+} & { [key in DefaultWidth]: RegExp };
+
+type ParsePatterns<Result extends LocaleUnit, DefaultWidth extends LocalePatternWidth> = {
+  [pattern in LocalePatternWidth]?: ParsePattern<Result>;
+} & { [key in DefaultWidth]: ParsePattern<Result> };
+
+type ParsePattern<Result extends LocaleUnit> = Result extends LocaleDayPeriod
+  ? Record<LocaleDayPeriod, RegExp>
+  : Result extends Quarter
+  ? readonly [RegExp, RegExp, RegExp, RegExp]
+  : Result extends Era
+  ? readonly [RegExp, RegExp]
+  : Result extends Day
+  ? readonly [RegExp, RegExp, RegExp, RegExp, RegExp, RegExp, RegExp]
+  : Result extends Month
+  ? readonly [
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+      RegExp,
+    ]
+  : never;
+
+type BuildMatchFn<
+  Result extends LocaleUnit,
+  DefaultMatchWidth extends LocalePatternWidth,
+  DefaultParseWidth extends LocalePatternWidth,
+> = (args: BuildMatchFnArgs<Result, DefaultMatchWidth, DefaultParseWidth>) => MatchFn<Result>;
+
+type MatchFn<Result, ExtraOptions = Record<string, unknown>> = (
+  str: string,
+  options?: {
+    width?: LocalePatternWidth;
+    /**
+     * @deprecated Map the value manually instead.
+     * @example
+     * const matchResult = locale.match.ordinalNumber('1st')
+     * if (matchResult) {
+     *   matchResult.value = valueCallback(matchResult.value)
+     * }
+     */
+    valueCallback?: MatchValueCallback<string, Result>;
+  } & ExtraOptions,
+) => { value: Result; rest: string } | null;
+
+type MatchValueCallback<Arg, Result> = (value: Arg) => Result;
+
+interface Match {
+  ordinalNumber: MatchFn<
+    number,
+    {
+      unit: LocaleOrdinalUnit;
+    }
+  >;
+  era: MatchFn<Era>;
+  quarter: MatchFn<Quarter>;
+  month: MatchFn<Month>;
+  day: MatchFn<Day>;
+  dayPeriod: MatchFn<LocaleDayPeriod>;
+}
+
+type LocaleOrdinalUnit =
+  | 'second'
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'quarter'
+  | 'year'
+  | 'date'
+  | 'dayOfYear';
+
+type LocalePatternWidth = 'narrow' | 'short' | 'abbreviated' | 'wide' | 'any';
+
+type LocaleDayPeriod =
+  | 'am'
+  | 'pm'
+  | 'midnight'
+  | 'noon'
+  | 'morning'
+  | 'afternoon'
+  | 'evening'
+  | 'night';
+
+type LocaleOptionUnit =
+  | 'year'
+  | 'quarter'
+  | 'month'
+  | 'week'
+  | 'date'
+  | 'dayOfYear'
+  | 'day'
+  | 'hour'
+  | 'minute'
+  | 'second';
+
+type FormatLongWidth = 'full' | 'long' | 'medium' | 'short' | 'any';
+
+type DateTimeFormat = { [format in FormatLongWidth]: string };
+
+type LocaleUnit = Era | Quarter | Month | Day | LocaleDayPeriod;
+
+interface FormatLong {
+  date: FormatLongFn;
+  time: FormatLongFn;
+  dateTime: FormatLongFn;
+}
+
+interface FormatLongFnOptions {
+  width?: FormatLongWidth;
+}
+
+type FormatLongFn = (options: FormatLongFnOptions) => string;
+
+type BuildLocalizeFnArgCallback<Result extends LocaleUnit | number> = (
+  value: Result
+) => LocalizeUnitIndex<Result>
+
+type LocalizeEraValues = readonly [string, string]
+
+type LocalizeQuarterValues = readonly [string, string, string, string]
+
+type LocalizeDayValues = readonly [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string
+]
+
+type LocalizeMonthValues = readonly [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string
+]
+
+type LocalizeUnitValuesIndex<
+  Values extends LocalizeUnitValues<any>
+> = Values extends Record<LocaleDayPeriod, string>
+  ? string
+  : Values extends LocalizeEraValues
+  ? Era
+  : Values extends LocalizeQuarterValues
+  ? Quarter
+  : Values extends LocalizeDayValues
+  ? Day
+  : Values extends LocalizeMonthValues
+  ? Month
+  : never
+
+type LocalizeUnitValues<
+  Unit extends LocaleUnit
+> = Unit extends LocaleDayPeriod
+  ? Record<LocaleDayPeriod, string>
+  : Unit extends Era
+  ? LocalizeEraValues
+  : Unit extends Quarter
+  ? LocalizeQuarterValues
+  : Unit extends Day
+  ? LocalizeDayValues
+  : Unit extends Month
+  ? LocalizeMonthValues
+  : never
+
+interface LocaleData {
+  code: string;
+  formatDistance: FormatDistanceFn;
+  formatRelative: FormatRelativeFn;
+  localize: Localize;
+  formatLong: FormatLong;
+  match: Match;
+  options?: LocaleOptions;
+}
+
+/**
+ * =========================================================
+ * =============== COMPONENT API INTERFACES  ===============
+ * =========================================================
+ */
+
+/**
+ * https://gestalt.pinterest.systems/web/datepicker
+ */
+export interface DatePickerProps {
+    id: string,
+  disabled?: boolean | undefined,
+  errorMessage?: string | undefined,
+  excludeDates?: Date[] | undefined,
+  helperText?: string | undefined,
+  idealDirection?: 'up' | 'right' | 'down' | 'left' | undefined,
+  includeDates?: Date[] | undefined,
+  label?: string | undefined,
+  localeData?: LocaleData | undefined,
+  maxDate?: Date | undefined,
+  minDate?: Date | undefined,
+  name?: string | undefined,
+  nextRef?: { current?: HTMLElement | undefined } | undefined;
+  onChange:  AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: Date }>;
+  placeholder?: string | undefined,
+  rangeEndDate?: Date | undefined,
+  rangeSelector?: 'start' | 'end' | undefined,
+  rangeStartDate?: Date | undefined,
+  ref?: { current?: HTMLElement | undefined } | undefined;
+  selectLists?: ('month' | 'year')[] | undefined
+  value?: Date | undefined,
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/datefield
+ */
+export interface DateFieldProps {
+  id: string;
+  onChange: (arg: { value: Date | null | undefined }) => void;
+  onClearInput: () => void;
+  autoComplete?: 'bday' | 'off' | undefined;
+  disabled?: boolean;
+  disableRange?: 'disableFuture' | 'disablePast' | undefined;
+  errorMessage?: string | undefined;
+  helperText?: string | undefined;
+  label?: string | undefined;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+  localeData?: LocaleData | undefined;
+  maxDate?: Date | undefined;
+  minDate?: Date | undefined;
+  mobileEnterKeyHint?:
+    | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send'
+    | undefined;
+  name?: string | undefined;
+  onBlur?:
+    | AbstractEventHandler<
+        React.FocusEvent<HTMLInputElement>,
+        {
+          value: string;
+        }
+      >
+    | undefined;
+  onError?: (arg: { errorMessage: string; value: Date | null | undefined }) => void;
+  onFocus?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>
+    | undefined;
+  readOnly?: boolean | undefined;
+  value: Date | null | undefined | undefined;
+}
+
+/**
+ * =========================================================
+ * ========================= INDEX =========================
+ * =========================================================
+ */
+
+export const DatePicker: ReactForwardRef<HTMLInputElement, DatePickerProps>;
+
+export const DateField: React.FunctionComponent<DateFieldProps>;

--- a/packages/gestalt-datepicker/dist/index.d.ts
+++ b/packages/gestalt-datepicker/dist/index.d.ts
@@ -283,22 +283,14 @@ interface FormatLongFnOptions {
 type FormatLongFn = (options: FormatLongFnOptions) => string;
 
 type BuildLocalizeFnArgCallback<Result extends LocaleUnit | number> = (
-  value: Result
-) => LocalizeUnitIndex<Result>
+  value: Result,
+) => LocalizeUnitIndex<Result>;
 
-type LocalizeEraValues = readonly [string, string]
+type LocalizeEraValues = readonly [string, string];
 
-type LocalizeQuarterValues = readonly [string, string, string, string]
+type LocalizeQuarterValues = readonly [string, string, string, string];
 
-type LocalizeDayValues = readonly [
-  string,
-  string,
-  string,
-  string,
-  string,
-  string,
-  string
-]
+type LocalizeDayValues = readonly [string, string, string, string, string, string, string];
 
 type LocalizeMonthValues = readonly [
   string,
@@ -312,12 +304,13 @@ type LocalizeMonthValues = readonly [
   string,
   string,
   string,
-  string
-]
+  string,
+];
 
-type LocalizeUnitValuesIndex<
-  Values extends LocalizeUnitValues<any>
-> = Values extends Record<LocaleDayPeriod, string>
+type LocalizeUnitValuesIndex<Values extends LocalizeUnitValues<any>> = Values extends Record<
+  LocaleDayPeriod,
+  string
+>
   ? string
   : Values extends LocalizeEraValues
   ? Era
@@ -327,11 +320,9 @@ type LocalizeUnitValuesIndex<
   ? Day
   : Values extends LocalizeMonthValues
   ? Month
-  : never
+  : never;
 
-type LocalizeUnitValues<
-  Unit extends LocaleUnit
-> = Unit extends LocaleDayPeriod
+type LocalizeUnitValues<Unit extends LocaleUnit> = Unit extends LocaleDayPeriod
   ? Record<LocaleDayPeriod, string>
   : Unit extends Era
   ? LocalizeEraValues
@@ -341,7 +332,7 @@ type LocalizeUnitValues<
   ? LocalizeDayValues
   : Unit extends Month
   ? LocalizeMonthValues
-  : never
+  : never;
 
 interface LocaleData {
   code: string;
@@ -359,36 +350,30 @@ interface LocaleData {
  * =========================================================
  */
 
-/**
- * https://gestalt.pinterest.systems/web/datepicker
- */
 export interface DatePickerProps {
-    id: string,
-  disabled?: boolean | undefined,
-  errorMessage?: string | undefined,
-  excludeDates?: Date[] | undefined,
-  helperText?: string | undefined,
-  idealDirection?: 'up' | 'right' | 'down' | 'left' | undefined,
-  includeDates?: Date[] | undefined,
-  label?: string | undefined,
-  localeData?: LocaleData | undefined,
-  maxDate?: Date | undefined,
-  minDate?: Date | undefined,
-  name?: string | undefined,
+  id: string;
+  disabled?: boolean | undefined;
+  errorMessage?: string | undefined;
+  excludeDates?: Date[] | undefined;
+  helperText?: string | undefined;
+  idealDirection?: 'up' | 'right' | 'down' | 'left' | undefined;
+  includeDates?: Date[] | undefined;
+  label?: string | undefined;
+  localeData?: LocaleData | undefined;
+  maxDate?: Date | undefined;
+  minDate?: Date | undefined;
+  name?: string | undefined;
   nextRef?: { current?: HTMLElement | undefined } | undefined;
-  onChange:  AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: Date }>;
-  placeholder?: string | undefined,
-  rangeEndDate?: Date | undefined,
-  rangeSelector?: 'start' | 'end' | undefined,
-  rangeStartDate?: Date | undefined,
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: Date }>;
+  placeholder?: string | undefined;
+  rangeEndDate?: Date | undefined;
+  rangeSelector?: 'start' | 'end' | undefined;
+  rangeStartDate?: Date | undefined;
   ref?: { current?: HTMLElement | undefined } | undefined;
-  selectLists?: ('month' | 'year')[] | undefined
-  value?: Date | undefined,
+  selectLists?: ('month' | 'year')[] | undefined;
+  value?: Date | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/datefield
- */
 export interface DateFieldProps {
   id: string;
   onChange: (arg: { value: Date | null | undefined }) => void;
@@ -435,6 +420,12 @@ export interface DateFieldProps {
  * =========================================================
  */
 
+/**
+ * https://gestalt.pinterest.systems/web/datepicker
+ */
 export const DatePicker: ReactForwardRef<HTMLInputElement, DatePickerProps>;
 
+/**
+ * https://gestalt.pinterest.systems/web/datefield
+ */
 export const DateField: React.FunctionComponent<DateFieldProps>;

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://gestalt.pinterest.systems/",
   "description": "A React UI datepicker component which enforces Pinterest’s design language",
   "main": "dist/gestalt-datepicker.js",
+  "types": "dist/index.d.ts",
   "jsnext:main": "dist/gestalt-datepicker.es.js",
   "module": "dist/gestalt-datepicker.es.js",
   "style": "dist/gestalt-datepicker.css",

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -318,19 +318,13 @@ type DismissingElementChildrenType = (arg: { onDismissStart: () => void }) => No
  * =========================================================
  */
 
-/**
- * https://gestalt.pinterest.systems/web/utilities/colorschemeprovider
- */
-export interface ColorSchemeProviderProps {
+interface ColorSchemeProviderProps {
   children: Node;
   colorScheme: 'light' | 'dark' | 'userPreference';
   id?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/utilities/defaultlabelprovider
- */
-export interface DefaultLabelProviderProps {
+interface DefaultLabelProviderProps {
   children: Node;
   labels?:
     | {
@@ -383,18 +377,12 @@ export interface DefaultLabelProviderProps {
     | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/utilities/devicetypeprovider
- */
-export interface DeviceTypeProviderProps {
+interface DeviceTypeProviderProps {
   children: Node;
   deviceType: 'desktop' | 'mobile';
 }
 
-/**
- * https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider
- */
-export interface OnLinkNavigationProviderProps {
+interface OnLinkNavigationProviderProps {
   children: Node;
   onNavigation?:
     | ((args: {
@@ -404,10 +392,7 @@ export interface OnLinkNavigationProviderProps {
     | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/scrollboundarycontainer
- */
-export interface ScrollBoundaryContainerProps {
+interface ScrollBoundaryContainerProps {
   children: Node;
   height?: number | string | undefined;
   overflow?: 'scroll' | 'scrollX' | 'scrollY' | 'auto' | 'visible' | undefined;
@@ -419,10 +404,7 @@ export interface ScrollBoundaryContainerProps {
  * =========================================================
  */
 
-/**
- * https://gestalt.pinterest.systems/web/activationcard
- */
-export interface ActivationCardProps {
+interface ActivationCardProps {
   message: string;
   status: 'notStarted' | 'pending' | 'needsAttention' | 'complete';
   statusMessage: string;
@@ -440,10 +422,7 @@ export interface ActivationCardProps {
     | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/avatar
- */
-export interface AvatarProps {
+interface AvatarProps {
   name: string;
   accessibilityLabel?: string | undefined;
   outline?: boolean | undefined;
@@ -452,10 +431,7 @@ export interface AvatarProps {
   verified?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/avatargroup
- */
-export interface AvatarGroupProps {
+interface AvatarGroupProps {
   accessibilityLabel: string;
   collaborators: ReadonlyArray<{ name: string; src?: string | undefined }>;
   accessibilityControls?: string | undefined;
@@ -468,10 +444,7 @@ export interface AvatarGroupProps {
   size?: 'xs' | 'sm' | 'md' | 'fit' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/badge
- */
-export interface BadgeProps {
+interface BadgeProps {
   text: string;
   position?: 'middle' | 'top' | undefined;
   type?:
@@ -486,7 +459,7 @@ export interface BadgeProps {
     | undefined;
 }
 
-export type BoxPassthroughProps = Omit<
+type BoxPassthroughProps = Omit<
   React.ComponentProps<'div'>,
   'onClick' | 'className' | 'style' | 'ref'
 > &
@@ -500,10 +473,7 @@ type FlexType = 'grow' | 'shrink' | 'none';
 type JustifyContentType = 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly';
 type OverflowType = 'visible' | 'hidden' | 'scroll' | 'scrollX' | 'scrollY' | 'auto';
 
-/**
- * https://gestalt.pinterest.systems/web/box
- */
-export interface BoxProps extends BoxPassthroughProps {
+interface BoxProps extends BoxPassthroughProps {
   alignContent?: AlignContentType | undefined;
   alignItems?: AlignItemsType | undefined;
   smAlignItems?: AlignItemsType | undefined;
@@ -681,22 +651,13 @@ interface ButtonSubmitProps extends CommonButtonProps {
   type: 'submit';
 }
 
-/**
- * https://gestalt.pinterest.systems/web/button
- */
-export type ButtonProps = ButtonLinkProps | ButtonButtonProps | ButtonSubmitProps;
+type ButtonProps = ButtonLinkProps | ButtonButtonProps | ButtonSubmitProps;
 
-/**
- * https://gestalt.pinterest.systems/web/buttongroup
- */
-export interface ButtonGroupProps {
+interface ButtonGroupProps {
   children?: Node | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/callout
- */
-export interface CalloutProps {
+interface CalloutProps {
   iconAccessibilityLabel: string;
   message: string;
   type: 'error' | 'info' | 'recommendation' | 'success' | 'warning';
@@ -706,10 +667,7 @@ export interface CalloutProps {
   title?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/checkbox
- */
-export interface CheckboxProps {
+interface CheckboxProps {
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
   checked?: boolean | undefined;
@@ -727,10 +685,7 @@ export interface CheckboxProps {
   size?: 'sm' | 'md' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/collage
- */
-export interface CollageProps {
+interface CollageProps {
   columns: number;
   height: number;
   renderImage: (args: { width: number; height: number; index: number }) => Node;
@@ -740,10 +695,7 @@ export interface CollageProps {
   layoutKey?: number | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/column
- */
-export interface ColumnProps {
+interface ColumnProps {
   span: UnsignedUpTo12;
   smSpan?: UnsignedUpTo12 | undefined;
   mdSpan?: UnsignedUpTo12 | undefined;
@@ -751,16 +703,13 @@ export interface ColumnProps {
   children?: Node | undefined;
 }
 
-export interface ComboBoxItemType {
+interface ComboBoxItemType {
   label: string;
   subtext?: string;
   value: string;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/combobox
- */
-export interface ComboBoxProps {
+interface ComboBoxProps {
   id: string;
   label: string;
   options: ComboBoxItemType[];
@@ -799,17 +748,11 @@ export interface ComboBoxProps {
   zIndex?: Indexable | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/container
- */
-export interface ContainerProps {
+interface ContainerProps {
   children?: Node | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/datapoint
- */
-export interface DatapointProps {
+interface DatapointProps {
   title: string;
   value: string;
   badge?: BadgeObject | undefined;
@@ -820,10 +763,7 @@ export interface DatapointProps {
   trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/dropdown
- */
-export interface DropdownProps {
+interface DropdownProps {
   children: Node;
   id: string;
   onDismiss: () => void;
@@ -835,16 +775,13 @@ export interface DropdownProps {
   zIndex?: Indexable | undefined;
 }
 
-export interface DropdownOption {
+interface DropdownOption {
   label: string;
   value: string;
   subtext?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item
- */
-export interface DropdownItemProps {
+interface DropdownItemProps {
   onSelect: AbstractEventHandler<
     React.FocusEvent<HTMLInputElement>,
     {
@@ -858,10 +795,7 @@ export interface DropdownItemProps {
   selected?: DropdownOption | ReadonlyArray<DropdownOption> | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Link
- */
-export interface DropdownLinkProps {
+interface DropdownLinkProps {
   href: string;
   option: DropdownOption;
   badge?: BadgeObject | undefined;
@@ -871,18 +805,12 @@ export interface DropdownLinkProps {
   onClick?: ButtonEventHandlerType | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Section
- */
-export interface DropdownSectionProps {
+interface DropdownSectionProps {
   children: Node;
   label: string;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/fieldset
- */
-export interface FieldsetProps {
+interface FieldsetProps {
   children: Node;
   legend: string;
   id?: string;
@@ -890,10 +818,7 @@ export interface FieldsetProps {
   legendDisplay?: 'visible' | 'hidden' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/flex
- */
-export interface FlexProps {
+interface FlexProps {
   alignContent?: AlignContentType | undefined;
   alignItems?: AlignItemsType | undefined;
   alignSelf?: 'auto' | AlignItemsType | undefined;
@@ -916,10 +841,7 @@ export interface FlexProps {
   wrap?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/flex#Flex.Item
- */
-export interface FlexItemProps {
+interface FlexItemProps {
   alignSelf?: 'auto' | AlignItemsType | undefined;
   children?: Node | undefined;
   dataTestId?: string | undefined;
@@ -929,10 +851,7 @@ export interface FlexItemProps {
   minWidth?: number | string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/heading
- */
-export interface HeadingProps {
+interface HeadingProps {
   accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6 | 'none' | undefined;
   align?: TextAlignType | undefined;
   children?: Node | undefined;
@@ -943,10 +862,7 @@ export interface HeadingProps {
   size?: TextSizeType | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/helpbutton
- */
-export interface HelpButtonProps {
+interface HelpButtonProps {
   accessibilityLabel: string;
   accessibilityPopoverLabel: string;
   text: string | React.ReactElement<typeof Text>;
@@ -980,10 +896,7 @@ export interface HelpButtonProps {
   zIndex?: Indexable | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/icon
- */
-export interface IconProps {
+interface IconProps {
   accessibilityLabel: string;
   color?:
     | 'default'
@@ -1051,15 +964,9 @@ interface IconButtonSubmitProps extends CommonIconButtonProps {
   type: 'submit';
 }
 
-/**
- * https://gestalt.pinterest.systems/web/iconbutton
- */
-export type IconButtonProps = IconButtonLinkProps | IconButtonButtonProps | IconButtonSubmitProps;
+type IconButtonProps = IconButtonLinkProps | IconButtonButtonProps | IconButtonSubmitProps;
 
-/**
- * https://gestalt.pinterest.systems/web/iconbuttonfloating
- */
-export interface IconButtonFloatingProps {
+interface IconButtonFloatingProps {
   accessibilityPopupRole: 'menu' | 'dialog';
   accessibilityLabel: string;
   icon: Icons;
@@ -1077,10 +984,7 @@ export interface IconButtonFloatingProps {
   selected?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/image
- */
-export interface ImageProps {
+interface ImageProps {
   alt: string;
   naturalHeight: number;
   naturalWidth: number;
@@ -1100,36 +1004,24 @@ export interface ImageProps {
   srcSet?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/label
- */
-export interface LabelProps {
+interface LabelProps {
   htmlFor: string;
   children?: Node | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/layer
- */
-export interface LayerProps {
+interface LayerProps {
   children: Node;
   zIndex?: Indexable | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/letterbox
- */
-export interface LetterboxProps {
+interface LetterboxProps {
   contentAspectRatio: number;
   height: number;
   width: number;
   children?: Node | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/link
- */
-export interface LinkProps {
+interface LinkProps {
   href: string;
   accessibilityLabel?: string | undefined;
   children?: Node | undefined;
@@ -1156,10 +1048,7 @@ export interface LinkProps {
   underline?: 'auto' | 'none' | 'always' | 'hover' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/list
- */
-export interface ListProps {
+interface ListProps {
   children: Node;
   label?: string | React.ReactElement<typeof Text>;
   labelDisplay?: 'visible' | 'hidden' | undefined;
@@ -1167,10 +1056,7 @@ export interface ListProps {
   type?: 'bare' | 'ordered' | 'unordered' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/list#List.Itemt
- */
-export interface ListItemProps {
+interface ListItemProps {
   text: string | React.ReactElement<typeof Text>;
   children?:
     | string
@@ -1179,10 +1065,7 @@ export interface ListItemProps {
     | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/mask
- */
-export interface MaskProps {
+interface MaskProps {
   children?: Node | undefined;
   height?: number | string | undefined;
   rounding?: 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
@@ -1191,17 +1074,14 @@ export interface MaskProps {
   willChangeTransform?: boolean | undefined;
 }
 
-export interface MeasurementStore<K, V> {
+interface MeasurementStore<K, V> {
   get(key: K): V | undefined;
   has(key: K): boolean;
   set(key: K, value: V): void;
   reset(): void;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/masonry
- */
-export interface MasonryProps<T = any> {
+interface MasonryProps<T = any> {
   _batchPaints?: boolean | undefined;
   items: ReadonlyArray<T>;
   renderItem: (args: { data: T; itemIdx: number; isMeasuring: boolean }) => Node;
@@ -1225,11 +1105,7 @@ export interface MasonryProps<T = any> {
   virtualize?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/modal
- */
-
-export interface ModalProps {
+interface ModalProps {
   accessibilityModalLabel: string;
   onDismiss: () => void;
   _dangerouslyDisableScrollBoundaryContainer?: boolean;
@@ -1244,7 +1120,7 @@ export interface ModalProps {
   subHeading?: string | undefined;
 }
 
-export interface ModalAlertActionDataType {
+interface ModalAlertActionDataType {
   accessibilityLabel: string;
   label: string;
   dataTestId?: string | undefined;
@@ -1255,10 +1131,7 @@ export interface ModalAlertActionDataType {
   target?: TargetType | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/modalalert
- */
-export interface ModalAlertProps {
+interface ModalAlertProps {
   accessibilityModalLabel: string;
   children: Node;
   heading: string;
@@ -1269,10 +1142,7 @@ export interface ModalAlertProps {
   type?: 'default' | 'warning' | 'error' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/module
- */
-export interface ModuleProps {
+interface ModuleProps {
   id: string;
   badge?: BadgeObject | undefined;
   children?: Node | undefined;
@@ -1283,10 +1153,7 @@ export interface ModuleProps {
   type?: 'error' | 'info' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/module#Module.Expandable
- */
-export interface ModuleExpandableProps {
+interface ModuleExpandableProps {
   accessibilityCollapseLabel: string;
   accessibilityExpandLabel: string;
   id: string;
@@ -1304,10 +1171,7 @@ export interface ModuleExpandableProps {
   onExpandedChange?: ((expandedIndex: number | null) => void) | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/numberfield
- */
-export interface NumberFieldProps {
+interface NumberFieldProps {
   id: string;
   onChange: AbstractEventHandler<
     React.SyntheticEvent<HTMLInputElement>,
@@ -1356,10 +1220,7 @@ export interface NumberFieldProps {
 
 type NodeOrRenderProp = ((prop: { onDismissStart: () => void }) => Node) | Node;
 
-/**
- * https://gestalt.pinterest.systems/web/overlaypanel
- */
-export interface OverlayPanelProps {
+interface OverlayPanelProps {
   accessibilityLabel: string;
   children?: NodeOrRenderProp | undefined;
   onDismiss: () => void;
@@ -1386,14 +1247,11 @@ export interface OverlayPanelProps {
   subHeading?: NodeOrRenderProp | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/overlaypanel#DismissingElement
- */
-export interface OverlayPanelDismissingElementProps {
+interface OverlayPanelDismissingElementProps {
   children: DismissingElementChildrenType;
 }
 
-export interface PageHeaderAction {
+interface PageHeaderAction {
   component:
     | React.ReactElement<
         typeof Button | typeof IconButton | typeof Link | typeof Tooltip | typeof Text
@@ -1406,10 +1264,7 @@ export interface PageHeaderAction {
     | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/pageheader
- */
-export interface PageHeaderProps {
+interface PageHeaderProps {
   title: string;
   badge?:
     | {
@@ -1444,10 +1299,7 @@ export interface PageHeaderProps {
   thumbnail?: React.ReactElement<typeof Image> | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/pog
- */
-export interface PogProps {
+interface PogProps {
   accessibilityLabel?: string | undefined;
   active?: boolean | undefined;
   bgColor?:
@@ -1469,10 +1321,7 @@ export interface PogProps {
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/popover
- */
-export interface PopoverProps {
+interface PopoverProps {
   anchor: HTMLElement | null | undefined;
   onDismiss: () => void;
   accessibilityDismissButtonLabel?: string | undefined;
@@ -1491,10 +1340,7 @@ export interface PopoverProps {
   __dangerouslySetMaxHeight?: '30vh' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/popovereducational
- */
-export interface PopoverEducationalProps {
+interface PopoverEducationalProps {
   accessibilityLabel?: string | undefined;
   anchor: HTMLElement | null | undefined;
   onDismiss: () => void;
@@ -1518,18 +1364,12 @@ export interface PopoverEducationalProps {
   zIndex?: Indexable | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/pulsar
- */
-export interface PulsarProps {
+interface PulsarProps {
   paused?: boolean | undefined;
   size?: number | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/radiobutton
- */
-export interface RadioButtonProps {
+interface RadioButtonProps {
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
   value: string;
@@ -1542,10 +1382,7 @@ export interface RadioButtonProps {
   subtext?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/radiogroup
- */
-export interface RadioGroupProps {
+interface RadioGroupProps {
   id: string;
   children: Node;
   legend: string;
@@ -1554,10 +1391,7 @@ export interface RadioGroupProps {
   legendDisplay?: 'visible' | 'hidden' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/radiogroup#RadioGroup.RadioButtonProps
- */
-export interface RadioGroupRadioButtonProps {
+interface RadioGroupRadioButtonProps {
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
   value: string;
@@ -1570,10 +1404,7 @@ export interface RadioGroupRadioButtonProps {
   size?: 'sm' | 'md' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/searchfield
- */
-export interface SearchFieldProps {
+interface SearchFieldProps {
   accessibilityLabel: string;
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>;
@@ -1595,20 +1426,14 @@ export interface SearchFieldProps {
   value?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/segmentedcontrol
- */
-export interface SegmentedControlProps {
+interface SegmentedControlProps {
   items: Node[];
   onChange: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>, { activeIndex: number }>;
   selectedItemIndex: number;
   responsive?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/selectlist
- */
-export interface SelectListProps {
+interface SelectListProps {
   children: Node;
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLElement>, { value: string }>;
@@ -1623,19 +1448,13 @@ export interface SelectListProps {
   value?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/selectlist#SelectList.Option
- */
-export interface SelectListOptionProps {
+interface SelectListOptionProps {
   label: string;
   value: string;
   disabled?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/selectlist#SelectList.Group
- */
-export interface SelectListGroupProps {
+interface SelectListGroupProps {
   children: Node;
   label: string;
   disabled?: boolean | undefined;
@@ -1652,10 +1471,7 @@ type PrimaryActionType = {
   dropdownItems?: Array<React.ReactElement<typeof Dropdown['Item']>>;
 };
 
-/**
- * https://gestalt.pinterest.systems/web/sheetmobile
- */
-export interface SheetMobileProps {
+interface SheetMobileProps {
   heading: string;
   onDismiss: () => void;
   accessibilityLabel?: string | undefined;
@@ -1709,17 +1525,11 @@ export interface SheetMobileProps {
   };
 }
 
-/**
- * https://gestalt.pinterest.systems/web/sheetmobile#DismissingElement
- */
-export interface SheetMobileDismissingElementProps {
+interface SheetMobileDismissingElementProps {
   children: DismissingElementChildrenType;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/sidenavigation
- */
-export interface SideNavigationProps {
+interface SideNavigationProps {
   accessibilityLabel: string;
   children: Node;
   dismissButton?: { accessibilityLabel?: string; onDismiss: () => void } | undefined;
@@ -1729,18 +1539,12 @@ export interface SideNavigationProps {
   title?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Section
- */
-export interface SideNavigationSectionProps {
+interface SideNavigationSectionProps {
   children: Node;
   label: string;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.TopItem
- */
-export interface SideNavigationTopItemProps {
+interface SideNavigationTopItemProps {
   href: string;
   label: string;
   active?: 'page' | 'section' | undefined;
@@ -1757,10 +1561,7 @@ export interface SideNavigationTopItemProps {
   primaryAction?: PrimaryActionType | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem
- */
-export interface SideNavigationNestedItemProps {
+interface SideNavigationNestedItemProps {
   href: string;
   label: string;
   active?: 'page' | 'section' | undefined;
@@ -1768,10 +1569,7 @@ export interface SideNavigationNestedItemProps {
   onClick?: ButtonEventHandlerType | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Group
- */
-export interface SideNavigationGroupProps {
+interface SideNavigationGroupProps {
   children: Node;
   label: string;
   badge?: BadgeProps | undefined;
@@ -1782,20 +1580,14 @@ export interface SideNavigationGroupProps {
   primaryAction?: PrimaryActionType | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedGroup
- */
-export interface SideNavigationNestedGroupProps {
+interface SideNavigationNestedGroupProps {
   children: Node;
   label: string;
   counter?: { number: string; accessibilityLabel: string } | undefined;
   display?: 'expandable' | 'static' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/slimbanner
- */
-export interface SlimBannerProps {
+interface SlimBannerProps {
   message: React.ReactElement<typeof Text> | string;
   dismissButton?: OnDismissButtonObject | undefined;
   helperLink?: {
@@ -1846,10 +1638,7 @@ export interface SlimBannerProps {
     | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/spinner
- */
-export interface SpinnerProps {
+interface SpinnerProps {
   accessibilityLabel: string;
   show: boolean;
   color?: 'default' | 'subtle' | undefined;
@@ -1857,20 +1646,14 @@ export interface SpinnerProps {
   size?: 'sm' | 'md' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/status
- */
-export interface StatusProps {
+interface StatusProps {
   type: 'unstarted' | 'inProgress' | 'halted' | 'ok' | 'problem' | 'canceled' | 'warning';
   accessibilityLabel?: string | undefined;
   subtext?: string | undefined;
   title?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/sticky
- */
-export interface StickyProps {
+interface StickyProps {
   children: Node;
   bottom?: number | string | undefined;
   height?: number | undefined;
@@ -1880,10 +1663,7 @@ export interface StickyProps {
   zIndex?: Indexable | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/switch
- */
-export interface SwitchProps {
+interface SwitchProps {
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: boolean }>;
   disabled?: boolean | undefined;
@@ -1891,10 +1671,7 @@ export interface SwitchProps {
   switched?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table
- */
-export interface TableProps {
+interface TableProps {
   accessibilityLabel: string;
   children: Node;
   borderStyle?: 'sm' | 'none' | undefined;
@@ -1902,53 +1679,35 @@ export interface TableProps {
   stickyColumns?: number | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.Header
- */
-export interface TableHeaderProps {
+interface TableHeaderProps {
   children: Node;
   display?: 'tableHeaderGroup' | 'visuallyHidden' | undefined;
   sticky?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.Body
- */
-export interface TableBodyProps {
+interface TableBodyProps {
   children: Node;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.Footer
- */
-export interface TableFooterProps {
+interface TableFooterProps {
   children: Node;
   sticky?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.Cell
- */
-export interface TableCellProps {
+interface TableCellProps {
   children: Node;
   colSpan?: number | undefined;
   rowSpan?: number | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.HeaderCell
- */
-export interface TableHeaderCellProps {
+interface TableHeaderCellProps {
   children: Node;
   scope?: 'col' | 'row' | 'colgroup' | 'rowgroup' | undefined;
   colSpan?: number | undefined;
   rowSpan?: number | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.SortableHeaderCell
- */
-export interface TableSortableHeaderCellProps {
+interface TableSortableHeaderCellProps {
   children: Node;
   onSortChange: AbstractEventHandler<
     React.MouseEvent<HTMLTableCellElement> | React.KeyboardEvent<HTMLTableCellElement>
@@ -1960,17 +1719,11 @@ export interface TableSortableHeaderCellProps {
   rowSpan?: number | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.Row
- */
-export interface TableRowProps {
+interface TableRowProps {
   children: Node;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.RowExpandable
- */
-export interface TableRowExpandableProps {
+interface TableRowExpandableProps {
   accessibilityCollapseLabel: string;
   accessibilityExpandLabel: string;
   children: Node;
@@ -1981,19 +1734,13 @@ export interface TableRowExpandableProps {
   onExpand?: BareButtonEventHandlerType | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/table#Table.RowDrawer
- */
-export interface TableRowDrawerProps {
+interface TableRowDrawerProps {
   children: Node;
   drawerContents: Node;
   id: string;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/tabs
- */
-export interface TabsProps {
+interface TabsProps {
   activeTabIndex: number;
   onChange: AbstractEventHandler<
     | React.MouseEvent<HTMLDivElement>
@@ -2013,10 +1760,7 @@ export interface TabsProps {
   bgColor?: 'default' | 'transparent' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/tag
- */
-export interface TagProps {
+interface TagProps {
   onRemove: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>>;
   text: string;
   accessibilityRemoveIconLabel?: string | undefined;
@@ -2087,15 +1831,9 @@ interface TapAreaButtonProps extends CommonTapAreaProps {
   accessibilityHaspopup?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/taparea
- */
-export type TapAreaProps = TapAreaLinkProps | TapAreaButtonProps;
+type TapAreaProps = TapAreaLinkProps | TapAreaButtonProps;
 
-/**
- * https://gestalt.pinterest.systems/web/text
- */
-export interface TextProps {
+interface TextProps {
   align?: TextAlignType | undefined;
   children?: Node | undefined;
   color?: BaseTextColorType | 'link' | undefined;
@@ -2109,10 +1847,7 @@ export interface TextProps {
   title?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/textarea
- */
-export interface TextAreaProps {
+interface TextAreaProps {
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLTextAreaElement>, { value: string }>;
   disabled?: boolean | undefined;
@@ -2139,10 +1874,7 @@ export interface TextAreaProps {
   value?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/textfield
- */
-export interface TextFieldProps {
+interface TextFieldProps {
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>;
   autoComplete?:
@@ -2176,10 +1908,7 @@ export interface TextFieldProps {
   value?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/toast
- */
-export interface ToastProps {
+interface ToastProps {
   text: string | React.ReactElement<typeof Text>;
   dissmissButton:
     | {
@@ -2215,10 +1944,7 @@ export interface ToastProps {
   variant?: 'default' | 'success' | 'error' | 'progress' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/tooltip
- */
-export interface TooltipProps {
+interface TooltipProps {
   children: Node;
   text: string;
   accessibilityLabel?: string | undefined;
@@ -2228,10 +1954,7 @@ export interface TooltipProps {
   zIndex?: Indexable | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/upsell
- */
-export interface UpsellProps {
+interface UpsellProps {
   message: string | React.ReactElement<typeof Text>;
   children?: React.ReactElement<typeof Upsell.Form>;
   dismissButton?: OnDismissButtonObject | undefined;
@@ -2252,10 +1975,7 @@ export interface UpsellProps {
   title?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/upsell#Upsell.Form
- */
-export interface UpsellFormProps {
+interface UpsellFormProps {
   children: Node;
   onSubmit: BareButtonEventHandlerType;
   submitButtonText: string;
@@ -2263,10 +1983,7 @@ export interface UpsellFormProps {
   submitButtonDisabled?: boolean | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/video
- */
-export interface VideoProps {
+interface VideoProps {
   accessibilityMaximizeLabel: string;
   accessibilityMinimizeLabel: string;
   accessibilityMuteLabel: string;
@@ -2335,16 +2052,481 @@ export interface VideoProps {
   volume?: number | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/washanimated
- */
-export interface WashAnimatedProps {
+interface WashAnimatedProps {
   active?: boolean | undefined;
   children?: Node | undefined;
   image?: Node | undefined;
   onMouseEnter?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>> | undefined;
   onMouseLeave?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>> | undefined;
 }
+
+/**
+ * =========================================================
+ * ========================= INDEX =========================
+ * =========================================================
+ */
+
+/**
+ * https://gestalt.pinterest.systems/web/activationcard
+ */
+export const ActivationCard: React.FunctionComponent<ActivationCardProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/avatar
+ */
+export const Avatar: React.FunctionComponent<AvatarProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/avatargroup
+ */
+export const AvatarGroup: React.FunctionComponent<AvatarGroupProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/badge
+ */
+export const Badge: React.FunctionComponent<BadgeProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/box
+ */
+export const Box: ReactForwardRef<HTMLDivElement, BoxProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/button
+ */
+export const Button: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/buttongroup
+ */
+export const ButtonGroup: React.FunctionComponent<ButtonGroupProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/callout
+ */
+export const Callout: React.FunctionComponent<CalloutProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/checkbox
+ */
+export const Checkbox: ReactForwardRef<HTMLInputElement, CheckboxProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/collage
+ */
+export const Collage: React.FunctionComponent<CollageProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/colorschemeprovider
+ */
+export const ColorSchemeProvider: React.FunctionComponent<
+  React.PropsWithChildren<ColorSchemeProviderProps>
+>;
+
+/**
+ * https://gestalt.pinterest.systems/web/column
+ */
+export const Column: React.FunctionComponent<ColumnProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/combobox
+ */
+export const ComboBox: React.FunctionComponent<ComboBoxProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/container
+ */
+export const Container: React.FunctionComponent<ContainerProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/datapoint
+ */
+export const Datapoint: React.FunctionComponent<DatapointProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/devicetypeprovider
+ */
+export const DeviceTypeProvider: React.FunctionComponent<
+  React.PropsWithChildren<DeviceTypeProviderProps>
+>;
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/defaultlabelprovider
+ */
+export const DefaultLabelProvider: React.FunctionComponent<
+  React.PropsWithChildren<DefaultLabelProviderProps>
+>;
+
+/**
+ * https://gestalt.pinterest.systems/web/divider
+ */
+export const Divider: React.FunctionComponent;
+
+
+export interface DropdownSubComponents {
+  Item: React.FunctionComponent<DropdownItemProps>;
+  Link: React.FunctionComponent<DropdownLinkProps>;
+  Section: React.FunctionComponent<DropdownSectionProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/dropdown
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Link
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Section
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item
+ */
+export const Dropdown: React.FunctionComponent<DropdownProps> & DropdownSubComponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/fieldset
+ */
+export const Fieldset: React.FunctionComponent<FieldsetProps>;
+
+
+export interface FlexSubComponents {
+  Item: React.FunctionComponent<FlexItemProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/flex
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/flex#Flex.Item
+ */
+export const Flex: React.FunctionComponent<FlexProps> & FlexSubComponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/heading
+ */
+export const Heading: React.FunctionComponent<HeadingProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/helpbutton
+ */
+export const HelpButton: React.FunctionComponent<HelpButtonProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/icon
+ */
+export const Icon: React.FunctionComponent<IconProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/iconbutton
+ */
+export const IconButton: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, IconButtonProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/iconbuttonfloating
+ */
+export const IconButtonFloating: React.FunctionComponent<IconButtonFloatingProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/image
+ */
+export const Image: React.FunctionComponent<ImageProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/label
+ */
+export const Label: React.FunctionComponent<LabelProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/layer
+ */
+export const Layer: React.FunctionComponent<LayerProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/letterbox
+ */
+export const Letterbox: React.FunctionComponent<LetterboxProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/link
+ */
+export const Link: ReactForwardRef<HTMLAnchorElement, LinkProps>;
+
+
+export interface ListSubCmoponents {
+  Item: React.FunctionComponent<React.PropsWithChildren<ListItemProps>>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/list
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/list#List.Itemt
+ */
+export const List: React.FunctionComponent<React.PropsWithChildren<ListProps>> & ListSubCmoponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/mask
+ */
+export const Mask: React.FunctionComponent<MaskProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/masonry
+ */
+export const Masonry: React.FunctionComponent<MasonryProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/modal
+ */
+export const Modal: ReactForwardRef<HTMLDivElement, ModalProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/modalalert
+ */
+export const ModalAlert: React.FunctionComponent<React.PropsWithChildren<ModalAlertProps>>;
+
+
+export interface ModuleSubComponents {
+  Expandable: React.FunctionComponent<ModuleExpandableProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/module
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/module#Module.Expandable
+ */
+export const Module: React.FunctionComponent<React.PropsWithChildren<ModuleProps>> &
+  ModuleSubComponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/numberfield
+ */
+export const NumberField: ReactForwardRef<HTMLInputElement, NumberFieldProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider
+ */
+export const OnLinkNavigationProvider: React.FunctionComponent<OnLinkNavigationProviderProps>;
+
+
+export interface OverlayPanelSubComponents {
+  DismissingElement: React.FunctionComponent<OverlayPanelDismissingElementProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/overlaypanel
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/overlaypanel#DismissingElement
+ */
+export const OverlayPanel: ReactForwardRef<HTMLDivElement, OverlayPanelProps> &
+  OverlayPanelSubComponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/pageheader
+ */
+export const PageHeader: React.FunctionComponent<PageHeaderProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/pog
+ */
+export const Pog: React.FunctionComponent<PogProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/popover
+ */
+export const Popover: React.FunctionComponent<PopoverProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/popovereducational
+ */
+export const Popovereducational: React.FunctionComponent<PopoverEducationalProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/pulsar
+ */
+export const Pulsar: React.FunctionComponent<PulsarProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/radiobutton
+ */
+export const RadioButton: ReactForwardRef<HTMLInputElement, RadioButtonProps>;
+
+
+export interface RadioGroupSubComponents {
+  RadioButton: React.FunctionComponent<RadioGroupRadioButtonProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/radiogroup
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/radiogroup#RadioGroup.RadioButtonProps
+ */
+export const RadioGroup: React.FunctionComponent<RadioGroupProps> & RadioGroupSubComponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/scrollboundarycontainer
+ */
+export const ScrollBoundaryContainer: React.FunctionComponent<ScrollBoundaryContainerProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/searchfield
+ */
+export const SearchField: ReactForwardRef<HTMLInputElement, SearchFieldProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/segmentedcontrol
+ */
+export const SegmentedControl: React.FunctionComponent<SegmentedControlProps>;
+
+export interface SelectListSubComponents {
+  Option: React.FunctionComponent<SelectListOptionProps>;
+  Group: React.FunctionComponent<SelectListGroupProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/selectlist
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/selectlist#SelectList.Group
+ * https://gestalt.pinterest.systems/web/selectlist#SelectList.Option
+ */
+export const SelectList: React.FunctionComponent<SelectListProps> & SelectListSubComponents;
+
+export interface SheetMobileSubComponents {
+  DismissingElement: React.FunctionComponent<SheetMobileDismissingElementProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/sheetmobile
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/sheetmobile#DismissingElement
+ */
+export const SheetMobile: ReactForwardRef<HTMLDivElement, SheetMobileProps> &
+  SheetMobileSubComponents;
+
+export interface SideNavigationSubcomponents {
+  Section: React.FunctionComponent<SideNavigationSectionProps>;
+  TopItem: React.FunctionComponent<SideNavigationTopItemProps>;
+  NestedItem: React.FunctionComponent<SideNavigationNestedItemProps>;
+  Group: React.FunctionComponent<SideNavigationGroupProps>;
+  NestedGroup: React.FunctionComponent<SideNavigationNestedGroupProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/sidenavigation
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Group
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.TopItem
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Section
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedGroup
+ */
+export const SideNavigation: React.FunctionComponent<SideNavigationProps> &
+  SideNavigationSubcomponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/slimbanner
+ */
+export const SlimBanner: React.FunctionComponent<SlimBannerProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/spinner
+ */
+export const Spinner: React.FunctionComponent<SpinnerProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/status
+ */
+export const Status: React.FunctionComponent<StatusProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/sticky
+ */
+export const Sticky: React.FunctionComponent<StickyProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/switch
+ */
+export const Switch: React.FunctionComponent<SwitchProps>;
+
+export interface TableSubComponents {
+  Body: React.FunctionComponent<TableBodyProps>;
+  Cell: React.FunctionComponent<TableCellProps>;
+  Footer: React.FunctionComponent<TableFooterProps>;
+  Header: React.FunctionComponent<TableHeaderProps>;
+  HeaderCell: React.FunctionComponent<TableHeaderCellProps>;
+  Row: React.FunctionComponent<TableRowProps>;
+  RowExpandable: React.FunctionComponent<TableRowExpandableProps>;
+  SortableHeaderCell: React.FunctionComponent<TableSortableHeaderCellProps>;
+  RowDrawer: React.FunctionComponent<TableRowDrawerProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/table
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/table#Table.RowDrawer
+ * https://gestalt.pinterest.systems/web/table#Table.RowExpandable
+ * https://gestalt.pinterest.systems/web/table#Table.Row
+ * https://gestalt.pinterest.systems/web/table#Table.SortableHeaderCell
+ * https://gestalt.pinterest.systems/web/table#Table.HeaderCell
+ * https://gestalt.pinterest.systems/web/table#Table.Cell
+ * https://gestalt.pinterest.systems/web/table#Table.Footer
+ * https://gestalt.pinterest.systems/web/table#Table.Body
+ * https://gestalt.pinterest.systems/web/table#Table.Header
+ */
+export const Table: React.FunctionComponent<TableProps> & TableSubComponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/tabs
+ */
+export const Tabs: React.FunctionComponent<TabsProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/tag
+ */
+export const Tag: React.FunctionComponent<TagProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/taparea
+ */
+export const TapArea: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, TapAreaProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/text
+ */
+export const Text: ReactForwardRef<HTMLDivElement | HTMLSpanElement, TextProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/textarea
+ */
+export const TextArea: ReactForwardRef<HTMLTextAreaElement, TextAreaProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/textfield
+ */
+export const TextField: ReactForwardRef<HTMLInputElement, TextFieldProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/toast
+ */
+export const Toast: React.FunctionComponent<ToastProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/tooltip
+ */
+export const Tooltip: React.FunctionComponent<TooltipProps>;
+
+export interface UpsellSubComponents {
+  Form: React.FunctionComponent<UpsellFormProps>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/upsell
+ * Subcomponents:
+ * https://gestalt.pinterest.systems/web/upsell#Upsell.Form
+ */
+export const Upsell: React.FunctionComponent<UpsellProps> & UpsellSubComponents;
+
+/**
+ * https://gestalt.pinterest.systems/web/video
+ */
+export const Video: React.FunctionComponent<VideoProps>;
+
+/**
+ * https://gestalt.pinterest.systems/web/washanimated
+ */
+export const WashAnimated: React.FunctionComponent<WashAnimatedProps>;
 
 /**
  * https://gestalt.pinterest.systems/web/zindex_classes#FixedZIndex
@@ -2365,220 +2547,11 @@ export class CompositeZIndex implements Indexable {
 }
 
 /**
- * =========================================================
- * ========================= INDEX =========================
- * =========================================================
+ * https://gestalt.pinterest.systems/web/utilities/usereducedmotion
  */
-
-export const ActivationCard: React.FunctionComponent<ActivationCardProps>;
-
-export const Avatar: React.FunctionComponent<AvatarProps>;
-
-export const AvatarGroup: React.FunctionComponent<AvatarGroupProps>;
-
-export const Badge: React.FunctionComponent<BadgeProps>;
-
-export const Box: ReactForwardRef<HTMLDivElement, BoxProps>;
-
-export const Button: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>;
-
-export const ButtonGroup: React.FunctionComponent<ButtonGroupProps>;
-
-export const Callout: React.FunctionComponent<CalloutProps>;
-
-export const ComboBox: React.FunctionComponent<ComboBoxProps>;
-
-export const Checkbox: ReactForwardRef<HTMLInputElement, CheckboxProps>;
-
-export const Collage: React.FunctionComponent<CollageProps>;
-
-export const ColorSchemeProvider: React.FunctionComponent<
-  React.PropsWithChildren<ColorSchemeProviderProps>
->;
-
-export const Column: React.FunctionComponent<ColumnProps>;
-
-export const Container: React.FunctionComponent<ContainerProps>;
-
-export const Datapoint: React.FunctionComponent<DatapointProps>;
-
-export const ScrollBoundaryContainer: React.FunctionComponent<ScrollBoundaryContainerProps>;
-
-export const DeviceTypeProvider: React.FunctionComponent<
-  React.PropsWithChildren<DeviceTypeProviderProps>
->;
-
-export const DefaultLabelProvider: React.FunctionComponent<
-  React.PropsWithChildren<DefaultLabelProviderProps>
->;
-
-export const Divider: React.FunctionComponent;
-
-export interface DropdownSubComponents {
-  Item: React.FunctionComponent<DropdownItemProps>;
-  Link: React.FunctionComponent<DropdownLinkProps>;
-  Section: React.FunctionComponent<DropdownSectionProps>;
-}
-
-export const Dropdown: React.FunctionComponent<DropdownProps> & DropdownSubComponents;
-
-export const Fieldset: React.FunctionComponent<FieldsetProps>;
-
-export interface FlexSubComponents {
-  Item: React.FunctionComponent<FlexItemProps>;
-}
-
-export const Flex: React.FunctionComponent<FlexProps> & FlexSubComponents;
-
-export const Heading: React.FunctionComponent<HeadingProps>;
-
-export const HelpButton: React.FunctionComponent<HelpButtonProps>;
-
-export const Icon: React.FunctionComponent<IconProps>;
-
-export const IconButton: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, IconButtonProps>;
-
-export const IconButtonFloating: React.FunctionComponent<IconButtonFloatingProps>;
-
-export const Image: React.FunctionComponent<ImageProps>;
-
-export const Label: React.FunctionComponent<LabelProps>;
-
-export const Layer: React.FunctionComponent<LayerProps>;
-
-export const Letterbox: React.FunctionComponent<LetterboxProps>;
-
-export const Link: ReactForwardRef<HTMLAnchorElement, LinkProps>;
-
-export interface ListSubCmoponents {
-  Item: React.FunctionComponent<React.PropsWithChildren<ListItemProps>>;
-}
-
-export const List: React.FunctionComponent<React.PropsWithChildren<ListProps>> & ListSubCmoponents;
-
-export const Mask: React.FunctionComponent<MaskProps>;
-
-export const Masonry: React.FunctionComponent<MasonryProps>;
-
-export const Modal: ReactForwardRef<HTMLDivElement, ModalProps>;
-
-export const ModalAlert: React.FunctionComponent<React.PropsWithChildren<ModalAlertProps>>;
-
-export interface ModuleSubComponents {
-  Expandable: React.FunctionComponent<ModuleExpandableProps>;
-}
-
-export const Module: React.FunctionComponent<React.PropsWithChildren<ModuleProps>> &
-  ModuleSubComponents;
-
-export const NumberField: ReactForwardRef<HTMLInputElement, NumberFieldProps>;
-
-export const OnLinkNavigationProvider: React.FunctionComponent<OnLinkNavigationProviderProps>;
-
-export const PageHeader: React.FunctionComponent<PageHeaderProps>;
-
-export const Pog: React.FunctionComponent<PogProps>;
-
-export const Popover: React.FunctionComponent<PopoverProps>;
-
-export const Popovereducational: React.FunctionComponent<PopoverEducationalProps>;
-
-export const Pulsar: React.FunctionComponent<PulsarProps>;
-
-export const RadioButton: ReactForwardRef<HTMLInputElement, RadioButtonProps>;
-
-export interface RadioGroupSubComponents {
-  RadioButton: React.FunctionComponent<RadioGroupRadioButtonProps>;
-}
-
-export const RadioGroup: React.FunctionComponent<RadioGroupProps> & RadioGroupSubComponents;
-
-export const SearchField: ReactForwardRef<HTMLInputElement, SearchFieldProps>;
-
-export const SegmentedControl: React.FunctionComponent<SegmentedControlProps>;
-
-export interface SelectListSubComponents {
-  Option: React.FunctionComponent<SelectListOptionProps>;
-  Group: React.FunctionComponent<SelectListGroupProps>;
-}
-
-export const SelectList: React.FunctionComponent<SelectListProps> & SelectListSubComponents;
-
-export interface SideNavigationSubcomponents {
-  Section: React.FunctionComponent<SideNavigationSectionProps>;
-  TopItem: React.FunctionComponent<SideNavigationTopItemProps>;
-  NestedItem: React.FunctionComponent<SideNavigationNestedItemProps>;
-  Group: React.FunctionComponent<SideNavigationGroupProps>;
-  NestedGroup: React.FunctionComponent<SideNavigationNestedGroupProps>;
-}
-
-export const SideNavigation: React.FunctionComponent<SideNavigationProps> &
-  SideNavigationSubcomponents;
-
-export interface OverlayPanelSubComponents {
-  DismissingElement: React.FunctionComponent<OverlayPanelDismissingElementProps>;
-}
-
-export const OverlayPanel: ReactForwardRef<HTMLDivElement, OverlayPanelProps> &
-  OverlayPanelSubComponents;
-
-export interface SheetMobileSubComponents {
-  DismissingElement: React.FunctionComponent<SheetMobileDismissingElementProps>;
-}
-
-export const SheetMobile: ReactForwardRef<HTMLDivElement, SheetMobileProps> &
-  SheetMobileSubComponents;
-
-export const SlimBanner: React.FunctionComponent<SlimBannerProps>;
-
-export const Spinner: React.FunctionComponent<SpinnerProps>;
-
-export const Status: React.FunctionComponent<StatusProps>;
-
-export const Sticky: React.FunctionComponent<StickyProps>;
-
-export const Switch: React.FunctionComponent<SwitchProps>;
-
-export interface TableSubComponents {
-  Body: React.FunctionComponent<TableBodyProps>;
-  Cell: React.FunctionComponent<TableCellProps>;
-  Footer: React.FunctionComponent<TableFooterProps>;
-  Header: React.FunctionComponent<TableHeaderProps>;
-  HeaderCell: React.FunctionComponent<TableHeaderCellProps>;
-  Row: React.FunctionComponent<TableRowProps>;
-  RowExpandable: React.FunctionComponent<TableRowExpandableProps>;
-  SortableHeaderCell: React.FunctionComponent<TableSortableHeaderCellProps>;
-  RowDrawer: React.FunctionComponent<TableRowDrawerProps>;
-}
-
-export const Table: React.FunctionComponent<TableProps> & TableSubComponents;
-
-export const Tabs: React.FunctionComponent<TabsProps>;
-
-export const Tag: React.FunctionComponent<TagProps>;
-
-export const TapArea: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, TapAreaProps>;
-
-export const Text: ReactForwardRef<HTMLDivElement | HTMLSpanElement, TextProps>;
-
-export const TextArea: ReactForwardRef<HTMLTextAreaElement, TextAreaProps>;
-
-export const TextField: ReactForwardRef<HTMLInputElement, TextFieldProps>;
-
-export const Toast: React.FunctionComponent<ToastProps>;
-
-export const Tooltip: React.FunctionComponent<TooltipProps>;
-
-export interface UpsellSubCompnents {
-  Form: React.FunctionComponent<UpsellFormProps>;
-}
-
-export const Upsell: React.FunctionComponent<UpsellProps> & UpsellSubCompnents;
-
-export const Video: React.FunctionComponent<VideoProps>;
-
-export const WashAnimated: React.FunctionComponent<WashAnimatedProps>;
-
 export function useReducedMotion(): boolean;
 
+/**
+ * https://gestalt.pinterest.systems/web/utilities/usefocusvisible
+ */
 export function useFocusVisible(): { isFocusVisible: boolean };

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1,0 +1,2459 @@
+import React = require('react');
+
+/**
+ * Helpers
+ */
+
+export type AbstractEventHandler<T extends React.SyntheticEvent<HTMLElement> | Event, U = {}> = (
+  arg: U & {
+    readonly event: T;
+  },
+) => void;
+export type ReactForwardRef<T, P> = React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<P> & React.RefAttributes<T>
+>;
+
+export type FourDirections = 'up' | 'right' | 'down' | 'left';
+
+export type EventHandlerType = (args: { readonly event: React.SyntheticEvent }) => void;
+
+export interface OnNavigationArgs {
+  href: string;
+  target?: null | 'self' | 'blank' | undefined;
+}
+
+export type OnNavigationType = (args: OnNavigationArgs) => EventHandlerType | null | undefined;
+export type UnsignedUpTo12 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type SignedUpTo12 =
+  | -12
+  | -11
+  | -10
+  | -9
+  | -8
+  | -7
+  | -6
+  | -5
+  | -4
+  | -3
+  | -2
+  | -1
+  | UnsignedUpTo12;
+
+export interface BadgeObject {
+  text: string;
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'darkWash'
+    | 'lightWash'
+    | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/activationcard
+ */
+export interface ActivationCardProps {
+  message: string;
+  status: 'notStarted' | 'pending' | 'needsAttention' | 'complete';
+  statusMessage: string;
+  title: string;
+  dismissButton?:
+    | {
+        accessibilityLabel: string;
+        onDismiss: () => void;
+      }
+    | undefined;
+  link?:
+    | {
+        accessibilityLabel: string;
+        href: string;
+        label: string;
+        onClick?:
+          | AbstractEventHandler<
+              | React.MouseEvent<HTMLButtonElement>
+              | React.MouseEvent<HTMLAnchorElement>
+              | React.KeyboardEvent<HTMLAnchorElement>
+              | React.KeyboardEvent<HTMLButtonElement>,
+              { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+            >
+          | undefined;
+        rel?: 'none' | 'nofollow' | undefined;
+        target?: null | 'self' | 'blank' | undefined;
+      }
+    | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/avatar
+ */
+export interface AvatarProps {
+  name: string;
+  accessibilityLabel?: string | undefined;
+  outline?: boolean | undefined;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'fit' | undefined;
+  src?: string | undefined;
+  verified?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/avatargroup
+ */
+export interface AvatarGroupProps {
+  accessibilityLabel: string;
+  collaborators: ReadonlyArray<{ name: string; src?: string | undefined }>;
+
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+  addCollaborators?: boolean | undefined;
+  href?: string | undefined;
+  onClick?: OnTapType | undefined;
+  role?: 'button' | 'link' | undefined;
+  size?: 'xs' | 'sm' | 'md' | 'fit' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/badge
+ */
+export interface BadgeProps {
+  text: string;
+  position?: 'middle' | 'top' | undefined;
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'darkWash'
+    | 'lightWash'
+    | 'recommendation'
+    | undefined;
+}
+
+export type BoxPassthroughProps = Omit<
+  React.ComponentProps<'div'>,
+  'onClick' | 'className' | 'style' | 'ref'
+> &
+  React.RefAttributes<HTMLDivElement>;
+
+/**
+ * https://gestalt.pinterest.systems/web/box
+ */
+export interface BoxProps extends BoxPassthroughProps {
+  alignContent?:
+    | 'start'
+    | 'end'
+    | 'center'
+    | 'between'
+    | 'around'
+    | 'evenly'
+    | 'stretch'
+    | undefined;
+  alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  smAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  mdAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  lgAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  as?:
+    | 'article'
+    | 'aside'
+    | 'details'
+    | 'div'
+    | 'figcaption'
+    | 'figure'
+    | 'footer'
+    | 'header'
+    | 'main'
+    | 'nav'
+    | 'section'
+    | 'summary'
+    | undefined;
+  borderStyle?:
+    | 'sm'
+    | 'lg'
+    | 'shadow'
+    | 'raisedTopShadow'
+    | 'raisedBottomShadow'
+    | 'none'
+    | undefined;
+  bottom?: boolean | undefined;
+  children?: React.ReactNode | undefined;
+  color?:
+    | 'darkWash'
+    | 'lightWash'
+    | 'transparent'
+    | 'transparentDarkGray'
+    | 'default'
+    | 'infoBase'
+    | 'infoWeak'
+    | 'errorBase'
+    | 'errorWeak'
+    | 'warningBase'
+    | 'warningWeak'
+    | 'successBase'
+    | 'successWeak'
+    | 'recommendationBase'
+    | 'recommendationWeak'
+    | 'shopping'
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'selected'
+    | 'inverse'
+    | 'brand'
+    | 'education'
+    | 'elevationAccent'
+    | 'elevationFloating'
+    | 'elevationRaised'
+    | 'dark'
+    | 'light'
+    | undefined;
+  column?: UnsignedUpTo12 | undefined;
+  smColumn?: UnsignedUpTo12 | undefined;
+  mdColumn?: UnsignedUpTo12 | undefined;
+  lgColumn?: UnsignedUpTo12 | undefined;
+  dangerouslySetInlineStyle?:
+    | {
+        __style: {
+          [key: string]: string | number | undefined;
+        };
+      }
+    | undefined;
+  direction?: 'row' | 'column' | undefined;
+  smDirection?: 'row' | 'column' | undefined;
+  mdDirection?: 'row' | 'column' | undefined;
+  lgDirection?: 'row' | 'column' | undefined;
+  display?: 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden' | undefined;
+  smDisplay?: 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden' | undefined;
+  mdDisplay?: 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden' | undefined;
+  lgDisplay?: 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden' | undefined;
+  fit?: boolean | undefined;
+  flex?: 'grow' | 'shrink' | 'none' | undefined;
+  height?: number | string | undefined;
+  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | undefined;
+  left?: boolean | undefined;
+  margin?: SignedUpTo12 | 'auto' | undefined;
+  smMargin?: SignedUpTo12 | 'auto' | undefined;
+  mdMargin?: SignedUpTo12 | 'auto' | undefined;
+  lgMargin?: SignedUpTo12 | 'auto' | undefined;
+  marginBottom?: SignedUpTo12 | 'auto' | undefined;
+  smMarginBottom?: SignedUpTo12 | 'auto' | undefined;
+  mdMarginBottom?: SignedUpTo12 | 'auto' | undefined;
+  lgMarginBottom?: SignedUpTo12 | 'auto' | undefined;
+  marginEnd?: SignedUpTo12 | 'auto' | undefined;
+  smMarginEnd?: SignedUpTo12 | 'auto' | undefined;
+  mdMarginEnd?: SignedUpTo12 | 'auto' | undefined;
+  lgMarginEnd?: SignedUpTo12 | 'auto' | undefined;
+  marginStart?: SignedUpTo12 | 'auto' | undefined;
+  smMarginStart?: SignedUpTo12 | 'auto' | undefined;
+  mdMarginStart?: SignedUpTo12 | 'auto' | undefined;
+  lgMarginStart?: SignedUpTo12 | 'auto' | undefined;
+  marginTop?: SignedUpTo12 | 'auto' | undefined;
+  smMarginTop?: SignedUpTo12 | 'auto' | undefined;
+  mdMarginTop?: SignedUpTo12 | 'auto' | undefined;
+  lgMarginTop?: SignedUpTo12 | 'auto' | undefined;
+  maxHeight?: number | string | undefined;
+  maxWidth?: number | string | undefined;
+  minHeight?: number | string | undefined;
+  minWidth?: number | string | undefined;
+  opacity?: 0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1 | undefined;
+  overflow?: 'visible' | 'hidden' | 'scroll' | 'scrollX' | 'scrollY' | 'auto' | undefined;
+  padding?: UnsignedUpTo12 | undefined;
+  smPadding?: UnsignedUpTo12 | undefined;
+  mdPadding?: UnsignedUpTo12 | undefined;
+  lgPadding?: UnsignedUpTo12 | undefined;
+  paddingX?: UnsignedUpTo12 | undefined;
+  smPaddingX?: UnsignedUpTo12 | undefined;
+  mdPaddingX?: UnsignedUpTo12 | undefined;
+  lgPaddingX?: UnsignedUpTo12 | undefined;
+  paddingY?: UnsignedUpTo12 | undefined;
+  smPaddingY?: UnsignedUpTo12 | undefined;
+  mdPaddingY?: UnsignedUpTo12 | undefined;
+  lgPaddingY?: UnsignedUpTo12 | undefined;
+  position?: 'static' | 'absolute' | 'relative' | 'fixed' | undefined;
+  right?: boolean | undefined;
+  role?: string | undefined;
+  rounding?: 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
+  top?: boolean | undefined;
+  userSelect?: 'auto' | 'none' | undefined;
+  width?: number | string | undefined;
+  wrap?: boolean | undefined;
+  zIndex?: Indexable | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/button
+ */
+export interface ButtonProps {
+  text: string;
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+  accessibilityLabel?: string | undefined;
+  color?:
+    | 'gray'
+    | 'red'
+    | 'blue'
+    | 'transparent'
+    | 'semiTransparentWhite'
+    | 'transparentWhiteText'
+    | 'white'
+    | undefined;
+  disabled?: boolean | undefined;
+  href?: string | undefined;
+  iconEnd?: Icons | undefined;
+  fullWidth?: boolean | undefined;
+  name?: string | undefined;
+  onClick?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLButtonElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+      >
+    | undefined;
+  rel?: 'none' | 'nofollow' | undefined;
+  role?: 'button' | 'link' | undefined;
+  selected?: boolean | undefined;
+  size?: 'sm' | 'md' | 'lg' | undefined;
+  tabIndex?: -1 | 0 | undefined;
+  target?: null | 'self' | 'blank' | undefined;
+  type?: 'submit' | 'button' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/buttongroup
+ */
+export interface ButtonGroupProps {
+  children?: React.ReactNode | undefined;
+}
+
+export interface ActionData {
+  accessibilityLabel: string;
+  disabled?: boolean;
+  href?: string | undefined;
+  label: string;
+  onClick?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+      >
+    | undefined;
+  rel?: 'none' | 'nofollow' | undefined;
+  target?: null | 'self' | 'blank' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/callout
+ */
+export interface CalloutProps {
+  iconAccessibilityLabel: string;
+  message: string;
+  type: 'error' | 'info' | 'recommendation' | 'success' | 'warning';
+  dismissButton?:
+    | {
+        accessibilityLabel: string;
+        onDismiss: () => void;
+      }
+    | undefined;
+  primaryAction?: ActionData | undefined;
+  secondaryAction?: ActionData | undefined;
+  title?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/checkbox
+ */
+export interface CheckboxProps {
+  id: string;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
+  checked?: boolean | undefined;
+  disabled?: boolean | undefined;
+  errorMessage?: string | undefined;
+  hasError?: boolean | undefined;
+  image?: React.ReactNode | undefined;
+  indeterminate?: boolean | undefined;
+  label?: string | undefined;
+  name?: string | undefined;
+  onClick?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>
+    | undefined;
+  size?: 'sm' | 'md' | undefined;
+  subtext?: string | undefined;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+}
+
+export interface ComboBoxItemType {
+  label: string;
+  subtext?: string;
+  value: string;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/combobox
+ */
+export interface ComboBoxProps {
+  accessibilityClearButtonLabel: string;
+  id: string;
+  label: string;
+  options: ComboBoxItemType[];
+  noResultText: string;
+  zIndex?: Indexable | undefined;
+  disabled?: boolean | undefined;
+  errorMessage?: string | undefined;
+  helperText?: string | undefined;
+  inputValue?: string | undefined;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+  onChange?:
+    | ((args: { event: React.SyntheticEvent<HTMLInputElement>; value: string }) => void)
+    | undefined;
+  onBlur?:
+    | ((args: {
+        event: React.FocusEvent<HTMLInputElement> | React.SyntheticEvent<HTMLInputElement>;
+        value: string;
+      }) => void)
+    | undefined;
+  onFocus?:
+    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: string }) => void)
+    | undefined;
+  onKeyDown?:
+    | ((args: { event: React.KeyboardEvent<HTMLInputElement>; value: string }) => void)
+    | undefined;
+  onClear?: (() => void) | undefined;
+  onSelect?:
+    | ((args: {
+        event: React.SyntheticEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>;
+        item: ComboBoxItemType;
+      }) => void)
+    | undefined;
+  placeholder?: string | undefined;
+  selectedOption?: ComboBoxItemType | undefined;
+  size?: 'md' | 'lg' | undefined;
+  tags?: ReadonlyArray<React.ReactElement<TagProps, typeof Tag>> | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/collage
+ */
+export interface CollageProps {
+  columns: number;
+  height: number;
+  renderImage: (args: { width: number; height: number; index: number }) => React.ReactNode;
+  width: number;
+  cover?: boolean | undefined;
+  gutter?: number | undefined;
+  layoutKey?: number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/colorschemeprovider
+ */
+export interface ColorSchemeProviderProps {
+  colorScheme: 'light' | 'dark' | 'userPreference';
+  id?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/column
+ */
+export interface ColumnProps {
+  span: UnsignedUpTo12;
+  smSpan?: UnsignedUpTo12 | undefined;
+  mdSpan?: UnsignedUpTo12 | undefined;
+  lgSpan?: UnsignedUpTo12 | undefined;
+  children?: React.ReactNode | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/container
+ */
+export interface ContainerProps {
+  children?: React.ReactNode | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/datapoint
+ */
+export interface DatapointProps {
+  title: string;
+  value: string;
+  size?: 'md' | 'lg' | undefined;
+  tooltipText?: string | undefined;
+  trend?: { accessibilityLabel: string; value: number } | undefined;
+  trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto' | undefined;
+  badge?: BadgeObject | undefined;
+  tooltipZIndex?: Indexable | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/devicetypeprovider
+ */
+export interface DeviceTypeProviderProps {
+  deviceType: 'desktop' | 'mobile';
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/defaultlabelprovider
+ */
+export interface DefaultLabelProviderProps {
+  labels?:
+    | {
+        ComboBox: {
+          accessibilityClearButtonLabel: string;
+        };
+        Link: {
+          accessibilityNewTabLabel: string;
+        };
+        ModalAlert: {
+          accessibilityDismissButtonLabel: string;
+        };
+        Popover: {
+          accessibilityDismissButtonLabel: string;
+        };
+        Tag: {
+          accessibilityErrorIconLabel: string;
+          accessibilityRemoveIconLabel: string;
+          accessibilityWarningIconLabel: string;
+        };
+        TextField: {
+          accessibilityHidePasswordLabel: string;
+          accessibilityShowPasswordLabel: string;
+        };
+      }
+    | undefined;
+}
+
+export interface DropdownOption {
+  label: string;
+  value: string;
+  subtext?: string | undefined;
+}
+/**
+ * https://gestalt.pinterest.systems/web/dropdown
+ */
+export interface DropdownProps {
+  children:
+    | React.ReactElement<DropdownItemProps | DropdownSectionProps>
+    | Array<React.ReactElement<DropdownItemProps | DropdownSectionProps>>;
+  id: string;
+  onDismiss: () => void;
+  anchor?: HTMLElement | null | undefined;
+  dangerouslyRemoveLayer?: boolean;
+  headerContent?: React.ReactNode | undefined;
+  idealDirection?: FourDirections | undefined;
+  maxHeight?: '30vh' | undefined;
+  zIndex?: Indexable | undefined;
+}
+
+export interface DropdownItemProps {
+  children?: React.ReactNode;
+  onSelect: AbstractEventHandler<
+    React.FocusEvent<HTMLInputElement>,
+    {
+      item: DropdownOption;
+    }
+  >;
+  option: DropdownOption;
+  badge?: BadgeObject | undefined;
+  dataTestId?: string | undefined;
+  selected?: DropdownOption | ReadonlyArray<DropdownOption> | undefined;
+}
+
+export interface DropdownLinkProps {
+  href: string;
+  option: DropdownOption;
+  badge?: BadgeObject | undefined;
+  children?: React.ReactNode;
+  dataTestId?: string | undefined;
+  isExternal?: boolean | undefined;
+  onClick?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLButtonElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLAnchorElement>,
+        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+      >
+    | undefined;
+}
+
+export interface DropdownSectionProps {
+  children:
+    | React.ReactElement<DropdownItemProps>
+    | ReadonlyArray<React.ReactElement<DropdownItemProps>>;
+  label: string;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/fieldset
+ */
+export interface FieldsetProps {
+  children: React.ReactNode;
+  id?: string;
+  legend: string;
+  legendDisplay?: 'visible' | 'hidden' | undefined;
+  errorMessage?: string;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/flex
+ */
+export interface FlexProps {
+  alignContent?:
+    | 'start'
+    | 'end'
+    | 'center'
+    | 'between'
+    | 'around'
+    | 'evenly'
+    | 'stretch'
+    | undefined;
+  alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  smAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  mdAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  lgAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  children?: React.ReactNode | undefined;
+  direction?: 'row' | 'column' | undefined;
+  flex?: 'grow' | 'shrink' | 'none' | undefined;
+  gap?: UnsignedUpTo12 | { row: UnsignedUpTo12; column: UnsignedUpTo12 } | undefined;
+  height?: number | string | undefined;
+  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | undefined;
+  maxHeight?: number | string | undefined;
+  maxWidth?: number | string | undefined;
+  minHeight?: number | string | undefined;
+  minWidth?: number | string | undefined;
+  width?: number | string | undefined;
+  wrap?: boolean | undefined;
+  dataTestId?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/flex#Flex.Item
+ */
+export interface FlexItemProps {
+  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  children?: React.ReactNode | undefined;
+  flex?: 'grow' | 'shrink' | 'none' | undefined;
+  minWidth?: number | string | undefined;
+  flexBasis?: string | number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/heading
+ */
+export interface HeaderProps {
+  accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6 | 'none' | undefined;
+  align?: 'start' | 'end' | 'center' | 'forceLeft' | 'forceRight' | undefined;
+  children?: React.ReactNode | undefined;
+  color?:
+    | 'default'
+    | 'subtle'
+    | 'success'
+    | 'error'
+    | 'warning'
+    | 'shopping'
+    | 'inverse'
+    | 'light'
+    | 'dark'
+    | undefined;
+  id?: string | undefined;
+  overflow?: 'normal' | 'breakWord' | undefined;
+  size?: '100' | '200' | '300' | '400' | '500' | '600' | undefined;
+  truncate?: boolean | undefined;
+  lineClamp?: number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/helpbutton
+ */
+export interface HelpButtonProps {
+  accessibilityLabel: string;
+  accessibilityPopoverLabel: string;
+  idealDirection?: 'up' | 'right' | 'down' | 'left' | undefined;
+  isWithinFixedContainer?: boolean | undefined;
+  link?:
+    | {
+        accessibilityLabel?: string | undefined;
+        externalLinkIcon?:
+          | 'none'
+          | 'default'
+          | {
+              color: IconProps['color'];
+              size: IconProps['size'];
+            };
+        href: string;
+        onClick?:
+          | AbstractEventHandler<
+              React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>,
+              {
+                dangerouslyDisableOnNavigation: () => void;
+              }
+            >
+          | undefined;
+        text: string;
+        ref?: React.Ref<'a'>;
+        target?: null | 'self' | 'blank';
+      }
+    | undefined;
+  onClick?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLDivElement>
+        | React.KeyboardEvent<HTMLDivElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>,
+        {
+          dangerouslyDisableOnNavigation: () => void;
+        }
+      >
+    | undefined;
+  text: string | React.ReactElement<typeof Text>;
+  zIndex?: Indexable | undefined;
+}
+
+export type Icons =
+  | 'ad'
+  | 'ad-group'
+  | 'add'
+  | 'add-circle'
+  | 'add-layout'
+  | 'add-pin'
+  | 'ads-stats'
+  | 'ads-overview'
+  | 'alert'
+  | 'align-bottom-center'
+  | 'align-bottom-left'
+  | 'align-bottom-right'
+  | 'align-bottom'
+  | 'align-middle'
+  | 'align-top-center'
+  | 'align-top-left'
+  | 'align-top-right'
+  | 'align-top'
+  | 'android-share'
+  | 'angled-pin'
+  | 'apps'
+  | 'arrow-back'
+  | 'arrow-circle-down'
+  | 'arrow-circle-forward'
+  | 'arrow-circle-up'
+  | 'arrow-down'
+  | 'arrow-end'
+  | 'arrow-forward'
+  | 'arrow-start'
+  | 'arrow-up'
+  | 'arrow-up-right'
+  | 'bell'
+  | 'calendar'
+  | 'camera'
+  | 'camera-roll'
+  | 'cancel'
+  | 'canonical-pin'
+  | 'captions'
+  | 'color-picker'
+  | 'check'
+  | 'check-circle'
+  | 'circle-outline'
+  | 'clear'
+  | 'clock'
+  | 'code'
+  | 'cog'
+  | 'compass'
+  | 'compose'
+  | 'copy-to-clipboard'
+  | 'crop'
+  | 'dash'
+  | 'conversion-tag'
+  | 'credit-card'
+  | 'directional-arrow-left'
+  | 'directional-arrow-right'
+  | 'download'
+  | 'drag-drop'
+  | 'duplicate'
+  | 'edit'
+  | 'ellipsis'
+  | 'ellipsis-circle-outline'
+  | 'envelope'
+  | 'eye'
+  | 'eye-hide'
+  | 'facebook'
+  | 'face-happy'
+  | 'face-neutral'
+  | 'face-sad'
+  | 'face-smiley'
+  | 'file-unknown'
+  | 'fill-opaque'
+  | 'fill-transparent'
+  | 'filter'
+  | 'flag'
+  | 'flash'
+  | 'flashlight'
+  | 'flipHorizontal'
+  | 'flipVertical'
+  | 'folder'
+  | 'gif'
+  | 'globe'
+  | 'globe-checked'
+  | 'gmail'
+  | 'google-plus'
+  | 'graph-bar'
+  | 'handle'
+  | 'hand-pointing'
+  | 'heart'
+  | 'heart-outline'
+  | 'heart-broken'
+  | 'history'
+  | 'home'
+  | 'idea-pin'
+  | 'impressum'
+  | 'insights-audience'
+  | 'insights-conversions'
+  | 'info-circle'
+  | 'key'
+  | 'knoop'
+  | 'lightbulb'
+  | 'lightning-bolt-circle'
+  | 'link'
+  | 'location'
+  | 'lock'
+  | 'logo-large'
+  | 'logo-small'
+  | 'logout'
+  | 'margins-large'
+  | 'margins-medium'
+  | 'margins-small'
+  | 'maximize'
+  | 'megaphone'
+  | 'menu'
+  | 'minimize'
+  | 'move'
+  | 'mute'
+  | 'music-off'
+  | 'music-on'
+  | 'overlay-text'
+  | 'overview'
+  | 'pause'
+  | 'people'
+  | 'person'
+  | 'person-add'
+  | 'phone'
+  | 'pin'
+  | 'pincode'
+  | 'pin-hide'
+  | 'pinterest'
+  | 'play'
+  | 'protect'
+  | 'refresh'
+  | 'question-mark'
+  | 'remove'
+  | 'reorder-images'
+  | 'replace'
+  | 'report'
+  | 'rotate'
+  | 'scale'
+  | 'search'
+  | 'security'
+  | 'shopping-bag'
+  | 'smiley'
+  | 'smiley-outline'
+  | 'send'
+  | 'share'
+  | 'sound'
+  | 'sort-ascending'
+  | 'sort-descending'
+  | 'sparkle'
+  | 'speech'
+  | 'speech-ellipsis'
+  | 'star'
+  | 'star-half'
+  | 'switch-account'
+  | 'tag'
+  | 'terms'
+  | 'text-align-left'
+  | 'text-align-center'
+  | 'text-align-right'
+  | 'text-all-caps'
+  | 'text-extra-small'
+  | 'text-large'
+  | 'text-line-height'
+  | 'text-medium'
+  | 'text-sentence-case'
+  | 'text-size'
+  | 'text-small'
+  | 'text-spacing'
+  | 'trash-can'
+  | 'trending'
+  | 'twitter'
+  | 'video-camera'
+  | 'view-type-default'
+  | 'view-type-dense'
+  | 'view-type-list'
+  | 'visit'
+  | 'workflow-status-all'
+  | 'workflow-status-canceled'
+  | 'workflow-status-halted'
+  | 'workflow-status-in-progress'
+  | 'workflow-status-ok'
+  | 'workflow-status-problem'
+  | 'workflow-status-unstarted'
+  | 'workflow-status-warning';
+
+/**
+ * https://gestalt.pinterest.systems/web/icon
+ */
+export interface IconProps {
+  accessibilityLabel: string;
+
+  color?:
+    | 'default'
+    | 'subtle'
+    | 'success'
+    | 'error'
+    | 'warning'
+    | 'info'
+    | 'inverse'
+    | 'shopping'
+    | 'brandPrimary'
+    | 'light'
+    | 'dark'
+    | undefined;
+  dangerouslySetSvgPath?: { __path: string } | undefined;
+  icon?: Icons | undefined;
+  inline?: boolean | undefined;
+  size?: number | string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/iconbutton
+ */
+export interface IconButtonProps {
+  bgColor?:
+    | 'transparent'
+    | 'darkGray'
+    | 'transparentDarkGray'
+    | 'gray'
+    | 'lightGray'
+    | 'white'
+    | 'red'
+    | undefined;
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+  accessibilityLabel: string;
+
+  dangerouslySetSvgPath?: { __path: string } | undefined;
+  disabled?: boolean | undefined;
+  href?: string | undefined;
+  icon?: Icons | undefined;
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary' | undefined;
+  onClick?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+      >
+    | undefined;
+  padding?: 1 | 2 | 3 | 4 | 5 | undefined;
+  rel?: 'none' | 'nofollow' | undefined;
+  role?: 'button' | 'link' | undefined;
+  selected?: boolean | undefined;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | undefined;
+  tabIndex?: -1 | 0 | undefined;
+  target?: null | 'self' | 'blank' | undefined;
+  tooltip?:
+    | Pick<TooltipProps, 'accessibilityLabel' | 'inline' | 'idealDirection' | 'text' | 'zIndex'>
+    | undefined;
+  type?: 'submit' | 'button' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/iconbuttonfloating
+ */
+export interface IconButtonFloatingProps {
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityPopupRole: 'menu' | 'dialog';
+  accessibilityLabel: string;
+  icon: Icons;
+  onClick?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+      >
+    | undefined;
+  selected?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/image
+ */
+export interface ImageProps {
+  alt: string;
+  color: string;
+  crossOrigin?: 'anonymous' | 'use-credentials' | undefined;
+  decoding?: 'sync' | 'async' | 'auto';
+  elementTiming?: string | undefined;
+  naturalHeight: number;
+  naturalWidth: number;
+  src: string;
+  children?: React.ReactNode | undefined;
+  fit?: 'cover' | 'contain' | 'none' | undefined;
+  fetchPriority?: 'high' | 'low' | 'auto' | undefined;
+  loading?: 'eager' | 'lazy' | 'auto' | undefined;
+  onError?: AbstractEventHandler<React.SyntheticEvent<HTMLImageElement>> | undefined;
+  onLoad?: AbstractEventHandler<React.SyntheticEvent<HTMLImageElement>> | undefined;
+  role?: 'img' | 'presentation' | undefined;
+  sizes?: string | undefined;
+  srcSet?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/label
+ */
+export interface LabelProps {
+  htmlFor: string;
+  children?: React.ReactNode | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/layer
+ */
+export interface LayerProps {
+  children: React.ReactNode;
+  zIndex?: Indexable | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/letterbox
+ */
+export interface LetterboxProps {
+  contentAspectRatio: number;
+  height: number;
+  width: number;
+  children?: React.ReactNode | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/link
+ */
+export type ExternalLinkIcon =
+  | 'none'
+  | 'default'
+  | { color: IconProps['color']; size: TextProps['size'] };
+export interface LinkProps {
+  href: string;
+  accessibilityLabel?: string | undefined;
+  children?: React.ReactNode | undefined;
+  hoverStyle?: 'none' | 'underline' | undefined;
+  id?: string | undefined;
+  display?: 'inline' | 'inlineBlock' | 'block' | undefined;
+  externalLinkIcon?: ExternalLinkIcon | undefined;
+  onBlur?: AbstractEventHandler<React.FocusEvent<HTMLAnchorElement>> | undefined;
+  onClick?:
+    | AbstractEventHandler<
+        React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>,
+        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+      >
+    | undefined;
+  onFocus?: AbstractEventHandler<React.FocusEvent<HTMLAnchorElement>> | undefined;
+  rel?: 'none' | 'nofollow' | undefined;
+  rounding?: 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
+  tapStyle?: 'none' | 'compress' | undefined;
+  target?: null | 'self' | 'blank' | undefined;
+  underline?: 'auto' | 'none' | 'always' | 'hover' | undefined;
+}
+
+export interface ListItemProps {
+  text: string | React.ReactElement<typeof Text>;
+}
+
+export interface ListProps {
+  label: string | React.ReactElement<typeof Text>;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+  spacing?: 'regular' | 'condensed' | undefined;
+  type?: 'bare' | 'ordered' | 'unordered' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/mask
+ */
+export interface MaskProps {
+  children?: React.ReactNode | undefined;
+  height?: number | string | undefined;
+  rounding?: 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
+  wash?: boolean | undefined;
+  width?: number | string | undefined;
+  willChangeTransform?: boolean | undefined;
+}
+
+export interface MasonryCache<K, V> {
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, value: V): void;
+  reset(): void;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/masonry
+ */
+export interface MasonryProps<T = any> {
+  columnWidth?: number | undefined;
+  gutterWidth?: number | undefined;
+  items: ReadonlyArray<T>;
+  loadItems?: false | ((_arg?: { from: number }) => undefined | boolean | {}) | undefined;
+  measurementStore?: MasonryCache<T, any>;
+  layout?:
+    | 'basic'
+    | 'basicCentered'
+    | 'flexible'
+    | 'serverRenderedFlexible'
+    | 'uniformRow'
+    | undefined;
+  renderItem: (args: { data: T; itemIdx: number; isMeasuring: boolean }) => React.ReactNode;
+  flexible?: boolean | undefined;
+  minCols?: number | undefined;
+  scrollContainer?: (() => HTMLElement) | undefined;
+  virtualBoundsBottom?: number | undefined;
+  virtualBoundsTop?: number | undefined;
+  virtualize?: boolean | undefined;
+  virtualBufferFactor?: number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/modal
+ */
+
+export interface ModalProps {
+  _dangerouslyDisableScrollBoundaryContainer?: boolean;
+  accessibilityModalLabel: string;
+  align?: 'center' | 'start' | undefined;
+  children?: React.ReactNode | undefined;
+  closeOnOutsideClick?: boolean | undefined;
+  footer?: React.ReactNode | undefined;
+  heading?: React.ReactNode | undefined;
+  onDismiss: () => void;
+  pending?: 'defaut' | 'none' | undefined;
+  role?: 'alertdialog' | 'dialog' | undefined;
+  size?: 'sm' | 'md' | 'lg' | number | undefined;
+  subHeading?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/modalalert
+ */
+
+export interface ModalAlertActionDataType {
+  accessibilityLabel: string;
+  disabled?: boolean | undefined;
+  href?: string | undefined;
+  label: string;
+  onClick: AbstractEventHandler<
+    | React.KeyboardEvent<HTMLButtonElement>
+    | React.MouseEvent<HTMLAnchorElement>
+    | React.KeyboardEvent<HTMLAnchorElement>
+    | React.MouseEvent<HTMLButtonElement>,
+    { dangerouslyDisableOnNavigation: () => void }
+  >;
+  rel?: 'none' | 'nofollow' | undefined;
+  target?: null | 'self' | 'blank' | undefined;
+}
+
+export interface ModalAlertProps {
+  accessibilityDismissButtonLabel?: string | undefined;
+  accessibilityModalLabel: string;
+  heading: string;
+  onDismiss: () => void;
+  type?: 'default' | 'warning' | 'error' | undefined;
+  primaryAction: ModalAlertActionDataType;
+  secondaryAction?: ModalAlertActionDataType | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/module
+ */
+export interface ModuleProps {
+  id: string;
+  badge?: BadgeObject | undefined;
+  icon?: Icons | undefined;
+  iconAccessibilityLabel?: string | undefined;
+  iconButton?: React.ReactElement<typeof IconButton> | undefined;
+  title?: string | undefined;
+  type?: 'error' | 'info' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/module#Module.Expandable
+ */
+export interface ModuleExpandableProps {
+  accessibilityCollapseLabel: string;
+  accessibilityExpandLabel: string;
+  id: string;
+  items: ReadonlyArray<{
+    title: string;
+    icon?: Icons | undefined;
+    iconButton?: React.ReactElement<typeof IconButton> | undefined;
+    summary?: ReadonlyArray<string> | undefined;
+    type?: 'info' | 'error' | undefined;
+    iconAccessibilityLabel?: string | undefined;
+    children?: React.ReactNode | undefined;
+    badge?: BadgeObject | undefined;
+  }>;
+  expandedIndex?: number | null | undefined;
+  onExpandedChange?: ((expandedIndex: number | null) => void) | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/numberfield
+ */
+export interface NumberFieldProps {
+  id: string;
+  onChange: (args: {
+    event: React.SyntheticEvent<HTMLInputElement>;
+    value: number | undefined;
+  }) => void;
+  autoComplete?: 'on' | 'off' | undefined;
+  disabled?: boolean | undefined;
+  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
+  errorMessage?: React.ReactNode | undefined;
+  helperText?: string | undefined;
+  label?: string | undefined;
+  max?: number | undefined;
+  min?: number | undefined;
+  name?: string | undefined;
+  onBlur?:
+    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: number | undefined }) => void)
+    | undefined;
+  onFocus?:
+    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: number | undefined }) => void)
+    | undefined;
+  onKeyDown?:
+    | ((args: { event: React.KeyboardEvent<HTMLInputElement>; value: number | undefined }) => void)
+    | undefined;
+  placeholder?: string | undefined;
+  size?: 'md' | 'lg' | undefined;
+  step?: number | undefined;
+  value?: number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider
+ */
+export interface OnLinkNavigationProviderProps {
+  onNavigation?: OnNavigationType | undefined;
+}
+
+export interface PageHeaderBadge {
+  text: string;
+  tooltipText?: string | undefined;
+}
+
+export interface PageHeaderHelperIconButton {
+  accessibilityLabel?: string | undefined;
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  onClick: (args: {
+    event:
+      | React.MouseEvent<HTMLAnchorElement>
+      | React.KeyboardEvent<HTMLAnchorElement>
+      | React.KeyboardEvent<HTMLButtonElement>
+      | React.MouseEvent<HTMLButtonElement>;
+    dangerouslyDisableOnNavigation: () => void;
+  }) => void;
+}
+export interface PageHeaderAction {
+  component?:
+    | React.ReactElement<
+        typeof Button | typeof IconButton | typeof Link | typeof Tooltip | typeof Text
+      >
+    | undefined;
+  dropdownItems?:
+    | ReadonlyArray<React.ReactElement<DropdownItemProps | DropdownLinkProps, typeof Dropdown>>
+    | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/pageheader
+ */
+export interface PageHeaderProps {
+  title: string;
+  badge?: PageHeaderBadge | undefined;
+  borderStyle?: 'sm' | 'none' | undefined;
+  helperIconButton?: PageHeaderHelperIconButton | undefined;
+  helperLink?: {
+    accessibilityLabel: string;
+    text: string;
+    href: string;
+    onClick?: (args: {
+      event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
+      dangerouslyDisableOnNavigation: () => void;
+    }) => void | undefined;
+  };
+  items?: ReadonlyArray<React.ReactNode> | undefined;
+  dropdownAccessibilityLabel?: string | undefined;
+  maxWidth?: number | string | undefined;
+  primaryAction?: PageHeaderAction | undefined;
+  secondaryAction?: PageHeaderAction | undefined;
+  subtext?: string | undefined;
+  thumbnail?: React.ReactElement<typeof Image>;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/pog
+ */
+export interface PogProps {
+  accessibilityLabel?: string | undefined;
+  active?: boolean | undefined;
+  bgColor?:
+    | 'transparent'
+    | 'darkGray'
+    | 'transparentDarkGray'
+    | 'gray'
+    | 'lightGray'
+    | 'white'
+    | 'red'
+    | undefined;
+  dangerouslySetSvgPath?: { __path: string } | undefined;
+  focused?: boolean | undefined;
+  hovered?: boolean | undefined;
+  icon?: Icons | undefined;
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary' | undefined;
+  padding?: 1 | 2 | 3 | 4 | 5 | undefined;
+  selected?: boolean | undefined;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/popover
+ */
+export interface PopoverProps {
+  anchor: HTMLElement | null | undefined;
+  onDismiss: () => void;
+  children?: React.ReactNode | undefined;
+  color?: 'blue' | 'orange' | 'red' | 'white' | 'darkGray' | undefined;
+  id?: string | undefined;
+  idealDirection?: FourDirections | undefined;
+  positionRelativeToAnchor?: boolean | undefined;
+  shouldFocus?: boolean | undefined;
+  showCaret?: boolean | undefined;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number | undefined;
+  __dangerouslySetMaxHeight?: '30vh';
+  onKeyDown?: AbstractEventHandler<React.KeyboardEvent<HTMLElement>>;
+  accessibilityDismissButtonLabel?: string | undefined;
+  showDismissButton?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/popovereducational
+ */
+export interface PopoverEducationalProps {
+  accessibilityLabel: string;
+  anchor: HTMLElement | null | undefined;
+  onDismiss: () => void;
+  children?: React.ReactNode | undefined;
+  id?: string | undefined;
+  idealDirection?: FourDirections | undefined;
+  message?: React.ReactElement<typeof Text> | undefined;
+  primaryAction?:
+    | {
+        accessibilityLabel?: string | undefined;
+        href?: string | undefined;
+        text: string | undefined;
+        onClick?:
+          | AbstractEventHandler<
+              | React.MouseEvent<HTMLButtonElement>
+              | React.MouseEvent<HTMLAnchorElement>
+              | React.KeyboardEvent<HTMLAnchorElement>
+              | React.KeyboardEvent<HTMLButtonElement>,
+              {
+                dangerouslyDisableOnNavigation: () => void;
+              }
+            >
+          | undefined;
+        rel?: 'none' | 'nofollow' | undefined;
+        target?: null | 'self' | 'blank' | undefined;
+      }
+    | undefined;
+  role?: 'dialog' | 'tooltip' | undefined;
+  shouldFocus?: boolean | undefined;
+  zIndex?: Indexable | undefined;
+  size?: 'sm' | 'flexible' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/pulsar
+ */
+export interface PulsarProps {
+  paused?: boolean | undefined;
+  size?: number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/radiobutton
+ */
+export interface RadioButtonProps {
+  id: string;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
+  value: string;
+  checked?: boolean | undefined;
+  helperText?: string | undefined;
+  disabled?: boolean | undefined;
+  image?: React.ReactNode | undefined;
+  label?: string | undefined;
+  name?: string | undefined;
+  size?: 'sm' | 'md' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/radiogroup
+ */
+export interface RadioGroupProps {
+  id: string;
+  children: React.ReactNode;
+  legend: string;
+  direction?: 'column' | 'row' | undefined;
+  errorMessage?: string | undefined;
+  legendDisplay?: 'visible' | 'hidden' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/scrollboundarycontainer
+ */
+export interface ScrollBoundaryContainerProps {
+  children: React.ReactNode;
+  height?: number | string | undefined;
+  overflow?: 'scroll' | 'scrollX' | 'scrollY' | 'auto' | 'visible' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/searchfield
+ */
+export interface SearchFieldProps {
+  accessibilityLabel: string;
+  accessibilityClearButtonLabel?: string;
+  id: string;
+  autoComplete?: 'on' | 'off' | 'username' | 'name' | undefined;
+  errorMessage?: string | undefined;
+  onChange: (args: {
+    value: string;
+    syntheticEvent: React.SyntheticEvent<HTMLInputElement>;
+  }) => void;
+  onBlur?: ((args: { event: React.SyntheticEvent<HTMLInputElement> }) => void) | undefined;
+  onFocus?:
+    | ((args: { value: string; syntheticEvent: React.SyntheticEvent<HTMLInputElement> }) => void)
+    | undefined;
+  onKeyDown?:
+    | ((args: { event: React.KeyboardEvent<HTMLInputElement>; value: string }) => void)
+    | undefined;
+  placeholder?: string | undefined;
+  size?: 'md' | 'lg' | undefined;
+  value?: string | undefined;
+  label?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/segmentedcontrol
+ */
+export interface SegmentedControlProps {
+  items: React.ReactNode[];
+  onChange: (args: { event: React.SyntheticEvent<React.MouseEvent>; activeIndex: number }) => void;
+  selectedItemIndex: number;
+  responsive?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/selectlist
+ */
+export interface SelectListProps {
+  children: React.ReactNode;
+  id: string;
+  onChange: (args: { event: React.SyntheticEvent<HTMLElement>; value: string }) => void;
+  disabled?: boolean | undefined;
+  errorMessage?: string | undefined;
+  helperText?: string | undefined;
+  label?: string | undefined;
+  labelDisplay?: 'visible' | 'hidden';
+  name?: string | undefined;
+  placeholder?: string | undefined;
+  size?: 'md' | 'lg' | undefined;
+  value?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/selectlist#SelectList.Option
+ */
+export interface SelectListOptionProps {
+  label: string;
+  value: string;
+  disabled?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/selectlist#SelectList.Group
+ */
+export interface SelectListGroupProps {
+  children: React.ReactNode;
+  label: string;
+  disabled?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/sidenavigation
+ */
+export interface SideNaviationProps {
+  accessibilityLabel: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode | undefined;
+  header?: React.ReactNode | undefined;
+  showBorder?: boolean | undefined;
+  title?: string | undefined;
+  dismissButton?: { accessibilityLabel?: string; onDismiss: () => void } | undefined;
+}
+
+export interface SideNavigationSectionProps {
+  children: React.ReactNode;
+  label: string;
+}
+
+export interface SideNavigationTopItemProps {
+  active?: 'page' | 'section' | undefined;
+  badge?:
+    | {
+        text: string;
+        type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | undefined;
+      }
+    | undefined;
+  counter?: { number: string; accessibilityLabel: string } | undefined;
+  href: string;
+  icon?: Icons | { __path: string };
+  notificationAccessibilityLabel?: string;
+  onClick?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLButtonElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+      >
+    | undefined;
+  label: string;
+  primaryAction?:
+    | {
+        icon?: 'ellipsis' | 'edit' | 'trash-can';
+        onClick?:
+          | AbstractEventHandler<
+              | React.MouseEvent<HTMLButtonElement>
+              | React.MouseEvent<HTMLAnchorElement>
+              | React.KeyboardEvent<HTMLAnchorElement>
+              | React.KeyboardEvent<HTMLButtonElement>
+            >
+          | undefined;
+        tooltip: {
+          accessibilityLabel?: string | undefined;
+          text: string;
+          zIndex?: Indexable | undefined;
+        };
+        dropdownItems?: Array<React.ReactElement<typeof Dropdown['Item']>>;
+      }
+    | undefined;
+}
+
+export interface SideNavigationNestedItemProps {
+  active?: 'page' | 'section' | undefined;
+  href: string;
+  label: string;
+  onClick?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLButtonElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLButtonElement>,
+        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+      >
+    | undefined;
+}
+
+export interface SideNavigationNestedGroupProps {
+  badge?: BadgeProps | undefined;
+  children: React.ReactNode;
+  counter?: { number: string; accessibilityLabel: string } | undefined;
+  display?: 'expandable' | 'static' | undefined;
+  icon?: Icons;
+  notificationAccessibilityLabel?: string | undefined;
+  label: string;
+  primaryAction?:
+    | {
+        icon?: 'ellipsis' | 'edit' | 'trash-can';
+        onClick?:
+          | AbstractEventHandler<
+              | React.MouseEvent<HTMLButtonElement>
+              | React.MouseEvent<HTMLAnchorElement>
+              | React.KeyboardEvent<HTMLAnchorElement>
+              | React.KeyboardEvent<HTMLButtonElement>
+            >
+          | undefined;
+        tooltip: {
+          accessibilityLabel?: string | undefined;
+          text: string;
+          zIndex?: Indexable | undefined;
+        };
+        dropdownItems?: Array<React.ReactElement<typeof Dropdown['Item']>>;
+      }
+    | undefined;
+}
+
+export interface SideNavigationNestedGroup {
+  children: React.ReactNode;
+  display?: 'expandable' | 'static' | undefined;
+  label: string;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/overlaypanel
+ */
+export type OverlayPanelNodeOrRenderProp =
+  | ((prop: { onDismissStart: () => void }) => React.ReactNode)
+  | React.ReactNode;
+export type OnAnimationEndStateType = 'in' | 'out';
+export interface OverlayPanel {
+  accessibilityDismissButtonLabel?: string | undefined;
+  accessibilityLabel: string;
+  children?: OverlayPanelNodeOrRenderProp | undefined;
+  closeOnOutsideClick?: boolean | undefined;
+  footer?: OverlayPanelNodeOrRenderProp | undefined;
+  heading?: string | undefined;
+  onAnimationEnd?: (args: { animationState: OnAnimationEndStateType }) => void;
+  dismissConfirmation?: {
+    message?: string | undefined;
+    subtext?: string | undefined;
+    primaryAction?: {
+      accessibilityLabel?: string | undefined;
+      text?: string | undefined;
+      onClick?:
+        | AbstractEventHandler<
+            | React.MouseEvent<HTMLButtonElement>
+            | React.MouseEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLButtonElement>
+          >
+        | undefined;
+    };
+    secondaryAction?: {
+      accessibilityLabel?: string | undefined;
+      text?: string | undefined;
+      onClick?:
+        | AbstractEventHandler<
+            | React.MouseEvent<HTMLButtonElement>
+            | React.MouseEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLButtonElement>
+          >
+        | undefined;
+    };
+  };
+  onDismiss: () => void;
+  size?: 'sm' | 'md' | 'lg' | undefined;
+  subHeading?: OverlayPanelNodeOrRenderProp | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/slimbanner
+ */
+export interface SlimBannerProps {
+  dismissButton?:
+    | {
+        accessibilityLabel: string;
+        onDismiss: () => void;
+      }
+    | undefined;
+  primaryAction?:
+    | {
+        accessibilityLabel: string;
+        disabled?: boolean;
+        href?: string;
+        label: string;
+        onClick?:
+          | AbstractEventHandler<
+              | React.MouseEvent<HTMLButtonElement>
+              | React.MouseEvent<HTMLAnchorElement>
+              | React.MouseEvent<HTMLAnchorElement>
+              | React.MouseEvent<HTMLButtonElement>,
+              {
+                rel?: 'none' | 'nofollow';
+                target?: null | 'self' | 'blank';
+              }
+            >
+          | undefined;
+      }
+    | undefined;
+  helperLink?: {
+    accessibilityLabel: string;
+    href: string;
+    target?: null | 'self' | 'blank' | undefined;
+    text: string;
+    onClick?:
+      | AbstractEventHandler<
+          React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>,
+          { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+        >
+      | undefined;
+  };
+  iconAccessibilityLabel?: string | undefined;
+  message: React.ReactElement<typeof Text> | string;
+  type?:
+    | 'neutral'
+    | 'error'
+    | 'info'
+    | 'warning'
+    | 'success'
+    | 'errorBare'
+    | 'infoBare'
+    | 'warningBare'
+    | 'successBare'
+    | 'recommendation'
+    | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/spinner
+ */
+export interface SpinnerProps {
+  accessibilityLabel: string;
+  show: boolean;
+  delay?: boolean | undefined;
+  size?: 'sm' | 'md' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/flex
+ */
+export interface FlexProps {
+  alignContent?:
+    | 'start'
+    | 'end'
+    | 'center'
+    | 'between'
+    | 'around'
+    | 'evenly'
+    | 'stretch'
+    | undefined;
+  alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  children?: React.ReactNode | undefined;
+  fit?: boolean | undefined;
+  flex?: 'grow' | 'shrink' | 'none' | undefined;
+  gap?: UnsignedUpTo12 | undefined;
+  height?: number | string | undefined;
+  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | undefined;
+  maxHeight?: number | string | undefined;
+  maxWidth?: number | string | undefined;
+  minHeight?: number | string | undefined;
+  minWidth?: number | string | undefined;
+  width?: number | string | undefined;
+  wrap?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/status
+ */
+export interface StatusProps {
+  type: 'unstarted' | 'inProgress' | 'halted' | 'ok' | 'problem' | 'canceled' | 'warning';
+  accessibilityLabel?: string | undefined;
+  subtext?: string | undefined;
+  title?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/sticky
+ */
+export interface StickyProps {
+  bottom?: number | string | undefined;
+  children?: React.ReactNode | undefined;
+  height?: number | undefined;
+  left?: number | string | undefined;
+  right?: number | string | undefined;
+  top?: number | string | undefined;
+  zIndex?: Indexable | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/switch
+ */
+export interface SwitchProps {
+  id: string;
+  onChange?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: boolean }>
+    | undefined;
+  disabled?: boolean | undefined;
+  name?: string | undefined;
+  switched?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/table
+ */
+export interface TableProps {
+  accessibilityLabel: string;
+  borderStyle?: 'sm' | 'none' | undefined;
+  children?: React.ReactNode | undefined;
+  maxHeight?: number | string | undefined;
+  stickyColumns?: number | undefined;
+}
+
+export interface TableBodyProps {
+  children?: React.ReactNode | undefined;
+}
+
+export interface TableCellProps {
+  children?: React.ReactNode | undefined;
+  colSpan?: number | undefined;
+  rowSpan?: number | undefined;
+}
+
+export interface TableFooterProps {
+  children?: React.ReactNode | undefined;
+  sticky?: boolean | undefined;
+}
+
+export interface TableHeaderProps {
+  children?: React.ReactNode | undefined;
+  display?: 'tableHeaderGroup' | 'visuallyHidden';
+  sticky?: boolean | undefined;
+}
+
+export interface TableHeaderCellProps extends TableCellProps {
+  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
+  colSpan?: number;
+  rowSpan?: number;
+}
+
+export interface TableRowProps {
+  children?: React.ReactNode | undefined;
+}
+
+export interface TableRowDrawerProps {
+  children:
+    | React.ReactElement<TableCellProps>
+    | Array<React.ReactElement<TableCellProps>>
+    | undefined;
+  drawerContents: React.ReactNode;
+  id: string;
+}
+
+export interface TableRowExpandableProps {
+  accessibilityCollapseLabel: string;
+  accessibilityExpandLabel: string;
+  expandedContents: React.ReactNode;
+  id: string;
+  children?: React.ReactNode | undefined;
+  hoverStyle?: 'none' | 'gray' | undefined;
+  onExpand?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLButtonElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLButtonElement>
+      >
+    | undefined;
+}
+
+export interface TableSortableHeaderCellProps extends TableHeaderCellProps {
+  onSortChange: AbstractEventHandler<
+    React.MouseEvent<HTMLTableCellElement> | React.KeyboardEvent<HTMLTableCellElement>
+  >;
+  sortOrder: 'asc' | 'desc';
+  status: 'active' | 'inactive';
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/tabs
+ */
+export interface TabsProps {
+  activeTabIndex: number;
+  onChange: (args: {
+    event: React.SyntheticEvent<React.MouseEvent>;
+    activeTabIndex: number;
+    dangerouslyDisableOnNavigation: () => void;
+  }) => void;
+  tabs: ReadonlyArray<{
+    href: string;
+    text: React.ReactNode;
+    id?: string | undefined;
+    indicator?: 'dot' | number | undefined;
+    ref?: { current?: HTMLElement | undefined } | undefined;
+  }>;
+  size?: 'md' | 'lg';
+  wrap?: boolean;
+  bgColor?: 'default' | 'transparent';
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/tag
+ */
+export interface TagProps {
+  accessibilityRemoveIconLabel?: string;
+  disabled?: boolean | undefined;
+  onRemove?: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>> | undefined;
+  text: string;
+  type?: 'default' | 'error' | 'warning';
+}
+
+export type OnTapType = AbstractEventHandler<
+  | React.MouseEvent<HTMLDivElement>
+  | React.KeyboardEvent<HTMLDivElement>
+  | React.MouseEvent<HTMLAnchorElement>
+  | React.KeyboardEvent<HTMLAnchorElement>,
+  { dangerouslydangerouslyDisableOnNavigation?: (() => void) | undefined }
+>;
+
+/**
+ * https://gestalt.pinterest.systems/web/taparea
+ */
+export interface TapAreaProps {
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+  accessibilityLabel?: string | undefined;
+  children?: React.ReactNode | undefined;
+  disabled?: boolean | undefined;
+  fullHeight?: boolean | undefined;
+  fullWidth?: boolean | undefined;
+  href?: string | undefined;
+  mouseCursor?:
+    | 'copy'
+    | 'grab'
+    | 'grabbing'
+    | 'move'
+    | 'noDrop'
+    | 'pointer'
+    | 'zoomIn'
+    | 'zoomOut'
+    | undefined;
+  onBlur?: AbstractEventHandler<React.FocusEvent<HTMLDivElement | HTMLAnchorElement>> | undefined;
+  onFocus?: AbstractEventHandler<React.FocusEvent<HTMLDivElement | HTMLAnchorElement>> | undefined;
+  onMouseDown?:
+    | AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>
+    | undefined;
+  onMouseEnter?:
+    | AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>
+    | undefined;
+  onMouseLeave?:
+    | AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>
+    | undefined;
+  onTap?: OnTapType | undefined;
+  rel?: 'none' | 'nofollow' | undefined;
+  role?: 'button' | 'link' | undefined;
+  rounding?: 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
+  tabIndex?: -1 | 0 | undefined;
+  tapStyle?: 'none' | 'compress' | undefined;
+  target?: null | 'self' | 'blank' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/text
+ */
+export interface TextProps {
+  align?: 'start' | 'end' | 'center' | 'forceLeft' | 'forceRight' | undefined;
+  children?: React.ReactNode | undefined;
+  color?:
+    | 'default'
+    | 'subtle'
+    | 'success'
+    | 'error'
+    | 'warning'
+    | 'shopping'
+    | 'link'
+    | 'inverse'
+    | 'light'
+    | 'dark'
+    | undefined;
+  inline?: boolean | undefined;
+  italic?: boolean | undefined;
+  overflow?: 'normal' | 'breakWord' | 'noWrap' | undefined;
+  size?: '100' | '200' | '300' | '400' | '500' | '600' | undefined;
+  lineClamp?: number;
+  underline?: boolean | undefined;
+  weight?: 'bold' | 'normal' | undefined;
+  title?: string | undefined;
+}
+
+export interface MaxLength {
+  characterCount: number;
+  errorAccessibilityLabel: string;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/textarea
+ */
+export interface TextAreaProps {
+  id: string;
+  onChange: (args: { event: React.SyntheticEvent<HTMLTextAreaElement>; value: string }) => void;
+  disabled?: boolean | undefined;
+  errorMessage?: React.ReactNode | undefined;
+  helperText?: string | undefined;
+  label?: string | undefined;
+  name?: string | undefined;
+  onBlur?:
+    | ((args: { event: React.FocusEvent<HTMLTextAreaElement>; value: string }) => void)
+    | undefined;
+  onFocus?:
+    | ((args: { event: React.FocusEvent<HTMLTextAreaElement>; value: string }) => void)
+    | undefined;
+  onKeyDown?:
+    | ((args: { event: React.KeyboardEvent<HTMLTextAreaElement>; value: string }) => void)
+    | undefined;
+  placeholder?: string | undefined;
+  rows?: number | undefined;
+  tags?: ReadonlyArray<React.ReactElement<TagProps, typeof Tag>> | undefined;
+  maxLength?: MaxLength | undefined;
+  value?: string | undefined;
+  readonly?: boolean;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/textfield
+ */
+export interface TextFieldProps {
+  id: string;
+  onChange: (args: { event: React.SyntheticEvent<HTMLInputElement>; value: string }) => void;
+  autoComplete?:
+    | 'bday'
+    | 'current-password'
+    | 'email'
+    | 'new-password'
+    | 'on'
+    | 'off'
+    | 'username'
+    | undefined;
+  disabled?: boolean | undefined;
+
+  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
+  errorMessage?: React.ReactNode | undefined;
+  helperText?: string | undefined;
+  maxLength?: MaxLength | undefined;
+  label?: string | undefined;
+  name?: string | undefined;
+  onBlur?:
+    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: string }) => void)
+    | undefined;
+  onFocus?:
+    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: string }) => void)
+    | undefined;
+  onKeyDown?:
+    | ((args: { event: React.KeyboardEvent<HTMLInputElement>; value: string }) => void)
+    | undefined;
+  placeholder?: string | undefined;
+
+  size?: 'md' | 'lg' | undefined;
+  tags?: ReadonlyArray<React.ReactElement<TagProps, typeof Tag>> | undefined;
+  type?: 'date' | 'email' | 'password' | 'text' | 'url' | 'tel' | undefined;
+  value?: string | undefined;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/toast
+ */
+export interface ToastProps {
+  text: string | React.ReactElement<typeof Text>;
+  dissmissButton:
+    | {
+        accessibilityLabel?: string | undefined;
+        onDismiss: () => void;
+      }
+    | undefined;
+  helperLink?:
+    | {
+        text: string;
+        accessibilityLabel: string;
+        href: string;
+        onClick?: AbstractEventHandler<
+          React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+          { dangerouslyDisableOnNavigation: () => void }
+        >;
+      }
+    | undefined;
+  primaryAction?: {
+    accessibilityLabel: string;
+    href?: string;
+    label: string;
+    onClick?: ButtonProps['onClick'] | undefined;
+    rel?: LinkProps['rel'] | undefined;
+    size?: ButtonProps['size'] | undefined;
+    target?: LinkProps['target'] | undefined;
+  };
+  thumbnail?:
+    | { image: React.ReactElement<typeof Image> }
+    | { avatar: React.ReactElement<typeof Avatar> }
+    | { icon: React.ReactElement<typeof Icon> }
+    | undefined;
+  variant?: 'default' | 'success' | 'error' | 'progress' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/tooltip
+ */
+export interface TooltipProps {
+  children: React.ReactNode;
+  text: string;
+  idealDirection?: FourDirections | undefined;
+  inline?: boolean | undefined;
+  link?: React.ReactNode | undefined;
+  zIndex?: Indexable | undefined;
+  accessibilityLabel?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/upsell
+ */
+export interface UpsellProps {
+  children?: React.ReactElement;
+  message: string | React.ReactElement<typeof Text>;
+  dismissButton?:
+    | {
+        accessibilityLabel: string;
+        onDismiss: () => void;
+      }
+    | undefined;
+  imageData?:
+    | {
+        component: React.ReactElement<any, typeof Image | typeof Icon>;
+        width?: number | undefined;
+        mask?:
+          | {
+              rounding: 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+              wash: boolean;
+            }
+          | undefined;
+      }
+    | undefined;
+  primaryAction?: ActionData | undefined;
+  secondaryAction?: ActionData | undefined;
+  title?: string | undefined;
+}
+
+export interface UpsellFormProps {
+  onSubmit: AbstractEventHandler<
+    | React.MouseEvent<HTMLButtonElement>
+    | React.MouseEvent<HTMLAnchorElement>
+    | React.KeyboardEvent<HTMLButtonElement>
+    | React.KeyboardEvent<HTMLAnchorElement>
+  >;
+  submitButtonText: string;
+  submitButtonAccessibilityLabel: string;
+  submitButtonDisabled?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/video
+ */
+export interface VideoProps {
+  accessibilityMaximizeLabel?: string | undefined;
+  accessibilityMinimizeLabel?: string | undefined;
+  accessibilityMuteLabel?: string | undefined;
+  accessibilityPauseLabel?: string | undefined;
+  accessibilityPlayLabel?: string | undefined;
+  accessibilityUnmuteLabel?: string | undefined;
+  aspectRatio: number;
+  backgroundColor?: 'black' | 'transparent' | undefined;
+  captions: string;
+  playbackRate?: number | undefined;
+  playing?: boolean | undefined;
+  preload?: 'auto' | 'metadata' | 'none' | undefined;
+  src: string | ReadonlyArray<{ type: 'video/m3u8' | 'video/mp4' | 'video/ogg'; src: string }>;
+  volume?: number | undefined;
+  children?: Node | undefined;
+  controls?: boolean | undefined;
+  disableRemotePlayback?: boolean | undefined;
+  crossOrigin?: 'anonymous' | 'use-credentials' | undefined;
+  loop?: boolean | undefined;
+  objectFit?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down' | undefined;
+  onDurationChange?:
+    | ((args: { event: React.SyntheticEvent<HTMLVideoElement>; duration: number }) => void)
+    | undefined;
+  onEnded?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onFullscreenChange?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>, { fullscreen: boolean }>
+    | undefined;
+  onLoadedChange?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>, { loaded: number }>
+    | undefined;
+  onPlay?: AbstractEventHandler<React.SyntheticEvent<HTMLDivElement>> | undefined;
+  onPlayheadDown?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>> | undefined;
+  onPlayheadUp?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>> | undefined;
+  onPause?: AbstractEventHandler<React.SyntheticEvent<HTMLDivElement>> | undefined;
+  onReady?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onSeek?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onTimeChange?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>, { time: number }>
+    | undefined;
+  onVolumeChange?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLDivElement>, { volume: number }>
+    | undefined;
+  onError?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onLoadStart?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onPlaying?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onSeeking?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onStalled?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onWaiting?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  playsInline?: boolean | undefined;
+  poster?: string | undefined;
+  startTime?: number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/washanimated
+ */
+export interface WashAnimatedProps {
+  active?: boolean | undefined;
+  children?: React.ReactNode | undefined;
+  image?: React.ReactNode | undefined;
+  onMouseEnter?:
+    | ((args: { event: React.SyntheticEvent<React.MouseEvent<HTMLDivElement>> }) => void)
+    | undefined;
+  onMouseLeave?:
+    | ((args: { event: React.SyntheticEvent<React.MouseEvent<HTMLDivElement>> }) => void)
+    | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/cIndexClasses#zindex
+ */
+export interface Indexable {
+  index(): number;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/cIndexClasses#FixedZIndex
+ */
+export class FixedZIndex implements Indexable {
+  z: number;
+  constructor(z: number);
+  index(): number;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/cIndexClasses#CompositeZIndex
+ */
+export class CompositeZIndex implements Indexable {
+  deps: Array<FixedZIndex | CompositeZIndex>;
+  constructor(deps: Array<FixedZIndex | CompositeZIndex>);
+  index(): number;
+}
+
+/**
+ * ========================= INDEX =========================
+ */
+
+export const ActivationCard: React.FunctionComponent<ActivationCardProps>;
+
+export const Avatar: React.FunctionComponent<AvatarProps>;
+
+export const AvatarGroup: React.FunctionComponent<AvatarGroupProps>;
+
+export const Badge: React.FunctionComponent<BadgeProps>;
+
+export const Box: ReactForwardRef<HTMLDivElement, BoxProps>;
+
+export const Button: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>;
+
+export const ButtonGroup: React.FunctionComponent<ButtonGroupProps>;
+
+export const Callout: React.FunctionComponent<CalloutProps>;
+
+export const ComboBox: React.FunctionComponent<ComboBoxProps>;
+
+export const Checkbox: ReactForwardRef<HTMLInputElement, CheckboxProps>;
+
+export const Collage: React.FunctionComponent<CollageProps>;
+
+export const ColorSchemeProvider: React.FunctionComponent<
+  React.PropsWithChildren<ColorSchemeProviderProps>
+>;
+
+export const Column: React.FunctionComponent<ColumnProps>;
+
+export const Container: React.FunctionComponent<ContainerProps>;
+
+export const Datapoint: React.FunctionComponent<DatapointProps>;
+
+export const ScrollBoundaryContainer: React.FunctionComponent<ScrollBoundaryContainerProps>;
+
+export const DeviceTypeProvider: React.FunctionComponent<
+  React.PropsWithChildren<DeviceTypeProviderProps>
+>;
+
+export const DefaultLabelProvider: React.FunctionComponent<
+  React.PropsWithChildren<DefaultLabelProviderProps>
+>;
+
+export const Divider: React.FunctionComponent;
+
+export interface DropdownSubComponents {
+  Item: React.FunctionComponent<DropdownItemProps>;
+  Link: React.FunctionComponent<DropdownLinkProps>;
+  Section: React.FunctionComponent<DropdownSectionProps>;
+}
+
+export const Dropdown: React.FunctionComponent<DropdownProps> & DropdownSubComponents;
+
+export const Fieldset: React.FunctionComponent<FieldsetProps>;
+
+export interface FlexSubComponents {
+  Item: React.FunctionComponent<FlexItemProps>;
+}
+
+export const Flex: React.FunctionComponent<FlexProps> & FlexSubComponents;
+
+export const Heading: React.FunctionComponent<HeaderProps>;
+
+export const HelpButton: React.FunctionComponent<HelpButtonProps>;
+
+export const Icon: React.FunctionComponent<IconProps>;
+
+export const IconButton: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, IconButtonProps>;
+
+export const IconButtonFloating: React.FunctionComponent<IconButtonFloatingProps>;
+
+export const Image: React.FunctionComponent<ImageProps>;
+
+export const Label: React.FunctionComponent<LabelProps>;
+
+export const Layer: React.FunctionComponent<LayerProps>;
+
+export const Letterbox: React.FunctionComponent<LetterboxProps>;
+
+export const Link: ReactForwardRef<HTMLAnchorElement, LinkProps>;
+
+export interface ListSubCmoponents {
+  Item: React.FunctionComponent<React.PropsWithChildren<ListItemProps>>;
+}
+
+export const List: React.FunctionComponent<React.PropsWithChildren<ListProps>> & ListSubCmoponents;
+
+export const Mask: React.FunctionComponent<MaskProps>;
+
+export const Masonry: React.FunctionComponent<MasonryProps>;
+
+export const Modal: ReactForwardRef<HTMLDivElement, ModalProps>;
+
+export const ModalAlert: React.FunctionComponent<React.PropsWithChildren<ModalAlertProps>>;
+
+export interface ModuleSubComponents {
+  Expandable: React.FunctionComponent<ModuleExpandableProps>;
+}
+
+export const Module: React.FunctionComponent<React.PropsWithChildren<ModuleProps>> &
+  ModuleSubComponents;
+
+export const NumberField: ReactForwardRef<HTMLInputElement, NumberFieldProps>;
+
+export const OnLinkNavigationProvider: React.FunctionComponent<OnLinkNavigationProviderProps>;
+
+export const PageHeader: React.FunctionComponent<PageHeaderProps>;
+
+export const Pog: React.FunctionComponent<PogProps>;
+
+export const Popover: React.FunctionComponent<PopoverProps>;
+
+export const Popovereducational: React.FunctionComponent<PopoverEducationalProps>;
+
+export const Pulsar: React.FunctionComponent<PulsarProps>;
+
+export const RadioButton: ReactForwardRef<HTMLInputElement, RadioButtonProps>;
+
+export interface RadioGroupSubCompnents {
+  RadioButton: typeof RadioButton;
+}
+
+export const RadioGroup: React.FunctionComponent<RadioGroupProps> & RadioGroupSubCompnents;
+
+export const SearchField: ReactForwardRef<HTMLInputElement, SearchFieldProps>;
+
+export const SegmentedControl: React.FunctionComponent<SegmentedControlProps>;
+
+export interface SelectListSubComponents {
+  Option: React.FunctionComponent<SelectListOptionProps>;
+  Group: React.FunctionComponent<SelectListGroupProps>;
+}
+
+export const SelectList: React.FunctionComponent<SelectListProps> & SelectListSubComponents;
+
+export interface SideNavigationSubcomponents {
+  Section: React.FunctionComponent<SideNavigationSectionProps>;
+  TopItem: React.FunctionComponent<SideNavigationTopItemProps>;
+  NestedItem: React.FunctionComponent<SideNavigationNestedItemProps>;
+  Group: React.FunctionComponent<SideNavigationNestedGroupProps>;
+  NestedGroup: React.FunctionComponent<SideNavigationNestedGroupProps>;
+}
+
+export const SideNavigation: React.FunctionComponent<SideNaviationProps> &
+  SideNavigationSubcomponents;
+
+export const OverlayPanel: ReactForwardRef<HTMLDivElement, OverlayPanel>;
+
+export const SlimBanner: React.FunctionComponent<SlimBannerProps>;
+
+export const Spinner: React.FunctionComponent<SpinnerProps>;
+
+export const Status: React.FunctionComponent<StatusProps>;
+
+export const Sticky: React.FunctionComponent<StickyProps>;
+
+export const Switch: React.FunctionComponent<SwitchProps>;
+
+export interface TableSubCompnents {
+  Body: React.FunctionComponent<TableBodyProps>;
+  Cell: React.FunctionComponent<TableCellProps>;
+  Footer: React.FunctionComponent<TableFooterProps>;
+  Header: React.FunctionComponent<TableHeaderProps>;
+  HeaderCell: React.FunctionComponent<TableHeaderCellProps>;
+  Row: React.FunctionComponent<TableRowProps>;
+  RowExpandable: React.FunctionComponent<TableRowExpandableProps>;
+  SortableHeaderCell: React.FunctionComponent<TableSortableHeaderCellProps>;
+  RowDrawer: React.FunctionComponent<TableRowDrawerProps>;
+}
+
+export const Table: React.FunctionComponent<TableProps> & TableSubCompnents;
+
+export const Tabs: React.FunctionComponent<TabsProps>;
+
+export const Tag: React.FunctionComponent<TagProps>;
+
+export const TapArea: ReactForwardRef<HTMLButtonElement | HTMLAnchorElement, TapAreaProps>;
+
+export const Text: ReactForwardRef<HTMLDivElement | HTMLSpanElement, TextProps>;
+
+export const TextArea: ReactForwardRef<HTMLTextAreaElement, TextAreaProps>;
+
+export const TextField: ReactForwardRef<HTMLInputElement, TextFieldProps>;
+
+export const Toast: React.FunctionComponent<ToastProps>;
+
+export const Tooltip: React.FunctionComponent<TooltipProps>;
+
+export interface UpsellSubCompnents {
+  Form: React.FunctionComponent<UpsellFormProps>;
+}
+
+export const Upsell: React.FunctionComponent<UpsellProps> & UpsellSubCompnents;
+
+export const Video: React.FunctionComponent<VideoProps>;
+
+export const WashAnimated: React.FunctionComponent<WashAnimatedProps>;
+
+export function useReducedMotion(): boolean;
+
+export function useFocusVisible(): { isFocusVisible: boolean };

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -2,9 +2,11 @@ import React = require('react');
 
 /**
  * =========================================================
- * ====================== SHARED TYPED =====================
+ * ====================== SHARED UTILS =====================
  * =========================================================
  */
+
+type Node = React.ReactNode;
 
 type AbstractEventHandler<T extends React.SyntheticEvent<HTMLElement> | Event, U = {}> = (
   arg: U & {
@@ -16,6 +18,12 @@ type ReactForwardRef<T, P> = React.ForwardRefExoticComponent<
   React.PropsWithoutRef<P> & React.RefAttributes<T>
 >;
 
+/**
+ * =========================================================
+ * ====================== SHARED TYPED =====================
+ * =========================================================
+ */
+
 type FourDirections = 'up' | 'right' | 'down' | 'left';
 
 type TapAreaEventHandlerType = AbstractEventHandler<
@@ -26,6 +34,13 @@ type TapAreaEventHandlerType = AbstractEventHandler<
   { dangerouslydangerouslyDisableOnNavigation?: (() => void) | undefined }
 >;
 
+type BareButtonEventHandlerType = AbstractEventHandler<
+  | React.MouseEvent<HTMLButtonElement>
+  | React.MouseEvent<HTMLAnchorElement>
+  | React.KeyboardEvent<HTMLAnchorElement>
+  | React.KeyboardEvent<HTMLButtonElement>
+>;
+
 type ButtonEventHandlerType = AbstractEventHandler<
   | React.MouseEvent<HTMLButtonElement>
   | React.MouseEvent<HTMLAnchorElement>
@@ -34,16 +49,15 @@ type ButtonEventHandlerType = AbstractEventHandler<
   { dangerouslyDisableOnNavigation?: (() => void) | undefined }
 >;
 
-type EventHandlerType = (args: { readonly event: React.SyntheticEvent }) => void;
+type VideoEventHandlerType = AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>>;
 
-type OnNavigationType = (args: {
-  href: string;
-  target?: null | 'self' | 'blank' | undefined;
-}) => EventHandlerType | null | undefined;
+type EventHandlerType = (args: { readonly event: React.SyntheticEvent }) => void;
 
 type UnsignedUpTo12 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 type SignedUpTo12 = -12 | -11 | -10 | -9 | -8 | -7 | -6 | -5 | -4 | -3 | -2 | -1 | UnsignedUpTo12;
+
+type OnAnimationEndType = (args: { animationState: 'in' | 'out' }) => void;
 
 interface BadgeObject {
   text: string;
@@ -68,636 +82,11 @@ interface MaxLength {
   errorAccessibilityLabel: string;
 }
 
-/**
- * =========================================================
- * ==================== API INTERFACES  ====================
- * =========================================================
- */
-
-/**
- * https://gestalt.pinterest.systems/web/activationcard
- */
-export interface ActivationCardProps {
-  message: string;
-  status: 'notStarted' | 'pending' | 'needsAttention' | 'complete';
-  statusMessage: string;
-  title: string;
-  dismissButton?: OnDismissButtonObject | undefined;
-  link?:
-    | {
-        accessibilityLabel: string;
-        href: string;
-        label: string;
-        onClick?: ButtonEventHandlerType | undefined;
-        rel?: 'none' | 'nofollow' | undefined;
-        target?: null | 'self' | 'blank' | undefined;
-      }
-    | undefined;
+interface Indexable {
+  index(): number;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/avatar
- */
-export interface AvatarProps {
-  name: string;
-  accessibilityLabel?: string | undefined;
-  outline?: boolean | undefined;
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'fit' | undefined;
-  src?: string | undefined;
-  verified?: boolean | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/avatargroup
- */
-export interface AvatarGroupProps {
-  accessibilityLabel: string;
-  collaborators: ReadonlyArray<{ name: string; src?: string | undefined }>;
-  accessibilityControls?: string | undefined;
-  accessibilityExpanded?: boolean | undefined;
-  accessibilityHaspopup?: boolean | undefined;
-  addCollaborators?: boolean | undefined;
-  href?: string | undefined;
-  onClick?: TapAreaEventHandlerType | undefined;
-  role?: 'button' | 'link' | undefined;
-  size?: 'xs' | 'sm' | 'md' | 'fit' | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/badge
- */
-export interface BadgeProps {
-  text: string;
-  position?: 'middle' | 'top' | undefined;
-  type?:
-    | 'info'
-    | 'error'
-    | 'warning'
-    | 'success'
-    | 'neutral'
-    | 'darkWash'
-    | 'lightWash'
-    | 'recommendation'
-    | undefined;
-}
-
-export type BoxPassthroughProps = Omit<
-  React.ComponentProps<'div'>,
-  'onClick' | 'className' | 'style' | 'ref'
-> &
-  React.RefAttributes<HTMLDivElement>;
-
-/**
- * https://gestalt.pinterest.systems/web/box
- */
-export interface BoxProps extends BoxPassthroughProps {
-  alignContent?:
-    | 'start'
-    | 'end'
-    | 'center'
-    | 'between'
-    | 'around'
-    | 'evenly'
-    | 'stretch'
-    | undefined;
-  alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  smAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  mdAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  lgAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  as?:
-    | 'article'
-    | 'aside'
-    | 'details'
-    | 'div'
-    | 'figcaption'
-    | 'figure'
-    | 'footer'
-    | 'header'
-    | 'main'
-    | 'nav'
-    | 'section'
-    | 'summary'
-    | undefined;
-  borderStyle?:
-    | 'sm'
-    | 'lg'
-    | 'shadow'
-    | 'raisedTopShadow'
-    | 'raisedBottomShadow'
-    | 'none'
-    | undefined;
-  bottom?: boolean | undefined;
-  children?: React.ReactNode | undefined;
-  color?:
-    | 'darkWash'
-    | 'lightWash'
-    | 'transparent'
-    | 'transparentDarkGray'
-    | 'default'
-    | 'infoBase'
-    | 'infoWeak'
-    | 'errorBase'
-    | 'errorWeak'
-    | 'warningBase'
-    | 'warningWeak'
-    | 'successBase'
-    | 'successWeak'
-    | 'recommendationBase'
-    | 'recommendationWeak'
-    | 'shopping'
-    | 'primary'
-    | 'secondary'
-    | 'tertiary'
-    | 'selected'
-    | 'inverse'
-    | 'brand'
-    | 'education'
-    | 'elevationAccent'
-    | 'elevationFloating'
-    | 'elevationRaised'
-    | 'dark'
-    | 'light'
-    | undefined;
-  column?: UnsignedUpTo12 | undefined;
-  smColumn?: UnsignedUpTo12 | undefined;
-  mdColumn?: UnsignedUpTo12 | undefined;
-  lgColumn?: UnsignedUpTo12 | undefined;
-  dangerouslySetInlineStyle?:
-    | {
-        __style: {
-          [key: string]: string | number | undefined;
-        };
-      }
-    | undefined;
-  direction?: 'row' | 'column' | undefined;
-  smDirection?: 'row' | 'column' | undefined;
-  mdDirection?: 'row' | 'column' | undefined;
-  lgDirection?: 'row' | 'column' | undefined;
-  display?: 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden' | undefined;
-  smDisplay?: 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden' | undefined;
-  mdDisplay?: 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden' | undefined;
-  lgDisplay?: 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden' | undefined;
-  fit?: boolean | undefined;
-  flex?: 'grow' | 'shrink' | 'none' | undefined;
-  height?: number | string | undefined;
-  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | undefined;
-  left?: boolean | undefined;
-  margin?: SignedUpTo12 | 'auto' | undefined;
-  smMargin?: SignedUpTo12 | 'auto' | undefined;
-  mdMargin?: SignedUpTo12 | 'auto' | undefined;
-  lgMargin?: SignedUpTo12 | 'auto' | undefined;
-  marginBottom?: SignedUpTo12 | 'auto' | undefined;
-  smMarginBottom?: SignedUpTo12 | 'auto' | undefined;
-  mdMarginBottom?: SignedUpTo12 | 'auto' | undefined;
-  lgMarginBottom?: SignedUpTo12 | 'auto' | undefined;
-  marginEnd?: SignedUpTo12 | 'auto' | undefined;
-  smMarginEnd?: SignedUpTo12 | 'auto' | undefined;
-  mdMarginEnd?: SignedUpTo12 | 'auto' | undefined;
-  lgMarginEnd?: SignedUpTo12 | 'auto' | undefined;
-  marginStart?: SignedUpTo12 | 'auto' | undefined;
-  smMarginStart?: SignedUpTo12 | 'auto' | undefined;
-  mdMarginStart?: SignedUpTo12 | 'auto' | undefined;
-  lgMarginStart?: SignedUpTo12 | 'auto' | undefined;
-  marginTop?: SignedUpTo12 | 'auto' | undefined;
-  smMarginTop?: SignedUpTo12 | 'auto' | undefined;
-  mdMarginTop?: SignedUpTo12 | 'auto' | undefined;
-  lgMarginTop?: SignedUpTo12 | 'auto' | undefined;
-  maxHeight?: number | string | undefined;
-  maxWidth?: number | string | undefined;
-  minHeight?: number | string | undefined;
-  minWidth?: number | string | undefined;
-  opacity?: 0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1 | undefined;
-  overflow?: 'visible' | 'hidden' | 'scroll' | 'scrollX' | 'scrollY' | 'auto' | undefined;
-  padding?: UnsignedUpTo12 | undefined;
-  smPadding?: UnsignedUpTo12 | undefined;
-  mdPadding?: UnsignedUpTo12 | undefined;
-  lgPadding?: UnsignedUpTo12 | undefined;
-  paddingX?: UnsignedUpTo12 | undefined;
-  smPaddingX?: UnsignedUpTo12 | undefined;
-  mdPaddingX?: UnsignedUpTo12 | undefined;
-  lgPaddingX?: UnsignedUpTo12 | undefined;
-  paddingY?: UnsignedUpTo12 | undefined;
-  smPaddingY?: UnsignedUpTo12 | undefined;
-  mdPaddingY?: UnsignedUpTo12 | undefined;
-  lgPaddingY?: UnsignedUpTo12 | undefined;
-  position?: 'static' | 'absolute' | 'relative' | 'fixed' | undefined;
-  right?: boolean | undefined;
-  role?: string | undefined;
-  rounding?: 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
-  top?: boolean | undefined;
-  userSelect?: 'auto' | 'none' | undefined;
-  width?: number | string | undefined;
-  wrap?: boolean | undefined;
-  zIndex?: Indexable | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/button
- */
-export interface ButtonProps {
-  text: string;
-  accessibilityControls?: string | undefined;
-  accessibilityExpanded?: boolean | undefined;
-  accessibilityHaspopup?: boolean | undefined;
-  accessibilityLabel?: string | undefined;
-  color?:
-    | 'gray'
-    | 'red'
-    | 'blue'
-    | 'transparent'
-    | 'semiTransparentWhite'
-    | 'transparentWhiteText'
-    | 'white'
-    | undefined;
-  disabled?: boolean | undefined;
-  href?: string | undefined;
-  iconEnd?: Icons | undefined;
-  fullWidth?: boolean | undefined;
-  name?: string | undefined;
-  onClick?: ButtonEventHandlerType | undefined;
-  rel?: 'none' | 'nofollow' | undefined;
-  role?: 'button' | 'link' | undefined;
-  selected?: boolean | undefined;
-  size?: 'sm' | 'md' | 'lg' | undefined;
-  tabIndex?: -1 | 0 | undefined;
-  target?: null | 'self' | 'blank' | undefined;
-  type?: 'submit' | 'button' | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/buttongroup
- */
-export interface ButtonGroupProps {
-  children?: React.ReactNode | undefined;
-}
-
-export interface ActionData {
-  accessibilityLabel: string;
-  disabled?: boolean;
-  href?: string | undefined;
-  label: string;
-  onClick?: ButtonEventHandlerType | undefined;
-  rel?: 'none' | 'nofollow' | undefined;
-  target?: null | 'self' | 'blank' | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/callout
- */
-export interface CalloutProps {
-  iconAccessibilityLabel: string;
-  message: string;
-  type: 'error' | 'info' | 'recommendation' | 'success' | 'warning';
-  dismissButton?: OnDismissButtonObject | undefined;
-  primaryAction?: ActionData | undefined;
-  secondaryAction?: ActionData | undefined;
-  title?: string | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/checkbox
- */
-export interface CheckboxProps {
-  id: string;
-  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
-  checked?: boolean | undefined;
-  disabled?: boolean | undefined;
-  errorMessage?: string | undefined;
-  hasError?: boolean | undefined;
-  image?: React.ReactNode | undefined;
-  indeterminate?: boolean | undefined;
-  label?: string | undefined;
-  name?: string | undefined;
-  onClick?:
-    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>
-    | undefined;
-  size?: 'sm' | 'md' | undefined;
-  subtext?: string | undefined;
-  labelDisplay?: 'visible' | 'hidden' | undefined;
-}
-
-export interface ComboBoxItemType {
-  label: string;
-  subtext?: string;
-  value: string;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/combobox
- */
-export interface ComboBoxProps {
-  accessibilityClearButtonLabel: string;
-  id: string;
-  label: string;
-  options: ComboBoxItemType[];
-  noResultText: string;
-  zIndex?: Indexable | undefined;
-  disabled?: boolean | undefined;
-  errorMessage?: string | undefined;
-  helperText?: string | undefined;
-  inputValue?: string | undefined;
-  labelDisplay?: 'visible' | 'hidden' | undefined;
-  onChange?:
-    | ((args: { event: React.SyntheticEvent<HTMLInputElement>; value: string }) => void)
-    | undefined;
-  onBlur?:
-    | ((args: {
-        event: React.FocusEvent<HTMLInputElement> | React.SyntheticEvent<HTMLInputElement>;
-        value: string;
-      }) => void)
-    | undefined;
-  onFocus?:
-    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: string }) => void)
-    | undefined;
-  onKeyDown?:
-    | ((args: { event: React.KeyboardEvent<HTMLInputElement>; value: string }) => void)
-    | undefined;
-  onClear?: (() => void) | undefined;
-  onSelect?:
-    | ((args: {
-        event: React.SyntheticEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>;
-        item: ComboBoxItemType;
-      }) => void)
-    | undefined;
-  placeholder?: string | undefined;
-  selectedOption?: ComboBoxItemType | undefined;
-  size?: 'md' | 'lg' | undefined;
-  tags?: ReadonlyArray<React.ReactElement<TagProps, typeof Tag>> | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/collage
- */
-export interface CollageProps {
-  columns: number;
-  height: number;
-  renderImage: (args: { width: number; height: number; index: number }) => React.ReactNode;
-  width: number;
-  cover?: boolean | undefined;
-  gutter?: number | undefined;
-  layoutKey?: number | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/utilities/colorschemeprovider
- */
-export interface ColorSchemeProviderProps {
-  colorScheme: 'light' | 'dark' | 'userPreference';
-  id?: string | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/column
- */
-export interface ColumnProps {
-  span: UnsignedUpTo12;
-  smSpan?: UnsignedUpTo12 | undefined;
-  mdSpan?: UnsignedUpTo12 | undefined;
-  lgSpan?: UnsignedUpTo12 | undefined;
-  children?: React.ReactNode | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/container
- */
-export interface ContainerProps {
-  children?: React.ReactNode | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/datapoint
- */
-export interface DatapointProps {
-  title: string;
-  value: string;
-  size?: 'md' | 'lg' | undefined;
-  tooltipText?: string | undefined;
-  trend?: { accessibilityLabel: string; value: number } | undefined;
-  trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto' | undefined;
-  badge?: BadgeObject | undefined;
-  tooltipZIndex?: Indexable | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/utilities/devicetypeprovider
- */
-export interface DeviceTypeProviderProps {
-  deviceType: 'desktop' | 'mobile';
-}
-
-/**
- * https://gestalt.pinterest.systems/web/utilities/defaultlabelprovider
- */
-export interface DefaultLabelProviderProps {
-  labels?:
-    | {
-        ComboBox: {
-          accessibilityClearButtonLabel: string;
-        };
-        Link: {
-          accessibilityNewTabLabel: string;
-        };
-        ModalAlert: {
-          accessibilityDismissButtonLabel: string;
-        };
-        Popover: {
-          accessibilityDismissButtonLabel: string;
-        };
-        Tag: {
-          accessibilityErrorIconLabel: string;
-          accessibilityRemoveIconLabel: string;
-          accessibilityWarningIconLabel: string;
-        };
-        TextField: {
-          accessibilityHidePasswordLabel: string;
-          accessibilityShowPasswordLabel: string;
-        };
-      }
-    | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/dropdown
- */
-export interface DropdownProps {
-  children:
-    | React.ReactElement<DropdownItemProps | DropdownSectionProps>
-    | Array<React.ReactElement<DropdownItemProps | DropdownSectionProps>>;
-  id: string;
-  onDismiss: () => void;
-  anchor?: HTMLElement | null | undefined;
-  dangerouslyRemoveLayer?: boolean;
-  headerContent?: React.ReactNode | undefined;
-  idealDirection?: FourDirections | undefined;
-  maxHeight?: '30vh' | undefined;
-  zIndex?: Indexable | undefined;
-}
-
-export interface DropdownOption {
-  label: string;
-  value: string;
-  subtext?: string | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item
- */
-export interface DropdownItemProps {
-  children?: React.ReactNode;
-  onSelect: AbstractEventHandler<
-    React.FocusEvent<HTMLInputElement>,
-    {
-      item: DropdownOption;
-    }
-  >;
-  option: DropdownOption;
-  badge?: BadgeObject | undefined;
-  dataTestId?: string | undefined;
-  selected?: DropdownOption | ReadonlyArray<DropdownOption> | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Link
- */
-export interface DropdownLinkProps {
-  href: string;
-  option: DropdownOption;
-  badge?: BadgeObject | undefined;
-  children?: React.ReactNode;
-  dataTestId?: string | undefined;
-  isExternal?: boolean | undefined;
-  onClick?: ButtonEventHandlerType | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Section
- */
-export interface DropdownSectionProps {
-  children:
-    | React.ReactElement<DropdownItemProps>
-    | ReadonlyArray<React.ReactElement<DropdownItemProps>>;
-  label: string;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/fieldset
- */
-export interface FieldsetProps {
-  children: React.ReactNode;
-  id?: string;
-  legend: string;
-  legendDisplay?: 'visible' | 'hidden' | undefined;
-  errorMessage?: string;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/flex
- */
-export interface FlexProps {
-  alignContent?:
-    | 'start'
-    | 'end'
-    | 'center'
-    | 'between'
-    | 'around'
-    | 'evenly'
-    | 'stretch'
-    | undefined;
-  alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  smAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  mdAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  lgAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  children?: React.ReactNode | undefined;
-  direction?: 'row' | 'column' | undefined;
-  flex?: 'grow' | 'shrink' | 'none' | undefined;
-  gap?: UnsignedUpTo12 | { row: UnsignedUpTo12; column: UnsignedUpTo12 } | undefined;
-  height?: number | string | undefined;
-  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | undefined;
-  maxHeight?: number | string | undefined;
-  maxWidth?: number | string | undefined;
-  minHeight?: number | string | undefined;
-  minWidth?: number | string | undefined;
-  width?: number | string | undefined;
-  wrap?: boolean | undefined;
-  dataTestId?: string | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/flex#Flex.Item
- */
-export interface FlexItemProps {
-  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  children?: React.ReactNode | undefined;
-  flex?: 'grow' | 'shrink' | 'none' | undefined;
-  minWidth?: number | string | undefined;
-  flexBasis?: string | number | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/heading
- */
-export interface HeaderProps {
-  accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6 | 'none' | undefined;
-  align?: 'start' | 'end' | 'center' | 'forceLeft' | 'forceRight' | undefined;
-  children?: React.ReactNode | undefined;
-  color?:
-    | 'default'
-    | 'subtle'
-    | 'success'
-    | 'error'
-    | 'warning'
-    | 'shopping'
-    | 'inverse'
-    | 'light'
-    | 'dark'
-    | undefined;
-  id?: string | undefined;
-  overflow?: 'normal' | 'breakWord' | undefined;
-  size?: '100' | '200' | '300' | '400' | '500' | '600' | undefined;
-  truncate?: boolean | undefined;
-  lineClamp?: number | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/helpbutton
- */
-export interface HelpButtonProps {
-  accessibilityLabel: string;
-  accessibilityPopoverLabel: string;
-  idealDirection?: 'up' | 'right' | 'down' | 'left' | undefined;
-  isWithinFixedContainer?: boolean | undefined;
-  link?:
-    | {
-        accessibilityLabel?: string | undefined;
-        externalLinkIcon?:
-          | 'none'
-          | 'default'
-          | {
-              color: IconProps['color'];
-              size: IconProps['size'];
-            };
-        href: string;
-        onClick?:
-          | AbstractEventHandler<
-              React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>,
-              {
-                dangerouslyDisableOnNavigation: () => void;
-              }
-            >
-          | undefined;
-        text: string;
-        ref?: React.Ref<'a'>;
-        target?: null | 'self' | 'blank';
-      }
-    | undefined;
-  onClick?: TapAreaEventHandlerType | undefined;
-  text: string | React.ReactElement<typeof Text>;
-  zIndex?: Indexable | undefined;
-}
-
-export type Icons =
+type Icons =
   | 'ad'
   | 'ad-group'
   | 'add'
@@ -884,12 +273,722 @@ export type Icons =
   | 'workflow-status-unstarted'
   | 'workflow-status-warning';
 
+type RoundingType = 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+type RelType = 'none' | 'nofollow';
+
+type TargetType = null | 'self' | 'blank';
+
+type TextSizeType = '100' | '200' | '300' | '400' | '500' | '600';
+
+type TextAlignType = 'start' | 'end' | 'center' | 'forceLeft' | 'forceRight';
+
+type BaseTextColorType =
+  | 'default'
+  | 'subtle'
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'shopping'
+  | 'inverse'
+  | 'light'
+  | 'dark';
+
+type IdealDirectionType = 'up' | 'right' | 'down' | 'left';
+
+type MobileEnterKeyHintType = 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
+
+interface ActionData {
+  accessibilityLabel: string;
+  disabled?: boolean;
+  href?: string | undefined;
+  label: string;
+  onClick?: ButtonEventHandlerType | undefined;
+  rel?: RelType | undefined;
+  target?: TargetType | undefined;
+}
+
+type DismissingElementChildrenType = (arg: { onDismissStart: () => void }) => Node;
+
+/**
+ * =========================================================
+ * ================= UTILITY API INTERFACES ================
+ * =========================================================
+ */
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/colorschemeprovider
+ */
+export interface ColorSchemeProviderProps {
+  children: Node;
+  colorScheme: 'light' | 'dark' | 'userPreference';
+  id?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/defaultlabelprovider
+ */
+export interface DefaultLabelProviderProps {
+  children: Node;
+  labels?:
+    | {
+        ComboBox: {
+          accessibilityClearButtonLabel: string;
+        };
+        Link: {
+          accessibilityNewTabLabel: string;
+        };
+        Modal: {
+          accessibilityDismissButtonLabel: string;
+        };
+        Popover: {
+          accessibilityDismissButtonLabel: string;
+        };
+        OverlayPanel: {
+          accessibilityDismissButtonLabel: string;
+          dismissConfirmationMessage: string;
+          dismissConfirmationSubtext: string;
+          dismissConfirmationPrimaryActionText: string;
+          dismissConfirmationPrimaryActionTextLabel: string;
+          dismissConfirmationSecondaryActionText: string;
+          dismissConfirmationSecondaryActionTextLabel: string;
+        };
+        SheetMobile: {
+          accessibilityDismissButtonLabel: string;
+          accessibilityGrabberLabel: string;
+          accessibilityLabel: string;
+        };
+        Tag: {
+          accessibilityErrorIconLabel: string;
+          accessibilityRemoveIconLabel: string;
+          accessibilityWarningIconLabel: string;
+        };
+        TextField: {
+          accessibilityHidePasswordLabel: string;
+          accessibilityShowPasswordLabel: string;
+        };
+        HelpButton: {
+          tooltipMessage: string;
+        };
+        Toast: {
+          accessibilityDismissButtonLabel: string;
+          accessibilityIconSuccessLabel: string;
+          accessibilityIconErrorLabel: string;
+          accessibilityProcessingLabel: string;
+        };
+      }
+    | null
+    | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/devicetypeprovider
+ */
+export interface DeviceTypeProviderProps {
+  children: Node;
+  deviceType: 'desktop' | 'mobile';
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider
+ */
+export interface OnLinkNavigationProviderProps {
+  children: Node;
+  onNavigation?:
+    | ((args: {
+        href: string;
+        target?: null | 'self' | 'blank' | undefined;
+      }) => EventHandlerType | null | undefined)
+    | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/scrollboundarycontainer
+ */
+export interface ScrollBoundaryContainerProps {
+  children: Node;
+  height?: number | string | undefined;
+  overflow?: 'scroll' | 'scrollX' | 'scrollY' | 'auto' | 'visible' | undefined;
+}
+
+/**
+ * =========================================================
+ * =============== COMPONENT API INTERFACES  ===============
+ * =========================================================
+ */
+
+/**
+ * https://gestalt.pinterest.systems/web/activationcard
+ */
+export interface ActivationCardProps {
+  message: string;
+  status: 'notStarted' | 'pending' | 'needsAttention' | 'complete';
+  statusMessage: string;
+  title: string;
+  dismissButton?: OnDismissButtonObject | undefined;
+  link?:
+    | {
+        accessibilityLabel: string;
+        href: string;
+        label: string;
+        onClick?: ButtonEventHandlerType | undefined;
+        rel?: RelType | undefined;
+        target?: TargetType | undefined;
+      }
+    | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/avatar
+ */
+export interface AvatarProps {
+  name: string;
+  accessibilityLabel?: string | undefined;
+  outline?: boolean | undefined;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'fit' | undefined;
+  src?: string | undefined;
+  verified?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/avatargroup
+ */
+export interface AvatarGroupProps {
+  accessibilityLabel: string;
+  collaborators: ReadonlyArray<{ name: string; src?: string | undefined }>;
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+  addCollaborators?: boolean | undefined;
+  href?: string | undefined;
+  onClick?: TapAreaEventHandlerType | undefined;
+  role?: 'button' | 'link' | undefined;
+  size?: 'xs' | 'sm' | 'md' | 'fit' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/badge
+ */
+export interface BadgeProps {
+  text: string;
+  position?: 'middle' | 'top' | undefined;
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'darkWash'
+    | 'lightWash'
+    | 'recommendation'
+    | undefined;
+}
+
+export type BoxPassthroughProps = Omit<
+  React.ComponentProps<'div'>,
+  'onClick' | 'className' | 'style' | 'ref'
+> &
+  React.RefAttributes<HTMLDivElement>;
+
+type AlignContentType = 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | 'stretch';
+type AlignItemsType = 'start' | 'end' | 'center' | 'baseline' | 'stretch';
+type DirectionType = 'row' | 'column';
+type DisplayType = 'none' | 'flex' | 'block' | 'inlineBlock' | 'visuallyHidden';
+type FlexType = 'grow' | 'shrink' | 'none';
+type JustifyContentType = 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly';
+type OverflowType = 'visible' | 'hidden' | 'scroll' | 'scrollX' | 'scrollY' | 'auto';
+
+/**
+ * https://gestalt.pinterest.systems/web/box
+ */
+export interface BoxProps extends BoxPassthroughProps {
+  alignContent?: AlignContentType | undefined;
+  alignItems?: AlignItemsType | undefined;
+  smAlignItems?: AlignItemsType | undefined;
+  mdAlignItems?: AlignItemsType | undefined;
+  lgAlignItems?: AlignItemsType | undefined;
+  alignSelf?: 'auto' | AlignItemsType | undefined;
+  as?:
+    | 'article'
+    | 'aside'
+    | 'caption'
+    | 'details'
+    | 'div'
+    | 'figcaption'
+    | 'figure'
+    | 'footer'
+    | 'header'
+    | 'main'
+    | 'nav'
+    | 'section'
+    | 'summary'
+    | undefined;
+  borderStyle?:
+    | 'sm'
+    | 'lg'
+    | 'shadow'
+    | 'raisedTopShadow'
+    | 'raisedBottomShadow'
+    | 'none'
+    | undefined;
+  bottom?: boolean | undefined;
+  children?: Node | undefined;
+  color?:
+    | 'darkWash'
+    | 'lightWash'
+    | 'transparent'
+    | 'transparentDarkGray'
+    | 'default'
+    | 'infoBase'
+    | 'infoWeak'
+    | 'errorBase'
+    | 'errorWeak'
+    | 'warningBase'
+    | 'warningWeak'
+    | 'successBase'
+    | 'successWeak'
+    | 'recommendationBase'
+    | 'recommendationWeak'
+    | 'shopping'
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'selected'
+    | 'inverse'
+    | 'brand'
+    | 'education'
+    | 'elevationAccent'
+    | 'elevationFloating'
+    | 'elevationRaised'
+    | 'dark'
+    | 'light'
+    | undefined;
+  column?: UnsignedUpTo12 | undefined;
+  smColumn?: UnsignedUpTo12 | undefined;
+  mdColumn?: UnsignedUpTo12 | undefined;
+  lgColumn?: UnsignedUpTo12 | undefined;
+  dangerouslySetInlineStyle?:
+    | {
+        __style: {
+          [key: string]: string | number | undefined;
+        };
+      }
+    | undefined;
+  direction?: DirectionType | undefined;
+  smDirection?: DirectionType | undefined;
+  mdDirection?: DirectionType | undefined;
+  lgDirection?: DirectionType | undefined;
+  display?: DisplayType | undefined;
+  smDisplay?: DisplayType | undefined;
+  mdDisplay?: DisplayType | undefined;
+  lgDisplay?: DisplayType | undefined;
+  fit?: boolean | undefined;
+  flex?: FlexType | undefined;
+  height?: number | string | undefined;
+  justifyContent?: JustifyContentType | undefined;
+  left?: boolean | undefined;
+  margin?: SignedUpTo12 | 'auto' | undefined;
+  smMargin?: SignedUpTo12 | 'auto' | undefined;
+  mdMargin?: SignedUpTo12 | 'auto' | undefined;
+  lgMargin?: SignedUpTo12 | 'auto' | undefined;
+  marginBottom?: SignedUpTo12 | 'auto' | undefined;
+  smMarginBottom?: SignedUpTo12 | 'auto' | undefined;
+  mdMarginBottom?: SignedUpTo12 | 'auto' | undefined;
+  lgMarginBottom?: SignedUpTo12 | 'auto' | undefined;
+  marginEnd?: SignedUpTo12 | 'auto' | undefined;
+  smMarginEnd?: SignedUpTo12 | 'auto' | undefined;
+  mdMarginEnd?: SignedUpTo12 | 'auto' | undefined;
+  lgMarginEnd?: SignedUpTo12 | 'auto' | undefined;
+  marginStart?: SignedUpTo12 | 'auto' | undefined;
+  smMarginStart?: SignedUpTo12 | 'auto' | undefined;
+  mdMarginStart?: SignedUpTo12 | 'auto' | undefined;
+  lgMarginStart?: SignedUpTo12 | 'auto' | undefined;
+  marginTop?: SignedUpTo12 | 'auto' | undefined;
+  smMarginTop?: SignedUpTo12 | 'auto' | undefined;
+  mdMarginTop?: SignedUpTo12 | 'auto' | undefined;
+  lgMarginTop?: SignedUpTo12 | 'auto' | undefined;
+  maxHeight?: number | string | undefined;
+  maxWidth?: number | string | undefined;
+  minHeight?: number | string | undefined;
+  minWidth?: number | string | undefined;
+  opacity?: 0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1 | undefined;
+  overflow?: OverflowType | undefined;
+  padding?: UnsignedUpTo12 | undefined;
+  smPadding?: UnsignedUpTo12 | undefined;
+  mdPadding?: UnsignedUpTo12 | undefined;
+  lgPadding?: UnsignedUpTo12 | undefined;
+  paddingX?: UnsignedUpTo12 | undefined;
+  smPaddingX?: UnsignedUpTo12 | undefined;
+  mdPaddingX?: UnsignedUpTo12 | undefined;
+  lgPaddingX?: UnsignedUpTo12 | undefined;
+  paddingY?: UnsignedUpTo12 | undefined;
+  smPaddingY?: UnsignedUpTo12 | undefined;
+  mdPaddingY?: UnsignedUpTo12 | undefined;
+  lgPaddingY?: UnsignedUpTo12 | undefined;
+  position?: 'static' | 'absolute' | 'relative' | 'fixed' | undefined;
+  right?: boolean | undefined;
+  role?: string | undefined;
+  rounding?: RoundingType | undefined;
+  top?: boolean | undefined;
+  userSelect?: 'auto' | 'none' | undefined;
+  width?: number | string | undefined;
+  wrap?: boolean | undefined;
+  zIndex?: Indexable | undefined;
+}
+
+type ConditionalButtonProps =
+  | {
+      href: string;
+      role: 'link';
+      rel?: RelType | undefined;
+      target?: TargetType | undefined;
+    }
+  | {
+      accessibilityControls?: string | undefined;
+      accessibilityExpanded?: boolean | undefined;
+      accessibilityHaspopup?: boolean | undefined;
+      selected?: boolean | undefined;
+      role?: 'button' | undefined;
+      type?: 'button' | undefined;
+    }
+  | {
+      role?: 'button' | undefined;
+      type?: 'submit' | undefined;
+    };
+
+type CommonButtonProps = {
+  text: string;
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+  accessibilityLabel?: string | undefined;
+  color?:
+    | 'gray'
+    | 'red'
+    | 'blue'
+    | 'transparent'
+    | 'semiTransparentWhite'
+    | 'transparentWhiteText'
+    | 'white'
+    | undefined;
+  dataTestId?: string;
+  disabled?: boolean | undefined;
+  fullWidth?: boolean | undefined;
+  href?: string | undefined;
+  iconEnd?: Icons | undefined;
+  name?: string | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
+  rel?: 'none' | 'nofollow' | undefined;
+  size?: 'sm' | 'md' | 'lg' | undefined;
+  tabIndex?: -1 | 0 | undefined;
+  target?: null | 'self' | 'blank' | undefined;
+  type?: 'submit' | 'button' | undefined;
+};
+
+/**
+ * https://gestalt.pinterest.systems/web/button
+ */
+export type ButtonProps = CommonButtonProps & ConditionalButtonProps;
+
+/**
+ * https://gestalt.pinterest.systems/web/buttongroup
+ */
+export interface ButtonGroupProps {
+  children?: Node | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/callout
+ */
+export interface CalloutProps {
+  iconAccessibilityLabel: string;
+  message: string;
+  type: 'error' | 'info' | 'recommendation' | 'success' | 'warning';
+  dismissButton?: OnDismissButtonObject | undefined;
+  primaryAction?: ActionData | undefined;
+  secondaryAction?: ActionData | undefined;
+  title?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/checkbox
+ */
+export interface CheckboxProps {
+  id: string;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
+  checked?: boolean | undefined;
+  disabled?: boolean | undefined;
+  errorMessage?: string | undefined;
+  helperText?: string | undefined;
+  image?: Node | undefined;
+  indeterminate?: boolean | undefined;
+  label?: string | undefined;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+  name?: string | undefined;
+  onClick?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>
+    | undefined;
+  size?: 'sm' | 'md' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/collage
+ */
+export interface CollageProps {
+  columns: number;
+  height: number;
+  renderImage: (args: { width: number; height: number; index: number }) => Node;
+  width: number;
+  cover?: boolean | undefined;
+  gutter?: number | undefined;
+  layoutKey?: number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/column
+ */
+export interface ColumnProps {
+  span: UnsignedUpTo12;
+  smSpan?: UnsignedUpTo12 | undefined;
+  mdSpan?: UnsignedUpTo12 | undefined;
+  lgSpan?: UnsignedUpTo12 | undefined;
+  children?: Node | undefined;
+}
+
+export interface ComboBoxItemType {
+  label: string;
+  subtext?: string;
+  value: string;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/combobox
+ */
+export interface ComboBoxProps {
+  id: string;
+  label: string;
+  options: ComboBoxItemType[];
+  noResultText: string;
+  accessibilityClearButtonLabel?: string | undefined;
+  disabled?: boolean | undefined;
+  errorMessage?: string | undefined;
+
+  helperText?: string | undefined;
+  inputValue?: string | null | undefined;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+  onChange?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>
+    | undefined;
+  onBlur?:
+    | AbstractEventHandler<
+        React.FocusEvent<HTMLInputElement> | React.SyntheticEvent<HTMLInputElement>,
+        { value: string }
+      >
+    | undefined;
+  onFocus?: AbstractEventHandler<React.FocusEvent<HTMLInputElement>, { value: string }> | undefined;
+  onKeyDown?:
+    | AbstractEventHandler<React.KeyboardEvent<HTMLInputElement>, { value: string }>
+    | undefined;
+  onClear?: (() => void) | undefined;
+  onSelect?:
+    | AbstractEventHandler<
+        React.SyntheticEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
+        { item: ComboBoxItemType }
+      >
+    | undefined;
+  placeholder?: string | undefined;
+  selectedOption?: ComboBoxItemType | undefined;
+  size?: 'md' | 'lg' | undefined;
+  tags?: ReadonlyArray<React.ReactElement<TagProps, typeof Tag>> | undefined;
+  zIndex?: Indexable | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/container
+ */
+export interface ContainerProps {
+  children?: Node | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/datapoint
+ */
+export interface DatapointProps {
+  title: string;
+  value: string;
+  badge?: BadgeObject | undefined;
+  size?: 'md' | 'lg' | undefined;
+  tooltipText?: string | undefined;
+  tooltipZIndex?: Indexable | undefined;
+  trend?: { accessibilityLabel: string; value: number } | undefined;
+  trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/dropdown
+ */
+export interface DropdownProps {
+  children: Node;
+  id: string;
+  onDismiss: () => void;
+  anchor?: HTMLElement | null | undefined;
+  headerContent?: Node | undefined;
+  idealDirection?: FourDirections | undefined;
+  isWithinFixedContainer?: boolean | undefined;
+  maxHeight?: '30vh' | undefined;
+  zIndex?: Indexable | undefined;
+}
+
+export interface DropdownOption {
+  label: string;
+  value: string;
+  subtext?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item
+ */
+export interface DropdownItemProps {
+  onSelect: AbstractEventHandler<
+    React.FocusEvent<HTMLInputElement>,
+    {
+      item: DropdownOption;
+    }
+  >;
+  option: DropdownOption;
+  badge?: BadgeObject | undefined;
+  children?: Node;
+  dataTestId?: string | undefined;
+  selected?: DropdownOption | ReadonlyArray<DropdownOption> | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Link
+ */
+export interface DropdownLinkProps {
+  href: string;
+  option: DropdownOption;
+  badge?: BadgeObject | undefined;
+  children?: Node;
+  dataTestId?: string | undefined;
+  isExternal?: boolean | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Section
+ */
+export interface DropdownSectionProps {
+  children: Node;
+  label: string;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/fieldset
+ */
+export interface FieldsetProps {
+  children: Node;
+  legend: string;
+  id?: string;
+  errorMessage?: string;
+  legendDisplay?: 'visible' | 'hidden' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/flex
+ */
+export interface FlexProps {
+  alignContent?: AlignContentType | undefined;
+  alignItems?: AlignItemsType | undefined;
+  alignSelf?: 'auto' | AlignItemsType | undefined;
+  smAlignItems?: AlignItemsType | undefined;
+  mdAlignItems?: AlignItemsType | undefined;
+  lgAlignItems?: AlignItemsType | undefined;
+  children?: Node | undefined;
+  dataTestId?: string | undefined;
+  direction?: DirectionType | undefined;
+  flex?: FlexType | undefined;
+  gap?: UnsignedUpTo12 | { row: UnsignedUpTo12; column: UnsignedUpTo12 } | undefined;
+  height?: number | string | undefined;
+  justifyContent?: JustifyContentType | undefined;
+  maxHeight?: number | string | undefined;
+  maxWidth?: number | string | undefined;
+  minHeight?: number | string | undefined;
+  minWidth?: number | string | undefined;
+  overflow?: OverflowType | undefined;
+  width?: number | string | undefined;
+  wrap?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/flex#Flex.Item
+ */
+export interface FlexItemProps {
+  alignSelf?: 'auto' | AlignItemsType | undefined;
+  children?: Node | undefined;
+  dataTestId?: string | undefined;
+  flex?: FlexType | undefined;
+  flexBasis?: string | number | undefined;
+  maxWidth?: number | string | undefined;
+  minWidth?: number | string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/heading
+ */
+export interface HeadingProps {
+  accessibilityLevel?: 1 | 2 | 3 | 4 | 5 | 6 | 'none' | undefined;
+  align?: TextAlignType | undefined;
+  children?: Node | undefined;
+  color?: BaseTextColorType | undefined;
+  id?: string | undefined;
+  lineClamp?: number | undefined;
+  overflow?: 'normal' | 'breakWord' | undefined;
+  size?: TextSizeType | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/helpbutton
+ */
+export interface HelpButtonProps {
+  accessibilityLabel: string;
+  accessibilityPopoverLabel: string;
+  text: string | React.ReactElement<typeof Text>;
+  idealDirection?: IdealDirectionType | undefined;
+  isWithinFixedContainer?: boolean | undefined;
+  link?:
+    | {
+        accessibilityLabel?: string | undefined;
+        externalLinkIcon?:
+          | 'none'
+          | 'default'
+          | {
+              color: IconProps['color'];
+              size: IconProps['size'];
+            }
+          | undefined;
+        href: string;
+        onClick?:
+          | AbstractEventHandler<
+              React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>,
+              {
+                dangerouslyDisableOnNavigation: () => void;
+              }
+            >
+          | undefined;
+        ref?: React.Ref<'a'>;
+        target?: TargetType | undefined;
+      }
+    | undefined;
+  onClick?: TapAreaEventHandlerType | undefined;
+  zIndex?: Indexable | undefined;
+}
+
 /**
  * https://gestalt.pinterest.systems/web/icon
  */
 export interface IconProps {
   accessibilityLabel: string;
-
   color?:
     | 'default'
     | 'subtle'
@@ -897,6 +996,7 @@ export interface IconProps {
     | 'error'
     | 'warning'
     | 'info'
+    | 'recommendation'
     | 'inverse'
     | 'shopping'
     | 'brandPrimary'
@@ -909,10 +1009,25 @@ export interface IconProps {
   size?: number | string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/iconbutton
- */
-export interface IconButtonProps {
+type ConditionalIconButtonProps =
+  | {
+      role?: 'link';
+      href: string | undefined;
+      target?: TargetType | undefined;
+      rel?: RelType | undefined;
+    }
+  | {
+      role?: 'button' | undefined;
+      accessibilityControls?: string | undefined;
+      accessibilityExpanded?: boolean | undefined;
+      accessibilityHaspopup?: boolean | undefined;
+      accessibilityPopupRole?: 'menu' | 'dialog' | undefined;
+      selected?: boolean | undefined;
+      type?: 'submit' | 'button' | undefined;
+    };
+
+type CommonIconButtonProps = {
+  accessibilityLabel: string;
   bgColor?:
     | 'transparent'
     | 'darkGray'
@@ -922,40 +1037,43 @@ export interface IconButtonProps {
     | 'white'
     | 'red'
     | undefined;
-  accessibilityControls?: string | undefined;
-  accessibilityExpanded?: boolean | undefined;
-  accessibilityHaspopup?: boolean | undefined;
-  accessibilityLabel: string;
-
   dangerouslySetSvgPath?: { __path: string } | undefined;
   disabled?: boolean | undefined;
-  href?: string | undefined;
   icon?: Icons | undefined;
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary' | undefined;
   onClick?: ButtonEventHandlerType | undefined;
   padding?: 1 | 2 | 3 | 4 | 5 | undefined;
-  rel?: 'none' | 'nofollow' | undefined;
   role?: 'button' | 'link' | undefined;
-  selected?: boolean | undefined;
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | undefined;
   tabIndex?: -1 | 0 | undefined;
-  target?: null | 'self' | 'blank' | undefined;
   tooltip?:
     | Pick<TooltipProps, 'accessibilityLabel' | 'inline' | 'idealDirection' | 'text' | 'zIndex'>
     | undefined;
-  type?: 'submit' | 'button' | undefined;
-}
+};
+
+/**
+ * https://gestalt.pinterest.systems/web/iconbutton
+ */
+export type IconButtonProps = CommonIconButtonProps & ConditionalIconButtonProps;
 
 /**
  * https://gestalt.pinterest.systems/web/iconbuttonfloating
  */
 export interface IconButtonFloatingProps {
-  accessibilityControls?: string | undefined;
-  accessibilityExpanded?: boolean | undefined;
   accessibilityPopupRole: 'menu' | 'dialog';
   accessibilityLabel: string;
   icon: Icons;
-  onClick?: ButtonEventHandlerType | undefined;
+  onClick: ButtonEventHandlerType;
+  tooltip: {
+    accessibilityLabel?: string | undefined;
+    inline?: boolean | undefined;
+    text: string;
+    zIndex?: Indexable | undefined;
+  };
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  dangerouslySetSvgPath?: { __path: string } | undefined;
+  disabled?: boolean | undefined;
   selected?: boolean | undefined;
 }
 
@@ -964,16 +1082,16 @@ export interface IconButtonFloatingProps {
  */
 export interface ImageProps {
   alt: string;
-  color: string;
-  crossOrigin?: 'anonymous' | 'use-credentials' | undefined;
-  decoding?: 'sync' | 'async' | 'auto';
-  elementTiming?: string | undefined;
   naturalHeight: number;
   naturalWidth: number;
   src: string;
-  children?: React.ReactNode | undefined;
-  fit?: 'cover' | 'contain' | 'none' | undefined;
+  children?: Node | undefined;
+  color?: string | undefined;
+  crossOrigin?: 'anonymous' | 'use-credentials' | undefined;
+  decoding?: 'sync' | 'async' | 'auto' | undefined;
+  elementTiming?: string | undefined;
   fetchPriority?: 'high' | 'low' | 'auto' | undefined;
+  fit?: 'cover' | 'contain' | 'none' | undefined;
   loading?: 'eager' | 'lazy' | 'auto' | undefined;
   onError?: AbstractEventHandler<React.SyntheticEvent<HTMLImageElement>> | undefined;
   onLoad?: AbstractEventHandler<React.SyntheticEvent<HTMLImageElement>> | undefined;
@@ -987,14 +1105,14 @@ export interface ImageProps {
  */
 export interface LabelProps {
   htmlFor: string;
-  children?: React.ReactNode | undefined;
+  children?: Node | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/layer
  */
 export interface LayerProps {
-  children: React.ReactNode;
+  children: Node;
   zIndex?: Indexable | undefined;
 }
 
@@ -1005,7 +1123,7 @@ export interface LetterboxProps {
   contentAspectRatio: number;
   height: number;
   width: number;
-  children?: React.ReactNode | undefined;
+  children?: Node | undefined;
 }
 
 /**
@@ -1014,15 +1132,15 @@ export interface LetterboxProps {
 export interface LinkProps {
   href: string;
   accessibilityLabel?: string | undefined;
-  children?: React.ReactNode | undefined;
-  hoverStyle?: 'none' | 'underline' | undefined;
-  id?: string | undefined;
+  children?: Node | undefined;
   display?: 'inline' | 'inlineBlock' | 'block' | undefined;
   externalLinkIcon?:
     | 'none'
     | 'default'
     | { color: IconProps['color']; size: TextProps['size'] }
     | undefined;
+
+  id?: string | undefined;
   onBlur?: AbstractEventHandler<React.FocusEvent<HTMLAnchorElement>> | undefined;
   onClick?:
     | AbstractEventHandler<
@@ -1031,10 +1149,10 @@ export interface LinkProps {
       >
     | undefined;
   onFocus?: AbstractEventHandler<React.FocusEvent<HTMLAnchorElement>> | undefined;
-  rel?: 'none' | 'nofollow' | undefined;
-  rounding?: 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
+  rel?: RelType | undefined;
+  rounding?: RoundingType | undefined;
   tapStyle?: 'none' | 'compress' | undefined;
-  target?: null | 'self' | 'blank' | undefined;
+  target?: TargetType | undefined;
   underline?: 'auto' | 'none' | 'always' | 'hover' | undefined;
 }
 
@@ -1042,7 +1160,8 @@ export interface LinkProps {
  * https://gestalt.pinterest.systems/web/list
  */
 export interface ListProps {
-  label: string | React.ReactElement<typeof Text>;
+  children: Node;
+  label?: string | React.ReactElement<typeof Text>;
   labelDisplay?: 'visible' | 'hidden' | undefined;
   spacing?: 'regular' | 'condensed' | undefined;
   type?: 'bare' | 'ordered' | 'unordered' | undefined;
@@ -1053,13 +1172,18 @@ export interface ListProps {
  */
 export interface ListItemProps {
   text: string | React.ReactElement<typeof Text>;
+  children?:
+    | string
+    | React.ReactElement<typeof List>
+    | React.ReactElement<typeof List.Item>
+    | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/mask
  */
 export interface MaskProps {
-  children?: React.ReactNode | undefined;
+  children?: Node | undefined;
   height?: number | string | undefined;
   rounding?: 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
   wash?: boolean | undefined;
@@ -1067,7 +1191,7 @@ export interface MaskProps {
   willChangeTransform?: boolean | undefined;
 }
 
-export interface MasonryCache<K, V> {
+export interface MeasurementStore<K, V> {
   get(key: K): V | undefined;
   has(key: K): boolean;
   set(key: K, value: V): void;
@@ -1078,11 +1202,11 @@ export interface MasonryCache<K, V> {
  * https://gestalt.pinterest.systems/web/masonry
  */
 export interface MasonryProps<T = any> {
+  items: ReadonlyArray<T>;
+  renderItem: (args: { data: T; itemIdx: number; isMeasuring: boolean }) => Node;
+
   columnWidth?: number | undefined;
   gutterWidth?: number | undefined;
-  items: ReadonlyArray<T>;
-  loadItems?: false | ((_arg?: { from: number }) => undefined | boolean | {}) | undefined;
-  measurementStore?: MasonryCache<T, any>;
   layout?:
     | 'basic'
     | 'basicCentered'
@@ -1090,14 +1214,14 @@ export interface MasonryProps<T = any> {
     | 'serverRenderedFlexible'
     | 'uniformRow'
     | undefined;
-  renderItem: (args: { data: T; itemIdx: number; isMeasuring: boolean }) => React.ReactNode;
-  flexible?: boolean | undefined;
+  loadItems?: false | ((_arg?: { from: number }) => undefined | boolean | {}) | undefined;
+  measurementStore?: MeasurementStore<T, any>;
   minCols?: number | undefined;
   scrollContainer?: (() => HTMLElement) | undefined;
   virtualBoundsBottom?: number | undefined;
   virtualBoundsTop?: number | undefined;
-  virtualize?: boolean | undefined;
   virtualBufferFactor?: number | undefined;
+  virtualize?: boolean | undefined;
 }
 
 /**
@@ -1105,15 +1229,15 @@ export interface MasonryProps<T = any> {
  */
 
 export interface ModalProps {
-  _dangerouslyDisableScrollBoundaryContainer?: boolean;
   accessibilityModalLabel: string;
-  align?: 'center' | 'start' | undefined;
-  children?: React.ReactNode | undefined;
-  closeOnOutsideClick?: boolean | undefined;
-  footer?: React.ReactNode | undefined;
-  heading?: React.ReactNode | undefined;
   onDismiss: () => void;
-  pending?: 'defaut' | 'none' | undefined;
+  _dangerouslyDisableScrollBoundaryContainer?: boolean;
+  align?: 'center' | 'start' | undefined;
+  children?: Node | undefined;
+  closeOnOutsideClick?: boolean | undefined;
+  footer?: Node | undefined;
+  heading?: Node | undefined;
+  padding?: 'defaut' | 'none' | undefined;
   role?: 'alertdialog' | 'dialog' | undefined;
   size?: 'sm' | 'md' | 'lg' | number | undefined;
   subHeading?: string | undefined;
@@ -1121,31 +1245,27 @@ export interface ModalProps {
 
 export interface ModalAlertActionDataType {
   accessibilityLabel: string;
+  label: string;
+  dataTestId?: string | undefined;
   disabled?: boolean | undefined;
   href?: string | undefined;
-  label: string;
-  onClick: AbstractEventHandler<
-    | React.KeyboardEvent<HTMLButtonElement>
-    | React.MouseEvent<HTMLAnchorElement>
-    | React.KeyboardEvent<HTMLAnchorElement>
-    | React.MouseEvent<HTMLButtonElement>,
-    { dangerouslyDisableOnNavigation: () => void }
-  >;
-  rel?: 'none' | 'nofollow' | undefined;
-  target?: null | 'self' | 'blank' | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
+  rel?: RelType | undefined;
+  target?: TargetType | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/modalalert
  */
 export interface ModalAlertProps {
-  accessibilityDismissButtonLabel?: string | undefined;
   accessibilityModalLabel: string;
+  children: Node;
   heading: string;
   onDismiss: () => void;
-  type?: 'default' | 'warning' | 'error' | undefined;
   primaryAction: ModalAlertActionDataType;
+  accessibilityDismissButtonLabel?: string | undefined;
   secondaryAction?: ModalAlertActionDataType | undefined;
+  type?: 'default' | 'warning' | 'error' | undefined;
 }
 
 /**
@@ -1154,6 +1274,7 @@ export interface ModalAlertProps {
 export interface ModuleProps {
   id: string;
   badge?: BadgeObject | undefined;
+  children?: Node | undefined;
   icon?: Icons | undefined;
   iconAccessibilityLabel?: string | undefined;
   iconButton?: React.ReactElement<typeof IconButton> | undefined;
@@ -1170,13 +1291,13 @@ export interface ModuleExpandableProps {
   id: string;
   items: ReadonlyArray<{
     title: string;
+    badge?: BadgeObject | undefined;
+    children?: Node | undefined;
     icon?: Icons | undefined;
+    iconAccessibilityLabel?: string | undefined;
     iconButton?: React.ReactElement<typeof IconButton> | undefined;
     summary?: ReadonlyArray<string> | undefined;
     type?: 'info' | 'error' | undefined;
-    iconAccessibilityLabel?: string | undefined;
-    children?: React.ReactNode | undefined;
-    badge?: BadgeObject | undefined;
   }>;
   expandedIndex?: number | null | undefined;
   onExpandedChange?: ((expandedIndex: number | null) => void) | undefined;
@@ -1187,27 +1308,44 @@ export interface ModuleExpandableProps {
  */
 export interface NumberFieldProps {
   id: string;
-  onChange: (args: {
-    event: React.SyntheticEvent<HTMLInputElement>;
-    value: number | undefined;
-  }) => void;
+  onChange: AbstractEventHandler<
+    React.SyntheticEvent<HTMLInputElement>,
+    {
+      value: number | undefined;
+    }
+  >;
   autoComplete?: 'on' | 'off' | undefined;
   disabled?: boolean | undefined;
-  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
-  errorMessage?: React.ReactNode | undefined;
+  errorMessage?: Node | undefined;
   helperText?: string | undefined;
   label?: string | undefined;
   max?: number | undefined;
   min?: number | undefined;
+  mobileEnterKeyHint?: MobileEnterKeyHintType | undefined;
   name?: string | undefined;
   onBlur?:
-    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: number | undefined }) => void)
+    | AbstractEventHandler<
+        React.FocusEvent<HTMLInputElement>,
+        {
+          value: number | undefined;
+        }
+      >
     | undefined;
   onFocus?:
-    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: number | undefined }) => void)
+    | AbstractEventHandler<
+        React.FocusEvent<HTMLInputElement>,
+        {
+          value: number | undefined;
+        }
+      >
     | undefined;
   onKeyDown?:
-    | ((args: { event: React.KeyboardEvent<HTMLInputElement>; value: number | undefined }) => void)
+    | AbstractEventHandler<
+        React.KeyboardEvent<HTMLInputElement>,
+        {
+          value: number | undefined;
+        }
+      >
     | undefined;
   placeholder?: string | undefined;
   size?: 'md' | 'lg' | undefined;
@@ -1215,21 +1353,55 @@ export interface NumberFieldProps {
   value?: number | undefined;
 }
 
+type NodeOrRenderProp = ((prop: { onDismissStart: () => void }) => Node) | Node;
+
 /**
- * https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider
+ * https://gestalt.pinterest.systems/web/overlaypanel
  */
-export interface OnLinkNavigationProviderProps {
-  onNavigation?: OnNavigationType | undefined;
+export interface OverlayPanelProps {
+  accessibilityLabel: string;
+  children?: NodeOrRenderProp | undefined;
+  onDismiss: () => void;
+  accessibilityDismissButtonLabel?: string | undefined;
+  closeOnOutsideClick?: boolean | undefined;
+  dismissConfirmation?: {
+    message?: string | undefined;
+    subtext?: string | undefined;
+    primaryAction?: {
+      accessibilityLabel?: string | undefined;
+      text?: string | undefined;
+      onClick?: BareButtonEventHandlerType | undefined;
+    };
+    secondaryAction?: {
+      accessibilityLabel?: string | undefined;
+      text?: string | undefined;
+      onClick?: BareButtonEventHandlerType | undefined;
+    };
+  };
+  footer?: NodeOrRenderProp | undefined;
+  heading?: string | undefined;
+  onAnimationEnd?: OnAnimationEndType;
+  size?: 'sm' | 'md' | 'lg' | undefined;
+  subHeading?: NodeOrRenderProp | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/overlaypanel#DismissingElement
+ */
+export interface OverlayPanelDismissingElementProps {
+  children: DismissingElementChildrenType;
 }
 
 export interface PageHeaderAction {
-  component?:
+  component:
     | React.ReactElement<
         typeof Button | typeof IconButton | typeof Link | typeof Tooltip | typeof Text
       >
     | undefined;
-  dropdownItems?:
-    | ReadonlyArray<React.ReactElement<DropdownItemProps | DropdownLinkProps, typeof Dropdown>>
+  dropdownItems:
+    | ReadonlyArray<
+        React.ReactElement<typeof Dropdown.Item | typeof Dropdown.Link, typeof Dropdown>
+      >
     | undefined;
 }
 
@@ -1245,37 +1417,30 @@ export interface PageHeaderProps {
       }
     | undefined;
   borderStyle?: 'sm' | 'none' | undefined;
+  dropdownAccessibilityLabel?: string | undefined;
   helperIconButton?:
     | {
-        accessibilityLabel?: string | undefined;
-        accessibilityControls?: string | undefined;
-        accessibilityExpanded?: boolean | undefined;
-        onClick: (args: {
-          event:
-            | React.MouseEvent<HTMLAnchorElement>
-            | React.KeyboardEvent<HTMLAnchorElement>
-            | React.KeyboardEvent<HTMLButtonElement>
-            | React.MouseEvent<HTMLButtonElement>;
-          dangerouslyDisableOnNavigation: () => void;
-        }) => void;
+        accessibilityLabel: string | undefined;
+        accessibilityControls: string | undefined;
+        accessibilityExpanded: boolean | undefined;
+        onClick: ButtonEventHandlerType;
       }
     | undefined;
   helperLink?: {
     accessibilityLabel: string;
     text: string;
     href: string;
-    onClick?: (args: {
-      event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
-      dangerouslyDisableOnNavigation: () => void;
-    }) => void | undefined;
+    onClick?: AbstractEventHandler<
+      React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>,
+      { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+    >;
   };
-  items?: ReadonlyArray<React.ReactNode> | undefined;
-  dropdownAccessibilityLabel?: string | undefined;
+  items?: ReadonlyArray<Node> | undefined;
   maxWidth?: number | string | undefined;
   primaryAction?: PageHeaderAction | undefined;
   secondaryAction?: PageHeaderAction | undefined;
   subtext?: string | undefined;
-  thumbnail?: React.ReactElement<typeof Image>;
+  thumbnail?: React.ReactElement<typeof Image> | undefined;
 }
 
 /**
@@ -1309,18 +1474,20 @@ export interface PogProps {
 export interface PopoverProps {
   anchor: HTMLElement | null | undefined;
   onDismiss: () => void;
-  children?: React.ReactNode | undefined;
+  accessibilityDismissButtonLabel?: string | undefined;
+  accessibilityLabel?: string | undefined;
+  children?: Node | undefined;
   color?: 'blue' | 'red' | 'white' | 'darkGray' | undefined;
   id?: string | undefined;
   idealDirection?: FourDirections | undefined;
+  onKeyDown?: AbstractEventHandler<React.KeyboardEvent<HTMLElement>>;
   positionRelativeToAnchor?: boolean | undefined;
+  role?: 'dialog' | 'listbox' | 'menu' | 'tooltip' | undefined;
   shouldFocus?: boolean | undefined;
   showCaret?: boolean | undefined;
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number | undefined;
-  __dangerouslySetMaxHeight?: '30vh';
-  onKeyDown?: AbstractEventHandler<React.KeyboardEvent<HTMLElement>>;
-  accessibilityDismissButtonLabel?: string | undefined;
   showDismissButton?: boolean | undefined;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number | undefined;
+  __dangerouslySetMaxHeight?: '30vh' | undefined;
 }
 
 /**
@@ -1330,24 +1497,24 @@ export interface PopoverEducationalProps {
   accessibilityLabel: string;
   anchor: HTMLElement | null | undefined;
   onDismiss: () => void;
-  children?: React.ReactNode | undefined;
+  children?: Node | undefined;
   id?: string | undefined;
   idealDirection?: FourDirections | undefined;
-  message?: React.ReactElement<typeof Text> | undefined;
+  message?: string | React.ReactElement<typeof Text> | undefined;
   primaryAction?:
     | {
         accessibilityLabel?: string | undefined;
         href?: string | undefined;
         text: string | undefined;
         onClick?: ButtonEventHandlerType | undefined;
-        rel?: 'none' | 'nofollow' | undefined;
-        target?: null | 'self' | 'blank' | undefined;
+        rel?: RelType | undefined;
+        target?: TargetType | undefined;
       }
     | undefined;
   role?: 'dialog' | 'tooltip' | undefined;
   shouldFocus?: boolean | undefined;
-  zIndex?: Indexable | undefined;
   size?: 'sm' | 'flexible' | undefined;
+  zIndex?: Indexable | undefined;
 }
 
 /**
@@ -1366,12 +1533,12 @@ export interface RadioButtonProps {
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
   value: string;
   checked?: boolean | undefined;
-  helperText?: string | undefined;
   disabled?: boolean | undefined;
-  image?: React.ReactNode | undefined;
+  image?: Node | undefined;
   label?: string | undefined;
   name?: string | undefined;
   size?: 'sm' | 'md' | undefined;
+  subtext?: string | undefined;
 }
 
 /**
@@ -1379,7 +1546,7 @@ export interface RadioButtonProps {
  */
 export interface RadioGroupProps {
   id: string;
-  children: React.ReactNode;
+  children: Node;
   legend: string;
   direction?: 'column' | 'row' | undefined;
   errorMessage?: string | undefined;
@@ -1387,12 +1554,19 @@ export interface RadioGroupProps {
 }
 
 /**
- * https://gestalt.pinterest.systems/web/scrollboundarycontainer
+ * https://gestalt.pinterest.systems/web/radiogroup#RadioGroup.RadioButtonProps
  */
-export interface ScrollBoundaryContainerProps {
-  children: React.ReactNode;
-  height?: number | string | undefined;
-  overflow?: 'scroll' | 'scrollX' | 'scrollY' | 'auto' | 'visible' | undefined;
+export interface RadioGroupRadioButtonProps {
+  id: string;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
+  value: string;
+  checked?: boolean | undefined;
+  disabled?: boolean | undefined;
+  helperText?: string | undefined;
+  image?: Node | undefined;
+  label?: string | undefined;
+  name?: string | undefined;
+  size?: 'sm' | 'md' | undefined;
 }
 
 /**
@@ -1400,33 +1574,32 @@ export interface ScrollBoundaryContainerProps {
  */
 export interface SearchFieldProps {
   accessibilityLabel: string;
-  accessibilityClearButtonLabel?: string;
   id: string;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>;
+  accessibilityClearButtonLabel?: string | undefined;
   autoComplete?: 'on' | 'off' | 'username' | 'name' | undefined;
   errorMessage?: string | undefined;
-  onChange: (args: {
-    value: string;
-    syntheticEvent: React.SyntheticEvent<HTMLInputElement>;
-  }) => void;
-  onBlur?: ((args: { event: React.SyntheticEvent<HTMLInputElement> }) => void) | undefined;
+  label?: string | undefined;
+  onBlur?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>
+    | undefined;
   onFocus?:
-    | ((args: { value: string; syntheticEvent: React.SyntheticEvent<HTMLInputElement> }) => void)
+    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>
     | undefined;
   onKeyDown?:
-    | ((args: { event: React.KeyboardEvent<HTMLInputElement>; value: string }) => void)
+    | AbstractEventHandler<React.KeyboardEvent<HTMLInputElement>, { value: string }>
     | undefined;
   placeholder?: string | undefined;
   size?: 'md' | 'lg' | undefined;
   value?: string | undefined;
-  label?: string | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/segmentedcontrol
  */
 export interface SegmentedControlProps {
-  items: React.ReactNode[];
-  onChange: (args: { event: React.SyntheticEvent<React.MouseEvent>; activeIndex: number }) => void;
+  items: Node[];
+  onChange: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>, { activeIndex: number }>;
   selectedItemIndex: number;
   responsive?: boolean | undefined;
 }
@@ -1435,14 +1608,14 @@ export interface SegmentedControlProps {
  * https://gestalt.pinterest.systems/web/selectlist
  */
 export interface SelectListProps {
-  children: React.ReactNode;
+  children: Node;
   id: string;
-  onChange: (args: { event: React.SyntheticEvent<HTMLElement>; value: string }) => void;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLElement>, { value: string }>;
   disabled?: boolean | undefined;
   errorMessage?: string | undefined;
   helperText?: string | undefined;
   label?: string | undefined;
-  labelDisplay?: 'visible' | 'hidden';
+  labelDisplay?: 'visible' | 'hidden' | undefined;
   name?: string | undefined;
   placeholder?: string | undefined;
   size?: 'md' | 'lg' | undefined;
@@ -1462,29 +1635,104 @@ export interface SelectListOptionProps {
  * https://gestalt.pinterest.systems/web/selectlist#SelectList.Group
  */
 export interface SelectListGroupProps {
-  children: React.ReactNode;
+  children: Node;
   label: string;
   disabled?: boolean | undefined;
+}
+
+type PrimaryActionType = {
+  icon?: 'ellipsis' | 'edit' | 'trash-can';
+  onClick?: ButtonEventHandlerType | undefined;
+  tooltip: {
+    accessibilityLabel?: string | undefined;
+    text: string;
+    zIndex?: Indexable | undefined;
+  };
+  dropdownItems?: Array<React.ReactElement<typeof Dropdown['Item']>>;
+};
+
+/**
+ * https://gestalt.pinterest.systems/web/sheetmobile
+ */
+export interface SheetMobileProps {
+  heading: string;
+  onDismiss: () => void;
+  accessibilityLabel?: string | undefined;
+  align?: 'start' | 'center' | undefined;
+  backIconButton?: {
+    accessibilityLabel: string;
+    onClick:
+      | AbstractEventHandler<
+          | React.MouseEvent<HTMLButtonElement>
+          | React.KeyboardEvent<HTMLButtonElement>
+          | React.MouseEvent<HTMLAnchorElement>
+          | React.KeyboardEvent<HTMLAnchorElement>,
+          { onDismissStart: () => void }
+        >
+      | undefined;
+    children?: Node | undefined;
+    closeOnOutsideClick?: boolean | undefined;
+    footer?: Node | undefined;
+    forwardIconButton?: {
+      accessibilityLabel: string;
+      onClick:
+        | AbstractEventHandler<
+            | React.MouseEvent<HTMLButtonElement>
+            | React.KeyboardEvent<HTMLButtonElement>
+            | React.MouseEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLAnchorElement>,
+            { onDismissStart: () => void }
+          >
+        | undefined;
+      onAnimationEnd?: OnAnimationEndType | undefined;
+      primaryAction?: {
+        accessibilityLabel: string;
+        label: string;
+        onClick: AbstractEventHandler<
+          | React.MouseEvent<HTMLButtonElement>
+          | React.KeyboardEvent<HTMLButtonElement>
+          | React.MouseEvent<HTMLAnchorElement>
+          | React.KeyboardEvent<HTMLAnchorElement>,
+          { onDismissStart: () => void }
+        >;
+        href?: string | undefined;
+        rel?: RelType | undefined;
+        size?: 'sm' | 'md' | 'lg' | undefined;
+        target?: TargetType | undefined;
+      };
+      role?: 'alertdialog' | 'dialog' | undefined;
+      showDismissButton?: boolean | undefined;
+      subHeading?: string | undefined;
+      size?: 'default' | 'full' | 'auto' | undefined;
+    };
+  };
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/sheetmobile#DismissingElement
+ */
+export interface SheetMobileDismissingElementProps {
+  children: DismissingElementChildrenType;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/sidenavigation
  */
-export interface SideNaviationProps {
+export interface SideNavigationProps {
   accessibilityLabel: string;
-  children: React.ReactNode;
-  footer?: React.ReactNode | undefined;
-  header?: React.ReactNode | undefined;
+  children: Node;
+  dismissButton?: { accessibilityLabel?: string; onDismiss: () => void } | undefined;
+  footer?: Node | undefined;
+  header?: Node | undefined;
   showBorder?: boolean | undefined;
   title?: string | undefined;
-  dismissButton?: { accessibilityLabel?: string; onDismiss: () => void } | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Section
  */
 export interface SideNavigationSectionProps {
-  children: React.ReactNode;
+  children: Node;
   label: string;
 }
 
@@ -1492,6 +1740,8 @@ export interface SideNavigationSectionProps {
  * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.TopItem
  */
 export interface SideNavigationTopItemProps {
+  href: string;
+  label: string;
   active?: 'page' | 'section' | undefined;
   badge?:
     | {
@@ -1500,32 +1750,20 @@ export interface SideNavigationTopItemProps {
       }
     | undefined;
   counter?: { number: string; accessibilityLabel: string } | undefined;
-  href: string;
-  icon?: Icons | { __path: string };
-  notificationAccessibilityLabel?: string;
+  icon?: Icons | { __path: string } | undefined;
+  notificationAccessibilityLabel?: string | undefined;
   onClick?: ButtonEventHandlerType | undefined;
-  label: string;
-  primaryAction?:
-    | {
-        icon?: 'ellipsis' | 'edit' | 'trash-can';
-        onClick?: ButtonEventHandlerType | undefined;
-        tooltip: {
-          accessibilityLabel?: string | undefined;
-          text: string;
-          zIndex?: Indexable | undefined;
-        };
-        dropdownItems?: Array<React.ReactElement<typeof Dropdown['Item']>>;
-      }
-    | undefined;
+  primaryAction?: PrimaryActionType | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem
  */
 export interface SideNavigationNestedItemProps {
-  active?: 'page' | 'section' | undefined;
   href: string;
   label: string;
+  active?: 'page' | 'section' | undefined;
+  counter?: { number: string; accessibilityLabel: string } | undefined;
   onClick?: ButtonEventHandlerType | undefined;
 }
 
@@ -1533,122 +1771,37 @@ export interface SideNavigationNestedItemProps {
  * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Group
  */
 export interface SideNavigationGroupProps {
+  children: Node;
+  label: string;
   badge?: BadgeProps | undefined;
-  children: React.ReactNode;
   counter?: { number: string; accessibilityLabel: string } | undefined;
   display?: 'expandable' | 'static' | undefined;
-  icon?: Icons;
+  icon?: Icons | undefined;
   notificationAccessibilityLabel?: string | undefined;
-  label: string;
-  primaryAction?:
-    | {
-        icon?: 'ellipsis' | 'edit' | 'trash-can';
-        onClick?:
-          | AbstractEventHandler<
-              | React.MouseEvent<HTMLButtonElement>
-              | React.MouseEvent<HTMLAnchorElement>
-              | React.KeyboardEvent<HTMLAnchorElement>
-              | React.KeyboardEvent<HTMLButtonElement>
-            >
-          | undefined;
-        tooltip: {
-          accessibilityLabel?: string | undefined;
-          text: string;
-          zIndex?: Indexable | undefined;
-        };
-        dropdownItems?: Array<React.ReactElement<typeof Dropdown['Item']>>;
-      }
-    | undefined;
+  primaryAction?: PrimaryActionType | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedGroup
  */
 export interface SideNavigationNestedGroupProps {
-  children: React.ReactNode;
-  display?: 'expandable' | 'static' | undefined;
+  children: Node;
   label: string;
-}
-
-export type OverlayPanelNodeOrRenderProp =
-  | ((prop: { onDismissStart: () => void }) => React.ReactNode)
-  | React.ReactNode;
-
-/**
- * https://gestalt.pinterest.systems/web/overlaypanel
- */
-export type OnAnimationEndStateType = 'in' | 'out';
-export interface OverlayPanel {
-  accessibilityDismissButtonLabel?: string | undefined;
-  accessibilityLabel: string;
-  children?: OverlayPanelNodeOrRenderProp | undefined;
-  closeOnOutsideClick?: boolean | undefined;
-  footer?: OverlayPanelNodeOrRenderProp | undefined;
-  heading?: string | undefined;
-  onAnimationEnd?: (args: { animationState: OnAnimationEndStateType }) => void;
-  dismissConfirmation?: {
-    message?: string | undefined;
-    subtext?: string | undefined;
-    primaryAction?: {
-      accessibilityLabel?: string | undefined;
-      text?: string | undefined;
-      onClick?:
-        | AbstractEventHandler<
-            | React.MouseEvent<HTMLButtonElement>
-            | React.MouseEvent<HTMLAnchorElement>
-            | React.KeyboardEvent<HTMLAnchorElement>
-            | React.KeyboardEvent<HTMLButtonElement>
-          >
-        | undefined;
-    };
-    secondaryAction?: {
-      accessibilityLabel?: string | undefined;
-      text?: string | undefined;
-      onClick?:
-        | AbstractEventHandler<
-            | React.MouseEvent<HTMLButtonElement>
-            | React.MouseEvent<HTMLAnchorElement>
-            | React.KeyboardEvent<HTMLAnchorElement>
-            | React.KeyboardEvent<HTMLButtonElement>
-          >
-        | undefined;
-    };
-  };
-  onDismiss: () => void;
-  size?: 'sm' | 'md' | 'lg' | undefined;
-  subHeading?: OverlayPanelNodeOrRenderProp | undefined;
+  counter?: { number: string; accessibilityLabel: string } | undefined;
+  display?: 'expandable' | 'static' | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/slimbanner
  */
 export interface SlimBannerProps {
+  message: React.ReactElement<typeof Text> | string;
   dismissButton?: OnDismissButtonObject | undefined;
-  primaryAction?:
-    | {
-        accessibilityLabel: string;
-        disabled?: boolean;
-        href?: string;
-        label: string;
-        onClick?:
-          | AbstractEventHandler<
-              | React.MouseEvent<HTMLButtonElement>
-              | React.MouseEvent<HTMLAnchorElement>
-              | React.MouseEvent<HTMLAnchorElement>
-              | React.MouseEvent<HTMLButtonElement>,
-              {
-                rel?: 'none' | 'nofollow';
-                target?: null | 'self' | 'blank';
-              }
-            >
-          | undefined;
-      }
-    | undefined;
   helperLink?: {
     accessibilityLabel: string;
     href: string;
-    target?: null | 'self' | 'blank' | undefined;
     text: string;
+    target?: TargetType | undefined;
     onClick?:
       | AbstractEventHandler<
           React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>,
@@ -1657,18 +1810,38 @@ export interface SlimBannerProps {
       | undefined;
   };
   iconAccessibilityLabel?: string | undefined;
-  message: React.ReactElement<typeof Text> | string;
+  primaryAction?:
+    | {
+        accessibilityLabel: string;
+        label: string;
+        disabled?: boolean | undefined;
+        href?: string | undefined;
+        onClick?:
+          | AbstractEventHandler<
+              | React.MouseEvent<HTMLButtonElement>
+              | React.MouseEvent<HTMLAnchorElement>
+              | React.MouseEvent<HTMLAnchorElement>
+              | React.MouseEvent<HTMLButtonElement>,
+              {
+                rel?: RelType | undefined;
+                target?: TargetType | undefined;
+              }
+            >
+          | undefined;
+      }
+    | undefined;
   type?:
     | 'neutral'
     | 'error'
     | 'info'
     | 'warning'
     | 'success'
+    | 'recommendation'
     | 'errorBare'
     | 'infoBare'
     | 'warningBare'
     | 'successBare'
-    | 'recommendation'
+    | 'recommendationBare'
     | undefined;
 }
 
@@ -1678,6 +1851,7 @@ export interface SlimBannerProps {
 export interface SpinnerProps {
   accessibilityLabel: string;
   show: boolean;
+  color?: 'default' | 'subtle' | undefined;
   delay?: boolean | undefined;
   size?: 'sm' | 'md' | undefined;
 }
@@ -1696,8 +1870,8 @@ export interface StatusProps {
  * https://gestalt.pinterest.systems/web/sticky
  */
 export interface StickyProps {
+  children: Node;
   bottom?: number | string | undefined;
-  children?: React.ReactNode | undefined;
   height?: number | undefined;
   left?: number | string | undefined;
   right?: number | string | undefined;
@@ -1710,9 +1884,7 @@ export interface StickyProps {
  */
 export interface SwitchProps {
   id: string;
-  onChange?:
-    | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: boolean }>
-    | undefined;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: boolean }>;
   disabled?: boolean | undefined;
   name?: string | undefined;
   switched?: boolean | undefined;
@@ -1723,71 +1895,75 @@ export interface SwitchProps {
  */
 export interface TableProps {
   accessibilityLabel: string;
+  children: Node;
   borderStyle?: 'sm' | 'none' | undefined;
-  children?: React.ReactNode | undefined;
   maxHeight?: number | string | undefined;
   stickyColumns?: number | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/table#Table.Body
- */
-export interface TableBodyProps {
-  children?: React.ReactNode | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/table#Table.Cell
- */
-export interface TableCellProps {
-  children?: React.ReactNode | undefined;
-  colSpan?: number | undefined;
-  rowSpan?: number | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/table#Table.Footer
- */
-export interface TableFooterProps {
-  children?: React.ReactNode | undefined;
-  sticky?: boolean | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/table#Table.Header
  */
 export interface TableHeaderProps {
-  children?: React.ReactNode | undefined;
-  display?: 'tableHeaderGroup' | 'visuallyHidden';
+  children: Node;
+  display?: 'tableHeaderGroup' | 'visuallyHidden' | undefined;
   sticky?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.Body
+ */
+export interface TableBodyProps {
+  children: Node;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.Footer
+ */
+export interface TableFooterProps {
+  children: Node;
+  sticky?: boolean | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.Cell
+ */
+export interface TableCellProps {
+  children: Node;
+  colSpan?: number | undefined;
+  rowSpan?: number | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/table#Table.HeaderCell
  */
-export interface TableHeaderCellProps extends TableCellProps {
-  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
-  colSpan?: number;
-  rowSpan?: number;
+export interface TableHeaderCellProps {
+  children: Node;
+  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup' | undefined;
+  colSpan?: number | undefined;
+  rowSpan?: number | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.SortableHeaderCell
+ */
+export interface TableSortableHeaderCellProps {
+  children: Node;
+  onSortChange: AbstractEventHandler<
+    React.MouseEvent<HTMLTableCellElement> | React.KeyboardEvent<HTMLTableCellElement>
+  >;
+  sortOrder: 'asc' | 'desc';
+  status: 'active' | 'inactive';
+  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup' | undefined;
+  colSpan?: number | undefined;
+  rowSpan?: number | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/table#Table.Row
  */
 export interface TableRowProps {
-  children?: React.ReactNode | undefined;
-}
-
-/**
- * https://gestalt.pinterest.systems/web/table#Table.RowDrawer
- */
-export interface TableRowDrawerProps {
-  children:
-    | React.ReactElement<TableCellProps>
-    | Array<React.ReactElement<TableCellProps>>
-    | undefined;
-  drawerContents: React.ReactNode;
-  id: string;
+  children: Node;
 }
 
 /**
@@ -1796,29 +1972,21 @@ export interface TableRowDrawerProps {
 export interface TableRowExpandableProps {
   accessibilityCollapseLabel: string;
   accessibilityExpandLabel: string;
-  expandedContents: React.ReactNode;
+  children: Node;
+  expandedContents: Node;
   id: string;
-  children?: React.ReactNode | undefined;
+  expanded?: string | undefined;
   hoverStyle?: 'none' | 'gray' | undefined;
-  onExpand?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLButtonElement>
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLButtonElement>
-      >
-    | undefined;
+  onExpand?: BareButtonEventHandlerType | undefined;
 }
 
 /**
- * https://gestalt.pinterest.systems/web/table#Table.SortableHeaderCell
+ * https://gestalt.pinterest.systems/web/table#Table.RowDrawer
  */
-export interface TableSortableHeaderCellProps extends TableHeaderCellProps {
-  onSortChange: AbstractEventHandler<
-    React.MouseEvent<HTMLTableCellElement> | React.KeyboardEvent<HTMLTableCellElement>
-  >;
-  sortOrder: 'asc' | 'desc';
-  status: 'active' | 'inactive';
+export interface TableRowDrawerProps {
+  children: Node;
+  drawerContents: Node;
+  id: string;
 }
 
 /**
@@ -1826,47 +1994,66 @@ export interface TableSortableHeaderCellProps extends TableHeaderCellProps {
  */
 export interface TabsProps {
   activeTabIndex: number;
-  onChange: (args: {
-    event: React.SyntheticEvent<React.MouseEvent>;
-    activeTabIndex: number;
-    dangerouslyDisableOnNavigation: () => void;
-  }) => void;
+  onChange: AbstractEventHandler<
+    | React.MouseEvent<HTMLDivElement>
+    | React.KeyboardEvent<HTMLDivElement>
+    | React.MouseEvent<HTMLAnchorElement>
+    | React.KeyboardEvent<HTMLAnchorElement>,
+    { activeTabIndex: number; dangerouslydangerouslyDisableOnNavigation?: (() => void) | undefined }
+  >;
   tabs: ReadonlyArray<{
     href: string;
-    text: React.ReactNode;
+    text: Node;
     id?: string | undefined;
     indicator?: 'dot' | number | undefined;
     ref?: { current?: HTMLElement | undefined } | undefined;
   }>;
-  size?: 'md' | 'lg';
-  wrap?: boolean;
-  bgColor?: 'default' | 'transparent';
+  wrap?: boolean | undefined;
+  bgColor?: 'default' | 'transparent' | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/tag
  */
 export interface TagProps {
-  accessibilityRemoveIconLabel?: string;
-  disabled?: boolean | undefined;
-  onRemove?: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>> | undefined;
+  onRemove: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>>;
   text: string;
-  type?: 'default' | 'error' | 'warning';
+  accessibilityRemoveIconLabel?: string | undefined;
+  disabled?: boolean | undefined;
+  type?: 'default' | 'error' | 'warning' | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/taparea
- */
-export interface TapAreaProps {
-  accessibilityControls?: string | undefined;
-  accessibilityExpanded?: boolean | undefined;
-  accessibilityHaspopup?: boolean | undefined;
+type ConditionalTapAreaProps =
+  | {
+      href: string;
+      role: 'link';
+      rel?: RelType | undefined;
+      target?: TargetType | undefined;
+      accessibilityCurrent?:
+        | 'page'
+        | 'step'
+        | 'location'
+        | 'date'
+        | 'time'
+        | 'true'
+        | 'false'
+        | 'section';
+    }
+  | {
+      role?: 'button' | 'switch' | undefined;
+      accessibilityChecked?: boolean | undefined;
+      accessibilityControls?: string | undefined;
+      accessibilityExpanded?: boolean | undefined;
+      accessibilityHaspopup?: boolean | undefined;
+      type?: 'submit' | 'button' | undefined;
+    };
+
+type CommonTapAreaProps = {
   accessibilityLabel?: string | undefined;
-  children?: React.ReactNode | undefined;
+  children?: Node | undefined;
   disabled?: boolean | undefined;
   fullHeight?: boolean | undefined;
   fullWidth?: boolean | undefined;
-  href?: string | undefined;
   mouseCursor?:
     | 'copy'
     | 'grab'
@@ -1879,7 +2066,13 @@ export interface TapAreaProps {
     | undefined;
   onBlur?: AbstractEventHandler<React.FocusEvent<HTMLDivElement | HTMLAnchorElement>> | undefined;
   onFocus?: AbstractEventHandler<React.FocusEvent<HTMLDivElement | HTMLAnchorElement>> | undefined;
+  onKeyDown?:
+    | AbstractEventHandler<React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement>>
+    | undefined;
   onMouseDown?:
+    | AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>
+    | undefined;
+  onMouseUp?:
     | AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>
     | undefined;
   onMouseEnter?:
@@ -1889,37 +2082,29 @@ export interface TapAreaProps {
     | AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>
     | undefined;
   onTap?: TapAreaEventHandlerType | undefined;
-  rel?: 'none' | 'nofollow' | undefined;
   role?: 'button' | 'link' | undefined;
-  rounding?: 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
+  rounding?: RoundingType | undefined;
   tabIndex?: -1 | 0 | undefined;
   tapStyle?: 'none' | 'compress' | undefined;
-  target?: null | 'self' | 'blank' | undefined;
-}
+};
+
+/**
+ * https://gestalt.pinterest.systems/web/taparea
+ */
+export type TapAreaProps = CommonTapAreaProps & ConditionalTapAreaProps;
 
 /**
  * https://gestalt.pinterest.systems/web/text
  */
 export interface TextProps {
-  align?: 'start' | 'end' | 'center' | 'forceLeft' | 'forceRight' | undefined;
-  children?: React.ReactNode | undefined;
-  color?:
-    | 'default'
-    | 'subtle'
-    | 'success'
-    | 'error'
-    | 'warning'
-    | 'shopping'
-    | 'link'
-    | 'inverse'
-    | 'light'
-    | 'dark'
-    | undefined;
+  align?: TextAlignType | undefined;
+  children?: Node | undefined;
+  color?: BaseTextColorType | 'link' | undefined;
   inline?: boolean | undefined;
   italic?: boolean | undefined;
+  lineClamp?: number | undefined;
   overflow?: 'normal' | 'breakWord' | 'noWrap' | undefined;
-  size?: '100' | '200' | '300' | '400' | '500' | '600' | undefined;
-  lineClamp?: number;
+  size?: TextSizeType | undefined;
   underline?: boolean | undefined;
   weight?: 'bold' | 'normal' | undefined;
   title?: string | undefined;
@@ -1930,28 +2115,29 @@ export interface TextProps {
  */
 export interface TextAreaProps {
   id: string;
-  onChange: (args: { event: React.SyntheticEvent<HTMLTextAreaElement>; value: string }) => void;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLTextAreaElement>, { value: string }>;
   disabled?: boolean | undefined;
-  errorMessage?: React.ReactNode | undefined;
+  errorMessage?: Node | undefined;
+  hasError?: boolean | undefined;
   helperText?: string | undefined;
   label?: string | undefined;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+  maxLength?: MaxLength | undefined;
   name?: string | undefined;
   onBlur?:
-    | ((args: { event: React.FocusEvent<HTMLTextAreaElement>; value: string }) => void)
+    | AbstractEventHandler<React.FocusEvent<HTMLTextAreaElement>, { value: string }>
     | undefined;
   onFocus?:
-    | ((args: { event: React.FocusEvent<HTMLTextAreaElement>; value: string }) => void)
+    | AbstractEventHandler<React.FocusEvent<HTMLTextAreaElement>, { value: string }>
     | undefined;
   onKeyDown?:
-    | ((args: { event: React.KeyboardEvent<HTMLTextAreaElement>; value: string }) => void)
+    | AbstractEventHandler<React.KeyboardEvent<HTMLTextAreaElement>, { value: string }>
     | undefined;
   placeholder?: string | undefined;
+  readonly?: boolean | undefined;
   rows?: number | undefined;
   tags?: ReadonlyArray<React.ReactElement<TagProps, typeof Tag>> | undefined;
-  maxLength?: MaxLength | undefined;
   value?: string | undefined;
-  readonly?: boolean;
-  labelDisplay?: 'visible' | 'hidden' | undefined;
 }
 
 /**
@@ -1959,7 +2145,7 @@ export interface TextAreaProps {
  */
 export interface TextFieldProps {
   id: string;
-  onChange: (args: { event: React.SyntheticEvent<HTMLInputElement>; value: string }) => void;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>;
   autoComplete?:
     | 'bday'
     | 'current-password'
@@ -1970,28 +2156,25 @@ export interface TextFieldProps {
     | 'username'
     | undefined;
   disabled?: boolean | undefined;
-  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
-  errorMessage?: React.ReactNode | undefined;
+  errorMessage?: Node | undefined;
+  hasError?: boolean | undefined;
   helperText?: string | undefined;
-  maxLength?: MaxLength | undefined;
   label?: string | undefined;
+  labelDisplay?: 'visible' | 'hidden' | undefined;
+  maxLength?: MaxLength | undefined;
+  mobileEnterKeyHint?: MobileEnterKeyHintType | undefined;
+  mobileInputMode?: 'none' | 'text' | 'decimal' | 'numeric' | undefined;
   name?: string | undefined;
-  onBlur?:
-    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: string }) => void)
-    | undefined;
-  onFocus?:
-    | ((args: { event: React.FocusEvent<HTMLInputElement>; value: string }) => void)
-    | undefined;
+  onBlur?: AbstractEventHandler<React.FocusEvent<HTMLInputElement>, { value: string }> | undefined;
+  onFocus?: AbstractEventHandler<React.FocusEvent<HTMLInputElement>, { value: string }> | undefined;
   onKeyDown?:
-    | ((args: { event: React.KeyboardEvent<HTMLInputElement>; value: string }) => void)
+    | AbstractEventHandler<React.KeyboardEvent<HTMLInputElement>, { value: string }>
     | undefined;
   placeholder?: string | undefined;
-
   size?: 'md' | 'lg' | undefined;
   tags?: ReadonlyArray<React.ReactElement<TagProps, typeof Tag>> | undefined;
   type?: 'date' | 'email' | 'password' | 'text' | 'url' | 'tel' | undefined;
   value?: string | undefined;
-  labelDisplay?: 'visible' | 'hidden' | undefined;
 }
 
 /**
@@ -2018,12 +2201,12 @@ export interface ToastProps {
     | undefined;
   primaryAction?: {
     accessibilityLabel: string;
-    href?: string;
     label: string;
+    href?: string | undefined;
     onClick?: ButtonEventHandlerType | undefined;
-    rel?: LinkProps['rel'] | undefined;
-    size?: ButtonProps['size'] | undefined;
-    target?: LinkProps['target'] | undefined;
+    rel?: RelType | undefined;
+    size?: 'sm' | 'md' | 'lg' | undefined;
+    target?: TargetType | undefined;
   };
   thumbnail?:
     | { image: React.ReactElement<typeof Image> }
@@ -2037,26 +2220,25 @@ export interface ToastProps {
  * https://gestalt.pinterest.systems/web/tooltip
  */
 export interface TooltipProps {
-  children: React.ReactNode;
+  children: Node;
   text: string;
+  accessibilityLabel?: string | undefined;
   idealDirection?: FourDirections | undefined;
   inline?: boolean | undefined;
-  link?: React.ReactNode | undefined;
+  link?: Node | undefined;
   zIndex?: Indexable | undefined;
-  accessibilityLabel?: string | undefined;
 }
 
 /**
  * https://gestalt.pinterest.systems/web/upsell
  */
 export interface UpsellProps {
-  children?: React.ReactElement;
   message: string | React.ReactElement<typeof Text>;
-  dismissButton?: OnDismissButtonObject
-    | undefined;
+  children?: React.ReactElement<typeof Upsell.Form>;
+  dismissButton?: OnDismissButtonObject | undefined;
   imageData?:
     | {
-        component: React.ReactElement<any, typeof Image | typeof Icon>;
+        component: React.ReactElement<typeof Image | typeof Icon>;
         width?: number | undefined;
         mask?:
           | {
@@ -2075,12 +2257,8 @@ export interface UpsellProps {
  * https://gestalt.pinterest.systems/web/upsell#Upsell.Form
  */
 export interface UpsellFormProps {
-  onSubmit: AbstractEventHandler<
-    | React.MouseEvent<HTMLButtonElement>
-    | React.MouseEvent<HTMLAnchorElement>
-    | React.KeyboardEvent<HTMLButtonElement>
-    | React.KeyboardEvent<HTMLAnchorElement>
-  >;
+  children: Node;
+  onSubmit: BareButtonEventHandlerType;
   submitButtonText: string;
   submitButtonAccessibilityLabel: string;
   submitButtonDisabled?: boolean | undefined;
@@ -2090,57 +2268,72 @@ export interface UpsellFormProps {
  * https://gestalt.pinterest.systems/web/video
  */
 export interface VideoProps {
-  accessibilityMaximizeLabel?: string | undefined;
-  accessibilityMinimizeLabel?: string | undefined;
-  accessibilityMuteLabel?: string | undefined;
-  accessibilityPauseLabel?: string | undefined;
-  accessibilityPlayLabel?: string | undefined;
-  accessibilityUnmuteLabel?: string | undefined;
+  accessibilityMaximizeLabel: string;
+  accessibilityMinimizeLabel: string;
+  accessibilityMuteLabel: string;
+  accessibilityPauseLabel: string;
+  accessibilityPlayLabel: string;
+  accessibilityProgressBarLabel: string;
+  accessibilityUnmuteLabel: string;
   aspectRatio: number;
-  backgroundColor?: 'black' | 'transparent' | undefined;
-  captions: string;
-  playbackRate?: number | undefined;
-  playing?: boolean | undefined;
-  preload?: 'auto' | 'metadata' | 'none' | undefined;
+  onPlay: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>>;
+  onPlayError: (args: { error: Error }) => void;
   src: string | ReadonlyArray<{ type: 'video/m3u8' | 'video/mp4' | 'video/ogg'; src: string }>;
-  volume?: number | undefined;
+  accessibilityHideCaptionsLabel?: string | undefined;
+  accessibilityShowCaptionsLabel?: string | undefined;
+  autoplay?: boolean | undefined;
+  backgroundColor?: 'black' | 'transparent' | undefined;
+  captions?: string | undefined;
   children?: Node | undefined;
   controls?: boolean | undefined;
-  disableRemotePlayback?: boolean | undefined;
   crossOrigin?: 'anonymous' | 'use-credentials' | undefined;
+  disableRemotePlayback?: boolean | undefined;
   loop?: boolean | undefined;
   objectFit?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down' | undefined;
-  onDurationChange?:
-    | ((args: { event: React.SyntheticEvent<HTMLVideoElement>; duration: number }) => void)
+  onControlsPause?:
+    | AbstractEventHandler<
+        React.SyntheticEvent<HTMLDivElement> | React.SyntheticEvent<HTMLAnchorElement>
+      >
     | undefined;
-  onEnded?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onControlsPlay?:
+    | AbstractEventHandler<
+        React.SyntheticEvent<HTMLDivElement> | React.SyntheticEvent<HTMLAnchorElement>
+      >
+    | undefined;
+  onDurationChange?:
+    | AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>, { duration: number }>
+    | undefined;
+  onEnded?: VideoEventHandlerType | undefined;
+  onError?: VideoEventHandlerType | undefined;
   onFullscreenChange?:
     | AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>, { fullscreen: boolean }>
     | undefined;
   onLoadedChange?:
     | AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>, { loaded: number }>
     | undefined;
-  onPlay?: AbstractEventHandler<React.SyntheticEvent<HTMLDivElement>> | undefined;
+  onLoadStart?: VideoEventHandlerType | undefined;
+  onPause?: AbstractEventHandler<React.SyntheticEvent<HTMLDivElement>> | undefined;
   onPlayheadDown?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>> | undefined;
   onPlayheadUp?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>> | undefined;
-  onPause?: AbstractEventHandler<React.SyntheticEvent<HTMLDivElement>> | undefined;
-  onReady?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
-  onSeek?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onPlaying?: VideoEventHandlerType | undefined;
+  onReady?: VideoEventHandlerType | undefined;
+  onSeek?: VideoEventHandlerType | undefined;
+  onSeeking?: VideoEventHandlerType | undefined;
+  onStalled?: VideoEventHandlerType | undefined;
   onTimeChange?:
     | AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>, { time: number }>
     | undefined;
   onVolumeChange?:
     | AbstractEventHandler<React.SyntheticEvent<HTMLDivElement>, { volume: number }>
     | undefined;
-  onError?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
-  onLoadStart?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
-  onPlaying?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
-  onSeeking?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
-  onStalled?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
-  onWaiting?: AbstractEventHandler<React.SyntheticEvent<HTMLVideoElement>> | undefined;
+  onWaiting?: VideoEventHandlerType | undefined;
+  playbackRate?: number | undefined;
+  playing?: boolean | undefined;
   playsInline?: boolean | undefined;
   poster?: string | undefined;
+  preload?: 'auto' | 'metadata' | 'none' | undefined;
   startTime?: number | undefined;
+  volume?: number | undefined;
 }
 
 /**
@@ -2148,18 +2341,10 @@ export interface VideoProps {
  */
 export interface WashAnimatedProps {
   active?: boolean | undefined;
-  children?: React.ReactNode | undefined;
-  image?: React.ReactNode | undefined;
-  onMouseEnter?:
-    | ((args: { event: React.SyntheticEvent<React.MouseEvent<HTMLDivElement>> }) => void)
-    | undefined;
-  onMouseLeave?:
-    | ((args: { event: React.SyntheticEvent<React.MouseEvent<HTMLDivElement>> }) => void)
-    | undefined;
-}
-
-export interface Indexable {
-  index(): number;
+  children?: Node | undefined;
+  image?: Node | undefined;
+  onMouseEnter?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>> | undefined;
+  onMouseLeave?: AbstractEventHandler<React.MouseEvent<HTMLDivElement>> | undefined;
 }
 
 /**
@@ -2246,7 +2431,7 @@ export interface FlexSubComponents {
 
 export const Flex: React.FunctionComponent<FlexProps> & FlexSubComponents;
 
-export const Heading: React.FunctionComponent<HeaderProps>;
+export const Heading: React.FunctionComponent<HeadingProps>;
 
 export const HelpButton: React.FunctionComponent<HelpButtonProps>;
 
@@ -2303,11 +2488,11 @@ export const Pulsar: React.FunctionComponent<PulsarProps>;
 
 export const RadioButton: ReactForwardRef<HTMLInputElement, RadioButtonProps>;
 
-export interface RadioGroupSubCompnents {
-  RadioButton: typeof RadioButton;
+export interface RadioGroupSubComponents {
+  RadioButton: React.FunctionComponent<RadioGroupRadioButtonProps>;
 }
 
-export const RadioGroup: React.FunctionComponent<RadioGroupProps> & RadioGroupSubCompnents;
+export const RadioGroup: React.FunctionComponent<RadioGroupProps> & RadioGroupSubComponents;
 
 export const SearchField: ReactForwardRef<HTMLInputElement, SearchFieldProps>;
 
@@ -2328,10 +2513,22 @@ export interface SideNavigationSubcomponents {
   NestedGroup: React.FunctionComponent<SideNavigationNestedGroupProps>;
 }
 
-export const SideNavigation: React.FunctionComponent<SideNaviationProps> &
+export const SideNavigation: React.FunctionComponent<SideNavigationProps> &
   SideNavigationSubcomponents;
 
-export const OverlayPanel: ReactForwardRef<HTMLDivElement, OverlayPanel>;
+export interface OverlayPanelSubComponents {
+  DismissingElement: React.FunctionComponent<OverlayPanelDismissingElementProps>;
+}
+
+export const OverlayPanel: ReactForwardRef<HTMLDivElement, OverlayPanelProps> &
+  OverlayPanelSubComponents;
+
+export interface SheetMobileSubComponents {
+  DismissingElement: React.FunctionComponent<SheetMobileDismissingElementProps>;
+}
+
+export const SheetMobile: ReactForwardRef<HTMLDivElement, SheetMobileProps> &
+  SheetMobileSubComponents;
 
 export const SlimBanner: React.FunctionComponent<SlimBannerProps>;
 
@@ -2343,7 +2540,7 @@ export const Sticky: React.FunctionComponent<StickyProps>;
 
 export const Switch: React.FunctionComponent<SwitchProps>;
 
-export interface TableSubCompnents {
+export interface TableSubComponents {
   Body: React.FunctionComponent<TableBodyProps>;
   Cell: React.FunctionComponent<TableCellProps>;
   Footer: React.FunctionComponent<TableFooterProps>;
@@ -2355,7 +2552,7 @@ export interface TableSubCompnents {
   RowDrawer: React.FunctionComponent<TableRowDrawerProps>;
 }
 
-export const Table: React.FunctionComponent<TableProps> & TableSubCompnents;
+export const Table: React.FunctionComponent<TableProps> & TableSubComponents;
 
 export const Tabs: React.FunctionComponent<TabsProps>;
 

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -201,6 +201,7 @@ type Icons =
   | 'megaphone'
   | 'menu'
   | 'minimize'
+  | 'moon'
   | 'move'
   | 'mute'
   | 'music-off'
@@ -241,6 +242,7 @@ type Icons =
   | 'speech-ellipsis'
   | 'star'
   | 'star-half'
+  | 'sun'
   | 'switch-account'
   | 'tag'
   | 'terms'
@@ -636,31 +638,8 @@ export interface BoxProps extends BoxPassthroughProps {
   zIndex?: Indexable | undefined;
 }
 
-type ConditionalButtonProps =
-  | {
-      href: string;
-      role: 'link';
-      rel?: RelType | undefined;
-      target?: TargetType | undefined;
-    }
-  | {
-      accessibilityControls?: string | undefined;
-      accessibilityExpanded?: boolean | undefined;
-      accessibilityHaspopup?: boolean | undefined;
-      selected?: boolean | undefined;
-      role?: 'button' | undefined;
-      type?: 'button' | undefined;
-    }
-  | {
-      role?: 'button' | undefined;
-      type?: 'submit' | undefined;
-    };
-
-type CommonButtonProps = {
+interface CommonButtonProps {
   text: string;
-  accessibilityControls?: string | undefined;
-  accessibilityExpanded?: boolean | undefined;
-  accessibilityHaspopup?: boolean | undefined;
   accessibilityLabel?: string | undefined;
   color?:
     | 'gray'
@@ -674,21 +653,38 @@ type CommonButtonProps = {
   dataTestId?: string;
   disabled?: boolean | undefined;
   fullWidth?: boolean | undefined;
-  href?: string | undefined;
   iconEnd?: Icons | undefined;
   name?: string | undefined;
   onClick?: ButtonEventHandlerType | undefined;
-  rel?: 'none' | 'nofollow' | undefined;
   size?: 'sm' | 'md' | 'lg' | undefined;
   tabIndex?: -1 | 0 | undefined;
-  target?: null | 'self' | 'blank' | undefined;
-  type?: 'submit' | 'button' | undefined;
-};
+}
+
+interface ButtonLinkProps extends CommonButtonProps {
+  role: 'link';
+  href: string;
+  rel?: RelType | undefined;
+  target?: TargetType | undefined;
+}
+
+interface ButtonButtonProps extends CommonButtonProps {
+  role?: 'button' | undefined;
+  type?: 'button' | undefined;
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+  selected?: boolean | undefined;
+}
+
+interface ButtonSubmitProps extends CommonButtonProps {
+  role: 'button';
+  type: 'submit';
+}
 
 /**
  * https://gestalt.pinterest.systems/web/button
  */
-export type ButtonProps = CommonButtonProps & ConditionalButtonProps;
+export type ButtonProps = ButtonLinkProps | ButtonButtonProps | ButtonSubmitProps;
 
 /**
  * https://gestalt.pinterest.systems/web/buttongroup
@@ -1009,24 +1005,7 @@ export interface IconProps {
   size?: number | string | undefined;
 }
 
-type ConditionalIconButtonProps =
-  | {
-      role?: 'link';
-      href: string | undefined;
-      target?: TargetType | undefined;
-      rel?: RelType | undefined;
-    }
-  | {
-      role?: 'button' | undefined;
-      accessibilityControls?: string | undefined;
-      accessibilityExpanded?: boolean | undefined;
-      accessibilityHaspopup?: boolean | undefined;
-      accessibilityPopupRole?: 'menu' | 'dialog' | undefined;
-      selected?: boolean | undefined;
-      type?: 'submit' | 'button' | undefined;
-    };
-
-type CommonIconButtonProps = {
+interface CommonIconButtonProps {
   accessibilityLabel: string;
   bgColor?:
     | 'transparent'
@@ -1043,18 +1022,39 @@ type CommonIconButtonProps = {
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary' | undefined;
   onClick?: ButtonEventHandlerType | undefined;
   padding?: 1 | 2 | 3 | 4 | 5 | undefined;
-  role?: 'button' | 'link' | undefined;
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | undefined;
   tabIndex?: -1 | 0 | undefined;
   tooltip?:
     | Pick<TooltipProps, 'accessibilityLabel' | 'inline' | 'idealDirection' | 'text' | 'zIndex'>
     | undefined;
-};
+}
+
+interface IconButtonLinkProps extends CommonIconButtonProps {
+  role: 'link';
+  href: string;
+  rel?: RelType | undefined;
+  target?: TargetType | undefined;
+}
+
+interface IconButtonButtonProps extends CommonIconButtonProps {
+  role?: 'button' | undefined;
+  type?: 'button' | undefined;
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+  accessibilityPopupRole?: 'menu' | 'dialog' | undefined;
+  selected?: boolean | undefined;
+}
+
+interface IconButtonSubmitProps extends CommonIconButtonProps {
+  role: 'button' | undefined;
+  type: 'submit';
+}
 
 /**
  * https://gestalt.pinterest.systems/web/iconbutton
  */
-export type IconButtonProps = CommonIconButtonProps & ConditionalIconButtonProps;
+export type IconButtonProps = IconButtonLinkProps | IconButtonButtonProps | IconButtonSubmitProps;
 
 /**
  * https://gestalt.pinterest.systems/web/iconbuttonfloating
@@ -1202,6 +1202,7 @@ export interface MeasurementStore<K, V> {
  * https://gestalt.pinterest.systems/web/masonry
  */
 export interface MasonryProps<T = any> {
+  _batchPaints?: boolean | undefined;
   items: ReadonlyArray<T>;
   renderItem: (args: { data: T; itemIdx: number; isMeasuring: boolean }) => Node;
 
@@ -1494,7 +1495,7 @@ export interface PopoverProps {
  * https://gestalt.pinterest.systems/web/popovereducational
  */
 export interface PopoverEducationalProps {
-  accessibilityLabel: string;
+  accessibilityLabel?: string | undefined;
   anchor: HTMLElement | null | undefined;
   onDismiss: () => void;
   children?: Node | undefined;
@@ -2023,34 +2024,9 @@ export interface TagProps {
   type?: 'default' | 'error' | 'warning' | undefined;
 }
 
-type ConditionalTapAreaProps =
-  | {
-      href: string;
-      role: 'link';
-      rel?: RelType | undefined;
-      target?: TargetType | undefined;
-      accessibilityCurrent?:
-        | 'page'
-        | 'step'
-        | 'location'
-        | 'date'
-        | 'time'
-        | 'true'
-        | 'false'
-        | 'section';
-    }
-  | {
-      role?: 'button' | 'switch' | undefined;
-      accessibilityChecked?: boolean | undefined;
-      accessibilityControls?: string | undefined;
-      accessibilityExpanded?: boolean | undefined;
-      accessibilityHaspopup?: boolean | undefined;
-      type?: 'submit' | 'button' | undefined;
-    };
-
-type CommonTapAreaProps = {
+interface CommonTapAreaProps {
   accessibilityLabel?: string | undefined;
-  children?: Node | undefined;
+  children: Node;
   disabled?: boolean | undefined;
   fullHeight?: boolean | undefined;
   fullWidth?: boolean | undefined;
@@ -2082,16 +2058,39 @@ type CommonTapAreaProps = {
     | AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>
     | undefined;
   onTap?: TapAreaEventHandlerType | undefined;
-  role?: 'button' | 'link' | undefined;
   rounding?: RoundingType | undefined;
   tabIndex?: -1 | 0 | undefined;
   tapStyle?: 'none' | 'compress' | undefined;
-};
+}
+
+interface TapAreaLinkProps extends CommonTapAreaProps {
+  role: 'link';
+  href: string;
+  rel?: RelType | undefined;
+  target?: TargetType | undefined;
+  accessibilityCurrent?:
+    | 'page'
+    | 'step'
+    | 'location'
+    | 'date'
+    | 'time'
+    | 'true'
+    | 'false'
+    | 'section';
+}
+
+interface TapAreaButtonProps extends CommonTapAreaProps {
+  role?: 'button' | 'switch' | undefined;
+  accessibilityChecked?: boolean | undefined;
+  accessibilityControls?: string | undefined;
+  accessibilityExpanded?: boolean | undefined;
+  accessibilityHaspopup?: boolean | undefined;
+}
 
 /**
  * https://gestalt.pinterest.systems/web/taparea
  */
-export type TapAreaProps = CommonTapAreaProps & ConditionalTapAreaProps;
+export type TapAreaProps = TapAreaLinkProps | TapAreaButtonProps;
 
 /**
  * https://gestalt.pinterest.systems/web/text

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1,45 +1,51 @@
 import React = require('react');
 
 /**
- * Helpers
+ * =========================================================
+ * ====================== SHARED TYPED =====================
+ * =========================================================
  */
 
-export type AbstractEventHandler<T extends React.SyntheticEvent<HTMLElement> | Event, U = {}> = (
+type AbstractEventHandler<T extends React.SyntheticEvent<HTMLElement> | Event, U = {}> = (
   arg: U & {
     readonly event: T;
   },
 ) => void;
-export type ReactForwardRef<T, P> = React.ForwardRefExoticComponent<
+
+type ReactForwardRef<T, P> = React.ForwardRefExoticComponent<
   React.PropsWithoutRef<P> & React.RefAttributes<T>
 >;
 
-export type FourDirections = 'up' | 'right' | 'down' | 'left';
+type FourDirections = 'up' | 'right' | 'down' | 'left';
 
-export type EventHandlerType = (args: { readonly event: React.SyntheticEvent }) => void;
+type TapAreaEventHandlerType = AbstractEventHandler<
+  | React.MouseEvent<HTMLDivElement>
+  | React.KeyboardEvent<HTMLDivElement>
+  | React.MouseEvent<HTMLAnchorElement>
+  | React.KeyboardEvent<HTMLAnchorElement>,
+  { dangerouslydangerouslyDisableOnNavigation?: (() => void) | undefined }
+>;
 
-export interface OnNavigationArgs {
+type ButtonEventHandlerType = AbstractEventHandler<
+  | React.MouseEvent<HTMLButtonElement>
+  | React.MouseEvent<HTMLAnchorElement>
+  | React.KeyboardEvent<HTMLAnchorElement>
+  | React.KeyboardEvent<HTMLButtonElement>,
+  { dangerouslyDisableOnNavigation?: (() => void) | undefined }
+>;
+
+type EventHandlerType = (args: { readonly event: React.SyntheticEvent }) => void;
+
+type OnNavigationType = (args: {
   href: string;
   target?: null | 'self' | 'blank' | undefined;
-}
+}) => EventHandlerType | null | undefined;
 
-export type OnNavigationType = (args: OnNavigationArgs) => EventHandlerType | null | undefined;
-export type UnsignedUpTo12 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
-export type SignedUpTo12 =
-  | -12
-  | -11
-  | -10
-  | -9
-  | -8
-  | -7
-  | -6
-  | -5
-  | -4
-  | -3
-  | -2
-  | -1
-  | UnsignedUpTo12;
+type UnsignedUpTo12 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-export interface BadgeObject {
+type SignedUpTo12 = -12 | -11 | -10 | -9 | -8 | -7 | -6 | -5 | -4 | -3 | -2 | -1 | UnsignedUpTo12;
+
+interface BadgeObject {
   text: string;
   type?:
     | 'info'
@@ -52,6 +58,22 @@ export interface BadgeObject {
     | undefined;
 }
 
+interface OnDismissButtonObject {
+  accessibilityLabel: string;
+  onDismiss: () => void;
+}
+
+interface MaxLength {
+  characterCount: number;
+  errorAccessibilityLabel: string;
+}
+
+/**
+ * =========================================================
+ * ==================== API INTERFACES  ====================
+ * =========================================================
+ */
+
 /**
  * https://gestalt.pinterest.systems/web/activationcard
  */
@@ -60,26 +82,13 @@ export interface ActivationCardProps {
   status: 'notStarted' | 'pending' | 'needsAttention' | 'complete';
   statusMessage: string;
   title: string;
-  dismissButton?:
-    | {
-        accessibilityLabel: string;
-        onDismiss: () => void;
-      }
-    | undefined;
+  dismissButton?: OnDismissButtonObject | undefined;
   link?:
     | {
         accessibilityLabel: string;
         href: string;
         label: string;
-        onClick?:
-          | AbstractEventHandler<
-              | React.MouseEvent<HTMLButtonElement>
-              | React.MouseEvent<HTMLAnchorElement>
-              | React.KeyboardEvent<HTMLAnchorElement>
-              | React.KeyboardEvent<HTMLButtonElement>,
-              { dangerouslyDisableOnNavigation?: (() => void) | undefined }
-            >
-          | undefined;
+        onClick?: ButtonEventHandlerType | undefined;
         rel?: 'none' | 'nofollow' | undefined;
         target?: null | 'self' | 'blank' | undefined;
       }
@@ -104,13 +113,12 @@ export interface AvatarProps {
 export interface AvatarGroupProps {
   accessibilityLabel: string;
   collaborators: ReadonlyArray<{ name: string; src?: string | undefined }>;
-
   accessibilityControls?: string | undefined;
   accessibilityExpanded?: boolean | undefined;
   accessibilityHaspopup?: boolean | undefined;
   addCollaborators?: boolean | undefined;
   href?: string | undefined;
-  onClick?: OnTapType | undefined;
+  onClick?: TapAreaEventHandlerType | undefined;
   role?: 'button' | 'link' | undefined;
   size?: 'xs' | 'sm' | 'md' | 'fit' | undefined;
 }
@@ -153,10 +161,10 @@ export interface BoxProps extends BoxPassthroughProps {
     | 'stretch'
     | undefined;
   alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
   smAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
   mdAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
   lgAlignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
+  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
   as?:
     | 'article'
     | 'aside'
@@ -307,15 +315,7 @@ export interface ButtonProps {
   iconEnd?: Icons | undefined;
   fullWidth?: boolean | undefined;
   name?: string | undefined;
-  onClick?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLButtonElement>
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
-      >
-    | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
   rel?: 'none' | 'nofollow' | undefined;
   role?: 'button' | 'link' | undefined;
   selected?: boolean | undefined;
@@ -337,15 +337,7 @@ export interface ActionData {
   disabled?: boolean;
   href?: string | undefined;
   label: string;
-  onClick?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLAnchorElement>
-        | React.MouseEvent<HTMLButtonElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
-      >
-    | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
   rel?: 'none' | 'nofollow' | undefined;
   target?: null | 'self' | 'blank' | undefined;
 }
@@ -357,12 +349,7 @@ export interface CalloutProps {
   iconAccessibilityLabel: string;
   message: string;
   type: 'error' | 'info' | 'recommendation' | 'success' | 'warning';
-  dismissButton?:
-    | {
-        accessibilityLabel: string;
-        onDismiss: () => void;
-      }
-    | undefined;
+  dismissButton?: OnDismissButtonObject | undefined;
   primaryAction?: ActionData | undefined;
   secondaryAction?: ActionData | undefined;
   title?: string | undefined;
@@ -530,11 +517,6 @@ export interface DefaultLabelProviderProps {
     | undefined;
 }
 
-export interface DropdownOption {
-  label: string;
-  value: string;
-  subtext?: string | undefined;
-}
 /**
  * https://gestalt.pinterest.systems/web/dropdown
  */
@@ -552,6 +534,15 @@ export interface DropdownProps {
   zIndex?: Indexable | undefined;
 }
 
+export interface DropdownOption {
+  label: string;
+  value: string;
+  subtext?: string | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Item
+ */
 export interface DropdownItemProps {
   children?: React.ReactNode;
   onSelect: AbstractEventHandler<
@@ -566,6 +557,9 @@ export interface DropdownItemProps {
   selected?: DropdownOption | ReadonlyArray<DropdownOption> | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Link
+ */
 export interface DropdownLinkProps {
   href: string;
   option: DropdownOption;
@@ -573,17 +567,12 @@ export interface DropdownLinkProps {
   children?: React.ReactNode;
   dataTestId?: string | undefined;
   isExternal?: boolean | undefined;
-  onClick?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLButtonElement>
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLButtonElement>
-        | React.KeyboardEvent<HTMLAnchorElement>,
-        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
-      >
-    | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/dropdown#Dropdown.Section
+ */
 export interface DropdownSectionProps {
   children:
     | React.ReactElement<DropdownItemProps>
@@ -703,17 +692,7 @@ export interface HelpButtonProps {
         target?: null | 'self' | 'blank';
       }
     | undefined;
-  onClick?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLDivElement>
-        | React.KeyboardEvent<HTMLDivElement>
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLAnchorElement>,
-        {
-          dangerouslyDisableOnNavigation: () => void;
-        }
-      >
-    | undefined;
+  onClick?: TapAreaEventHandlerType | undefined;
   text: string | React.ReactElement<typeof Text>;
   zIndex?: Indexable | undefined;
 }
@@ -953,15 +932,7 @@ export interface IconButtonProps {
   href?: string | undefined;
   icon?: Icons | undefined;
   iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary' | undefined;
-  onClick?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLAnchorElement>
-        | React.MouseEvent<HTMLButtonElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
-      >
-    | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
   padding?: 1 | 2 | 3 | 4 | 5 | undefined;
   rel?: 'none' | 'nofollow' | undefined;
   role?: 'button' | 'link' | undefined;
@@ -984,15 +955,7 @@ export interface IconButtonFloatingProps {
   accessibilityPopupRole: 'menu' | 'dialog';
   accessibilityLabel: string;
   icon: Icons;
-  onClick?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLAnchorElement>
-        | React.MouseEvent<HTMLButtonElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
-      >
-    | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
   selected?: boolean | undefined;
 }
 
@@ -1048,10 +1011,6 @@ export interface LetterboxProps {
 /**
  * https://gestalt.pinterest.systems/web/link
  */
-export type ExternalLinkIcon =
-  | 'none'
-  | 'default'
-  | { color: IconProps['color']; size: TextProps['size'] };
 export interface LinkProps {
   href: string;
   accessibilityLabel?: string | undefined;
@@ -1059,7 +1018,11 @@ export interface LinkProps {
   hoverStyle?: 'none' | 'underline' | undefined;
   id?: string | undefined;
   display?: 'inline' | 'inlineBlock' | 'block' | undefined;
-  externalLinkIcon?: ExternalLinkIcon | undefined;
+  externalLinkIcon?:
+    | 'none'
+    | 'default'
+    | { color: IconProps['color']; size: TextProps['size'] }
+    | undefined;
   onBlur?: AbstractEventHandler<React.FocusEvent<HTMLAnchorElement>> | undefined;
   onClick?:
     | AbstractEventHandler<
@@ -1075,15 +1038,21 @@ export interface LinkProps {
   underline?: 'auto' | 'none' | 'always' | 'hover' | undefined;
 }
 
-export interface ListItemProps {
-  text: string | React.ReactElement<typeof Text>;
-}
-
+/**
+ * https://gestalt.pinterest.systems/web/list
+ */
 export interface ListProps {
   label: string | React.ReactElement<typeof Text>;
   labelDisplay?: 'visible' | 'hidden' | undefined;
   spacing?: 'regular' | 'condensed' | undefined;
   type?: 'bare' | 'ordered' | 'unordered' | undefined;
+}
+
+/**
+ * https://gestalt.pinterest.systems/web/list#List.Itemt
+ */
+export interface ListItemProps {
+  text: string | React.ReactElement<typeof Text>;
 }
 
 /**
@@ -1150,10 +1119,6 @@ export interface ModalProps {
   subHeading?: string | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/modalalert
- */
-
 export interface ModalAlertActionDataType {
   accessibilityLabel: string;
   disabled?: boolean | undefined;
@@ -1170,6 +1135,9 @@ export interface ModalAlertActionDataType {
   target?: null | 'self' | 'blank' | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/modalalert
+ */
 export interface ModalAlertProps {
   accessibilityDismissButtonLabel?: string | undefined;
   accessibilityModalLabel: string;
@@ -1254,24 +1222,6 @@ export interface OnLinkNavigationProviderProps {
   onNavigation?: OnNavigationType | undefined;
 }
 
-export interface PageHeaderBadge {
-  text: string;
-  tooltipText?: string | undefined;
-}
-
-export interface PageHeaderHelperIconButton {
-  accessibilityLabel?: string | undefined;
-  accessibilityControls?: string | undefined;
-  accessibilityExpanded?: boolean | undefined;
-  onClick: (args: {
-    event:
-      | React.MouseEvent<HTMLAnchorElement>
-      | React.KeyboardEvent<HTMLAnchorElement>
-      | React.KeyboardEvent<HTMLButtonElement>
-      | React.MouseEvent<HTMLButtonElement>;
-    dangerouslyDisableOnNavigation: () => void;
-  }) => void;
-}
 export interface PageHeaderAction {
   component?:
     | React.ReactElement<
@@ -1288,9 +1238,28 @@ export interface PageHeaderAction {
  */
 export interface PageHeaderProps {
   title: string;
-  badge?: PageHeaderBadge | undefined;
+  badge?:
+    | {
+        text: string;
+        tooltipText?: string | undefined;
+      }
+    | undefined;
   borderStyle?: 'sm' | 'none' | undefined;
-  helperIconButton?: PageHeaderHelperIconButton | undefined;
+  helperIconButton?:
+    | {
+        accessibilityLabel?: string | undefined;
+        accessibilityControls?: string | undefined;
+        accessibilityExpanded?: boolean | undefined;
+        onClick: (args: {
+          event:
+            | React.MouseEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLAnchorElement>
+            | React.KeyboardEvent<HTMLButtonElement>
+            | React.MouseEvent<HTMLButtonElement>;
+          dangerouslyDisableOnNavigation: () => void;
+        }) => void;
+      }
+    | undefined;
   helperLink?: {
     accessibilityLabel: string;
     text: string;
@@ -1341,7 +1310,7 @@ export interface PopoverProps {
   anchor: HTMLElement | null | undefined;
   onDismiss: () => void;
   children?: React.ReactNode | undefined;
-  color?: 'blue' | 'orange' | 'red' | 'white' | 'darkGray' | undefined;
+  color?: 'blue' | 'red' | 'white' | 'darkGray' | undefined;
   id?: string | undefined;
   idealDirection?: FourDirections | undefined;
   positionRelativeToAnchor?: boolean | undefined;
@@ -1370,17 +1339,7 @@ export interface PopoverEducationalProps {
         accessibilityLabel?: string | undefined;
         href?: string | undefined;
         text: string | undefined;
-        onClick?:
-          | AbstractEventHandler<
-              | React.MouseEvent<HTMLButtonElement>
-              | React.MouseEvent<HTMLAnchorElement>
-              | React.KeyboardEvent<HTMLAnchorElement>
-              | React.KeyboardEvent<HTMLButtonElement>,
-              {
-                dangerouslyDisableOnNavigation: () => void;
-              }
-            >
-          | undefined;
+        onClick?: ButtonEventHandlerType | undefined;
         rel?: 'none' | 'nofollow' | undefined;
         target?: null | 'self' | 'blank' | undefined;
       }
@@ -1521,11 +1480,17 @@ export interface SideNaviationProps {
   dismissButton?: { accessibilityLabel?: string; onDismiss: () => void } | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Section
+ */
 export interface SideNavigationSectionProps {
   children: React.ReactNode;
   label: string;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.TopItem
+ */
 export interface SideNavigationTopItemProps {
   active?: 'page' | 'section' | undefined;
   badge?:
@@ -1538,27 +1503,12 @@ export interface SideNavigationTopItemProps {
   href: string;
   icon?: Icons | { __path: string };
   notificationAccessibilityLabel?: string;
-  onClick?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLButtonElement>
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
-      >
-    | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
   label: string;
   primaryAction?:
     | {
         icon?: 'ellipsis' | 'edit' | 'trash-can';
-        onClick?:
-          | AbstractEventHandler<
-              | React.MouseEvent<HTMLButtonElement>
-              | React.MouseEvent<HTMLAnchorElement>
-              | React.KeyboardEvent<HTMLAnchorElement>
-              | React.KeyboardEvent<HTMLButtonElement>
-            >
-          | undefined;
+        onClick?: ButtonEventHandlerType | undefined;
         tooltip: {
           accessibilityLabel?: string | undefined;
           text: string;
@@ -1569,22 +1519,20 @@ export interface SideNavigationTopItemProps {
     | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem
+ */
 export interface SideNavigationNestedItemProps {
   active?: 'page' | 'section' | undefined;
   href: string;
   label: string;
-  onClick?:
-    | AbstractEventHandler<
-        | React.MouseEvent<HTMLButtonElement>
-        | React.MouseEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLAnchorElement>
-        | React.KeyboardEvent<HTMLButtonElement>,
-        { dangerouslyDisableOnNavigation?: (() => void) | undefined }
-      >
-    | undefined;
+  onClick?: ButtonEventHandlerType | undefined;
 }
 
-export interface SideNavigationNestedGroupProps {
+/**
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.Group
+ */
+export interface SideNavigationGroupProps {
   badge?: BadgeProps | undefined;
   children: React.ReactNode;
   counter?: { number: string; accessibilityLabel: string } | undefined;
@@ -1613,18 +1561,22 @@ export interface SideNavigationNestedGroupProps {
     | undefined;
 }
 
-export interface SideNavigationNestedGroup {
+/**
+ * https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedGroup
+ */
+export interface SideNavigationNestedGroupProps {
   children: React.ReactNode;
   display?: 'expandable' | 'static' | undefined;
   label: string;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/overlaypanel
- */
 export type OverlayPanelNodeOrRenderProp =
   | ((prop: { onDismissStart: () => void }) => React.ReactNode)
   | React.ReactNode;
+
+/**
+ * https://gestalt.pinterest.systems/web/overlaypanel
+ */
 export type OnAnimationEndStateType = 'in' | 'out';
 export interface OverlayPanel {
   accessibilityDismissButtonLabel?: string | undefined;
@@ -1671,12 +1623,7 @@ export interface OverlayPanel {
  * https://gestalt.pinterest.systems/web/slimbanner
  */
 export interface SlimBannerProps {
-  dismissButton?:
-    | {
-        accessibilityLabel: string;
-        onDismiss: () => void;
-      }
-    | undefined;
+  dismissButton?: OnDismissButtonObject | undefined;
   primaryAction?:
     | {
         accessibilityLabel: string;
@@ -1736,35 +1683,6 @@ export interface SpinnerProps {
 }
 
 /**
- * https://gestalt.pinterest.systems/web/flex
- */
-export interface FlexProps {
-  alignContent?:
-    | 'start'
-    | 'end'
-    | 'center'
-    | 'between'
-    | 'around'
-    | 'evenly'
-    | 'stretch'
-    | undefined;
-  alignItems?: 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  alignSelf?: 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch' | undefined;
-  children?: React.ReactNode | undefined;
-  fit?: boolean | undefined;
-  flex?: 'grow' | 'shrink' | 'none' | undefined;
-  gap?: UnsignedUpTo12 | undefined;
-  height?: number | string | undefined;
-  justifyContent?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly' | undefined;
-  maxHeight?: number | string | undefined;
-  maxWidth?: number | string | undefined;
-  minHeight?: number | string | undefined;
-  minWidth?: number | string | undefined;
-  width?: number | string | undefined;
-  wrap?: boolean | undefined;
-}
-
-/**
  * https://gestalt.pinterest.systems/web/status
  */
 export interface StatusProps {
@@ -1811,37 +1729,58 @@ export interface TableProps {
   stickyColumns?: number | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.Body
+ */
 export interface TableBodyProps {
   children?: React.ReactNode | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.Cell
+ */
 export interface TableCellProps {
   children?: React.ReactNode | undefined;
   colSpan?: number | undefined;
   rowSpan?: number | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.Footer
+ */
 export interface TableFooterProps {
   children?: React.ReactNode | undefined;
   sticky?: boolean | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.Header
+ */
 export interface TableHeaderProps {
   children?: React.ReactNode | undefined;
   display?: 'tableHeaderGroup' | 'visuallyHidden';
   sticky?: boolean | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.HeaderCell
+ */
 export interface TableHeaderCellProps extends TableCellProps {
   scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
   colSpan?: number;
   rowSpan?: number;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.Row
+ */
 export interface TableRowProps {
   children?: React.ReactNode | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.RowDrawer
+ */
 export interface TableRowDrawerProps {
   children:
     | React.ReactElement<TableCellProps>
@@ -1851,6 +1790,9 @@ export interface TableRowDrawerProps {
   id: string;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.RowExpandable
+ */
 export interface TableRowExpandableProps {
   accessibilityCollapseLabel: string;
   accessibilityExpandLabel: string;
@@ -1868,6 +1810,9 @@ export interface TableRowExpandableProps {
     | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/table#Table.SortableHeaderCell
+ */
 export interface TableSortableHeaderCellProps extends TableHeaderCellProps {
   onSortChange: AbstractEventHandler<
     React.MouseEvent<HTMLTableCellElement> | React.KeyboardEvent<HTMLTableCellElement>
@@ -1909,14 +1854,6 @@ export interface TagProps {
   type?: 'default' | 'error' | 'warning';
 }
 
-export type OnTapType = AbstractEventHandler<
-  | React.MouseEvent<HTMLDivElement>
-  | React.KeyboardEvent<HTMLDivElement>
-  | React.MouseEvent<HTMLAnchorElement>
-  | React.KeyboardEvent<HTMLAnchorElement>,
-  { dangerouslydangerouslyDisableOnNavigation?: (() => void) | undefined }
->;
-
 /**
  * https://gestalt.pinterest.systems/web/taparea
  */
@@ -1951,7 +1888,7 @@ export interface TapAreaProps {
   onMouseLeave?:
     | AbstractEventHandler<React.MouseEvent<HTMLDivElement | HTMLAnchorElement>>
     | undefined;
-  onTap?: OnTapType | undefined;
+  onTap?: TapAreaEventHandlerType | undefined;
   rel?: 'none' | 'nofollow' | undefined;
   role?: 'button' | 'link' | undefined;
   rounding?: 'pill' | 'circle' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | undefined;
@@ -1986,11 +1923,6 @@ export interface TextProps {
   underline?: boolean | undefined;
   weight?: 'bold' | 'normal' | undefined;
   title?: string | undefined;
-}
-
-export interface MaxLength {
-  characterCount: number;
-  errorAccessibilityLabel: string;
 }
 
 /**
@@ -2038,7 +1970,6 @@ export interface TextFieldProps {
     | 'username'
     | undefined;
   disabled?: boolean | undefined;
-
   enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
   errorMessage?: React.ReactNode | undefined;
   helperText?: string | undefined;
@@ -2089,7 +2020,7 @@ export interface ToastProps {
     accessibilityLabel: string;
     href?: string;
     label: string;
-    onClick?: ButtonProps['onClick'] | undefined;
+    onClick?: ButtonEventHandlerType | undefined;
     rel?: LinkProps['rel'] | undefined;
     size?: ButtonProps['size'] | undefined;
     target?: LinkProps['target'] | undefined;
@@ -2121,11 +2052,7 @@ export interface TooltipProps {
 export interface UpsellProps {
   children?: React.ReactElement;
   message: string | React.ReactElement<typeof Text>;
-  dismissButton?:
-    | {
-        accessibilityLabel: string;
-        onDismiss: () => void;
-      }
+  dismissButton?: OnDismissButtonObject
     | undefined;
   imageData?:
     | {
@@ -2144,6 +2071,9 @@ export interface UpsellProps {
   title?: string | undefined;
 }
 
+/**
+ * https://gestalt.pinterest.systems/web/upsell#Upsell.Form
+ */
 export interface UpsellFormProps {
   onSubmit: AbstractEventHandler<
     | React.MouseEvent<HTMLButtonElement>
@@ -2228,15 +2158,12 @@ export interface WashAnimatedProps {
     | undefined;
 }
 
-/**
- * https://gestalt.pinterest.systems/web/cIndexClasses#zindex
- */
 export interface Indexable {
   index(): number;
 }
 
 /**
- * https://gestalt.pinterest.systems/web/cIndexClasses#FixedZIndex
+ * https://gestalt.pinterest.systems/web/zindex_classes#FixedZIndex
  */
 export class FixedZIndex implements Indexable {
   z: number;
@@ -2245,7 +2172,7 @@ export class FixedZIndex implements Indexable {
 }
 
 /**
- * https://gestalt.pinterest.systems/web/cIndexClasses#CompositeZIndex
+ * https://gestalt.pinterest.systems/web/zindex_classes#CompositeZIndex
  */
 export class CompositeZIndex implements Indexable {
   deps: Array<FixedZIndex | CompositeZIndex>;
@@ -2254,7 +2181,9 @@ export class CompositeZIndex implements Indexable {
 }
 
 /**
+ * =========================================================
  * ========================= INDEX =========================
+ * =========================================================
  */
 
 export const ActivationCard: React.FunctionComponent<ActivationCardProps>;
@@ -2395,7 +2324,7 @@ export interface SideNavigationSubcomponents {
   Section: React.FunctionComponent<SideNavigationSectionProps>;
   TopItem: React.FunctionComponent<SideNavigationTopItemProps>;
   NestedItem: React.FunctionComponent<SideNavigationNestedItemProps>;
-  Group: React.FunctionComponent<SideNavigationNestedGroupProps>;
+  Group: React.FunctionComponent<SideNavigationGroupProps>;
   NestedGroup: React.FunctionComponent<SideNavigationNestedGroupProps>;
 }
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://gestalt.pinterest.systems/",
   "description": "A set of React UI components which enforce Pinterest’s design language",
   "main": "dist/gestalt.js",
+  "types": "/dist/index.d.ts",
   "jsnext:main": "dist/gestalt.es.js",
   "module": "dist/gestalt.es.js",
   "style": "dist/gestalt.css",

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://gestalt.pinterest.systems/",
   "description": "A set of React UI components which enforce Pinterest’s design language",
   "main": "dist/gestalt.js",
-  "types": "/dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "jsnext:main": "dist/gestalt.es.js",
   "module": "dist/gestalt.es.js",
   "style": "dist/gestalt.css",

--- a/scripts/templates/README.md
+++ b/scripts/templates/README.md
@@ -73,6 +73,24 @@ Before merging
 
 yarn run flow-generate:css
 
+## Update the TypeScript declaration files
+
+`packages/gestalt/dist/index.d.ts`
+
+Add:
+
+/\*\*
+
+- https://gestalt.pinterest.systems/web/componentname
+  \*/
+  export interface ComponentNameProps {
+  prop: value;
+  prop: value;
+  prop: value;
+  }
+
+export const ComponentName: React.FunctionComponent<ComponentNameProps>;
+
 ## Update all Gestalt packages builds running rollup
 
 yarn build

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "./",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "target": "es6",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "strictFunctionTypes": true,
+    "skipLibCheck": false
+  },
+  "exclude": [
+    "node_modules",
+    "**/*.json" // Don't try and check JSON files
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "allowJs": true,
+    "allowJs": false,
     "baseUrl": "./",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17327,6 +17327,11 @@ typescript@^3.8.3, typescript@^3.9.7:
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
+typescript@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"
+  integrity sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==
+
 ua-parser-js@^1.0.33:
   version "1.0.33"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.33.tgz#f21f01233e90e7ed0f059ceab46eb190ff17f8f4"


### PR DESCRIPTION
### Breaking change

If your app was previously using https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/gestalt or https://www.npmjs.com/package/@types/gestalt, Gestalt now supports TypeScrip declaration files.

They are maintained manually. The types are based on the ones from https://www.npmjs.com/package/@types/gestalt but they were reviewed manually. Many errors were found and they all were corrected.

Please, report if you find any incorrect TypeScript type for any of the components 


### Summary

#### What changed?

Internal:  add TypeScript declaration files

#### Why?

Support Gestalt in apps using TypeScript rather than Flow. 
Internalize ownership of https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/gestalt/index.d.ts for better maintenance

Test 
`yarn tsc` with no issues
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/235802265-6a9988d7-1fc5-4369-a912-c320e4a87023.png)


alpha release in bextools
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/236002998-aa5da2cc-7134-4be8-8e46-ca3863fb399c.png)
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/236003115-672e42d8-9bc2-413e-b997-4eee7e9949e2.png)
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/236008902-5f6a831a-e3c4-44e0-92f8-2ebd33e7f471.png)

