### PR TITLE
Docs: fix bug in navigation

### DIFF
--- a/docs/docs-components/navigationContext.js
+++ b/docs/docs-components/navigationContext.js
@@ -34,7 +34,7 @@ function NavigationContextProvider({ children }: {| children?: Node |}): Node {
 
   const [cookies, setCookies] = useCookies([localStorageOrganizedByKey]);
 
-  const { pathname } = useRouter();
+  const { asPath: pathname } = useRouter();
 
   let currentPlatform = null;
 
@@ -47,7 +47,6 @@ function NavigationContextProvider({ children }: {| children?: Node |}): Node {
   } else if (pathname.includes('/ios/')) {
     currentPlatform = 'ios';
   }
-
   let currentSiteSection = null;
 
   if (currentPlatform) {


### PR DESCRIPTION
### Summary

#### What changed?

Docs: fix bug in navigation

#### Why?

<img width="396" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/12a37840-aae7-4a4a-8368-fa235f143b8c">

http://localhost:8888/android/text

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/c7188dfd-7eed-4347-b70a-70c368a862d1)

Behaviour only on ios and android. It might have to do with the markdown implementation?

[GESTALT-5854](https://jira.pinadmin.com/browse/GESTALT-5854)