### PR TITLE
Internal: disable `import/no-namespace` for test files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -166,6 +166,7 @@ module.exports = {
         'browser': true,
       },
       'rules': {
+        'import/no-namespace': OFF,
         'jest/expect-expect': [
           ERROR,
           { 'assertFunctionNames': ['expect', 'runInlineTest', 'runTest'] },

--- a/packages/gestalt/src/OverlayPanel.jsdom.test.js
+++ b/packages/gestalt/src/OverlayPanel.jsdom.test.js
@@ -2,7 +2,7 @@
 import { act, fireEvent, screen, render } from '@testing-library/react';
 import { ESCAPE } from './keyCodes.js';
 import OverlayPanel from './OverlayPanel.js';
-import * as AnimationControllerModule from './animation/AnimationContext.js'; // eslint-disable-line import/no-namespace
+import * as AnimationControllerModule from './animation/AnimationContext.js';
 
 describe('OverlayPanel', () => {
   let useAnimationMock;

--- a/packages/gestalt/src/animation/AnimationContext.jsdom.test.js
+++ b/packages/gestalt/src/animation/AnimationContext.jsdom.test.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { fireEvent, getNodeText, render } from '@testing-library/react';
-import * as useReducedMotionHook from '../useReducedMotion.js'; // eslint-disable-line import/no-namespace
+import * as useReducedMotionHook from '../useReducedMotion.js';
 import AnimationProvider, { useAnimation, ANIMATION_STATE } from './AnimationContext.js';
 
 jest.mock('../useReducedMotion.js');


### PR DESCRIPTION
This doesn't make sense given how we often mock imports