### PR TITLE
Internal: fixes to pass `flow codemod annotate-react-hooks --write .`

### DIFF
--- a/docs/docs-components/ExampleCode.js
+++ b/docs/docs-components/ExampleCode.js
@@ -40,7 +40,7 @@ export default function ExampleCode({
   const [expanded, setExpanded] = useState(developmentEditor);
   const [showExpandButton, setShowExpandButton] = useState(hideCodePreview);
   const [maxHeight, setMaxHeight] = useState('500px');
-  const codeExampleRef = useRef(null);
+  const codeExampleRef = useRef<null | HTMLDivElement>(null);
   const codeBoxMinHeight = hideCodePreview ? undefined : '152px';
   let containerBoxMaxHeight;
 

--- a/docs/docs-components/SkipToContent.js
+++ b/docs/docs-components/SkipToContent.js
@@ -10,7 +10,7 @@ import { SKIP_TO_CONTENT_ZINDEX } from './z-indices.js';
  */
 export default function SkipToContent(): Node {
   const [focused, setFocused] = useState(false);
-  const [mainContent, setMainContent] = useState(null);
+  const [mainContent, setMainContent] = useState<null | HTMLElement>(null);
 
   const handleTabIndex = useCallback(() => {
     mainContent?.removeAttribute('tabindex');

--- a/docs/docs-components/Toc.js
+++ b/docs/docs-components/Toc.js
@@ -74,10 +74,10 @@ type Props = {|
 |};
 
 export default function Toc({ cards }: Props): Node {
-  const [anchors, setAnchors] = useState([]);
-  const [activeState, setActiveState] = useState(null);
+  const [anchors, setAnchors] = useState<$ReadOnlyArray<HTMLElement>>([]);
+  const [activeState, setActiveState] = useState<null | string>(null);
   const clickedRef = useRef(false);
-  const unsetClickedRef = useRef(null);
+  const unsetClickedRef = useRef<null | TimeoutID>(null);
 
   const findActiveIndex = useCallback(() => {
     // Don't set the active index based on scroll if a link was just clicked

--- a/docs/docs-components/highlight.js
+++ b/docs/docs-components/highlight.js
@@ -10,7 +10,7 @@ type Props = {|
 |};
 
 export default function Highlighter({ children, classNames }: Props): React$Element<'pre'> {
-  const node = useRef();
+  const node = useRef<?HTMLPreElement>();
 
   useEffect(() => {
     highlightjs.highlightBlock(node.current);

--- a/docs/examples/button/accessibilityDropdownExample.js
+++ b/docs/examples/button/accessibilityDropdownExample.js
@@ -4,7 +4,11 @@ import { Button, Dropdown, Box } from 'gestalt';
 
 export default function ActionDropdownExample(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
 
   const onSelect = ({

--- a/docs/examples/combobox/labels.js
+++ b/docs/examples/combobox/labels.js
@@ -34,7 +34,7 @@ export default function Example(): Node {
     value: `value${index}`,
   }));
 
-  const [errorMessage, setErrorMessage] = useState();
+  const [errorMessage, setErrorMessage] = useState<?string>();
 
   const handleOnBlur = ({
     value,

--- a/docs/examples/combobox/localization.js
+++ b/docs/examples/combobox/localization.js
@@ -13,7 +13,7 @@ export default function Example(): Node {
 
   const options = PRONOUNS.map((pronoun, index) => ({ label: pronoun, value: `value${index}` }));
 
-  const [errorMessage, setErrorMessage] = useState();
+  const [errorMessage, setErrorMessage] = useState<?string>();
 
   const handleOnBlur = ({
     value,

--- a/docs/examples/combobox/main.js
+++ b/docs/examples/combobox/main.js
@@ -17,7 +17,7 @@ export default function Example(): Node {
 
   const options = PRONOUNS.map((pronoun, index) => ({ label: pronoun, value: `value${index}` }));
 
-  const [errorMessage, setErrorMessage] = useState();
+  const [errorMessage, setErrorMessage] = useState<?string>();
 
   const handleOnBlur = ({
     value,

--- a/docs/examples/combobox/programmatic.js
+++ b/docs/examples/combobox/programmatic.js
@@ -35,7 +35,11 @@ export default function Example(): Node {
 
   const [inputValue, setInputValue] = useState('');
 
-  const [selectedOption, setSelectedOption] = useState();
+  const [selectedOption, setSelectedOption] = useState<void | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>();
 
   const resetOptions = () => {
     setSuggestedOptions(CATEGORIES[currentCategory]);

--- a/docs/examples/combobox/tags.js
+++ b/docs/examples/combobox/tags.js
@@ -4,7 +4,7 @@ import { Box, ComboBox, Flex, Tag } from 'gestalt';
 
 export default function Example(): Node {
   const ref = useRef();
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<$ReadOnlyArray<string>>([]);
   const [searchTerm, setSearchTerm] = useState('');
 
   const PRONOUNS = [

--- a/docs/examples/combobox/uncontrolled.js
+++ b/docs/examples/combobox/uncontrolled.js
@@ -17,7 +17,7 @@ export default function Example(): Node {
 
   const options = PRONOUNS.map((pronoun, index) => ({ label: pronoun, value: `value${index}` }));
 
-  const [errorMessage, setErrorMessage] = useState();
+  const [errorMessage, setErrorMessage] = useState<?string>();
 
   const handleOnBlur = ({
     value,

--- a/docs/examples/datefield/disabled.js
+++ b/docs/examples/datefield/disabled.js
@@ -4,11 +4,11 @@ import { Box, Flex } from 'gestalt';
 import { DateField } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValueDisableFuture, setDateValueDisableFuture] = useState(null);
-  const [dateValueDisablePast, setDatealueDisablePast] = useState(null);
+  const [dateValueDisableFuture, setDateValueDisableFuture] = useState<?Date>(null);
+  const [dateValueDisablePast, setDatealueDisablePast] = useState<?Date>(null);
 
-  const [errorTextDisableFuture, setErrorTextDisableFuture] = useState(null);
-  const [errorTextDisablePast, setErrorTextDisablePast] = useState(null);
+  const [errorTextDisableFuture, setErrorTextDisableFuture] = useState<?string>(null);
+  const [errorTextDisablePast, setErrorTextDisablePast] = useState<?string>(null);
 
   return (
     <Flex

--- a/docs/examples/datefield/error.js
+++ b/docs/examples/datefield/error.js
@@ -4,8 +4,8 @@ import { Box, Flex } from 'gestalt';
 import { DateField } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValue, setDateValue] = useState(null);
-  const [errorText, setErrorText] = useState(null);
+  const [dateValue, setDateValue] = useState<?Date>(null);
+  const [errorText, setErrorText] = useState<?string>(null);
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">

--- a/docs/examples/datefield/main.js
+++ b/docs/examples/datefield/main.js
@@ -4,8 +4,8 @@ import { Box, Flex } from 'gestalt';
 import { DateField } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValue, setDateValue] = useState(null);
-  const [errorText, setErrorText] = useState(null);
+  const [dateValue, setDateValue] = useState<?Date>(null);
+  const [errorText, setErrorText] = useState<?string>(null);
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">

--- a/docs/examples/defaultlabelprovider/no-translations.js
+++ b/docs/examples/defaultlabelprovider/no-translations.js
@@ -15,7 +15,7 @@ const pronouns = [
 ];
 
 export default function Example(): Node {
-  const [errorMessage, setErrorMessage] = useState();
+  const [errorMessage, setErrorMessage] = useState<?string>();
 
   const handleOnBlur = ({
     value,

--- a/docs/examples/defaultlabelprovider/translations.js
+++ b/docs/examples/defaultlabelprovider/translations.js
@@ -68,7 +68,7 @@ const pronouns = [
 ];
 
 export default function Example(): Node {
-  const [errorMessage, setErrorMessage] = useState();
+  const [errorMessage, setErrorMessage] = useState<?string>();
 
   const handleOnBlur = ({
     value,

--- a/docs/examples/dropdown/action.js
+++ b/docs/examples/dropdown/action.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/badges.js
+++ b/docs/examples/dropdown/badges.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/customHeader.js
+++ b/docs/examples/dropdown/customHeader.js
@@ -5,7 +5,11 @@ import { Link, Box, Button, Dropdown, Flex, Text, FixedZIndex, CompositeZIndex }
 export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const [open, setOpen] = useState(false);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({

--- a/docs/examples/dropdown/doFeatures.js
+++ b/docs/examples/dropdown/doFeatures.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/doIcons.js
+++ b/docs/examples/dropdown/doIcons.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/doOrder.js
+++ b/docs/examples/dropdown/doOrder.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/dontCustom.js
+++ b/docs/examples/dropdown/dontCustom.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/dontSelectList.js
+++ b/docs/examples/dropdown/dontSelectList.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/dontTooltips.js
+++ b/docs/examples/dropdown/dontTooltips.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/main.js
+++ b/docs/examples/dropdown/main.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/sections.js
+++ b/docs/examples/dropdown/sections.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/subtext.js
+++ b/docs/examples/dropdown/subtext.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/dropdown/truncation.js
+++ b/docs/examples/dropdown/truncation.js
@@ -6,7 +6,11 @@ export default function CustomIconButtonPopoverExample(): Node {
   const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
 
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] = useState<null | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(null);
   const anchorRef = useRef(null);
   const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
     item,

--- a/docs/examples/iconbutton/aria.js
+++ b/docs/examples/iconbutton/aria.js
@@ -4,7 +4,9 @@ import { Box, IconButton, Flex, Dropdown } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = useRef(null);
 
   const onSelect = ({

--- a/docs/examples/iconbutton/grouping.js
+++ b/docs/examples/iconbutton/grouping.js
@@ -4,7 +4,8 @@ import { Box, IconButton, Flex, Tooltip, Dropdown, Button } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] =
+    useState<?{| label: string, subtext?: string, value: string |}>(null);
   const anchorRef = useRef(null);
   const onSelect = ({
     item,

--- a/docs/examples/iconbutton/main.js
+++ b/docs/examples/iconbutton/main.js
@@ -4,7 +4,9 @@ import { IconButton, Dropdown, Flex } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = useRef(null);
 
   const onSelect = ({

--- a/docs/examples/iconbutton/selectedState.js
+++ b/docs/examples/iconbutton/selectedState.js
@@ -4,7 +4,9 @@ import { Box, IconButton, Flex, Dropdown } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = useRef(null);
 
   const onSelect = ({

--- a/docs/examples/iconbuttonfloating/dontNegative.js
+++ b/docs/examples/iconbuttonfloating/dontNegative.js
@@ -4,7 +4,9 @@ import { IconButtonFloating, Dropdown, Flex } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = useRef(null);
 
   const onSelect = ({

--- a/docs/examples/iconbuttonfloating/main.js
+++ b/docs/examples/iconbuttonfloating/main.js
@@ -4,7 +4,9 @@ import { IconButtonFloating, Box, Dropdown, Flex } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = useRef(null);
 
   const onSelect = ({

--- a/docs/examples/iconbuttonfloating/variantsA11y.js
+++ b/docs/examples/iconbuttonfloating/variantsA11y.js
@@ -49,7 +49,9 @@ const pins = [
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = useRef(null);
 
   const onSelect = ({

--- a/docs/examples/iconbuttonfloating/variantsWithTooltip.js
+++ b/docs/examples/iconbuttonfloating/variantsWithTooltip.js
@@ -4,7 +4,9 @@ import { IconButtonFloating, Box, Dropdown, Flex } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = useRef(null);
 
   const onSelect = ({

--- a/docs/examples/numberfield/bestPractices-do-errorMessage.js
+++ b/docs/examples/numberfield/bestPractices-do-errorMessage.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>(undefined);
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/bestPractices-do-helperText.js
+++ b/docs/examples/numberfield/bestPractices-do-helperText.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>(undefined);
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/bestPractices-do-label.js
+++ b/docs/examples/numberfield/bestPractices-do-label.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<number | void>(undefined);
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/bestPractices-do-related.js
+++ b/docs/examples/numberfield/bestPractices-do-related.js
@@ -1,10 +1,10 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [height, setHeight] = useState();
-  const [width, setWidth] = useState();
+export default function Example(): Node {
+  const [height, setHeight] = useState<void | number>();
+  const [width, setWidth] = useState<void | number>();
 
   return (
     <Box height="100%" padding={3}>

--- a/docs/examples/numberfield/bestPractices-dont-errorMessage.js
+++ b/docs/examples/numberfield/bestPractices-dont-errorMessage.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/bestPractices-dont-label.js
+++ b/docs/examples/numberfield/bestPractices-dont-label.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/bestPractices-dont-placeholder.js
+++ b/docs/examples/numberfield/bestPractices-dont-placeholder.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/bestPractices-dont-related.js
+++ b/docs/examples/numberfield/bestPractices-dont-related.js
@@ -1,10 +1,10 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [ageValue, setAgeValue] = useState();
-  const [petsValue, setPetsValue] = useState();
+export default function Example(): Node {
+  const [ageValue, setAgeValue] = useState<void | number>();
+  const [petsValue, setPetsValue] = useState<void | number>();
 
   return (
     <Box height="100%" padding={3}>

--- a/docs/examples/numberfield/disabled.js
+++ b/docs/examples/numberfield/disabled.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/enterKeyHint.js
+++ b/docs/examples/numberfield/enterKeyHint.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/errorMessage.js
+++ b/docs/examples/numberfield/errorMessage.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/helperText.js
+++ b/docs/examples/numberfield/helperText.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
 
   return (
     <Flex alignItems="center" justifyContent="center" height="100%" width="100%">

--- a/docs/examples/numberfield/main.js
+++ b/docs/examples/numberfield/main.js
@@ -1,9 +1,9 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">

--- a/docs/examples/numberfield/minMaxStep.js
+++ b/docs/examples/numberfield/minMaxStep.js
@@ -1,10 +1,10 @@
 // @flow strict
-import { useState } from 'react';
+import { useState, type Node } from 'react';
 import { Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [value1, setValue1] = useState();
-  const [value2, setValue2] = useState();
+export default function Example(): Node {
+  const [value1, setValue1] = useState<void | number>();
+  const [value2, setValue2] = useState<void | number>();
 
   return (
     <Flex

--- a/docs/examples/numberfield/ref.js
+++ b/docs/examples/numberfield/ref.js
@@ -1,10 +1,10 @@
 // @flow strict
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type Node } from 'react';
 import { Box, Flex, NumberField } from 'gestalt';
 
-export default function Example(): React$Node {
-  const [currentValue, setCurrentValue] = useState();
-  const [errorMessage, setErrorMessage] = useState(undefined);
+export default function Example(): Node {
+  const [currentValue, setCurrentValue] = useState<void | number>();
+  const [errorMessage, setErrorMessage] = useState<void | string>(undefined);
   const ref = useRef();
 
   useEffect(() => {

--- a/docs/examples/pageheader/primaryActionExample.js
+++ b/docs/examples/pageheader/primaryActionExample.js
@@ -14,7 +14,9 @@ import {
 
 export default function PrimaryActionExample(): Node {
   const [open, setOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState([]);
+  const [selected, setSelected] = React.useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = React.useRef(null);
   const handleSelect = ({
     item,

--- a/docs/examples/pageheader/responsiveExample.js
+++ b/docs/examples/pageheader/responsiveExample.js
@@ -4,7 +4,9 @@ import { Button, Dropdown, IconButton, PageHeader, Tooltip } from 'gestalt';
 
 export default function SecondaryActionsExample(): Node {
   const [open, setOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState([]);
+  const [selected, setSelected] = React.useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = React.useRef(null);
   const handleSelect = ({
     item,

--- a/docs/examples/pageheader/secondaryActionExample.js
+++ b/docs/examples/pageheader/secondaryActionExample.js
@@ -4,7 +4,9 @@ import { Button, Divider, Dropdown, Flex, IconButton, PageHeader, Tooltip } from
 
 export default function SecondaryActionsExample(): Node {
   const [open, setOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState([]);
+  const [selected, setSelected] = React.useState<
+    $ReadOnlyArray<{| label: string, subtext?: string, value: string |}>,
+  >([]);
   const anchorRef = React.useRef(null);
   const handleSelect = ({
     item,

--- a/docs/examples/pulsar/size.js
+++ b/docs/examples/pulsar/size.js
@@ -3,7 +3,7 @@ import { type Node, useState } from 'react';
 import { Box, Flex, NumberField, Pulsar } from 'gestalt';
 
 export default function Example(): Node {
-  const [sizePX, setSizePx] = useState();
+  const [sizePX, setSizePx] = useState<void | number>();
 
   return (
     <Box padding={2}>

--- a/docs/examples/radiogroup/main.js
+++ b/docs/examples/radiogroup/main.js
@@ -3,7 +3,7 @@ import { useState, type Node } from 'react';
 import { Box, RadioGroup } from 'gestalt';
 
 export default function Example(): Node {
-  const [favorite, setFavorite] = useState();
+  const [favorite, setFavorite] = useState<void | string>();
 
   return (
     <Box width="100%" height="100%" padding={4} display="flex" justifyContent="center">

--- a/docs/examples/scrollboundarycontainer/autoOverflowExample.js
+++ b/docs/examples/scrollboundarycontainer/autoOverflowExample.js
@@ -12,9 +12,9 @@ import {
 } from 'gestalt';
 
 export default function Example(): Node {
-  const [content, setContent] = useState(null);
-  const [claimed, setClaimed] = useState(null);
-  const [device, setDevice] = useState(null);
+  const [content, setContent] = useState<null | string>(null);
+  const [claimed, setClaimed] = useState<null | string>(null);
+  const [device, setDevice] = useState<null | string>(null);
 
   return (
     <Box padding={4} color="secondary" height="100%">

--- a/docs/examples/scrollboundarycontainer/modalExample.js
+++ b/docs/examples/scrollboundarycontainer/modalExample.js
@@ -19,7 +19,8 @@ import {
 export default function ScrollBoundaryContainerExample(): Node {
   const [showComponent, setShowComponent] = useState(false);
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState(null);
+  const [selected, setSelected] =
+    useState<?{| label: string, subtext?: string, value: string |}>(null);
   const [parentComponent, setParentComponent] = useState('modal');
   const anchorDropdownRef = useRef(null);
 

--- a/docs/examples/scrollboundarycontainer/visibleOverflowExample.js
+++ b/docs/examples/scrollboundarycontainer/visibleOverflowExample.js
@@ -12,9 +12,9 @@ import {
 } from 'gestalt';
 
 export default function Example(): Node {
-  const [content, setContent] = useState(null);
-  const [claimed, setClaimed] = useState(null);
-  const [device, setDevice] = useState(null);
+  const [content, setContent] = useState<?string>(null);
+  const [claimed, setClaimed] = useState<?string>(null);
+  const [device, setDevice] = useState<?string>(null);
 
   return (
     <Box padding={4} color="secondary" height="100%">

--- a/docs/examples/sheetmobile/differentSize.js
+++ b/docs/examples/sheetmobile/differentSize.js
@@ -14,8 +14,8 @@ import {
 
 export default function Example(): Node {
   const [showComponent, setShowComponent] = useState(true);
-  const [showComponentData, setShowComponentData] = useState(null);
-  const [showNextData, setShowNextData] = useState(null);
+  const [showComponentData, setShowComponentData] = useState<?string>(null);
+  const [showNextData, setShowNextData] = useState<?string>(null);
 
   const PAGE_HEADER_ZINDEX: FixedZIndex = new FixedZIndex(10);
   const ABOVE_PAGE_HEADER_ZINDEX: CompositeZIndex = new CompositeZIndex([PAGE_HEADER_ZINDEX]);

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -45,7 +45,7 @@ function IconTile({
   iconDescription: string,
   onTap: () => void,
 |}) {
-  const [hovered, setHovered] = useState();
+  const [hovered, setHovered] = useState<?boolean>();
 
   return (
     <Tooltip text={iconDescription} accessibilityLabel={iconDescription} idealDirection="down">
@@ -140,7 +140,7 @@ export default function IconPage(): Node {
     });
 
   const [suggestedOptions, setSuggestedOptions] = useState(iconOptions);
-  const [inputValue, setInputValue] = useState();
+  const [inputValue, setInputValue] = useState<void | string>();
   const [sortedAlphabetical, setSortedAlphabetical] = useState(true);
 
   const handleOnChange = ({

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -83,8 +83,8 @@ type Props = {|
 function ExampleMasonry({ id, layout }: Props): Node {
   const [pins, setPins] = useState<$ReadOnlyArray<Pin>>([]);
   const [width, setWidth] = useState<number>(700);
-  const scrollContainerRef = useRef();
-  const gridRef = useRef();
+  const scrollContainerRef = useRef<?HTMLDivElement>();
+  const gridRef = useRef<?Masonry<Pin>>();
 
   useEffect(() => {
     getPins().then((startPins) => {

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -176,7 +176,7 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLDivElement> = forwa
   }: Props,
   ref,
 ): Element<'div'> {
-  const innerRef = useRef(null);
+  const innerRef = useRef<null | HTMLDivElement>(null);
   useImperativeHandle(ref, () => innerRef.current);
 
   const [selected, setSelected] = useState<?Date>(dateValue);

--- a/packages/gestalt/src/Checkbox.js
+++ b/packages/gestalt/src/Checkbox.js
@@ -107,7 +107,7 @@ const CheckboxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
   }: Props,
   ref,
 ): Node {
-  const innerRef = useRef(null);
+  const innerRef = useRef<null | HTMLInputElement>(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Checkbox ref={inputRef} /> to call inputRef.current.focus()
   useImperativeHandle(ref, () => innerRef.current);

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -21,7 +21,7 @@ import Popover from './Popover.js';
 import Tag from './Tag.js';
 import Text from './Text.js';
 import { type Indexable } from './zIndex.js';
-import ComboBoxItem from './ComboBox/Item.js';
+import ComboBoxItem, { type ComboBoxItemType } from './ComboBox/Item.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import InternalTextField from './TextField/InternalTextField.js';
 import InternalTextFieldIconButton from './TextField/InternalTextFieldIconButton.js';
@@ -198,7 +198,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
 
   const innerRef = useRef(null);
   const optionRef = useRef(null);
-  const dropdownRef = useRef(null);
+  const dropdownRef = useRef<null | HTMLElement>(null);
   // When using both forwardRef and innerRefs, useimperativehandle() allows to externally set focus via the ref prop: textfieldRef.current.focus()
   useImperativeHandle(ref, () => innerRef.current);
 
@@ -253,8 +253,16 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
 
   // ==== EVENT HANDLING: ComboBoxItem ====
 
-  const handleSelectItem = useCallback(
-    ({ event, item }) => {
+  const handleSelectItem: (
+    | {| event: SyntheticInputEvent<HTMLInputElement>, item: ComboBoxItemType |}
+    | {| event: SyntheticKeyboardEvent<HTMLElement>, item: OptionType |},
+  ) => void = useCallback(
+    ({
+      event,
+      item,
+    }:
+      | {| event: SyntheticInputEvent<HTMLInputElement>, item: ComboBoxItemType |}
+      | {| event: SyntheticKeyboardEvent<HTMLElement>, item: OptionType |}) => {
       onSelect?.({ event, item });
       if (isNotControlled) {
         setSelectedItem(item);
@@ -268,7 +276,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
   // ==== KEYBOARD NAVIGATION LOGIC: Keyboard navigation is handled by ComboBox while onClick selection is handled in ComboBoxItem ====
 
   const handleKeyNavigation = useCallback(
-    (event, direction: DirectionOptionType) => {
+    (event: SyntheticKeyboardEvent<HTMLElement>, direction: DirectionOptionType) => {
       if (!showOptionsList) setShowOptionsList(true);
 
       const getNextHoveredIndex = (keyboardDirection: DirectionOptionType) => {
@@ -316,7 +324,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
   // ==== EVENT HANDLING: Popover ====
 
   const handleKeyDown = useCallback(
-    ({ event }) => {
+    ({ event }: {| event: SyntheticKeyboardEvent<HTMLElement> |}) => {
       const { keyCode } = event;
 
       if (keyCode === UP_ARROW) {
@@ -341,14 +349,22 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
 
   // ==== EVENT HANDLING: InternalTextField ====
 
-  const handleOnBlur = useCallback(({ event, value }) => onBlur?.({ event, value }), [onBlur]);
+  const handleOnBlur = useCallback(
+    ({ event, value }: {| event: SyntheticFocusEvent<HTMLInputElement>, value: string |}) =>
+      onBlur?.({ event, value }),
+    [onBlur],
+  );
 
-  const handleOnFocus = useCallback(({ event, value }) => onFocus?.({ event, value }), [onFocus]);
+  const handleOnFocus = useCallback(
+    ({ event, value }: {| event: SyntheticFocusEvent<HTMLInputElement>, value: string |}) =>
+      onFocus?.({ event, value }),
+    [onFocus],
+  );
 
   const handleSetShowOptionsList = useCallback(() => setShowOptionsList(true), []);
 
   const handleOnChange = useCallback(
-    ({ event, value }) => {
+    ({ event, value }: {| event: SyntheticInputEvent<HTMLInputElement>, value: string |}) => {
       setHoveredItemIndex(null);
       if (isNotControlled) {
         setSelectedItem(null);
@@ -372,7 +388,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
   }, [isNotControlled, onClear, options]);
 
   const handleOnKeyDown = useCallback(
-    ({ event, value }) => {
+    ({ event, value }: {| event: SyntheticKeyboardEvent<HTMLInputElement>, value: string |}) => {
       if (!showOptionsList && event.keyCode !== TAB) setShowOptionsList(true);
       onKeyDown?.({ event, value });
     },

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -165,7 +165,7 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
   }: Props,
   ref,
 ): Element<'a'> {
-  const innerRef = useRef(null);
+  const innerRef = useRef<null | HTMLAnchorElement>(null);
 
   useImperativeHandle(ref, () => innerRef.current);
 

--- a/packages/gestalt/src/Link/InternalLink.js
+++ b/packages/gestalt/src/Link/InternalLink.js
@@ -103,7 +103,7 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
   }: Props,
   ref,
 ): Element<'a'> {
-  const innerRef = useRef(null);
+  const innerRef = useRef<null | HTMLAnchorElement>(null);
 
   useImperativeHandle(ref, () => innerRef.current);
 

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -121,7 +121,7 @@ const SearchFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = fo
   const [focused, setFocused] = useState<boolean>(false);
 
   // Ref to the input
-  const inputRef = useRef(null);
+  const inputRef = useRef<null | HTMLInputElement>(null);
   useImperativeHandle(ref, () => inputRef.current);
 
   const handleChange = (event: SyntheticEvent<HTMLInputElement>) => {

--- a/packages/gestalt/src/TableRow.js
+++ b/packages/gestalt/src/TableRow.js
@@ -14,8 +14,8 @@ type Props = {|
  */
 export default function TableRow({ children }: Props): Node {
   const { stickyColumns } = useTableContext();
-  const rowRef = useRef();
-  const [columnWidths, setColumnWidths] = useState([]);
+  const rowRef = useRef<?HTMLTableRowElement>();
+  const [columnWidths, setColumnWidths] = useState<$ReadOnlyArray<number>>([]);
 
   useEffect(() => {
     if (rowRef?.current && stickyColumns) {

--- a/packages/gestalt/src/TableRowDrawer.js
+++ b/packages/gestalt/src/TableRowDrawer.js
@@ -25,8 +25,8 @@ type Props = {|
  */
 export default function TableRowDrawer({ children, drawerContents, id }: Props): Node {
   const { stickyColumns } = useTableContext();
-  const rowRef = useRef();
-  const [columnWidths, setColumnWidths] = useState([]);
+  const rowRef = useRef<?HTMLTableRowElement>();
+  const [columnWidths, setColumnWidths] = useState<$ReadOnlyArray<number>>([]);
 
   useEffect(() => {
     if (rowRef?.current && stickyColumns) {

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -63,8 +63,8 @@ export default function TableRowExpandable({
   hoverStyle = 'gray',
 }: Props): Node {
   const { stickyColumns } = useTableContext();
-  const rowRef = useRef();
-  const [columnWidths, setColumnWidths] = useState([]);
+  const rowRef = useRef<?HTMLTableRowElement>();
+  const [columnWidths, setColumnWidths] = useState<$ReadOnlyArray<number>>([]);
   const [isExpanded, setIsExpanded] = useState(expandedControlled ?? false);
 
   useEffect(() => {

--- a/packages/gestalt/src/TextField/InternalTextField.js
+++ b/packages/gestalt/src/TextField/InternalTextField.js
@@ -109,7 +109,7 @@ const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement
   ref,
 ): Node {
   // ==== REFS ====
-  const innerRef = useRef(null);
+  const innerRef = useRef<null | HTMLInputElement | HTMLDivElement>(null);
   // When using both forwardRef and innerRefs, useimperativehandle() allows to externally set focus via the ref prop: textfieldRef.current.focus()
   // $FlowFixMe[incompatible-call]
   useImperativeHandle(ref, () => innerRef.current);

--- a/packages/gestalt/src/animation/RequestAnimationFrameContext.js
+++ b/packages/gestalt/src/animation/RequestAnimationFrameContext.js
@@ -83,7 +83,7 @@ export default function RequestAnimationFrameProvider({
 > | null {
   const reducedMotion = useReducedMotion();
   const { animationState, setAnimationState, handleExternalDismiss } = useAnimation();
-  const requestAnimationFrameId = useRef(null);
+  const requestAnimationFrameId = useRef<null | number>(null);
   /*
   Summary to understand what event controls requestAnimationFrame during the lifecycle of the component
     "in" animation

--- a/packages/gestalt/src/contexts/ScrollBoundaryContainerProvider.js
+++ b/packages/gestalt/src/contexts/ScrollBoundaryContainerProvider.js
@@ -27,11 +27,13 @@ const ScrollBoundaryContainerContext: Context<ScrollBoundaryContainerContextType
 const { Provider } = ScrollBoundaryContainerContext;
 
 function ScrollBoundaryContainerProvider({ children }: Props): Element<typeof Provider> {
-  const [scrollBoundaryContainerRef, setScrollBoundaryContainerRef] = useState(null);
+  const [scrollBoundaryContainerRef, setScrollBoundaryContainerRef] = useState<null | HTMLElement>(
+    null,
+  );
 
   const scrollBoundaryContainerContext = {
     scrollBoundaryContainerRef,
-    addRef: useCallback((ref) => {
+    addRef: useCallback((ref: HTMLElement) => {
       setScrollBoundaryContainerRef(ref);
     }, []),
   };

--- a/packages/gestalt/src/contexts/SideNavigationProvider.js
+++ b/packages/gestalt/src/contexts/SideNavigationProvider.js
@@ -38,7 +38,7 @@ const { Provider } = SideNavigationContext;
 
 function SideNavigationProvider({ children, dismissButton }: Props): Element<typeof Provider> {
   const [selectedItemId, setSelectedItemId] = useState('');
-  const [selectedMobileChildren, setSelectedMobileChildren] = useState(null);
+  const [selectedMobileChildren, setSelectedMobileChildren] = useState<Node>(null);
   const [hideActiveChildren, setHideActiveChildren] = useState(false);
 
   const sideNavigationContext = {

--- a/packages/gestalt/src/shared/FormHelperTextCounter.js
+++ b/packages/gestalt/src/shared/FormHelperTextCounter.js
@@ -13,7 +13,7 @@ type Props = {|
 
 export default function FormHelperTextCounter({ currentLength, maxLength }: Props): Node {
   const ref = useRef();
-  const [width, setWidth] = useState(undefined);
+  const [width, setWidth] = useState<void | number>(undefined);
 
   useEffect(() => {
     const containerWidth = ref?.current?.getBoundingClientRect().width;

--- a/packages/gestalt/src/shared/InternalDismissButton.js
+++ b/packages/gestalt/src/shared/InternalDismissButton.js
@@ -43,7 +43,7 @@ const InternalDismissIconButtonWithForwardRef: AbstractComponent<Props, HTMLButt
     }: Props,
     ref,
   ): Node {
-    const innerRef = useRef(null);
+    const innerRef = useRef<HTMLButtonElement | null>(null);
 
     // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
     // that renders <IconButton ref={inputRef} /> to call inputRef.current.focus()

--- a/packages/gestalt/src/useDebouncedCallback.js
+++ b/packages/gestalt/src/useDebouncedCallback.js
@@ -8,7 +8,7 @@ import { useEffect, useRef } from 'react';
  * result in a warning. See https://stackoverflow.com/a/60907638/117193 for more info
  */
 export default function useDebouncedCallback(callback: () => void, wait: number): () => void {
-  const timeout = useRef();
+  const timeout = useRef<void | TimeoutID>();
 
   function cleanup() {
     if (timeout.current) {

--- a/packages/gestalt/src/useTapFeedback.js
+++ b/packages/gestalt/src/useTapFeedback.js
@@ -32,7 +32,7 @@ export default function useTapFeedback({ height, width }: {| height: ?number, wi
     y: 0,
   });
 
-  const [compressStyle, setCompressStyle] = useState(null);
+  const [compressStyle, setCompressStyle] = useState<null | {| transform: string |}>(null);
 
   useEffect(() => {
     if (height != null && width != null) {

--- a/packages/gestalt/src/utils/keyboardNavigation.js
+++ b/packages/gestalt/src/utils/keyboardNavigation.js
@@ -8,7 +8,7 @@ export const KEYS = {
 export type DirectionOptionType = -1 | 0 | 1;
 type Props = {|
   direction: DirectionOptionType,
-  containerRef?: {| current: ?HTMLElement |},
+  containerRef?: {| current: null | HTMLElement |},
   currentHoveredOption: ?HTMLElement,
 |};
 


### PR DESCRIPTION
Internal: fixes to pass `flow codemod annotate-react-hooks --write .`

Prepping codebase to upgrade to Flow v 0.203.1


Annotate all parameters that are only required to be annotated in LTI.
- [ ] flow codemod annotate-functions-and-classes --include-lti --write .
Annotate declarations to help unbreak type cycles.
- [x] flow codemod annotate-cycles --write .
Annotate underconstrained react hooks like useState(null).
- [x] flow codemod annotate-react-hooks --write .
Annotate underconstrained empty arrays.
- [x] flow codemod annotate-empty-array --write .
Annotate under-constrained type arguments.
- [ ] flow codemod annotate-implicit-instantiations --write .
Annotate type arguments that might be widened. 
This is a noisy codemod that doesn't always produce what you might want.
- [ ] flow codemod annotate-implicit-instantiations --write --include-widened .
Same as above, but it will annotate function returns like 
`array.map((v): T => {...})` instead of `array.map<T, _>(v => {...})`
- [x]  flow codemod annotate-implicit-instantiations --write --include-widened --annotate-special-function-return .

From https://medium.com/flow-type/local-type-inference-for-flow-aaa65d071347

<img width="812" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/1ab2664d-0642-440f-b3e2-9a579f831040">
