### PR TITLE
Internal: Stop generating inline sourcemaps

### DIFF
--- a/packages/eslint-plugin-gestalt/rollup.config.js
+++ b/packages/eslint-plugin-gestalt/rollup.config.js
@@ -11,14 +11,14 @@ const rollupConfig = {
       format: 'umd',
       name: 'eslint-plugin-gestalt',
       exports: 'named',
-      sourcemap: 'inline',
+      sourcemap: false,
     },
     {
       file: 'dist/eslint-plugin-gestalt.es.js',
       format: 'es',
       name: 'eslint-plugin-gestalt',
       exports: 'named',
-      sourcemap: 'inline',
+      sourcemap: false,
     },
   ],
   plugins: [

--- a/packages/gestalt-datepicker/rollup.config.js
+++ b/packages/gestalt-datepicker/rollup.config.js
@@ -16,7 +16,7 @@ const rollupConfig = {
         'react-dom': 'ReactDOM',
         'react-datepicker': 'ReactDatePicker',
       },
-      sourcemap: 'inline',
+      sourcemap: true,
     },
     {
       file: 'dist/gestalt-datepicker.es.js',
@@ -30,7 +30,7 @@ const rollupConfig = {
         'react-dom': 'ReactDOM',
         'react-datepicker': 'ReactDatePicker',
       },
-      sourcemap: 'inline',
+      sourcemap: true,
     },
   ],
   external: ['react', 'classnames/bind', 'classnames', 'react-dom', 'react-datepicker', 'gestalt'],

--- a/packages/gestalt/rollup.config.js
+++ b/packages/gestalt/rollup.config.js
@@ -15,7 +15,7 @@ const rollupConfig = {
         'classnames/bind': 'classnames',
         'react-dom': 'ReactDOM',
       },
-      sourcemap: 'inline',
+      sourcemap: true,
     },
     {
       file: 'dist/gestalt.es.js',
@@ -28,7 +28,7 @@ const rollupConfig = {
         'classnames/bind': 'classnames',
         'react-dom': 'ReactDOM',
       },
-      sourcemap: 'inline',
+      sourcemap: true,
     },
   ],
   external: ['react', 'classnames/bind', 'classnames', 'react-dom'],


### PR DESCRIPTION
### Summary

#### What changed?

Stop generating inline sourcemaps for our dist bundles and generate separate .map files instead.

#### Why?
Our rollup configs are currently configured to generate inline sourcemaps, which means the sourcemap information is added to the generated bundle. This is convenient for development, but horrible for bundle size. Instead, we can change the configuration to generate separate .map files which will still allow consumers to have access to sourcemaps without the bundle size cost

Based on local testing, this should cut down bundle sizes for gestalt and gestalt-datepicker by well over 50%
