### PR TITLE
Dropdown: changed Dropdown.Link icon to "visit"

### DIFF
--- a/packages/gestalt/src/Dropdown/OptionItem.js
+++ b/packages/gestalt/src/Dropdown/OptionItem.js
@@ -147,7 +147,7 @@ const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forward
           // marginStart is for spacing relative to Badge, should not be moved to parent Flex's gap
           marginStart={2}
         >
-          <Icon accessibilityLabel="" color="default" icon="arrow-up-right" size={12} />
+          <Icon accessibilityLabel="" color="default" icon="visit" size={12} />
         </Box>
       )}
     </Flex>


### PR DESCRIPTION
## What
Dropdown: changed Dropdown.Link icon from `arrow-up-right` to `visit`

### BEFORE
<img width="392" alt="Screen Shot 2023-05-10 at 11 10 46 AM" src="https://github.com/pinterest/gestalt/assets/50343812/a9eefada-0fd3-4508-8718-b2811b01d7aa">

### AFTER
<img width="388" alt="Screen Shot 2023-05-10 at 11 12 00 AM" src="https://github.com/pinterest/gestalt/assets/50343812/4b047a78-a2fa-449e-8bdc-edddbe56eb24">
