### PR TITLE
Docs: fix outdated/incorrect links

### DIFF
--- a/docs/docs-components/Overview.js
+++ b/docs/docs-components/Overview.js
@@ -48,7 +48,7 @@ export default function Overview({
             name={`${platform} component overview`}
             description={`Gestalt provides an extensive set of React components for use in building larger web experiences and patterns. They include interactive UI components and developer utilities to help with implemention.
 
-Not sure which component to use? [Set up time with the Gestalt team.](/get_started/how_to_work_with_us#Slack-channels)`}
+Not sure which component to use? [Set up time with the Gestalt team.](/team_support/get_help#Slack-channels)`}
             type="guidelines"
           />
         </IllustrationContainer>

--- a/docs/pages/foundations/color/examples.js
+++ b/docs/pages/foundations/color/examples.js
@@ -221,7 +221,7 @@ export default function ColorExamplesPage(): Node {
           <MainSection.Card
             cardSize="md"
             type="don't"
-            description="Apply alternative colors not specified in our color tokens when switching between themes. If a new color value is needed for a specific use case, [let the Gestalt team know](/get_started/how_to_work_with_us#Meetings-and-events) and we will evaluate."
+            description="Apply alternative colors not specified in our color tokens when switching between themes. If a new color value is needed for a specific use case, [let the Gestalt team know](/team_support/get_help#Meetings-and-events) and we will evaluate."
             sandpackExample={
               <SandpackExample
                 code={alternativeColorTokensExample}
@@ -250,7 +250,7 @@ export default function ColorExamplesPage(): Node {
           <MainSection.Card
             cardSize="md"
             type="don't"
-            description="Apply colors and styles not available in our elevation tokens to elevate surfaces as it can create inconsistency, and eye strain. If a different color value is needed for a specific elevation use case, [let the Gestalt team know](/get_started/how_to_work_with_us#Meetings-and-events) and we will assist."
+            description="Apply colors and styles not available in our elevation tokens to elevate surfaces as it can create inconsistency, and eye strain. If a different color value is needed for a specific elevation use case, [let the Gestalt team know](/team_support/get_help#Meetings-and-events) and we will assist."
             sandpackExample={
               <SandpackExample
                 code={invalidElevationExample}

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -228,7 +228,7 @@ export default function IconPage(): Node {
       </Text>
       <Text>
         Need a new icon?{' '}
-        <Link display="inlineBlock" href="/get_started/how_to_work_with_us#Slack-channels">
+        <Link display="inlineBlock" href="/team_support/get_help#Slack-channels">
           Reach out to us
         </Link>
         , and we can evaluate your request.

--- a/docs/pages/foundations/iconography/usage.js
+++ b/docs/pages/foundations/iconography/usage.js
@@ -451,7 +451,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
             </Box>
           </Flex>
           <Box maxWidth={572}>
-            <Markdown text="Please [get in touch](/get_started/how_to_work_with_us#Slack-channels) if you need specific iOS and Android icons guidelines." />
+            <Markdown text="Please [get in touch](/team_support/get_help#Slack-channels) if you need specific iOS and Android icons guidelines." />
           </Box>
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -585,7 +585,7 @@ Generally 16px and 24px icons should be used in mobile interfaces. When icons ar
             </Flex>
           </Box>
           <Box maxWidth={572}>
-            <Markdown text="If you need a new logo set as an icon, [reach out to us](/get_started/how_to_work_with_us#Meetings-and-events), and we will direct you." />
+            <Markdown text="If you need a new logo set as an icon, [reach out to us](/team_support/get_help#Meetings-and-events), and we will direct you." />
           </Box>
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -319,7 +319,7 @@ For external links where an external Gestalt Link doesn't apply, check out [Butt
           columns={2}
           description={`To follow Link design guidelines and [best practices](#Best-practices), \`inline\` and \`underline\` props must be used accordingly. In addition, using Links consistently will ensure a great usability experience.
 
-We recommend showing the underline on the link, at least upon a hover behavior; it will sustain accessibility standards. Only hide the underline if the link element has a different hover behavior (e.g., a color background), and the user can still perceive the element as a link. In that case, it’s always a good idea to test this assumption with users. Reach out to [Gestalt for assistance](/get_started/how_to_work_with_us#Meetings-and-events).
+We recommend showing the underline on the link, at least upon a hover behavior; it will sustain accessibility standards. Only hide the underline if the link element has a different hover behavior (e.g., a color background), and the user can still perceive the element as a link. In that case, it’s always a good idea to test this assumption with users. Reach out to [Gestalt for assistance](/team_support/get_help#Meetings-and-events).
 
 Don’t underline [Text](/web/text) that isn’t a Link, as underline has a strong link affordance.
 

--- a/docs/pages/web/sheetmobile.js
+++ b/docs/pages/web/sheetmobile.js
@@ -360,13 +360,13 @@ When using these render props, just pass the argument \`onDismissStart\` to your
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[Modal](/Modal)**
+**[Modal](/web/modal)**
 Modal displays content that requires user interaction. Modals appear on a layer above the page and therefore block the content underneath, preventing users from interacting with anything else besides the Modal.
 
-**[ModalAlert](/ModalAlert)**
+**[ModalAlert](/web/modalalert)**
 ModalAlert is a simple modal dialog used to alert a user of an issue, or to request confirmation after a user-triggered action.
 
-**[OverlayPanel](/OverlayPanel)**
+**[OverlayPanel](/web/overlaypanel)**
 OverlayPanels are surfaces that allow users to view optional information or complete sub-tasks in a workflow while keeping the context of the current page.
     `}
         />

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -150,7 +150,7 @@ const misc = [
   },
   {
     source: '/get_started/how_to_work_with_us',
-    destination: '/team_support/contributions',
+    destination: '/team_support/overview',
     permanent: true,
   },
   {

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -21,7 +21,7 @@ type Type = 'date' | 'email' | 'password' | 'tel' | 'text' | 'url';
 
 type Props = {|
   /**
-   * Indicate if autocomplete should be available on the input, and the type of autocomplete. Autocomplete values are implemented upon request. [Reach out to the Gestalt team](https://gestalt.pinterest.systems/get_started/how_to_work_with_us#Slack-channels) if you need [additional autocomplete values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values) to be supported.
+   * Indicate if autocomplete should be available on the input, and the type of autocomplete. Autocomplete values are implemented upon request. [Reach out to the Gestalt team](https://gestalt.pinterest.systems/team_support/get_help#Slack-channels) if you need [additional autocomplete values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values) to be supported.
    */
   autoComplete?: 'bday' | 'current-password' | 'email' | 'new-password' | 'on' | 'off' | 'username',
   /**


### PR DESCRIPTION
found from `3xx` and `4xx` results on Algolia crawls