### PR TITLE
Link, Button, TapArea, IconButton: fix default label to target="blank".

### DIFF
--- a/docs/examples/table/main.js
+++ b/docs/examples/table/main.js
@@ -10,11 +10,6 @@ export default function Example(): Node {
           <Table.Header>
             <Table.Row>
               <Table.HeaderCell>
-                <Box display="visuallyHidden">
-                  <Text weight="bold">Open/Close row</Text>
-                </Box>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
                 <Text weight="bold">Campaign</Text>
               </Table.HeaderCell>
               <Table.HeaderCell>

--- a/packages/gestalt/src/NewTabAccessibilityLabel.js
+++ b/packages/gestalt/src/NewTabAccessibilityLabel.js
@@ -10,7 +10,7 @@ export default function NewTabAccessibilityLabel({
 |}): Node {
   const { accessibilityNewTabLabel } = useDefaultLabelContext('Link');
   return target === 'blank' ? (
-    <Box position="relative">
+    <Box position="relative" dangerouslySetInlineStyle={{ __style: { display: 'inline' } }}>
       <Box display="visuallyHidden">{`; ${accessibilityNewTabLabel}`}</Box>
     </Box>
   ) : null;

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -706,6 +706,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                   </div>
                   <div
                     class="box relative"
+                    style="display: inline;"
                   >
                     <div
                       class="box xsDisplayVisuallyHidden"
@@ -878,6 +879,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                   </div>
                   <div
                     class="box relative"
+                    style="display: inline;"
                   >
                     <div
                       class="box xsDisplayVisuallyHidden"
@@ -954,6 +956,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                   </div>
                   <div
                     class="box relative"
+                    style="display: inline;"
                   >
                     <div
                       class="box xsDisplayVisuallyHidden"

--- a/packages/gestalt/src/__snapshots__/Link.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.js.snap
@@ -164,6 +164,11 @@ exports[`target blank 1`] = `
   Link
   <div
     className="box relative"
+    style={
+      Object {
+        "display": "inline",
+      }
+    }
   >
     <div
       className="box xsDisplayVisuallyHidden"


### PR DESCRIPTION
Link, Button, TapArea, IconButton: fix default label to target="blank".

BEFORE

![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/234420730-71f6fbd1-3a6f-4cf7-bb94-96fee5b33fa3.png)

inline block 
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/234424390-052798b6-3064-4949-9939-80171c0a8b7e.png)
vs inline
![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/234423876-be73bd8a-50d3-467b-b393-143a3642e762.png)


AFTER

![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/234420887-14182954-c336-4d39-90c6-0fcd98859eee.png)
