### PR TITLE
Internal: upgrade Flow to 0.188.2

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.187.0
+0.188.2
 
 [ignore]
 <PROJECT_ROOT>/packages/gestalt-codemods/.*/__testfixtures__

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-testing-library": "^5.6.0",
     "eslint-plugin-validate-jsx-nesting": "^0.1.0",
-    "flow-bin": "^0.187.0",
+    "flow-bin": "^0.188.2",
     "flow-remove-types": "^2.184.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "28.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8182,10 +8182,10 @@ flatten@^1.0.2:
   resolved "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@^0.187.0:
-  version "0.187.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.187.0.tgz#3a2a0331f926b9ce285d726108f8a9af9158e13e"
-  integrity sha512-f0c3e7D33+xYT7comdqPtckBeSxlaQq+NtckDarGM0LU3ofgDQfMzt0XlyWjL9/8y3QzwwaUdM0JJbI7hTiscA==
+flow-bin@^0.188.2:
+  version "0.188.2"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.188.2.tgz#ddea41323fc50a1997334b0b496af2e27a25a91d"
+  integrity sha512-zvm1bEEj4n3wdsXm+EA49e/CiZ966kLFJpHbheYdr73P/qMzKk25zeoPTRauNHSsKILK0mL+2QadKii/nf+fkw==
 
 flow-parser@0.*:
   version "0.122.0"


### PR DESCRIPTION
[Release notes](https://github.com/facebook/flow/releases/tag/v0.188.2)
This gets us closer to parity with Pinboard. The next few upgrades will be more work — this is as far as we can get without running codemods or making other changes, which we'll address in future PRs.