### PR TITLE
Internal: Add 03 Dark Value to Data Viz Pallete

### DIFF
--- a/docs/pages/foundations/data_visualization/palette.js
+++ b/docs/pages/foundations/data_visualization/palette.js
@@ -10,7 +10,7 @@ import capitalizeFirstLetter from '../../../utils/capitalizeFirstLetter.js';
 const MAIN_STEPS = [
   { name: '01', lightText: 'light', darkText: 'light' },
   { name: '02', lightText: 'dark', darkText: 'dark' },
-  { name: '03', lightText: 'light', darkText: 'light' },
+  { name: '03', lightText: 'light', darkText: 'dark' },
   { name: '04', lightText: 'dark', darkText: 'dark' },
   { name: '05', lightText: 'dark', darkText: 'dark' },
   { name: '06', lightText: 'dark', darkText: 'light' },

--- a/packages/gestalt-design-tokens/tokens/color/data-visualization/base.json
+++ b/packages/gestalt-design-tokens/tokens/color/data-visualization/base.json
@@ -13,6 +13,7 @@
       },
       "03": {
         "value": "#924AF7",
+        "darkValue": "#974CFF",
         "comment": "Third option for data visualization colors"
       },
       "04": {

--- a/packages/gestalt-design-tokens/tokens/color/data-visualization/base.json
+++ b/packages/gestalt-design-tokens/tokens/color/data-visualization/base.json
@@ -13,7 +13,7 @@
       },
       "03": {
         "value": "#924AF7",
-        "darkValue": "#974CFF",
+        "darkValue": "#B190FF",
         "comment": "Third option for data visualization colors"
       },
       "04": {

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -77,7 +77,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-data-visualization-error-text: #eb4242;
   --color-data-visualization-01: #005fcb;
   --color-data-visualization-02: #75e4d5;
-  --color-data-visualization-03: #974CFF;
+  --color-data-visualization-03: #B190FF;
   --color-data-visualization-04: #FDA600;
   --color-data-visualization-05: #75bfff;
   --color-data-visualization-06: #de2c62;
@@ -442,7 +442,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-data-visualization-error-text: #eb4242;
   --color-data-visualization-01: #005fcb;
   --color-data-visualization-02: #75e4d5;
-  --color-data-visualization-03: #974CFF;
+  --color-data-visualization-03: #B190FF;
   --color-data-visualization-04: #FDA600;
   --color-data-visualization-05: #75bfff;
   --color-data-visualization-06: #de2c62;

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -77,6 +77,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-data-visualization-error-text: #eb4242;
   --color-data-visualization-01: #005fcb;
   --color-data-visualization-02: #75e4d5;
+  --color-data-visualization-03: #974CFF;
   --color-data-visualization-04: #FDA600;
   --color-data-visualization-05: #75bfff;
   --color-data-visualization-06: #de2c62;
@@ -167,6 +168,7 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --color-data-visualization-error-text: #cc0000;
   --color-data-visualization-01: #003c96;
   --color-data-visualization-02: #11a69c;
+  --color-data-visualization-03: #924af7;
   --color-data-visualization-04: #d17711;
   --color-data-visualization-05: #0081fe;
   --color-data-visualization-06: #ff5383;
@@ -257,6 +259,7 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --color-data-visualization-error-text: #cc0000;
   --color-data-visualization-01: #003c96;
   --color-data-visualization-02: #11a69c;
+  --color-data-visualization-03: #924af7;
   --color-data-visualization-04: #d17711;
   --color-data-visualization-05: #0081fe;
   --color-data-visualization-06: #ff5383;
@@ -347,6 +350,7 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --color-data-visualization-error-text: #cc0000;
   --color-data-visualization-01: #003c96;
   --color-data-visualization-02: #11a69c;
+  --color-data-visualization-03: #924af7;
   --color-data-visualization-04: #d17711;
   --color-data-visualization-05: #0081fe;
   --color-data-visualization-06: #ff5383;
@@ -438,6 +442,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-data-visualization-error-text: #eb4242;
   --color-data-visualization-01: #005fcb;
   --color-data-visualization-02: #75e4d5;
+  --color-data-visualization-03: #974CFF;
   --color-data-visualization-04: #FDA600;
   --color-data-visualization-05: #75bfff;
   --color-data-visualization-06: #de2c62;


### PR DESCRIPTION
### Summary
The 03 Dark mode palette was incorrect, and missing. This adds it as a token value

https://deploy-preview-2933--gestalt.netlify.app/foundations/data_visualization/palette

#### What changed?

See 03

BEFORE
<img width="341" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/f16d565d-ed24-47a6-9f29-df559987cf20">

AFTER
<img width="335" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/255c4b93-907b-473c-86ea-c5ffea61a700">





#### Why?
We need if for TileData

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
