### PR TITLE
Internal: fixes to pass ` flow codemod annotate-implicit-instantiations --write --include-widened .` & `flow codemod annotate-implicit-instantiations --write .`

### DIFF
--- a/docs/examples/combobox/controlled.js
+++ b/docs/examples/combobox/controlled.js
@@ -68,7 +68,11 @@ export default function Example(): Node {
 
   const [suggestedOptions, setSuggestedOptions] = useState(usStatesOptions);
   const [inputValue, setInputValue] = useState(usStatesOptions[5].label);
-  const [selected, setSelected] = useState(usStatesOptions[5]);
+  const [selected, setSelected] = useState<void | {|
+    label: string,
+    subtext?: string,
+    value: string,
+  |}>(usStatesOptions[5]);
 
   const handleOnChange = ({
     value,

--- a/docs/examples/iconbuttonfloating/variantsA11y.js
+++ b/docs/examples/iconbuttonfloating/variantsA11y.js
@@ -71,7 +71,7 @@ export default function Example(): Node {
     <Box margin={3}>
       <Box role="main">
         <Flex justifyContent="center" width="100%" height="100%" gap={5} alignItems="center" wrap>
-          {[...new Array(3)].map(() =>
+          {[...new Array<void | $ReadOnlyArray<Node>>(3)].map(() =>
             pins.map((pin) => (
               <Mask rounding={2} key={pin.name} height={170} width={100}>
                 <Image

--- a/docs/examples/numberfield/bestPractices-do-required.js
+++ b/docs/examples/numberfield/bestPractices-do-required.js
@@ -3,7 +3,11 @@ import { useState } from 'react';
 import { Flex, NumberField } from 'gestalt';
 
 export default function Example(): React$Node {
-  const [values, setValues] = useState({
+  const [values, setValues] = useState<{|
+    first: ?number,
+    second: ?number,
+    third: ?number,
+  |}>({
     first: undefined,
     second: undefined,
     third: undefined,
@@ -24,6 +28,7 @@ export default function Example(): React$Node {
         onChange={({ value }) => {
           setValues((prevValues) => ({ ...prevValues, first: value }));
         }}
+        // $FlowFixMe[incompatible-type]
         value={values.first}
       />
       <NumberField
@@ -32,6 +37,7 @@ export default function Example(): React$Node {
         onChange={({ value }) => {
           setValues((prevValues) => ({ ...prevValues, second: value }));
         }}
+        // $FlowFixMe[incompatible-type]
         value={values.second}
       />
       <NumberField
@@ -40,6 +46,7 @@ export default function Example(): React$Node {
         onChange={({ value }) => {
           setValues((prevValues) => ({ ...prevValues, third: value }));
         }}
+        // $FlowFixMe[incompatible-type]
         value={values.third}
       />
     </Flex>

--- a/docs/examples/numberfield/bestPractices-dont-required.js
+++ b/docs/examples/numberfield/bestPractices-dont-required.js
@@ -3,7 +3,11 @@ import { useState } from 'react';
 import { Flex, NumberField } from 'gestalt';
 
 export default function Example(): React$Node {
-  const [values, setValues] = useState({
+  const [values, setValues] = useState<{|
+    first: ?number,
+    second: ?number,
+    third: ?number,
+  |}>({
     first: undefined,
     second: undefined,
     third: undefined,
@@ -25,6 +29,7 @@ export default function Example(): React$Node {
         onChange={({ value }) => {
           setValues((prevValues) => ({ ...prevValues, first: value }));
         }}
+        // $FlowFixMe[incompatible-type]
         value={values.first}
       />
       <NumberField
@@ -34,6 +39,7 @@ export default function Example(): React$Node {
         onChange={({ value }) => {
           setValues((prevValues) => ({ ...prevValues, second: value }));
         }}
+        // $FlowFixMe[incompatible-type]
         value={values.second}
       />
       <NumberField
@@ -42,6 +48,7 @@ export default function Example(): React$Node {
         onChange={({ value }) => {
           setValues((prevValues) => ({ ...prevValues, third: value }));
         }}
+        // $FlowFixMe[incompatible-type]
         value={values.third}
       />
     </Flex>

--- a/docs/examples/spinner/doOverlay.js
+++ b/docs/examples/spinner/doOverlay.js
@@ -16,7 +16,7 @@ function DataTable() {
       </Table.Header>
 
       <Table.Body>
-        {[...new Array(8)].map((_, i) => (
+        {[...new Array<void | Node>(8)].map((_, i) => (
           // eslint-disable-next-line react/no-array-index-key
           <Table.Row key={i}>
             {['$0.00', '0 clicks', '$0.00 CPC', '0', '$0.00'].map((item) => (

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -126,7 +126,7 @@ function iconHasKeyword(iconName?: string, searchTerm: string) {
 }
 
 export default function IconPage(): Node {
-  const [showToastText, setShowToastText] = useState(false);
+  const [showToastText, setShowToastText] = useState<void | string>();
 
   const iconOptions = icons
     .map((name, index) => ({

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -13,7 +13,7 @@ import MasonryContainer from '../../integration-test-helpers/masonry/MasonryCont
 // This can get bumped up another order of magnitude or so if needed…perf drops off pretty rapidly after that
 const REALISTIC_PINS_DATASET_SIZE = 1000;
 
-const measurementStore = Masonry.createMeasurementStore();
+const measurementStore = Masonry.createMeasurementStore<{ ... }, mixed>();
 
 // This is the counterpart to `normalizeValue` in `playwright/masonry/utils/getServerURL.mjs`
 function booleanize(value: string): boolean {

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -48,7 +48,17 @@ const getPins = () => {
     },
   ];
 
-  const pinList = [...new Array(3)].map(() => [...pins]).flat();
+  const pinList = [
+    ...new Array<void | {|
+      color: string,
+      height: number,
+      name: string,
+      src: string,
+      width: number,
+    |}>(3),
+  ]
+    .map(() => [...pins])
+    .flat();
   return Promise.resolve(pinList);
 };
 

--- a/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
+++ b/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
@@ -19,7 +19,10 @@ function DatePickerWrap({ showMonthYearDropdown }: {| showMonthYearDropdown?: bo
 }
 
 describe('DatePicker', () => {
-  const mockOnChange = jest.fn();
+  const mockOnChange = jest.fn<
+    [{| event: SyntheticInputEvent<HTMLInputElement>, value: Date |}],
+    void,
+  >();
 
   global.document.createRange = () => ({
     setStart: () => {},

--- a/packages/gestalt/src/ActivationCard.jsdom.test.js
+++ b/packages/gestalt/src/ActivationCard.jsdom.test.js
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import ActivationCard from './ActivationCard.js';
 
 test('ActivationCard handles onDismiss callback', () => {
-  const mockOnDismiss = jest.fn();
+  const mockOnDismiss = jest.fn<[], void>();
   const { getByLabelText } = render(
     <ActivationCard
       status="pending"

--- a/packages/gestalt/src/AvatarGroup.jsdom.test.js
+++ b/packages/gestalt/src/AvatarGroup.jsdom.test.js
@@ -172,8 +172,20 @@ describe('AvatarGroup', () => {
   });
 
   it('should render clickable TapArea with button role and ref', () => {
-    const onClickMock = jest.fn();
-    const ref = createRef();
+    const onClickMock = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event:
+            | SyntheticMouseEvent<HTMLDivElement>
+            | SyntheticKeyboardEvent<HTMLDivElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
+    const ref = createRef<mixed>();
     renderCmp({
       collaborators: [
         {
@@ -192,8 +204,20 @@ describe('AvatarGroup', () => {
   });
 
   it('should render clickable TapArea with link role and ref', () => {
-    const onClickMock = jest.fn();
-    const ref = createRef();
+    const onClickMock = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event:
+            | SyntheticMouseEvent<HTMLDivElement>
+            | SyntheticKeyboardEvent<HTMLDivElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
+    const ref = createRef<mixed>();
     renderCmp({
       collaborators: [
         {
@@ -213,7 +237,19 @@ describe('AvatarGroup', () => {
   });
 
   it('should not call onClick when clicked on display-only role', () => {
-    const onClickMock = jest.fn();
+    const onClickMock = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event:
+            | SyntheticMouseEvent<HTMLDivElement>
+            | SyntheticKeyboardEvent<HTMLDivElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     renderCmp({
       collaborators: [
         {

--- a/packages/gestalt/src/Box.jsdom.test.js
+++ b/packages/gestalt/src/Box.jsdom.test.js
@@ -5,7 +5,7 @@ import Box from './Box.js';
 
 describe('Box', () => {
   it('forwards a ref to the innermost div element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLElement>();
     render(<Box title="test" ref={ref} />);
     expect(ref.current instanceof HTMLDivElement).toEqual(true);
     expect(ref.current?.title).toEqual('test');

--- a/packages/gestalt/src/Button.jsdom.test.js
+++ b/packages/gestalt/src/Button.jsdom.test.js
@@ -5,7 +5,19 @@ import Button from './Button.js';
 
 describe('Button', () => {
   it('handles click', () => {
-    const mockOnClick = jest.fn();
+    const mockOnClick = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event:
+            | SyntheticMouseEvent<HTMLButtonElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLButtonElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(<Button text="ButtonText" onClick={mockOnClick} />);
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     getByText('ButtonText').click();
@@ -13,14 +25,14 @@ describe('Button', () => {
   });
 
   it('renders a submit button and forwards a ref to the innermost <button> element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(<Button type="submit" text="test" ref={ref} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current?.type).toEqual('submit');
   });
 
   it('renders a default button with sequential keyboard navigation and forwards a ref to the innermost <button> element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(<Button text="test" ref={ref} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current?.type).toEqual('button');
@@ -68,7 +80,7 @@ describe('Button', () => {
   });
 
   it('renders a link button with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(
       <Button text="test" role="link" href="http://www.pinterest.com" ref={ref} target="blank" />,
     );
@@ -80,14 +92,14 @@ describe('Button', () => {
   });
 
   it('renders a disabled button', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(<Button text="test" disabled ref={ref} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current instanceof HTMLButtonElement && ref.current?.disabled).toEqual(true);
   });
 
   it('renders a disabled link button', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(
       <Button
         text="test"
@@ -103,14 +115,14 @@ describe('Button', () => {
   });
 
   it('renders a button removed from sequential keyboard navigation via tabIndex', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(<Button text="test" ref={ref} tabIndex={-1} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current instanceof HTMLButtonElement && ref.current?.tabIndex).toEqual(-1);
   });
 
   it('renders a link button removed from sequential keyboard navigation via tabIndex', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(
       <Button
         text="test"

--- a/packages/gestalt/src/Callout.jsdom.test.js
+++ b/packages/gestalt/src/Callout.jsdom.test.js
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import Callout from './Callout.js';
 
 test('Callout handles onDismiss callback', () => {
-  const mockOnDismiss = jest.fn();
+  const mockOnDismiss = jest.fn<[], void>();
   const { getByLabelText } = render(
     <Callout
       message="Insert a clever error callout message here"

--- a/packages/gestalt/src/Checkbox.jsdom.test.js
+++ b/packages/gestalt/src/Checkbox.jsdom.test.js
@@ -3,8 +3,14 @@ import { createRef } from 'react';
 import { render } from '@testing-library/react';
 import Checkbox from './Checkbox.js';
 
-const mockOnClick = jest.fn();
-const mockOnChange = jest.fn();
+const mockOnClick = jest.fn<
+  [{| checked: boolean, event: SyntheticInputEvent<HTMLInputElement> |}],
+  void,
+>();
+const mockOnChange = jest.fn<
+  [{| checked: boolean, event: SyntheticInputEvent<HTMLInputElement> |}],
+  void,
+>();
 
 describe('Checkbox', () => {
   it('Checkbox handles click', () => {
@@ -21,14 +27,14 @@ describe('Checkbox', () => {
   });
 
   it('forwards a ref to the innermost input element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLInputElement>();
     render(<Checkbox checked id="testcheckbox" onChange={mockOnChange} ref={ref} />);
     expect(ref.current instanceof HTMLInputElement).toEqual(true);
     expect(ref.current?.checked).toEqual(true);
   });
 
   it('sets the innermost input to indeterminate with ref', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLInputElement>();
     render(<Checkbox indeterminate id="testcheckbox" onChange={mockOnChange} ref={ref} />);
     expect(ref.current instanceof HTMLInputElement).toEqual(true);
     expect(ref.current?.indeterminate).toEqual(true);

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -100,8 +100,8 @@ function getCollageLayout({
   // that here? a.) fewer dependencies and b.) we need the algorithm to
   // roughly preserve the order of the collages from when they were ordered
   // by Masonry.
-  const colHeights = new Array(gridCols).fill(0);
-  const colCounts = new Array(gridCols).fill(0);
+  const colHeights = new Array<number>(gridCols).fill(0);
+  const colCounts = new Array<number>(gridCols).fill(0);
 
   // We iterate over every position that we think we could _potentially_ have
   // so that we can fill them with empty sections if need be.

--- a/packages/gestalt/src/Dropdown.jsdom.test.js
+++ b/packages/gestalt/src/Dropdown.jsdom.test.js
@@ -10,8 +10,16 @@ describe('Dropdown', () => {
   });
 
   it('renders a menu of 6 items', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
 
     const { baseElement } = render(
@@ -58,8 +66,16 @@ describe('Dropdown', () => {
   });
 
   it('renders a menu of 3 items conditionally', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
     const renderOptions = true;
 
@@ -90,8 +106,16 @@ describe('Dropdown', () => {
   });
 
   it('renders dropdown sections', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
 
     render(
@@ -143,8 +167,16 @@ describe('Dropdown', () => {
   });
 
   it('renders a custom header', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
 
     render(
@@ -200,8 +232,16 @@ describe('Dropdown', () => {
   });
 
   it('closes when esc key is pressed', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
 
     render(
@@ -251,8 +291,16 @@ describe('Dropdown', () => {
   });
 
   it('closes when tab key is pressed', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
 
     render(
@@ -302,8 +350,16 @@ describe('Dropdown', () => {
   });
 
   it('changes active descendant when arrow keys are pressed', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
 
     render(
@@ -369,8 +425,16 @@ describe('Dropdown', () => {
   });
 
   it('should call item onSelect when enter key is pressed', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
 
     render(
@@ -429,9 +493,26 @@ describe('Dropdown', () => {
   });
 
   it('should call link onClick when enter key is pressed', () => {
-    const mockOnDismiss = jest.fn();
-    const onSelectMock = jest.fn();
-    const onClickMock = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const onSelectMock = jest.fn<
+      [
+        {|
+          event: SyntheticInputEvent<HTMLInputElement>,
+          item: {| label: string, subtext?: string, value: string |},
+        |},
+      ],
+      void,
+    >();
+    const onClickMock = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+          mobileOnDismissStart: () => void,
+        |},
+      ],
+      void,
+    >();
     const element = document.createElement('button');
 
     render(

--- a/packages/gestalt/src/Dropdown/OptionItem.jsdom.test.js
+++ b/packages/gestalt/src/Dropdown/OptionItem.jsdom.test.js
@@ -11,7 +11,7 @@ describe('OptionItem', () => {
       label: 'Option item label',
       value: 'Option item value',
     },
-    setHoveredItemIndex: jest.fn(),
+    setHoveredItemIndex: jest.fn<[number], void>(),
   };
 
   it('Should render correctly', () => {

--- a/packages/gestalt/src/DropdownItem.jsdom.test.js
+++ b/packages/gestalt/src/DropdownItem.jsdom.test.js
@@ -3,7 +3,15 @@ import { render, screen } from '@testing-library/react';
 import Dropdown from './Dropdown.js';
 
 describe('Dropdown.Item', () => {
-  const onSelectMock = jest.fn();
+  const onSelectMock = jest.fn<
+    [
+      {|
+        event: SyntheticInputEvent<HTMLInputElement>,
+        item: {| label: string, subtext?: string, value: string |},
+      |},
+    ],
+    void,
+  >();
 
   test('calls onSelect when Item clicked', () => {
     render(

--- a/packages/gestalt/src/DropdownLink.jsdom.test.js
+++ b/packages/gestalt/src/DropdownLink.jsdom.test.js
@@ -3,7 +3,16 @@ import { render, screen } from '@testing-library/react';
 import Dropdown from './Dropdown.js';
 
 describe('Dropdown.Link', () => {
-  const onClickMock = jest.fn();
+  const onClickMock = jest.fn<
+    [
+      {|
+        dangerouslyDisableOnNavigation: () => void,
+        event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        mobileOnDismissStart: () => void,
+      |},
+    ],
+    void,
+  >();
 
   test('calls onClick when Item clicked', () => {
     render(

--- a/packages/gestalt/src/HelpButton.jsdom.test.js
+++ b/packages/gestalt/src/HelpButton.jsdom.test.js
@@ -160,7 +160,15 @@ describe('HelpButton', () => {
   });
 
   it('renders a link spying the link trigger', () => {
-    const spy = jest.fn();
+    const spy = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     render(
       <HelpButton
         accessibilityLabel="Click to learn more about Pinterest"

--- a/packages/gestalt/src/IconButton.jsdom.test.js
+++ b/packages/gestalt/src/IconButton.jsdom.test.js
@@ -5,7 +5,19 @@ import IconButton from './IconButton.js';
 
 describe('IconButton', () => {
   it('handles click', () => {
-    const mockOnClick = jest.fn();
+    const mockOnClick = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event:
+            | SyntheticMouseEvent<HTMLButtonElement>
+            | SyntheticKeyboardEvent<HTMLButtonElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByRole } = render(
       <IconButton accessibilityLabel="test" icon="add" onClick={mockOnClick} />,
     );
@@ -15,14 +27,14 @@ describe('IconButton', () => {
   });
 
   it('renders a button with sequential keyboard navigation and forwards a ref to the innermost <button> element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(<IconButton accessibilityLabel="test" ref={ref} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current instanceof HTMLButtonElement && ref.current?.tabIndex).toEqual(0);
   });
 
   it('renders a link button with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(
       <IconButton
         accessibilityLabel="test"
@@ -41,7 +53,7 @@ describe('IconButton', () => {
   });
 
   it('renders a disabled link button', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(
       <IconButton
         disabled
@@ -58,21 +70,21 @@ describe('IconButton', () => {
   });
 
   it('renders a disabled button', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(<IconButton disabled accessibilityLabel="test" icon="add" ref={ref} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current instanceof HTMLButtonElement && ref.current?.disabled).toEqual(true);
   });
 
   it('renders an IconButton removed from sequential keyboard navigation via tabIndex', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(<IconButton accessibilityLabel="test" icon="add" ref={ref} tabIndex={-1} />);
     expect(ref.current instanceof HTMLButtonElement).toEqual(true);
     expect(ref.current instanceof HTMLButtonElement && ref.current?.tabIndex).toEqual(-1);
   });
 
   it('renders a link IconButton removed from sequential keyboard navigation via tabIndex', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLButtonElement | HTMLAnchorElement>();
     render(
       <IconButton
         accessibilityLabel="test"

--- a/packages/gestalt/src/Link.jsdom.test.js
+++ b/packages/gestalt/src/Link.jsdom.test.js
@@ -4,7 +4,15 @@ import Link from './Link.js';
 
 describe('Link', () => {
   test('Link handles onClick callback', () => {
-    const mockOnClick = jest.fn();
+    const mockOnClick = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(
       <Link href="https://example.com" onClick={mockOnClick}>
         Link

--- a/packages/gestalt/src/Link/InternalLink.jsdom.test.js
+++ b/packages/gestalt/src/Link/InternalLink.jsdom.test.js
@@ -3,7 +3,15 @@ import { render } from '@testing-library/react';
 import InternalLink from './InternalLink.js';
 
 test('InternalLink handles onClick callback', () => {
-  const mockOnClick = jest.fn();
+  const mockOnClick = jest.fn<
+    [
+      {|
+        dangerouslyDisableOnNavigation: () => void,
+        event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,
+      |},
+    ],
+    void,
+  >();
   const { getByText } = render(
     <InternalLink
       wrappedComponent="button"

--- a/packages/gestalt/src/Masonry/MeasureItems.js
+++ b/packages/gestalt/src/Masonry/MeasureItems.js
@@ -33,7 +33,7 @@ export default function MeasureItems<T>({
     // Do we have a full batch of refs?
     if (refsSize === items.length) {
       // Measure all the refs
-      const heights = new Map();
+      const heights = new Map<T, number>();
       refs.forEach((el, data) => {
         heights.set(data, el.clientHeight);
       });

--- a/packages/gestalt/src/Masonry/defaultLayout.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.js
@@ -36,7 +36,7 @@ const defaultLayout =
     const columnWidthAndGutter = columnWidth + gutter;
     const columnCount = Math.max(Math.floor((width + gutter) / columnWidthAndGutter), minCols);
     // the total height of each column
-    const heights = new Array(columnCount).fill(0);
+    const heights = new Array<number>(columnCount).fill(0);
 
     let centerOffset;
     if (justify === 'center') {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.js
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.js
@@ -35,7 +35,7 @@ const fullWidthLayout = <T>({
 
   return (items: $ReadOnlyArray<T>) => {
     // the total height of each column
-    const heights = new Array(columnCount).fill(0);
+    const heights = new Array<number>(columnCount).fill(0);
 
     return items.reduce((acc, item) => {
       const positions = acc;

--- a/packages/gestalt/src/Module/ExpandableItem.jsdom.test.js
+++ b/packages/gestalt/src/Module/ExpandableItem.jsdom.test.js
@@ -10,7 +10,7 @@ describe('ModuleExpandableItem', () => {
     title: 'test title',
     summary: ['summary1', 'summary2', 'summary3'],
     isCollapsed: true,
-    onModuleClicked: jest.fn(),
+    onModuleClicked: jest.fn<[boolean], void>(),
     type: 'info',
   };
 

--- a/packages/gestalt/src/ModuleExpandable.jsdom.test.js
+++ b/packages/gestalt/src/ModuleExpandable.jsdom.test.js
@@ -117,7 +117,7 @@ describe('ModuleExpandable', () => {
     const newProps = {
       ...props,
       expandedIndex: 0,
-      onExpandedChange: jest.fn(),
+      onExpandedChange: jest.fn<[?number], void>(),
     };
     render(<ModuleExpandable {...newProps} />);
 

--- a/packages/gestalt/src/NumberField.jsdom.test.js
+++ b/packages/gestalt/src/NumberField.jsdom.test.js
@@ -44,7 +44,7 @@ describe('NumberField', () => {
   });
 
   it('forwards a ref to <input />', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLInputElement>();
     render(
       <NumberField
         id="test"
@@ -60,7 +60,10 @@ describe('NumberField', () => {
   });
 
   it('handles blur events', () => {
-    const mockBlur = jest.fn();
+    const mockBlur = jest.fn<
+      [{| event: SyntheticFocusEvent<HTMLInputElement>, value: number | void |}],
+      void,
+    >();
     const { getByDisplayValue } = render(
       <NumberField id="test" onBlur={mockBlur} onChange={jest.fn()} value={42} />,
     );
@@ -71,7 +74,10 @@ describe('NumberField', () => {
   });
 
   it('handles change events', () => {
-    const mockChange = jest.fn();
+    const mockChange = jest.fn<
+      [{| event: SyntheticInputEvent<HTMLInputElement>, value: number | void |}],
+      void,
+    >();
     const { container } = render(<NumberField id="test" onChange={mockChange} value={42} />);
 
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Please fix the next time this file is touched!
@@ -87,7 +93,10 @@ describe('NumberField', () => {
   });
 
   it('handles focus events', () => {
-    const mockFocus = jest.fn();
+    const mockFocus = jest.fn<
+      [{| event: SyntheticFocusEvent<HTMLInputElement>, value: number | void |}],
+      void,
+    >();
     const { getByDisplayValue } = render(
       <NumberField id="test" onChange={jest.fn()} onFocus={mockFocus} value={42} />,
     );
@@ -98,7 +107,10 @@ describe('NumberField', () => {
   });
 
   it('handles key down events', () => {
-    const mockKeyDown = jest.fn();
+    const mockKeyDown = jest.fn<
+      [{| event: SyntheticKeyboardEvent<HTMLInputElement>, value: number | void |}],
+      void,
+    >();
     const { container } = render(
       <NumberField id="test" onChange={() => {}} onKeyDown={mockKeyDown} value={42} />,
     );

--- a/packages/gestalt/src/OverlayPanel.jsdom.test.js
+++ b/packages/gestalt/src/OverlayPanel.jsdom.test.js
@@ -111,7 +111,7 @@ describe('OverlayPanel', () => {
   // This test was skipped because, despite the logic works fine, the animationState is not being correctly updated in the test in the handleExternalDismiss function. We should try to make it work.
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should trigger onAnimationEnd', async () => {
-    const mockOnAnimationEnd = jest.fn();
+    const mockOnAnimationEnd = jest.fn<$ReadOnlyArray<$FlowFixMe>, mixed>();
     render(
       <OverlayPanel
         accessibilityDismissButtonLabel="Dismiss"
@@ -130,7 +130,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should dismiss from the dismiss button', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     render(
       <OverlayPanel
@@ -151,7 +151,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should dismiss from the ESC key', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     render(
       <OverlayPanel
@@ -172,7 +172,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should dismiss from clicking outside when closeOnOutsideClick is true', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     render(
       <OverlayPanel
@@ -195,7 +195,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should dismiss from clicking on the children content', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     const { getByText } = render(
       <OverlayPanel
@@ -223,7 +223,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should dismiss from clicking on the footer content', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     const { getByText } = render(
       <OverlayPanel
@@ -254,7 +254,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should dismiss from clicking on the subHeading content', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     const { getByText } = render(
       <OverlayPanel
@@ -286,7 +286,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should not dismiss from the backdrop click when closeOnOutsideClick is false', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     render(
       <OverlayPanel
@@ -308,7 +308,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should not dismiss from the backdrop click when closeOnOutsideClick and dismissConfirmation are true', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     render(
       <OverlayPanel
@@ -331,7 +331,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should not dismiss from the dismiss button key when closeOnOutsideClick and dismissConfirmation are true', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     render(
       <OverlayPanel
@@ -354,7 +354,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should not dismiss from the ESC keys when closeOnOutsideClick and dismissConfirmation are true', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     render(
       <OverlayPanel
@@ -380,7 +380,7 @@ describe('OverlayPanel', () => {
   });
 
   it('renders OverlayPanel with confirmation modal', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     const { container } = render(
       <OverlayPanel
@@ -403,7 +403,7 @@ describe('OverlayPanel', () => {
   });
 
   it('should show confirmation when closeOnOutsideClick and dismissConfirmation are true', () => {
-    const mockOnDismiss = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
 
     render(
       <OverlayPanel
@@ -458,8 +458,8 @@ describe('OverlayPanel', () => {
   });
 
   it('should show custom confirmation when closeOnOutsideClick and dismissConfirmation are true', () => {
-    const mockOnDismiss = jest.fn();
-    const mockOnAnimationEnd = jest.fn();
+    const mockOnDismiss = jest.fn<[], void>();
+    const mockOnAnimationEnd = jest.fn<$ReadOnlyArray<$FlowFixMe>, mixed>();
     useAnimationMock.mockReturnValue({
       animationState: 'unmount',
       handleAnimationEnd: mockOnAnimationEnd,

--- a/packages/gestalt/src/RadioButton.jsdom.test.js
+++ b/packages/gestalt/src/RadioButton.jsdom.test.js
@@ -3,11 +3,14 @@ import { createRef } from 'react';
 import { render } from '@testing-library/react';
 import RadioButton from './RadioButton.js';
 
-const mockOnChange = jest.fn();
+const mockOnChange = jest.fn<
+  [{| checked: boolean, event: SyntheticInputEvent<HTMLInputElement> |}],
+  void,
+>();
 
 describe('RadioButton', () => {
   it('forwards a ref to <Box ref={ref}><input/></Box>', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLInputElement>();
     render(
       <RadioButton value="test" checked id="testRadioButton" onChange={mockOnChange} ref={ref} />,
     );

--- a/packages/gestalt/src/ScrollBoundaryContainer.jsdom.test.js
+++ b/packages/gestalt/src/ScrollBoundaryContainer.jsdom.test.js
@@ -7,7 +7,7 @@ import { useScrollBoundaryContainer } from './contexts/ScrollBoundaryContainerPr
 
 describe('ScrollBoundaryContainer', () => {
   it('renders successfully', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLElement>();
 
     const { getByTestId } = render(
       <ScrollBoundaryContainer overflow="scroll">
@@ -20,7 +20,7 @@ describe('ScrollBoundaryContainer', () => {
   });
 
   it('passes default ScrollBoundaryContainer props through context correctly', () => {
-    const scrollBoundaryContainer = createRef();
+    const scrollBoundaryContainer = createRef<void | HTMLElement>();
 
     function TestBox() {
       const { scrollBoundaryContainerRef } = useScrollBoundaryContainer();
@@ -46,7 +46,7 @@ describe('ScrollBoundaryContainer', () => {
   });
 
   it('passes custom ScrollBoundaryContainer props through context correctly', () => {
-    const scrollBoundaryContainer = createRef();
+    const scrollBoundaryContainer = createRef<void | HTMLElement>();
 
     function TestBox() {
       const { scrollBoundaryContainerRef } = useScrollBoundaryContainer();

--- a/packages/gestalt/src/SegmentedControl.jsdom.test.js
+++ b/packages/gestalt/src/SegmentedControl.jsdom.test.js
@@ -4,7 +4,10 @@ import SegmentedControl from './SegmentedControl.js';
 
 describe('<SegmentedControl />', () => {
   it('handles a click', () => {
-    const mockOnChange = jest.fn();
+    const mockOnChange = jest.fn<
+      [{| activeIndex: number, event: SyntheticMouseEvent<HTMLButtonElement> |}],
+      void,
+    >();
     const { getByText } = render(
       <SegmentedControl items={['Item1', 'Item2']} selectedItemIndex={0} onChange={mockOnChange} />,
     );

--- a/packages/gestalt/src/SelectList.jsdom.test.js
+++ b/packages/gestalt/src/SelectList.jsdom.test.js
@@ -30,7 +30,10 @@ describe('<SelectList />', () => {
   });
 
   it('handles errorMessage prop change', () => {
-    const handleChange = jest.fn();
+    const handleChange = jest.fn<
+      [{| event: SyntheticInputEvent<HTMLSelectElement>, value: string |}],
+      void,
+    >();
     const { rerender } = render(
       <SelectList id="test" onChange={handleChange}>
         {options}

--- a/packages/gestalt/src/SheetMobile.jsdom.test.js
+++ b/packages/gestalt/src/SheetMobile.jsdom.test.js
@@ -128,8 +128,20 @@ describe('SheetMobile', () => {
   });
 
   it('calls onDismiss on full inanimated sheet', async () => {
-    const mockOnClick = jest.fn();
-    const mockOnClickPrimaryAction = jest.fn();
+    const mockOnClick = jest.fn<[], void>();
+    const mockOnClickPrimaryAction = jest.fn<
+      [
+        {|
+          event:
+            | SyntheticMouseEvent<HTMLButtonElement>
+            | SyntheticKeyboardEvent<HTMLButtonElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>,
+          onDismissStart: () => void,
+        |},
+      ],
+      void,
+    >();
 
     render(
       <DeviceTypeProvider deviceType="mobile">
@@ -163,8 +175,20 @@ describe('SheetMobile', () => {
   // This test was skipped because, despite the logic works fine, the animationState is not being correctly updated in the test in the handleExternalDismiss function. We should try to make it work.
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('calls onDismiss on animated partial sheet', async () => {
-    const mockOnClick = jest.fn();
-    const mockOnClickPrimaryAction = jest.fn();
+    const mockOnClick = jest.fn<[], void>();
+    const mockOnClickPrimaryAction = jest.fn<
+      [
+        {|
+          event:
+            | SyntheticMouseEvent<HTMLButtonElement>
+            | SyntheticKeyboardEvent<HTMLButtonElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>,
+          onDismissStart: () => void,
+        |},
+      ],
+      void,
+    >();
     useReducedMotionMock.mockReturnValue(false);
 
     render(

--- a/packages/gestalt/src/TableRowExpandable.jsdom.test.js
+++ b/packages/gestalt/src/TableRowExpandable.jsdom.test.js
@@ -7,7 +7,19 @@ import TableCell from './TableCell.js';
 import TableRowExpandable from './TableRowExpandable.js';
 import Text from './Text.js';
 
-const mockOnExpand = jest.fn();
+const mockOnExpand = jest.fn<
+  [
+    {|
+      event:
+        | SyntheticMouseEvent<HTMLButtonElement>
+        | SyntheticKeyboardEvent<HTMLButtonElement>
+        | SyntheticMouseEvent<HTMLAnchorElement>
+        | SyntheticKeyboardEvent<HTMLAnchorElement>,
+      expanded: boolean,
+    |},
+  ],
+  void,
+>();
 
 test('TableRowExpandable handles expand contents call', () => {
   const { getByText } = render(

--- a/packages/gestalt/src/TableSortableHeaderCell.jsdom.test.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.jsdom.test.js
@@ -3,7 +3,19 @@ import { fireEvent, render } from '@testing-library/react';
 import TableSortableHeaderCell from './TableSortableHeaderCell.js';
 
 test('mouse click calls onSortChange', () => {
-  const mockOnSortChange = jest.fn();
+  const mockOnSortChange = jest.fn<
+    [
+      {|
+        dangerouslyDisableOnNavigation: () => void,
+        event:
+          | SyntheticMouseEvent<HTMLDivElement>
+          | SyntheticKeyboardEvent<HTMLDivElement>
+          | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement>,
+      |},
+    ],
+    void,
+  >();
   const { getByText } = render(
     <table>
       <thead>
@@ -25,7 +37,19 @@ test('mouse click calls onSortChange', () => {
 });
 
 test('keypress calls onSortChange', () => {
-  const mockOnSortChange = jest.fn();
+  const mockOnSortChange = jest.fn<
+    [
+      {|
+        dangerouslyDisableOnNavigation: () => void,
+        event:
+          | SyntheticMouseEvent<HTMLDivElement>
+          | SyntheticKeyboardEvent<HTMLDivElement>
+          | SyntheticMouseEvent<HTMLAnchorElement>
+          | SyntheticKeyboardEvent<HTMLAnchorElement>,
+      |},
+    ],
+    void,
+  >();
   const { getByText } = render(
     <table>
       <thead>
@@ -41,7 +65,7 @@ test('keypress calls onSortChange', () => {
       </thead>
     </table>,
   );
-  const mockEvent = { charCode: 32, preventDefault: jest.fn() };
+  const mockEvent = { charCode: 32, preventDefault: jest.fn<$ReadOnlyArray<$FlowFixMe>, mixed>() };
   // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
   fireEvent.keyPress(getByText('column name'), mockEvent);
   expect(mockOnSortChange).toHaveBeenCalled();

--- a/packages/gestalt/src/Tabs.jsdom.test.js
+++ b/packages/gestalt/src/Tabs.jsdom.test.js
@@ -4,7 +4,20 @@ import Tabs from './Tabs.js';
 
 describe('<Tabs />', () => {
   it('handles click', () => {
-    const mockOnChange = jest.fn();
+    const mockOnChange = jest.fn<
+      [
+        {|
+          +activeTabIndex: number,
+          dangerouslyDisableOnNavigation: () => void,
+          event:
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>
+            | SyntheticMouseEvent<HTMLDivElement>
+            | SyntheticKeyboardEvent<HTMLDivElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(
       <Tabs
         tabs={[

--- a/packages/gestalt/src/TapArea.jsdom.test.js
+++ b/packages/gestalt/src/TapArea.jsdom.test.js
@@ -5,7 +5,19 @@ import TapArea from './TapArea.js';
 
 describe('TapArea', () => {
   it('TapArea handles onTap callback', () => {
-    const mockOnTap = jest.fn();
+    const mockOnTap = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event:
+            | SyntheticMouseEvent<HTMLDivElement>
+            | SyntheticKeyboardEvent<HTMLDivElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(<TapArea onTap={mockOnTap}>TapArea</TapArea>);
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     getByText('TapArea').click();
@@ -13,7 +25,14 @@ describe('TapArea', () => {
   });
 
   it('TapArea handles onBlur callback', () => {
-    const mockOnBlur = jest.fn();
+    const mockOnBlur = jest.fn<
+      [
+        {|
+          event: SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(<TapArea onBlur={mockOnBlur}>TapArea</TapArea>);
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     fireEvent.focus(getByText('TapArea'));
@@ -23,7 +42,14 @@ describe('TapArea', () => {
   });
 
   it('TapArea handles onFocus callback', () => {
-    const mockOnFocus = jest.fn();
+    const mockOnFocus = jest.fn<
+      [
+        {|
+          event: SyntheticFocusEvent<HTMLDivElement> | SyntheticFocusEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(<TapArea onFocus={mockOnFocus}>TapArea</TapArea>);
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     fireEvent.focus(getByText('TapArea'));
@@ -31,7 +57,14 @@ describe('TapArea', () => {
   });
 
   it('TapArea handles onMouseEnter callback', () => {
-    const mockOnMouseEnter = jest.fn();
+    const mockOnMouseEnter = jest.fn<
+      [
+        {|
+          event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(<TapArea onMouseEnter={mockOnMouseEnter}>TapArea</TapArea>);
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     fireEvent.mouseEnter(getByText('TapArea'));
@@ -39,7 +72,14 @@ describe('TapArea', () => {
   });
 
   it('TapArea handles onMouseLeave callback', () => {
-    const mockOnMouseLeave = jest.fn();
+    const mockOnMouseLeave = jest.fn<
+      [
+        {|
+          event: SyntheticMouseEvent<HTMLDivElement> | SyntheticMouseEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(<TapArea onMouseLeave={mockOnMouseLeave}>TapArea</TapArea>);
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     fireEvent.mouseLeave(getByText('TapArea'));
@@ -47,23 +87,38 @@ describe('TapArea', () => {
   });
 
   it('TapArea handles key press event', () => {
-    const mockOnTap = jest.fn();
+    const mockOnTap = jest.fn<
+      [
+        {|
+          dangerouslyDisableOnNavigation: () => void,
+          event:
+            | SyntheticMouseEvent<HTMLDivElement>
+            | SyntheticKeyboardEvent<HTMLDivElement>
+            | SyntheticMouseEvent<HTMLAnchorElement>
+            | SyntheticKeyboardEvent<HTMLAnchorElement>,
+        |},
+      ],
+      void,
+    >();
     const { getByText } = render(<TapArea onTap={mockOnTap}>TapArea</TapArea>);
-    const mockEvent = { charCode: 32, preventDefault: jest.fn() };
+    const mockEvent = {
+      charCode: 32,
+      preventDefault: jest.fn<$ReadOnlyArray<$FlowFixMe>, mixed>(),
+    };
     // eslint-disable-next-line testing-library/prefer-screen-queries -- Please fix the next time this file is touched!
     fireEvent.keyPress(getByText('TapArea'), mockEvent);
     expect(mockOnTap).toHaveBeenCalled();
   });
 
   it('renders a TapArea with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLAnchorElement | HTMLDivElement>();
     render(<TapArea ref={ref} />);
     expect(ref.current instanceof HTMLDivElement).toEqual(true);
     expect(ref.current instanceof HTMLDivElement && ref.current?.tabIndex).toEqual(0);
   });
 
   it('renders a link TapArea with sequential keyboard navigation and forwards a ref to the innermost <a> element', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLAnchorElement | HTMLDivElement>();
     render(<TapArea role="link" href="http://www.pinterest.com" ref={ref} target="blank" />);
     expect(ref.current instanceof HTMLAnchorElement).toEqual(true);
     expect(ref.current instanceof HTMLAnchorElement && ref.current?.href).toEqual(
@@ -73,14 +128,14 @@ describe('TapArea', () => {
   });
 
   it('renders a disabled TapArea', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLAnchorElement | HTMLDivElement>();
     render(<TapArea disabled ref={ref} />);
     expect(ref.current instanceof HTMLDivElement).toEqual(true);
     expect(ref.current instanceof HTMLDivElement && ref.current?.tabIndex).toEqual(-1);
   });
 
   it('renders a disabled link TapArea', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLAnchorElement | HTMLDivElement>();
     render(
       <TapArea role="link" href="http://www.pinterest.com" disabled ref={ref} target="blank" />,
     );
@@ -89,14 +144,14 @@ describe('TapArea', () => {
   });
 
   it('renders a TapArea removed from sequential keyboard navigation via tabIndex', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLAnchorElement | HTMLDivElement>();
     render(<TapArea tabIndex={-1} ref={ref} />);
     expect(ref.current instanceof HTMLDivElement).toEqual(true);
     expect(ref.current instanceof HTMLDivElement && ref.current?.tabIndex).toEqual(-1);
   });
 
   it('renders a link TapArea removed from sequential keyboard navigation via tabIndex', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLAnchorElement | HTMLDivElement>();
     render(
       <TapArea
         role="link"

--- a/packages/gestalt/src/TextArea.jsdom.test.js
+++ b/packages/gestalt/src/TextArea.jsdom.test.js
@@ -103,7 +103,10 @@ describe('TextArea', () => {
   });
 
   it('handles blur events', () => {
-    const mockBlur = jest.fn();
+    const mockBlur = jest.fn<
+      [{| event: SyntheticFocusEvent<HTMLTextAreaElement>, value: string |}],
+      void,
+    >();
     const { getByDisplayValue } = render(
       <TextArea id="test" onBlur={mockBlur} onChange={jest.fn()} value="TextArea Text" />,
     );
@@ -114,7 +117,10 @@ describe('TextArea', () => {
   });
 
   it('handles change events', () => {
-    const mockChange = jest.fn();
+    const mockChange = jest.fn<
+      [{| event: SyntheticInputEvent<HTMLTextAreaElement>, value: string |}],
+      void,
+    >();
     const { container } = render(
       <TextArea id="test" onChange={mockChange} value="TextArea Text" />,
     );
@@ -132,7 +138,10 @@ describe('TextArea', () => {
   });
 
   it('handles focus events', () => {
-    const mockFocus = jest.fn();
+    const mockFocus = jest.fn<
+      [{| event: SyntheticFocusEvent<HTMLTextAreaElement>, value: string |}],
+      void,
+    >();
     const { getByDisplayValue } = render(
       <TextArea id="test" onChange={jest.fn()} onFocus={mockFocus} value="TextArea Text" />,
     );
@@ -143,7 +152,10 @@ describe('TextArea', () => {
   });
 
   it('handles key down events', () => {
-    const mockKeyDown = jest.fn();
+    const mockKeyDown = jest.fn<
+      [{| event: SyntheticKeyboardEvent<HTMLTextAreaElement>, value: string |}],
+      void,
+    >();
     const { container } = render(
       <TextArea id="test" onChange={() => {}} onKeyDown={mockKeyDown} value="TextArea Text" />,
     );
@@ -161,7 +173,7 @@ describe('TextArea', () => {
   });
 
   it('forwards a ref to <input />', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLTextAreaElement>();
     render(
       <TextArea
         id="test"

--- a/packages/gestalt/src/TextField.jsdom.test.js
+++ b/packages/gestalt/src/TextField.jsdom.test.js
@@ -114,7 +114,7 @@ describe('TextField', () => {
   });
 
   it('forwards a ref to <input />', () => {
-    const ref = createRef();
+    const ref = createRef<HTMLInputElement>();
     render(
       <TextField
         id="test"
@@ -130,7 +130,10 @@ describe('TextField', () => {
   });
 
   it('handles blur events', () => {
-    const mockBlur = jest.fn();
+    const mockBlur = jest.fn<
+      [{| event: SyntheticFocusEvent<HTMLInputElement>, value: string |}],
+      void,
+    >();
     const { getByDisplayValue } = render(
       <TextField id="test" onBlur={mockBlur} onChange={jest.fn()} value="TextField Text" />,
     );
@@ -141,7 +144,10 @@ describe('TextField', () => {
   });
 
   it('handles change events', () => {
-    const mockChange = jest.fn();
+    const mockChange = jest.fn<
+      [{| event: SyntheticInputEvent<HTMLInputElement>, value: string |}],
+      void,
+    >();
     const { container } = render(
       <TextField id="test" onChange={mockChange} value="TextField Text" />,
     );
@@ -159,7 +165,10 @@ describe('TextField', () => {
   });
 
   it('handles focus events', () => {
-    const mockFocus = jest.fn();
+    const mockFocus = jest.fn<
+      [{| event: SyntheticFocusEvent<HTMLInputElement>, value: string |}],
+      void,
+    >();
     const { getByDisplayValue } = render(
       <TextField id="test" onChange={jest.fn()} onFocus={mockFocus} value="TextField Text" />,
     );
@@ -170,7 +179,10 @@ describe('TextField', () => {
   });
 
   it('handles key down events', () => {
-    const mockKeyDown = jest.fn();
+    const mockKeyDown = jest.fn<
+      [{| event: SyntheticKeyboardEvent<HTMLInputElement>, value: string |}],
+      void,
+    >();
     const { container } = render(
       <TextField id="test" onChange={() => {}} onKeyDown={mockKeyDown} value="TextField Text" />,
     );

--- a/packages/gestalt/src/Upsell.jsdom.test.js
+++ b/packages/gestalt/src/Upsell.jsdom.test.js
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import Upsell from './Upsell.js';
 
 test('Upsell handles onDismiss callback', () => {
-  const mockOnDismiss = jest.fn();
+  const mockOnDismiss = jest.fn<[], void>();
   const { getByLabelText } = render(
     <Upsell
       message="Insert a clever upsell message here"

--- a/packages/gestalt/src/Video/Controls.js
+++ b/packages/gestalt/src/Video/Controls.js
@@ -131,18 +131,18 @@ function VideoControls({
 
   const muted = volume === 0;
 
-  const [showFullscreenButton, setShowFullscreenButton] = useState(false);
+  const [showFullscreenButton, setShowFullscreenButton] = useState<boolean>(false);
 
   useEffect(() => {
     setShowFullscreenButton(
       typeof document !== 'undefined' &&
-        (document.fullscreenEnabled ||
+        (!!document.fullscreenEnabled ||
           // $FlowExpectedError[prop-missing]
-          document.webkitFullscreenEnabled ||
+          !!document.webkitFullscreenEnabled ||
           // $FlowExpectedError[prop-missing]
-          document.mozFullScreenEnabled ||
+          !!document.mozFullScreenEnabled ||
           // $FlowExpectedError[prop-missing]
-          document.msFullscreenEnabled),
+          !!document.msFullscreenEnabled),
     );
   }, []);
 

--- a/packages/gestalt/src/Video/Controls.jsdom.test.js
+++ b/packages/gestalt/src/Video/Controls.jsdom.test.js
@@ -3,7 +3,10 @@ import { fireEvent, render } from '@testing-library/react';
 import VideoControls from './Controls.js';
 
 test('VideoControls handles play events', () => {
-  const mockOnPlay = jest.fn();
+  const mockOnPlay = jest.fn<
+    [SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>],
+    void,
+  >();
   const { getByLabelText } = render(
     <VideoControls
       accessibilityHideCaptionsLabel="Hide captions"
@@ -37,7 +40,10 @@ test('VideoControls handles play events', () => {
 });
 
 test('VideoControls handles pause events', () => {
-  const mockOnPause = jest.fn();
+  const mockOnPause = jest.fn<
+    [SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>],
+    void,
+  >();
   const { getByLabelText } = render(
     <VideoControls
       accessibilityHideCaptionsLabel="Hide captions"
@@ -71,7 +77,10 @@ test('VideoControls handles pause events', () => {
 });
 
 test('VideoControls handles volume events', () => {
-  const mockOnVolumeChange = jest.fn();
+  const mockOnVolumeChange = jest.fn<
+    [SyntheticEvent<HTMLDivElement> | SyntheticEvent<HTMLAnchorElement>],
+    void,
+  >();
   const { getByLabelText } = render(
     <VideoControls
       accessibilityHideCaptionsLabel="Hide captions"

--- a/packages/gestalt/src/Video/Playhead.jsdom.test.js
+++ b/packages/gestalt/src/Video/Playhead.jsdom.test.js
@@ -3,8 +3,8 @@ import { fireEvent, render } from '@testing-library/react';
 import VideoPlayhead from './Playhead.js';
 
 test('VideoPlayhead handles on mouse down and up events', () => {
-  const mockOnPlayheadDown = jest.fn();
-  const mockOnPlayheadUp = jest.fn();
+  const mockOnPlayheadDown = jest.fn<[SyntheticMouseEvent<HTMLDivElement>], void>();
+  const mockOnPlayheadUp = jest.fn<[SyntheticMouseEvent<HTMLDivElement>], void>();
   const { getByRole } = render(
     <VideoPlayhead
       accessibilityProgressBarLabel="Progress bar"
@@ -31,8 +31,8 @@ test('VideoPlayhead handles on mouse down and up events', () => {
 });
 
 test('VideoPlayhead ends seek when mouse leaves', () => {
-  const mockOnPlayheadDown = jest.fn();
-  const mockOnPlayheadUp = jest.fn();
+  const mockOnPlayheadDown = jest.fn<[SyntheticMouseEvent<HTMLDivElement>], void>();
+  const mockOnPlayheadUp = jest.fn<[SyntheticMouseEvent<HTMLDivElement>], void>();
   const { getByRole } = render(
     <VideoPlayhead
       accessibilityProgressBarLabel="Progress bar"

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
@@ -84,7 +84,8 @@ describe('useColorScheme', () => {
   });
 
   it('uses theme based on matchMedia when userPreference', () => {
-    let listener = jest.fn();
+    // $FlowFixMe[unclear-type]
+    let listener = jest.fn<[{| matches: boolean |}], any>();
     window.matchMedia = () => ({
       addListener: (cb) => {
         listener = cb;

--- a/packages/gestalt/src/contexts/SideNavigationProvider.js
+++ b/packages/gestalt/src/contexts/SideNavigationProvider.js
@@ -10,8 +10,8 @@ type SideNavigationContextType = {|
   setSelectedItemId: (string) => void,
   selectedMobileChildren: Node | null,
   setSelectedMobileChildren: (Node | null) => void,
-  hideActiveChildren: boolean | null,
-  setHideActiveChildren: (boolean | null) => void,
+  hideActiveChildren: boolean,
+  setHideActiveChildren: (boolean) => void,
   dismissButton?: {|
     accessibilityLabel?: string,
     onDismiss: () => void,
@@ -39,7 +39,7 @@ const { Provider } = SideNavigationContext;
 function SideNavigationProvider({ children, dismissButton }: Props): Element<typeof Provider> {
   const [selectedItemId, setSelectedItemId] = useState('');
   const [selectedMobileChildren, setSelectedMobileChildren] = useState<Node>(null);
-  const [hideActiveChildren, setHideActiveChildren] = useState(false);
+  const [hideActiveChildren, setHideActiveChildren] = useState<boolean>(false);
 
   const sideNavigationContext = {
     selectedItemId,

--- a/packages/gestalt/src/useReducedMotion.jsdom.test.js
+++ b/packages/gestalt/src/useReducedMotion.jsdom.test.js
@@ -5,27 +5,49 @@ import useReducedMotion from './useReducedMotion.js';
 const mediaqueryDefaults = {
   matches: false,
   onchange: null,
-  addEventListener: jest.fn(),
-  removeEventListener: jest.fn(),
+  addEventListener: jest.fn<$ReadOnlyArray<$FlowFixMe>, mixed>(),
+  removeEventListener: jest.fn<$ReadOnlyArray<$FlowFixMe>, mixed>(),
 };
 
 describe('useReducedMotion', () => {
   test('returns true if "Reduced Motion" is enabled', () => {
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      ...mediaqueryDefaults,
-      matches: true,
-      media: query,
-    }));
+    window.matchMedia = jest
+      .fn<
+        _,
+        {|
+          addEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+          matches: boolean,
+          media: $FlowFixMe,
+          onchange: null,
+          removeEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+        |},
+      >()
+      .mockImplementation((query) => ({
+        ...mediaqueryDefaults,
+        matches: true,
+        media: query,
+      }));
 
     const { result } = renderHook(useReducedMotion);
     expect(result.current).toBe(true);
   });
 
   test('returns false if "Reduced Motion" is disabled', () => {
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      ...mediaqueryDefaults,
-      media: query,
-    }));
+    window.matchMedia = jest
+      .fn<
+        _,
+        {|
+          addEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+          matches: boolean,
+          media: $FlowFixMe,
+          onchange: null,
+          removeEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+        |},
+      >()
+      .mockImplementation((query) => ({
+        ...mediaqueryDefaults,
+        media: query,
+      }));
 
     const { result } = renderHook(useReducedMotion);
     expect(result.current).toBe(false);

--- a/packages/gestalt/src/useResponsiveMinWidth.jsdom.test.js
+++ b/packages/gestalt/src/useResponsiveMinWidth.jsdom.test.js
@@ -5,50 +5,94 @@ import useResponsiveMinWidth from './useResponsiveMinWidth.js';
 const mediaqueryDefaults = {
   matches: false,
   onchange: null,
-  addEventListener: jest.fn(),
-  removeEventListener: jest.fn(),
+  addEventListener: jest.fn<$ReadOnlyArray<$FlowFixMe>, mixed>(),
+  removeEventListener: jest.fn<$ReadOnlyArray<$FlowFixMe>, mixed>(),
 };
 
 describe('useResponsiveMinWidth', () => {
   test('returns `xs` for extra small screens', () => {
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      ...mediaqueryDefaults,
-      matches: query === '(min-width: 240px)',
-      media: query,
-    }));
+    window.matchMedia = jest
+      .fn<
+        _,
+        {|
+          addEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+          matches: boolean,
+          media: $FlowFixMe,
+          onchange: null,
+          removeEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+        |},
+      >()
+      .mockImplementation((query) => ({
+        ...mediaqueryDefaults,
+        matches: query === '(min-width: 240px)',
+        media: query,
+      }));
 
     const { result } = renderHook(useResponsiveMinWidth);
     expect(result.current).toBe('xs');
   });
 
   test('returns `sm` for small screens', () => {
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      ...mediaqueryDefaults,
-      matches: query === '(min-width: 576px)',
-      media: query,
-    }));
+    window.matchMedia = jest
+      .fn<
+        _,
+        {|
+          addEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+          matches: boolean,
+          media: $FlowFixMe,
+          onchange: null,
+          removeEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+        |},
+      >()
+      .mockImplementation((query) => ({
+        ...mediaqueryDefaults,
+        matches: query === '(min-width: 576px)',
+        media: query,
+      }));
 
     const { result } = renderHook(useResponsiveMinWidth);
     expect(result.current).toBe('sm');
   });
 
   test('returns `md` for medium screens', () => {
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      ...mediaqueryDefaults,
-      matches: query === '(min-width: 768px)',
-      media: query,
-    }));
+    window.matchMedia = jest
+      .fn<
+        _,
+        {|
+          addEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+          matches: boolean,
+          media: $FlowFixMe,
+          onchange: null,
+          removeEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+        |},
+      >()
+      .mockImplementation((query) => ({
+        ...mediaqueryDefaults,
+        matches: query === '(min-width: 768px)',
+        media: query,
+      }));
 
     const { result } = renderHook(useResponsiveMinWidth);
     expect(result.current).toBe('md');
   });
 
   test('returns `lg` for large screens', () => {
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      ...mediaqueryDefaults,
-      matches: query === '(min-width: 1312px)',
-      media: query,
-    }));
+    window.matchMedia = jest
+      .fn<
+        _,
+        {|
+          addEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+          matches: boolean,
+          media: $FlowFixMe,
+          onchange: null,
+          removeEventListener: JestMockFn<$ReadOnlyArray<$FlowFixMe>, mixed>,
+        |},
+      >()
+      .mockImplementation((query) => ({
+        ...mediaqueryDefaults,
+        matches: query === '(min-width: 1312px)',
+        media: query,
+      }));
 
     const { result } = renderHook(useResponsiveMinWidth);
     expect(result.current).toBe('lg');


### PR DESCRIPTION
Internal: fixes to pass ` flow codemod annotate-implicit-instantiations --write --include-widened .` & `flow codemod annotate-implicit-instantiations --write .`

Prepping codebase to upgrade to Flow v 0.203.1


Annotate all parameters that are only required to be annotated in LTI.
- [x] flow codemod annotate-functions-and-classes --include-lti --write .
Annotate declarations to help unbreak type cycles.
- [x] flow codemod annotate-cycles --write .
Annotate underconstrained react hooks like useState(null).
- [x] flow codemod annotate-react-hooks --write .
Annotate underconstrained empty arrays.
- [x] flow codemod annotate-empty-array --write .
Annotate under-constrained type arguments.
- [x] flow codemod annotate-implicit-instantiations --write .
Annotate type arguments that might be widened. 
This is a noisy codemod that doesn't always produce what you might want.
- [x] flow codemod annotate-implicit-instantiations --write --include-widened .
Same as above, but it will annotate function returns like 
`array.map((v): T => {...})` instead of `array.map<T, _>(v => {...})`
- [x]  flow codemod annotate-implicit-instantiations --write --include-widened --annotate-special-function-return .

From https://medium.com/flow-type/local-type-inference-for-flow-aaa65d071347

<img width="812" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/1ab2664d-0642-440f-b3e2-9a579f831040">
