### PR TITLE
TextArea: Add MaxHeight for Rows with Tags

### DIFF
--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -577,7 +577,7 @@ function TextAreaPopoverExample() {
             defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('');
-  const [tags, setTags] = React.useState(['San Francisco', 'New York']);
+  const [tags, setTags] = React.useState(Array(100).fill("New York", 0, 100));
   const ref = React.useRef();
 
   const onChangeTagManagement = ({ value }) => {

--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -645,7 +645,7 @@ function Example(props) {
         <MainSection.Subsection
           title="With rows"
           description={`
-  You can use the rows property to set the max height of the Textarea. It will begin to overflow after the rows limit has been reached`}
+          The rows prop sets the number of rows shown in TextArea. The input will show a scrollbar if the content exceeds the rows limit.`}
         >
           <MainSection.Card
             defaultCode={`          
@@ -655,17 +655,18 @@ const [value, setValue] = React.useState('');
 const [rows, setRows] = React.useState(2);
 
 return (
-  <Box width="100%">
-    <Box marginBottom={2}>
+  <Flex direction="column" width="100%" gap={4}>
+    <Box width={120}>
       <NumberField label="Number of Rows" onChange={({value})=>{setRows(value)}} value={rows}/>
     </Box>
     <TextArea
+      label="Rows example"
       onChange={({value})=>{setValue(value)}}
       placeholder={"this text area has " + rows + " rows"}
       value={value}
       rows={rows}
     />
-  </Box>
+  </Flex>
 );
 }
 `}

--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -577,7 +577,7 @@ function TextAreaPopoverExample() {
             defaultCode={`
 function Example(props) {
   const [value, setValue] = React.useState('');
-  const [tags, setTags] = React.useState(Array(100).fill("New York", 0, 100));
+  const [tags, setTags] = React.useState(['San Francisco', 'New York']);
   const ref = React.useRef();
 
   const onChangeTagManagement = ({ value }) => {

--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -567,17 +567,20 @@ function TextAreaPopoverExample() {
         <MainSection.Subsection
           title="With tags"
           description={`
-    You can include [Tag](/web/tag) elements in the input using the \`tags\` prop.
+    You can include [Tag](/web/tag) elements in the input using the \`tags\` prop. You can use the \`rows\` prop to limit the number of lines for tags.
 
     Note that the \`TextArea\` component does not internally manage tags. That should be handled in the application state through the component's event callbacks. We recommend creating new tags on enter key presses, and removing them on backspaces when the cursor is in the beginning of the field. We also recommend filtering out empty tags.
 
     This example showcases the recommended behavior.`}
         >
           <MainSection.Card
-            defaultCode={`
+            defaultCode={`          
 function Example(props) {
+  
+  const CITIES = ['San Francisco', 'New York']
   const [value, setValue] = React.useState('');
-  const [tags, setTags] = React.useState(['San Francisco', 'New York']);
+  const [tags, setTags] = React.useState(CITIES);
+
   const ref = React.useRef();
 
   const onChangeTagManagement = ({ value }) => {
@@ -634,6 +637,36 @@ function Example(props) {
       />
     </Box>
   );
+}
+`}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="With rows"
+          description={`
+  You can use the rows property to set the max height of the Textarea. It will begin to overflow after the rows limit has been reached`}
+        >
+          <MainSection.Card
+            defaultCode={`          
+function Example(props) {
+
+const [value, setValue] = React.useState('');
+const [rows, setRows] = React.useState(2);
+
+return (
+  <Box width="100%">
+    <Box marginBottom={2}>
+      <NumberField label="Number of Rows" onChange={({value})=>{setRows(value)}} value={rows}/>
+    </Box>
+    <TextArea
+      onChange={({value})=>{setValue(value)}}
+      placeholder={"this text area has " + rows + " rows"}
+      value={value}
+      rows={rows}
+    />
+  </Box>
+);
 }
 `}
           />

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -222,7 +222,6 @@ const TextAreaWithForwardRef: AbstractComponent<Props, HTMLTextAreaElement> = fo
   const tagsWrapperStyle = {
     minHeight: rows * ROW_HEIGHT + INPUT_PADDING_WITH_TAGS,
     maxHeight: rows * ROW_HEIGHT + INPUT_PADDING_WITH_TAGS,
-   
   };
 
   return (

--- a/packages/gestalt/src/TextArea.js
+++ b/packages/gestalt/src/TextArea.js
@@ -221,6 +221,8 @@ const TextAreaWithForwardRef: AbstractComponent<Props, HTMLTextAreaElement> = fo
 
   const tagsWrapperStyle = {
     minHeight: rows * ROW_HEIGHT + INPUT_PADDING_WITH_TAGS,
+    maxHeight: rows * ROW_HEIGHT + INPUT_PADDING_WITH_TAGS,
+   
   };
 
   return (

--- a/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
@@ -252,6 +252,7 @@ exports[`TextArea renders tags when supplied 1`] = `
     className="textArea base enabled normal textAreaWrapper"
     style={
       Object {
+        "maxHeight": 92,
         "minHeight": 92,
       }
     }


### PR DESCRIPTION
### Summary
Set max-height to rows when using Tags with TextArea

#### What changed?

Setting the maxHeight and minHeights to be the same in the TagsWrapper, so an overflow appears.

#### Why?
We have an issue with having too many tags, and not wrapping in the TextArea. This causes the div to grow past the given area. There may be a better design, though this adds consistency to the control in respecting the rows prop

### Links

- [Jira](https://jira.pinadmin.com/secure/RapidBoard.jspa?rapidView=1936&view=planning&selectedIssue=GESTALT-6019&quickFilter=12031&issueLimit=100)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist
- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
