### PR TITLE
Use Gestalt Test Index for Search

### DIFF
--- a/docs/docs-components/DocSearch.js
+++ b/docs/docs-components/DocSearch.js
@@ -136,7 +136,7 @@ export default function DocSearch({
       appId: 'GS3KDMZW6P',
       apiKey: '88c1825a5951ee68c92b4fbf4e85ec7f',
       debug: false, // Set debug to true if you want to keep open and inspect the dropdown
-      indexName: 'gestalt',
+      indexName: 'gestalt_test_index',
       inputSelector: `#${INPUT_ID}`,
     });
   }, []);


### PR DESCRIPTION
This is just for PR Preview so we can test out a new search settings. Updating the search index to gestalt_search_index in algolia so we can play with it in our deploys prior to publishing.

Can re-use this netlify preview in the future to test search changes.

Do not merge.

