### PR TITLE
Internal: alphabetize dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "stylelint-config-prettier": "^9.0.4",
     "stylelint-config-standard": "^23.0.0",
     "stylelint-order": "^5.0.0",
-    "xml2js": "^0.5.0",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2",
+    "xml2js": "^0.5.0"
   },
   "resolutions": {
     "ansi-regex": "5.0.1",


### PR DESCRIPTION
When dependencies were updated in #2812 ([package.json link](https://github.com/pinterest/gestalt/pull/2812/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)) they weren't added in alphabetical order, possibly from being added by manually editing the file. Any subsequent updates to dependencies cause these dependencies to be alphabetized, adding changed lines where nothing is actually changed.

This PR alphabetizes the dependencies so they stop appearing as changed lines in other PRs.