### PR TITLE
Internal: fixes to pass `flow codemod annotate-implicit-instantiations --write --include-widened --annotate-special-function-return .`

### DIFF
--- a/packages/gestalt/src/AvatarGroup.js
+++ b/packages/gestalt/src/AvatarGroup.js
@@ -117,21 +117,24 @@ const AvatarGroupWithForwardRef: AbstractComponent<Props, UnionRefs> = forwardRe
       (showCollaboratorsCount ? 1 : 0) +
       (showAddCollaboratorsButton ? 1 : 0);
 
-    const collaboratorStack = displayedCollaborators.map(({ src, name }, index) => (
-      <CollaboratorAvatar
-        hovered={hovered}
-        index={index}
-        // eslint-disable-next-line react/no-array-index-key
-        key={`collaboratorStack-${name}-${index}`}
-        name={name}
-        pileCount={pileCount}
-        size={size}
-        src={src || ''}
-      />
-    ));
+    let collaboratorStack: $ReadOnlyArray<Node> = displayedCollaborators.map(
+      ({ src, name }, index) => (
+        <CollaboratorAvatar
+          hovered={hovered}
+          index={index}
+          // eslint-disable-next-line react/no-array-index-key
+          key={`collaboratorStack-${name}-${index}`}
+          name={name}
+          pileCount={pileCount}
+          size={size}
+          src={src || ''}
+        />
+      ),
+    );
 
     if (showCollaboratorsCount) {
-      collaboratorStack.push(
+      collaboratorStack = [
+        ...collaboratorStack,
         <CollaboratorsCount
           count={collaborators.length - 2}
           showAddCollaboratorsButton={showAddCollaboratorsButton}
@@ -140,18 +143,19 @@ const AvatarGroupWithForwardRef: AbstractComponent<Props, UnionRefs> = forwardRe
           pileCount={pileCount}
           size={size}
         />,
-      );
+      ];
     }
 
     if (showAddCollaboratorsButton) {
-      collaboratorStack.push(
+      collaboratorStack = [
+        ...collaboratorStack,
         <AddCollaboratorsButton
           hovered={hovered}
           key={`collaboratorStack-addButton-${collaborators.length}`}
           pileCount={pileCount}
           size={size}
         />,
-      );
+      ];
     }
 
     const AvatarGroupStack = useCallback(


### PR DESCRIPTION
Internal: fixes to pass `flow codemod annotate-implicit-instantiations --write --include-widened --annotate-special-function-return .`



Prepping codebase to upgrade to Flow v 0.203.1


Annotate all parameters that are only required to be annotated in LTI.
- [ ] flow codemod annotate-functions-and-classes --include-lti --write .
Annotate declarations to help unbreak type cycles.
- [ ] flow codemod annotate-cycles --write .
Annotate underconstrained react hooks like useState(null).
- [ ] flow codemod annotate-react-hooks --write .
Annotate underconstrained empty arrays.
- [ ] flow codemod annotate-empty-array --write .
Annotate under-constrained type arguments.
- [ ] flow codemod annotate-implicit-instantiations --write .
Annotate type arguments that might be widened. 
This is a noisy codemod that doesn't always produce what you might want.
- [ ] flow codemod annotate-implicit-instantiations --write --include-widened .
Same as above, but it will annotate function returns like 
`array.map((v): T => {...})` instead of `array.map<T, _>(v => {...})`
- [x]  flow codemod annotate-implicit-instantiations --write --include-widened --annotate-special-function-return .

From https://medium.com/flow-type/local-type-inference-for-flow-aaa65d071347

<img width="812" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/1ab2664d-0642-440f-b3e2-9a579f831040">
