### PR TITLE
Callout: Convert examples to use Sandpack

### DIFF
--- a/docs/examples/callout/accessibilityExample.js
+++ b/docs/examples/callout/accessibilityExample.js
@@ -1,30 +1,34 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss this banner',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Info"
-      message="Apply to the Verified Merchant Program"
-      primaryAction={{
-        accessibilityLabel: 'Get started: Verified Merchant Program',
-        href: 'https://pinterest.com',
-        label: 'Get started',
-        target: 'blank',
-      }}
-      secondaryAction={{
-        accessibilityLabel: 'Learn more: Verified Merchant Program',
-        href: 'https://pinterest.com',
-        label: 'Learn more',
-        target: 'blank',
-      }}
-      title="Your business account was created!"
-      type="info"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message="Apply to the Verified Merchant Program"
+          primaryAction={{
+            accessibilityLabel: 'Get started: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Get started',
+            target: 'blank',
+          }}
+          secondaryAction={{
+            accessibilityLabel: 'Learn more: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="Your business account was created!"
+          type="info"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/accessibilityExample.js
+++ b/docs/examples/callout/accessibilityExample.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      dismissButton={{
+        accessibilityLabel: 'Dismiss this banner',
+        onDismiss: () => {},
+      }}
+      iconAccessibilityLabel="Info"
+      message="Apply to the Verified Merchant Program"
+      primaryAction={{
+        accessibilityLabel: 'Get started: Verified Merchant Program',
+        href: 'https://pinterest.com',
+        label: 'Get started',
+        target: 'blank',
+      }}
+      secondaryAction={{
+        accessibilityLabel: 'Learn more: Verified Merchant Program',
+        href: 'https://pinterest.com',
+        label: 'Learn more',
+        target: 'blank',
+      }}
+      title="Your business account was created!"
+      type="info"
+    />
+  );
+}

--- a/docs/examples/callout/actionsExample.js
+++ b/docs/examples/callout/actionsExample.js
@@ -1,0 +1,98 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import {
+  Box,
+  Callout,
+  Layer,
+  Modal,
+  Flex,
+  ButtonGroup,
+  Button,
+  Column,
+  Label,
+  Text,
+  TextField,
+  TextArea,
+} from 'gestalt';
+
+export default function Example(): Node {
+  const [showModal, setShowModal] = useState(false);
+  const toggleModal = () => {
+    setShowModal((currState) => !currState);
+  };
+
+  return (
+    <Box marginStart={-1} marginEnd={-1}>
+      <Callout
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        iconAccessibilityLabel="Info"
+        message="Apply to the Verified Merchant Program"
+        primaryAction={{
+          accessibilityLabel: 'Apply now: verified merchant program',
+          label: 'Apply now',
+          onClick: toggleModal,
+        }}
+        secondaryAction={{
+          accessibilityLabel: 'Learn more: Verified Merchant Program',
+          href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
+          label: 'Learn more',
+          target: 'blank',
+        }}
+        title="Your business account was created!"
+        type="info"
+      />
+
+      {showModal && (
+        <Layer>
+          <Modal
+            accessibilityModalLabel="Apply for the Verified Merchant Program"
+            footer={
+              <Flex flex="grow" justifyContent="end">
+                <ButtonGroup>
+                  <Button onClick={toggleModal} size="lg" text="Cancel" />
+                  <Button color="red" onClick={toggleModal} size="lg" text="Save" />
+                </ButtonGroup>
+              </Flex>
+            }
+            heading="Verified Merchant Program Application"
+            onDismiss={toggleModal}
+            size="md"
+          >
+            <Flex>
+              <Column span={12}>
+                <Box paddingY={2} paddingX={8} display="flex">
+                  <Column span={4}>
+                    <Label htmlFor="name">
+                      <Text align="start" weight="bold">
+                        Name
+                      </Text>
+                    </Label>
+                  </Column>
+                  <Column span={8}>
+                    <TextField id="name" onChange={() => {}} />
+                  </Column>
+                </Box>
+
+                <Box paddingY={2} paddingX={8} display="flex">
+                  <Column span={4}>
+                    <Label htmlFor="desc">
+                      <Text align="start" weight="bold">
+                        Business Description
+                      </Text>
+                    </Label>
+                  </Column>
+                  <Column span={8}>
+                    <TextArea id="desc" onChange={() => {}} />
+                  </Column>
+                </Box>
+              </Column>
+            </Flex>
+          </Modal>
+        </Layer>
+      )}
+    </Box>
+  );
+}

--- a/docs/examples/callout/actionsExample.js
+++ b/docs/examples/callout/actionsExample.js
@@ -22,77 +22,79 @@ export default function Example(): Node {
   };
 
   return (
-    <Box marginStart={-1} marginEnd={-1}>
-      <Callout
-        dismissButton={{
-          accessibilityLabel: 'Dismiss banner',
-          onDismiss: () => {},
-        }}
-        iconAccessibilityLabel="Info"
-        message="Apply to the Verified Merchant Program"
-        primaryAction={{
-          accessibilityLabel: 'Apply now: verified merchant program',
-          label: 'Apply now',
-          onClick: toggleModal,
-        }}
-        secondaryAction={{
-          accessibilityLabel: 'Learn more: Verified Merchant Program',
-          href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
-          label: 'Learn more',
-          target: 'blank',
-        }}
-        title="Your business account was created!"
-        type="info"
-      />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message="Apply to the Verified Merchant Program"
+          primaryAction={{
+            accessibilityLabel: 'Apply now: verified merchant program',
+            label: 'Apply now',
+            onClick: toggleModal,
+          }}
+          secondaryAction={{
+            accessibilityLabel: 'Learn more: Verified Merchant Program',
+            href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="Your business account was created!"
+          type="info"
+        />
 
-      {showModal && (
-        <Layer>
-          <Modal
-            accessibilityModalLabel="Apply for the Verified Merchant Program"
-            footer={
-              <Flex flex="grow" justifyContent="end">
-                <ButtonGroup>
-                  <Button onClick={toggleModal} size="lg" text="Cancel" />
-                  <Button color="red" onClick={toggleModal} size="lg" text="Save" />
-                </ButtonGroup>
+        {showModal && (
+          <Layer>
+            <Modal
+              accessibilityModalLabel="Apply for the Verified Merchant Program"
+              footer={
+                <Flex flex="grow" justifyContent="end">
+                  <ButtonGroup>
+                    <Button onClick={toggleModal} size="lg" text="Cancel" />
+                    <Button color="red" onClick={toggleModal} size="lg" text="Save" />
+                  </ButtonGroup>
+                </Flex>
+              }
+              heading="Verified Merchant Program Application"
+              onDismiss={toggleModal}
+              size="md"
+            >
+              <Flex>
+                <Column span={12}>
+                  <Box paddingY={2} paddingX={8} display="flex">
+                    <Column span={4}>
+                      <Label htmlFor="name">
+                        <Text align="start" weight="bold">
+                          Name
+                        </Text>
+                      </Label>
+                    </Column>
+                    <Column span={8}>
+                      <TextField id="name" onChange={() => {}} />
+                    </Column>
+                  </Box>
+
+                  <Box paddingY={2} paddingX={8} display="flex">
+                    <Column span={4}>
+                      <Label htmlFor="desc">
+                        <Text align="start" weight="bold">
+                          Business Description
+                        </Text>
+                      </Label>
+                    </Column>
+                    <Column span={8}>
+                      <TextArea id="desc" onChange={() => {}} />
+                    </Column>
+                  </Box>
+                </Column>
               </Flex>
-            }
-            heading="Verified Merchant Program Application"
-            onDismiss={toggleModal}
-            size="md"
-          >
-            <Flex>
-              <Column span={12}>
-                <Box paddingY={2} paddingX={8} display="flex">
-                  <Column span={4}>
-                    <Label htmlFor="name">
-                      <Text align="start" weight="bold">
-                        Name
-                      </Text>
-                    </Label>
-                  </Column>
-                  <Column span={8}>
-                    <TextField id="name" onChange={() => {}} />
-                  </Column>
-                </Box>
-
-                <Box paddingY={2} paddingX={8} display="flex">
-                  <Column span={4}>
-                    <Label htmlFor="desc">
-                      <Text align="start" weight="bold">
-                        Business Description
-                      </Text>
-                    </Label>
-                  </Column>
-                  <Column span={8}>
-                    <TextArea id="desc" onChange={() => {}} />
-                  </Column>
-                </Box>
-              </Column>
-            </Flex>
-          </Modal>
-        </Layer>
-      )}
-    </Box>
+            </Modal>
+          </Layer>
+        )}
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/dismissibleExample.js
+++ b/docs/examples/callout/dismissibleExample.js
@@ -1,30 +1,34 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss this banner',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Info"
-      message="Apply to the Verified Merchant Program"
-      primaryAction={{
-        accessibilityLabel: 'Get started: Verified Merchant Program',
-        href: 'https://pinterest.com',
-        label: 'Get started',
-        target: 'blank',
-      }}
-      secondaryAction={{
-        accessibilityLabel: 'Learn more: Verified Merchant Program',
-        href: 'https://pinterest.com',
-        label: 'Learn more',
-        target: 'blank',
-      }}
-      title="Your business account was created!"
-      type="info"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message="Apply to the Verified Merchant Program"
+          primaryAction={{
+            accessibilityLabel: 'Get started: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Get started',
+            target: 'blank',
+          }}
+          secondaryAction={{
+            accessibilityLabel: 'Learn more: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="Your business account was created!"
+          type="info"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/dismissibleExample.js
+++ b/docs/examples/callout/dismissibleExample.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      dismissButton={{
+        accessibilityLabel: 'Dismiss this banner',
+        onDismiss: () => {},
+      }}
+      iconAccessibilityLabel="Info"
+      message="Apply to the Verified Merchant Program"
+      primaryAction={{
+        accessibilityLabel: 'Get started: Verified Merchant Program',
+        href: 'https://pinterest.com',
+        label: 'Get started',
+        target: 'blank',
+      }}
+      secondaryAction={{
+        accessibilityLabel: 'Learn more: Verified Merchant Program',
+        href: 'https://pinterest.com',
+        label: 'Learn more',
+        target: 'blank',
+      }}
+      title="Your business account was created!"
+      type="info"
+    />
+  );
+}

--- a/docs/examples/callout/dontStack.js
+++ b/docs/examples/callout/dontStack.js
@@ -1,0 +1,51 @@
+// @flow strict
+import { type Node } from 'react';
+import { Flex, Icon, ButtonGroup, Button, Divider, Box, Upsell, Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Flex direction="column" gap={{ column: 4, row: 0 }}>
+      <Flex alignItems="center" justifyContent="start">
+        <Icon accessibilityLabel="" icon="pinterest" color="error" size={32} />
+        <ButtonGroup>
+          <Button color="transparent" iconEnd="arrow-down" text="Business" />
+          <Button color="transparent" iconEnd="arrow-down" text="Create" />
+          <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
+          <Button color="transparent" iconEnd="arrow-down" text="Ads" />
+        </ButtonGroup>
+      </Flex>
+
+      <Divider />
+
+      <Box marginTop={4}>
+        <Flex gap={{ column: 2, row: 0 }} direction="column">
+          <Upsell
+            imageData={{
+              component: <Icon icon="send" accessibilityLabel="Send" color="default" size={32} />,
+            }}
+            message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
+            primaryAction={{
+              accessibilityLabel: 'Claim ads credit now',
+              label: 'Claim now',
+            }}
+            title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
+          />
+          <Callout
+            dismissButton={{
+              accessibilityLabel: 'Dismiss this banner',
+              onDismiss: () => {},
+            }}
+            iconAccessibilityLabel="Info"
+            message="It may take up to 10 minutes to automatically detect a newly installed tag. If you'd like to manually verify your tag, please click the Verify Tag button."
+            primaryAction={{
+              accessibilityLabel: 'Manually verify tag',
+              label: 'Verify Tag',
+            }}
+            title="We have not yet detected your tag"
+            type="info"
+          />
+        </Flex>
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/callout/dontStack.js
+++ b/docs/examples/callout/dontStack.js
@@ -4,48 +4,50 @@ import { Flex, Icon, ButtonGroup, Button, Divider, Box, Upsell, Callout } from '
 
 export default function Example(): Node {
   return (
-    <Flex direction="column" gap={{ column: 4, row: 0 }}>
-      <Flex alignItems="center" justifyContent="start">
-        <Icon accessibilityLabel="" icon="pinterest" color="error" size={32} />
-        <ButtonGroup>
-          <Button color="transparent" iconEnd="arrow-down" text="Business" />
-          <Button color="transparent" iconEnd="arrow-down" text="Create" />
-          <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
-          <Button color="transparent" iconEnd="arrow-down" text="Ads" />
-        </ButtonGroup>
-      </Flex>
-
-      <Divider />
-
-      <Box marginTop={4}>
-        <Flex gap={{ column: 2, row: 0 }} direction="column">
-          <Upsell
-            imageData={{
-              component: <Icon icon="send" accessibilityLabel="Send" color="default" size={32} />,
-            }}
-            message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
-            primaryAction={{
-              accessibilityLabel: 'Claim ads credit now',
-              label: 'Claim now',
-            }}
-            title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
-          />
-          <Callout
-            dismissButton={{
-              accessibilityLabel: 'Dismiss this banner',
-              onDismiss: () => {},
-            }}
-            iconAccessibilityLabel="Info"
-            message="It may take up to 10 minutes to automatically detect a newly installed tag. If you'd like to manually verify your tag, please click the Verify Tag button."
-            primaryAction={{
-              accessibilityLabel: 'Manually verify tag',
-              label: 'Verify Tag',
-            }}
-            title="We have not yet detected your tag"
-            type="info"
-          />
+    <Box paddingY={8} paddingX={8}>
+      <Flex direction="column" gap={{ column: 4, row: 0 }}>
+        <Flex alignItems="center" justifyContent="start">
+          <Icon accessibilityLabel="" icon="pinterest" color="error" size={32} />
+          <ButtonGroup>
+            <Button color="transparent" iconEnd="arrow-down" text="Business" />
+            <Button color="transparent" iconEnd="arrow-down" text="Create" />
+            <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
+            <Button color="transparent" iconEnd="arrow-down" text="Ads" />
+          </ButtonGroup>
         </Flex>
-      </Box>
-    </Flex>
+
+        <Divider />
+
+        <Box marginTop={4}>
+          <Flex gap={{ column: 2, row: 0 }} direction="column">
+            <Upsell
+              imageData={{
+                component: <Icon icon="send" accessibilityLabel="Send" color="default" size={32} />,
+              }}
+              message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
+              primaryAction={{
+                accessibilityLabel: 'Claim ads credit now',
+                label: 'Claim now',
+              }}
+              title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
+            />
+            <Callout
+              dismissButton={{
+                accessibilityLabel: 'Dismiss this banner',
+                onDismiss: () => {},
+              }}
+              iconAccessibilityLabel="Info"
+              message="It may take up to 10 minutes to automatically detect a newly installed tag. If you'd like to manually verify your tag, please click the Verify Tag button."
+              primaryAction={{
+                accessibilityLabel: 'Manually verify tag',
+                label: 'Verify Tag',
+              }}
+              title="We have not yet detected your tag"
+              type="info"
+            />
+          </Flex>
+        </Box>
+      </Flex>
+    </Box>
   );
 }

--- a/docs/examples/callout/dontUseForMarketing.js
+++ b/docs/examples/callout/dontUseForMarketing.js
@@ -1,22 +1,26 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss this banner',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Info"
-      message="Earn $60 of ads credit, and send $30 of ads credit to a friend"
-      primaryAction={{
-        accessibilityLabel: 'Send ads invite',
-        label: 'Send invite',
-      }}
-      title="Give $30, get $60 in ads credit"
-      type="info"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message="Earn $60 of ads credit, and send $30 of ads credit to a friend"
+          primaryAction={{
+            accessibilityLabel: 'Send ads invite',
+            label: 'Send invite',
+          }}
+          title="Give $30, get $60 in ads credit"
+          type="info"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/dontUseForMarketing.js
+++ b/docs/examples/callout/dontUseForMarketing.js
@@ -1,0 +1,22 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      dismissButton={{
+        accessibilityLabel: 'Dismiss this banner',
+        onDismiss: () => {},
+      }}
+      iconAccessibilityLabel="Info"
+      message="Earn $60 of ads credit, and send $30 of ads credit to a friend"
+      primaryAction={{
+        accessibilityLabel: 'Send ads invite',
+        label: 'Send invite',
+      }}
+      title="Give $30, get $60 in ads credit"
+      type="info"
+    />
+  );
+}

--- a/docs/examples/callout/localizationExample.js
+++ b/docs/examples/callout/localizationExample.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      dismissButton={{
+        accessibilityLabel: 'Dismiss this banner',
+        onDismiss: () => {},
+      }}
+      iconAccessibilityLabel="Info"
+      message="Bewerben Sie sich beim Verified Merchant Program"
+      primaryAction={{
+        accessibilityLabel: 'Loslegen: Verified Merchant Program',
+        href: 'https://pinterest.com',
+        label: 'Loslegen',
+        target: 'blank',
+      }}
+      secondaryAction={{
+        accessibilityLabel: 'Erfahren Sie mehr: Verified Merchant Program',
+        href: 'https://pinterest.com',
+        label: 'Erfahren Sie mehr',
+        target: 'blank',
+      }}
+      title="Ihr Geschäftskonto wurde erstellt!"
+      type="info"
+    />
+  );
+}

--- a/docs/examples/callout/localizationExample.js
+++ b/docs/examples/callout/localizationExample.js
@@ -1,30 +1,34 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss this banner',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Info"
-      message="Bewerben Sie sich beim Verified Merchant Program"
-      primaryAction={{
-        accessibilityLabel: 'Loslegen: Verified Merchant Program',
-        href: 'https://pinterest.com',
-        label: 'Loslegen',
-        target: 'blank',
-      }}
-      secondaryAction={{
-        accessibilityLabel: 'Erfahren Sie mehr: Verified Merchant Program',
-        href: 'https://pinterest.com',
-        label: 'Erfahren Sie mehr',
-        target: 'blank',
-      }}
-      title="Ihr Geschäftskonto wurde erstellt!"
-      type="info"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message="Bewerben Sie sich beim Verified Merchant Program"
+          primaryAction={{
+            accessibilityLabel: 'Loslegen: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Loslegen',
+            target: 'blank',
+          }}
+          secondaryAction={{
+            accessibilityLabel: 'Erfahren Sie mehr: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Erfahren Sie mehr',
+            target: 'blank',
+          }}
+          title="Ihr Geschäftskonto wurde erstellt!"
+          type="info"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/main.js
+++ b/docs/examples/callout/main.js
@@ -1,32 +1,34 @@
 // @flow strict
 import React, { type Node } from 'react';
-import { Callout, Flex } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function ResponsiveExample(): Node {
   return (
-    <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <Callout
-        dismissButton={{
-          accessibilityLabel: 'Dismiss this banner',
-          onDismiss: () => {},
-        }}
-        iconAccessibilityLabel="Info"
-        message="Apply to the Verified Merchant Program"
-        primaryAction={{
-          accessibilityLabel: 'Get started: Verified Merchant Program',
-          href: 'https://pinterest.com',
-          label: 'Get started',
-          target: 'blank',
-        }}
-        secondaryAction={{
-          accessibilityLabel: 'Learn more: Verified Merchant Program',
-          href: 'https://pinterest.com',
-          label: 'Learn more',
-          target: 'blank',
-        }}
-        title="Your business account was created!"
-        type="info"
-      />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message="Apply to the Verified Merchant Program"
+          primaryAction={{
+            accessibilityLabel: 'Get started: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Get started',
+            target: 'blank',
+          }}
+          secondaryAction={{
+            accessibilityLabel: 'Learn more: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="Your business account was created!"
+          type="info"
+        />
+      </Box>
     </Flex>
   );
 }

--- a/docs/examples/callout/placeAtTop.js
+++ b/docs/examples/callout/placeAtTop.js
@@ -4,35 +4,39 @@ import { Flex, Icon, ButtonGroup, Button, Divider, Box, Callout } from 'gestalt'
 
 export default function Example(): Node {
   return (
-    <Flex direction="column" gap={{ column: 4, row: 0 }}>
-      <Flex alignItems="center" justifyContent="start">
-        <Icon accessibilityLabel="" icon="pinterest" color="error" size={32} />
-        <ButtonGroup>
-          <Button color="transparent" iconEnd="arrow-down" text="Business" />
-          <Button color="transparent" iconEnd="arrow-down" text="Create" />
-          <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
-          <Button color="transparent" iconEnd="arrow-down" text="Ads" />
-        </ButtonGroup>
+    <Box paddingY={8} paddingX={8}>
+      <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+        <Flex direction="column" gap={{ column: 4, row: 0 }}>
+          <Flex alignItems="center" justifyContent="start">
+            <Icon accessibilityLabel="" icon="pinterest" color="error" size={32} />
+            <ButtonGroup>
+              <Button color="transparent" iconEnd="arrow-down" text="Business" />
+              <Button color="transparent" iconEnd="arrow-down" text="Create" />
+              <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
+              <Button color="transparent" iconEnd="arrow-down" text="Ads" />
+            </ButtonGroup>
+          </Flex>
+
+          <Divider />
+
+          <Box marginTop={4}>
+            <Callout
+              dismissButton={{
+                accessibilityLabel: 'Dismiss this banner',
+                onDismiss: () => {},
+              }}
+              iconAccessibilityLabel="Info"
+              message="It may take up to 10 minutes to automatically detect a newly installed tag. If you'd like to manually verify your tag, please click the Verify Tag button."
+              primaryAction={{
+                accessibilityLabel: 'Manually verify tag',
+                label: 'Verify Tag',
+              }}
+              title="We have not yet detected your tag"
+              type="info"
+            />
+          </Box>
+        </Flex>
       </Flex>
-
-      <Divider />
-
-      <Box marginTop={4}>
-        <Callout
-          dismissButton={{
-            accessibilityLabel: 'Dismiss this banner',
-            onDismiss: () => {},
-          }}
-          iconAccessibilityLabel="Info"
-          message="It may take up to 10 minutes to automatically detect a newly installed tag. If you'd like to manually verify your tag, please click the Verify Tag button."
-          primaryAction={{
-            accessibilityLabel: 'Manually verify tag',
-            label: 'Verify Tag',
-          }}
-          title="We have not yet detected your tag"
-          type="info"
-        />
-      </Box>
-    </Flex>
+    </Box>
   );
 }

--- a/docs/examples/callout/placeAtTop.js
+++ b/docs/examples/callout/placeAtTop.js
@@ -1,0 +1,38 @@
+// @flow strict
+import { type Node } from 'react';
+import { Flex, Icon, ButtonGroup, Button, Divider, Box, Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Flex direction="column" gap={{ column: 4, row: 0 }}>
+      <Flex alignItems="center" justifyContent="start">
+        <Icon accessibilityLabel="" icon="pinterest" color="error" size={32} />
+        <ButtonGroup>
+          <Button color="transparent" iconEnd="arrow-down" text="Business" />
+          <Button color="transparent" iconEnd="arrow-down" text="Create" />
+          <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
+          <Button color="transparent" iconEnd="arrow-down" text="Ads" />
+        </ButtonGroup>
+      </Flex>
+
+      <Divider />
+
+      <Box marginTop={4}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message="It may take up to 10 minutes to automatically detect a newly installed tag. If you'd like to manually verify your tag, please click the Verify Tag button."
+          primaryAction={{
+            accessibilityLabel: 'Manually verify tag',
+            label: 'Verify Tag',
+          }}
+          title="We have not yet detected your tag"
+          type="info"
+        />
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/callout/productMessages.js
+++ b/docs/examples/callout/productMessages.js
@@ -1,0 +1,20 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      iconAccessibilityLabel="Error"
+      message="Your tag has errors, so information may be outdated. Fix your tag for the most accurate metrics."
+      primaryAction={{
+        accessibilityLabel: 'Fix Pinterest Tag',
+        href: 'https://pinterest.com',
+        label: 'Fix tag',
+        target: 'blank',
+      }}
+      title="Pinterest tag needs attention"
+      type="error"
+    />
+  );
+}

--- a/docs/examples/callout/productMessages.js
+++ b/docs/examples/callout/productMessages.js
@@ -1,20 +1,24 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      iconAccessibilityLabel="Error"
-      message="Your tag has errors, so information may be outdated. Fix your tag for the most accurate metrics."
-      primaryAction={{
-        accessibilityLabel: 'Fix Pinterest Tag',
-        href: 'https://pinterest.com',
-        label: 'Fix tag',
-        target: 'blank',
-      }}
-      title="Pinterest tag needs attention"
-      type="error"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          iconAccessibilityLabel="Error"
+          message="Your tag has errors, so information may be outdated. Fix your tag for the most accurate metrics."
+          primaryAction={{
+            accessibilityLabel: 'Fix Pinterest Tag',
+            href: 'https://pinterest.com',
+            label: 'Fix tag',
+            target: 'blank',
+          }}
+          title="Pinterest tag needs attention"
+          type="error"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/variantError.js
+++ b/docs/examples/callout/variantError.js
@@ -1,20 +1,24 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      iconAccessibilityLabel="Error"
-      message="Your tag has errors, so information may be outdated. Fix your tag for the most accurate metrics."
-      primaryAction={{
-        accessibilityLabel: 'Fix Pinterest tag',
-        href: 'https://pinterest.com',
-        label: 'Fix tag',
-        target: 'blank',
-      }}
-      title="Pinterest tag needs attention"
-      type="error"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          iconAccessibilityLabel="Error"
+          message="Your tag has errors, so information may be outdated. Fix your tag for the most accurate metrics."
+          primaryAction={{
+            accessibilityLabel: 'Fix Pinterest tag',
+            href: 'https://pinterest.com',
+            label: 'Fix tag',
+            target: 'blank',
+          }}
+          title="Pinterest tag needs attention"
+          type="error"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/variantError.js
+++ b/docs/examples/callout/variantError.js
@@ -1,0 +1,20 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      iconAccessibilityLabel="Error"
+      message="Your tag has errors, so information may be outdated. Fix your tag for the most accurate metrics."
+      primaryAction={{
+        accessibilityLabel: 'Fix Pinterest tag',
+        href: 'https://pinterest.com',
+        label: 'Fix tag',
+        target: 'blank',
+      }}
+      title="Pinterest tag needs attention"
+      type="error"
+    />
+  );
+}

--- a/docs/examples/callout/variantInfo.js
+++ b/docs/examples/callout/variantInfo.js
@@ -1,30 +1,34 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss this banner',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Info"
-      message="Apply to the Verified Merchant Program"
-      primaryAction={{
-        accessibilityLabel: 'Get started: Verified Merchant Program',
-        href: 'https://pinterest.com',
-        label: 'Get started',
-        target: 'blank',
-      }}
-      secondaryAction={{
-        accessibilityLabel: 'Learn more: Verified Merchant Program',
-        href: 'https://pinterest.com',
-        label: 'Learn more',
-        target: 'blank',
-      }}
-      title="Your business account was created!"
-      type="info"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message="Apply to the Verified Merchant Program"
+          primaryAction={{
+            accessibilityLabel: 'Get started: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Get started',
+            target: 'blank',
+          }}
+          secondaryAction={{
+            accessibilityLabel: 'Learn more: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="Your business account was created!"
+          type="info"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/variantInfo.js
+++ b/docs/examples/callout/variantInfo.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      dismissButton={{
+        accessibilityLabel: 'Dismiss this banner',
+        onDismiss: () => {},
+      }}
+      iconAccessibilityLabel="Info"
+      message="Apply to the Verified Merchant Program"
+      primaryAction={{
+        accessibilityLabel: 'Get started: Verified Merchant Program',
+        href: 'https://pinterest.com',
+        label: 'Get started',
+        target: 'blank',
+      }}
+      secondaryAction={{
+        accessibilityLabel: 'Learn more: Verified Merchant Program',
+        href: 'https://pinterest.com',
+        label: 'Learn more',
+        target: 'blank',
+      }}
+      title="Your business account was created!"
+      type="info"
+    />
+  );
+}

--- a/docs/examples/callout/variantRecommendation.js
+++ b/docs/examples/callout/variantRecommendation.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      dismissButton={{
+        accessibilityLabel: 'Dismiss this banner',
+        onDismiss: () => {},
+      }}
+      iconAccessibilityLabel="Recommendation"
+      message="When you run ads on Pinterest, you'll find recommendations to improve them here."
+      primaryAction={{
+        accessibilityLabel: 'Learn more: Ads on Pinterest',
+        href: 'https://pinterest.com',
+        label: 'Learn more',
+        target: 'blank',
+      }}
+      title="Advertise with confidence!"
+      type="recommendation"
+    />
+  );
+}

--- a/docs/examples/callout/variantRecommendation.js
+++ b/docs/examples/callout/variantRecommendation.js
@@ -1,24 +1,28 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss this banner',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Recommendation"
-      message="When you run ads on Pinterest, you'll find recommendations to improve them here."
-      primaryAction={{
-        accessibilityLabel: 'Learn more: Ads on Pinterest',
-        href: 'https://pinterest.com',
-        label: 'Learn more',
-        target: 'blank',
-      }}
-      title="Advertise with confidence!"
-      type="recommendation"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Recommendation"
+          message="When you run ads on Pinterest, you'll find recommendations to improve them here."
+          primaryAction={{
+            accessibilityLabel: 'Learn more: Ads on Pinterest',
+            href: 'https://pinterest.com',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="Advertise with confidence!"
+          type="recommendation"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/variantSuccess.js
+++ b/docs/examples/callout/variantSuccess.js
@@ -1,24 +1,28 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss this banner',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Success"
-      message="Keep it up by using recommendations to optimize your ad spend."
-      primaryAction={{
-        accessibilityLabel: 'Get started: Ad recommendations',
-        href: 'https://pinterest.com',
-        label: 'Get started',
-        target: 'blank',
-      }}
-      title="Your ads are doing great!"
-      type="success"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Success"
+          message="Keep it up by using recommendations to optimize your ad spend."
+          primaryAction={{
+            accessibilityLabel: 'Get started: Ad recommendations',
+            href: 'https://pinterest.com',
+            label: 'Get started',
+            target: 'blank',
+          }}
+          title="Your ads are doing great!"
+          type="success"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/examples/callout/variantSuccess.js
+++ b/docs/examples/callout/variantSuccess.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      dismissButton={{
+        accessibilityLabel: 'Dismiss this banner',
+        onDismiss: () => {},
+      }}
+      iconAccessibilityLabel="Success"
+      message="Keep it up by using recommendations to optimize your ad spend."
+      primaryAction={{
+        accessibilityLabel: 'Get started: Ad recommendations',
+        href: 'https://pinterest.com',
+        label: 'Get started',
+        target: 'blank',
+      }}
+      title="Your ads are doing great!"
+      type="success"
+    />
+  );
+}

--- a/docs/examples/callout/variantWarning.js
+++ b/docs/examples/callout/variantWarning.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { type Node } from 'react';
+import { Callout } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Callout
+      dismissButton={{
+        accessibilityLabel: 'Dismiss warning',
+        onDismiss: () => {},
+      }}
+      iconAccessibilityLabel="Warning"
+      message="We have noticed that you have audiences in your advertiser account that have been used in an ad campaign. Pinterest will be deleting any unused audiences on May 30, 2020."
+      primaryAction={{
+        accessibilityLabel: 'View unused audiences',
+        href: 'https://pinterest.com',
+        label: 'View audiences',
+        target: 'blank',
+      }}
+      title="Unused audiences are going away"
+      type="warning"
+    />
+  );
+}

--- a/docs/examples/callout/variantWarning.js
+++ b/docs/examples/callout/variantWarning.js
@@ -1,24 +1,28 @@
 // @flow strict
 import { type Node } from 'react';
-import { Callout } from 'gestalt';
+import { Callout, Flex, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Callout
-      dismissButton={{
-        accessibilityLabel: 'Dismiss warning',
-        onDismiss: () => {},
-      }}
-      iconAccessibilityLabel="Warning"
-      message="We have noticed that you have audiences in your advertiser account that have been used in an ad campaign. Pinterest will be deleting any unused audiences on May 30, 2020."
-      primaryAction={{
-        accessibilityLabel: 'View unused audiences',
-        href: 'https://pinterest.com',
-        label: 'View audiences',
-        target: 'blank',
-      }}
-      title="Unused audiences are going away"
-      type="warning"
-    />
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss warning',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Warning"
+          message="We have noticed that you have audiences in your advertiser account that have been used in an ad campaign. Pinterest will be deleting any unused audiences on May 30, 2020."
+          primaryAction={{
+            accessibilityLabel: 'View unused audiences',
+            href: 'https://pinterest.com',
+            label: 'View audiences',
+            target: 'blank',
+          }}
+          title="Unused audiences are going away"
+          type="warning"
+        />
+      </Box>
+    </Flex>
   );
 }

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -8,7 +8,20 @@ import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
+import accessibilityExample from '../../examples/callout/accessibilityExample.js';
+import actionsExample from '../../examples/callout/actionsExample.js';
+import dismissibleExample from '../../examples/callout/dismissibleExample.js';
+import dontStack from '../../examples/callout/dontStack.js';
+import dontUseForMarketing from '../../examples/callout/dontUseForMarketing.js';
+import localizationExample from '../../examples/callout/localizationExample.js';
 import main from '../../examples/callout/main.js';
+import placeAtTop from '../../examples/callout/placeAtTop.js';
+import productMessages from '../../examples/callout/productMessages.js';
+import variantError from '../../examples/callout/variantError.js';
+import variantInfo from '../../examples/callout/variantInfo.js';
+import variantRecommendation from '../../examples/callout/variantRecommendation.js';
+import variantSuccess from '../../examples/callout/variantSuccess.js';
+import variantWarning from '../../examples/callout/variantWarning.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -54,20 +67,13 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             cardSize="lg"
             type="do"
             description="Use Callout for messages coming from the product or user interaction. Can be used in both Business and Pinner products."
-            defaultCode={`
-          <Callout
-            iconAccessibilityLabel="Error"
-            message="Your tag has errors, so information may be outdated. Fix your tag for the most accurate metrics."
-            primaryAction={{
-              accessibilityLabel: 'Fix Pinterest Tag',
-              href: "https://pinterest.com",
-              label: "Fix tag",
-              target: "blank",
-            }}
-            title="Pinterest tag needs attention"
-            type="error"
-          />
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Do - Use Callout for product messages"
+                code={productMessages}
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="lg"
@@ -75,38 +81,13 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description={`
         Place Callout at the top of the page, under the primary navigation or page header when possible.
         `}
-            defaultCode={`
-          <Flex direction="column" gap={{ column: 4, row: 0 }}>
-            <Flex alignItems="center" justifyContent="start">
-              <Icon accessibilityLabel="" icon="pinterest" color="error" size={32}/>
-              <ButtonGroup>
-                <Button color="transparent" iconEnd="arrow-down" text="Business" />
-                <Button color="transparent" iconEnd="arrow-down" text="Create" />
-                <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
-                <Button color="transparent" iconEnd="arrow-down" text="Ads" />
-              </ButtonGroup>
-            </Flex>
-
-            <Divider/>
-
-            <Box marginTop={4}>
-              <Callout
-                dismissButton={{
-                  accessibilityLabel: 'Dismiss this banner',
-                  onDismiss: () => {},
-                }}
-                iconAccessibilityLabel="Info"
-                message="It may take up to 10 minutes to automatically detect a newly installed tag. If you'd like to manually verify your tag, please click the Verify Tag button."
-                primaryAction={{
-                  accessibilityLabel: "Manually verify tag",
-                  label: "Verify Tag",
-                }}
-                title="We have not yet detected your tag"
-                type="info"
+            sandpackExample={
+              <SandpackExample
+                name="Do - Place Callout at the top of the page"
+                code={placeAtTop}
+                hideEditor
               />
-            </Box>
-          </Flex>
-        `}
+            }
           />
           <MainSection.Card
             cardSize="lg"
@@ -114,22 +95,13 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description={`
         Use Callouts for marketing new products or features. Use [Upsell](/web/upsell) instead.
         `}
-            defaultCode={`
-          <Callout
-            dismissButton={{
-              accessibilityLabel: 'Dismiss this banner',
-              onDismiss: () => {},
-            }}
-            iconAccessibilityLabel="Info"
-            message="Earn $60 of ads credit, and send $30 of ads credit to a friend"
-            primaryAction={{
-              accessibilityLabel: "Send ads invite",
-              label: "Send invite",
-            }}
-            title="Give $30, get $60 in ads credit"
-            type="info"
-          />
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Don't - Use Callouts for marketing new products or features"
+                code={dontUseForMarketing}
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="lg"
@@ -137,51 +109,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description={`
         Stack Callouts. In the case that banners must be stacked, Callouts should come before Upsells.
         `}
-            defaultCode={`
-        <Flex direction="column" gap={{ column: 4, row: 0 }}>
-          <Flex alignItems="center" justifyContent="start">
-            <Icon accessibilityLabel="" icon="pinterest" color="error" size={32}/>
-            <ButtonGroup>
-              <Button color="transparent" iconEnd="arrow-down" text="Business" />
-              <Button color="transparent" iconEnd="arrow-down" text="Create" />
-              <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
-              <Button color="transparent" iconEnd="arrow-down" text="Ads" />
-            </ButtonGroup>
-          </Flex>
-
-          <Divider/>
-
-          <Box marginTop={4}>
-            <Flex gap={{ column: 2, row: 0 }} direction="column">
-              <Upsell
-                imageData={{
-                  component: <Icon icon="send" accessibilityLabel="Send" color="default" size={32}/>
-                }}
-                message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
-                primaryAction={{
-                  accessibilityLabel: "Claim ads credit now",
-                  label: "Claim now",
-                }}
-                title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
-              />
-              <Callout
-                dismissButton={{
-                  accessibilityLabel: 'Dismiss this banner',
-                  onDismiss: () => {},
-                }}
-                iconAccessibilityLabel="Info"
-                message="It may take up to 10 minutes to automatically detect a newly installed tag. If you'd like to manually verify your tag, please click the Verify Tag button."
-                primaryAction={{
-                  accessibilityLabel: "Manually verify tag",
-                  label: "Verify Tag",
-                }}
-                title="We have not yet detected your tag"
-                type="info"
-              />
-            </Flex>
-          </Box>
-        </Flex>
-        `}
+            sandpackExample={
+              <SandpackExample name="Don't - Stack Callouts" code={dontStack} hideEditor />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -199,30 +129,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Callout
-  dismissButton={{
-    accessibilityLabel: 'Dismiss this banner',
-    onDismiss: () => {},
-  }}
-  iconAccessibilityLabel="Info"
-  message="Apply to the Verified Merchant Program"
-  primaryAction={{
-    accessibilityLabel: "Get started: Verified Merchant Program",
-    href: "https://pinterest.com",
-    label: "Get started",
-    target: "blank",
-  }}
-  secondaryAction={{
-    accessibilityLabel: "Learn more: Verified Merchant Program",
-    href: "https://pinterest.com",
-    label: "Learn more",
-    target: "blank",
-  }}
-  title="Your business account was created!"
-  type="info"
-/>
-        `}
+            sandpackExample={
+              <SandpackExample name="Callout labels" code={accessibilityExample} hideEditor />
+            }
           />
         </MainSection.Subsection>
       </AccessibilitySection>
@@ -234,30 +143,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         <MainSection.Subsection>
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Callout
-  dismissButton={{
-    accessibilityLabel: 'Dismiss this banner',
-    onDismiss: () => {},
-  }}
-  iconAccessibilityLabel="Info"
-  message="Bewerben Sie sich beim Verified Merchant Program"
-  primaryAction={{
-    accessibilityLabel: "Loslegen: Verified Merchant Program",
-    href: "https://pinterest.com",
-    label: "Loslegen",
-    target: "blank",
-  }}
-  secondaryAction={{
-    accessibilityLabel: "Erfahren Sie mehr: Verified Merchant Program",
-    href: "https://pinterest.com",
-    label: "Erfahren Sie mehr",
-    target: "blank",
-  }}
-  title="Ihr Geschäftskonto wurde erstellt!"
-  type="info"
-/>
-        `}
+            sandpackExample={
+              <SandpackExample name="Callout localization" code={localizationExample} hideEditor />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -269,30 +157,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Callout
-  dismissButton={{
-    accessibilityLabel: 'Dismiss this banner',
-    onDismiss: () => {},
-  }}
-  iconAccessibilityLabel="Info"
-  message="Apply to the Verified Merchant Program"
-  primaryAction={{
-    accessibilityLabel: "Get started: Verified Merchant Program",
-    href: "https://pinterest.com",
-    label: "Get started",
-    target: "blank",
-  }}
-  secondaryAction={{
-    accessibilityLabel: "Learn more: Verified Merchant Program",
-    href: "https://pinterest.com",
-    label: "Learn more",
-    target: "blank",
-  }}
-  title="Your business account was created!"
-  type="info"
-/>
-`}
+            sandpackExample={
+              <SandpackExample name="Variants - Info" code={variantInfo} hideEditor />
+            }
           />
         </MainSection.Subsection>
 
@@ -302,24 +169,13 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Callout
-  dismissButton={{
-    accessibilityLabel: 'Dismiss this banner',
-    onDismiss: () => {},
-  }}
-  iconAccessibilityLabel="Recommendation"
-  message="When you run ads on Pinterest, you'll find recommendations to improve them here."
-  primaryAction={{
-    accessibilityLabel: "Learn more: Ads on Pinterest",
-    href: "https://pinterest.com",
-    label: "Learn more",
-    target: "blank",
-  }}
-  title="Advertise with confidence!"
-  type="recommendation"
-/>
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Variants - Recommendation"
+                code={variantRecommendation}
+                hideEditor
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -328,24 +184,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-  <Callout
-    dismissButton={{
-      accessibilityLabel: 'Dismiss this banner',
-      onDismiss: () => {},
-    }}
-    iconAccessibilityLabel="Success"
-    message="Keep it up by using recommendations to optimize your ad spend."
-    primaryAction={{
-      accessibilityLabel: "Get started: Ad recommendations",
-      href: "https://pinterest.com",
-      label: "Get started",
-      target: "blank",
-    }}
-    title="Your ads are doing great!"
-    type="success"
-  />
-`}
+            sandpackExample={
+              <SandpackExample name="Variants - Success" code={variantSuccess} hideEditor />
+            }
           />
         </MainSection.Subsection>
 
@@ -355,24 +196,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Callout
-  dismissButton={{
-    accessibilityLabel: 'Dismiss warning',
-    onDismiss: () => {},
-  }}
-  iconAccessibilityLabel="Warning"
-  message="We have noticed that you have audiences in your advertiser account that have been used in an ad campaign. Pinterest will be deleting any unused audiences on May 30, 2020."
-  primaryAction={{
-    accessibilityLabel: "View unused audiences",
-    href: "https://pinterest.com",
-    label: "View audiences",
-    target: "blank",
-  }}
-  title="Unused audiences are going away"
-  type="warning"
-/>
-`}
+            sandpackExample={
+              <SandpackExample name="Variants - Warning" code={variantWarning} hideEditor />
+            }
           />
         </MainSection.Subsection>
 
@@ -382,20 +208,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Callout
-  iconAccessibilityLabel="Error"
-  message="Your tag has errors, so information may be outdated. Fix your tag for the most accurate metrics."
-  primaryAction={{
-    accessibilityLabel: "Fix Pinterest tag",
-    href: "https://pinterest.com",
-    label: "Fix tag",
-    target: "blank",
-  }}
-  title="Pinterest tag needs attention"
-  type="error"
-/>
-`}
+            sandpackExample={
+              <SandpackExample name="Variants - Error" code={variantError} hideEditor />
+            }
           />
         </MainSection.Subsection>
 
@@ -414,98 +229,9 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example(props) {
-  const [showModal, setShowModal] = React.useState(false);
-  const toggleModal = () => {
-    setShowModal((currState) => !currState);
-  };
-
-  return (
-    <Box marginStart={-1} marginEnd={-1}>
-      <Callout
-        dismissButton={{
-          accessibilityLabel: 'Dismiss banner',
-          onDismiss: () => {},
-        }}
-        iconAccessibilityLabel="Info"
-        message="Apply to the Verified Merchant Program"
-        primaryAction={{
-          accessibilityLabel: "Apply now: verified merchant program",
-          label: "Apply now",
-          onClick: toggleModal,
-        }}
-        secondaryAction={{
-          accessibilityLabel: "Learn more: Verified Merchant Program",
-          href: "https://help.pinterest.com/en/business/article/verified-merchant-program",
-          label: "Learn more",
-          target: "blank",
-        }}
-        title="Your business account was created!"
-        type="info"
-      />
-
-      {showModal && (
-        <Layer>
-          <Modal
-            accessibilityModalLabel="Apply for the Verified Merchant Program"
-            footer={
-              <Flex flex="grow" justifyContent="end">
-                  <ButtonGroup>
-                    <Button
-                      onClick={toggleModal}
-                      size="lg"
-                      text="Cancel"
-                    />
-                    <Button
-                      color="red"
-                      onClick={toggleModal}
-                      size="lg"
-                      text="Save"
-                    />
-                  </ButtonGroup>
-              </Flex>
+            sandpackExample={
+              <SandpackExample name="Callout actions" code={actionsExample} hideEditor />
             }
-            heading="Verified Merchant Program Application"
-            onDismiss={toggleModal}
-            size="md"
-          >
-            <Flex>
-              <Column span={12}>
-                <Box paddingY={2} paddingX={8} display="flex">
-                  <Column span={4}>
-                    <Label htmlFor="name">
-                      <Text align="start" weight="bold">
-                        Name
-                      </Text>
-                    </Label>
-                  </Column>
-                  <Column span={8}>
-                    <TextField id="name" onChange={() => {}} />
-                  </Column>
-                </Box>
-
-                <Box paddingY={2} paddingX={8} display="flex">
-                  <Column span={4}>
-                    <Label htmlFor="desc">
-                      <Text align="start" weight="bold">
-                        Business Description
-                      </Text>
-                    </Label>
-                  </Column>
-                  <Column span={8}>
-                    <TextArea id="desc" onChange={() => {}} />
-                  </Column>
-                </Box>
-              </Column>
-            </Flex>
-          </Modal>
-        </Layer>
-      )}
-    </Box>
-  );
-}
-        `}
           />
         </MainSection.Subsection>
 
@@ -521,30 +247,9 @@ function Example(props) {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Callout
-  dismissButton={{
-    accessibilityLabel: 'Dismiss this banner',
-    onDismiss: () => {},
-  }}
-  iconAccessibilityLabel="Info"
-  message="Apply to the Verified Merchant Program"
-  primaryAction={{
-    accessibilityLabel: "Get started: Verified Merchant Program",
-    href: "https://pinterest.com",
-    label: "Get started",
-    target: "blank",
-  }}
-  secondaryAction={{
-    accessibilityLabel: "Learn more: Verified Merchant Program",
-    href: "https://pinterest.com",
-    label: "Learn more",
-    target: "blank",
-  }}
-  title="Your business account was created!"
-  type="info"
-/>
-      `}
+            sandpackExample={
+              <SandpackExample name="Dismissable Callout" code={dismissibleExample} hideEditor />
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -110,7 +110,12 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         Stack Callouts. In the case that banners must be stacked, Callouts should come before Upsells.
         `}
             sandpackExample={
-              <SandpackExample name="Don't - Stack Callouts" code={dontStack} hideEditor />
+              <SandpackExample
+                name="Don't - Stack Callouts"
+                code={dontStack}
+                hideEditor
+                previewHeight={552}
+              />
             }
           />
         </MainSection.Subsection>
@@ -197,7 +202,12 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample name="Variants - Warning" code={variantWarning} hideEditor />
+              <SandpackExample
+                name="Variants - Warning"
+                code={variantWarning}
+                hideEditor
+                previewHeight={460}
+              />
             }
           />
         </MainSection.Subsection>

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -30,6 +30,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}
+          layout="column"
           hideEditor
         />
       </PageHeader>
@@ -71,6 +72,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
               <SandpackExample
                 name="Do - Use Callout for product messages"
                 code={productMessages}
+                layout="column"
                 hideEditor
               />
             }
@@ -85,6 +87,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
               <SandpackExample
                 name="Do - Place Callout at the top of the page"
                 code={placeAtTop}
+                layout="column"
                 hideEditor
               />
             }
@@ -100,6 +103,8 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
                 name="Don't - Use Callouts for marketing new products or features"
                 code={dontUseForMarketing}
                 hideControls
+                layout="column"
+                hideEditor
               />
             }
           />
@@ -114,6 +119,8 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
                 name="Don't - Stack Callouts"
                 code={dontStack}
                 hideControls
+                layout="column"
+                hideEditor
                 previewHeight={552}
               />
             }
@@ -135,7 +142,12 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample name="Callout labels" code={accessibilityExample} hideEditor />
+              <SandpackExample
+                name="Callout labels"
+                code={accessibilityExample}
+                layout="column"
+                // hideEditor
+              />
             }
           />
         </MainSection.Subsection>
@@ -149,7 +161,13 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample name="Callout localization" code={localizationExample} hideEditor />
+              <SandpackExample
+                name="Callout localization"
+                code={localizationExample}
+                layout="column"
+                // hideEditor
+                previewHeight={380}
+              />
             }
           />
         </MainSection.Subsection>
@@ -163,7 +181,12 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample name="Variants - Info" code={variantInfo} hideEditor />
+              <SandpackExample
+                name="Variants - Info"
+                code={variantInfo}
+                layout="column"
+                // hideEditor
+              />
             }
           />
         </MainSection.Subsection>
@@ -178,7 +201,8 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
               <SandpackExample
                 name="Variants - Recommendation"
                 code={variantRecommendation}
-                hideEditor
+                layout="column"
+                // hideEditor
               />
             }
           />
@@ -190,7 +214,12 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample name="Variants - Success" code={variantSuccess} hideEditor />
+              <SandpackExample
+                name="Variants - Success"
+                code={variantSuccess}
+                layout="column"
+                // hideEditor
+              />
             }
           />
         </MainSection.Subsection>
@@ -205,7 +234,8 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
               <SandpackExample
                 name="Variants - Warning"
                 code={variantWarning}
-                hideEditor
+                layout="column"
+                // hideEditor
                 previewHeight={460}
               />
             }
@@ -219,7 +249,13 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample name="Variants - Error" code={variantError} hideEditor />
+              <SandpackExample
+                name="Variants - Error"
+                code={variantError}
+                layout="column"
+                // hideEditor
+                previewHeight={380}
+              />
             }
           />
         </MainSection.Subsection>
@@ -240,7 +276,12 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample name="Callout actions" code={actionsExample} hideEditor />
+              <SandpackExample
+                name="Callout actions"
+                code={actionsExample}
+                layout="column"
+                // hideEditor
+              />
             }
           />
         </MainSection.Subsection>
@@ -258,7 +299,12 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           <MainSection.Card
             cardSize="lg"
             sandpackExample={
-              <SandpackExample name="Dismissable Callout" code={dismissibleExample} hideEditor />
+              <SandpackExample
+                name="Dismissable Callout"
+                code={dismissibleExample}
+                layout="column"
+                // hideEditor
+              />
             }
           />
         </MainSection.Subsection>

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -99,7 +99,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
               <SandpackExample
                 name="Don't - Use Callouts for marketing new products or features"
                 code={dontUseForMarketing}
-                hideEditor
+                hideControls
               />
             }
           />
@@ -113,7 +113,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
               <SandpackExample
                 name="Don't - Stack Callouts"
                 code={dontStack}
-                hideEditor
+                hideControls
                 previewHeight={552}
               />
             }


### PR DESCRIPTION
### Summary

#### What changed?

Migrated examples in the docs from the old editor to the sandpack editor for the Callout component.

#### Why?

Ensures the editor remains consistent with other components, as part of the current migration efforts.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4876)

### Checklist

- [n/a] Added unit and Flow Tests
- [n/a] Added documentation + accessibility tests
- [n/a] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
