### PR TITLE
Internal: Unminify classname when developing

### DIFF
--- a/packages/gestalt-core/build.js
+++ b/packages/gestalt-core/build.js
@@ -57,7 +57,14 @@ const cssModules = (options = {}) => {
         scopeNames[hash] = classnameBuilder.getMinifiedClassname(hash);
       }
 
-      return scopeNames[hash];
+      // if it's dev mode, also append the full class name for debugging
+      const isDevMode = process.argv.includes('-w') || process.argv.includes('--watch');
+      let minifiedName = scopeNames[hash];
+      if (isDevMode) {
+        minifiedName = `${name}__${minifiedName}`;
+      }
+
+      return minifiedName;
     },
     getJSON: (filePath, exportTokens) => {
       Object.entries(exportTokens).forEach(([className, value]) => {

--- a/packages/gestalt-core/build.js
+++ b/packages/gestalt-core/build.js
@@ -57,14 +57,11 @@ const cssModules = (options = {}) => {
         scopeNames[hash] = classnameBuilder.getMinifiedClassname(hash);
       }
 
-      // if the DEVMODE environment variable is set, then don't minify the classnames
-      const isDevMode = process.env.DEVMODE === 'true';
-      let minifiedName = scopeNames[hash];
-      if (isDevMode) {
-        minifiedName = `${name}__${minifiedName}`;
-      }
+      // if it's not production, use the minfied name + extended name
+      const className =
+        process.env.DEVMODE === 'true' ? `${name}__${scopeNames[hash]}` : scopeNames[hash];
 
-      return minifiedName;
+      return className;
     },
     getJSON: (filePath, exportTokens) => {
       Object.entries(exportTokens).forEach(([className, value]) => {

--- a/packages/gestalt-core/build.js
+++ b/packages/gestalt-core/build.js
@@ -57,7 +57,7 @@ const cssModules = (options = {}) => {
         scopeNames[hash] = classnameBuilder.getMinifiedClassname(hash);
       }
 
-      // if it's dev mode, also append the full class name for debugging
+      // if rollup is running in watch mode, with the -w or --watch flag also append the full class name for debugging
       const isDevMode = process.argv.includes('-w') || process.argv.includes('--watch');
       let minifiedName = scopeNames[hash];
       if (isDevMode) {

--- a/packages/gestalt-core/build.js
+++ b/packages/gestalt-core/build.js
@@ -57,8 +57,8 @@ const cssModules = (options = {}) => {
         scopeNames[hash] = classnameBuilder.getMinifiedClassname(hash);
       }
 
-      // if rollup is running in watch mode, with the -w or --watch flag also append the full class name for debugging
-      const isDevMode = process.argv.includes('-w') || process.argv.includes('--watch');
+      // if the DEVMODE environment variable is set, then don't minify the classnames
+      const isDevMode = process.env.DEVMODE === 'true';
       let minifiedName = scopeNames[hash];
       if (isDevMode) {
         minifiedName = `${name}__${minifiedName}`;

--- a/packages/gestalt-core/build.js
+++ b/packages/gestalt-core/build.js
@@ -57,7 +57,7 @@ const cssModules = (options = {}) => {
         scopeNames[hash] = classnameBuilder.getMinifiedClassname(hash);
       }
 
-      // if it's not production, use the minfied name + extended name
+      // if it's not production, use the minified name + extended name
       const className =
         process.env.DEVMODE === 'true' ? `${name}__${scopeNames[hash]}` : scopeNames[hash];
 

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -26,7 +26,7 @@
     "build:prod": "NODE_ENV=production rollup -c rollup.config.js",
     "postpack": "rm README.md",
     "prepack": "cp ../../README.md .",
-    "watch": "rollup -c rollup.config.js --watch"
+    "watch": "DEVMODE=true rollup -c rollup.config.js --watch"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
When rollup is run watch mode (our development version), the outputted css will also include the full classname to make it easier for debugging in the inspect tab.

**Why?**
When building components, it's hard to track the minified css or know which class to modify. This can also encourage behavior to to write new classes instead of extending current ones. The code may write the style class like this `styles.button`, but when debugging, it's up to the developer to associate that with `DUt` as a className


What changed:
Classnames when in development are run as `fullClassName___minifiedClassName`

**BEFORE**
![image](https://github.com/pinterest/gestalt/assets/5509813/c6737956-0be4-4fd1-bbb7-30eb8577d5ae)

**AFTER**
![image](https://github.com/pinterest/gestalt/assets/5509813/17731be5-83c2-4911-b602-4690346266a8)
