### PR TITLE
DateField: undoing ._gestalt in DateField.css file as it breaks style

### DIFF
--- a/packages/gestalt-datepicker/src/DateField.css
+++ b/packages/gestalt-datepicker/src/DateField.css
@@ -1,4 +1,4 @@
-:global ._gestalt .MuiDialog-root {
+:global .MuiDialog-root {
   display: none;
 }
 


### PR DESCRIPTION
DateField: undoing ._gestalt in DateField.css file as it breaks style

It didn't work as I expected. I tested it but I guess I didn't get the changes right when I did it.