### PR TITLE
Internal: add PR title checker action

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,17 @@
+{
+  "LABEL": {
+    "name": "",
+    "color": ""
+  },
+  "CHECKS": {
+    "prefixes": ["Docs: ", "Internal: ", "Version bump: "],
+    "regexp": "^(?=.*(?:ActivationCard|Avatar|AvatarGroup|Badge|Box|Button|ButtonGroup|Callout|Checkbox|Collage|Column|ComboBox|Container|Datapoint|DatePicker|Divider|Dropdown|Fieldset|Flex|Heading|HelpButton|Icon|IconButton|IconButtonFloating|Image|Label|Layer|Letterbox|Link|List|Mask|Masonry|Modal|ModalAlert|Module|NumberField|OverlayPanel|PageHeader|Pog|Popover|PopoverEducational|Pulsar|RadioButton|RadioGroup|SearchField|SegmentedControl|SelectList|SheetMobile|SideNavigation|SlimBanner|Spinner|Status|Sticky|Switch|Table|Tabs|Tag|TapArea|Text|TextArea|TextField|Toast|Tooltip|Upsell|Video|WashAnimated|ZIndex-Classes|ColorSchemeProvider|DefaultLabelProvider|DeviceTypeProvider|OnLinkNavigationProvider|ScrollBoundaryContainer|useFocusVisible|useReducedMotion|Sheet):s.*)+",
+    "regexpFlags": "i",
+    "ignoreLabels": ["dont-check-PRs-with-this-label", "meta"]
+  },
+  "MESSAGES": {
+    "success": "All OK",
+    "failure": "PR title does not match the required format — please check the PR template for more information",
+    "notice": ""
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Thanks for creating a PR! Please follow this template and delete items/sections that are not relevant to your changes, including these instructions.
 
-Please also make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}: Description (mentioning platform if relevant)`
+Please also make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}: Description (mentioning platform if relevant)`, or `{ComponentName}, {OtherComponentName}: Description (mentioning platform if relevant)` if multiple components are affected.
 
 ### Summary
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Thanks for creating a PR! Please follow this template and delete items/sections that are not relevant to your changes, including these instructions.
 
-Please also make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}-{platform}: Description`
+Please also make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}: Description (mentioning platform if relevant)`
 
 ### Summary
 

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,19 @@
+name: "PR Title Checker"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.3.7
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: ".github/pr-title-checker-config.json"


### PR DESCRIPTION
> Please also make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}-{platform}: Description`

Our PR template provides these instructions for formatting PR titles. We currently have a couple of problems with this:
- Enforcement is via code reviewer, which is fallible and easily overlooked. This sort of check can and should be automated.
- This format assumes that each PR only affects one component, which is not a valid assumption. Many PRs touch multiple components. It's noisy and not scalable to include the platform for each component (e.g. "Box-web, Flex-web, Column-web: " is just annoying).

To address these problems, this PR does a couple of things:
- Reverts the PR format to a more simple `{ComponentName}: Description (mentioning platform if relevant)`, or `{ComponentName}, {OtherComponentName}: Description (mentioning platform if relevant)` if multiple components are affected. Given that active component development only happens for web components in this repo (all iOS/Android changes are docs-only), this format fits the primary use case for less noisy/verbose PR titles. It is a bummer to not include the platform in the automated check, but those are not the most frequent PRs. We can address that in the future with a more complex checker that also looks at the codepaths of changed files to see if iOS/Android files were touched.
- Adds [this action](https://github.com/marketplace/actions/pr-title-checker) to automate enforcement of our title format. It's checking for one or more component names (comma-separated with a space), followed by `: `. We'll have to keep the component name list updated as we add/remove/rename components in the library. Other acceptable entries are `Docs: `, `Internal: `, or `Version bump: ` (the last used by the publish script).