### PR TITLE
Docs: Android page layout consistency

### DIFF
--- a/docs/markdown/android/avatar.md
+++ b/docs/markdown/android/avatar.md
@@ -20,12 +20,12 @@ fullwidth: true
 </TwoCol>
 
 ## Best practices
-
+For general Avatar best practices, refer to the [Avatar web documentation](/web/avatar).
 - Use the default alternative if no image source is available. This will be the first character of the provided name.
 - Don’t place elements like washes, text or icons on Avatar.
 - Don’t use Avatar to represent metaphorical ideas, like a Board.
+<br/>
 
-For general Avatar best practices, refer to the [Avatar web documentation](/web/avatar).
 <TwoCol>
   <Group>
     <ImgContainer src="https://i.pinimg.com/originals/92/e5/ec/92e5ec30eb262ff1decfb70653a0d92c.png" alt="example profile with correct avatar size"/>
@@ -55,6 +55,10 @@ People use Android’s accessibility features, such as TalkBack and dynamic text
 
 ### Size
 
+Avatar comes in 6 different sizes.
+<br/>
+<ImgContainer src="https://i.pinimg.com/originals/af/75/6f/af756f3ad767857e5695d6cb626c1a12.png" alt="different avatar variations"/>
+
 1. **xxl** **(120px)**
 2. **xl** **(60px)**
 3. **lg** **(44px)**
@@ -62,7 +66,7 @@ People use Android’s accessibility features, such as TalkBack and dynamic text
 5. **sm** **(24px)**
 6. **xs** **(16px)**
 
-<ImgContainer src="https://i.pinimg.com/originals/af/75/6f/af756f3ad767857e5695d6cb626c1a12.png" alt="different avatar variations"/>
+<br/>
 
 ### Without an image
 
@@ -71,14 +75,3 @@ If there is no image source provided for the Avatar, the first character of the 
 <br/>
 
 <ImgContainer src="https://i.pinimg.com/originals/09/fb/35/09fb35ea880ea6748003d7ed0b3de426.png" alt="avatar without any image"/>
-
-## Related
-
-<ThreeCol>
-  <IllustrationCard
-  title="AvatarGroup"
-  description="AvatarGroup is the ideal component where multiple people/groups need to be displayed"
-  color="teal-spabattical-450"
-  image="avatar-group"
-  />
-</ThreeCol>

--- a/docs/markdown/android/button.md
+++ b/docs/markdown/android/button.md
@@ -40,7 +40,7 @@ People use Android's accessibility features, such as TalkBack and dynamic text s
 
 ### Size
 
-Mobile buttons are available in 2 sizes. The Button text always use [$font-size-300 token](/foundations/design_tokens#Font-size) (16dp).
+Mobile buttons are available in 2 sizes. The Button text always use [$font-size-300 token](/foundations/design_tokens#Font-size) (16sp).
 
 1. **lg (60dp)**
    Large should be primarily used on Pinner, business and internal surfaces.

--- a/docs/markdown/android/button.md
+++ b/docs/markdown/android/button.md
@@ -6,14 +6,35 @@ fullwidth: true
 
 <ImgContainer src="https://i.pinimg.com/originals/a8/24/be/a824be59514046f5088ae0f56a135b55.png" alt="a red button that says Save" />
 
-## Mobile best practices
+## Usage guidelines
 
+<TwoCol>
+  <Group>
+    <Do title="When to use" />
+      - Communicating an action that will occur.
+      - Triggering or enabling an action, such as submitting requested information.
+      - Progressing or regressing a user through a step in a flow.
+  </Group>
+  <Group>
+  <Dont title="When not to use" />
+     - Directing users to a new page or different part within the same page. Instead, use [Link](https://gestalt.pinterest.systems/web/link).
+     - Limited space available. Consider using an [IconButton](https://gestalt.pinterest.systems/android/iconbutton) instead.
+  </Group>
+</TwoCol>
+
+## Mobile best practices
+For general Button best practices, refer to the [Button web documentation](/web/button).
 - Place primary buttons to the right or top of other buttons when in a button group.
 - Keep elements inside a button container grouped. Label text and icons should remain centered when the Button width increases.
 - Avoid using multiple button sizes in the same experience.
 - If necessary, adjust the button placement and size when scaling from large screens to small screens.
 
-For general Button best practices, refer to the [Button web documentation](/web/button).
+## Accessibility
+
+People use Android's accessibility features, such as TalkBack and dynamic text sizing to personalize how they interact with their devices. Supporting these personalizations ensures that everyone has a great user experience. See Material Design and development documentation about accessibility for Android:
+
+[Accessible design on Android](https://material.io/design/usability/accessibility.html#understanding-accessibility)
+[Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility)
 
 ## Variants
 
@@ -57,21 +78,14 @@ fullWidth
 </Group>
 </TwoCol>
 
-### Styling
+## Styling
 
 For information on color, icons, roles, and states, refer to the [web Button documentation](/web/button).
 
-### Writing
+## Writing
 
 For writing best practices, refer to the [web Button documentation](/web/button).
 
-## Accessibility
-
-People use Android's accessibility features, such as TalkBack and dynamic text sizing to personalize how they interact with their devices. Supporting these personalizations ensures that everyone has a great user experience. See Material Design and development documentation about accessibility for Android:
-
-[Accessible design on Android](https://material.io/design/usability/accessibility.html#understanding-accessibility)
-[Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility)
-
 ## Localization
 
-For RTL (right-to-left) languages, the layout of the button is mirrored. The icon is placed on the right side of the text.
+For RTL (right-to-left) languages, the layout of the button is mirrored.

--- a/docs/markdown/android/checkbox.md
+++ b/docs/markdown/android/checkbox.md
@@ -69,19 +69,6 @@ People use Apple and Android’s accessibility features, such as VoiceOver and T
   </Group>
 </TwoCol>
 
-## Writing
-
-<TwoCol>
-  <Group>
-    <Do title="Do" />
-    - Be clear and brief with checkbox labels so they are easily scanned
-  </Group>
-
-  <Group>
-    <Dont title="Don't" />
-    - Include lengthy text labels that make it hard for a user to scan a list of choices
-  </Group>
-</TwoCol>
 
 ## Variants
 
@@ -125,11 +112,17 @@ Checkbox supports helper text to provide more detail about an option.
 
 <ImgContainer src="https://i.pinimg.com/originals/dd/12/5a/dd125a30d6fb4cdd8c44c002f363dd56.jpg" noPadding alt="Example of checkbox with helper text" />
 
-## Related
+## Writing
 
-- [RadioGroup](https://gestalt.pinterest.systems/web/radiogroup)
-  Use when presenting a user with a list of choices for which there can only be one selection.
-- [Switch](https://gestalt.pinterest.systems/android/switch)
-  Use for single-cell options that can be turned on or off. Examples include a list of settings that take effect immediately without having to confirm Form submission.
-- [Fieldset](https://gestalt.pinterest.systems/web/fieldset)
-  Use to group a list of related Checkboxes with a legend that describes the list.
+<TwoCol>
+  <Group>
+    <Do title="Do" />
+    - Be clear and brief with checkbox labels so they are easily scanned
+  </Group>
+
+  <Group>
+    <Dont title="Don't" />
+    - Include lengthy text labels that make it hard for a user to scan a list of choices
+  </Group>
+</TwoCol>
+

--- a/docs/markdown/android/icon.md
+++ b/docs/markdown/android/icon.md
@@ -97,7 +97,7 @@ Used sparingly to draw attention to an icon that might otherwise be missed
   </Group>
 </TwoCol>
 
-### Color
+## Color
 
 Icon colors are semantic—they have a specific meaning and aren't arbitrary. There is no disabled color for icons, as that is handled by the button state that an icon is in.
 
@@ -109,7 +109,7 @@ Icon colors are semantic—they have a specific meaning and aren't arbitrary. Th
 
 <iframe style={{border:0}} width="100%" height="490" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FREw1COFYAktmVWrUBh3Ov8%2FGestalt-for-Android%3Fnode-id%3D5058%253A19057%26t%3DEOtvT24P2BprSIEh-1" allowFullScreen></iframe>
 
-### Platform-specific icons
+## Platform-specific icons
 
 1. **Share**
 On Android, use the `android-share` icon to indicate the ability to share an element.

--- a/docs/markdown/android/icon.md
+++ b/docs/markdown/android/icon.md
@@ -97,16 +97,16 @@ Used sparingly to draw attention to an icon that might otherwise be missed
   </Group>
 </TwoCol>
 
-## Color
+### Color
 
 Icon colors are semantic—they have a specific meaning and aren't arbitrary. There is no disabled color for icons, as that is handled by the button state that an icon is in.
 
 #### Light mode
-
+<br/>
 <iframe style={{border:0}} width="100%" height="490" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FREw1COFYAktmVWrUBh3Ov8%2FGestalt-for-Android%3Fnode-id%3D5058%253A18866%26t%3D0eckWD5MZ5KL7Upr-1" allowFullScreen></iframe>
 
 #### Dark mode
-
+<br/>
 <iframe style={{border:0}} width="100%" height="490" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FREw1COFYAktmVWrUBh3Ov8%2FGestalt-for-Android%3Fnode-id%3D5058%253A19057%26t%3DEOtvT24P2BprSIEh-1" allowFullScreen></iframe>
 
 ## Platform-specific icons

--- a/docs/markdown/android/searchfield.md
+++ b/docs/markdown/android/searchfield.md
@@ -52,15 +52,6 @@ Feedback should be provided to describe a successful search, one that is process
 <iframe style={{border:0}} width="100%" height="692" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FREw1COFYAktmVWrUBh3Ov8%2FGestalt-for-Android%3Fnode-id%3D9334%253A20613%26t%3DuRG22TuwKvZC87MH-1" allowFullScreen></iframe>
 
 
-## Content
-- Don't truncate label text. If the text is too long for one line, it should be reduced.
-- Use clear labeling with placeholder text that indicates what the user can search for. For example, “Search products”, Search Users,” etc.
-- Use consistent language/naming for the SearchField and it’s labels across screens. 
-- Provide clear and concise error messages that are easy to understand and provide guidance on how to correct the search query or find alternative content.
-- If needed, provide helper text to clarify the SearchFields purpose. Especially when users could be unfamiliar with the app or it’s search functionality. 
-
-For writing best practices, refer to the [Content standards](https://gestalt.pinterest.systems/foundations/content_standards/voice). 
-
 ## Anatomy
 <iframe style={{border:0}} width="100%" height="350" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FREw1COFYAktmVWrUBh3Ov8%2FGestalt-for-Android%3Fnode-id%3D9334%253A19655%26t%3DuRG22TuwKvZC87MH-11" allowFullScreen></iframe>
 
@@ -113,16 +104,10 @@ The SearchField can include an Button trailing after the field. This button serv
 </Group>
 </TwoCol>
 
-{/*
-## Related
-
-<TwoCol>
-
-<TextField
-              title="TextField"
-              description="TextField allows for multiple types of text input."
-              color="green-matchacado-50"
-              image="text-field"
-            />
-
-</TwoCol> */}
+## Writing
+For writing best practices, refer to the [Content standards](https://gestalt.pinterest.systems/foundations/content_standards/voice). 
+- Don't truncate label text. If the text is too long for one line, it should be reduced.
+- Use clear labeling with placeholder text that indicates what the user can search for. For example, “Search products”, Search Users,” etc.
+- Use consistent language/naming for the SearchField and it’s labels across screens. 
+- Provide clear and concise error messages that are easy to understand and provide guidance on how to correct the search query or find alternative content.
+- If needed, provide helper text to clarify the SearchFields purpose. Especially when users could be unfamiliar with the app or it’s search functionality. 

--- a/docs/markdown/android/sheet.md
+++ b/docs/markdown/android/sheet.md
@@ -56,6 +56,13 @@ fullwidth: true
   </Group>
 </TwoCol>
 
+## Accessibility
+
+People use Android’s accessibility features, such as TalkBack and dynamic text sizing to personalize how they interact with their device. Supporting these personalizations ensures that everyone has a great user experience. See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html#understanding-accessibility)
+- [Accessible development on Android](hhttps://developer.android.com/guide/topics/ui/accessibility)
+
 ## Variants
 
 ### Size
@@ -103,13 +110,8 @@ Sheets can utilize several navigation actions.
 5. **Outside click**
    For the Partial Sheet and Action Sheet the user may be able to tap outside of the sheet to exit.
 
-### Animation
+## Animation
 
 By default, Sheet animates in from the bottom of the screen. It animates out when the header close button is pressed, the user swipes down or the user taps outside of the sheet. Visit Material Design for more information on [container motion](https://material.io/design/motion/the-motion-system.html#container-transform).
 
-## Accessibility
 
-People use Android’s accessibility features, such as TalkBack and dynamic text sizing to personalize how they interact with their device. Supporting these personalizations ensures that everyone has a great user experience. See Material Design and development documentation about accessibility for Android:
-
-- [Accessible design on Android](https://material.io/design/usability/accessibility.html#understanding-accessibility)
-- [Accessible development on Android](hhttps://developer.android.com/guide/topics/ui/accessibility)

--- a/docs/markdown/android/switch.md
+++ b/docs/markdown/android/switch.md
@@ -66,24 +66,6 @@ People use Apple and Android’s accessibility features, such as VoiceOver and T
   </Group>
 </TwoCol>
 
-## Writing
-
-<TwoCol>
-  <Group>
-    <Do title="Do" />
-    - Be clear and brief with Switch labels so they can be easily understood.
-    - When possible, use verbs to clarify the action. Something like “set…” or “show…”.
-    - If possible, be clear whether the setting is activated or deactivated.
-    - Use sentence case for labels.
-  </Group>
-
-  <Group>
-    <Dont title="Don't" />
-    - Use vague language out of context, like “turn on” or “turn off” repeating the state of the switch is redundant and can clutter the interface.
-    - Don’t use “you,” “your,” or “my” to describe an action. Instead of “turn on your notifications,” say “turn on notifications.”
-  </Group>
-</TwoCol>
-
 ## Variants
 
 ### Disabled and active states
@@ -119,11 +101,20 @@ People use Apple and Android’s accessibility features, such as VoiceOver and T
   </Group>
 </TwoCol>
 
-## Related
+## Writing
 
-- [RadioGroup](https://gestalt.pinterest.systems/web/radiogroup)
-  Use when presenting a user with a list of choices for which there can only be one selection.
-- [Checkbox](https://gestalt.pinterest.systems/android/checkbox)
-  Used when presenting a user with a list of choices for which there can be multiple selections.
-- [Fieldset](https://gestalt.pinterest.systems/web/fieldset)
-  Used to group a list of related Switches with a legend that describes the list.
+<TwoCol>
+  <Group>
+    <Do title="Do" />
+    - Be clear and brief with Switch labels so they can be easily understood.
+    - When possible, use verbs to clarify the action. Something like “set…” or “show…”.
+    - If possible, be clear whether the setting is activated or deactivated.
+    - Use sentence case for labels.
+  </Group>
+
+  <Group>
+    <Dont title="Don't" />
+    - Use vague language out of context, like “turn on” or “turn off” repeating the state of the switch is redundant and can clutter the interface.
+    - Don’t use “you,” “your,” or “my” to describe an action. Instead of “turn on your notifications,” say “turn on notifications.”
+  </Group>
+</TwoCol>

--- a/docs/markdown/android/tabs.md
+++ b/docs/markdown/android/tabs.md
@@ -104,17 +104,6 @@ The underline style of Tabs sits primarily in the header of the screen.
   </Group>
 </TwoCol>
 
-### Animation
+## Animation
 
 By default, Sheet animates in from the bottom of the screen. It animates out when the header close button is pressed, the user swipes down or the user taps outside of the sheet. Visit Material Design for more information on [container motion](https://material.io/design/motion/the-motion-system.html#container-transform).
-
-## Related
-
-<ThreeCol>
-  <IllustrationCard
-  title="SegmentedControl"
-  description="SegmentedControl is used to switch between views within a small area of content, such as a Popover."
-  color="teal-spabattical-450"
-  image="segmented-control"
-  />
-</ThreeCol>

--- a/docs/markdown/android/text.md
+++ b/docs/markdown/android/text.md
@@ -94,7 +94,7 @@ fullwidth: true
 
 ### Minimum text size
 
-A minimum text size of 16dp is recommended for readability, especially for longer blocks of text. Some short text labels or secondary text can go lower than that, but smaller sizes should be kept to a minimum. Making text brief will also help with readability.
+A minimum text size of 16sp is recommended for readability, especially for longer blocks of text. Some short text labels or secondary text can go lower than that, but smaller sizes should be kept to a minimum. Making text brief will also help with readability.
 
 ### Color
 
@@ -142,7 +142,7 @@ These font sizes follow those available through our [Typography scale](https://g
 <iframe style={{border:0}} width="100%" height="776" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FREw1COFYAktmVWrUBh3Ov8%2FGestalt-for-Android%3Fnode-id%3D11171%253A20317%26t%3D852gzGIkINao5ZEY-1" allowfullscreen></iframe>
 
 ## Weight
-For emphasizing text in body copy and in sizes below 16dp and below, use `bold`. For titles and headings, use `semibold`.
+For emphasizing text in body copy and in sizes below 16sp and below, use `bold`. For titles and headings, use `semibold`.
 <br/>
 
 <iframe style={{border:0}} width="100%" height="411" src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FREw1COFYAktmVWrUBh3Ov8%2FGestalt-for-Android%3Fnode-id%3D11171%253A20481%26t%3D852gzGIkINao5ZEY-1" allowfullscreen></iframe>


### PR DESCRIPTION
Fixed the layout of a few Android docs pages to create consistency across all pages: Avatar, Button, Checkbox, Icon, SearchField, Sheet, Switch, Tabs, Text