### PR TITLE
Internal: Fix TileData Examples

### DIFF
--- a/docs/examples/tiledata/color.js
+++ b/docs/examples/tiledata/color.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node, useState } from 'react';
-import { TileData, Flex } from 'gestalt';
+import { Box, TileData, Flex } from 'gestalt';
 
 type DataVisualizationColors =
   | '01'
@@ -34,28 +34,30 @@ export default function Example(): Node {
   const [selectedColors, setSelectedColors] = useState(allColors);
 
   return (
-    <Flex gap={4} wrap justifyContent="center">
-      {allColors.map((color) => (
-        <TileData
-          id={color}
-          key={color}
-          color={color}
-          selected={selectedColors.includes(color)}
-          onTap={({ id: selectedId, selected }) => {
-            if (!selectedId) {
-              return;
-            }
+    <Box overflow="scrollY" height="90%" padding={2}>
+      <Flex gap={4} wrap justifyContent="center">
+        {allColors.map((color) => (
+          <TileData
+            id={color}
+            key={color}
+            color={color}
+            selected={selectedColors.includes(color)}
+            onTap={({ id: selectedId, selected }) => {
+              if (!selectedId) {
+                return;
+              }
 
-            setSelectedColors((currSelectedColors) =>
-              !selected
-                ? currSelectedColors.filter((tileId) => tileId !== color)
-                : currSelectedColors.concat([color]),
-            );
-          }}
-          title={`Color ${color}`}
-          value="41.25m"
-        />
-      ))}
-    </Flex>
+              setSelectedColors((currSelectedColors) =>
+                !selected
+                  ? currSelectedColors.filter((tileId) => tileId !== color)
+                  : currSelectedColors.concat([color]),
+              );
+            }}
+            title={`Color ${color}`}
+            value="41.25m"
+          />
+        ))}
+      </Flex>
+    </Box>
   );
 }

--- a/docs/examples/tiledata/disabled.js
+++ b/docs/examples/tiledata/disabled.js
@@ -4,7 +4,7 @@ import { Flex, TileData } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Flex justifyContent="center">
+    <Flex justifyContent="center" alignItems="center" width="100%" height="100%">
       <TileData
         tooltip={{ text: 'Weekly Active Users' }}
         title="WAU"

--- a/docs/examples/tiledata/group.js
+++ b/docs/examples/tiledata/group.js
@@ -32,7 +32,7 @@ export default function Example(): Node {
   const [selectedItems, setSelectedItems] = useState(allIds);
 
   return (
-    <Flex gap={4} justifyContent="center">
+    <Flex gap={4} justifyContent="center" alignItems="center" width="100%" height="100%" wrap>
       {dataSources.map(({ id, color, tooltip, name, value }) => (
         <TileData
           key={id}

--- a/docs/examples/tiledata/main.js
+++ b/docs/examples/tiledata/main.js
@@ -7,7 +7,7 @@ export default function Example(): Node {
   const isSelected = (id: string) => selectedId === id;
 
   return (
-    <Flex gap={5} justifyContent="center">
+    <Flex gap={5} justifyContent="center" alignItems="center" width="100%" height="100%">
       <TileData
         id="01"
         title="Impressions"

--- a/docs/examples/tiledata/tooltip.js
+++ b/docs/examples/tiledata/tooltip.js
@@ -4,7 +4,7 @@ import { Flex, TileData } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Flex justifyContent="center">
+    <Flex justifyContent="center" alignItems="center" width="100%" height="100%">
       <TileData tooltip={{ text: 'Weekly Active Users' }} title="WAU" value="1.25M" selected />{' '}
     </Flex>
   );


### PR DESCRIPTION
Fixing TileData examples

BEFORE

<img width="951" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/4f914a8e-eb5b-4935-864a-d178bd04c9bb">


AFTER

<img width="928" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/802063f8-c38a-4580-8cff-6f26d45f0798">


