### PR TITLE
Masonry: add experimental prop to batch paints

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -240,11 +240,9 @@ export default class MasonryContainer extends Component<Props, State> {
             randomNumberSeed: this.randomNumberSeed,
           });
 
-    setTimeout(() => {
-      this.setState(({ items }) => ({
-        items: [...items, ...newItems],
-      }));
-    }, 2000);
+    this.setState(({ items }) => ({
+      items: [...items, ...newItems],
+    }));
   };
 
   // $FlowFixMe[unclear-type]

--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -21,6 +21,8 @@ import getRandomNumberGenerator from './items-utils/getRandomNumberGenerator.js'
 type Props = {|
   // The actual Masonry component to be used (if using an experimental version of Masonry).
   MasonryComponent: typeof Masonry,
+  // Experimental prop to batch paints of measured items.
+  batchPaints?: boolean,
   // Sets up props to display a collage layout.
   collage?: boolean,
   // Constrains the width of the grid rendering.
@@ -238,9 +240,11 @@ export default class MasonryContainer extends Component<Props, State> {
             randomNumberSeed: this.randomNumberSeed,
           });
 
-    this.setState(({ items }) => ({
-      items: [...items, ...newItems],
-    }));
+    setTimeout(() => {
+      this.setState(({ items }) => ({
+        items: [...items, ...newItems],
+      }));
+    }, 2000);
   };
 
   // $FlowFixMe[unclear-type]
@@ -255,17 +259,18 @@ export default class MasonryContainer extends Component<Props, State> {
   render(): Element<'div'> {
     const {
       MasonryComponent,
-      finiteLength,
-      flexible,
+      batchPaints,
       collage,
       constrained,
       externalCache,
+      finiteLength,
+      flexible,
       measurementStore,
       noScroll,
       offsetTop,
-      virtualize,
-      virtualBoundsTop,
       virtualBoundsBottom,
+      virtualBoundsTop,
+      virtualize,
     } = this.props;
 
     const { hasScrollContainer, mountGrid, items } = this.state;
@@ -322,14 +327,15 @@ export default class MasonryContainer extends Component<Props, State> {
         {mountGrid && (
           // $FlowFixMe[incompatible-exact]
           <MasonryComponent
-            ref={this.gridRef}
-            renderItem={this.renderItem}
+            _batchPaints={batchPaints}
+            columnWidth={columnWidth}
+            gutterWidth={0}
             items={items}
             layout={flexible ? 'flexible' : undefined}
             measurementStore={externalCache ? measurementStore : undefined}
+            ref={this.gridRef}
+            renderItem={this.renderItem}
             virtualize={virtualize}
-            columnWidth={columnWidth}
-            gutterWidth={0}
             {...dynamicGridProps}
           />
         )}

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -61,6 +61,7 @@ export default function TestPage({
 |}): Node {
   const router = useRouter();
   const {
+    batchPaints,
     constrained,
     deferMount,
     externalCache,
@@ -97,6 +98,7 @@ export default function TestPage({
     <ColorSchemeProvider colorScheme="light">
       <MaybeLazyHydrate ssrOnly={ssrOnly}>
         <MasonryContainer
+          batchPaints={booleanize(batchPaints)}
           constrained={booleanize(constrained)}
           externalCache={booleanize(externalCache)}
           finiteLength={booleanize(finiteLength)}

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -543,6 +543,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       const height = positions.length
         ? Math.max(...positions.map((pos) => pos.top + pos.height))
         : 0;
+
       gridBody = (
         <div style={{ width: '100%' }} ref={this.setGridWrapperRef}>
           <div className={styles.Masonry} role="list" style={{ height, width }}>
@@ -553,7 +554,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
               <MeasureItems
                 baseIndex={itemsToRender.length}
                 getPositions={getPositions}
-                items={items}
+                items={itemsToMeasure}
                 measurementStore={measurementStore}
                 renderItem={renderItem}
               />

--- a/packages/gestalt/src/Masonry/MeasureItems.js
+++ b/packages/gestalt/src/Masonry/MeasureItems.js
@@ -1,0 +1,70 @@
+// @flow strict
+import { Fragment, type Node, useLayoutEffect, useMemo } from 'react';
+import { type Cache } from './Cache.js';
+import { type Position } from './types.js';
+
+const layoutNumberToCssDimension = (n) => (n !== Infinity ? n : undefined);
+
+type Props<T> = {|
+  baseIndex: number,
+  getPositions: (items: $ReadOnlyArray<T>) => $ReadOnlyArray<Position>,
+  items: $ReadOnlyArray<T>,
+  measurementStore: Cache<T, number>,
+  renderItem: ({|
+    +data: T,
+    +itemIdx: number,
+    +isMeasuring: boolean,
+  |}) => Node,
+|};
+
+export default function MeasureItems<T>({
+  baseIndex,
+  getPositions,
+  items,
+  measurementStore,
+  renderItem,
+}: Props<T>): Node {
+  const measuringPositions = getPositions(items);
+  const refs = useMemo(() => new Map(), []);
+
+  useLayoutEffect(() => {
+    if (refs.size === items.length) {
+      refs.forEach((el, data) => {
+        measurementStore.set(data, el.clientHeight);
+      });
+    }
+  }, [items.length, measurementStore, refs]);
+
+  return (
+    <Fragment>
+      {items.map((data, i) => {
+        // itemsToMeasure is always the length of minCols, so i will always be 0..minCols.length
+        // we normalize the index here relative to the item list as a whole so that itemIdx is correct
+        // and so that React doesnt reuse the measurement nodes
+        const measurementIndex = baseIndex + i;
+        const position = measuringPositions[i];
+        return (
+          <div
+            key={`measuring-${measurementIndex}`}
+            style={{
+              visibility: 'hidden',
+              position: 'absolute',
+              top: layoutNumberToCssDimension(position.top),
+              left: layoutNumberToCssDimension(position.left),
+              width: layoutNumberToCssDimension(position.width),
+              height: layoutNumberToCssDimension(position.height),
+            }}
+            ref={(el) => {
+              if (el) {
+                // measurementStore.set(data, el.clientHeight);
+                refs.set(data, el);
+              }
+            }}
+          >
+            {renderItem({ data, itemIdx: measurementIndex, isMeasuring: true })}
+          </div>
+        );
+      })}
+    </Fragment>
+  );
+}

--- a/packages/gestalt/src/Masonry/MeasureItems.js
+++ b/packages/gestalt/src/Masonry/MeasureItems.js
@@ -37,12 +37,12 @@ export default function MeasureItems<T>({
 
   return (
     <Fragment>
-      {items.map((data, i) => {
-        // itemsToMeasure is always the length of minCols, so i will always be 0..minCols.length
+      {items.map((data, index) => {
+        // items is always the length of minCols, so index will always be 0..minCols.length
         // we normalize the index here relative to the item list as a whole so that itemIdx is correct
         // and so that React doesnt reuse the measurement nodes
-        const measurementIndex = baseIndex + i;
-        const position = measuringPositions[i];
+        const measurementIndex = baseIndex + index;
+        const position = measuringPositions[index];
         return (
           <div
             key={`measuring-${measurementIndex}`}
@@ -56,7 +56,6 @@ export default function MeasureItems<T>({
             }}
             ref={(el) => {
               if (el) {
-                // measurementStore.set(data, el.clientHeight);
                 refs.set(data, el);
               }
             }}

--- a/packages/gestalt/src/Masonry/MeasureItems.js
+++ b/packages/gestalt/src/Masonry/MeasureItems.js
@@ -3,7 +3,7 @@ import { Fragment, type Node, useLayoutEffect, useMemo } from 'react';
 import { type Cache } from './Cache.js';
 import { type Position } from './types.js';
 
-const layoutNumberToCssDimension = (n) => (n !== Infinity ? n : undefined);
+const layoutNumberToCssDimension = (n: number) => (n !== Infinity ? n : undefined);
 
 type Props<T> = {|
   baseIndex: number,

--- a/packages/gestalt/src/Masonry/MeasureItems.js
+++ b/packages/gestalt/src/Masonry/MeasureItems.js
@@ -26,14 +26,25 @@ export default function MeasureItems<T>({
 }: Props<T>): Node {
   const measuringPositions = getPositions(items);
   const refs = useMemo(() => new Map(), []);
+  // Need a separate variable for use in useLayoutEffect's dependency array
+  const refsSize = refs.size;
 
   useLayoutEffect(() => {
-    if (refs.size === items.length) {
+    // Do we have a full batch of refs?
+    if (refsSize === items.length) {
+      // Measure all the refs
+      const heights = new Map();
       refs.forEach((el, data) => {
-        measurementStore.set(data, el.clientHeight);
+        heights.set(data, el.clientHeight);
       });
+      // Store the measurements, which should trigger a paint
+      heights.forEach((height, data) => {
+        measurementStore.set(data, height);
+      });
+      // We're done with this batch, so clear the way for the next one
+      refs.clear();
     }
-  }, [items.length, measurementStore, refs]);
+  }, [items.length, measurementStore, refs, refsSize]);
 
   return (
     <Fragment>

--- a/playwright/masonry/utils/getServerURL.mjs
+++ b/playwright/masonry/utils/getServerURL.mjs
@@ -12,6 +12,7 @@ const normalizeValue = (val /*: boolean | number */) => {
 
 /*::
 type Options = ?{|
+  batchPaints?: boolean,
   constrained?: boolean,
   deferMount?: boolean,
   externalCache?: boolean,


### PR DESCRIPTION
Currently Masonry measures and paints items sequentially, like
```
measure
paint
measure
paint
measure
paint
```
We're probably going to need to alter this behavior for future 2-col module work. @liuyenwei had the idea to test out that change independent of the modules and algorithm changes, by batching paints. So we'd instead do something like
```
measure
measure
measure
paint
paint
paint
```
in the hope that the browser can batch the paints together, which would be more efficient and performant.

This PR introduces a mechanism to experimentally batch Masonry paints, which we can run immediately to start testing out hypotheses around batching performance.

Preliminary perf output looks promising…
_no batching_
![Screen Shot 2023-04-19 at 3 22 38 PM](https://user-images.githubusercontent.com/12059539/233213160-d681f944-f19e-4efb-90cc-abdcf7f6e007.png)

_batching, reading clientHeight and setting immediately_
![Screen Shot 2023-04-19 at 3 24 28 PM](https://user-images.githubusercontent.com/12059539/233213188-16ec4dbb-d50b-4522-8046-bfc4c6afb1bb.png)

_batching, also batching clientHeight reads_
![Screen Shot 2023-04-19 at 3 28 54 PM](https://user-images.githubusercontent.com/12059539/233213733-04c409c9-e8f6-4e1a-9ad5-f4c6c378e72a.png)

Looking at paints (dark purple): all three begin with a couple of paints, first `Pre-Paint` and then `Layerize`. The non-batched version also has a couple of additional paints, `Recalculate Style` and `Layout`. These additional paints appear not per item, but per set of `minCol` items. Since both versions of batching eliminate these two paints, that's possible indication of a perf win.

Batching clientHeight reads also seems to avoid the (very) tall column of `recursivelyTraverseMutationEffects`/`commitMutationEffectsOnFiber`. I'm not sure if this is something we care about, but it is noticeable in the flame chart.