### PR TITLE
PopoverEducational: changing `accessibilityLabel` prop to optional

### DIFF
--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -29,7 +29,7 @@ type PrimaryActionType = {|
 |};
 
 function PrimaryAction({
-  accessibilityLabel = 'Popover',
+  accessibilityLabel,
   href,
   text,
   onClick,
@@ -121,7 +121,7 @@ type Props = {|
  * ![PopoverEducational dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/PopoverEducational-dark.spec.mjs-snapshots/PopoverEducational-dark-chromium-darwin.png)
  */
 export default function PopoverEducational({
-  accessibilityLabel = 'PopoverEducational',
+  accessibilityLabel = 'Popover',
   anchor,
   children,
   id,

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -29,7 +29,7 @@ type PrimaryActionType = {|
 |};
 
 function PrimaryAction({
-  accessibilityLabel,
+  accessibilityLabel = 'Popover',
   href,
   text,
   onClick,
@@ -64,7 +64,7 @@ type Props = {|
   /**
    * Unique label to describe each PopoverEducational. See the [accessibility section](https://gestalt.pinterest.systems/web/popovereducational#ARIA-attributes) for more guidance.
    */
-  accessibilityLabel: string,
+  accessibilityLabel?: string,
   /**
    * The reference element that PopoverEducational uses to set its position.
    */


### PR DESCRIPTION
### Summary

accessibilityLabel is now not a required prop in PopoverEducational

#### Why?

It shouldn't have been required, given in many cases there is no context to define an appropriate specific accessibilityLabel, and a default is provided by the component.

