### PR TITLE
Box, Textfield, TextArea: fixed `visuallyHidden` prop CSS configuration, fixed bug in overflowing `maxLength.errorAccessibilityLabel`

### DIFF
--- a/packages/gestalt/src/Box.css
+++ b/packages/gestalt/src/Box.css
@@ -12,6 +12,7 @@
   clip: rect(0 0 0 0);
   height: 1px;
   margin: -1px;
+  overflow: hidden;
   padding: 0;
   position: absolute;
   white-space: nowrap;


### PR DESCRIPTION
### Summary

#### What changed?

Box, Textfield, TextArea: fixed `visuallyHidden` prop CSS configuration, fixed bug in overflowing `maxLength.errorAccessibilityLabel`

#### Why?

Anything contained within a `visuallyHidden` Box should not overflow, as it creates ghostly empty spaces.


https://jira.pinadmin.com/browse/BUG-158982