### PR TITLE
TextField: fix tooltip triggering on icon button

### DIFF
--- a/packages/gestalt/src/TextField/InternalTextFieldIconButton.js
+++ b/packages/gestalt/src/TextField/InternalTextFieldIconButton.js
@@ -8,6 +8,16 @@ import TapArea from '../TapArea.js';
 import Tooltip from '../Tooltip.js';
 import styles from './InternalTextField.css';
 
+function MaybeTooltip({ children, tooltipText }: {| children: Node, tooltipText: ?string |}) {
+  return tooltipText ? (
+    <Tooltip inline text={tooltipText}>
+      {children}
+    </Tooltip>
+  ) : (
+    children
+  );
+}
+
 type Props = {|
   accessibilityChecked?: boolean,
   accessibilityHidden?: boolean,
@@ -35,7 +45,7 @@ export default function InternalTextFieldIconButton({
 }: Props): Node {
   const [focused, setFocused] = useState(false);
 
-  const iconButton = (
+  return (
     // styles.actionButtonContainer is required for RTL positioning
     <div className={classnames(styles.actionButtonContainer)}>
       <Box
@@ -46,41 +56,35 @@ export default function InternalTextFieldIconButton({
         marginEnd={2}
         rounding="circle"
       >
-        <TapArea
-          accessibilityChecked={accessibilityChecked}
-          accessibilityLabel={accessibilityLabel}
-          onBlur={() => setFocused(false)}
-          onFocus={() => setFocused(true)}
-          onKeyDown={({ event }) => {
-            if ([ENTER, SPACE].includes(event.keyCode)) onClick();
-            if (event.keyCode !== TAB) event.preventDefault();
-          }}
-          onMouseEnter={() => setFocused(true)}
-          onMouseLeave={() => setFocused(false)}
-          onTap={onClick}
-          role={role}
-          rounding="circle"
-          tabIndex={accessibilityHidden ? -1 : 0}
-          tapStyle={tapStyle}
-        >
-          <Pog
-            accessibilityLabel=""
-            bgColor={focused && hoverStyle === 'default' ? 'lightGray' : 'transparent'}
-            icon={icon}
-            iconColor="darkGray"
-            padding={pogPadding}
-            size="xs"
-          />
-        </TapArea>
+        <MaybeTooltip tooltipText={tooltipText}>
+          <TapArea
+            accessibilityChecked={accessibilityChecked}
+            accessibilityLabel={accessibilityLabel}
+            onBlur={() => setFocused(false)}
+            onFocus={() => setFocused(true)}
+            onKeyDown={({ event }) => {
+              if ([ENTER, SPACE].includes(event.keyCode)) onClick();
+              if (event.keyCode !== TAB) event.preventDefault();
+            }}
+            onMouseEnter={() => setFocused(true)}
+            onMouseLeave={() => setFocused(false)}
+            onTap={onClick}
+            role={role}
+            rounding="circle"
+            tabIndex={accessibilityHidden ? -1 : 0}
+            tapStyle={tapStyle}
+          >
+            <Pog
+              accessibilityLabel=""
+              bgColor={focused && hoverStyle === 'default' ? 'lightGray' : 'transparent'}
+              icon={icon}
+              iconColor="darkGray"
+              padding={pogPadding}
+              size="xs"
+            />
+          </TapArea>
+        </MaybeTooltip>
       </Box>
     </div>
-  );
-
-  return tooltipText ? (
-    <Tooltip inline text={tooltipText}>
-      {iconButton}
-    </Tooltip>
-  ) : (
-    iconButton
   );
 }


### PR DESCRIPTION
TextField includes margin spacing to the right of the icon button that appears on `type="password"`. This margin is included in the tooltip triggering area, which causes the tooltip to be triggered when the user hovers over the area to the right of the icon button. This can interfere with layouts in certain situations. This PR moves the tooltip triggering area to only enclose the icon button and not the margin as well.

_the margin in question_
![Screen Shot 2023-04-19 at 11 38 53 AM](https://user-images.githubusercontent.com/12059539/233170668-fbe344f3-b377-47e7-838c-45f34c710595.png)

_before_
![Screen Shot 2023-04-19 at 11 40 11 AM](https://user-images.githubusercontent.com/12059539/233170704-4b139ca8-1020-4498-a099-833bddff1336.png)

_after_
![Screen Shot 2023-04-19 at 11 40 57 AM](https://user-images.githubusercontent.com/12059539/233170732-76c0e63c-8f42-429c-a4ed-1f38215b5185.png)