### PR TITLE
Docs: Design handoff page typo fix

### DIFF
--- a/docs/markdown/team_support/design_file_hygiene/design_handoff.md
+++ b/docs/markdown/team_support/design_file_hygiene/design_handoff.md
@@ -4,7 +4,7 @@ description: Instructions and tolls to help you setting up design files for deve
 fullwidth: true
 ---
 When your design file is ready to hand off for development, we ask you to follow the best practices below to make it super clear what designs need to be implemented. 
-We've created a library to facilitate your design handoff process by providing tips, annotation assets, design specs, and ready-to-use components. You can enable our [Handoff Kit library](https://www.figma.com/file/50RRYnFcgPTQzy1AIjQoWB/%5BLibrary%5D-Gestalt-Handoff-Kit?node-id=249%3A517&t=3H5nmocXTsIKd8sf-1) to learn more about hiding components. in your Figma files and get all its benefits. 
+We've created a library to facilitate your design handoff process by providing tips, annotation assets, design specs, and ready-to-use components. You can enable our [Handoff Kit library](https://www.figma.com/file/50RRYnFcgPTQzy1AIjQoWB/%5BLibrary%5D-Gestalt-Handoff-Kit?node-id=249%3A517&t=3H5nmocXTsIKd8sf-1) in your Figma files and get all its benefits. 
 
 ## Adding covers to files
 The cover should have all the essential information to help design system users understand its context. It includes: the project type, title, related Jira ticket and platform, status, and owner. 


### PR DESCRIPTION
### Summary
It is only a tiny typo fix on the page Design handoff (under Design file hygiene section). A line was probably copied by accident, and we didn't catch it on the review. 

#### What changed?

A line of text was removed.

#### Why?

It was a typo!

### Links

- [Jira](N/A)
- [TDD](N/A)
- [Figma](https://www.figma.com/file/tdOhnardSfDs5LI96NIxqv/File-hygiene?type=design&node-id=1205%3A5270&t=dcwIQ7ZcdyhOlpyP-1)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
