### PR TITLE
Internal: fixes to pass `flow codemod annotate-functions-and-classes --include-lti --write .`

### DIFF
--- a/docs/docs-components/Combination.js
+++ b/docs/docs-components/Combination.js
@@ -19,7 +19,7 @@ const combinations = (variationsByField: { heading?: boolean, ... }) => {
       throw new Error(`Please provide a non-empty array of possible values for prop ${fieldName}`);
     }
 
-    const vs = variationsForField.map((fieldValue) => ({
+    const vs = variationsForField.map((fieldValue: string) => ({
       ...acc,
       [fieldName]: fieldValue,
     }));
@@ -27,7 +27,7 @@ const combinations = (variationsByField: { heading?: boolean, ... }) => {
     if (!restFieldNames.length) {
       return vs;
     }
-    return vs.flatMap((newAcc) => combine(restFieldNames, newAcc));
+    return vs.flatMap((newAcc: { [string]: string }) => combine(restFieldNames, newAcc));
   };
 
   return combine(fieldNames, {});

--- a/docs/docs-components/CombinationNew.js
+++ b/docs/docs-components/CombinationNew.js
@@ -27,7 +27,7 @@ const combinations = (variationsByField: { ... }) => {
       throw new Error(`Please provide a non-empty array of possible values for prop ${fieldName}`);
     }
 
-    const vs = variationsForField.map((fieldValue) => ({
+    const vs = variationsForField.map((fieldValue: string) => ({
       ...acc,
       [fieldName]: fieldValue,
     }));
@@ -35,7 +35,7 @@ const combinations = (variationsByField: { ... }) => {
     if (!restFieldNames.length) {
       return vs;
     }
-    return vs.flatMap((newAcc) => combine(restFieldNames, newAcc));
+    return vs.flatMap((newAcc: { [string]: string }) => combine(restFieldNames, newAcc));
   };
 
   return combine(fieldNames, {});

--- a/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-useless-props.js
@@ -29,8 +29,11 @@ function getAttributeName(attributeName): ?string {
   return attributeName?.name;
 }
 
-// $FlowFixMe[missing-local-annot]
-function getExpressionValues(valueExpression): $ReadOnlyArray<string> {
+function getExpressionValues(valueExpression: {|
+  value: string,
+  consequent: {| value: string |},
+  alternate: {| value: string |},
+|}): $ReadOnlyArray<string> {
   return [valueExpression.consequent, valueExpression.alternate].map((option) => option.value);
 }
 
@@ -61,9 +64,23 @@ function getAttributeValue(attributeValue): ?(string | $ReadOnlyArray<string>) {
   return undefined;
 }
 
-// $FlowFixMe[missing-local-annot]
-// $FlowExpectedError[unclear-type]
-function getDangerouslySetStyles(attributeValue): null | { [string]: Object } {
+function getDangerouslySetStyles(attributeValue: {|
+  expression: {|
+    properties: $ReadOnlyArray<{
+      key: {| name: string |},
+      value: {
+        properties: $ReadOnlyArray<{
+          key: {| name: string |},
+          value: { properties: $ReadOnlyArray<{ ... }>, ... },
+          ...
+        }>,
+        ...
+      },
+      ...
+    }>,
+  |},
+  // $FlowFixMe[unclear-type]
+|}): any {
   const valueExpression = attributeValue.expression;
   const styleObject = valueExpression?.properties?.find(({ key }) => key.name === '__style');
   if (!styleObject) {
@@ -78,8 +95,15 @@ function getDangerouslySetStyles(attributeValue): null | { [string]: Object } {
   );
 }
 
-// $FlowFixMe[missing-local-annot]
-function hasDangerouslySetFlexDisplay(stylesObject): boolean {
+function hasDangerouslySetFlexDisplay(
+  stylesObject: null | {|
+    display: {|
+      value: string,
+      consequent: {| value: string |},
+      alternate: {| value: string |},
+    |},
+  |},
+): boolean {
   if (!stylesObject || !stylesObject.display) {
     return false;
   }

--- a/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
+++ b/packages/eslint-plugin-gestalt/src/no-workflow-status-icon.js
@@ -41,8 +41,8 @@ const rule: ESLintRule = {
     let gestaltImportNode;
     let componentName = 'Icon';
 
-    // $FlowFixMe[missing-local-annot]
-    const matchValues = (node) => {
+    // $FlowFixMe[unclear-type]
+    const matchValues = (node: any) => {
       const reducedPropValues = node.attributes.reduce((acc, { name, value }) => {
         const newAcc = { ...acc };
         newAcc[name?.name] = value?.value || value?.expression?.value;
@@ -61,8 +61,8 @@ const rule: ESLintRule = {
       return node;
     };
 
-    // $FlowFixMe[missing-local-annot]
-    const importDeclarationFnc = (node) => {
+    // $FlowFixMe[unclear-type]
+    const importDeclarationFnc = (node: any) => {
       if (!node) return;
 
       const isGestaltImportNode = hasImport({ importNode: node, path: 'gestalt' });
@@ -74,8 +74,8 @@ const rule: ESLintRule = {
       gestaltImportNode = node;
     };
 
-    // $FlowFixMe[missing-local-annot]
-    const jSXOpeningElementFnc = (node) => {
+    // $FlowFixMe[unclear-type]
+    const jSXOpeningElementFnc = (node: any) => {
       // exit if Gestalt is not imported
       if (!gestaltImportNode) return null;
 

--- a/packages/eslint-plugin-gestalt/src/prefer-box-inline-style.js
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-inline-style.js
@@ -20,16 +20,30 @@ function getInlineDefinedStyles(attr) {
   return attr.value.expression.properties ? attr.value.expression.properties : null;
 }
 
-// $FlowFixMe[missing-local-annot]
-function getVariableDefinedStyles(ref) {
-  return ref.resolved &&
+function getVariableDefinedStyles(ref: {|
+  resolved: {|
+    defs: $ReadOnlyArray<{|
+      node: {|
+        init: {|
+          properties: $ReadOnlyArray<{|
+            key: { value: string, name: string, ... },
+            type: string,
+            value: { value: string, ... },
+          |}>,
+        |},
+      |},
+    |}>,
+  |},
+|}) {
+  return (
+    ref.resolved &&
     ref.resolved.defs &&
     ref.resolved.defs[0] &&
     ref.resolved.defs[0].node &&
     ref.resolved.defs[0].node.init &&
+    ref.resolved.defs[0].node.init.properties &&
     ref.resolved.defs[0].node.init.properties
-    ? ref.resolved.defs[0].node.init.properties
-    : null;
+  );
 }
 
 const rule: ESLintRule = {
@@ -94,7 +108,9 @@ const rule: ESLintRule = {
           const matched = attr.name && attr.name.name === 'style';
           if (matched) {
             // If we have style properties here, this is an object declared inline
-            let styleProperties = getInlineDefinedStyles(attr);
+            let styleProperties: null | $ReadOnlyArray<{ ... }>;
+            styleProperties = getInlineDefinedStyles(attr);
+
             // Not declared inline? Check to see if there's a variable matching the name defined
             if (!styleProperties && attr.value.expression.name) {
               const scope = context.getScope(node);
@@ -111,7 +127,7 @@ const rule: ESLintRule = {
                 .map(({ key, type, value }) => {
                   // Handle things like spread props
                   if (!key || value.value === undefined) {
-                    return { name: type, value: null };
+                    return { name: type, value: '' };
                   }
                   return { name: key.name, value: value.value };
                 })

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -60,7 +60,7 @@ const CustomTextField = forwardRef(
       onMouseUp,
       ownerState,
     }: CustomTextFieldProps,
-    inputRef,
+    inputRef: ((null | HTMLInputElement) => mixed) | { current: null | HTMLInputElement, ... },
   ): Node => {
     const [iconFocused, setIconFocused] = useState(false);
 

--- a/packages/gestalt/src/Collage/Collection.js
+++ b/packages/gestalt/src/Collage/Collection.js
@@ -69,17 +69,31 @@ export default function Collection(props: Props): Node {
 
   // Calculates which items from the item layer to render in the viewport
   // layer.
-  const items = layout.reduce((acc, position, idx) => {
-    if (
-      position.top + position.height > viewportTop &&
-      position.top < viewportHeight + viewportTop &&
-      position.left < viewportWidth + viewportLeft &&
-      position.left + position.width > viewportLeft
-    ) {
-      acc.push({ idx, ...position });
-    }
-    return acc;
-  }, []);
+  const items = layout.reduce(
+    (
+      acc: $ReadOnlyArray<{|
+        height: number,
+        idx: number,
+        left: number,
+        top: number,
+        width: number,
+      |}>,
+      position,
+      idx,
+    ) => {
+      const newAcc = [...acc];
+      if (
+        position.top + position.height > viewportTop &&
+        position.top < viewportHeight + viewportTop &&
+        position.left < viewportWidth + viewportLeft &&
+        position.left + position.width > viewportLeft
+      ) {
+        newAcc.push({ idx, ...position });
+      }
+      return newAcc;
+    },
+    [],
+  );
 
   return (
     <div className={layoutStyles.relative} style={{ width, height }}>

--- a/packages/gestalt/src/OverlayPanel/InternalOverlayPanel.js
+++ b/packages/gestalt/src/OverlayPanel/InternalOverlayPanel.js
@@ -102,8 +102,9 @@ export default function InternalOverlayPanel({
 
   const { message, subtext, primaryAction, secondaryAction } = dismissConfirmation ?? {};
 
-  // $FlowFixMe[missing-local-annot]
-  function buildDismissableSubcomponent(component) {
+  function buildDismissableSubcomponent(
+    component: Node | (({| onDismissStart: () => void |}) => Node),
+  ) {
     return typeof component === 'function'
       ? component({ onDismissStart: onExternalDismiss })
       : component;

--- a/packages/gestalt/src/SideNavigationGroup.js
+++ b/packages/gestalt/src/SideNavigationGroup.js
@@ -108,8 +108,7 @@ export default function SideNavigationGroup({
     filterLevel: 'nested',
   });
 
-  // $FlowFixMe[missing-local-annot]
-  const hasActiveChildCallback = (child) =>
+  const hasActiveChildCallback = (child: {| props: {| active: 'page' | 'section' |} |}) =>
     child?.props?.active && ['page', 'section'].includes(child?.props?.active);
 
   const hasActiveChildren = !!navigationChildren.find(hasActiveChildCallback);

--- a/playwright/masonry/flexible-resize.spec.mjs
+++ b/playwright/masonry/flexible-resize.spec.mjs
@@ -6,8 +6,8 @@ import resizeWidth from './utils/resizeWidth.mjs';
 import selectors from './utils/selectors.mjs';
 import waitForRenderedItems from './utils/waitForRenderedItems.mjs';
 
-// $FlowFixMe[missing-local-annot]
-async function getItemColumnMap(gridItems) {
+// $FlowFixMe[unclear-type]
+async function getItemColumnMap(gridItems: any) {
   const itemLeftMap = {};
   for (let i = 0; i < gridItems.length; i += 1) {
     const boundingBox = await gridItems[i].boundingBox();
@@ -89,7 +89,7 @@ test.describe('Masonry: flexible resize', () => {
     for (let i = 0; i < originalColumns.length; i += 1) {
       const originalCol = originalItemMap[originalColumns[i]];
       const newCol = newItemMap[newColumns[i]];
-      originalCol.forEach((item, row) => {
+      originalCol.forEach((item, row: number) => {
         const newItem = newCol[row];
         expect(newItem).not.toBeUndefined();
         expect(item.text).toEqual(newItem.text);

--- a/playwright/masonry/shuffle-items.spec.mjs
+++ b/playwright/masonry/shuffle-items.spec.mjs
@@ -1,14 +1,14 @@
 // @flow strict
-import { expect, test } from '@playwright/test';
+import { expect, test, Page } from '@playwright/test';
 import getGridItems from './utils/getGridItems.mjs';
 import getServerURL from './utils/getServerURL.mjs';
 import selectors from './utils/selectors.mjs';
 import waitForRenderedItems from './utils/waitForRenderedItems.mjs';
 
-// $FlowFixMe[missing-local-annot]
-const getItemColumnMap = async (page) => {
+const getItemColumnMap = async (page: typeof Page) => {
   const gridItems = await getGridItems(page);
-  const itemLeftMap = {};
+  // $FlowFixMe[unclear-type]
+  const itemLeftMap: any = {};
 
   for (let i = 0; i < gridItems.length; i += 1) {
     const boundingBox = await gridItems[i].boundingBox();

--- a/playwright/masonry/utils/getGridItems.mjs
+++ b/playwright/masonry/utils/getGridItems.mjs
@@ -1,7 +1,13 @@
 // @flow strict
+import { Page } from '@playwright/test';
 import selectors from './selectors.mjs';
 
-// $FlowExpectedError[unclear-type] flow-typed def for playwright is…lacking
-export default function getGridItems(page /*: Object */) /*: Promise<any> */ {
+export default function getGridItems(page: typeof Page): Promise<
+  $ReadOnlyArray<{|
+    innerText: () => void,
+    textContent: () => void,
+    boundingBox: () => Promise<{| [string]: number |}>,
+  |}>
+> {
   return page.locator(selectors.gridItem).all();
 }


### PR DESCRIPTION
Internal: fixes to pass `flow codemod annotate-react-hooks --write .`

Prepping codebase to upgrade to Flow v 0.203.1


Annotate all parameters that are only required to be annotated in LTI.
- [x] flow codemod annotate-functions-and-classes --include-lti --write .
Annotate declarations to help unbreak type cycles.
- [x] flow codemod annotate-cycles --write .
Annotate underconstrained react hooks like useState(null).
- [x] flow codemod annotate-react-hooks --write .
Annotate underconstrained empty arrays.
- [x] flow codemod annotate-empty-array --write .
Annotate under-constrained type arguments.
- [ ] flow codemod annotate-implicit-instantiations --write .
Annotate type arguments that might be widened. 
This is a noisy codemod that doesn't always produce what you might want.
- [ ] flow codemod annotate-implicit-instantiations --write --include-widened .
Same as above, but it will annotate function returns like 
`array.map((v): T => {...})` instead of `array.map<T, _>(v => {...})`
- [x]  flow codemod annotate-implicit-instantiations --write --include-widened --annotate-special-function-return .

From https://medium.com/flow-type/local-type-inference-for-flow-aaa65d071347

<img width="812" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/1ab2664d-0642-440f-b3e2-9a579f831040">
