### PR TITLE
Icon: add "briefcase" icon

### DIFF
--- a/docs/pages/foundations/iconography/ICON_DATA.json
+++ b/docs/pages/foundations/iconography/ICON_DATA.json
@@ -267,6 +267,12 @@
       "keywords": ["notifications"]
     },
     {
+      "name": "briefcase",
+      "categories": ["Utility and tools"],
+      "description": "Indicates business manager and business-related tasks",
+      "keywords": ["business manager", "business", "company"]
+    },
+    {
       "name": "calendar",
       "categories": ["Time", "Toggle"],
       "description": "Indicates date selection",

--- a/packages/gestalt/src/icons/briefcase.svg
+++ b/packages/gestalt/src/icons/briefcase.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M6.5 7.5V5A2.5 2.5 0 019 2.5h6A2.5 2.5 0 0117.5 5v2.5H21a2 2 0 012 2v11a2 2 0 01-2 2H3a2 2 0 01-2-2v-11c0-1.1.9-2 2-2zm8 0v-2h-5v2z"/></svg>

--- a/packages/gestalt/src/icons/index.js
+++ b/packages/gestalt/src/icons/index.js
@@ -38,6 +38,7 @@ import arrowUpRight from './arrow-up-right.svg';
 import arrowUp from './arrow-up.svg';
 import bell from './bell.svg';
 import board from './board.svg';
+import briefcase from './briefcase.svg';
 import calendarCheck from './calendar-check.svg';
 import calendar from './calendar.svg';
 import cameraRoll from './camera-roll.svg';
@@ -250,8 +251,9 @@ const icons = Object.freeze({
   'arrow-start': arrowStart,
   'arrow-up': arrowUp,
   'arrow-up-right': arrowUpRight,
-  board,
   bell,
+  board,
+  briefcase,
   calendar,
   'calendar-check': calendarCheck,
   camera,


### PR DESCRIPTION
### Summary

1. New icon for the m10n interface
<img width="200" alt="Screenshot by Dropbox Capture" src="https://user-images.githubusercontent.com/10593890/230697874-8455d7c7-acac-465e-8dc3-d2392fa746a2.png">
<img width="206" alt="Screenshot by Dropbox Capture" src="https://user-images.githubusercontent.com/10593890/230697877-15c3348e-4467-4698-89a9-4d83773fa5ca.png">


#### What changed?

Added the briefcase icon for use in ads as a business manager icon.



#### Why?

A new icon for an alpha release.

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
