### PR TITLE
Internal: fixes to pass `flow codemod annotate-cycles --write .`

### DIFF
--- a/docs/docs-components/Combination.js
+++ b/docs/docs-components/Combination.js
@@ -9,7 +9,10 @@ const combinations = (variationsByField: { heading?: boolean, ... }) => {
 
   if (!fieldNames.length) return [{}];
 
-  const combine = ([fieldName, ...restFieldNames]: $ReadOnlyArray<'heading'>, acc: { ... }) => {
+  const combine = (
+    [fieldName, ...restFieldNames]: $ReadOnlyArray<'heading'>,
+    acc: { ... },
+  ): $ReadOnlyArray<{||}> => {
     const variationsForField = variationsByField[fieldName];
 
     if (!Array.isArray(variationsForField) || !variationsForField.length) {

--- a/docs/docs-components/CombinationNew.js
+++ b/docs/docs-components/CombinationNew.js
@@ -17,7 +17,10 @@ const combinations = (variationsByField: { ... }) => {
 
   if (!fieldNames.length) return [{}];
 
-  const combine = ([fieldName, ...restFieldNames]: $ReadOnlyArray<empty>, acc: { ... }) => {
+  const combine = (
+    [fieldName, ...restFieldNames]: $ReadOnlyArray<empty>,
+    acc: { ... },
+  ): $ReadOnlyArray<{||}> => {
     const variationsForField = variationsByField[fieldName];
 
     if (!Array.isArray(variationsForField) || !variationsForField.length) {

--- a/docs/docs-components/SkipToContent.js
+++ b/docs/docs-components/SkipToContent.js
@@ -12,7 +12,7 @@ export default function SkipToContent(): Node {
   const [focused, setFocused] = useState(false);
   const [mainContent, setMainContent] = useState(null);
 
-  const handleTabIndex = useCallback(() => {
+  const handleTabIndex: () => void = useCallback(() => {
     mainContent?.removeAttribute('tabindex');
     mainContent?.removeEventListener('blur', handleTabIndex);
     mainContent?.removeEventListener('focusout', handleTabIndex);

--- a/docs/docs-components/useGetSideNavItems.js
+++ b/docs/docs-components/useGetSideNavItems.js
@@ -17,7 +17,7 @@ const useGetSideNavItems = ({ sectionInfo }: {| sectionInfo: siteIndexType |}): 
     navItem: siteIndexType,
     previousSectionName: string,
     nestingLevel: number = 0,
-  ) => {
+  ): Node => {
     // in nextjs, if it's a dynamic route, the dynamic route id will be passed as part of the query obj
     const { id: pathId } = query;
     const urlPath = pathId ? pathId.join('/') : '';

--- a/docs/examples/tag/variantDismissable.js
+++ b/docs/examples/tag/variantDismissable.js
@@ -6,7 +6,7 @@ export default function Example(): Node {
   // eslint-disable-next-line no-use-before-define
   const [tags, setTags] = useState<$ReadOnlyArray<Element<typeof Tag>>>([generateTag()]);
 
-  function generateTag() {
+  function generateTag(): Element<typeof Tag> {
     return (
       <Tag
         onRemove={() => {

--- a/packages/gestalt/src/List/getChildrenToArray.js
+++ b/packages/gestalt/src/List/getChildrenToArray.js
@@ -17,7 +17,7 @@ const getChildrenToArray = ({
   const navigationChildren = [];
   let recursionLevel = 0;
 
-  const getChildren = ({ nodeChildren }: {| nodeChildren: Node |}) =>
+  const getChildren: ({| nodeChildren: Node |}) => void = ({ nodeChildren }) =>
     Children.toArray(nodeChildren).forEach((child) => {
       // We need to check for Fragment first, so we can check for display namevalid
       if (child?.type === Fragment) {

--- a/packages/gestalt/src/OverlayPanel.jsdom.test.js
+++ b/packages/gestalt/src/OverlayPanel.jsdom.test.js
@@ -214,7 +214,7 @@ describe('OverlayPanel', () => {
       </OverlayPanel>,
     );
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
-    const button = getByText('Submit');
+    const button: HTMLElement = getByText('Submit');
     fireEvent.click(button);
 
     fireEvent.animationEnd(screen.getByRole('dialog'));
@@ -245,7 +245,7 @@ describe('OverlayPanel', () => {
       </OverlayPanel>,
     );
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
-    const button = getByText('Submit');
+    const button: HTMLElement = getByText('Submit');
     fireEvent.click(button);
 
     fireEvent.animationEnd(screen.getByRole('dialog'));
@@ -277,7 +277,7 @@ describe('OverlayPanel', () => {
       </OverlayPanel>,
     );
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
-    const button = getByText('Submit');
+    const button: HTMLElement = getByText('Submit');
     fireEvent.click(button);
 
     fireEvent.animationEnd(screen.getByRole('dialog'));

--- a/packages/gestalt/src/SideNavigation/getChildrenToArray.js
+++ b/packages/gestalt/src/SideNavigation/getChildrenToArray.js
@@ -17,7 +17,7 @@ const getChildrenToArray = ({
   const navigationChildren = [];
 
   let recursionLevel = 0;
-  const getChildren = ({ nodeChildren }: {| nodeChildren: Node |}) =>
+  const getChildren: ({| nodeChildren: Node |}) => void = ({ nodeChildren }) =>
     Children.toArray(nodeChildren).forEach((child) => {
       // Detect incorrect subcomponent usage at the main level
       if (filterLevel === 'main' && ALLOWED_CHILDREN_MAP.nested.includes(child.type.displayName)) {

--- a/packages/gestalt/src/animation/RequestAnimationFrameContext.js
+++ b/packages/gestalt/src/animation/RequestAnimationFrameContext.js
@@ -43,7 +43,7 @@ function getRequestAnimationFrame(callback: () => void): number {
   }
 
   /* the callback routine must itself call requestAnimationFrame() again to animate another frame at the next repaint. requestAnimationFrame() is 1 shot. */
-  let requestId;
+  let requestId: number | null;
   /* update the requestId each time requestAnimationFrame is called */
   requestId = window.requestAnimationFrame(() => {
     requestId = window.requestAnimationFrame(() => {


### PR DESCRIPTION
Internal: fixes to pass `flow codemod annotate-cycles --write .`

Prepping codebase to upgrade to Flow v 0.203.1


Annotate all parameters that are only required to be annotated in LTI.
- [ ] flow codemod annotate-functions-and-classes --include-lti --write .
Annotate declarations to help unbreak type cycles.
- [x] flow codemod annotate-cycles --write .
Annotate underconstrained react hooks like useState(null).
- [ ] flow codemod annotate-react-hooks --write .
Annotate underconstrained empty arrays.
- [x] flow codemod annotate-empty-array --write .
Annotate under-constrained type arguments.
- [ ] flow codemod annotate-implicit-instantiations --write .
Annotate type arguments that might be widened. 
This is a noisy codemod that doesn't always produce what you might want.
- [ ] flow codemod annotate-implicit-instantiations --write --include-widened .
Same as above, but it will annotate function returns like 
`array.map((v): T => {...})` instead of `array.map<T, _>(v => {...})`
- [x]  flow codemod annotate-implicit-instantiations --write --include-widened --annotate-special-function-return .

From https://medium.com/flow-type/local-type-inference-for-flow-aaa65d071347

<img width="812" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/1ab2664d-0642-440f-b3e2-9a579f831040">
