### PR TITLE
PopoverEducational: fix unresponsive `zIndex` prop

### DIFF
--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -161,7 +161,7 @@ export default function PopoverEducational({
   }
 
   return (
-    <Box zIndex={zIndex}>
+    <Box zIndex={zIndex} position={zIndex ? 'relative' : undefined}>
       <InternalPopover
         accessibilityLabel={accessibilityLabel}
         anchor={anchor}


### PR DESCRIPTION
PopoverEducational: fix unresponsive `zIndex` prop

![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/236504237-f3a18bc5-a32a-4940-af7f-a54d4ce939c5.png)

<img width="1496" alt="Screenshot by Dropbox Capture" src="https://user-images.githubusercontent.com/10593890/236504317-da5a4c92-bcef-4d5e-ab7d-1083adf92028.png">

![Screenshot by Dropbox Capture](https://user-images.githubusercontent.com/10593890/236504883-ec47a076-208f-4d8c-89b8-e027877f07ca.png)
