### PR TITLE
Docs: add support for dark mode and RTL in Sandpack examples

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,7 +125,6 @@ module.exports = {
     'react/sort-comp': OFF,
     'react/state-in-constructor': [ERROR, NEVER],
     'react/static-property-placement': [ERROR, 'static public field'],
-    'testing-library/no-node-access': [ERROR, { 'allowContainerFirstChild': true }],
     'validate-jsx-nesting/no-invalid-jsx-nesting': ERROR,
   },
   'overrides': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,6 +125,7 @@ module.exports = {
     'react/sort-comp': OFF,
     'react/state-in-constructor': [ERROR, NEVER],
     'react/static-property-placement': [ERROR, 'static public field'],
+    'testing-library/no-node-access': [ERROR, { 'allowContainerFirstChild': true }],
     'validate-jsx-nesting/no-invalid-jsx-nesting': ERROR,
   },
   'overrides': [

--- a/docs/docs-components/SandpackExample.js
+++ b/docs/docs-components/SandpackExample.js
@@ -11,6 +11,8 @@ import { Box, Flex } from 'gestalt';
 import { useAppContext } from './appContext.js';
 import clipboardCopy from './clipboardCopy.js';
 import DevelopmentEditor from './DevelopmentEditor.js';
+import CodeExampleDarkModeButton from './buttons/CodeExampleDarkModeButton.js';
+import CodeExampleTextDirectionButton from './buttons/CodeExampleTextDirectionButton.js';
 import CopyCodeButton from './buttons/CopyCodeButton.js';
 import OpenInCodeSandboxButton from './buttons/OpenInCodeSandboxButton.js';
 import ShowHideEditorButton from './buttons/ShowHideEditorButton.js';
@@ -30,20 +32,29 @@ async function copyCode({ code }: {| code: ?string |}) {
 }
 
 function SandpackContainer({
+  exampleColorScheme,
+  exampleTextDirection,
+  hideControls = false,
+  hideEditor = false,
   layout,
   name,
   previewHeight,
-  hideControls = false,
-  hideEditor = false,
+  toggleExampleColorScheme,
+  toggleExampleTextDirection,
 }: {|
+  exampleColorScheme: 'light' | 'dark',
+  exampleTextDirection: 'ltr' | 'rtl',
+  hideControls?: boolean,
+  hideEditor?: boolean,
   layout: 'row' | 'column' | 'mobileRow' | 'mobileColumn',
   name: string,
   previewHeight?: number,
-  hideControls?: boolean,
-  hideEditor?: boolean,
+  toggleExampleColorScheme: () => void,
+  toggleExampleTextDirection: () => void,
 |}) {
   const [editorShown, setEditorShown] = useState(!hideEditor);
   const { sandpack } = useSandpack();
+
   const isMobileRowLayout = layout === 'mobileRow';
   const isMobileColumnLayout = layout === 'mobileColumn';
   let codeEditorHeight = MIN_EDITOR_HEIGHT;
@@ -79,12 +90,13 @@ function SandpackContainer({
           />
           {editorShown && (
             <SandpackCodeEditor
-              wrapContent
+              showTabs={false}
               style={{
                 height: codeEditorHeight,
                 width: '100%',
                 flex: ['mobileColumn', 'column'].includes(layout) ? 'none' : null,
               }}
+              wrapContent
             />
           )}
         </SandpackLayout>
@@ -96,14 +108,17 @@ function SandpackContainer({
       />
       {!hideControls && (
         <Box marginTop={2}>
-          <Flex
-            justifyContent="end"
-            alignItems="center"
-            gap={{
-              row: 2,
-              column: 0,
-            }}
-          >
+          <Flex justifyContent="end" alignItems="center" gap={2}>
+            <CodeExampleDarkModeButton
+              currentMode={exampleColorScheme}
+              onClick={toggleExampleColorScheme}
+            />
+
+            <CodeExampleTextDirectionButton
+              currentTextDirection={exampleTextDirection}
+              onClick={toggleExampleTextDirection}
+            />
+
             <OpenInCodeSandboxButton />
 
             <CopyCodeButton
@@ -141,8 +156,9 @@ export default function SandpackExample({
   hideEditor?: boolean,
 |}): Node {
   const { files } = useLocalFiles();
-
-  const { devExampleMode } = useAppContext();
+  const { colorScheme, devExampleMode, textDirection } = useAppContext();
+  const [exampleColorScheme, setExampleColorScheme] = useState<'light' | 'dark'>(colorScheme);
+  const [exampleTextDirection, setExampleTextDirection] = useState<'ltr' | 'rtl'>(textDirection);
 
   return devExampleMode === 'default' ? (
     <SandpackProvider
@@ -195,7 +211,25 @@ export default function SandpackExample({
             }
           : {}),
         '/App.js': {
-          code: devExampleMode === 'default' ? code : '',
+          code,
+        },
+        '/index.js': {
+          code: `import React, { StrictMode } from "react";
+          import { createRoot } from "react-dom/client";
+          import "./styles.css";
+          import { Box, ColorSchemeProvider } from 'gestalt';
+          import App from "./App";
+
+          const root = createRoot(document.getElementById("root"));
+          root.render(
+            <StrictMode>
+              <ColorSchemeProvider colorScheme="${exampleColorScheme}" fullDimensions>
+                <Box color="default" height="100%" width="100%" dir="${exampleTextDirection}">
+                  <App />
+                </Box>
+              </ColorSchemeProvider>
+            </StrictMode>
+          );`,
         },
       }}
       theme="dark"
@@ -210,11 +244,19 @@ export default function SandpackExample({
       }}
     >
       <SandpackContainer
+        exampleColorScheme={exampleColorScheme}
+        exampleTextDirection={exampleTextDirection}
+        hideControls={hideControls}
+        hideEditor={hideEditor}
         layout={layout}
         name={name}
         previewHeight={previewHeight}
-        hideControls={hideControls}
-        hideEditor={hideEditor}
+        toggleExampleColorScheme={() =>
+          setExampleColorScheme((currVal) => (currVal === 'dark' ? 'light' : 'dark'))
+        }
+        toggleExampleTextDirection={() =>
+          setExampleTextDirection((currVal) => (currVal === 'ltr' ? 'rtl' : 'ltr'))
+        }
       />
     </SandpackProvider>
   ) : (

--- a/docs/docs-components/buttons/CodeExampleDarkModeButton.js
+++ b/docs/docs-components/buttons/CodeExampleDarkModeButton.js
@@ -1,0 +1,32 @@
+// @flow strict
+import { type Node } from 'react';
+import { IconButton } from 'gestalt';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  currentMode: 'light' | 'dark',
+  onClick: () => void,
+|};
+
+export default function CodeExampleDarkModeButton({ currentMode, onClick }: Props): Node {
+  const label = `Toggle ${currentMode === 'dark' ? 'light' : 'dark'} mode for code example`;
+
+  return (
+    <IconButton
+      accessibilityLabel={label}
+      iconColor={currentMode === 'dark' ? 'gray' : 'darkGray'}
+      icon="lightbulb"
+      onClick={() => {
+        trackButtonClick('Toggle dark mode for code example');
+        onClick();
+      }}
+      size="xs"
+      tooltip={{
+        text: label,
+        inline: true,
+        idealDirection: 'up',
+        accessibilityLabel: '',
+      }}
+    />
+  );
+}

--- a/docs/docs-components/buttons/CodeExampleTextDirectionButton.js
+++ b/docs/docs-components/buttons/CodeExampleTextDirectionButton.js
@@ -1,0 +1,35 @@
+// @flow strict
+import { type Node } from 'react';
+import { IconButton } from 'gestalt';
+import trackButtonClick from './trackButtonClick.js';
+
+type Props = {|
+  currentTextDirection: 'ltr' | 'rtl',
+  onClick: () => void,
+|};
+
+export default function CodeExampleTextDirectionButton({
+  currentTextDirection,
+  onClick,
+}: Props): Node {
+  const label = 'Toggle text direction for code example';
+
+  return (
+    <IconButton
+      accessibilityLabel={label}
+      iconColor="darkGray"
+      icon={currentTextDirection === 'ltr' ? 'text-align-right' : 'text-align-left'}
+      onClick={() => {
+        trackButtonClick(label);
+        onClick();
+      }}
+      size="xs"
+      tooltip={{
+        text: label,
+        inline: true,
+        idealDirection: 'up',
+        accessibilityLabel: '',
+      }}
+    />
+  );
+}

--- a/packages/gestalt/src/Layout.css
+++ b/packages/gestalt/src/Layout.css
@@ -326,3 +326,13 @@
 .minWidth60 {
   min-width: 60px;
 }
+
+/* Dimensions */
+
+.fullWidth {
+  width: 100%;
+}
+
+.fullHeight {
+  height: 100%;
+}

--- a/packages/gestalt/src/Layout.css.flow
+++ b/packages/gestalt/src/Layout.css.flow
@@ -20,6 +20,8 @@ declare module.exports: {|
   +'flexGrow': string,
   +'flexNone': string,
   +'flexWrap': string,
+  +'fullHeight': string,
+  +'fullWidth': string,
   +'inline': string,
   +'inlineBlock': string,
   +'inlineFlex': string,

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.js
@@ -8,8 +8,10 @@ import {
   useEffect,
   useState,
 } from 'react';
+import classnames from 'classnames';
 import darkColorDesignTokens from 'gestalt-design-tokens/dist/json/variables-dark.json';
 import lightColorDesignTokens from 'gestalt-design-tokens/dist/json/variables-light.json';
+import layoutStyles from '../Layout.css';
 
 export type ColorScheme = 'light' | 'dark' | 'userPreference';
 
@@ -142,6 +144,10 @@ type Props = {|
    */
   colorScheme?: ColorScheme,
   /**
+   * Sets the dimensions of the outputted `<div>` to 100% width and height.
+   */
+  fullDimensions?: boolean,
+  /**
    * An optional id for your color scheme provider. If not passed in, settings will be applied as globally as possible (ex. setting color scheme variables at :root).
    */
   id?: ?string,
@@ -153,6 +159,7 @@ type Props = {|
 export default function ColorSchemeProvider({
   children,
   colorScheme = 'light',
+  fullDimensions = false,
   id,
 }: Props): Element<typeof ThemeContext.Provider> {
   const [theme, setTheme] = useState(getTheme(colorScheme));
@@ -188,7 +195,14 @@ ${themeToStyles(darkModeTheme)} }
 ${themeToStyles(theme)} }`,
         }}
       />
-      <div className={className}>{children}</div>
+      <div
+        className={classnames(className, {
+          [layoutStyles.fullHeight]: fullDimensions,
+          [layoutStyles.fullWidth]: fullDimensions,
+        })}
+      >
+        {children}
+      </div>
     </ThemeContext.Provider>
   );
 }

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
@@ -12,7 +12,9 @@ describe('ColorSchemeProvider', () => {
     const { container } = render(<ColorSchemeProvider>Child 1</ColorSchemeProvider>);
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('div')).toMatchInlineSnapshot(`
-        <div class="">
+        <div
+          class=""
+        >
           Child 1
         </div>
       `);

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
@@ -10,7 +10,8 @@ function ThemeAwareComponent() {
 describe('ColorSchemeProvider', () => {
   it('renders child content in a div', () => {
     const { container } = render(<ColorSchemeProvider>Child 1</ColorSchemeProvider>);
-    expect(container.firstChild).toMatchInlineSnapshot(`
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('div')).toMatchInlineSnapshot(`
         <div class="">
           Child 1
         </div>
@@ -19,7 +20,7 @@ describe('ColorSchemeProvider', () => {
 
   it('renders styling for light mode when no color scheme specified', () => {
     const { container } = render(<ColorSchemeProvider>Content</ColorSchemeProvider>);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('style')).toMatchSnapshot();
   });
 

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import ColorSchemeProvider, { useColorScheme } from './ColorSchemeProvider.js';
 
 function ThemeAwareComponent() {
@@ -10,71 +10,76 @@ function ThemeAwareComponent() {
 describe('ColorSchemeProvider', () => {
   it('renders child content in a div', () => {
     const { container } = render(<ColorSchemeProvider>Child 1</ColorSchemeProvider>);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
-    expect(container.querySelector('div')).toMatchInlineSnapshot(`
-        <div>
+    expect(container.firstChild).toMatchInlineSnapshot(`
+        <div class="">
           Child 1
         </div>
       `);
   });
+
   it('renders styling for light mode when no color scheme specified', () => {
     const { container } = render(<ColorSchemeProvider>Content</ColorSchemeProvider>);
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
     expect(container.querySelector('style')).toMatchSnapshot();
   });
+
   it('renders styling for light mode when specified', () => {
     const { container } = render(
       <ColorSchemeProvider colorScheme="light">Content</ColorSchemeProvider>,
     );
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('style')).toMatchSnapshot();
   });
+
   it('renders styling for dark mode when specified', () => {
     const { container } = render(
       <ColorSchemeProvider colorScheme="dark">Content</ColorSchemeProvider>,
     );
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('style')).toMatchSnapshot();
   });
+
   it('renders styling with media query when userPreference', () => {
     const { container } = render(
       <ColorSchemeProvider colorScheme="userPreference">Content</ColorSchemeProvider>,
     );
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('style')).toMatchSnapshot();
   });
+
   it('renders styling with a custom class if has an id', () => {
     const { container } = render(<ColorSchemeProvider id="testId">Content</ColorSchemeProvider>);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('.__gestaltThemetestId')).toBeTruthy();
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     expect(container.querySelector('style')).toMatchSnapshot();
   });
 });
+
 describe('useColorScheme', () => {
   it('uses light mode theme when not in theme provider', () => {
-    const { getByText } = render(<ThemeAwareComponent />);
-    // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
-    expect(getByText('lightMode')).toBeTruthy();
+    render(<ThemeAwareComponent />);
+    expect(screen.getByText('lightMode')).toBeTruthy();
   });
+
   it('uses light mode theme when specified', () => {
-    const { getByText } = render(
+    render(
       <ColorSchemeProvider colorScheme="light">
         <ThemeAwareComponent />
       </ColorSchemeProvider>,
     );
-    // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
-    expect(getByText('lightMode')).toBeTruthy();
+    expect(screen.getByText('lightMode')).toBeTruthy();
   });
+
   it('uses dark mode theme when specified', () => {
-    const { getByText } = render(
+    render(
       <ColorSchemeProvider colorScheme="dark">
         <ThemeAwareComponent />
       </ColorSchemeProvider>,
     );
-    // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
-    expect(getByText('darkMode')).toBeTruthy();
+    expect(screen.getByText('darkMode')).toBeTruthy();
   });
+
   it('uses theme based on matchMedia when userPreference', () => {
     let listener = jest.fn();
     window.matchMedia = () => ({
@@ -83,15 +88,13 @@ describe('useColorScheme', () => {
       },
       removeListener: jest.fn(),
     });
-    const { getByText } = render(
+    render(
       <ColorSchemeProvider colorScheme="userPreference">
         <ThemeAwareComponent />
       </ColorSchemeProvider>,
     );
-    // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
-    expect(getByText('lightMode')).toBeTruthy();
+    expect(screen.getByText('lightMode')).toBeTruthy();
     act(() => listener({ matches: true }));
-    // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
-    expect(getByText('darkMode')).toBeTruthy();
+    expect(screen.getByText('darkMode')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Sandpack is awesome overall. But unfortunately due to how it renders examples in iframes, we lose the surrounding app context, most noticeably with dark mode and text direction. However, I've never been happy with needing to toggle dark mode or text direction for the entire site just to see how a single example responds — it's very disorienting, particularly text direction. 

This PR adds a couple of buttons to every Sandpack example (that we show any buttons for) to allow the user to toggle dark mode and text direction on a per-example basis. We track these clicks as with any other, so we can monitor usage. The icons used for text direction seem fine to me. The dark mode ones should be considered temporary; it'd be great to use a 🌞 / 🌚  combo as seen on most other sites.

Note that I needed to add a `fullDimensions` option to ColorSchemeProvider to set height and width to 100%. Since Sandpack only points at the current published version of Gestalt, that change is not reflected in this preview deploy or the screenshots below. But I tested by adding the styles manually to ColorSchemeProvider's div and everything looked great.

_default view_
![Screen Shot 2023-04-14 at 2 48 58 PM](https://user-images.githubusercontent.com/12059539/232161719-74ad909f-24b5-41da-aa85-173c1bb7b610.png)

_dark mode_
![Screen Shot 2023-04-14 at 2 48 40 PM](https://user-images.githubusercontent.com/12059539/232161735-f92e4fdd-6a85-494b-9133-a04b31dbe4a2.png)

_RTL_
![Screen Shot 2023-04-14 at 2 48 49 PM](https://user-images.githubusercontent.com/12059539/232161752-aa30f27c-86be-4ff9-be38-98b2510e5341.png)

_dark mode and RTL_
![Screen Shot 2023-04-14 at 2 49 06 PM](https://user-images.githubusercontent.com/12059539/232161782-ed535be1-20d1-4403-9be8-3f8961deddfc.png)