### PR TITLE
Table: added "selected"and "hoverStyle" prop  to all Table.Row subcomponents

### DIFF
--- a/docs/examples/table/selected.js
+++ b/docs/examples/table/selected.js
@@ -1,0 +1,136 @@
+// @flow strict
+import { useState, type Node } from 'react';
+import { Table, Checkbox, Flex, Text, Box } from 'gestalt';
+
+export default function Example(): Node {
+  const [selected, setSelectedRow] = useState<$ReadOnlyArray<string>>([]);
+
+  return (
+    <Box height="100%" width="100%" overflow="scroll">
+      <Flex alignItems="start" gap={4} height="100%" justifyContent="center" width="100%">
+        <Table accessibilityLabel="Selected row example table">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Text />
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Selected</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Column</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Column</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Subcomponent</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row
+              key="row1"
+              hoverStyle="gray"
+              selected={selected.includes('row') ? 'selected' : 'unselected'}
+            >
+              <Table.Cell>
+                <Text />
+              </Table.Cell>
+              <Table.Cell>
+                <Checkbox
+                  id="Row"
+                  onChange={() =>
+                    setSelectedRow((value) =>
+                      value.includes('row')
+                        ? value.filter((item) => item !== 'row')
+                        : [...value, 'row'],
+                    )
+                  }
+                  size="sm"
+                  checked={selected.includes('row')}
+                />
+              </Table.Cell>
+              <Table.Cell>
+                <Text>value</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>value</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Table.Row</Text>
+              </Table.Cell>
+            </Table.Row>
+            <Table.RowExpandable
+              accessibilityCollapseLabel="Collapse"
+              accessibilityExpandLabel="Expand"
+              expandedContents={<Text>Content</Text>}
+              key="row2"
+              id="row2"
+              hoverStyle="gray"
+              selected={selected.includes('rowExpandable') ? 'selected' : 'unselected'}
+            >
+              <Table.Cell>
+                <Checkbox
+                  id="RowExpandable"
+                  onChange={() =>
+                    setSelectedRow((value) =>
+                      value.includes('rowExpandable')
+                        ? value.filter((item) => item !== 'rowExpandable')
+                        : [...value, 'rowExpandable'],
+                    )
+                  }
+                  size="sm"
+                  checked={selected.includes('rowExpandable')}
+                />
+              </Table.Cell>
+              <Table.Cell>
+                <Text>value</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>value</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Table.RowExpandable</Text>
+              </Table.Cell>
+            </Table.RowExpandable>
+            <Table.RowDrawer
+              drawerContents={<Text>Content</Text>}
+              key="row3"
+              id="row3"
+              hoverStyle="gray"
+              selected={selected.includes('rowDrawer') ? 'selected' : 'unselected'}
+            >
+              <Table.Cell>
+                <Text />
+              </Table.Cell>
+              <Table.Cell>
+                <Checkbox
+                  id="rowDrawer"
+                  onChange={() =>
+                    setSelectedRow((value) =>
+                      value.includes('rowDrawer')
+                        ? value.filter((item) => item !== 'rowDrawer')
+                        : [...value, 'rowDrawer'],
+                    )
+                  }
+                  size="sm"
+                  checked={selected.includes('rowDrawer')}
+                />
+              </Table.Cell>
+              <Table.Cell>
+                <Text>value</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>value</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Table.RowDrawer</Text>
+              </Table.Cell>
+            </Table.RowDrawer>
+          </Table.Body>
+        </Table>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/pages/web/table.js
+++ b/docs/pages/web/table.js
@@ -10,6 +10,7 @@ import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
 import controlledExpandable from '../../examples/table/controlledExpandable.js';
 import main from '../../examples/table/main.js';
+import selected from '../../examples/table/selected.js';
 import uncontrolledExpandable from '../../examples/table/uncontrolledExpandable.js';
 
 export default function DocsPage({
@@ -2457,6 +2458,19 @@ function Example() {
       );
     }
 `}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Selected & hovered state"
+          description={`Table.Row, Table.RowExpandable and Table.RowDrawer support hovered and selected states.
+
+If a row subcomponent is selectable, toggle the \`selected\` prop between "selected" and "unselected" to keep a constant border space in the row that is only visible when the row is selected.
+
+If the row is not selectable, the \`selected\` prop should not be set. In this case, it doesn't set a side border.
+          `}
+        >
+          <MainSection.Card
+            sandpackExample={<SandpackExample code={selected} name="Selected example" />}
           />
         </MainSection.Subsection>
       </MainSection>

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1729,6 +1729,8 @@ interface TableSortableHeaderCellProps {
 
 interface TableRowProps {
   children: Node;
+  hoverStyle?: 'gray' | 'none' | undefined;
+  selected?: 'selected' | 'unselected' | undefined;
 }
 
 interface TableRowExpandableProps {
@@ -1736,16 +1738,19 @@ interface TableRowExpandableProps {
   accessibilityExpandLabel: string;
   children: Node;
   expandedContents: Node;
-  id: string;
   expanded?: string | undefined;
-  hoverStyle?: 'none' | 'gray' | undefined;
+  hoverStyle?: 'gray' | 'none' | undefined;
+  id: string;
   onExpand?: BareButtonEventHandlerType | undefined;
+  selected?: 'selected' | 'unselected' | undefined;
 }
 
 interface TableRowDrawerProps {
   children: Node;
   drawerContents: Node;
+  hoverStyle?: 'gray' | 'none' | undefined;
   id: string;
+  selected?: 'selected' | 'unselected' | undefined;
 }
 
 interface TabsProps {

--- a/packages/gestalt/src/Table.css
+++ b/packages/gestalt/src/Table.css
@@ -88,3 +88,23 @@
 .hoverShadeGray:hover .columnSticky {
   background-color: var(--g-colorGray100);
 }
+
+.selected {
+  background-color: var(--g-colorGray100);
+}
+
+html:not([dir="rtl"]) .selected td:first-child {
+  border-left: 3px solid var(--g-colorGray400);
+}
+
+html[dir="rtl"] .selected td:first-child {
+  border-right: 3px solid var(--g-colorGray400);
+}
+
+html:not([dir="rtl"]) .unselected td:first-child {
+  border-left: 3px solid var(--color-background-elevation-floating);
+}
+
+html[dir="rtl"] .unselected td:first-child {
+  border-right: 3px solid var(--color-background-elevation-floating);
+}

--- a/packages/gestalt/src/Table.css.flow
+++ b/packages/gestalt/src/Table.css.flow
@@ -7,6 +7,7 @@ declare module.exports: {|
   +'horizontalScrollLeft': string,
   +'horizontalScrollRight': string,
   +'hoverShadeGray': string,
+  +'selected': string,
   +'stickyFooter': string,
   +'stickyHeader': string,
   +'table': string,
@@ -15,4 +16,5 @@ declare module.exports: {|
   +'tfooter': string,
   +'th': string,
   +'thead': string,
+  +'unselected': string,
 |};

--- a/packages/gestalt/src/TableRow.js
+++ b/packages/gestalt/src/TableRow.js
@@ -1,5 +1,7 @@
 // @flow strict
 import { type Node, Children, cloneElement, useEffect, useRef, useState } from 'react';
+import classnames from 'classnames';
+import styles from './Table.css';
 import { useTableContext } from './contexts/TableContext.js';
 
 type Props = {|
@@ -7,12 +9,20 @@ type Props = {|
    * Must be instances of Table.Cell, Table.HeaderCell, or Table.SortableHeaderCell components. See the [Subcomponent section](https://gestalt.pinterest.systems/web/table#Subcomponents) to learn more.
    */
   children: Node,
+  /**
+   * Sets the background color on hover over the row. See the [selected and hovered state variant](https://gestalt.pinterest.systems/web/table#Selected-and-hovered-state) to learn more.
+   */
+  hoverStyle?: 'gray' | 'none',
+  /**
+   * Indicates if Table.Row is currently selected or unselected. See the [selected and hovered state variant](https://gestalt.pinterest.systems/web/table#Selected-and-hovered-state) to learn more.
+   */
+  selected?: 'selected' | 'unselected',
 |};
 
 /**
  * Use [Table.Row](https://gestalt.pinterest.systems/web/table#Table.Row) to define a row in Table.
  */
-export default function TableRow({ children }: Props): Node {
+export default function TableRow({ children, hoverStyle = 'none', selected }: Props): Node {
   const { stickyColumns } = useTableContext();
   const rowRef = useRef<?HTMLTableRowElement>();
   const [columnWidths, setColumnWidths] = useState<$ReadOnlyArray<number>>([]);
@@ -35,8 +45,14 @@ export default function TableRow({ children }: Props): Node {
     return cloneElement(child, { shouldBeSticky, previousTotalWidth, shouldHaveShadow });
   };
 
+  const rowStyle = classnames({
+    [styles.hoverShadeGray]: hoverStyle === 'gray' && selected !== 'selected',
+    [styles.selected]: selected === 'selected',
+    [styles.unselected]: selected === 'unselected',
+  });
+
   return (
-    <tr ref={rowRef}>
+    <tr className={rowStyle} ref={rowRef}>
       {Number(stickyColumns) > 0 ? Children.map(children, renderCellWithIndex) : children}
     </tr>
   );

--- a/packages/gestalt/src/TableRowDrawer.js
+++ b/packages/gestalt/src/TableRowDrawer.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { type Node, Children, cloneElement, Fragment, useEffect, useRef, useState } from 'react';
+import classnames from 'classnames';
 import styles from './Table.css';
 import Box from './Box.js';
 import { useTableContext } from './contexts/TableContext.js';
@@ -15,15 +16,30 @@ type Props = {|
    */
   drawerContents: Node,
   /**
+   * Sets the background color on hover over the row. See the [selected and hovered state variant](https://gestalt.pinterest.systems/web/table#Selected-and-hovered-state) to learn more.
+   */
+  hoverStyle?: 'gray' | 'none',
+
+  /**
    * Unique id for Table.RowDrawer.
    */
   id: string,
+  /**
+   * Indicates if Table.RowDrawer is currently selected or unselected. See the [selected and hovered state variant](https://gestalt.pinterest.systems/web/table#Selected-and-hovered-state) to learn more.
+   */
+  selected?: 'selected' | 'unselected',
 |};
 
 /**
  * Use [Table.RowDrawer](https://gestalt.pinterest.systems/web/table#Table.RowDrawer) to define a row drawer to display additional content.
  */
-export default function TableRowDrawer({ children, drawerContents, id }: Props): Node {
+export default function TableRowDrawer({
+  children,
+  drawerContents,
+  hoverStyle = 'none',
+  id,
+  selected,
+}: Props): Node {
   const { stickyColumns } = useTableContext();
   const rowRef = useRef<?HTMLTableRowElement>();
   const [columnWidths, setColumnWidths] = useState<$ReadOnlyArray<number>>([]);
@@ -50,9 +66,15 @@ export default function TableRowDrawer({ children, drawerContents, id }: Props):
     return cloneElement(child, { shouldBeSticky, previousTotalWidth, shouldHaveShadow });
   };
 
+  const rowStyle = classnames({
+    [styles.hoverShadeGray]: hoverStyle === 'gray' && selected !== 'selected',
+    [styles.selected]: selected === 'selected',
+    [styles.unselected]: selected === 'unselected',
+  });
+
   return (
     <Fragment>
-      <tr aria-details={drawerContents ? id : undefined} ref={rowRef}>
+      <tr aria-details={drawerContents ? id : undefined} className={rowStyle} ref={rowRef}>
         {/* This needs to be fixed for children wrapped in React.Fragment when sticky columns are present */}
         {Number(stickyColumns) > 0 ? Children.map(children, renderCellWithAdjustedIndex) : children}
       </tr>

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { type Node, Children, cloneElement, Fragment, useEffect, useRef, useState } from 'react';
+import classnames from 'classnames';
 import styles from './Table.css';
 import Box from './Box.js';
 import IconButton from './IconButton.js';
@@ -40,13 +41,17 @@ type Props = {|
     expanded: boolean,
   |}) => void,
   /**
-   * Sets the background color on hover over the row.
+   * Sets the background color on hover over the row. See the [selected and hovered state variant](https://gestalt.pinterest.systems/web/table#Selected-and-hovered-state) to learn more.
    */
   hoverStyle?: 'gray' | 'none',
   /**
    * Unique id for Table.RowExpandable.
    */
   id: string,
+  /**
+   * Indicates if Table.RowExpandable is currently selected or unselected. See the [selected and hovered state variant](https://gestalt.pinterest.systems/web/table#Selected-and-hovered-state) to learn more.
+   */
+  selected?: 'selected' | 'unselected',
 |};
 
 /**
@@ -61,6 +66,7 @@ export default function TableRowExpandable({
   onExpand,
   id,
   hoverStyle = 'gray',
+  selected,
 }: Props): Node {
   const { stickyColumns } = useTableContext();
   const rowRef = useRef<?HTMLTableRowElement>();
@@ -95,9 +101,15 @@ export default function TableRowExpandable({
     return cloneElement(child, { shouldBeSticky, previousTotalWidth, shouldHaveShadow });
   };
 
+  const rowStyle = classnames({
+    [styles.hoverShadeGray]: hoverStyle === 'gray' && selected !== 'selected',
+    [styles.selected]: selected === 'selected',
+    [styles.unselected]: selected === 'unselected',
+  });
+
   return (
     <Fragment>
-      <tr className={hoverStyle === 'gray' ? styles.hoverShadeGray : null} ref={rowRef}>
+      <tr className={rowStyle} ref={rowRef}>
         <TableCell
           shouldBeSticky={stickyColumns ? stickyColumns > 0 : false}
           previousTotalWidth={0}

--- a/packages/gestalt/src/__snapshots__/TableFooter.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableFooter.jsdom.test.js.snap
@@ -20,7 +20,9 @@ exports[`Table.Footer renders correctly 1`] = `
         <tfoot
           class="tfooter"
         >
-          <tr>
+          <tr
+            class=""
+          >
             <td
               class="td"
             >
@@ -58,7 +60,9 @@ exports[`Table.Footer sticky footer renders correctly 1`] = `
         <tfoot
           class="stickyFooter"
         >
-          <tr>
+          <tr
+            class=""
+          >
             <td
               class="td"
             >

--- a/packages/gestalt/src/__snapshots__/TableHeader..jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableHeader..jsdom.test.js.snap
@@ -20,7 +20,9 @@ exports[`Table.Header renders correctly 1`] = `
         <thead
           class="thead"
         >
-          <tr>
+          <tr
+            class=""
+          >
             <td
               class="td"
             >
@@ -58,7 +60,9 @@ exports[`Table.Header sticky header renders correctly 1`] = `
         <thead
           class="stickyHeader"
         >
-          <tr>
+          <tr
+            class=""
+          >
             <td
               class="td"
             >

--- a/packages/gestalt/src/__snapshots__/TableRow.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableRow.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  className=""
+>
   <div>
     row cells
   </div>

--- a/packages/gestalt/src/__snapshots__/TableRowDrawer.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableRowDrawer.test.js.snap
@@ -29,7 +29,9 @@ exports[`renders correctly with drawer 1`] = `
     <thead
       className="thead"
     >
-      <tr>
+      <tr
+        className=""
+      >
         <th
           className="th"
           scope="col"
@@ -101,6 +103,7 @@ exports[`renders correctly with drawer 1`] = `
     >
       <tr
         aria-details="drawerTest"
+        className=""
       >
         <td
           className="td"
@@ -229,7 +232,9 @@ exports[`renders correctly with drawer 1`] = `
           </div>
         </td>
       </tr>
-      <tr>
+      <tr
+        className=""
+      >
         <td
           className="td"
           style={

--- a/packages/gestalt/src/__snapshots__/TableRowExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableRowExpandable.test.js.snap
@@ -136,7 +136,7 @@ exports[`renders correctly with explicit hover 1`] = `
 
 exports[`renders correctly without hover 1`] = `
 <tr
-  className={null}
+  className=""
 >
   <td
     className="td"


### PR DESCRIPTION
## Summary

#### What changed?

Table: added "selected"and "hoverStyle" prop to all Table.Row subcomponents

![Brave Browser - Table - Gestalt 2023-05-19 at 4 52 02 AM](https://github.com/pinterest/gestalt/assets/10593890/2a22db86-404a-4d7b-8b53-c0039f91570b)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4697)
- [Figma](https://www.figma.com/file/pGpBsKBAXMwl2bv1dMISfs/Documentation-Table-Selected-Row?type=design&node-id=1%3A1956&t=J4YninrFn7P6Wzyb-1)

### Checklist

- [ ] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
