### PR TITLE
Internal: add test for Masonry scroll performance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     'react',
     'react-hooks',
     'testing-library',
+    'ui-testing',
     'validate-jsx-nesting',
   ],
   'settings': {
@@ -176,6 +177,13 @@ module.exports = {
       'files': ['**/*.flowtest.js'],
       'rules': {
         'no-unused-vars': OFF,
+      },
+    },
+    {
+      'files': ['performance-tests/*.mjs'],
+      'extends': ['plugin:ui-testing/puppeteer'],
+      'rules': {
+        'no-console': OFF,
       },
     },
     {

--- a/flow-typed/npm/puppeteer_v13.x.x.js
+++ b/flow-typed/npm/puppeteer_v13.x.x.js
@@ -1,0 +1,1372 @@
+// @flow
+
+/**
+ * Based on typescript definitions found at the url below
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/puppeteer
+ */
+
+declare module 'puppeteer' {
+  import type { ChildProcess } from 'child_process';
+
+  declare class OverridableEventEmitter extends events$EventEmitter {
+    /* eslint-disable flowtype/no-weak-types */
+    +on: Function;
+    +once: Function;
+    /* eslint-enable flowtype/no-weak-types */
+  }
+
+  /** Keyboard provides an api for managing a virtual keyboard. */
+  declare export type Keyboard = {
+   /**
+    * Dispatches a keydown event.
+    * @param key Name of key to press, such as ArrowLeft.
+    * @param options Specifies a input text event.
+    */
+   down(key: string, options?: { text?: string, ... }): Promise<void>,
+   /** Shortcut for `keyboard.down` and `keyboard.up`. */
+   press(key: string, options?: {
+    delay?: number,
+    text?: string,
+    ...
+   }): Promise<void>,
+   /** Dispatches a `keypress` and `input` event. This does not send a `keydown` or keyup `event`. */
+   sendCharacter(char: string): Promise<void>,
+   /**
+    * Sends a keydown, keypress/input, and keyup event for each character in the text.
+    * @param text A text to type into a focused element.
+    * @param options Specifies the typing options.
+    */
+   type(text: string, options?: { delay?: number, ... }): Promise<void>,
+   /**
+    * Dispatches a keyup event.
+    * @param key Name of key to release, such as ArrowLeft.
+    */
+   up(key: string): Promise<void>,
+   ...
+  };
+
+  declare export type MousePressOptions = {
+   /**
+    * left, right, or middle.
+    * @default left
+    */
+   button?: MouseButtons,
+   /**
+    * The number of clicks.
+    * @default 1
+    */
+   clickCount?: number,
+   ...
+  };
+
+  declare export type Mouse = {
+   /**
+    * Shortcut for `mouse.move`, `mouse.down` and `mouse.up`.
+    * @param x The x position.
+    * @param y The y position.
+    * @param options The click options.
+    */
+   click(x: number, y: number, options?: ClickOptions): Promise<void>,
+   /**
+    * Dispatches a `mousedown` event.
+    * @param options The mouse press options.
+    */
+   down(options?: MousePressOptions): Promise<void>,
+   /**
+    * Dispatches a `mousemove` event.
+    * @param x The x position.
+    * @param y The y position.
+    * @param options The mouse move options.
+    */
+   move(x: number, y: number, options?: { steps: number, ... }): Promise<void>,
+   /**
+    * Dispatches a `mouseup` event.
+    * @param options The mouse press options.
+    */
+   up(options?: MousePressOptions): Promise<void>,
+   ...
+  };
+
+  declare export type Touchscreen = { /**
+   * Dispatches a touchstart and touchend event.
+   * @param x The x position.
+   * @param y The y position.
+   */
+  tap(x: number, y: number): Promise<void>, ... };
+
+  /**
+   * You can use `tracing.start` and `tracing.stop` to create a trace file which can be opened in Chrome DevTools or timeline viewer.
+   */
+  declare export type Tracing = {
+   start(options: TracingStartOptions): Promise<void>,
+   stop(): Promise<void>,
+   ...
+  };
+
+  declare export type TracingStartOptions = {
+   categories?: Array<string>,
+   path: string,
+   screenshots?: boolean,
+   ...
+  };
+
+  /** Dialog objects are dispatched by page via the 'dialog' event. */
+  declare export type Dialog = {
+   /**
+    * Accepts the dialog.
+    * @param promptText A text to enter in prompt. Does not cause any effects if the dialog's type is not prompt.
+    */
+   accept(promptText?: string): Promise<void>,
+   /** If dialog is prompt, returns default prompt value. Otherwise, returns empty string. */
+   defaultValue(): string,
+   /** Dismiss the dialog */
+   dismiss(): Promise<void>,
+   /** Returns the message displayed in the dialog. */
+   message(): string,
+   /** The dialog type. Dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prompt`. */
+   type(): 'alert' | 'beforeunload' | 'confirm' | 'prompt',
+   ...
+  };
+
+  /** ConsoleMessage objects are dispatched by page via the 'console' event. */
+  declare export type ConsoleMessage = {
+   /** The message arguments. */
+   args(): Array<JSHandle>,
+   /** The message text. */
+   text(): string,
+   type():
+     | 'log'
+     | 'debug'
+     | 'info'
+     | 'error'
+     | 'warning'
+     | 'dir'
+     | 'dirxml'
+     | 'table'
+     | 'trace'
+     | 'clear'
+     | 'startGroup'
+     | 'startGroupCollapsed'
+     | 'endGroup'
+     | 'assert'
+     | 'profile'
+     | 'profileEnd'
+     | 'count'
+     | 'timeEnd',
+   ...
+  };
+
+  declare export type PageEvents =
+    | 'console'
+    | 'dialog'
+    | 'error'
+    | 'frameattached'
+    | 'framedetached'
+    | 'framenavigated'
+    | 'load'
+    | 'pageerror'
+    | 'request'
+    | 'requestfailed'
+    | 'requestfinished'
+    | 'response';
+
+  declare export type BrowserEvents =
+    | 'disconnected'
+    | 'targetchanged'
+    | 'targetcreated'
+    | 'targetdestroyed';
+
+  declare export type AuthOptions = {
+   password: string,
+   username: string,
+   ...
+  };
+
+  declare export type MouseButtons = 'left' | 'right' | 'middle';
+
+  declare export type ClickOptions = {
+   /** defaults to left */
+   button?: MouseButtons,
+   /** defaults to 1 */
+   clickCount?: number,
+   /**
+    * Time to wait between mousedown and mouseup in milliseconds.
+    * Defaults to 0.
+    */
+   delay?: number,
+   ...
+  };
+
+  /** Represents a browser cookie. */
+  declare export type Cookie = {
+   /** The cookie domain. */
+   domain: string,
+   /** The cookie Unix expiration time in seconds. */
+   expires: number,
+   /** The cookie http only flag. */
+   httpOnly: boolean,
+   /** The cookie name. */
+   name: string,
+   /** The cookie path. */
+   path: string,
+   /** The cookie same site definition. */
+   sameSite: 'Strict' | 'Lax',
+   /** The cookie secure flag. */
+   secure: boolean,
+   /** The cookie value. */
+   value: string,
+   ...
+  };
+
+  declare export type DeleteCookie = {
+   domain?: string,
+   /** The cookie name. */
+   name: string,
+   path?: string,
+   secure?: boolean,
+   url?: string,
+   ...
+  };
+
+  declare export type SetCookie = {
+   /** The cookie domain. */
+   domain?: string,
+   /** The cookie Unix expiration time in seconds. */
+   expires?: number,
+   /** The cookie http only flag. */
+   httpOnly?: boolean,
+   /** The cookie name. */
+   name: string,
+   /** The cookie path. */
+   path?: string,
+   /** The cookie same site definition. */
+   sameSite?: 'Strict' | 'Lax',
+   /** The cookie secure flag. */
+   secure?: boolean,
+   /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. */
+   url?: string,
+   /** The cookie value. */
+   value: string,
+   ...
+  };
+
+  declare export type Viewport = {
+   /**
+    * Specify device scale factor (can be thought of as dpr).
+    * @default 1
+    */
+   deviceScaleFactor?: number,
+   /**
+    * Specifies if viewport supports touch events.
+    * @default false
+    */
+   hasTouch?: boolean,
+   /** The page height in pixels. */
+   height: number,
+   /**
+    * Specifies if viewport is in landscape mode.
+    * @default false
+    */
+   isLandscape?: boolean,
+   /**
+    * Whether the `meta viewport` tag is taken into account.
+    * @default false
+    */
+   isMobile?: boolean,
+   /** The page width in pixels. */
+   width: number,
+   ...
+  };
+
+  /** Page emulation options. */
+  declare export type EmulateOptions = {
+   /** The emulated user-agent. */
+   userAgent?: string,
+   /** The viewport emulation options. */
+   viewport?: Viewport,
+   ...
+  };
+
+  declare export type EvaluateFn = string | ((...args: Array<mixed>) => mixed);
+
+  declare export type LoadEvent = 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
+
+  /** The navigation options. */
+  declare export type NavigationOptions = {
+   /**
+    * Maximum navigation time in milliseconds, pass 0 to disable timeout.
+    * @default 30000
+    */
+   timeout?: number,
+   /**
+    * When to consider navigation succeeded.
+    * @default load Navigation is consider when the `load` event is fired.
+    */
+   waitUntil?: LoadEvent | Array<LoadEvent>,
+   ...
+  };
+
+  declare export type PDFFormat =
+    | 'Letter'
+    | 'Legal'
+    | 'Tabload'
+    | 'Ledger'
+    | 'A0'
+    | 'A1'
+    | 'A2'
+    | 'A3'
+    | 'A4'
+    | 'A5';
+
+  declare export type PDFOptions = {
+   /**
+    * Display header and footer.
+    * @default false
+    */
+   displayHeaderFooter?: boolean,
+   /**
+    * HTML template for the print footer. Should be valid HTML markup with following classes used to inject printing values into them:
+    * - `date` formatted print date
+    * - `title` document title
+    * - `url` document location
+    * - `pageNumber` current page number
+    * - `totalPages` total pages in the document
+    */
+   footerTemplate?: string,
+   /** Paper format. If set, takes priority over width or height options. Defaults to 'Letter'. */
+   format?: PDFFormat,
+   /**
+    * HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
+    * - `date` formatted print date
+    * - `title` document title
+    * - `url` document location
+    * - `pageNumber` current page number
+    * - `totalPages` total pages in the document
+    */
+   headerTemplate?: string,
+   /** Paper height, accepts values labeled with units. */
+   height?: string,
+   /**
+    * Paper orientation.
+    * @default false
+    */
+   landscape?: boolean,
+   /** Paper margins, defaults to none.  */
+   margin?: {
+    /** Bottom margin, accepts values labeled with units. */
+    bottom?: string,
+    /** Left margin, accepts values labeled with units. */
+    left?: string,
+    /** Right margin, accepts values labeled with units. */
+    right?: string,
+    /** Top margin, accepts values labeled with units. */
+    top?: string,
+    ...
+   },
+   /**
+    * Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty
+    * string, which means print all pages.
+    */
+   pageRanges?: string,
+   /**
+    * The file path to save the PDF to.
+    * If `path` is a relative path, then it is resolved relative to current working directory.
+    * If no path is provided, the PDF won't be saved to the disk.
+    */
+   path?: string,
+   /**
+    * Print background graphics.
+    * @default false
+    */
+   printBackground?: boolean,
+   /**
+    * Scale of the webpage rendering.
+    * @default 1
+    */
+   scale?: number,
+   /** Paper width, accepts values labeled with units. */
+   width?: string,
+   ...
+  };
+
+  /** Defines the screenshot options. */
+  declare export type ScreenshotOptions = {
+   /**
+    * An object which specifies clipping region of the page.
+    */
+   clip?: BoundingBox,
+   /**
+    * When true, takes a screenshot of the full scrollable page.
+    * @default false
+    */
+   fullPage?: boolean,
+   /**
+    * Hides default white background and allows capturing screenshots with transparency.
+    * @default false
+    */
+   omitBackground?: boolean,
+   /**
+    * The file path to save the image to. The screenshot type will be inferred from file extension.
+    * If `path` is a relative path, then it is resolved relative to current working directory.
+    * If no path is provided, the image won't be saved to the disk.
+    */
+   path?: string,
+   /** The quality of the image, between 0-100. Not applicable to png images. */
+   quality?: number,
+   /**
+    * The screenshot type.
+    * @default png
+    */
+   type?: 'jpeg' | 'png',
+   ...
+  };
+
+  /** Options for `addStyleTag` */
+  declare export type StyleTagOptions = {
+   /** Raw CSS content to be injected into frame. */
+   content?: string,
+   /** Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
+   path?: string,
+   /** Url of the <link> tag. */
+   url?: string,
+   ...
+  };
+  /** Options for `addScriptTag` */
+  declare export type ScriptTagOptions = {
+   /** Raw JavaScript content to be injected into frame. */
+   content?: string,
+   /** Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to current working directory. */
+   path?: string,
+   /** Script type. Use 'module' in order to load a Javascript ES6 module. */
+   type?: string,
+   /** Url of a script to be added. */
+   url?: string,
+   ...
+  };
+
+  declare export type PageFnOptions = {
+   polling?: 'raf' | 'mutation' | number,
+   timeout?: number,
+   ...
+  };
+
+  declare export type BoundingBox = {
+   /** The height. */
+   height: number,
+   /** The width. */
+   width: number,
+   /** The x-coordinate of top-left corner. */
+   x: number,
+   /** The y-coordinate of top-left corner. */
+   y: number,
+   ...
+  };
+
+  /**
+   * Represents an in-page DOM element. ElementHandles can be created with the page.$ method.
+   */
+  declare export type ElementHandle = JSHandle & {
+   /**
+    * The method runs element.querySelector within the page. If no element matches the selector, the return value resolve to null.
+    * @param selector A selector to query element for
+    * @since 0.13.0
+    */
+   $(selector: string): Promise<ElementHandle | null>,
+   /**
+    * The method runs element.querySelectorAll within the page. If no elements match the selector, the return value resolve to [].
+    * @param selector A selector to query element for
+    * @since 0.13.0
+    */
+   $$(selector: string): Promise<Array<ElementHandle>>,
+   /**
+    * @param selector XPath expression to evaluate.
+    */
+   $x(expression: string): Promise<Array<ElementHandle>>,
+   /**
+    * This method returns the value resolve to the bounding box of the element (relative to the main frame), or null if the element is not visible.
+    */
+   boundingBox(): Promise<BoundingBox | null>,
+   /**
+    * This method scrolls element into view if needed, and then uses page.mouse to click in the center of the element.
+    * If the element is detached from DOM, the method throws an error.
+    * @param options Specifies the options.
+    * @since 0.9.0
+    */
+   click(options?: ClickOptions): Promise<void>,
+   /**
+    * @returns Resolves to the content frame for element handles referencing iframe nodes, or null otherwise.
+    * @since 1.2.0
+    */
+   contentFrame(): Promise<?Frame>,
+   /**
+    * Calls focus on the element.
+    */
+   focus(): Promise<void>,
+   /**
+    * This method scrolls element into view if needed, and then uses page.mouse to hover over the center of the element.
+    * If the element is detached from DOM, the method throws an error.
+    */
+   hover(): Promise<void>,
+   /**
+    * Focuses the element, and then uses keyboard.down and keyboard.up.
+    * @param key Name of key to press, such as ArrowLeft. See USKeyboardLayout for a list of all key names.
+    * @param options The text and delay options.
+    */
+   press(key: string, options?: {
+    delay?: number,
+    text?: string,
+    ...
+   }): Promise<void>,
+   /**
+    * This method scrolls element into view if needed, and then uses page.screenshot to take a screenshot of the element.
+    * If the element is detached from DOM, the method throws an error.
+    * @param options Same options as in page.screenshot.
+    */
+   screenshot(options?: ScreenshotOptions): Promise<Buffer>,
+   /**
+    * This method scrolls element into view if needed, and then uses touchscreen.tap to tap in the center of the element.
+    * If the element is detached from DOM, the method throws an error.
+    */
+   tap(): Promise<void>,
+   toString(): string,
+   /**
+    * Focuses the element, and then sends a keydown, keypress/input, and keyup event for each character in the text.
+    * @param text A text to type into a focused element.
+    * @param options The typing options.
+    */
+   type(text: string, options?: { delay: number, ... }): Promise<void>,
+   /**
+    * This method expects elementHandle to point to an input element.
+    * @param filePaths Sets the value of the file input these paths. If some of the filePaths are relative paths, then they are resolved relative to current working directory.
+    */
+   uploadFile(...filePaths: Array<string>): Promise<void>,
+   ...
+  };
+
+  /** The class represents a context for JavaScript execution. */
+  declare export type ExecutionContext = {
+   evaluate(fn: EvaluateFn, ...args: Array<mixed>): Promise<mixed>,
+   evaluateHandle(fn: EvaluateFn, ...args: Array<mixed>): Promise<JSHandle>,
+   queryObjects(prototypeHandle: JSHandle): JSHandle,
+   ...
+  };
+
+  /** JSHandle represents an in-page JavaScript object. */
+  declare export type JSHandle = {
+   /**
+    * Returns a ElementHandle
+    */
+   asElement(): ElementHandle | null,
+   /**
+    * Stops referencing the element handle.
+    */
+   dispose(): Promise<void>,
+   /**
+    * Gets the execution context.
+    */
+   executionContext(): ExecutionContext,
+   /**
+    * Returns a map with property names as keys and JSHandle instances for the property values.
+    */
+   getProperties(): Promise<Map<string, JSHandle>>,
+   /**
+    * Fetches a single property from the objectHandle.
+    * @param propertyName The property to get.
+    */
+   getProperty(propertyName: string): Promise<JSHandle>,
+   /**
+    * Returns a JSON representation of the object.
+    * The JSON is generated by running JSON.stringify on the object in page and consequent JSON.parse in puppeteer.
+    * @throws The method will throw if the referenced object is not stringifiable.
+    */
+   jsonValue(): Promise<mixed>,
+   ...
+  };
+
+  declare export type Metrics = {
+   /** Number of documents in the page. */
+   Documents: number,
+   /** Number of frames in the page. */
+   Frames: number,
+   /** Number of events in the page. */
+   JSEventListeners: number,
+   /** Total JavaScript heap size. */
+   JSHeapTotalSize: number,
+   /** Used JavaScript heap size. */
+   JSHeapUsedSize: number,
+   /** Total number of full or partial page layout. */
+   LayoutCount: number,
+   /** Combined durations of all page layouts. */
+   LayoutDuration: number,
+   /** Number of DOM nodes in the page. */
+   Nodes: number,
+   /** Total number of page style recalculations. */
+   RecalcStyleCount: number,
+   /** Combined duration of all page style recalculations. */
+   RecalcStyleDuration: number,
+   /** Combined duration of JavaScript execution. */
+   ScriptDuration: number,
+   /** Combined duration of all tasks performed by the browser. */
+   TaskDuration: number,
+   /** The timestamp when the metrics sample was taken. */
+   Timestamp: number,
+   ...
+  };
+
+  declare export type Headers = { [key: string]: string, ... };
+  declare export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE' | 'OPTIONS';
+
+  declare export type ResourceType =
+    | 'document'
+    | 'stylesheet'
+    | 'image'
+    | 'media'
+    | 'font'
+    | 'script'
+    | 'texttrack'
+    | 'xhr'
+    | 'fetch'
+    | 'eventsource'
+    | 'websocket'
+    | 'manifest'
+    | 'other';
+
+  declare export type Overrides = {
+   headers?: Headers,
+   method?: HttpMethod,
+   postData?: string,
+   url?: string,
+   ...
+  };
+
+  /** Represents a page request. */
+  declare export type Request = {
+   /**
+    * Aborts request.
+    * To use this, request interception should be enabled with `page.setRequestInterception`.
+    * @throws An exception is immediately thrown if the request interception is not enabled.
+    */
+   abort(): Promise<void>,
+   /**
+    * Continues request with optional request overrides.
+    * To use this, request interception should be enabled with `page.setRequestInterception`.
+    * @throws An exception is immediately thrown if the request interception is not enabled.
+    */
+   continue(overrides?: Overrides): Promise<void>,
+   /**
+    * @returns The `Frame` object that initiated the request, or `null` if navigating to error pages
+    */
+   frame(): Promise<?Frame>,
+   /**
+    * An object with HTTP headers associated with the request.
+    * All header names are lower-case.
+    */
+   headers(): Headers,
+   /** Returns the request's method (GET, POST, etc.) */
+
+   method(): HttpMethod,
+   /** Contains the request's post body, if any. */
+   postData(): ?string,
+   /**
+    * A `redirectChain` is a chain of requests initiated to fetch a resource.
+    *
+    * - If there are no redirects and the request was successful, the chain will be empty.
+    * - If a server responds with at least a single redirect, then the chain will contain all the requests that were redirected.
+    *
+    * `redirectChain` is shared between all the requests of the same chain.
+    *
+    * @since 1.2.0
+    */
+   redirectChain(): Array<Request>,
+   /** Contains the request's resource type as it was perceived by the rendering engine.  */
+   resourceType(): ResourceType,
+   /**
+    * Fulfills request with given response.
+    * To use this, request interception should be enabled with `page.setRequestInterception`.
+    * @throws An exception is immediately thrown if the request interception is not enabled.
+    * @param response The response options that will fulfill this request.
+    */
+   respond(response: RespondOptions): Promise<void>,
+   /** A matching `Response` object, or `null` if the response has not been received yet. */
+   response(): ?Response,
+   /** Contains the URL of the request. */
+   url(): string,
+   ...
+  };
+
+  /** Options for `Request.respond` method */
+  declare export type RespondOptions = {
+   /** Specifies the response body. */
+   body?: Buffer | string,
+   /** Specifies the Content-Type response header. */
+   contentType?: string,
+   /** Specifies the response headers. */
+   headers?: Headers,
+   /**
+    * Specifies the response status code.
+    * @default 200
+    */
+   status?: number,
+   ...
+  };
+
+  /** Response class represents responses which are received by page. */
+  declare export type Response = {
+   /** Promise which resolves to a buffer with response body. */
+   buffer(): Promise<Buffer>,
+   /** True if the response was served from either the browser's disk cache or memory cache. */
+   fromCache(): boolean,
+   /** True if the response was served by a service worker. */
+   fromServiceWorker(): boolean,
+   /** An object with HTTP headers associated with the response. All header names are lower-case. */
+   headers(): Headers,
+   /**
+    * Promise which resolves to a JSON representation of response body.
+    * @throws This method will throw if the response body is not parsable via `JSON.parse`.
+    */
+   json(): Promise<mixed>,
+   /** Contains a boolean stating whether the response was successful (status in the range 200-299) or not. */
+   ok(): boolean,
+   /** A matching Request object. */
+   request(): Request,
+   /** Contains the status code of the response (e.g., 200 for a success). */
+   status(): number,
+   /** Promise which resolves to a text representation of response body. */
+   text(): Promise<string>,
+   /** Contains the URL of the response. */
+   url(): string,
+   ...
+  };
+
+  declare class FrameBase {
+    /**
+     * The method runs document.querySelector within the page.
+     * If no element matches the selector, the return value resolve to null.
+     */
+    $: (selector: string) => Promise<?ElementHandle>;
+
+    /**
+     * The method runs document.querySelectorAll within the page. If no elements match the selector, the return value resolve to [].
+     */
+    $$: (selector: string) => Promise<Array<ElementHandle>>;
+
+    /**
+     * This method runs document.querySelectorAll within the page and passes it as the first argument to `fn`.
+     * If `fn` returns a Promise, then $$eval would wait for the promise to resolve and return its value.
+     * @param selector A selector to query frame for
+     * @param fn Function to be evaluated in browser context
+     * @param args Arguments to pass to pageFunction
+     * @returns Promise which resolves to the return value of pageFunction
+     */
+    $$eval: (
+      selector: string,
+      pageFunction: (
+        elements: NodeList<Element>,
+        ...args: Array<mixed>
+      ) => mixed,
+      ...args: Array<mixed>
+    ) => Promise<mixed>;
+
+    /**
+     * This method runs document.querySelector within the page and passes it as the first argument to `fn`.
+     * If there's no element matching selector, the method throws an error.
+     * If `fn` returns a Promise, then $eval would wait for the promise to resolve and return its value.
+     */
+    $eval: (
+      selector: string,
+      pageFunction: (element: Element, ...args: Array<mixed>) => mixed,
+      ...args: Array<mixed>
+    ) => Promise<mixed>;
+
+    /**
+     * @param expression XPath expression to evaluate.
+     */
+    $x: (expression: string) => Promise<Array<ElementHandle>>;
+
+    /** Adds a `<script>` tag into the page with the desired url or content. */
+    addScriptTag: (options: ScriptTagOptions) => Promise<void>;
+
+    /** Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the content. */
+    addStyleTag: (options: StyleTagOptions) => Promise<void>;
+
+    /** Gets the full HTML contents of the page, including the doctype. */
+    content: () => Promise<string>;
+
+    /**
+     * Evaluates a function in the browser context.
+     * If the function, passed to the frame.evaluate, returns a Promise, then frame.evaluate would wait for the promise to resolve and return its value.
+     * If the function passed into frame.evaluate returns a non-Serializable value, then frame.evaluate resolves to undefined.
+     * @param fn Function to be evaluated in browser context
+     * @param args Arguments to pass to `fn`
+     */
+    evaluate: (fn: EvaluateFn, ...args: Array<mixed>) => Promise<mixed>;
+
+    /**
+     * Sets the page content.
+     * @param html HTML markup to assign to the page.
+     */
+    setContent: (html: string) => Promise<void>;
+
+    /** Returns page's title. */
+    +title: () => Promise<string>;
+
+    /** Returns frame's url. */
+    +url: () => string;
+
+    waitFor: (
+      // fn can be an abritary function
+      // eslint-disable-next-line flowtype/no-weak-types
+      selectorOrFunctionOrTimeout: string | number | Function,
+      options?: mixed,
+      ...args: Array<mixed>
+    ) => Promise<mixed>;
+
+    waitForFunction: (
+      // fn can be an abritary function
+      // eslint-disable-next-line flowtype/no-weak-types
+      fn: string | Function,
+      options?: PageFnOptions,
+      ...args: Array<mixed>
+    ) => Promise<mixed>;
+
+    waitForSelector: (
+      selector: string,
+      options?: {
+       hidden?: boolean,
+       timeout?: number,
+       visible?: boolean,
+       ...
+      }
+    ) => Promise<ElementHandle>;
+  }
+
+  declare export type Frame = FrameBase & {
+   childFrames(): Array<Frame>,
+   /** Execution context associated with this frame. */
+   executionContext(): ExecutionContext,
+   /** Returns `true` if the frame has been detached, or `false` otherwise. */
+   isDetached(): boolean,
+   /** Returns frame's name attribute as specified in the tag. */
+   name(): string,
+   /** Returns parent frame, if any. Detached frames and main frames return null. */
+   parentFrame(): ?Frame,
+   ...
+  };
+
+  declare export type PageEventObj = {
+   /**
+    * Emitted when JavaScript within the page calls one of console API methods, e.g. console.log or console.dir.
+    * Also emitted if the page throws an error or a warning.
+    */
+   console: ConsoleMessage,
+   /**
+    * Emitted when a JavaScript dialog appears, such as alert, prompt, confirm or beforeunload.
+    * Puppeteer can respond to the dialog via Dialog's accept or dismiss methods.
+    */
+   dialog: Dialog,
+   /** Emitted when the page crashes. */
+   error: Error,
+   /** Emitted when a frame is attached. */
+   frameattached: Frame,
+   /** Emitted when a frame is detached. */
+   framedetached: Frame,
+   /** Emitted when a frame is navigated to a new url. */
+   framenavigated: Frame,
+   /** Emitted when the JavaScript load event is dispatched. */
+   load: void,
+   /**
+    * Emitted when the JavaScript code makes a call to `console.timeStamp`.
+    * For the list of metrics see `page.metrics`.
+    */
+   metrics: {
+    metrics: mixed,
+    title: string,
+    ...
+   },
+   /** Emitted when an uncaught exception happens within the page. */
+   pageerror: string,
+   /**
+    * Emitted when a page issues a request. The request object is read-only.
+    * In order to intercept and mutate requests, see page.setRequestInterceptionEnabled.
+    */
+   request: Request,
+   /** Emitted when a request fails, for example by timing out. */
+   requestfailed: Request,
+   /** Emitted when a request finishes successfully. */
+   requestfinished: Request,
+   /** Emitted when a response is received. */
+   response: Response,
+   ...
+  };
+
+  /** Page provides methods to interact with a single tab in Chromium. One Browser instance might have multiple Page instances. */
+  declare export interface Page extends OverridableEventEmitter, FrameBase {
+    /**
+     * Provide credentials for http authentication.
+     * To disable authentication, pass `null`.
+     */
+    authenticate(credentials: AuthOptions | null): Promise<void>;
+
+    /** Brings page to front (activates tab). */
+    bringToFront(): Promise<void>;
+
+    /**
+     * This method fetches an element with selector, scrolls it into view if needed, and
+     * then uses `page.mouse` to click in the center of the element. If there's no element
+     * matching selector, the method throws an error.
+     * @param selector A selector to search for element to click. If there are multiple elements satisfying the selector, the first will be clicked.
+     * @param options Specifies the click options.
+     */
+    click(selector: string, options?: ClickOptions): Promise<void>;
+
+    /** Closes the current page. */
+    close(): Promise<void>;
+
+    /**
+     * Gets the cookies.
+     * If no URLs are specified, this method returns cookies for the current page URL.
+     * If URLs are specified, only cookies for those URLs are returned.
+     */
+    cookies(...urls: Array<string>): Promise<Array<Cookie>>;
+
+    coverage: Coverage;
+
+    /**
+     * Deletes the specified cookies.
+     */
+    deleteCookie(...cookies: Array<DeleteCookie>): Promise<void>;
+
+    /** Emulates given device metrics and user agent. This method is a shortcut for `setUserAgent` and `setViewport`.  */
+    emulate(options: $Shape<EmulateOptions>): Promise<void>;
+
+    /** Emulates the media. */
+    emulateMedia(mediaType: 'screen' | 'print' | null): Promise<void>;
+
+    /**
+     * Evaluates a function in the page context.
+     * If the function, passed to the page.evaluateHandle, returns a Promise, then page.evaluateHandle
+     * would wait for the promise to resolve and return its value.
+     * @param fn The function to be evaluated in the page context.
+     * @param args The arguments to pass to the `fn`.
+     * @returns A promise which resolves to return value of `fn`.
+     */
+    evaluateHandle(fn: EvaluateFn, ...args: Array<mixed>): Promise<JSHandle>;
+
+    /**
+     * Adds a function which would be invoked in one of the following scenarios: whenever the page is navigated; whenever the child frame is attached or navigated.
+     * The function is invoked after the document was created but before any of its scripts were run. This is useful to amend JavaScript environment, e.g. to seed Math.random.
+     * @param fn The function to be evaluated in browser context.
+     * @param args The arguments to pass to the `fn`.
+     */
+    evaluateOnNewDocument(fn: EvaluateFn, ...args: Array<mixed>): Promise<void>;
+
+    /**
+     * The method adds a function called name on the page's `window` object.
+     * When called, the function executes `puppeteerFunction` in node.js and returns a
+     * Promise which resolves to the return value of `puppeteerFunction`.
+     * @param name The name of the function on the window object.
+     * @param fn Callback function which will be called in Puppeteer's context.
+     */
+    exposeFunction(
+      name: string,
+      puppeteerFunction: (...args: Array<mixed>) => mixed
+    ): Promise<void>;
+
+    /** This method fetches an element with selector and focuses it. */
+    focus(selector: string): Promise<void>;
+
+    /** An array of all frames attached to the page. */
+    frames(): Array<Frame>;
+
+    /**
+     * Navigate to the previous page in history.
+     * @param options The navigation parameters.
+     */
+    goBack(options?: $Shape<NavigationOptions>): Promise<Response | null>;
+
+    /**
+     * Navigate to the next page in history.
+     * @param options The navigation parameters.
+     */
+    goForward(options?: $Shape<NavigationOptions>): Promise<Response | null>;
+
+    /**
+     * Navigates to a URL.
+     * @param url URL to navigate page to. The url should include scheme, e.g. `https://`
+     * @param options The navigation parameters.
+     */
+    goto(url: string, options?: $Shape<NavigationOptions>): Promise<Response | null>;
+
+    /**
+     * This method fetches an element with `selector`, scrolls it into view if needed,
+     * and then uses page.mouse to hover over the center of the element. If there's no
+     * element matching `selector`, the method throws an error.
+     * @param selector A selector to search for element to hover. If there are multiple elements satisfying the selector, the first will be hovered.
+     */
+    hover(selector: string): Promise<void>;
+
+    /** Returns the virtual keyboard. */
+    keyboard: Keyboard;
+
+    /** Page is guaranteed to have a main frame which persists during navigation's. */
+    mainFrame(): Frame;
+
+    /** Gets the page metrics. */
+    metrics(): Promise<Metrics>;
+
+    /** Gets the virtual mouse. */
+    mouse: Mouse;
+
+    /**
+     * Adds the listener function to the end of the listeners array for the event named `eventName`.
+     * No checks are made to see if the listener has already been added. Multiple calls passing the same combination of
+     * `eventName` and listener will result in the listener being added, and called, multiple times.
+     * @param event The name of the event.
+     * @param handler The callback function.
+     */
+    on<K: PageEvents>(
+      eventName: K,
+      handler: (e: $ElementType<PageEventObj, K>, ...args: Array<mixed>) => void
+    ): Page;
+
+    /**
+     * Adds a one time listener function for the event named `eventName`.
+     * The next time `eventName` is triggered, this listener is removed and then invoked.
+     * @param event The name of the event.
+     * @param handler The callback function.
+     */
+    once<K: PageEvents>(
+      eventName: K,
+      handler: (e: $ElementType<PageEventObj, K>, ...args: Array<mixed>) => void
+    ): Page;
+
+    /**
+     * Generates a PDF of the page with `print` css media.
+     * To generate a pdf with `screen` media, call `page.emulateMedia('screen')` before calling `page.pdf()`:
+     * @param options The PDF parameters.
+     */
+    pdf(options?: $Shape<PDFOptions>): Promise<Buffer>;
+
+    /**
+     * The method iterates JavaScript heap and finds all the objects with the given prototype.
+     * @param prototypeHandle A handle to the object prototype.
+     */
+    queryObjects(prototypeHandle: JSHandle): Promise<JSHandle>;
+
+    /**
+     * Reloads the current page.
+     * @param options The navigation parameters.
+     */
+    reload(options?: NavigationOptions): Promise<Response>;
+
+    /**
+     * Captures a screenshot of the page.
+     * @param options The screenshot options.
+     */
+    screenshot(options?: ScreenshotOptions): Promise<Buffer>;
+
+    /**
+     * Triggers a `change` and `input` event once all the provided options have been selected.
+     * If there's no `<select>` element matching selector, the method throws an error.
+     * @param selector A selector to query page for.
+     * @param values Values of options to select. If the `<select>` has the `multiple` attribute,
+     * all values are considered, otherwise only the first one is taken into account.
+     */
+    select(selector: string, ...values: Array<string>): Promise<Array<string>>;
+
+    /**
+     * Determines whether cache is enabled on the page.
+     * @param enabled Whether or not to enable cache on the page.
+     */
+    setCacheEnabled(enabled: boolean): Promise<void>;
+
+    /**
+     * Sets the cookies on the page.
+     * @param cookies The cookies to set.
+     */
+    setCookie(...cookies: Array<SetCookie>): Promise<void>;
+
+    /**
+     * This setting will change the default maximum navigation time of 30 seconds for the following methods:
+     * - `page.goto`
+     * - `page.goBack`
+     * - `page.goForward`
+     * - `page.reload`
+     * - `page.waitForNavigation`
+     */
+    setDefaultNavigationTimeout(timeout: number): void;
+
+    /**
+     * The extra HTTP headers will be sent with every request the page initiates.
+     * @param headers An object containing additional http headers to be sent with every request. All header values must be strings.
+     */
+    setExtraHTTPHeaders(headers: Headers): Promise<void>;
+
+    /**
+     * Determines whether JavaScript is enabled on the page.
+     * @param enable Whether or not to enable JavaScript on the page.
+     */
+    setJavaScriptEnabled(enabled: boolean): Promise<void>;
+
+    /**
+     * Determines whether the offline mode is enabled.
+     * @param enabled When `true`, enables the offline mode for the page.
+     */
+    setOfflineMode(enabled: boolean): Promise<void>;
+
+    /**
+     * Determines whether the request interception is enabled.
+     * @param enabled When `true` the methods `request.abort`, `request.continue` and `request.respond` must be used.
+     */
+    setRequestInterception(enabled: boolean): Promise<void>;
+
+    /**
+     * Specifies the User-Agent used in this page.
+     * @param userAgent The user-agent to be used in the page.
+     */
+    setUserAgent(userAgent: string): Promise<void>;
+
+    /**
+     * Sets the viewport of the page.
+     * @param viewport The viewport parameters.
+     */
+    setViewport(viewport: Viewport): Promise<void>;
+
+    /**
+     * This method fetches an element with `selector`, scrolls it into view if needed,
+     * and then uses page.touchscreen to tap in the center of the element.
+     * @param selector A `selector` to search for element to tap. If there are multiple elements
+     * satisfying the selector, the first will be tapped.
+     */
+    tap(selector: string): Promise<void>;
+
+    /** @returns The target this page was created from */
+    target(): Target;
+
+    /** Returns the page's title. */
+    +title: () => Promise<string>;
+
+    /** Returns the virtual touchscreen object. */
+    touchscreen: Touchscreen;
+
+    /** Returns the tracing object. */
+    tracing: Tracing;
+
+    /**
+     * Sends a `keydown`, `keypress/input`, and `keyup` event for each character in the text.
+     * @param selector A selector of an element to type into. If there are multiple elements satisfying the selector, the first will be used.
+     * @param text: A text to type into a focused element.
+     * @param options: The typing parameters.
+     */
+    type(selector: string, text: string, options?: { delay: number, ... }): Promise<void>;
+
+    /**
+     * The page's URL. This is a shortcut for `page.mainFrame().url()`
+     */
+    +url: () => string;
+
+    /** Gets the page viewport. */
+    viewport(): Viewport;
+
+    /**
+     * Wait for the page navigation occur.
+     * @param options The navigation parameters.
+     */
+    waitForNavigation(options?: NavigationOptions): Promise<Response>;
+  }
+
+  /** A Browser is created when Puppeteer connects to a Chromium instance, either through puppeteer.launch or puppeteer.connect. */
+  declare export interface Browser extends OverridableEventEmitter {
+    /**
+     * Closes browser with all the pages (if any were opened).
+     * The browser object itself is considered to be disposed and can not be used anymore.
+     */
+    close(): Promise<void>;
+
+    /**
+     * Disconnects Puppeteer from the browser, but leaves the Chromium process running.
+     * After calling `disconnect`, the browser object is considered disposed and cannot be used anymore.
+     */
+    disconnect(): void;
+
+    /** Promise which resolves to a new Page object. */
+    newPage(): Promise<Page>;
+
+    /**
+     * Adds the listener function to the end of the listeners array for the event named `eventName`.
+     * No checks are made to see if the listener has already been added. Multiple calls passing the same combination of
+     * `eventName` and listener will result in the listener being added, and called, multiple times.
+     * @param event The name of the event.
+     * @param handler The callback function.
+     */
+    on<K: BrowserEvents>(
+      eventName: K,
+      handler: (e: $ElementType<BrowserEventObj, K>, ...args: Array<mixed>) => void
+    ): Browser;
+
+    /**
+     * Adds a one time listener function for the event named `eventName`.
+     * The next time `eventName` is triggered, this listener is removed and then invoked.
+     * @param event The name of the event.
+     * @param handler The callback function.
+     */
+    once<K: BrowserEvents>(
+      eventName: K,
+      handler: (e: $ElementType<BrowserEventObj, K>, ...args: Array<mixed>) => void
+    ): Browser;
+
+    /** Promise which resolves to an array of all open pages. */
+    pages(): Promise<Array<Page>>;
+
+    /** Spawned browser process. Returns `null` if the browser instance was created with `puppeteer.connect` method */
+    process(): ChildProcess;
+
+    /** Promise which resolves to an array of all active targets. */
+    targets(): Promise<Array<Target>>;
+
+    /**
+     * Promise which resolves to the browser's original user agent.
+     * **NOTE** Pages can override browser user agent with `page.setUserAgent`.
+     */
+    userAgent(): Promise<string>;
+
+    /** For headless Chromium, this is similar to HeadlessChrome/61.0.3153.0. For non-headless, this is similar to Chrome/61.0.3153.0. */
+    version(): Promise<string>;
+
+    /** Browser websocket endpoint which can be used as an argument to puppeteer.connect. The format is ws://${host}:${port}/devtools/browser/<id> */
+    wsEndpoint(): string;
+  }
+
+  declare export type BrowserEventObj = {
+   /** Emitted when puppeteer gets disconnected from the browser instance. */
+   disconnected: void,
+   /** Emitted when the url of a target changes. */
+   targetchanged: Target,
+   /** Emitted when a target is created, for example when a new page is opened by `window.open` or `browser.newPage`. */
+   targetcreated: Target,
+   /** Emitted when a target is destroyed, for example when a page is closed. */
+   targetdestroyed: Target,
+   ...
+  };
+
+  declare export type Target = {
+   /** Creates a Chrome Devtools Protocol session attached to the target. */
+   createCDPSession(): Promise<CDPSession>,
+   /** Returns the target `Page` or a `null` if the type of the page is not "page". */
+   page(): Promise<Page>,
+   /** Identifies what kind of target this is.  */
+   type(): 'page' | 'service_worker' | 'other',
+   /** Returns the target URL. */
+   url(): string,
+   ...
+  };
+
+  declare export type LaunchOptions = {
+   /** Whether to open chrome in appMode. Defaults to false. */
+   appMode?: boolean,
+   /**
+    * Additional arguments to pass to the Chromium instance. List of Chromium
+    * flags can be found here.
+    */
+   args?: Array<string>,
+   /** Whether to auto-open DevTools panel for each tab. If this option is true, the headless option will be set false. */
+   devtools?: boolean,
+   /**
+    * Whether to pipe browser process stdout and stderr into process.stdout and
+    * process.stderr. Defaults to false.
+    */
+   dumpio?: boolean,
+   /** Specify environment variables that will be visible to Chromium. Defaults to process.env. */
+   env?: mixed,
+   /**
+    * Path to a Chromium executable to run instead of bundled Chromium. If
+    * executablePath is a relative path, then it is resolved relative to current
+    * working directory.
+    */
+   executablePath?: string,
+   /** Close chrome process on SIGHUP. Defaults to true. */
+   handleSIGHUP?: boolean,
+   /** Close chrome process on Ctrl-C. Defaults to true. */
+   handleSIGINT?: boolean,
+   /** Close chrome process on SIGTERM. Defaults to true. */
+   handleSIGTERM?: boolean,
+   /** Whether to run Chromium in headless mode. Defaults to true. */
+   headless?: boolean | 'new',
+   /** Do not use `puppeteer.defaultArgs()` for launching Chromium. Defaults to false. */
+   ignoreDefaultArgs?: boolean,
+   /** Whether to ignore HTTPS errors during navigation. Defaults to false. */
+   ignoreHTTPSErrors?: boolean,
+   /**
+    * Slows down Puppeteer operations by the specified amount of milliseconds.
+    * Useful so that you can see what is going on.
+    */
+   slowMo?: number,
+   /**
+    * Maximum time in milliseconds to wait for the Chrome instance to start.
+    * Defaults to 30000 (30 seconds). Pass 0 to disable timeout.
+    */
+   timeout?: number,
+   /** Path to a User Data Directory. */
+   userDataDir?: string,
+   ...
+  };
+
+  declare export type ConnectOptions = {
+   /** A browser websocket endpoint to connect to. */
+   browserWSEndpoint?: string,
+   /**
+    * Whether to ignore HTTPS errors during navigation.
+    * @default false
+    */
+   ignoreHTTPSErrors?: boolean,
+   ...
+  };
+
+  declare export interface CDPSession extends events$EventEmitter {
+    /**
+     * Detaches session from target. Once detached, session won't emit any events and can't be used
+     * to send messages.
+     */
+    detach(): Promise<void>;
+
+    /**
+     * @param method Protocol method name
+     */
+    // eslint-disable-next-line flowtype/no-weak-types
+    send(method: string, params?: Object): Promise<mixed>;
+  }
+
+  declare export type Coverage = {
+   startCSSCoverage(options?: StartCoverageOptions): Promise<void>,
+   startJSCoverage(options?: StartCoverageOptions): Promise<void>,
+   stopCSSCoverage(): Promise<Array<CoverageEntry>>,
+   stopJSCoverage(): Promise<Array<CoverageEntry>>,
+   ...
+  };
+
+  declare export type StartCoverageOptions = { /** Whether to reset coverage on every navigation. Defaults to `true`. */
+  resetOnNavigation?: boolean, ... };
+
+  declare export type CoverageEntry = {
+   ranges: Array<{
+    end: number,
+    start: number,
+    ...
+   }>,
+   text: string,
+   url: string,
+   ...
+  };
+
+  declare module.exports: {
+    /** Attaches Puppeteer to an existing Chromium instance */
+    connect: (options?: ConnectOptions) => Promise<Browser>;
+    /** The default flags that Chromium will be launched with */
+    defaultArgs: () => Array<string>;
+    /** Path where Puppeteer expects to find bundled Chromium */
+    executablePath: () => string;
+    /** The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed. */
+    launch: (options?: LaunchOptions) => Promise<Browser>;
+    ...
+  }
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-testing-library": "^5.6.0",
+    "eslint-plugin-ui-testing": "^2.0.1",
     "eslint-plugin-validate-jsx-nesting": "^0.1.0",
     "flow-bin": "^0.202.1",
     "flow-remove-types": "^2.184.0",
@@ -71,6 +72,7 @@
     "postcss-modules": "^4.3.0",
     "postcss-preset-env": "^7.2.0",
     "prettier": "2.8.0",
+    "puppeteer": "^20.1.0",
     "react-docgen": "^5.4.0",
     "react-lazy-hydration": "^0.1.0",
     "react-test-renderer": "^18.1.0",
@@ -83,8 +85,8 @@
     "stylelint-config-prettier": "^9.0.4",
     "stylelint-config-standard": "^23.0.0",
     "stylelint-order": "^5.0.0",
-    "xml2js": "^0.5.0",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2",
+    "xml2js": "^0.5.0"
   },
   "resolutions": {
     "ansi-regex": "5.0.1",

--- a/performance-tests/index.mjs
+++ b/performance-tests/index.mjs
@@ -1,0 +1,99 @@
+// @flow strict
+import puppeteer from 'puppeteer';
+import waitForRenderedItems from './waitForRenderedItems.mjs';
+
+const URL = 'http://localhost:8888/integration-test/masonry';
+const DEFAULT_SCROLL_COUNT = 5;
+const PINS_COUNT = 20;
+const PAGE_HEIGHT = 1000;
+
+/**
+ * Args:
+ * --scroll-count: number
+ *  Number of times to scroll the page and fetch items
+ * --debug: flag
+ *  Open browser with dev tools, more verbose logging, and don't close browser when done
+ * --verbosity: 'silent' | 'default' | 'verbose'
+ * Logging verbosity
+ */
+(async () => {
+  // Get args
+  const args = process.argv.slice(2);
+
+  const scrollCountArg =
+    args.find((arg) => arg.startsWith('--scroll-count='))?.split('=')[1] ??
+    DEFAULT_SCROLL_COUNT;
+  const scrollCount = parseInt(scrollCountArg, 10);
+
+  const debug = args.includes('--debug');
+
+  const verbosityArg = args
+    .find((arg) => arg.startsWith('--verbosity='))
+    ?.split('=')[1];
+
+  const launchOptions = debug
+    ? { headless: false, devtools: false }
+    : { headless: 'new' };
+
+  const log = (message /*: string */) =>
+    ['default', 'verbose'].includes(verbosityArg)
+      ? console.log(message)
+      : undefined;
+
+  // Launch browser and page
+  const browser = await puppeteer.launch(launchOptions);
+  const page = await browser.newPage();
+
+  if (verbosityArg === 'verbose') {
+    // Patch console output to show in node
+    console.log('Verbose mode enabled, console patched through');
+    page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
+  }
+
+  // Set viewport and open the test page
+  await page.setViewport({ width: 1600, height: PAGE_HEIGHT });
+  await page.goto(URL);
+
+  const performanceTimings = [performance.now()];
+
+  for (let i = 0; i < scrollCount; i += 1) {
+    log(`Scrolling to ${PAGE_HEIGHT * (i + 1)}`);
+    await page.evaluate(
+      // $FlowFixMe[incompatible-use]
+      ({ pageHeight, index }) => {
+        window.scrollTo({ top: pageHeight * index, behavior: 'smooth' });
+      },
+      { pageHeight: PAGE_HEIGHT, index: i }
+    );
+    log(`Waiting for ${PINS_COUNT * (i + 1)} items`);
+    await waitForRenderedItems({
+      page,
+      args: { targetItemsGTE: PINS_COUNT * (i + 1) },
+      debug: verbosityArg === 'verbose',
+    });
+    log(`Done waiting for ${PINS_COUNT * (i + 1)} items`);
+    performanceTimings.push(performance.now());
+  }
+
+  const deltas = performanceTimings
+    .map((t, i) => {
+      if (i === 0) {
+        return null;
+      }
+      return t - performanceTimings[i - 1];
+    })
+    .filter(Boolean);
+
+  const meanDelta = deltas.reduce((a, b) => a + b, 0) / deltas.length;
+  const medianDelta = deltas.sort()[Math.floor(deltas.length / 2)];
+  console.log(`
+Performance stats:
+  Mean delta: ${meanDelta.toFixed(2)}ms
+  Median delta: ${medianDelta.toFixed(2)}ms
+  Deltas: ${deltas.map((d) => d.toFixed(2)).join(', ')}
+  `);
+
+  if (!debug) {
+    await browser.close();
+  }
+})();

--- a/performance-tests/selectors.mjs
+++ b/performance-tests/selectors.mjs
@@ -1,0 +1,23 @@
+// @flow strict
+
+const selectors = {
+  addItems: '#add-items',
+  afterGrid: '.afterGrid',
+  expandGridItems: '#expand-grid-items',
+  gridItem: '[data-grid-item]',
+  incrementItemCounter: (id /*: number */) /*: string */ =>
+    `#increment-counter-${id}`,
+  insertItem: '#insert-item',
+  insertNullItems: '#insert-null-items',
+  itemCounter: (id /*: number */) /*: string */ => `#item-counter-${id}`,
+  pushFirstItemDown: '#push-first-down',
+  pushGridDown: '#push-grid-down',
+  scrollContainer: '[data-scroll-container]',
+  shuffleItems: '#shuffle-items',
+  staticItem: '[data-grid-item].static, .Masonry-Premount .Collection-Item',
+  toggleMount: '#toggle-mount',
+  toggleScrollContainer: '#toggle-scroll-container',
+  updateGridItems: '#update-grid-items',
+};
+
+export default selectors;

--- a/performance-tests/waitForRenderedItems.mjs
+++ b/performance-tests/waitForRenderedItems.mjs
@@ -1,0 +1,212 @@
+// @flow strict
+import selectors from './selectors.mjs';
+
+// When Masonry is given a list of items, it uses dynamic rendering to measure
+// them offscreen in batches. Sometimes this takes many renders and happens
+// asyncronously. waitForRenderedItems waits for a specified number of items to
+// be added to the DOM with no others waiting for measurement.
+// GT = greater than
+// GTE = greater than or equal to
+// LT = less than
+// LTE = less than or equal to
+/*::
+type Args = {|
+  scrollHeight?: number,
+  targetItems?: number,
+  targetItemsGT?: number,
+  targetItemsGTE?: number,
+  targetItemsLT?: number,
+  targetItemsLTE?: number,
+|};
+
+type WaitForRenderedItemsArgs = {|
+  // $FlowExpectedError[unclear-type]
+  page: Object,
+  args: Args,
+  timeout?: number,
+  debug?: boolean,
+|};
+*/
+
+export default async function waitForRenderedItems(
+  { page, args, timeout = 5000, debug } /*: WaitForRenderedItemsArgs */
+  // prettier-ignore
+) // $FlowExpectedError[unclear-type]
+/*: Promise<any> */ {
+  return page
+    .waitForFunction(
+      ({
+        selector,
+        args: {
+          targetItems,
+          targetItemsLT,
+          targetItemsLTE,
+          targetItemsGT,
+          targetItemsGTE,
+          scrollHeight,
+        },
+        debugMode,
+      }) => {
+        const log = (message /*: string */) => debugMode ? console.log(`waitForRenderedItems: ${message}`) : undefined;
+
+        const items = Array.from(document.querySelectorAll(selector));
+        const loadedItems = items.filter(
+          (item) => item.style.visibility !== 'hidden'
+        );
+        const loadingItems = items.filter(
+          (item) => item.style.visibility === 'hidden'
+        );
+
+        if (loadingItems.length > 0) {
+          log(`Still loading: ${loadingItems.length} items.`)
+          return false;
+        }
+
+        if (
+          typeof targetItems !== 'undefined' &&
+          loadedItems.length !== targetItems
+        ) {
+          log(`targetItems failed: ${loadedItems.length} items loaded, expected ${targetItems}`)
+          return false;
+        }
+        if (
+          typeof targetItemsLT !== 'undefined' &&
+          loadedItems.length >= targetItemsLT
+        ) {
+          log(`targetItemsLT failed: ${loadedItems.length} items loaded, expected < ${targetItemsLT}`)
+          return false;
+        }
+        if (
+          typeof targetItemsLTE !== 'undefined' &&
+          loadedItems.length > targetItemsLTE
+        ) {
+          log(`targetItemsLTE failed: ${loadedItems.length} items loaded, expected <= ${targetItemsLTE}`)
+          return false;
+        }
+        if (
+          typeof targetItemsGT !== 'undefined' &&
+          loadedItems.length <= targetItemsGT
+        ) {
+          log(`targetItemsGT failed: ${loadedItems.length} items loaded, expected > ${targetItemsGT}`)
+          return false;
+        }
+        if (
+          typeof targetItemsGTE !== 'undefined' &&
+          loadedItems.length < targetItemsGTE
+        ) {
+          log(`targetItemsGTE failed: ${loadedItems.length} items loaded, expected >= ${targetItemsGTE}`)
+          return false;
+        }
+        if (
+          typeof scrollHeight !== 'undefined' &&
+          document.body?.scrollHeight < scrollHeight
+        ) {
+          log(`scrollHeight failed: ${document.body?.scrollHeight ?? 'undefined'} < ${scrollHeight}`)
+          return false;
+        }
+
+        log(`
+Success!
+  ${loadedItems.length} items loaded
+  ${scrollHeight ? `${scrollHeight} achieved` : ''}
+`)
+        return true;
+      },
+      {
+        timeout,
+      },
+      {
+        selector: selectors.gridItem,
+        args,
+        debugMode: debug,
+      }
+    )
+    .catch(async (err) => {
+      const {
+        targetItems,
+        targetItemsLT,
+        targetItemsLTE,
+        targetItemsGT,
+        targetItemsGTE,
+        scrollHeight,
+      } = args;
+
+      let error = '';
+
+      // Count the number of loading items.
+      const loadingItems = await page.evaluate(
+        (selector) =>
+          Array.from(document.querySelectorAll(selector)).filter(
+            (item) => item.style.visibility === 'hidden'
+          ).length,
+        selectors.gridItem
+      );
+
+      if (loadingItems > 0) {
+        error = `Grid items still loading (${loadingItems}).`;
+        return false;
+      }
+
+      // Count the number of rendered items.
+      const renderedItems = await page.evaluate(
+        (selector) =>
+          Array.from(document.querySelectorAll(selector)).filter(
+            (item) => item.style.visibility !== 'hidden'
+          ).length,
+        selectors.gridItem
+      );
+
+      if (typeof targetItems !== 'undefined' && renderedItems !== targetItems) {
+        error = `${renderedItems} items rendered -- expected ${targetItems}.`;
+        return false;
+      }
+      if (
+        typeof targetItemsLT !== 'undefined' &&
+        renderedItems >= targetItemsLT
+      ) {
+        error = `${renderedItems} items rendered -- expected < ${targetItemsLT}.`;
+        return false;
+      }
+      if (
+        typeof targetItemsLTE !== 'undefined' &&
+        renderedItems > targetItemsLTE
+      ) {
+        error = `${renderedItems} items rendered -- expected <= ${targetItemsLTE}.`;
+        return false;
+      }
+      if (
+        typeof targetItemsGT !== 'undefined' &&
+        renderedItems <= targetItemsGT
+      ) {
+        error = `${renderedItems} items rendered -- expected > ${targetItemsGT}.`;
+        return false;
+      }
+      if (
+        typeof targetItemsGTE !== 'undefined' &&
+        renderedItems < targetItemsGTE
+      ) {
+        error = `${renderedItems} items rendered -- expected >= ${targetItemsGTE}.`;
+        return false;
+      }
+
+      if (typeof scrollHeight !== 'undefined') {
+        // Get the actual content height.
+        const actualScrollHeight = await page.evaluate(() => {
+          const { documentElement } = document;
+          return documentElement?.scrollHeight;
+        });
+
+        error = `scrollHeight = ${actualScrollHeight} -- expected ${scrollHeight}.`;
+      }
+
+      await page.screenshot({ path: 'items-timeout.png' });
+
+      throw new Error(`
+waitForRenderedItems timed out. ${error}
+
+See items-timeout.png for a screenshot of the page.
+
+System error: ${err.message}
+`);
+    });
+}

--- a/performance-tests/waitForRenderedItems.mjs
+++ b/performance-tests/waitForRenderedItems.mjs
@@ -25,14 +25,15 @@ type WaitForRenderedItemsArgs = {|
   args: Args,
   timeout?: number,
   debug?: boolean,
-|};
+  |};
+
+  // $FlowExpectedError[unclear-type]
+  type WaitForRenderedItemsOutput = Promise<any>;
 */
 
 export default async function waitForRenderedItems(
   { page, args, timeout = 5000, debug } /*: WaitForRenderedItemsArgs */
-  // prettier-ignore
-) // $FlowExpectedError[unclear-type]
-/*: Promise<any> */ {
+) /*: WaitForRenderedItemsOutput */ {
   return page
     .waitForFunction(
       ({
@@ -47,7 +48,10 @@ export default async function waitForRenderedItems(
         },
         debugMode,
       }) => {
-        const log = (message /*: string */) => debugMode ? console.log(`waitForRenderedItems: ${message}`) : undefined;
+        const log = (message /*: string */) =>
+          debugMode
+            ? console.log(`waitForRenderedItems: ${message}`)
+            : undefined;
 
         const items = Array.from(document.querySelectorAll(selector));
         const loadedItems = items.filter(
@@ -58,7 +62,7 @@ export default async function waitForRenderedItems(
         );
 
         if (loadingItems.length > 0) {
-          log(`Still loading: ${loadingItems.length} items.`)
+          log(`Still loading: ${loadingItems.length} items.`);
           return false;
         }
 
@@ -66,42 +70,56 @@ export default async function waitForRenderedItems(
           typeof targetItems !== 'undefined' &&
           loadedItems.length !== targetItems
         ) {
-          log(`targetItems failed: ${loadedItems.length} items loaded, expected ${targetItems}`)
+          log(
+            `targetItems failed: ${loadedItems.length} items loaded, expected ${targetItems}`
+          );
           return false;
         }
         if (
           typeof targetItemsLT !== 'undefined' &&
           loadedItems.length >= targetItemsLT
         ) {
-          log(`targetItemsLT failed: ${loadedItems.length} items loaded, expected < ${targetItemsLT}`)
+          log(
+            `targetItemsLT failed: ${loadedItems.length} items loaded, expected < ${targetItemsLT}`
+          );
           return false;
         }
         if (
           typeof targetItemsLTE !== 'undefined' &&
           loadedItems.length > targetItemsLTE
         ) {
-          log(`targetItemsLTE failed: ${loadedItems.length} items loaded, expected <= ${targetItemsLTE}`)
+          log(
+            `targetItemsLTE failed: ${loadedItems.length} items loaded, expected <= ${targetItemsLTE}`
+          );
           return false;
         }
         if (
           typeof targetItemsGT !== 'undefined' &&
           loadedItems.length <= targetItemsGT
         ) {
-          log(`targetItemsGT failed: ${loadedItems.length} items loaded, expected > ${targetItemsGT}`)
+          log(
+            `targetItemsGT failed: ${loadedItems.length} items loaded, expected > ${targetItemsGT}`
+          );
           return false;
         }
         if (
           typeof targetItemsGTE !== 'undefined' &&
           loadedItems.length < targetItemsGTE
         ) {
-          log(`targetItemsGTE failed: ${loadedItems.length} items loaded, expected >= ${targetItemsGTE}`)
+          log(
+            `targetItemsGTE failed: ${loadedItems.length} items loaded, expected >= ${targetItemsGTE}`
+          );
           return false;
         }
         if (
           typeof scrollHeight !== 'undefined' &&
           document.body?.scrollHeight < scrollHeight
         ) {
-          log(`scrollHeight failed: ${document.body?.scrollHeight ?? 'undefined'} < ${scrollHeight}`)
+          log(
+            `scrollHeight failed: ${
+              document.body?.scrollHeight ?? 'undefined'
+            } < ${scrollHeight}`
+          );
           return false;
         }
 
@@ -109,7 +127,7 @@ export default async function waitForRenderedItems(
 Success!
   ${loadedItems.length} items loaded
   ${scrollHeight ? `${scrollHeight} achieved` : ''}
-`)
+`);
         return true;
       },
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2271,6 +2271,13 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
   integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
 "@eslint/eslintrc@^0.1.3":
   version "0.1.3"
   resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz"
@@ -3716,6 +3723,20 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.7.tgz#ccab5c8f7dc557a52ca3288c10075c9ccd37fff7"
   integrity sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==
 
+"@puppeteer/browsers@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-1.0.0.tgz#89de56a718c922857b1d802aac473ebbe1f54d99"
+  integrity sha512-YKecOIlwH0UsiM9zkKy31DYg11iD8NhOoQ7SQ4oCpwDSd1Ud31WYRoAldbVlVBj9b4hLJIXxn7XSnkH1ta1tpA==
+  dependencies:
+    debug "4.3.4"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    yargs "17.7.1"
+
 "@react-hook/intersection-observer@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@react-hook/intersection-observer/-/intersection-observer-3.1.1.tgz#6b8fdb80d133c9c28bc8318368ecb3a1f8befc50"
@@ -4328,6 +4349,11 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz"
   integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
 
+"@types/semver@^7.3.12":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz"
@@ -4383,6 +4409,20 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yauzl@^2.9.1":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
+  integrity sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==
+  dependencies:
+    "@types/node" "*"
+
+"@typescript-eslint/experimental-utils@^5.3.0":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.59.2.tgz#c2785247c4c8929cb6946e46280ea44f54d9cf79"
+  integrity sha512-JLw2UImsjHDuVukpA8Nt+UK7JKE/LQAeV3tU5f7wJo2/NNYVwcakzkWjoYzu/2qzWY/Z9c7zojngNDfecNt92g==
+  dependencies:
+    "@typescript-eslint/utils" "5.59.2"
+
 "@typescript-eslint/scope-manager@5.10.2":
   version "5.10.2"
   resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz"
@@ -4399,6 +4439,14 @@
     "@typescript-eslint/types" "5.19.0"
     "@typescript-eslint/visitor-keys" "5.19.0"
 
+"@typescript-eslint/scope-manager@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz#f699fe936ee4e2c996d14f0fdd3a7da5ba7b9a4c"
+  integrity sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.2"
+    "@typescript-eslint/visitor-keys" "5.59.2"
+
 "@typescript-eslint/types@5.10.2":
   version "5.10.2"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.2.tgz"
@@ -4408,6 +4456,11 @@
   version "5.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.19.0.tgz#12d3d600d754259da771806ee8b2c842d3be8d12"
   integrity sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==
+
+"@typescript-eslint/types@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.2.tgz#b511d2b9847fe277c5cb002a2318bd329ef4f655"
+  integrity sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==
 
 "@typescript-eslint/typescript-estree@5.10.2":
   version "5.10.2"
@@ -4435,6 +4488,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz#6e2fabd3ba01db5d69df44e0b654c0b051fe9936"
+  integrity sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==
+  dependencies:
+    "@typescript-eslint/types" "5.59.2"
+    "@typescript-eslint/visitor-keys" "5.59.2"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/typescript-estree@^2.29.0":
   version "2.34.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz"
@@ -4447,6 +4513,20 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
+
+"@typescript-eslint/utils@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.2.tgz#0c45178124d10cc986115885688db6abc37939f4"
+  integrity sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.59.2"
+    "@typescript-eslint/types" "5.59.2"
+    "@typescript-eslint/typescript-estree" "5.59.2"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
 
 "@typescript-eslint/utils@^5.10.0":
   version "5.10.2"
@@ -4487,6 +4567,14 @@
   dependencies:
     "@typescript-eslint/types" "5.19.0"
     eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz#37a419dc2723a3eacbf722512b86d6caf7d3b750"
+  integrity sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==
+  dependencies:
+    "@typescript-eslint/types" "5.59.2"
+    eslint-visitor-keys "^3.3.0"
 
 "@ungap/from-entries@^0.2.1":
   version "0.2.1"
@@ -5735,6 +5823,13 @@ chownr@^1.1.1:
   resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chromium-bidi@0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.7.tgz#4c022c2b0fb1d1c9b571fadf373042160e71d236"
+  integrity sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==
+  dependencies:
+    mitt "3.0.0"
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz"
@@ -5933,6 +6028,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 clone-regexp@^2.1.0:
@@ -6318,6 +6422,16 @@ core-util-is@~1.0.0:
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cosmiconfig@8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.3.tgz#0e614a118fcc2d9e5afc2f87d53cd09931015689"
+  integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
+  dependencies:
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+
 cosmiconfig@^5.0.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz"
@@ -6436,6 +6550,13 @@ crelt@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
   integrity sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==
+
+cross-fetch@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -6764,7 +6885,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@4.3.4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -7116,6 +7237,11 @@ detective-typescript@^5.8.0:
     ast-module-types "^2.6.0"
     node-source-walk "^4.2.0"
     typescript "^3.8.3"
+
+devtools-protocol@0.0.1120988:
+  version "0.0.1120988"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz#8fe49088919ae3b8df7235774633763f1f925066"
+  integrity sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -7687,6 +7813,13 @@ eslint-plugin-testing-library@^5.6.0:
   dependencies:
     "@typescript-eslint/utils" "^5.13.0"
 
+eslint-plugin-ui-testing@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ui-testing/-/eslint-plugin-ui-testing-2.0.1.tgz#4aaf74f764589bf4fdc12a81d720408d2f2bc56a"
+  integrity sha512-GpvE0u03GSytsJ/K49C2dJlvDKQSfh+PX4lAEjBIc5RxUWEpGf9/jY3JTFd7F0gQ9ElGfYskJceVKyz7knbFFw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.3.0"
+
 eslint-plugin-validate-jsx-nesting@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-validate-jsx-nesting/-/eslint-plugin-validate-jsx-nesting-0.1.0.tgz#a7678264abdfb0d58dfed790ba3a57a2f5d1d4a8"
@@ -8205,6 +8338,17 @@ extract-stack@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz"
   integrity sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==
+
+extract-zip@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -9532,6 +9676,14 @@ http-shutdown@^1.2.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz"
   integrity sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==
+
+https-proxy-agent@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 https-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -12564,6 +12716,11 @@ minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
+mitt@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
+  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz"
@@ -13022,7 +13179,7 @@ node-fetch-native@^0.1.8:
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-0.1.8.tgz#19e2eaf6d86ac14e711ebd2612f40517c3468f2a"
   integrity sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q==
 
-node-fetch@^2.0.0, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.6, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.0.0, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.6, node-fetch@^2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.8.tgz#a68d30b162bc1d8fd71a367e81b997e1f4d4937e"
   integrity sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==
@@ -14794,7 +14951,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-progress@^2.0.0:
+progress@2.0.3, progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -14842,6 +14999,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~0.0.0:
   version "0.0.0"
@@ -14914,6 +15076,35 @@ pupa@^2.1.1:
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
   dependencies:
     escape-goat "^2.0.0"
+
+puppeteer-core@20.1.0:
+  version "20.1.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-20.1.0.tgz#c74e21ad642b0adb273da83b4bf444fdecc6500f"
+  integrity sha512-/xTvabzAN4mnnuYkJCuWNnnEhOb3JrBTa3sY6qVi1wybuIEk5ODRg8Z5PPiKUGiKC9iG7GWOJ5CjF3iuMuxZSA==
+  dependencies:
+    "@puppeteer/browsers" "1.0.0"
+    chromium-bidi "0.4.7"
+    cross-fetch "3.1.5"
+    debug "4.3.4"
+    devtools-protocol "0.0.1120988"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    proxy-from-env "1.1.0"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.13.0"
+
+puppeteer@^20.1.0:
+  version "20.1.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-20.1.0.tgz#30331e2729b235b3306a39cab3ad5b0cf2b90e7d"
+  integrity sha512-kZp1eYScK1IpHxkgnDaFSGKKCzt27iZfsxO6Xlv/cklzYrhobxTK9/PxzCacPCrYnxNQwKwHzHLPOCuSyjw1jg==
+  dependencies:
+    "@puppeteer/browsers" "1.0.0"
+    cosmiconfig "8.1.3"
+    https-proxy-agent "5.0.1"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    puppeteer-core "20.1.0"
 
 q@^1.1.2:
   version "1.5.1"
@@ -16829,7 +17020,7 @@ table@^6.7.2:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tar-fs@^2.0.0, tar-fs@^2.1.1:
+tar-fs@2.1.1, tar-fs@^2.0.0, tar-fs@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz"
   integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
@@ -17364,7 +17555,7 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-unbzip2-stream@^1.0.9:
+unbzip2-stream@1.4.3, unbzip2-stream@^1.0.9:
   version "1.4.3"
   resolved "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz"
   integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
@@ -18117,7 +18308,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@7.4.6, ws@^8.2.3, ws@^8.9.0:
+ws@7.4.6, ws@8.13.0, ws@^8.2.3, ws@^8.9.0:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
@@ -18239,6 +18430,24 @@ yargs-parser@^21.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@17.7.1:
+  version "17.7.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
+  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
 yargs@^15.3.0, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz"
@@ -18304,7 +18513,7 @@ yarn@^1.21.1:
   resolved "https://registry.npmjs.org/yarn/-/yarn-1.22.4.tgz"
   integrity sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==
 
-yauzl@^2.4.2:
+yauzl@^2.10.0, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=


### PR DESCRIPTION
To speed up the feedback on future Masonry algorithm changes, we'd like to have internal scroll performance test(s) to give us early feedback on the viability of solutions. This PR adds a simple MVP perf test, which we may improve in the future.

Known shortcomings:
- This hits localhost, not a permanent test URL
- This does not persist timings/deltas, which will need to be tracked manually