### PR TITLE
Internal: fixes to pass `flow codemod annotate-empty-array --write . `

### DIFF
--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -21,7 +21,7 @@ const stubCache = (measurements?: { [item: string]: number, ... } = {}) => {
 };
 
 test('empty', () => {
-  const items = [];
+  const items: Array<string> = [];
   const layout = defaultLayout({
     cache: stubCache(),
     justify: 'start',


### PR DESCRIPTION
Internal: fixes to pass `flow codemod annotate-empty-array --write . `


Prepping codebase to upgrade to Flow v 0.203.1


Annotate all parameters that are only required to be annotated in LTI.
- [ ] flow codemod annotate-functions-and-classes --include-lti --write .
Annotate declarations to help unbreak type cycles.
- [x] flow codemod annotate-cycles --write .
Annotate underconstrained react hooks like useState(null).
- [ ] flow codemod annotate-react-hooks --write .
Annotate underconstrained empty arrays.
- [x] flow codemod annotate-empty-array --write .
Annotate under-constrained type arguments.
- [ ] flow codemod annotate-implicit-instantiations --write .
Annotate type arguments that might be widened. 
This is a noisy codemod that doesn't always produce what you might want.
- [ ] flow codemod annotate-implicit-instantiations --write --include-widened .
Same as above, but it will annotate function returns like 
`array.map((v): T => {...})` instead of `array.map<T, _>(v => {...})`
- [x]  flow codemod annotate-implicit-instantiations --write --include-widened --annotate-special-function-return .

From https://medium.com/flow-type/local-type-inference-for-flow-aaa65d071347

<img width="812" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/1ab2664d-0642-440f-b3e2-9a579f831040">
