### PR TITLE
Internal: upgrade to Flow 0.206.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.204.1
+0.206.0
 
 [ignore]
 <PROJECT_ROOT>/packages/gestalt-codemods/.*/__testfixtures__

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-testing-library": "^5.6.0",
     "eslint-plugin-validate-jsx-nesting": "^0.1.0",
-    "flow-bin": "^0.204.1",
+    "flow-bin": "^0.206.0",
     "flow-remove-types": "^2.184.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "28.0.3",

--- a/packages/gestalt/src/Divider.js
+++ b/packages/gestalt/src/Divider.js
@@ -9,6 +9,7 @@ import styles from './Divider.css';
  * ![Divider dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Divider-dark.spec.mjs-snapshots/Divider-dark-chromium-darwin.png)
  *
  */
-export default function Divider(): Node {
+// eslint-disable-next-line no-empty-pattern
+export default function Divider({}: {||}): Node {
   return <hr className={styles.divider} />;
 }

--- a/packages/gestalt/src/debounce.js
+++ b/packages/gestalt/src/debounce.js
@@ -35,5 +35,6 @@ export default function debounce(
     }
   };
 
+  // $FlowFixMe[incompatible-exact]
   return debounced;
 }

--- a/packages/gestalt/src/throttle.js
+++ b/packages/gestalt/src/throttle.js
@@ -38,5 +38,6 @@ export default function throttle(
     }
   };
 
+  // $FlowFixMe[incompatible-exact]
   return throttled;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8523,10 +8523,10 @@ flatten@^1.0.2:
   resolved "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@^0.204.1:
-  version "0.204.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.204.1.tgz#096c1dc5413edfa3f8284f888449f436a10a68fc"
-  integrity sha512-gYlDS1cRIV/FnqLc8G0xb/pFdu9eGM+NuxZlihlxRrt3GTfei8IioPSXMpiJz11DPPkiAr9tpIyI+g5RcP1W7Q==
+flow-bin@^0.206.0:
+  version "0.206.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.206.0.tgz#a593304be5440a965ae773efcef55071b6d33178"
+  integrity sha512-cZTEs/OEWcbxfvb8BP+Fw0Cep5wrEyEzQHGpXyjVpQXrAraRA5wZUXvTf1C5YHufQaAYY9YkKY5WAr461JvmOA==
 
 flow-parser@0.*:
   version "0.122.0"


### PR DESCRIPTION
Internal: upgrade to Flow 0.206.0

https://github.com/facebook/flow/releases/tag/v0.205.0
https://github.com/facebook/flow/releases/tag/v0.206.0