### PR TITLE
SheetMobile: adding `onOutsideClick` prop 

### DIFF
--- a/packages/gestalt/src/SheetMobile.js
+++ b/packages/gestalt/src/SheetMobile.js
@@ -68,6 +68,10 @@ type Props = {|
    */
   onDismiss: () => void,
   /**
+   * Callback fired when clicking on the backdrop (gray area) outside of SheetMobile.
+   */
+  onOutsideClick?: () => void,
+  /**
    * The main SheetMobile content section has a "default" padding. For those cases where full bleed is needed, set `padding` to "none".
    */
   padding?: 'default' | 'none',
@@ -130,6 +134,7 @@ function SheetMobile({
   forwardIconButton,
   onAnimationEnd,
   onDismiss,
+  onOutsideClick,
   footer,
   padding,
   primaryAction,
@@ -179,6 +184,7 @@ function SheetMobile({
             forwardIconButton={forwardIconButton}
             onAnimationEnd={onAnimationEnd}
             onDismiss={onDismiss}
+            onOutsideClick={onOutsideClick}
             footer={footer}
             heading={heading}
             padding={padding}

--- a/packages/gestalt/src/SheetMobile/PartialPage.js
+++ b/packages/gestalt/src/SheetMobile/PartialPage.js
@@ -47,6 +47,7 @@ type Props = {|
   heading?: Node,
   onAnimationEnd: ?({| animationState: 'in' | 'out' |}) => void,
   onDismiss: () => void,
+  onOutsideClick?: () => void,
   padding?: 'default' | 'none',
   primaryAction?: {|
     accessibilityLabel: string,
@@ -72,6 +73,7 @@ export default function PartialPage({
   closeOnOutsideClick = true,
   onAnimationEnd,
   onDismiss,
+  onOutsideClick,
   footer,
   forwardIconButton,
   padding,
@@ -99,10 +101,12 @@ export default function PartialPage({
   }, [animationState, onAnimationEnd, handleAnimationEnd, handleRequestAnimationFrame]);
 
   const handleBackdropClick = useCallback(() => {
+    onOutsideClick?.();
+
     if (closeOnOutsideClick) {
       onExternalDismiss();
     }
-  }, [closeOnOutsideClick, onExternalDismiss]);
+  }, [closeOnOutsideClick, onExternalDismiss, onOutsideClick]);
 
   useEffect(() => {
     function handleKeyDown(event: SyntheticKeyboardEvent<HTMLDivElement>) {


### PR DESCRIPTION
### Summary

#### What changed?

SheetMobile: adding `onOutsideClick` prop 

#### Why?

Mobile Modal in Pinboard does logging/tracking when the user clicks outside the SheetMobile bottom sheet.
This enables getting closer to the functionality in Pinboard.

https://sourcegraph.pinadmin.com/github.com/pinternal/pinboard/-/blob/webapp/app/packages/gestaltExtensions/Modal/MobileModal.js?L123:9&subtree=true&popover=pinned

Next steps

This should be replaced with a InteractionProvider. To unblock adoption of MobileSheet, we are adding this prop, but it will eventually be replaced with Providers passing the logic into the component directly as this events re only needed for "side effects" from user interaction
