### PR TITLE
Internal: Create ESLint rule to enforce List usage

### DIFF
--- a/docs/pages/get_started/developers/eslint_plugin.js
+++ b/docs/pages/get_started/developers/eslint_plugin.js
@@ -72,6 +72,13 @@ With AUTOFIX!
       `}
         />
         <MainSection.Subsection
+          title="gestalt/prefer-list"
+          description={`Prevent ul or ol list tags for basic use cases. Suggests using Gestalt List instead.
+
+[Read more about List](/web/list).
+      `}
+        />
+        <MainSection.Subsection
           title="gestalt/prefer-heading"
           description={`Prevent heading tags (h1 ... h6) using Gestalt Heading with the corresponding accessibilityLevel, instead.
 

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-list/invalid/no-gestalt-list-ol.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-list/invalid/no-gestalt-list-ol.js
@@ -1,0 +1,5 @@
+export default function TestElement() {
+  return <ol>
+    <li>Gestalt</li>
+  </ol>;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-list/invalid/no-gestalt-list-ul.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-list/invalid/no-gestalt-list-ul.js
@@ -1,0 +1,5 @@
+export default function TestElement() {
+  return <ul>
+    <li>Gestalt</li>
+  </ul>;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-list/valid/valid.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/prefer-list/valid/valid.js
@@ -1,0 +1,5 @@
+import { List } from 'gestalt';
+
+export default function TestElement() {
+  return <List><List.Item text="Gestalt"/></List>;
+}

--- a/packages/eslint-plugin-gestalt/src/index.js
+++ b/packages/eslint-plugin-gestalt/src/index.js
@@ -15,6 +15,7 @@ import preferBoxNoClassname from './prefer-box-no-disallowed.js';
 import preferFlex from './prefer-flex.js';
 import preferHeading from './prefer-heading.js';
 import preferLink from './prefer-link.js';
+import preferList from './prefer-list.js';
 
 module.exports = {
   rules: {
@@ -33,6 +34,7 @@ module.exports = {
     'prefer-flex': preferFlex,
     'prefer-heading': preferHeading,
     'prefer-link': preferLink,
+    'prefer-list': preferList,
   },
 };
 /* eslint-enable import/no-import-module-exports */

--- a/packages/eslint-plugin-gestalt/src/prefer-list.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-list.js
@@ -13,7 +13,7 @@ const rule: ESLintRule = {
         'Prefer List: Prevent ul or ol list tags for basic use cases. Use Gestalt List, instead',
       category: 'Gestalt alternatives',
       recommended: true,
-      url: 'https://gestalt.pinterest.systems/web/list',
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-list',
     },
     schema: [],
     messages: {
@@ -27,7 +27,7 @@ const rule: ESLintRule = {
         if (node.name.name === 'ul' || node.name.name === 'ol') {
           context.report({
             node,
-            messageId: 'useGestaltList',
+            messageId: 'messageList',
           });
         }
       },

--- a/packages/eslint-plugin-gestalt/src/prefer-list.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-list.js
@@ -13,7 +13,7 @@ const rule: ESLintRule = {
         'Prefer List: Prevent ul or ol list tags for basic use cases. Use Gestalt List, instead',
       category: 'Gestalt alternatives',
       recommended: true,
-      url: '',
+      url: 'https://gestalt.pinterest.systems/web/list',
     },
     schema: [],
     messages: {

--- a/packages/eslint-plugin-gestalt/src/prefer-list.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-list.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Prefer List: Prevent ul or ol list tags for basic use cases.
+ */
+
+// @flow strict
+import { type ESLintRule } from './helpers/eslintFlowTypes.js';
+
+const rule: ESLintRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer List: Prevent ul or ol list tags for basic use cases. Use Gestalt List, instead',
+      category: 'Gestalt alternatives',
+      recommended: true,
+      url: '',
+    },
+    schema: [],
+    messages: {
+      messageList: `Use List from Gestalt, <List><List.Item text=""/></List>\n`,
+    },
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.name === 'ul' || node.name.name === 'ol') {
+          context.report({
+            node,
+            messageId: 'useGestaltList',
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-gestalt/src/prefer-list.test.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-list.test.js
@@ -29,5 +29,5 @@ ruleTester.run('prefer-list', rule, {
   invalid: [
     [noGestaltListOl, messageList],
     [noGestaltListUl, messageList],
-  ].map(([input, output, errors]) => ({ code: input, output, errors })),
+  ].map(([input]) => ({ code: input, errors: [{ messageId: 'messageList' }] })),
 });

--- a/packages/eslint-plugin-gestalt/src/prefer-list.test.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-list.test.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { readFileSync } from 'fs';
+import path from 'path';
+import { RuleTester } from 'eslint';
+import rule from './prefer-list.js';
+import { parserOptions } from './helpers/testHelpers.js';
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const validCode = readFileSync(
+  path.resolve(__dirname, './__fixtures__/prefer-list/valid.js'),
+  'utf-8',
+);
+
+const noGestaltListOl = readFileSync(
+  path.resolve(__dirname, './__fixtures__/prefer-list/invalid/no-gestalt-list-ol.js'),
+  'utf-8',
+);
+
+const noGestaltListUl = readFileSync(
+  path.resolve(__dirname, './__fixtures__/prefer-list/invalid/no-gestalt-list-ul.js'),
+  'utf-8',
+);
+
+const messageList = `Use List from Gestalt, <List><List.Item text=""/></List>\n`;
+
+ruleTester.run('prefer-list', rule, {
+  valid: [{ code: validCode }],
+  invalid: [
+    [noGestaltListOl, messageList],
+    [noGestaltListUl, messageList],
+  ].map(([input, output, errors]) => ({ code: input, output, errors })),
+});

--- a/packages/eslint-plugin-gestalt/src/prefer-list.test.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-list.test.js
@@ -8,7 +8,7 @@ import { parserOptions } from './helpers/testHelpers.js';
 const ruleTester = new RuleTester({ parserOptions });
 
 const validCode = readFileSync(
-  path.resolve(__dirname, './__fixtures__/prefer-list/valid.js'),
+  path.resolve(__dirname, './__fixtures__/prefer-list/valid/valid.js'),
   'utf-8',
 );
 


### PR DESCRIPTION
### Summary

#### What changed?

Created a ESLint rule which prevents ol/ul tag usage and suggests the List component as replacement.

#### Why?

Improve adpotion of the List component in Pinboard. Deprecation of current ol/ul usage cases still pending.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-5612)

### Checklist

- [ Yes ] Added unit and Flow Tests
- [ Yes ] Added documentation + accessibility tests
- [ N/A ] Verified accessibility: keyboard & screen reader interaction
- [ N/A ] Checked dark mode, responsiveness, and right-to-left support
- [ Yes ] Checked stakeholder feedback (e.g. Gestalt designers)
