### PR TITLE
Table: Convert examples to use Sandpack

### DIFF
--- a/docs/examples/table/alignContent.js
+++ b/docs/examples/table/alignContent.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Table, Box, Label, Checkbox, Text } from 'gestalt';
 
-function HeaderRow({ id }: any) {
+function HeaderRow({ id }: {| id: string |}) {
   return (
     <Table.Header>
       <Table.Row>
@@ -24,7 +24,19 @@ function HeaderRow({ id }: any) {
   );
 }
 
-function BaseRow({ id, checked, disabled, text, spend }: any) {
+function BaseRow({
+  id,
+  checked,
+  disabled,
+  text,
+  spend,
+}: {|
+  id: string,
+  checked?: boolean,
+  disabled?: boolean,
+  text: string,
+  spend: string,
+|}) {
   return (
     <Table.Row>
       <Table.Cell>

--- a/docs/examples/table/alignContent.js
+++ b/docs/examples/table/alignContent.js
@@ -1,0 +1,72 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Box, Label, Checkbox, Text } from 'gestalt';
+
+function HeaderRow({ id }: any) {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Label htmlFor={id}>Not all checkboxes are checked</Label>
+          </Box>
+          <Checkbox id={id} onChange={() => {}} indeterminate size="sm" />
+        </Table.HeaderCell>
+        {['Campaign', 'Spend'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text align={title === 'Spend' ? 'end' : 'start'} weight="bold">
+              {title}
+            </Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ id, checked, disabled, text, spend }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Checkbox
+          id={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+          onChange={() => {}}
+          disabled={disabled}
+          size="sm"
+          checked={checked}
+        />
+      </Table.Cell>
+      <Table.Cell>
+        <Label
+          htmlFor={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+        >
+          <Text>{text}</Text>
+        </Label>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="end">{spend}</Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = "Example of a 'do' for table alignment";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow id={tableID} />
+      <Table.Body>
+        <BaseRow id={tableID} checked text="The best ad" spend="$5.50" />
+        <BaseRow id={tableID} disabled text="This ad is great" spend="$3,000.00" />
+        <BaseRow id={tableID} checked text="Mary's pincycle" spend="$1.75" />
+        <BaseRow id={tableID} checked={false} text="Best Purchase Wins" spend="$51,650,500.54" />
+        <BaseRow id={tableID} checked={false} text="The third campaign" spend="$67.60" />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/avoidOverStylingText.js
+++ b/docs/examples/table/avoidOverStylingText.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Table, Box, Label, Checkbox, Text } from 'gestalt';
 
-function HeaderRow({ id }: any) {
+function HeaderRow({ id }: {| id: string |}) {
   return (
     <Table.Header>
       <Table.Row>
@@ -22,7 +22,19 @@ function HeaderRow({ id }: any) {
   );
 }
 
-function BaseRow({ id, checked, disabled, text, campaign }: any) {
+function BaseRow({
+  id,
+  checked,
+  disabled,
+  text,
+  campaign,
+}: {|
+  id: string,
+  checked?: boolean,
+  disabled?: boolean,
+  text: string,
+  campaign: string,
+|}) {
   return (
     <Table.Row>
       <Table.Cell>
@@ -46,7 +58,7 @@ function BaseRow({ id, checked, disabled, text, campaign }: any) {
         </Label>
       </Table.Cell>
       <Table.Cell>
-        <Text color={disabled ? 'gray' : 'darkGray'}>{campaign}</Text>
+        <Text color={disabled ? 'subtle' : 'default'}>{campaign}</Text>
       </Table.Cell>
     </Table.Row>
   );

--- a/docs/examples/table/avoidOverStylingText.js
+++ b/docs/examples/table/avoidOverStylingText.js
@@ -1,0 +1,70 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Box, Label, Checkbox, Text } from 'gestalt';
+
+function HeaderRow({ id }: any) {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Label htmlFor={id}>Not all checkboxes are checked</Label>
+          </Box>
+          <Checkbox id={id} onChange={() => {}} indeterminate size="sm" />
+        </Table.HeaderCell>
+        {['Status', 'Campaign'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text weight="bold">{title}</Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ id, checked, disabled, text, campaign }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Checkbox
+          id={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+          onChange={() => {}}
+          disabled={disabled}
+          size="sm"
+          checked={checked}
+        />
+      </Table.Cell>
+      <Table.Cell>
+        <Label
+          htmlFor={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+        >
+          <Text>{text}</Text>
+        </Label>
+      </Table.Cell>
+      <Table.Cell>
+        <Text color={disabled ? 'gray' : 'darkGray'}>{campaign}</Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = "Example of a 'do' for table style";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow id={tableID} />
+      <Table.Body>
+        <BaseRow id={tableID} checked text="The best ad" campaign="Engagement" />
+        <BaseRow id={tableID} disabled text="This ad is great" campaign="Awareness" />
+        <BaseRow id={tableID} checked text="Mary's pincycle" campaign="Catalogs" />
+        <BaseRow id={tableID} checked={false} text="Best Purchase Wins" campaign="Awareness" />
+        <BaseRow id={tableID} checked={false} text="The third campaign" campaign="Conversions" />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/bottomCaptionExample.js
+++ b/docs/examples/table/bottomCaptionExample.js
@@ -1,0 +1,106 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Box, Label, Checkbox, Text, Status, Flex } from 'gestalt';
+
+function HeaderRow({ id }: any) {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Label htmlFor={id}>Not all checkboxes are checked</Label>
+          </Box>
+          <Checkbox id={id} onChange={() => {}} indeterminate size="sm" />
+        </Table.HeaderCell>
+        {['Status', 'Campaign'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text weight="bold">{title}</Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ id, checked, disabled, type, text, subtext, campaign }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Checkbox
+          id={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+          onChange={() => {}}
+          disabled={disabled}
+          size="sm"
+          checked={checked}
+        />
+      </Table.Cell>
+      <Table.Cell>
+        <Status type={type} title={text} subtext={subtext} />
+      </Table.Cell>
+      <Table.Cell>
+        <Label
+          htmlFor={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+        >
+          <Text color={disabled ? 'gray' : 'darkGray'}>{campaign}</Text>
+        </Label>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = 'Example of correct accessibility with bottom caption';
+
+  return (
+    <Box padding={4}>
+      <Flex gap={{ column: 2, row: 0 }} direction="column">
+        <Table accessibilityLabel="Your campaigns summary">
+          <HeaderRow id={tableID} />
+          <Table.Body>
+            <BaseRow
+              id={tableID}
+              checked
+              type="inProgress"
+              text="In progress"
+              subtext="Ends 11/20/2021"
+              campaign="Engagement"
+            />
+            <BaseRow
+              id={tableID}
+              disabled
+              type="halted"
+              text="Paused"
+              subtext="Ends 11/20/2021"
+              campaign="Awareness"
+            />
+            <BaseRow
+              id={tableID}
+              checked
+              type="warning"
+              text="Warning"
+              subtext="Ends 11/20/2021"
+              campaign="Catalogs"
+            />
+            <BaseRow
+              id={tableID}
+              checked={false}
+              type="ok"
+              text="Complete"
+              subtext="Ends 11/20/2021"
+              campaign="Awareness"
+            />
+          </Table.Body>
+        </Table>
+        <Box aria-hidden>
+          <Text align="center" size="100">
+            Your campaigns summary
+          </Text>
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/table/bottomCaptionExample.js
+++ b/docs/examples/table/bottomCaptionExample.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Table, Box, Label, Checkbox, Text, Status, Flex } from 'gestalt';
 
-function HeaderRow({ id }: any) {
+function HeaderRow({ id }: {| id: string |}) {
   return (
     <Table.Header>
       <Table.Row>
@@ -22,7 +22,23 @@ function HeaderRow({ id }: any) {
   );
 }
 
-function BaseRow({ id, checked, disabled, type, text, subtext, campaign }: any) {
+function BaseRow({
+  id,
+  checked,
+  disabled,
+  type,
+  text,
+  subtext,
+  campaign,
+}: {|
+  id: string,
+  checked?: boolean,
+  disabled?: boolean,
+  type: $ElementType<React$ElementConfig<typeof Status>, 'type'>,
+  text: string,
+  subtext: string,
+  campaign: string,
+|}) {
   return (
     <Table.Row>
       <Table.Cell>
@@ -45,7 +61,7 @@ function BaseRow({ id, checked, disabled, type, text, subtext, campaign }: any) 
             .replace(/ /g, '_')
             .replace(/'/g, '')}`}
         >
-          <Text color={disabled ? 'gray' : 'darkGray'}>{campaign}</Text>
+          <Text color={disabled ? 'subtle' : 'default'}>{campaign}</Text>
         </Label>
       </Table.Cell>
     </Table.Row>

--- a/docs/examples/table/dontAddSoMuchContent.js
+++ b/docs/examples/table/dontAddSoMuchContent.js
@@ -1,0 +1,65 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Text } from 'gestalt';
+
+function HeaderRow() {
+  return (
+    <Table.Header>
+      <Table.Row>
+        {['Name', 'Total amounts for 2021 through 2022'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text align={title.startsWith('Total') ? 'end' : 'start'} weight="bold">
+              {title}
+            </Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ name, subtext, total, lineClamp }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Text color="default">{name}</Text>
+        <Text color="subtle" size="100" lineClamp={lineClamp}>
+          {subtext}
+        </Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="end" lineClamp={lineClamp}>
+          {total}
+        </Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = "Example of a 'don't' do for table content";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow
+          name="Video views for all Q3 campaigns and ad groups"
+          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
+          total=""
+        />
+        <BaseRow
+          name="Video views for all Q2 campaigns and ad groups"
+          subtext="David Brown, Carlota Ojeda"
+          total="5,000"
+        />
+        <BaseRow
+          name="Video views for all Q2 ad groups"
+          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
+          total="6,455,434"
+          lineClamp={1}
+        />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/dontAddSoMuchContent.js
+++ b/docs/examples/table/dontAddSoMuchContent.js
@@ -18,7 +18,7 @@ function HeaderRow() {
   );
 }
 
-// $FlowFixMe[unclear-type]
+// $FlowIgnore[unclear-type]
 function BaseRow({ name, subtext, total, lineClamp }: any) {
   return (
     <Table.Row>

--- a/docs/examples/table/dontAddSoMuchContent.js
+++ b/docs/examples/table/dontAddSoMuchContent.js
@@ -18,7 +18,7 @@ function HeaderRow() {
   );
 }
 
-// $FlowIgnore
+// $FlowFixMe[unclear-type]
 function BaseRow({ name, subtext, total, lineClamp }: any) {
   return (
     <Table.Row>

--- a/docs/examples/table/dontAddSoMuchContent.js
+++ b/docs/examples/table/dontAddSoMuchContent.js
@@ -18,6 +18,7 @@ function HeaderRow() {
   );
 }
 
+// $FlowIgnore
 function BaseRow({ name, subtext, total, lineClamp }: any) {
   return (
     <Table.Row>

--- a/docs/examples/table/dontAlignContent.js
+++ b/docs/examples/table/dontAlignContent.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Table, Box, Label, Checkbox, Text } from 'gestalt';
 
-function HeaderRow({ id }: any) {
+function HeaderRow({ id }: {| id: string |}) {
   return (
     <Table.Header>
       <Table.Row>
@@ -24,7 +24,21 @@ function HeaderRow({ id }: any) {
   );
 }
 
-function BaseRow({ id, checked, disabled, text, subtext, spend }: any) {
+function BaseRow({
+  id,
+  checked,
+  disabled,
+  text,
+  subtext,
+  spend,
+}: {|
+  id: string,
+  checked?: boolean,
+  disabled?: boolean,
+  text: string,
+  subtext: string,
+  spend: string,
+|}) {
   return (
     <Table.Row>
       <Table.Cell>

--- a/docs/examples/table/dontAlignContent.js
+++ b/docs/examples/table/dontAlignContent.js
@@ -1,0 +1,91 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Box, Label, Checkbox, Text } from 'gestalt';
+
+function HeaderRow({ id }: any) {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Label htmlFor={id}>Not all checkboxes are checked</Label>
+          </Box>
+          <Checkbox id={id} onChange={() => {}} indeterminate size="sm" />
+        </Table.HeaderCell>
+        {['Campaign', 'Spend'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text align={title === 'Campaign' ? 'center' : 'start'} weight="bold">
+              {title}
+            </Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ id, checked, disabled, text, subtext, spend }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Checkbox
+          id={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+          onChange={() => {}}
+          disabled={disabled}
+          size="sm"
+          checked={checked}
+        />
+      </Table.Cell>
+      <Table.Cell>
+        <Label
+          htmlFor={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+        >
+          <Text align="center">{text}</Text>
+          <Text align="center">{subtext}</Text>
+        </Label>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="end">{spend}</Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = "Example of a 'Dont' do for table alignment";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow id={tableID} />
+      <Table.Body>
+        <BaseRow id={tableID} checked text="The best ad" subtext="12/20/21" spend="$5" />
+        <BaseRow
+          id={tableID}
+          disabled
+          text="This ad is great"
+          subtext="01/16/21"
+          spend="$3,000.00"
+        />
+        <BaseRow id={tableID} checked text="Mary's pincycle" subtext="07/15/22" spend="$1.750" />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="Best Purchase Wins"
+          subtext="06/15/22"
+          spend="$51,650,500.54"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="The third campaign"
+          subtext="06/24/22"
+          spend="$67.60"
+        />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/dontMixTextAndGraphics.js
+++ b/docs/examples/table/dontMixTextAndGraphics.js
@@ -1,0 +1,56 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Text, Status } from 'gestalt';
+
+function HeaderRow() {
+  return (
+    <Table.Header>
+      <Table.Row>
+        {['Status', 'Rate'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text align={title === 'Rate' ? 'end' : 'start'} weight="bold">
+              {title}
+            </Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ disabled, type, title, subtext, rate }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Status type={type} title={title} subtext={subtext} />
+      </Table.Cell>
+      <Table.Cell>
+        <Text overflow="noWrap" align="end" color={disabled ? 'gray' : 'darkGray'}>
+          {rate}
+        </Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = "Another Example of a 'Dont' do for table alignment";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow type="inProgress" title="Active" subtext="Ends 11/20/2021" rate="100 CTR" />
+        <BaseRow
+          disabled
+          type="halted"
+          title="Paused"
+          subtext="Ends 11/20/2021"
+          rate="5,000 Engagement"
+        />
+        <BaseRow type="warning" title="Warning" subtext="Ends 11/20/2021" rate="2 Conversions" />
+        <BaseRow type="ok" title="Complete" subtext="Ends 11/20/2021" rate="50 CTR" />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/dontMixTextAndGraphics.js
+++ b/docs/examples/table/dontMixTextAndGraphics.js
@@ -18,6 +18,7 @@ function HeaderRow() {
   );
 }
 
+// $FlowIgnore
 function BaseRow({ disabled, type, title, subtext, rate }: any) {
   return (
     <Table.Row>
@@ -25,7 +26,7 @@ function BaseRow({ disabled, type, title, subtext, rate }: any) {
         <Status type={type} title={title} subtext={subtext} />
       </Table.Cell>
       <Table.Cell>
-        <Text overflow="noWrap" align="end" color={disabled ? 'gray' : 'darkGray'}>
+        <Text overflow="noWrap" align="end" color={disabled ? 'subtle' : 'default'}>
           {rate}
         </Text>
       </Table.Cell>

--- a/docs/examples/table/dontMixTextAndGraphics.js
+++ b/docs/examples/table/dontMixTextAndGraphics.js
@@ -18,7 +18,7 @@ function HeaderRow() {
   );
 }
 
-// $FlowFixMe[unclear-type]
+// $FlowIgnore[unclear-type]
 function BaseRow({ disabled, type, title, subtext, rate }: any) {
   return (
     <Table.Row>

--- a/docs/examples/table/dontMixTextAndGraphics.js
+++ b/docs/examples/table/dontMixTextAndGraphics.js
@@ -18,7 +18,7 @@ function HeaderRow() {
   );
 }
 
-// $FlowIgnore
+// $FlowFixMe[unclear-type]
 function BaseRow({ disabled, type, title, subtext, rate }: any) {
   return (
     <Table.Row>

--- a/docs/examples/table/dontOverStyleText.js
+++ b/docs/examples/table/dontOverStyleText.js
@@ -24,7 +24,7 @@ function HeaderRow({ id }: {| id: string |}) {
   );
 }
 
-// $FlowIgnore
+// $FlowFixMe[unclear-type]
 function BaseRow({ id, checked, disabled, text, campaign, bold, underline, italic, color }: any) {
   return (
     <Table.Row>

--- a/docs/examples/table/dontOverStyleText.js
+++ b/docs/examples/table/dontOverStyleText.js
@@ -1,0 +1,106 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Box, Label, Checkbox, Text } from 'gestalt';
+
+function HeaderRow({ id }: any) {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Label htmlFor={id}>Not all checkboxes are checked</Label>
+          </Box>
+          <Checkbox id={id} onChange={() => {}} indeterminate size="sm" />
+        </Table.HeaderCell>
+        {['Status', 'Campaign'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text color={title === 'Campaign' ? 'red' : 'blue'} weight="bold">
+              {title}
+            </Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ id, checked, disabled, text, campaign, bold, underline, italic, color }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Checkbox
+          id={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+          onChange={() => {}}
+          disabled={disabled}
+          size="sm"
+          checked={checked}
+        />
+      </Table.Cell>
+      <Table.Cell>
+        <Label
+          htmlFor={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+        >
+          <Text
+            weight={bold ? 'bold' : 'regular'}
+            underline={underline ? true : undefined}
+            italic={italic ? true : undefined}
+          >
+            {text}
+          </Text>
+        </Label>
+      </Table.Cell>
+      <Table.Cell>
+        <Text color={color}>{campaign}</Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = 'Example of a Dont do for table style';
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow id={tableID} />
+      <Table.Body>
+        <BaseRow id={tableID} checked text="The best ad" campaign="Engagement" color="red" />
+        <BaseRow
+          id={tableID}
+          disabled
+          bold
+          text="This ad is great"
+          campaign="Awareness"
+          color="blue"
+        />
+        <BaseRow
+          id={tableID}
+          checked
+          bold
+          italic
+          text="Mary's pincycle"
+          campaign="Catalogs"
+          color="red"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          underline
+          text="BEST PURCHASE WINS"
+          campaign="Awareness"
+          color="purple"
+        />
+        <BaseRow
+          id={tableID}
+          checked={false}
+          text="The third campaign"
+          campaign="CONVERSIONS"
+          color="green"
+        />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/dontOverStyleText.js
+++ b/docs/examples/table/dontOverStyleText.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Table, Box, Label, Checkbox, Text } from 'gestalt';
 
-function HeaderRow({ id }: any) {
+function HeaderRow({ id }: {| id: string |}) {
   return (
     <Table.Header>
       <Table.Row>
@@ -14,7 +14,7 @@ function HeaderRow({ id }: any) {
         </Table.HeaderCell>
         {['Status', 'Campaign'].map((title) => (
           <Table.HeaderCell key={title}>
-            <Text color={title === 'Campaign' ? 'red' : 'blue'} weight="bold">
+            <Text color={title === 'Campaign' ? 'error' : 'link'} weight="bold">
               {title}
             </Text>
           </Table.HeaderCell>
@@ -24,6 +24,7 @@ function HeaderRow({ id }: any) {
   );
 }
 
+// $FlowIgnore
 function BaseRow({ id, checked, disabled, text, campaign, bold, underline, italic, color }: any) {
   return (
     <Table.Row>
@@ -45,7 +46,7 @@ function BaseRow({ id, checked, disabled, text, campaign, bold, underline, itali
             .replace(/'/g, '')}`}
         >
           <Text
-            weight={bold ? 'bold' : 'regular'}
+            weight={bold ? 'bold' : 'normal'}
             underline={underline ? true : undefined}
             italic={italic ? true : undefined}
           >

--- a/docs/examples/table/dontOverStyleText.js
+++ b/docs/examples/table/dontOverStyleText.js
@@ -24,7 +24,7 @@ function HeaderRow({ id }: {| id: string |}) {
   );
 }
 
-// $FlowFixMe[unclear-type]
+// $FlowIgnore[unclear-type]
 function BaseRow({ id, checked, disabled, text, campaign, bold, underline, italic, color }: any) {
   return (
     <Table.Row>

--- a/docs/examples/table/dontUseExpandForDenseContent.js
+++ b/docs/examples/table/dontUseExpandForDenseContent.js
@@ -243,7 +243,7 @@ function HeaderRow() {
   );
 }
 
-// $FlowIgnore
+// $FlowFixMe[unclear-type]
 function RowExpandable({ campaign, status, empty, budget, scope }: any) {
   return (
     <Table.RowExpandable

--- a/docs/examples/table/dontUseExpandForDenseContent.js
+++ b/docs/examples/table/dontUseExpandForDenseContent.js
@@ -243,7 +243,7 @@ function HeaderRow() {
   );
 }
 
-// $FlowFixMe[unclear-type]
+// $FlowIgnore[unclear-type]
 function RowExpandable({ campaign, status, empty, budget, scope }: any) {
   return (
     <Table.RowExpandable

--- a/docs/examples/table/dontUseExpandForDenseContent.js
+++ b/docs/examples/table/dontUseExpandForDenseContent.js
@@ -45,7 +45,7 @@ function ExpandedContents() {
             Latest boards
           </Heading>
           <Flex gap={{ row: 6, column: 0 }} width="100%">
-            <Flex.Item width="50%">
+            <Flex.Item>
               <TapArea tapStyle="compress" onTap={() => {}}>
                 <Mask rounding={4}>
                   <Collage
@@ -108,7 +108,7 @@ function ExpandedContents() {
                   />
                 </Mask>
                 <Flex direction="column" gap={{ column: 2, row: 0 }}>
-                  <Heading size="400" accessibilityLevel={0}>
+                  <Heading size="400" accessibilityLevel="none">
                     Uniform
                   </Heading>
                   <Flex gap={{ column: 0, row: 5 }}>
@@ -139,7 +139,7 @@ function ExpandedContents() {
                   onChange={() => {}}
                   placeholder=""
                   label="Budget (USD)"
-                  value="100000"
+                  value={100000}
                 />
                 <TextField
                   id="scope"
@@ -243,6 +243,7 @@ function HeaderRow() {
   );
 }
 
+// $FlowIgnore
 function RowExpandable({ campaign, status, empty, budget, scope }: any) {
   return (
     <Table.RowExpandable

--- a/docs/examples/table/dontUseExpandForDenseContent.js
+++ b/docs/examples/table/dontUseExpandForDenseContent.js
@@ -1,0 +1,302 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import {
+  Flex,
+  Tabs,
+  Heading,
+  TapArea,
+  Mask,
+  Collage,
+  Image,
+  Text,
+  TextField,
+  TextArea,
+  NumberField,
+  Label,
+  Switch,
+  Button,
+  Module,
+  Box,
+  Datapoint,
+  IconButton,
+  Table,
+} from 'gestalt';
+
+function ExpandedContents() {
+  const [tabItem, setTabItem] = useState('campaign');
+
+  return (
+    <Flex direction="column" gap={{ column: 6, row: 0 }} width={800}>
+      <Tabs
+        activeTabIndex={tabItem === 'campaign' ? 0 : 1}
+        bgColor="transparent"
+        onChange={({ event }) => {
+          setTabItem(tabItem !== 'analytics' ? 'analytics' : 'campaign');
+          event.preventDefault();
+        }}
+        tabs={[
+          { href: '', text: 'Campaign', indicator: tabItem === 'campaign' ? 'dot' : undefined },
+          { href: '', text: 'Analytics', indicator: tabItem === 'analytics' ? 'dot' : undefined },
+        ]}
+      />
+      {tabItem === 'campaign' ? (
+        <Flex direction="column" gap={{ column: 6, row: 0 }} width="100%">
+          <Heading size="400" accessibilityLevel={2}>
+            Latest boards
+          </Heading>
+          <Flex gap={{ row: 6, column: 0 }} width="100%">
+            <Flex.Item width="50%">
+              <TapArea tapStyle="compress" onTap={() => {}}>
+                <Mask rounding={4}>
+                  <Collage
+                    columns={3}
+                    height={300}
+                    width={300}
+                    renderImage={({ index, width, height }) => {
+                      const images = [
+                        {
+                          color: 'rgb(111, 91, 77)',
+                          naturalHeight: 751,
+                          naturalWidth: 564,
+                          src: 'https://i.ibb.co/Lx54BCT/stock1.jpg',
+                        },
+                        {
+                          color: 'rgb(231, 186, 176)',
+                          naturalHeight: 200,
+                          naturalWidth: 98,
+                          src: 'https://i.ibb.co/7bQQYkX/stock2.jpg',
+                        },
+                        {
+                          color: '#000',
+                          naturalHeight: 300,
+                          naturalWidth: 200,
+                          src: 'https://i.ibb.co/d0pQsJz/stock3.jpg',
+                        },
+                        {
+                          color: '#000',
+                          naturalHeight: 517,
+                          naturalWidth: 564,
+                          src: 'https://i.ibb.co/SB0pXgS/stock4.jpg',
+                        },
+                        {
+                          color: '#000',
+                          naturalHeight: 806,
+                          naturalWidth: 564,
+                          src: 'https://i.ibb.co/jVR29XV/stock5.jpg',
+                        },
+                        {
+                          color: '#000',
+                          naturalHeight: 200,
+                          naturalWidth: 200,
+                          src: 'https://i.ibb.co/FY2MKr5/stock6.jpg',
+                        },
+                      ];
+                      const image = images[index] || {};
+                      return (
+                        <Mask wash width={width} height={height}>
+                          <Image
+                            alt="collage image"
+                            color={image.color}
+                            fit="cover"
+                            naturalHeight={image.naturalHeight}
+                            naturalWidth={image.naturalWidth}
+                            src={image.src}
+                          />
+                        </Mask>
+                      );
+                    }}
+                  />
+                </Mask>
+                <Flex direction="column" gap={{ column: 2, row: 0 }}>
+                  <Heading size="400" accessibilityLevel={0}>
+                    Uniform
+                  </Heading>
+                  <Flex gap={{ column: 0, row: 5 }}>
+                    <Text size="200">123 Pins</Text>
+                    <Text size="200">4 sections</Text>
+                  </Flex>
+                </Flex>
+              </TapArea>
+            </Flex.Item>
+            <Flex direction="column" gap={{ column: 4, row: 0 }} width="100%">
+              <TextField
+                id="name"
+                onChange={() => {}}
+                placeholder="Name"
+                label="Name"
+                value="December '21"
+              />
+              <TextArea
+                id="notes"
+                onChange={() => {}}
+                placeholder="Notes on updates..."
+                label="Notes"
+                value=""
+              />
+              <Flex gap={{ column: 0, row: 4 }}>
+                <NumberField
+                  id="budget"
+                  onChange={() => {}}
+                  placeholder=""
+                  label="Budget (USD)"
+                  value="100000"
+                />
+                <TextField
+                  id="scope"
+                  onChange={() => {}}
+                  placeholder=""
+                  label="Scope"
+                  value="Global"
+                />
+              </Flex>
+              <Label htmlFor="status">
+                <Text>Status</Text>
+              </Label>
+              <Switch onChange={() => {}} id="status" switched />
+            </Flex>
+          </Flex>
+          <Flex gap={{ column: 0, row: 3 }}>
+            <Button text="Cancel" />
+            <Flex.Item flex="grow">
+              <Button text="Pause" />
+            </Flex.Item>
+            <Button color="red" text="Edit" />
+          </Flex>
+        </Flex>
+      ) : (
+        <Flex gap={{ column: 0, row: 3 }}>
+          <Module id="Analitycs Overview" title="Analitycs Overview">
+            <Box width={300}>
+              <Datapoint
+                size="lg"
+                tooltipText="The number of times your ads were seen, including earned impressions"
+                title="Total impressions"
+                value="1K"
+                trend={{ value: 30, accessibilityLabel: 'Trending up' }}
+              />
+              <Datapoint
+                size="lg"
+                tooltipText="The number of times your ads were seen, including earned impressions"
+                title="Saves"
+                value="5"
+                trend={{ value: 5, accessibilityLabel: 'Trending up' }}
+              />
+              <Datapoint
+                size="lg"
+                tooltipText="The number of times your ads were seen, including earned impressions"
+                title="Outbound clicks"
+                value="10"
+                trend={{ value: 10, accessibilityLabel: 'Trending up' }}
+              />
+            </Box>
+          </Module>
+          <Flex direction="column" gap={{ column: 2, row: 0 }} maxWidth={800}>
+            <Module
+              id="Ads Overview"
+              title="Ads Overview"
+              iconButton={
+                <IconButton
+                  role="link"
+                  href="https://analytics.pinterest.com/"
+                  bgColor="lightGray"
+                  icon="arrow-up-right"
+                  iconColor="darkGray"
+                  accessibilityLabel="Get help"
+                  size="xs"
+                  onClick={() => {}}
+                  target="blank"
+                />
+              }
+            >
+              <Box width={300}>
+                <Text size="200">Content</Text>
+              </Box>
+            </Module>
+            <Module id="Top Pins" title="Top Pins">
+              <Box width={300}>
+                <Text size="200">Content</Text>
+              </Box>
+            </Module>
+          </Flex>
+        </Flex>
+      )}
+    </Flex>
+  );
+}
+
+function HeaderRow() {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Text weight="bold">Open/Close row</Text>
+          </Box>
+        </Table.HeaderCell>
+        {['Campaign', 'Status', 'Budget', 'Scope'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text weight="bold">{title}</Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function RowExpandable({ campaign, status, empty, budget, scope }: any) {
+  return (
+    <Table.RowExpandable
+      accessibilityExpandLabel="Expand"
+      accessibilityCollapseLabel="Collapse"
+      id="row1"
+      onExpand={() => {}}
+      expandedContents={
+        empty ? (
+          <Text>No metrics available. This campaign hasn&apos;t started yet.</Text>
+        ) : (
+          <ExpandedContents />
+        )
+      }
+    >
+      <Table.Cell>
+        <Text>{campaign}</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>{status}</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>{budget}</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>{scope}</Text>
+      </Table.Cell>
+    </Table.RowExpandable>
+  );
+}
+
+export default function MainExample(): Node {
+  const tableID = "Another example of a 'don't' do for table content";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <RowExpandable campaign="December '21" status="Active" budget="$100,000" scope="Global" />
+        <RowExpandable
+          campaign="January '22"
+          status="Draft"
+          budget="$50,000"
+          scope="Japan, Germany, Canada, Spain, Mexico, Thailand, Italy"
+          empty
+        />
+        <RowExpandable
+          campaign="February '22"
+          status="Draft"
+          budget="$50,000"
+          scope="Japan, Germany, Canada"
+          empty
+        />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/drawerRowExample.js
+++ b/docs/examples/table/drawerRowExample.js
@@ -1,0 +1,107 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Table, Text, SlimBanner } from 'gestalt';
+
+export default function Example(): Node {
+  const [showdrawer, setShowDrawer] = useState(true);
+
+  return (
+    <Box width="100%">
+      <Table accessibilityLabel="Table.RowDrawer example">
+        <colgroup>
+          <col span="1" style={{ width: '60%' }} />
+          <col span="1" style={{ width: '15%' }} />
+          <col span="1" style={{ width: '15%' }} />
+          <col span="1" style={{ width: '15%' }} />
+        </colgroup>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text weight="bold">Campaign</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text align="forceRight" weight="bold">
+                Spend
+              </Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text align="forceRight" weight="bold">
+                Impressions
+              </Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text align="forceRight" weight="bold">
+                CTR
+              </Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          <Table.RowDrawer
+            id="drawerExample"
+            drawerContents={
+              showdrawer ? (
+                <SlimBanner
+                  type="recommendation"
+                  iconAccessibilityLabel="Recommendation"
+                  message="Increasing your daily spend could increase clicks by 20%"
+                  primaryAction={{
+                    accessibilityLabel: 'Apply for increasing your daily spend',
+                    label: 'Apply',
+                    onClick: () => {},
+                  }}
+                  dismissButton={{
+                    accessibilityLabel: 'Dismiss',
+                    onDismiss: () => setShowDrawer(false),
+                  }}
+                />
+              ) : null
+            }
+          >
+            <Table.Cell>
+              <Text>Training treats</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">$3,200</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">3.4k</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">0.07%</Text>
+            </Table.Cell>
+          </Table.RowDrawer>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Vegan cuisine</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">$4,200</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">5k</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">0.40%</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Mexican cuisine</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">$5,000</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">20k</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text align="forceRight">0.10%</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/table/expandRows.js
+++ b/docs/examples/table/expandRows.js
@@ -21,7 +21,23 @@ function HeaderRow() {
   );
 }
 
-function BaseRow({ name, team, src, teamRole, hours, active, setActive }: any) {
+function BaseRow({
+  name,
+  team,
+  src,
+  teamRole,
+  hours,
+  active,
+  setActive,
+}: {|
+  name: string,
+  team: string,
+  src: string,
+  teamRole: string,
+  hours: string,
+  active: boolean,
+  setActive: (active: boolean) => void,
+|}) {
   return (
     <Table.RowExpandable
       accessibilityExpandLabel="Expand"

--- a/docs/examples/table/expandRows.js
+++ b/docs/examples/table/expandRows.js
@@ -1,0 +1,117 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Table, Box, Text, WashAnimated, Avatar, Link } from 'gestalt';
+
+function HeaderRow() {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Text weight="bold">Open/Close row</Text>
+          </Box>
+        </Table.HeaderCell>
+        {['Name', 'Team', 'Role', 'Office Hours'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text weight="bold">{title}</Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ name, team, src, teamRole, hours, active, setActive }: any) {
+  return (
+    <Table.RowExpandable
+      accessibilityExpandLabel="Expand"
+      accessibilityCollapseLabel="Collapse"
+      id={name}
+      onExpand={() => {}}
+      expandedContents={
+        <Box
+          onMouseEnter={() => setActive(true)}
+          onMouseLeave={() => setActive(false)}
+          display="flex"
+          justifyContent="center"
+          maxWidth={236}
+          padding={2}
+          column={12}
+        >
+          <WashAnimated
+            active={active}
+            image={
+              <Box display="flex" justifyContent="center" maxWidth={236} padding={2} column={12}>
+                <Avatar size="md" name={`${name}avatar`} src={src} />
+              </Box>
+            }
+          >
+            <Text align="center" weight="bold">
+              <Link href="https://pinterest.com" target="blank">
+                <Box paddingX={3} paddingY={2}>
+                  {`${name}'s Info`}
+                </Box>
+              </Link>
+            </Text>
+          </WashAnimated>
+        </Box>
+      }
+    >
+      <Table.Cell>
+        <Text>{name}</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>{team}</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>{teamRole}</Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text>{hours}</Text>
+      </Table.Cell>
+    </Table.RowExpandable>
+  );
+}
+
+export default function Example(): Node {
+  const [activeA, setActiveA] = useState(false);
+  const [activeB, setActiveB] = useState(false);
+  const [activeC, setActiveC] = useState(false);
+
+  const tableID = "Another Example of a 'do' for table content";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow
+          active={activeA}
+          setActive={setActiveA}
+          name="Ayesha Teng"
+          team="Gestalt"
+          src="https://i.ibb.co/QY9qR7h/luna.png"
+          teamRole="Engineer"
+          hours="Monday, Friday"
+        />
+        <BaseRow
+          active={activeB}
+          setActive={setActiveB}
+          name="Ryan Costa"
+          team="Analytics"
+          src="https://i.ibb.co/Hzcfxjt/draco.png"
+          teamRole="Designer"
+          hours="Wednesdays"
+        />
+        <BaseRow
+          active={activeC}
+          setActive={setActiveC}
+          name="Kate Steele"
+          team="Monetization"
+          src="https://i.ibb.co/JvY9DKK/neville.png"
+          teamRole="Design Technologist"
+          hours="Tuesdays, Thursdays"
+        />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/main.js
+++ b/docs/examples/table/main.js
@@ -1,47 +1,45 @@
 // @flow strict
 import { type Node } from 'react';
-import { Table, Flex, Text, Box } from 'gestalt';
+import { Table, Text, Box } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Box height="100%" width="100%" overflow="scroll">
-      <Flex alignItems="start" gap={4} height="100%" justifyContent="center" width="100%">
-        <Table accessibilityLabel="Main example table">
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Text weight="bold">Campaign</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Status</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Date</Text>
-              </Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
+    <Box padding={4} width="100%" height="100%" display="flex" justifyContent="center">
+      <Table accessibilityLabel="Main example table">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text weight="bold">Campaign</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Status</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Date</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
 
-          <Table.Body>
-            {[
-              { id: 'row1', campaign: 'Winter', status: 'Draft', date: 'December 25, 2023' },
-              { id: 'row2', campaign: 'Spring', status: 'Active', date: 'April 25, 2023' },
-              { id: 'row3', campaign: 'Fall', status: 'Finished', date: 'October 25, 2022' },
-            ].map(({ id, campaign, status, date }) => (
-              <Table.Row key={id}>
-                <Table.Cell>
-                  <Text>{campaign}</Text>
-                </Table.Cell>
-                <Table.Cell>
-                  <Text>{status}</Text>
-                </Table.Cell>
-                <Table.Cell>
-                  <Text>{date}</Text>
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-      </Flex>
+        <Table.Body>
+          {[
+            { id: 'row1', campaign: 'Winter', status: 'Draft', date: 'December 25, 2023' },
+            { id: 'row2', campaign: 'Spring', status: 'Active', date: 'April 25, 2023' },
+            { id: 'row3', campaign: 'Fall', status: 'Finished', date: 'October 25, 2022' },
+          ].map(({ id, campaign, status, date }) => (
+            <Table.Row key={id}>
+              <Table.Cell>
+                <Text>{campaign}</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>{status}</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>{date}</Text>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
     </Box>
   );
 }

--- a/docs/examples/table/makeContentDigestable.js
+++ b/docs/examples/table/makeContentDigestable.js
@@ -18,7 +18,17 @@ function HeaderRow() {
   );
 }
 
-function BaseRow({ name, subtext, total, lineClamp }: any) {
+function BaseRow({
+  name,
+  subtext,
+  total,
+  lineClamp,
+}: {|
+  name: string,
+  subtext: string,
+  total: string,
+  lineClamp?: number,
+|}) {
   return (
     <Table.Row>
       <Table.Cell>

--- a/docs/examples/table/makeContentDigestable.js
+++ b/docs/examples/table/makeContentDigestable.js
@@ -1,0 +1,64 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Text } from 'gestalt';
+
+function HeaderRow() {
+  return (
+    <Table.Header>
+      <Table.Row>
+        {['Name', 'Total'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text align={title === 'Total' ? 'end' : 'start'} weight="bold">
+              {title}
+            </Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ name, subtext, total, lineClamp }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Text color="default">{name}</Text>
+        <Text color="subtle" size="100" lineClamp={lineClamp}>
+          {subtext}
+        </Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="end">{total}</Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = "Example of a 'do' for table content";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow
+          name="Video views for all Q3 campaigns and ad groups"
+          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
+          total="--"
+          lineClamp={1}
+        />
+        <BaseRow
+          name="Video views for all Q2 campaigns and ad groups"
+          subtext="David Brown, Carlota Ojeda"
+          total="5,000"
+        />
+        <BaseRow
+          name="Video views for all Q2 ad groups"
+          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
+          total="6,455,434"
+          lineClamp={1}
+        />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/multipleStickyColumnsExample.js
+++ b/docs/examples/table/multipleStickyColumnsExample.js
@@ -1,0 +1,193 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Table, Text, Mask, Image } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box width="60%">
+        <Table
+          accessibilityLabel="Multiple sticky columns"
+          maxHeight={200}
+          stickyColumns={3}
+          borderStyle="none"
+        >
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Text weight="bold">Image</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Name</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Super Name</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Best Friend</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Favorite Food</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Super Powers</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Home</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Aliases</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Tony"
+                      src="https://i.ibb.co/r3R04Y9/ironman.jpg"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Tony Stark</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Iron Man</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Spiderman</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Shawarma</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Flight, Super strength</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>New York</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>N/A</Text>
+              </Table.Cell>
+            </Table.Row>
+
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Peter"
+                      src="https://i.ibb.co/64NxM43/spiderman.png"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Peter Parker</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Spiderman</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Iron Man</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Sandwiches</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Spidey senses, super strength, web shooters</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Brooklyn</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Friendly Neighborhood Spiderman</Text>
+              </Table.Cell>
+            </Table.Row>
+
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Wanda"
+                      src="https://i.ibb.co/hV6Vpbf/scarlet.png"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Wanda Maximoff</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Scarlet Witch</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Vision</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Chicken paprikash</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Chaos magic, spells, reality warping</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Sokovia</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>N/A</Text>
+              </Table.Cell>
+            </Table.Row>
+
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Black Panther"
+                      src="https://i.ibb.co/GpNtW5N/black-Panther.png"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>T&apos;Challa</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Black Panther</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Shuri</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Beef suya</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Enhanced strength, speed, reflexes + Vibranium suit</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Wakanda</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>King of the Dead</Text>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/table/rowExpandableWithStickyColumns.js
+++ b/docs/examples/table/rowExpandableWithStickyColumns.js
@@ -93,7 +93,7 @@ export default function Example(): Node {
             accessibilityCollapseLabel="Collapse"
             id="row2"
             expandedContents={
-              <Table maxWidth={800} maxHeight={500}>
+              <Table accessibilityLabel="none">
                 <Table.Header sticky>
                   <Table.Row>
                     <Table.HeaderCell>
@@ -105,7 +105,7 @@ export default function Example(): Node {
                   </Table.Row>
                 </Table.Header>
                 <Table.Body>
-                  <Table.Row colSpan={10}>
+                  <Table.Row>
                     <Table.Cell>
                       <Text>Vision</Text>
                     </Table.Cell>

--- a/docs/examples/table/rowExpandableWithStickyColumns.js
+++ b/docs/examples/table/rowExpandableWithStickyColumns.js
@@ -1,0 +1,210 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Text, Box, Table, WashAnimated, Avatar, Link } from 'gestalt';
+
+export default function Example(): Node {
+  const [textShown, setTextShown] = useState(false);
+  const showTextOnExpand = () => <Text>Row expanded</Text>;
+
+  return (
+    <Box width="70%" margin="auto" padding={4}>
+      <Table accessibilityLabel="Table.RowExpandable with Sticky Columns" stickyColumns={3}>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Box display="visuallyHidden">
+                <Text weight="bold">Open/Close row</Text>
+              </Box>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Name</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Super Name</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Best Friend</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Favorite Food</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Home</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Alias</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Box width={200}>
+                <Text weight="bold">Super Powers</Text>
+              </Box>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          <Table.RowExpandable
+            accessibilityExpandLabel="Expand"
+            accessibilityCollapseLabel="Collapse"
+            id="row1"
+            onExpand={() => setTextShown(!textShown)}
+            expandedContents={
+              <Box maxWidth={236} padding={2} column={12}>
+                <WashAnimated
+                  image={<Avatar name="tony avatar" src="https://i.ibb.co/8948ym5/avenge.png" />}
+                >
+                  <Text align="center" weight="bold">
+                    <Link href="https://pinterest.com">
+                      <Box paddingX={3} paddingY={2}>
+                        Tony&apos;s Info
+                      </Box>
+                    </Link>
+                  </Text>
+                  {textShown && showTextOnExpand()}
+                </WashAnimated>
+              </Box>
+            }
+          >
+            <Table.Cell>
+              <Text>Tony Stark</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Iron Man</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Spiderman</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Shawarma</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>New York City</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>N/A</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Flight, Super strength</Text>
+            </Table.Cell>
+          </Table.RowExpandable>
+
+          <Table.RowExpandable
+            accessibilityExpandLabel="Expand"
+            accessibilityCollapseLabel="Collapse"
+            id="row2"
+            expandedContents={
+              <Table maxWidth={800} maxHeight={500}>
+                <Table.Header sticky>
+                  <Table.Row>
+                    <Table.HeaderCell>
+                      <Text weight="bold">Name</Text>
+                    </Table.HeaderCell>
+                    <Table.HeaderCell>
+                      <Text weight="bold">Relationship</Text>
+                    </Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  <Table.Row colSpan={10}>
+                    <Table.Cell>
+                      <Text>Vision</Text>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Text>Husband</Text>
+                    </Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.Cell>
+                      <Text>Wiccan</Text>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Text>Child</Text>
+                    </Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.Cell>
+                      <Text>Speed</Text>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Text>Child</Text>
+                    </Table.Cell>
+                  </Table.Row>
+                </Table.Body>
+              </Table>
+            }
+          >
+            <Table.Cell>
+              <Text>Wanda Maximoff</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Scarlet Witch</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Vision</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Chicken paprikash</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Sokovia</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Wanda Frank</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Chaos magic, spells, reality warping</Text>
+            </Table.Cell>
+          </Table.RowExpandable>
+
+          <Table.RowExpandable
+            accessibilityExpandLabel="Expand"
+            accessibilityCollapseLabel="Collapse"
+            id="row3"
+            expandedContents={
+              <Box maxWidth={236} padding={2} column={12}>
+                <WashAnimated
+                  image={
+                    <Avatar
+                      name="Black panther avatar"
+                      src="https://i.ibb.co/GpNtW5N/black-Panther.png"
+                    />
+                  }
+                >
+                  <Text align="center" weight="bold">
+                    <Link href="https://pinterest.com">
+                      <Box paddingX={3} paddingY={2}>
+                        Black Panther&apos;s Info
+                      </Box>
+                    </Link>
+                  </Text>
+                </WashAnimated>
+              </Box>
+            }
+          >
+            <Table.Cell>
+              <Text>T&apos;Challa</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Black Panther</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Shuri</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Beef suya</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Wakana</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>King of the Dead</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Enhanced strength, speed, reflexes + Vibranium suit</Text>
+            </Table.Cell>
+          </Table.RowExpandable>
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/table/selected.js
+++ b/docs/examples/table/selected.js
@@ -1,136 +1,134 @@
 // @flow strict
 import { useState, type Node } from 'react';
-import { Table, Checkbox, Flex, Text, Box } from 'gestalt';
+import { Table, Checkbox, Text, Box } from 'gestalt';
 
 export default function Example(): Node {
   const [selected, setSelectedRow] = useState<$ReadOnlyArray<string>>([]);
 
   return (
     <Box height="100%" width="100%" overflow="scroll">
-      <Flex alignItems="start" gap={4} height="100%" justifyContent="center" width="100%">
-        <Table accessibilityLabel="Selected row example table">
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Text />
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Selected</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Column</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Column</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Subcomponent</Text>
-              </Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            <Table.Row
-              key="row1"
-              hoverStyle="gray"
-              selected={selected.includes('row') ? 'selected' : 'unselected'}
-            >
-              <Table.Cell>
-                <Text />
-              </Table.Cell>
-              <Table.Cell>
-                <Checkbox
-                  id="Row"
-                  onChange={() =>
-                    setSelectedRow((value) =>
-                      value.includes('row')
-                        ? value.filter((item) => item !== 'row')
-                        : [...value, 'row'],
-                    )
-                  }
-                  size="sm"
-                  checked={selected.includes('row')}
-                />
-              </Table.Cell>
-              <Table.Cell>
-                <Text>value</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>value</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Table.Row</Text>
-              </Table.Cell>
-            </Table.Row>
-            <Table.RowExpandable
-              accessibilityCollapseLabel="Collapse"
-              accessibilityExpandLabel="Expand"
-              expandedContents={<Text>Content</Text>}
-              key="row2"
-              id="row2"
-              hoverStyle="gray"
-              selected={selected.includes('rowExpandable') ? 'selected' : 'unselected'}
-            >
-              <Table.Cell>
-                <Checkbox
-                  id="RowExpandable"
-                  onChange={() =>
-                    setSelectedRow((value) =>
-                      value.includes('rowExpandable')
-                        ? value.filter((item) => item !== 'rowExpandable')
-                        : [...value, 'rowExpandable'],
-                    )
-                  }
-                  size="sm"
-                  checked={selected.includes('rowExpandable')}
-                />
-              </Table.Cell>
-              <Table.Cell>
-                <Text>value</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>value</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Table.RowExpandable</Text>
-              </Table.Cell>
-            </Table.RowExpandable>
-            <Table.RowDrawer
-              drawerContents={<Text>Content</Text>}
-              key="row3"
-              id="row3"
-              hoverStyle="gray"
-              selected={selected.includes('rowDrawer') ? 'selected' : 'unselected'}
-            >
-              <Table.Cell>
-                <Text />
-              </Table.Cell>
-              <Table.Cell>
-                <Checkbox
-                  id="rowDrawer"
-                  onChange={() =>
-                    setSelectedRow((value) =>
-                      value.includes('rowDrawer')
-                        ? value.filter((item) => item !== 'rowDrawer')
-                        : [...value, 'rowDrawer'],
-                    )
-                  }
-                  size="sm"
-                  checked={selected.includes('rowDrawer')}
-                />
-              </Table.Cell>
-              <Table.Cell>
-                <Text>value</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>value</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Table.RowDrawer</Text>
-              </Table.Cell>
-            </Table.RowDrawer>
-          </Table.Body>
-        </Table>
-      </Flex>
+      <Table accessibilityLabel="Selected row example table">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text />
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Selected</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Column</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Column</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Subcomponent</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row
+            key="row1"
+            hoverStyle="gray"
+            selected={selected.includes('row') ? 'selected' : 'unselected'}
+          >
+            <Table.Cell>
+              <Text />
+            </Table.Cell>
+            <Table.Cell>
+              <Checkbox
+                id="Row"
+                onChange={() =>
+                  setSelectedRow((value) =>
+                    value.includes('row')
+                      ? value.filter((item) => item !== 'row')
+                      : [...value, 'row'],
+                  )
+                }
+                size="sm"
+                checked={selected.includes('row')}
+              />
+            </Table.Cell>
+            <Table.Cell>
+              <Text>value</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>value</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Table.Row</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.RowExpandable
+            accessibilityCollapseLabel="Collapse"
+            accessibilityExpandLabel="Expand"
+            expandedContents={<Text>Content</Text>}
+            key="row2"
+            id="row2"
+            hoverStyle="gray"
+            selected={selected.includes('rowExpandable') ? 'selected' : 'unselected'}
+          >
+            <Table.Cell>
+              <Checkbox
+                id="RowExpandable"
+                onChange={() =>
+                  setSelectedRow((value) =>
+                    value.includes('rowExpandable')
+                      ? value.filter((item) => item !== 'rowExpandable')
+                      : [...value, 'rowExpandable'],
+                  )
+                }
+                size="sm"
+                checked={selected.includes('rowExpandable')}
+              />
+            </Table.Cell>
+            <Table.Cell>
+              <Text>value</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>value</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Table.RowExpandable</Text>
+            </Table.Cell>
+          </Table.RowExpandable>
+          <Table.RowDrawer
+            drawerContents={<Text>Content</Text>}
+            key="row3"
+            id="row3"
+            hoverStyle="gray"
+            selected={selected.includes('rowDrawer') ? 'selected' : 'unselected'}
+          >
+            <Table.Cell>
+              <Text />
+            </Table.Cell>
+            <Table.Cell>
+              <Checkbox
+                id="rowDrawer"
+                onChange={() =>
+                  setSelectedRow((value) =>
+                    value.includes('rowDrawer')
+                      ? value.filter((item) => item !== 'rowDrawer')
+                      : [...value, 'rowDrawer'],
+                  )
+                }
+                size="sm"
+                checked={selected.includes('rowDrawer')}
+              />
+            </Table.Cell>
+            <Table.Cell>
+              <Text>value</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>value</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Table.RowDrawer</Text>
+            </Table.Cell>
+          </Table.RowDrawer>
+        </Table.Body>
+      </Table>
     </Box>
   );
 }

--- a/docs/examples/table/separateUnitType.js
+++ b/docs/examples/table/separateUnitType.js
@@ -18,19 +18,33 @@ function HeaderRow() {
   );
 }
 
-function BaseRow({ disabled, type, title, subtext, rate, category }: any) {
+function BaseRow({
+  disabled,
+  type,
+  title,
+  subtext,
+  rate,
+  category,
+}: {|
+  disabled?: boolean,
+  type: $ElementType<React$ElementConfig<typeof Status>, 'type'>,
+  title: string,
+  subtext: string,
+  rate: number | string,
+  category: string,
+|}) {
   return (
     <Table.Row>
       <Table.Cell>
         <Status type={type} title={title} subtext={subtext} />
       </Table.Cell>
       <Table.Cell>
-        <Text align="end" color={disabled ? 'gray' : 'darkGray'}>
+        <Text align="end" color={disabled ? 'subtle' : 'default'}>
           {rate}
         </Text>
       </Table.Cell>
       <Table.Cell>
-        <Text color={disabled ? 'gray' : 'darkGray'}>{category}</Text>
+        <Text color={disabled ? 'subtle' : 'default'}>{category}</Text>
       </Table.Cell>
     </Table.Row>
   );
@@ -65,14 +79,7 @@ export default function Example(): Node {
           rate={2}
           category="Conversions"
         />
-        <BaseRow
-          checked={false}
-          type="ok"
-          title="Complete"
-          subtext="Ends 11/20/2021"
-          rate={50}
-          category="CTR"
-        />
+        <BaseRow type="ok" title="Complete" subtext="Ends 11/20/2021" rate={50} category="CTR" />
       </Table.Body>
     </Table>
   );

--- a/docs/examples/table/separateUnitType.js
+++ b/docs/examples/table/separateUnitType.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Table, Text, Status, Box } from 'gestalt';
+import { Table, Text, Status } from 'gestalt';
 
 function HeaderRow() {
   return (

--- a/docs/examples/table/separateUnitType.js
+++ b/docs/examples/table/separateUnitType.js
@@ -1,0 +1,79 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Text, Status, Box } from 'gestalt';
+
+function HeaderRow() {
+  return (
+    <Table.Header>
+      <Table.Row>
+        {['Status', 'Rate', 'Type'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text align={title === 'Rate' ? 'end' : 'start'} weight="bold">
+              {title}
+            </Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ disabled, type, title, subtext, rate, category }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Status type={type} title={title} subtext={subtext} />
+      </Table.Cell>
+      <Table.Cell>
+        <Text align="end" color={disabled ? 'gray' : 'darkGray'}>
+          {rate}
+        </Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Text color={disabled ? 'gray' : 'darkGray'}>{category}</Text>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = "Another example of a 'do' for table alignment";
+
+  return (
+    <Table accessibilityLabel={tableID}>
+      <HeaderRow />
+      <Table.Body>
+        <BaseRow
+          type="inProgress"
+          title="Active"
+          subtext="Ends 11/20/2021"
+          rate={100}
+          category="CTR"
+        />
+        <BaseRow
+          disabled
+          type="halted"
+          title="Paused"
+          subtext="Ends 11/20/2021"
+          rate="5,000"
+          category="Engagement"
+        />
+        <BaseRow
+          type="warning"
+          title="Warning"
+          subtext="Ends 11/20/2021"
+          rate={2}
+          category="Conversions"
+        />
+        <BaseRow
+          checked={false}
+          type="ok"
+          title="Complete"
+          subtext="Ends 11/20/2021"
+          rate={50}
+          category="CTR"
+        />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/docs/examples/table/sortableHeaderCellsWithStickyColumns.js
+++ b/docs/examples/table/sortableHeaderCellsWithStickyColumns.js
@@ -6,7 +6,7 @@ export default function SortableHeaderExample(): Node {
   const [sortOrder, setSortOrder] = useState('desc');
   const [sortCol, setSortCol] = useState('name');
 
-  const onSortChange = (col) => {
+  const onSortChange = (col: string) => {
     if (sortCol !== col) {
       setSortCol(col);
       setSortOrder('desc');

--- a/docs/examples/table/sortableHeaderCellsWithStickyColumns.js
+++ b/docs/examples/table/sortableHeaderCellsWithStickyColumns.js
@@ -1,0 +1,79 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Table, Text } from 'gestalt';
+
+export default function SortableHeaderExample(): Node {
+  const [sortOrder, setSortOrder] = useState('desc');
+  const [sortCol, setSortCol] = useState('name');
+
+  const onSortChange = (col) => {
+    if (sortCol !== col) {
+      setSortCol(col);
+      setSortOrder('desc');
+    } else {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    }
+  };
+
+  return (
+    <Box height="100%" display="flex" justifyContent="center" alignItems="center">
+      <Box width="70%">
+        <Table accessibilityLabel="Sortable header cells with sticky columns" stickyColumns={2}>
+          <Table.Header>
+            <Table.Row>
+              <Table.SortableHeaderCell
+                onSortChange={() => onSortChange('name')}
+                sortOrder={sortOrder}
+                status={sortCol === 'name' ? 'active' : 'inactive'}
+              >
+                <Text weight="bold">Name</Text>
+              </Table.SortableHeaderCell>
+              <Table.SortableHeaderCell
+                onSortChange={() => onSortChange('id')}
+                sortOrder={sortOrder}
+                status={sortCol === 'id' ? 'active' : 'inactive'}
+              >
+                <Text weight="bold">Nickname</Text>
+              </Table.SortableHeaderCell>
+              <Table.SortableHeaderCell
+                onSortChange={() => onSortChange('food')}
+                sortOrder={sortOrder}
+                status={sortCol === 'food' ? 'active' : 'inactive'}
+              >
+                <Text weight="bold">Favorite Food</Text>
+              </Table.SortableHeaderCell>
+              <Table.SortableHeaderCell
+                onSortChange={() => onSortChange('friend')}
+                sortOrder={sortOrder}
+                status={sortCol === 'friend' ? 'active' : 'inactive'}
+              >
+                <Text weight="bold">Best Friend</Text>
+              </Table.SortableHeaderCell>
+              <Table.SortableHeaderCell
+                onSortChange={() => onSortChange('birth')}
+                sortOrder={sortOrder}
+                status={sortCol === 'birth' ? 'active' : 'inactive'}
+              >
+                <Text weight="bold">Birthdate</Text>
+              </Table.SortableHeaderCell>
+              <Table.SortableHeaderCell
+                onSortChange={() => onSortChange('desc')}
+                sortOrder={sortOrder}
+                status={sortCol === 'desc' ? 'active' : 'inactive'}
+              >
+                <Text weight="bold">Description</Text>
+              </Table.SortableHeaderCell>
+              <Table.SortableHeaderCell
+                onSortChange={() => onSortChange('color')}
+                sortOrder={sortOrder}
+                status={sortCol === 'color' ? 'active' : 'inactive'}
+              >
+                <Text weight="bold">Favorite Color</Text>
+              </Table.SortableHeaderCell>
+            </Table.Row>
+          </Table.Header>
+        </Table>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/table/sortableTableCells.js
+++ b/docs/examples/table/sortableTableCells.js
@@ -6,7 +6,7 @@ export default function SortableHeaderExample(): Node {
   const [sortOrder, setSortOrder] = useState('desc');
   const [sortCol, setSortCol] = useState('name');
 
-  const onSortChange = (col) => {
+  const onSortChange = (col: string) => {
     if (sortCol !== col) {
       setSortCol(col);
       setSortOrder('desc');

--- a/docs/examples/table/sortableTableCells.js
+++ b/docs/examples/table/sortableTableCells.js
@@ -1,0 +1,42 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Table, Text, Box } from 'gestalt';
+
+export default function SortableHeaderExample(): Node {
+  const [sortOrder, setSortOrder] = useState('desc');
+  const [sortCol, setSortCol] = useState('name');
+
+  const onSortChange = (col) => {
+    if (sortCol !== col) {
+      setSortCol(col);
+      setSortOrder('desc');
+    } else {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    }
+  };
+
+  return (
+    <Box height="100%" display="flex" justifyContent="center" alignItems="center">
+      <Table accessibilityLabel="Sortable header cells">
+        <Table.Header>
+          <Table.Row>
+            <Table.SortableHeaderCell
+              onSortChange={() => onSortChange('name')}
+              sortOrder={sortOrder}
+              status={sortCol === 'name' ? 'active' : 'inactive'}
+            >
+              <Text weight="bold">Name</Text>
+            </Table.SortableHeaderCell>
+            <Table.SortableHeaderCell
+              onSortChange={() => onSortChange('id')}
+              sortOrder={sortOrder}
+              status={sortCol === 'id' ? 'active' : 'inactive'}
+            >
+              <Text weight="bold">Id</Text>
+            </Table.SortableHeaderCell>
+          </Table.Row>
+        </Table.Header>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/table/stickyColumnExample.js
+++ b/docs/examples/table/stickyColumnExample.js
@@ -1,0 +1,130 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Table, Text, Mask, Image } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box width="60%">
+        <Table accessibilityLabel="Sticky Column" maxHeight={200} stickyColumns={1}>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Text weight="bold">Image</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Name</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Super Name</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Favorite Food</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Best Friend</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Birthday</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Tony"
+                      src="https://i.ibb.co/r3R04Y9/ironman.jpg"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Tony Stark</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Iron Man</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Shawarma</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Spiderman</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Box width={200}>
+                  <Text>May 29, 1970</Text>
+                </Box>
+              </Table.Cell>
+            </Table.Row>
+
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Peter"
+                      src="https://i.ibb.co/64NxM43/spiderman.png"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Peter Parker</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Spiderman</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Sandwiches</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Iron Man</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>December 28, 1995</Text>
+              </Table.Cell>
+            </Table.Row>
+
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="T'Challa"
+                      src="https://i.ibb.co/GpNtW5N/black-Panther.png"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>T&apos;Challa</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Black Panther</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Beef suya</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Shuri</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>November 28, 1977</Text>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/table/stickyHeaderColumnExample.js
+++ b/docs/examples/table/stickyHeaderColumnExample.js
@@ -1,0 +1,193 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Table, Text, Mask, Image } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box width="60%">
+        <Table
+          accessibilityLabel="Sticky header and sticky columns"
+          maxHeight={200}
+          stickyColumns={3}
+          borderStyle="none"
+        >
+          <Table.Header sticky>
+            <Table.Row>
+              <Table.HeaderCell>
+                <Text weight="bold">Image</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Name</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Super Name</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Best Friend</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Favorite Food</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Super Powers</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Home</Text>
+              </Table.HeaderCell>
+              <Table.HeaderCell>
+                <Text weight="bold">Aliases</Text>
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Tony"
+                      src="https://i.ibb.co/r3R04Y9/ironman.jpg"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Tony Stark</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Iron Man</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Spiderman</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Shawarma</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Flight, Super strength</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>New York</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>N/A</Text>
+              </Table.Cell>
+            </Table.Row>
+
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Peter"
+                      src="https://i.ibb.co/64NxM43/spiderman.png"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Peter Parker</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Spiderman</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Iron Man</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Sandwiches</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Spidey senses, super strength, web shooters</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Brooklyn</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Friendly Neighborhood Spiderman</Text>
+              </Table.Cell>
+            </Table.Row>
+
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Wanda"
+                      src="https://i.ibb.co/hV6Vpbf/scarlet.png"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Wanda Maximoff</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Scarlet Witch</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Vision</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Chicken paprikash</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Chaos magic, spells, reality warping</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Sokovia</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>N/A</Text>
+              </Table.Cell>
+            </Table.Row>
+
+            <Table.Row>
+              <Table.Cell>
+                <Box width={50}>
+                  <Mask rounding="circle">
+                    <Image
+                      alt="Black Panther"
+                      src="https://i.ibb.co/GpNtW5N/black-Panther.png"
+                      naturalHeight={50}
+                      naturalWidth={50}
+                    />
+                  </Mask>
+                </Box>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>T&apos;Challa</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Black Panther</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Shuri</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Beef suya</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Enhanced strength, speed, reflexes + Vibranium suit</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>Wakanda</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text>King of the Dead</Text>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/table/stickyHeaderFooterExample.js
+++ b/docs/examples/table/stickyHeaderFooterExample.js
@@ -1,0 +1,84 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Text, Box } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Table accessibilityLabel="Sticky footer" maxHeight={200}>
+        <Table.Header sticky>
+          <Table.Row>
+            <Table.HeaderCell>
+              <Text weight="bold">Campaign</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Impression</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Cost</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Spring season</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>10,000</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>$500</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Autumn season</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>10,000</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>$500</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Summer season</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>10,000</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>$500</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Text>Winter season</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>10,000</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>$500</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+        <Table.Footer sticky>
+          <Table.Row>
+            <Table.Cell>
+              <Text weight="bold">Total</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text weight="bold">40,000</Text>
+            </Table.Cell>
+            <Table.Cell>
+              <Text weight="bold">$2,000</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/table/topCaptionExample.js
+++ b/docs/examples/table/topCaptionExample.js
@@ -1,0 +1,106 @@
+// @flow strict
+import { type Node } from 'react';
+import { Table, Box, Label, Checkbox, Text, Status, Flex } from 'gestalt';
+
+function HeaderRow({ id }: any) {
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          <Box display="visuallyHidden">
+            <Label htmlFor={id}>Not all checkboxes are checked</Label>
+          </Box>
+          <Checkbox id={id} onChange={() => {}} indeterminate size="sm" />
+        </Table.HeaderCell>
+        {['Status', 'Campaign'].map((title) => (
+          <Table.HeaderCell key={title}>
+            <Text weight="bold">{title}</Text>
+          </Table.HeaderCell>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function BaseRow({ id, checked, disabled, type, text, subtext, campaign }: any) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <Checkbox
+          id={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+          onChange={() => {}}
+          disabled={disabled}
+          size="sm"
+          checked={checked}
+        />
+      </Table.Cell>
+      <Table.Cell>
+        <Status type={type} title={text} subtext={subtext} />
+      </Table.Cell>
+      <Table.Cell>
+        <Label
+          htmlFor={`${id.replace(/ /g, '_').replace(/'/g, '')}_${text
+            .replace(/ /g, '_')
+            .replace(/'/g, '')}`}
+        >
+          <Text color={disabled ? 'gray' : 'darkGray'}>{campaign}</Text>
+        </Label>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default function Example(): Node {
+  const tableID = 'Example of correct accessibility with top caption';
+
+  return (
+    <Box padding={4}>
+      <Flex gap={{ column: 2, row: 0 }} direction="column">
+        <Box aria-hidden>
+          <Text size="400" weight="bold">
+            Your Campaigns Summary
+          </Text>
+        </Box>
+        <Table accessibilityLabel="Your campaigns summary">
+          <HeaderRow id={tableID} />
+          <Table.Body>
+            <BaseRow
+              id={tableID}
+              checked
+              type="inProgress"
+              text="In progress"
+              subtext="Ends 11/20/2021"
+              campaign="Engagement"
+            />
+            <BaseRow
+              id={tableID}
+              disabled
+              type="halted"
+              text="Paused"
+              subtext="Ends 11/20/2021"
+              campaign="Awareness"
+            />
+            <BaseRow
+              id={tableID}
+              checked
+              type="warning"
+              text="Warning"
+              subtext="Ends 11/20/2021"
+              campaign="Catalogs"
+            />
+            <BaseRow
+              id={tableID}
+              checked={false}
+              type="ok"
+              text="Complete"
+              subtext="Ends 11/20/2021"
+              campaign="Awareness"
+            />
+          </Table.Body>
+        </Table>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/table/topCaptionExample.js
+++ b/docs/examples/table/topCaptionExample.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Table, Box, Label, Checkbox, Text, Status, Flex } from 'gestalt';
 
-function HeaderRow({ id }: any) {
+function HeaderRow({ id }: {| id: string |}) {
   return (
     <Table.Header>
       <Table.Row>
@@ -22,7 +22,23 @@ function HeaderRow({ id }: any) {
   );
 }
 
-function BaseRow({ id, checked, disabled, type, text, subtext, campaign }: any) {
+function BaseRow({
+  id,
+  checked,
+  disabled,
+  type,
+  text,
+  subtext,
+  campaign,
+}: {|
+  id: string,
+  checked?: boolean,
+  disabled?: boolean,
+  type: $ElementType<React$ElementConfig<typeof Status>, 'type'>,
+  text: string,
+  subtext: string,
+  campaign: string,
+|}) {
   return (
     <Table.Row>
       <Table.Cell>
@@ -45,7 +61,7 @@ function BaseRow({ id, checked, disabled, type, text, subtext, campaign }: any) 
             .replace(/ /g, '_')
             .replace(/'/g, '')}`}
         >
-          <Text color={disabled ? 'gray' : 'darkGray'}>{campaign}</Text>
+          <Text color={disabled ? 'subtle' : 'default'}>{campaign}</Text>
         </Label>
       </Table.Cell>
     </Table.Row>

--- a/docs/pages/web/table.js
+++ b/docs/pages/web/table.js
@@ -8,9 +8,29 @@ import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
+import alignContent from '../../examples/table/alignContent.js';
+import avoidOverStylingText from '../../examples/table/avoidOverStylingText.js';
+import bottomCaptionExample from '../../examples/table/bottomCaptionExample.js';
 import controlledExpandable from '../../examples/table/controlledExpandable.js';
+import dontAddSoMuchContent from '../../examples/table/dontAddSoMuchContent.js';
+import dontAlignContent from '../../examples/table/dontAlignContent.js';
+import dontMixTextAndGraphics from '../../examples/table/dontMixTextAndGraphics.js';
+import dontOverStyleText from '../../examples/table/dontOverStyleText.js';
+import dontUseExpandForDenseContent from '../../examples/table/dontUseExpandForDenseContent.js';
+import drawerRowExample from '../../examples/table/drawerRowExample.js';
+import expandRows from '../../examples/table/expandRows.js';
 import main from '../../examples/table/main.js';
+import makeContentDigestable from '../../examples/table/makeContentDigestable.js';
+import multipleStickyColumnsExample from '../../examples/table/multipleStickyColumnsExample.js';
+import rowExpandableWithStickyColumns from '../../examples/table/rowExpandableWithStickyColumns.js';
 import selected from '../../examples/table/selected.js';
+import separateUnitType from '../../examples/table/separateUnitType.js';
+import sortableHeaderCellsWithStickyColumns from '../../examples/table/sortableHeaderCellsWithStickyColumns.js';
+import sortableTableCells from '../../examples/table/sortableTableCells.js';
+import stickyColumnExample from '../../examples/table/stickyColumnExample.js';
+import stickyHeaderColumnExample from '../../examples/table/stickyHeaderColumnExample.js';
+import stickyHeaderFooterExample from '../../examples/table/stickyHeaderFooterExample.js';
+import topCaptionExample from '../../examples/table/topCaptionExample.js';
 import uncontrolledExpandable from '../../examples/table/uncontrolledExpandable.js';
 
 export default function DocsPage({
@@ -59,209 +79,28 @@ export default function DocsPage({
             cardSize="md"
             type="do"
             description="Use accessible Gestalt grays for table text, and reserve colors to sparingly accent important status and information. Avoid over-styling text."
-            defaultCode={`
-function Example() {
-  const HeaderRow = ({ id }) => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>
-            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
-            <Checkbox
-              id={id}
-   onChange={() => {}}
-              indeterminate
-              size="sm"
-            />
-          </Table.HeaderCell>
-          {["Status", "Campaign"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ id, checked, disabled, text, campaign }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Checkbox
-            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
-            disabled={disabled}
-            size="sm"
-            checked={checked}
-          />
-        </Table.Cell>
-        <Table.Cell>
-          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
-            <Text>{text}</Text>
-          </Label>
-        </Table.Cell>
-        <Table.Cell>
-          <Text color={disabled ? "gray" : "darkGray"}>{campaign}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Example of a 'do' for table style";
-
-  return (
-    <Table accessibilityLabel={tableID}>
-      <HeaderRow id={tableID}/>
-      <Table.Body>
-        <BaseRow
-          id={tableID}
-          checked={true}
-          text="The best ad"
-          campaign="Engagement"
-        />
-        <BaseRow
-          id={tableID}
-          disabled
-          text="This ad is great"
-          campaign="Awareness"
-        />
-        <BaseRow
-          id={tableID}
-          checked={true}
-          text="Mary's pincycle"
-          campaign="Catalogs"
-        />
-        <BaseRow
-          id={tableID}
-          checked={false}
-          text="Best Purchase Wins"
-          campaign="Awareness"
-        />
-        <BaseRow
-          id={tableID}
-          checked={false}
-          text="The third campaign"
-          campaign="Conversions"
-        />
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Do - Use accessible Gestalt grays for table text"
+                code={avoidOverStylingText}
+                hideEditor
+                layout="column"
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Overuse color and styling for text in tables; it can make it hard to scan for important status updates and crucial information."
-            defaultCode={`
-function Example() {
-  const HeaderRow = ({ id }) => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>
-            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
-            <Checkbox
-              id={id}
-   onChange={() => {}}
-              indeterminate
-              size="sm"
-            />
-          </Table.HeaderCell>
-          {["Status", "Campaign"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text color={ title === "Campaign" ? "red" : "blue"} weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ id, checked, disabled, text, campaign, bold, underline, italic, color }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Checkbox
-            id={ id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "") }
- onChange={() => {}}
-            disabled={disabled}
-            size="sm"
-            checked={checked}
-          />
-        </Table.Cell>
-        <Table.Cell>
-          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
-            <Text
-              weight={bold ? "bold" : "regular"}
-              underline={underline ? true : undefined}
-              italic={italic ? true : undefined}
-            >
-              {text}
-            </Text>
-          </Label>
-        </Table.Cell>
-        <Table.Cell>
-          <Text color={color}>{campaign}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
- const tableID = "Example of a Dont do for table style";
-
-  return (
-    <Table accessibilityLabel={tableID}>
-      <HeaderRow id={tableID}/>
-      <Table.Body>
-        <BaseRow
-          id={tableID}
-          checked={true}
-          text="The best ad"
-          campaign="Engagement"
-          color="red"
-        />
-        <BaseRow
-          id={tableID}
-          disabled
-          bold
-          text="This ad is great"
-          campaign="Awareness"
-          color="blue"
-        />
-        <BaseRow
-          id={tableID}
-          checked={true}
-          bold
-          italic
-          text="Mary's pincycle"
-          campaign="Catalogs"
-          color="red"
-        />
-        <BaseRow
-          id={tableID}
-          checked={false}
-          underline
-          text="BEST PURCHASE WINS"
-          campaign="Awareness"
-          color="purple"
-        />
-        <BaseRow
-          id={tableID}
-          checked={false}
-          text="The third campaign"
-          campaign="CONVERSIONS"
-          color="green"
-        />
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Don't - Overuse color and styling for text in tables"
+                code={dontOverStyleText}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection title="Alignment" columns={2}>
@@ -273,97 +112,14 @@ function Example() {
 - End-align numbers only
 - Align headers with their corresponding content
 - Use tabular lining for numbers`}
-            defaultCode={`
-function Example() {
-  const HeaderRow = ({ id }) => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>
-            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
-            <Checkbox
-              id={id}
-   onChange={() => {}}
-              indeterminate
-              size="sm"
-            />
-          </Table.HeaderCell>
-          {["Campaign", "Spend"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text align={title === "Spend" ? "end" : "start"} weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ id, checked, disabled, text, spend }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Checkbox
-            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
-            disabled={disabled}
-            size="sm"
-            checked={checked}
-          />
-        </Table.Cell>
-        <Table.Cell>
-          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
-            <Text>{text}</Text>
-          </Label>
-        </Table.Cell>
-        <Table.Cell>
-          <Text align="end">{spend}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Example of a 'do' for table alignment";
-
-  return (
-    <Table accessibilityLabel={tableID}>
-      <HeaderRow id={tableID}/>
-      <Table.Body>
-       <BaseRow
-          id={tableID}
-          checked={true}
-          text="The best ad"
-          spend="$5.50"
-        />
-        <BaseRow
-          id={tableID}
-          disabled
-          text="This ad is great"
-          spend="$3,000.00"
-        />
-        <BaseRow
-          id={tableID}
-          checked={true}
-          text="Mary's pincycle"
-          spend="$1.75"
-        />
-        <BaseRow
-          id={tableID}
-          checked={false}
-          text="Best Purchase Wins"
-          spend="$51,650,500.54"
-        />
-        <BaseRow
-          id={tableID}
-          checked={false}
-          text="The third campaign"
-          spend="$67.60"
-        />
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Do - Align content"
+                code={alignContent}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
@@ -374,103 +130,15 @@ function Example() {
 - End-align text and combo-content (combinations of text, numbers and/or graphics)
 - Misalign headers with their corresponding content
 `}
-            defaultCode={`
-function Example() {
-  const HeaderRow = ({ id }) => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>
-            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
-            <Checkbox
-              id={id}
-   onChange={() => {}}
-              indeterminate
-              size="sm"
-            />
-          </Table.HeaderCell>
-          {["Campaign", "Spend"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text align={title === "Campaign" ? "center" : "start"} weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ id, checked, disabled, text, subtext, spend }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Checkbox
-            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
-            disabled={disabled}
-            size="sm"
-            checked={checked}
-          />
-        </Table.Cell>
-        <Table.Cell>
-          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
-            <Text align="center">{text}</Text>
-            <Text align="center">{subtext}</Text>
-          </Label>
-        </Table.Cell>
-        <Table.Cell>
-          <Text align="end">{spend}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Example of a 'Dont' do for table alignment";
-
-  return (
-    <Table accessibilityLabel={tableID}>
-      <HeaderRow id={tableID} />
-      <Table.Body>
-       <BaseRow
-          id={tableID}
-          checked={true}
-          text="The best ad"
-          subtext="12/20/21"
-          spend="$5"
-        />
-        <BaseRow
-          id={tableID}
-          disabled
-          text="This ad is great"
-          subtext="01/16/21"
-          spend="$3,000.00"
-        />
-        <BaseRow
-          id={tableID}
-          checked={true}
-          text="Mary's pincycle"
-          subtext="07/15/22"
-          spend="$1.750"
-        />
-        <BaseRow
-          id={tableID}
-          checked={false}
-          text="Best Purchase Wins"
-          subtext="06/15/22"
-          spend="$51,650,500.54"
-        />
-        <BaseRow
-          id={tableID}
-          checked={false}
-          text="The third campaign"
-          subtext="06/24/22"
-          spend="$67.60"
-        />
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Align content so that it makes it harder to scan, read, and compare.\n- Center-align content\n- Use proportional figures for numbers as they don’t quite align\n- End-align text and combo-content (combinations of text, numbers and/or graphics)\n- Misalign headers with their corresponding content"
+                code={dontAlignContent}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -478,153 +146,28 @@ function Example() {
             cardSize="md"
             type="do"
             description="Place unit type on a separate column so that amounts can still align and be compared."
-            defaultCode={`
-function Example() {
-  const HeaderRow = () => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          {["Status", "Rate", "Type"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text align={title === "Rate" ? "end" : "start"} weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ disabled, type, title, subtext, rate, category }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Status type={type} title={title} subtext={subtext} />
-        </Table.Cell>
-        <Table.Cell>
-          <Text align="end" color={disabled ? "gray" : "darkGray"}>{rate}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text color={disabled ? "gray" : "darkGray"}>{category}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Another example of a 'do' for table alignment";
-
-  return (
-    <Table accessibilityLabel={tableID}>
-      <HeaderRow />
-      <Table.Body>
-        <BaseRow
-          type="inProgress"
-          title="Active"
-          subtext="Ends 11/20/2021"
-          rate={100}
-          category="CTR"
-        />
-        <BaseRow
-          disabled
-          type="halted"
-          title="Paused"
-          subtext="Ends 11/20/2021"
-          rate="5,000"
-          category="Engagement"
-        />
-        <BaseRow
-          type="warning"
-          title="Warning"
-          subtext="Ends 11/20/2021"
-          rate={2}
-          category="Conversions"
-        />
-        <BaseRow
-          checked={false}
-          type="ok"
-          title="Complete"
-          subtext="Ends 11/20/2021"
-          rate={50}
-          category="CTR"
-        />
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Do - Place unit type on a separate column"
+                code={separateUnitType}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Mix text and graphics with numbers that need to be compared with each other."
-            defaultCode={`
-function Example() {
-  const HeaderRow = () => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          {["Status", "Rate"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text align={title === "Rate" ? "end" : "start"}  weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ disabled, type, title, subtext, rate }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Status type={type} title={title} subtext={subtext} />
-        </Table.Cell>
-        <Table.Cell>
-          <Text overflow="noWrap" align="end" color={disabled ? "gray" : "darkGray"}>{rate}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Another Example of a 'Dont' do for table alignment";
-
-  return (
-    <Table accessibilityLabel={tableID}>
-      <HeaderRow />
-      <Table.Body>
-        <BaseRow
-          type="inProgress"
-          title="Active"
-          subtext="Ends 11/20/2021"
-          rate="100 CTR"
-        />
-        <BaseRow
-          disabled
-          type="halted"
-          title="Paused"
-          subtext="Ends 11/20/2021"
-          rate="5,000 Engagement"
-        />
-        <BaseRow
-          type="warning"
-          title="Warning"
-          subtext="Ends 11/20/2021"
-          rate="2 Conversions"
-        />
-        <BaseRow
-          type="ok"
-          title="Complete"
-          subtext="Ends 11/20/2021"
-          rate="50 CTR"
-        />
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Don't - Mix text and graphics with numbers"
+                code={dontMixTextAndGraphics}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection title="Content" columns={2}>
@@ -638,66 +181,14 @@ function Example() {
 - Wrap important content to multiple lines
 - Truncate secondary information, especially if a user is going to get the full content upon click of a link in the table.
 "
-            defaultCode={`
-function Example() {
-  const HeaderRow = () => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          {["Name", "Total"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text align={title === "Total" ? "end" : "start"} weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ name, subtext, total, lineClamp }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Text color="default">{name}</Text>
-          <Text color="subtle" size="100" lineClamp={lineClamp}>{subtext}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text align="end">{total}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Example of a 'do' for table content";
-
-  return (
-    <Table accessibilityLabel={tableID}>
-      <HeaderRow />
-      <Table.Body>
-        <BaseRow
-          name="Video views for all Q3 campaigns and ad groups"
-          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
-          total="--"
-          lineClamp={1}
-        />
-        <BaseRow
-          name="Video views for all Q2 campaigns and ad groups"
-          subtext="David Brown, Carlota Ojeda"
-          total="5,000"
-        />
-        <BaseRow
-          name="Video views for all Q2 ad groups"
-          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
-          total="6,455,434"
-          lineClamp={1}
-        />
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Do - Make content digestible and scannable:\n- Keep headers clear and concise\n- Include an a visual indicator for cells that don’t have content.\n- Give enough space for content to account for localization.\n- Wrap important content to multiple lines\n- Truncate secondary information, especially if a user is going to get the full content upon click of a link in the table.\n"
+                code={makeContentDigestable}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
@@ -705,65 +196,15 @@ function Example() {
             description="Add so much content that it’s hard for a user to read, examine and scan:
 - Don’t truncate content that a user needs to examine in relation to other content in the table.
 - Leave cells blank so that it isn’t clear if all data has loaded."
-            defaultCode={`
-function Example() {
-  const HeaderRow = () => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          {["Name", "Total amounts for 2021 through 2022"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text align={title.startsWith("Total") ? "end" : "start"} weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ name, subtext, total, lineClamp }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Text color="default">{name}</Text>
-          <Text color="subtle" size="100" lineClamp={lineClamp}>{subtext}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text align="end" lineClamp={lineClamp}>{total}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Example of a 'don't' do for table content";
-
-  return (
-    <Table accessibilityLabel={tableID}>
-      <HeaderRow />
-      <Table.Body>
-        <BaseRow
-          name="Video views for all Q3 campaigns and ad groups"
-          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
-          total=""
-        />
-        <BaseRow
-          name="Video views for all Q2 campaigns and ad groups"
-          subtext="David Brown, Carlota Ojeda"
-          total="5,000"
-        />
-        <BaseRow
-          name="Video views for all Q2 ad groups"
-          subtext="David Brown, Carlota Ojeda, Olamide Olufemi, Rajesh Uttambai"
-          total="6,455,434"
-          lineClamp={1}
-        />
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Don't - Add so much content"
+                code={dontAddSoMuchContent}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection>
@@ -771,444 +212,28 @@ function Example() {
             cardSize="lg"
             type="do"
             description="Expand rows if the additional content is simple, doesn’t contain a lot of interaction and doesn’t take up more than 50% of the screen."
-            defaultCode={`
-    function Example() {
-      const [activeA, setActiveA] = React.useState(false);
-      const [activeB, setActiveB] = React.useState(false);
-      const [activeC, setActiveC] = React.useState(false);
-
-      const HeaderRow = () => {
-        return (
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Box display="visuallyHidden">
-                  <Text weight="bold">Open/Close row</Text>
-                </Box>
-              </Table.HeaderCell>
-              {["Name", "Team", "Role", "Office Hours"].map((title, idx) => {
-                return (
-                  <Table.HeaderCell key={idx}>
-                    <Text weight="bold">{title}</Text>
-                  </Table.HeaderCell>
-                );
-              })}
-            </Table.Row>
-          </Table.Header>
-        );
-      };
-
-      const BaseRow = ({ name, team, src, role, hours, active, setActive }) => {
-        return (
-            <Table.RowExpandable
-              accessibilityExpandLabel="Expand"
-              accessibilityCollapseLabel="Collapse"
-              id={name}
-              onExpand={() => {}}
-              expandedContents={
-                <Box
-                  onMouseEnter={() => setActive(true)}
-                  onMouseLeave={() => setActive(false)}
-                  display="flex"
-                  justifyContent="center"
-                  maxWidth={236}
-                  padding={2}
-                  column={12}
-                >
-                  <WashAnimated
-                    active={active}
-                    image={
-                      <Box
-                        display="flex"
-                        justifyContent="center"
-                        maxWidth={236}
-                        padding={2}
-                        column={12}
-                      >
-                        <Avatar
-                          size="md"
-                          name={name+"avatar"}
-                          src={src}
-                        />
-                      </Box>
-                    }
-                  >
-                    <Text align="center" weight="bold">
-                      <Link href="https://pinterest.com" target="blank">
-                        <Box paddingX={3} paddingY={2}>
-                          {name+"'s Info"}
-                        </Box>
-                      </Link>
-                    </Text>
-                  </WashAnimated>
-                </Box>
-              }
-            >
-            <Table.Cell>
-              <Text>{name}</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>{team}</Text>
-            </Table.Cell>
-             <Table.Cell>
-              <Text>{role}</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text>{hours}</Text>
-            </Table.Cell>
-          </Table.RowExpandable>
-        );
-      };
-
-    const tableID = "Another Example of a 'do' for table content";
-
-      return(
-    <Table accessibilityLabel={tableID}>
-          <HeaderRow />
-          <Table.Body>
-           <BaseRow
-              active={activeA}
-              setActive={setActiveA}
-              name="Ayesha Teng"
-              team="Gestalt"
-              src="https://i.ibb.co/QY9qR7h/luna.png"
-              role="Engineer"
-              hours="Monday, Friday"
-            />
-            <BaseRow
-              active={activeB}
-              setActive={setActiveB}
-              name="Ryan Costa"
-              team="Analytics"
-              src="https://i.ibb.co/Hzcfxjt/draco.png"
-              role="Designer"
-              hours="Wednesdays"
-            />
-            <BaseRow
-              active={activeC}
-              setActive={setActiveC}
-              name="Kate Steele"
-              team="Monetization"
-              src="https://i.ibb.co/JvY9DKK/neville.png"
-              role="Design Technologist"
-              hours="Tuesdays, Thursdays"
-            />
-          </Table.Body>
-        </Table>);
-    }
-    `}
+            sandpackExample={
+              <SandpackExample
+                name="Do - Expand rows"
+                code={expandRows}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="lg"
             type="don't"
             description="Use an expand to display dense, highly-interactive content. Use a new page or [OverlayPanel](/web/overlaypanel) for that."
-            defaultCode={`
-function MainExample() {
-  const ExpandedContents = () => {
-    const [tabItem, setTabItem] = React.useState('campaign');
-    const [extExpandedId, setExtExpandedId] = React.useState(null);
-    const mapIds = {
-      'first-0': 0,
-      'first-1': 1,
-      'first-2': 2,
-    };
-    return (
-      <Flex direction="column" gap={{ column: 6, row: 0 }} width={800}>
-        <Tabs
-          activeTabIndex={tabItem === 'campaign' ? 0 : 1}
-          bgColor="transparent"
-          onChange={({ event }) => {
-            setTabItem(tabItem !== 'analytics' ? 'analytics' : 'campaign');
-            event.preventDefault();
-          }}
-          tabs={[
-            { href: '', text: 'Campaign', indicator: tabItem === 'campaign' ? 'dot' : undefined },
-            { href: '', text: 'Analytics', indicator: tabItem === 'analytics' ? 'dot' : undefined },
-          ]}
-        />
-        {tabItem === 'campaign' ? (
-          <Flex direction="column" gap={{ column: 6, row: 0 }} width="100%">
-            <Heading size="400" accessibilityLevel={2}>
-              Latest boards
-            </Heading>
-            <Flex gap={{ row: 6, column: 0 }} width="100%">
-              <Flex.Item width="50%">
-                <TapArea tapStyle="compress" onTap={() => {}}>
-                  <Mask rounding={4}>
-                    <Collage
-                      columns={3}
-                      height={300}
-                      width={300}
-                      renderImage={({ index, width, height }) => {
-                        const images = [
-                          {
-                            color: 'rgb(111, 91, 77)',
-                            naturalHeight: 751,
-                            naturalWidth: 564,
-                            src: 'https://i.ibb.co/Lx54BCT/stock1.jpg',
-                          },
-                          {
-                            color: 'rgb(231, 186, 176)',
-                            naturalHeight: 200,
-                            naturalWidth: 98,
-                            src: 'https://i.ibb.co/7bQQYkX/stock2.jpg',
-                          },
-                          {
-                            color: '#000',
-                            naturalHeight: 300,
-                            naturalWidth: 200,
-                            src: 'https://i.ibb.co/d0pQsJz/stock3.jpg',
-                          },
-                          {
-                            color: '#000',
-                            naturalHeight: 517,
-                            naturalWidth: 564,
-                            src: 'https://i.ibb.co/SB0pXgS/stock4.jpg',
-                          },
-                          {
-                            color: '#000',
-                            naturalHeight: 806,
-                            naturalWidth: 564,
-                            src: 'https://i.ibb.co/jVR29XV/stock5.jpg',
-                          },
-                          {
-                            color: '#000',
-                            naturalHeight: 200,
-                            naturalWidth: 200,
-                            src: 'https://i.ibb.co/FY2MKr5/stock6.jpg',
-                          },
-                        ];
-                        const image = images[index] || {};
-                        return (
-                          <Mask wash width={width} height={height}>
-                            <Image
-                              alt="collage image"
-                              color={image.color}
-                              fit="cover"
-                              naturalHeight={image.naturalHeight}
-                              naturalWidth={image.naturalWidth}
-                              src={image.src}
-                            />
-                          </Mask>
-                        );
-                      }}
-                    />
-                  </Mask>
-                  <Flex direction="column" gap={{ column: 2, row: 0 }}>
-                    <Heading size="400" accessibilityLevel={0}>
-                      Uniform
-                    </Heading>
-                    <Flex gap={{ column: 0, row: 5 }}>
-                      <Text size="200">123 Pins</Text>
-                      <Text size="200">4 sections</Text>
-                    </Flex>
-                  </Flex>
-                </TapArea>
-              </Flex.Item>
-              <Flex direction="column" gap={{ column: 4, row: 0 }} width="100%">
-                <TextField
-                  id="name"
-                  onChange={() => {}}
-                  placeholder="Name"
-                  label="Name"
-                  value="December '21"
-                />
-                <TextArea
-                  id="notes"
-                  onChange={() => {}}
-                  placeholder="Notes on updates..."
-                  label="Notes"
-                  value=""
-                />
-                <Flex gap={{ column: 0, row: 4 }}>
-                  <NumberField
-                    id="budget"
-                    onChange={() => {}}
-                    placeholder=""
-                    label="Budget (USD)"
-                    value="100000"
-                  />
-                  <TextField
-                    id="scope"
-                    onChange={() => {}}
-                    placeholder=""
-                    label="Scope"
-                    value="Global"
-                  />
-                </Flex>
-                <Label htmlFor="status">
-                  <Text>Status</Text>
-                </Label>
-                <Switch onChange={() => {}} id="status" switched />
-              </Flex>
-            </Flex>
-            <Flex gap={{ column: 0, row: 3 }}>
-              <Button text="Cancel" />
-              <Flex.Item flex="grow">
-                <Button text="Pause" />
-              </Flex.Item>
-              <Button color="red" text="Edit" />
-            </Flex>
-          </Flex>
-        ) : (
-          <Flex gap={{ column: 0, row: 3 }}>
-            <Module id="Analitycs Overview" title="Analitycs Overview">
-              <Box width={300}>
-                <Datapoint
-                  size="lg"
-                  tooltipText="The number of times your ads were seen, including earned impressions"
-                  title="Total impressions"
-                  value="1K"
-                  trend={{ value: 30, accessibilityLabel: 'Trending up' }}
-                />
-                <Datapoint
-                  size="lg"
-                  tooltipText="The number of times your ads were seen, including earned impressions"
-                  title="Saves"
-                  value="5"
-                  trend={{ value: 5, accessibilityLabel: 'Trending up' }}
-                />
-                <Datapoint
-                  size="lg"
-                  tooltipText="The number of times your ads were seen, including earned impressions"
-                  title="Outbound clicks"
-                  value="10"
-                  trend={{ value: 10, accessibilityLabel: 'Trending up' }}
-                />
-              </Box>
-            </Module>
-            <Flex direction="column" gap={{ column: 2, row: 0 }} maxWidth={800}>
-              <Module
-                id="Ads Overview"
-                title="Ads Overview"
-                iconButton={
-                  <IconButton
-                    role="link"
-                    href="https://analytics.pinterest.com/"
-                    bgColor="lightGray"
-                    icon="arrow-up-right"
-                    iconColor="darkGray"
-                    accessibilityLabel="Get help"
-                    size="xs"
-                    onClick={() => {}}
-                    target="blank"
-                  />
-                }
-              >
-                <Box width={300}>
-                  <Text size="200">Content</Text>
-                </Box>
-              </Module>
-              <Module id="Top Pins" title="Top Pins">
-                <Box width={300}>
-                  <Text size="200">Content</Text>
-                </Box>
-              </Module>
-            </Flex>
-          </Flex>
-        )}
-      </Flex>
-    );
-  };
-
-  function Example() {
-    const HeaderRow = () => (
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>
-            <Box display="visuallyHidden">
-              <Text weight="bold">Open/Close row</Text>
-            </Box>
-          </Table.HeaderCell>
-          {['Campaign', 'Status', 'Budget', 'Scope'].map((title, idx) => (
-            <Table.HeaderCell key={idx}>
-              <Text weight="bold">{title}</Text>
-            </Table.HeaderCell>
-          ))}
-        </Table.Row>
-      </Table.Header>
-    );
-
-    const BaseRow = ({ campaign, status, budget, scope }) => (
-      <Table.Row>
-        <Table.HeaderCell>
-          <Box display="visuallyHidden">
-            <Text weight="bold">Open/Close row</Text>
-          </Box>
-        </Table.HeaderCell>
-        <Table.Cell>
-          <Text>{campaign}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text>{status}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text>{budget}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text>{scope}</Text>
-        </Table.Cell>
-      </Table.Row>
-    );
-
-    const RowExpandable = ({ campaign, status, empty, budget, scope }) => (
-      <Table.RowExpandable
-        accessibilityExpandLabel="Expand"
-        accessibilityCollapseLabel="Collapse"
-        id="row1"
-        onExpand={() => {}}
-        expandedContents={
-          empty ? (
-            <Text>No metrics available. This campaign hasn't started yet.</Text>
-          ) : (
-            <ExpandedContents />
-          )
-        }
-      >
-        <Table.Cell>
-          <Text>{campaign}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text>{status}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text>{budget}</Text>
-        </Table.Cell>
-        <Table.Cell>
-          <Text>{scope}</Text>
-        </Table.Cell>
-      </Table.RowExpandable>
-    );
-
-    const tableID = "Another example of a 'don't' do for table content";
-
-    return (
-      <Table accessibilityLabel={tableID}>
-        <HeaderRow />
-        <Table.Body>
-          <RowExpandable campaign="December '21" status="Active" budget="$100,000" scope="Global" />
-          <RowExpandable
-            campaign="January '22"
-            status="Draft"
-            budget="$50,000"
-            scope="Japan, Germany, Canada, Spain, Mexico, Thailand, Italy"
-            empty
-          />
-          <RowExpandable
-            campaign="February '22"
-            status="Draft"
-            budget="$50,000"
-            scope="Japan, Germany, Canada"
-            empty
-          />
-        </Table.Body>
-      </Table>
-    );
-  }
-
-  return <Example />;
-}
-    `}
+            sandpackExample={
+              <SandpackExample
+                name="Don't - Use an expand for dense content"
+                code={dontUseExpandForDenseContent}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -1248,211 +273,24 @@ See the examples below for more details.`}
           <MainSection.Card
             cardSize="md"
             title="Top captions"
-            defaultCode={`
-function Example() {
-  const HeaderRow = ({ id }) => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>
-            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
-            <Checkbox
-              id={id}
-   onChange={() => {}}
-              indeterminate
-              size="sm"
-            />
-          </Table.HeaderCell>
-          {["Status", "Campaign"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ id, checked, disabled, type, text, subtext, campaign }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Checkbox
-            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
-            disabled={disabled}
-            size="sm"
-            checked={checked}
-          />
-        </Table.Cell>
-        <Table.Cell>
-          <Status type={type} title={text} subtext={subtext} />
-        </Table.Cell>
-        <Table.Cell>
-          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
-            <Text color={disabled ? "gray" : "darkGray"}>{campaign}</Text>
-          </Label>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Example of correct accessibility with top caption";
-
-  return (
-    <Flex gap={{ column: 2, row: 0 }} direction="column">
-      <Box aria-hidden>
-        <Text
-          size="400"
-          weight="bold"
-        >
-          Your Campaigns Summary
-        </Text>
-      </Box>
-      <Table accessibilityLabel="Your campaigns summary">
-        <HeaderRow id={tableID}/>
-        <Table.Body>
-          <BaseRow
-            id={tableID}
-            checked={true}
-            type="inProgress"
-            text="In progress"
-            subtext="Ends 11/20/2021"
-            campaign="Engagement"
-          />
-          <BaseRow
-            id={tableID}
-            disabled
-            type="halted"
-            text="Paused"
-            subtext="Ends 11/20/2021"
-            campaign="Awareness"
-          />
-          <BaseRow
-            id={tableID}
-            checked={true}
-            type="warning"
-            text="Warning"
-            subtext="Ends 11/20/2021"
-            campaign="Catalogs"
-          />
-          <BaseRow
-            id={tableID}
-            checked={false}
-            type="ok"
-            text="Complete"
-            subtext="Ends 11/20/2021"
-            campaign="Awareness"
-          />
-        </Table.Body>
-      </Table>
-    </Flex>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Top caption example"
+                code={topCaptionExample}
+                layout="column"
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             title="Bottom captions"
-            defaultCode={`
-function Example() {
-  const HeaderRow = ({ id }) => {
-    return (
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>
-            <Box display="visuallyHidden"><Label htmlFor={id}>Not all checkboxes are checked</Label></Box>
-            <Checkbox
-              id={id}
-   onChange={() => {}}
-              indeterminate
-              size="sm"
-            />
-          </Table.HeaderCell>
-          {["Status", "Campaign"].map((title, idx) => {
-            return (
-              <Table.HeaderCell key={idx}>
-                <Text weight="bold">{title}</Text>
-              </Table.HeaderCell>
-            );
-          })}
-        </Table.Row>
-      </Table.Header>
-    );
-  };
-
-  const BaseRow = ({ id, checked, disabled, type, text, subtext, campaign }) => {
-    return (
-      <Table.Row>
-        <Table.Cell>
-          <Checkbox
-            id={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")} onChange={() => {}}
-            disabled={disabled}
-            size="sm"
-            checked={checked}
-          />
-        </Table.Cell>
-        <Table.Cell>
-          <Status type={type} title={text} subtext={subtext} />
-        </Table.Cell>
-        <Table.Cell>
-          <Label htmlFor={id.replace(/ /g, "_").replace(/'/g, "") + "_" + text.replace(/ /g, "_").replace(/'/g, "")}>
-            <Text color={disabled ? "gray" : "darkGray"}>{campaign}</Text>
-          </Label>
-        </Table.Cell>
-      </Table.Row>
-    );
-  };
-
-  const tableID = "Example of correct accessibility with bottom caption";
-
-  return (
-    <Flex gap={{ column: 2, row: 0 }} direction="column">
-      <Table accessibilityLabel="Your campaigns summary">
-        <HeaderRow id={tableID}/>
-        <Table.Body>
-          <BaseRow
-            id={tableID}
-            checked={true}
-            type="inProgress"
-            text="In progress"
-            subtext="Ends 11/20/2021"
-            campaign="Engagement"
-          />
-          <BaseRow
-            id={tableID}
-            disabled
-            type="halted"
-            text="Paused"
-            subtext="Ends 11/20/2021"
-            campaign="Awareness"
-          />
-          <BaseRow
-            id={tableID}
-            checked={true}
-            type="warning"
-            text="Warning"
-            subtext="Ends 11/20/2021"
-            campaign="Catalogs"
-          />
-          <BaseRow
-            id={tableID}
-            checked={false}
-            type="ok"
-            text="Complete"
-            subtext="Ends 11/20/2021"
-            campaign="Awareness"
-          />
-        </Table.Body>
-      </Table>
-      <Box aria-hidden>
-        <Text align="center" size="100">Your campaigns summary</Text>
-      </Box>
-    </Flex>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Bottom caption example"
+                code={bottomCaptionExample}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
       </AccessibilitySection>
@@ -1558,82 +396,13 @@ function Example() {
         <MainSection.Subsection title="Sticky header & footer">
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Table accessibilityLabel="Sticky footer" maxHeight={200}>
-  <Table.Header sticky>
-    <Table.Row>
-      <Table.HeaderCell>
-        <Text weight="bold">Campaign</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">Impression</Text>
-      </Table.HeaderCell>
-      <Table.HeaderCell>
-        <Text weight="bold">Cost</Text>
-      </Table.HeaderCell>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Spring season</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>10,000</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>$500</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Autumn season</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>10,000</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>$500</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Summer season</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>10,000</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>$500</Text>
-      </Table.Cell>
-    </Table.Row>
-    <Table.Row>
-      <Table.Cell>
-        <Text>Winter season</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>10,000</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text>$500</Text>
-      </Table.Cell>
-    </Table.Row>
-  </Table.Body>
-  <Table.Footer sticky>
-    <Table.Row>
-      <Table.Cell>
-        <Text weight="bold">Total</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text weight="bold">40,000</Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Text weight="bold">$2,000</Text>
-      </Table.Cell>
-    </Table.Row>
-  </Table.Footer>
-</Table>;
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Sticky header & footer example"
+                code={stickyHeaderFooterExample}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -1642,101 +411,13 @@ function Example() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Box width="50%">
-  <Table accessibilityLabel="Sticky Column" maxHeight={200} stickyColumns={1}>
-
-    <Table.Header>
-      <Table.Row>
-        <Table.HeaderCell>
-          <Text weight="bold">Image</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Name</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Super Name</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Favorite Food</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Best Friend</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Birthday</Text>
-        </Table.HeaderCell>
-      </Table.Row>
-    </Table.Header>
-
-    <Table.Body>
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Tony"
-                src="https://i.ibb.co/r3R04Y9/ironman.jpg"
-                naturalHeight={50}
-                naturalWidth={50}
+            sandpackExample={
+              <SandpackExample
+                name="Sticky column example"
+                code={stickyColumnExample}
+                layout="column"
               />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>Tony Stark</Text></Table.Cell>
-        <Table.Cell><Text>Iron Man</Text></Table.Cell>
-        <Table.Cell><Text>Shawarma</Text></Table.Cell>
-        <Table.Cell><Text>Spiderman</Text></Table.Cell>
-        <Table.Cell>
-          <Box width={200}><Text>May 29, 1970</Text></Box>
-        </Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Peter"
-                src="https://i.ibb.co/64NxM43/spiderman.png"
-                naturalHeight={50}
-                naturalWidth={50}
-              />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>Peter Parker</Text></Table.Cell>
-        <Table.Cell><Text>Spiderman</Text></Table.Cell>
-        <Table.Cell><Text>Sandwiches</Text></Table.Cell>
-        <Table.Cell><Text>Iron Man</Text></Table.Cell>
-        <Table.Cell><Text>December 28, 1995</Text></Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="T'Challa"
-                src="https://i.ibb.co/GpNtW5N/black-Panther.png"
-                naturalHeight={50}
-                naturalWidth={50}
-              />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>T'Challa</Text></Table.Cell>
-        <Table.Cell><Text>Black Panther</Text></Table.Cell>
-        <Table.Cell><Text>Beef suya</Text></Table.Cell>
-        <Table.Cell><Text>Shuri</Text></Table.Cell>
-        <Table.Cell><Text>November 28, 1977</Text></Table.Cell>
-      </Table.Row>
-
-    </Table.Body>
-  </Table>
-</Box>
-
-`}
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -1745,133 +426,13 @@ function Example() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Box width="60%">
-  <Table accessibilityLabel="Multiple sticky columns" maxHeight={200} stickyColumns={3} borderStyle="none">
-
-    <Table.Header>
-      <Table.Row>
-        <Table.HeaderCell>
-          <Text weight="bold">Image</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Name</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Super Name</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Best Friend</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Favorite Food</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Super Powers</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Home</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Aliases</Text>
-        </Table.HeaderCell>
-      </Table.Row>
-    </Table.Header>
-
-    <Table.Body>
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Tony"
-                src="https://i.ibb.co/r3R04Y9/ironman.jpg"
-                naturalHeight={50}
-                naturalWidth={50}
+            sandpackExample={
+              <SandpackExample
+                name="Multiple sticky columns example"
+                code={multipleStickyColumnsExample}
+                layout="column"
               />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>Tony Stark</Text></Table.Cell>
-        <Table.Cell><Text>Iron Man</Text></Table.Cell>
-        <Table.Cell><Text>Spiderman</Text></Table.Cell>
-        <Table.Cell><Text>Shawarma</Text></Table.Cell>
-        <Table.Cell><Text>Flight, Super strength</Text></Table.Cell>
-        <Table.Cell><Text>New York</Text></Table.Cell>
-        <Table.Cell><Text>N/A</Text></Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Peter"
-                src="https://i.ibb.co/64NxM43/spiderman.png"
-                naturalHeight={50}
-                naturalWidth={50}
-              />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>Peter Parker</Text></Table.Cell>
-        <Table.Cell><Text>Spiderman</Text></Table.Cell>
-        <Table.Cell><Text>Iron Man</Text></Table.Cell>
-        <Table.Cell><Text>Sandwiches</Text></Table.Cell>
-        <Table.Cell><Text>Spidey senses, super strength, web shooters</Text></Table.Cell>
-        <Table.Cell><Text>Brooklyn</Text></Table.Cell>
-        <Table.Cell><Text>Friendly Neighborhood Spiderman</Text></Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Wanda"
-                src="https://i.ibb.co/hV6Vpbf/scarlet.png"
-                naturalHeight={50}
-                naturalWidth={50}
-              />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>Wanda Maximoff</Text></Table.Cell>
-        <Table.Cell><Text>Scarlet Witch</Text></Table.Cell>
-        <Table.Cell><Text>Vision</Text></Table.Cell>
-        <Table.Cell><Text>Chicken paprikash</Text></Table.Cell>
-        <Table.Cell><Text>Chaos magic, spells, reality warping</Text></Table.Cell>
-        <Table.Cell><Text>Sokovia</Text></Table.Cell>
-        <Table.Cell><Text>N/A</Text></Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Black Panther"
-                src="https://i.ibb.co/GpNtW5N/black-Panther.png"
-                naturalHeight={50}
-                naturalWidth={50}
-              />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>T'Challa</Text></Table.Cell>
-        <Table.Cell><Text>Black Panther</Text></Table.Cell>
-        <Table.Cell><Text>Shuri</Text></Table.Cell>
-        <Table.Cell><Text>Beef suya</Text></Table.Cell>
-        <Table.Cell><Text>Enhanced strength, speed, reflexes + Vibranium suit</Text></Table.Cell>
-        <Table.Cell><Text>Wakanda</Text></Table.Cell>
-        <Table.Cell><Text>King of the Dead</Text></Table.Cell>
-      </Table.Row>
-
-    </Table.Body>
-  </Table>
-</Box>
-
-`}
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -1880,134 +441,13 @@ function Example() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Box width="60%">
-  <Table accessibilityLabel="Sticky header and sticky columns" maxHeight={200} stickyColumns={3} borderStyle="none">
-
-    <Table.Header sticky>
-      <Table.Row>
-        <Table.HeaderCell>
-          <Text weight="bold">Image</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Name</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Super Name</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Best Friend</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Favorite Food</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Super Powers</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Home</Text>
-        </Table.HeaderCell>
-        <Table.HeaderCell>
-          <Text weight="bold">Aliases</Text>
-        </Table.HeaderCell>
-      </Table.Row>
-    </Table.Header>
-
-    <Table.Body>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Tony"
-                src="https://i.ibb.co/r3R04Y9/ironman.jpg"
-                naturalHeight={50}
-                naturalWidth={50}
+            sandpackExample={
+              <SandpackExample
+                name="Sticky header and sticky columns example"
+                code={stickyHeaderColumnExample}
+                layout="column"
               />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>Tony Stark</Text></Table.Cell>
-        <Table.Cell><Text>Iron Man</Text></Table.Cell>
-        <Table.Cell><Text>Spiderman</Text></Table.Cell>
-        <Table.Cell><Text>Shawarma</Text></Table.Cell>
-        <Table.Cell><Text>Flight, Super strength</Text></Table.Cell>
-        <Table.Cell><Text>New York</Text></Table.Cell>
-        <Table.Cell><Text>N/A</Text></Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Peter"
-                src="https://i.ibb.co/64NxM43/spiderman.png"
-                naturalHeight={50}
-                naturalWidth={50}
-              />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>Peter Parker</Text></Table.Cell>
-        <Table.Cell><Text>Spiderman</Text></Table.Cell>
-        <Table.Cell><Text>Iron Man</Text></Table.Cell>
-        <Table.Cell><Text>Sandwiches</Text></Table.Cell>
-        <Table.Cell><Text>Spidey senses, super strength, web shooters</Text></Table.Cell>
-        <Table.Cell><Text>Brooklyn</Text></Table.Cell>
-        <Table.Cell><Text>Friendly Neighborhood Spiderman</Text></Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Wanda"
-                src="https://i.ibb.co/hV6Vpbf/scarlet.png"
-                naturalHeight={50}
-                naturalWidth={50}
-              />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>Wanda Maximoff</Text></Table.Cell>
-        <Table.Cell><Text>Scarlet Witch</Text></Table.Cell>
-        <Table.Cell><Text>Vision</Text></Table.Cell>
-        <Table.Cell><Text>Chicken paprikash</Text></Table.Cell>
-        <Table.Cell><Text>Chaos magic, spells, reality warping</Text></Table.Cell>
-        <Table.Cell><Text>Sokovia</Text></Table.Cell>
-        <Table.Cell><Text>N/A</Text></Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell>
-          <Box width={50}>
-            <Mask rounding="circle">
-              <Image
-                alt="Black Panther"
-                src="https://i.ibb.co/GpNtW5N/black-Panther.png"
-                naturalHeight={50}
-                naturalWidth={50}
-              />
-            </Mask>
-          </Box>
-        </Table.Cell>
-        <Table.Cell><Text>T'Challa</Text></Table.Cell>
-        <Table.Cell><Text>Black Panther</Text></Table.Cell>
-        <Table.Cell><Text>Shuri</Text></Table.Cell>
-        <Table.Cell><Text>Beef suya</Text></Table.Cell>
-        <Table.Cell><Text>Enhanced strength, speed, reflexes + Vibranium suit</Text></Table.Cell>
-        <Table.Cell><Text>Wakanda</Text></Table.Cell>
-        <Table.Cell><Text>King of the Dead</Text></Table.Cell>
-      </Table.Row>
-
-    </Table.Body>
-  </Table>
-</Box>
-
-`}
+            }
           />
         </MainSection.Subsection>
 
@@ -2047,223 +487,13 @@ When Table.RowExpandable is uncontrolled, use the clickable expand/collapse icon
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-    function Example() {
-      const [textShown, setTextShown] = React.useState(false);
-      const showTextOnExpand = () => {
-        return <Text>Row expanded</Text>;
-      };
-
-      return(
-      <Box width="60%">
-        <Table accessibilityLabel="Table.RowExpandable with Sticky Columns" stickyColumns={3}>
-
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>
-                <Box display="visuallyHidden">
-                  <Text weight="bold">Open/Close row</Text>
-                </Box>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Name</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Super Name</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Best Friend</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Favorite Food</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Home</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Text weight="bold">Alias</Text>
-              </Table.HeaderCell>
-              <Table.HeaderCell>
-                <Box width={200}>
-                  <Text weight="bold">Super Powers</Text>
-                </Box>
-              </Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-
-          <Table.Body>
-
-            <Table.RowExpandable
-              accessibilityExpandLabel="Expand"
-              accessibilityCollapseLabel="Collapse"
-              id="row1"
-              onExpand={() => setTextShown(!textShown)}
-              expandedContents={
-                <Box maxWidth={236} padding={2} column={12}>
-                  <WashAnimated
-                    image={
-                      <Avatar
-                        name="tony avatar"
-                        src="https://i.ibb.co/8948ym5/avenge.png"
-                      />
-                    }
-                  >
-                    <Text align="center" weight="bold">
-                      <Link href="https://pinterest.com">
-                        <Box paddingX={3} paddingY={2}>
-                          Tony's Info
-                        </Box>
-                      </Link>
-                    </Text>
-                    {textShown && showTextOnExpand()}
-                  </WashAnimated>
-                </Box>
-              }
-            >
-              <Table.Cell>
-                <Text>Tony Stark</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Iron Man</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Spiderman</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Shawarma</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>New York City</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>N/A</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Flight, Super strength</Text>
-              </Table.Cell>
-            </Table.RowExpandable>
-
-            <Table.RowExpandable
-              accessibilityExpandLabel="Expand"
-              accessibilityCollapseLabel="Collapse"
-              id="row2"
-              expandedContents={
-                <Table maxWidth={800} maxHeight={500}>
-                  <Table.Header sticky>
-                    <Table.Row>
-                      <Table.HeaderCell>
-                        <Text weight="bold">Name</Text>
-                      </Table.HeaderCell>
-                      <Table.HeaderCell>
-                        <Text weight="bold">Relationship</Text>
-                      </Table.HeaderCell>
-                    </Table.Row>
-                  </Table.Header>
-                  <Table.Body>
-                    <Table.Row colSpan={10}>
-                      <Table.Cell>
-                        <Text>Vision</Text>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Husband</Text>
-                      </Table.Cell>
-                    </Table.Row>
-                    <Table.Row>
-                      <Table.Cell>
-                        <Text>Wiccan</Text>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Child</Text>
-                      </Table.Cell>
-                    </Table.Row>
-                    <Table.Row>
-                      <Table.Cell>
-                        <Text>Speed</Text>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Text>Child</Text>
-                      </Table.Cell>
-                    </Table.Row>
-                  </Table.Body>
-                </Table>
-              }
-            >
-              <Table.Cell>
-                <Text>Wanda Maximoff</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Scarlet Witch</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Vision</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Chicken paprikash</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Sokovia</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Wanda Frank</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Chaos magic, spells, reality warping</Text>
-              </Table.Cell>
-            </Table.RowExpandable>
-
-            <Table.RowExpandable
-              accessibilityExpandLabel="Expand"
-              accessibilityCollapseLabel="Collapse"
-              id="row3"
-              expandedContents={
-                <Box maxWidth={236} padding={2} column={12}>
-                  <WashAnimated
-                    image={
-                      <Avatar
-                        name="Black panther avatar"
-                        src="https://i.ibb.co/GpNtW5N/black-Panther.png"
-                      />
-                    }
-                  >
-                    <Text align="center" weight="bold">
-                      <Link href="https://pinterest.com">
-                        <Box paddingX={3} paddingY={2}>
-                          Black Panther's Info
-                        </Box>
-                      </Link>
-                    </Text>
-                  </WashAnimated>
-                </Box>
-              }
-            >
-              <Table.Cell>
-                <Text>T'Challa</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Black Panther</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Shuri</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Beef suya</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Wakana</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>King of the Dead</Text>
-              </Table.Cell>
-              <Table.Cell>
-                <Text>Enhanced strength, speed, reflexes + Vibranium suit</Text>
-              </Table.Cell>
-            </Table.RowExpandable>
-
-          </Table.Body>
-        </Table>
-      </Box> );
-    }
-    `}
+            sandpackExample={
+              <SandpackExample
+                name="Table.RowExpandable with Sticky Columns example"
+                code={rowExpandableWithStickyColumns}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -2272,100 +502,13 @@ When Table.RowExpandable is uncontrolled, use the clickable expand/collapse icon
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example() {
-  const [showdrawer, setShowDrawer] = React.useState(true);
-
-  return(
-    <Box width="100%">
-      <Table accessibilityLabel="Table.RowDrawer example">
-        <colgroup>
-          <col span="1" style={{ width: "60%" }} />
-          <col span="1" style={{ width: "15%" }} />
-          <col span="1" style={{ width: "15%" }} />
-          <col span="1" style={{ width: "15%" }} />
-        </colgroup>
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell>
-              <Text weight="bold">Campaign</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text align="forceRight" weight="bold">Spend</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text align="forceRight" weight="bold">Impressions</Text>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <Text align="forceRight" weight="bold">CTR</Text>
-            </Table.HeaderCell>
-          </Table.Row>
-        </Table.Header>
-
-        <Table.Body>
-          <Table.RowDrawer
-            id="drawerExample"
-            drawerContents={ showdrawer ? <SlimBanner
-                type="recommendation"
-                iconAccessibilityLabel="Recommendation"
-                message="Increasing your daily spend could increase clicks by 20%"
-                primaryAction={{
-                  accessibilityLabel: 'Apply for increasing your daily spend',
-                  label: 'Apply',
-                  onClick: () => {},
-                }}
-                dismissButton={{
-                  accessibilityLabel: "Dismiss",
-                  onDismiss: () => setShowDrawer(false),
-                }}
-              /> : null }
-          >
-            <Table.Cell>
-              <Text>Training treats</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">$3,200</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">3.4k</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">0.07%</Text>
-            </Table.Cell>
-          </Table.RowDrawer>
-          <Table.Row>
-            <Table.Cell>
-              <Text>Vegan cuisine</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">$4,200</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">5k</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">0.40%</Text>
-            </Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>
-              <Text>Mexican cuisine</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">$5,000</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">20k</Text>
-            </Table.Cell>
-            <Table.Cell>
-              <Text align="forceRight">0.10%</Text>
-            </Table.Cell>
-          </Table.Row>
-        </Table.Body>
-      </Table>
-    </Box>
-)}
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Drawer row that is able to hold additional content"
+                code={drawerRowExample}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -2375,89 +518,25 @@ function Example() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-    function SortableHeaderExample() {
-      const [sortOrder, setSortOrder] = React.useState('desc');
-      const [sortCol, setSortCol] = React.useState('name');
-
-      const onSortChange = (col) => {
-        if (sortCol !== col) {
-          setSortCol(col);
-          setSortOrder('desc');
-        } else {
-          setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
-        }
-      }
-
-      return (
-        <Table accessibilityLabel="Sortable header cells">
-          <Table.Header>
-            <Table.Row>
-              <Table.SortableHeaderCell onSortChange={() => onSortChange('name')} sortOrder={sortOrder} status={sortCol === 'name' ? 'active' : 'inactive'}>
-                <Text weight="bold">Name</Text>
-              </Table.SortableHeaderCell>
-              <Table.SortableHeaderCell onSortChange={() => onSortChange('id')} sortOrder={sortOrder} status={sortCol === 'id' ? 'active' : 'inactive'}>
-                <Text weight="bold">Id</Text>
-              </Table.SortableHeaderCell>
-            </Table.Row>
-          </Table.Header>
-        </Table>
-      );
-    }
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Sortable header cells example"
+                code={sortableTableCells}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection title="Sortable header cells with sticky columns">
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-    function SortableHeaderExample() {
-      const [sortOrder, setSortOrder] = React.useState('desc');
-      const [sortCol, setSortCol] = React.useState('name');
-
-      const onSortChange = (col) => {
-        if (sortCol !== col) {
-          setSortCol(col);
-          setSortOrder('desc');
-        } else {
-          setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
-        }
-      }
-
-      return (
-        <Box width="70%">
-          <Table accessibilityLabel="Sortable header cells with sticky columns" stickyColumns={2}>
-            <Table.Header>
-              <Table.Row>
-                <Table.SortableHeaderCell onSortChange={() => onSortChange('name')} sortOrder={sortOrder} status={sortCol === 'name' ? 'active' : 'inactive'}>
-                  <Text weight="bold">Name</Text>
-                </Table.SortableHeaderCell>
-                <Table.SortableHeaderCell onSortChange={() => onSortChange('id')} sortOrder={sortOrder} status={sortCol === 'id' ? 'active' : 'inactive'}>
-                  <Text weight="bold">Nickname</Text>
-                </Table.SortableHeaderCell>
-                <Table.SortableHeaderCell onSortChange={() => onSortChange('food')} sortOrder={sortOrder} status={sortCol === 'food' ? 'active' : 'inactive'}>
-                  <Text weight="bold">Favorite Food</Text>
-                </Table.SortableHeaderCell>
-                <Table.SortableHeaderCell onSortChange={() => onSortChange('friend')} sortOrder={sortOrder} status={sortCol === 'friend' ? 'active' : 'inactive'}>
-                  <Text weight="bold">Best Friend</Text>
-                </Table.SortableHeaderCell>
-                <Table.SortableHeaderCell onSortChange={() => onSortChange('birth')} sortOrder={sortOrder} status={sortCol === 'birth' ? 'active' : 'inactive'}>
-                  <Text weight="bold">Birthdate</Text>
-                </Table.SortableHeaderCell>
-                <Table.SortableHeaderCell onSortChange={() => onSortChange('desc')} sortOrder={sortOrder} status={sortCol === 'desc' ? 'active' : 'inactive'}>
-                  <Text weight="bold">Description</Text>
-                </Table.SortableHeaderCell>
-                <Table.SortableHeaderCell onSortChange={() => onSortChange('color')} sortOrder={sortOrder} status={sortCol === 'color' ? 'active' : 'inactive'}>
-                  <Text weight="bold">Favorite Color</Text>
-                </Table.SortableHeaderCell>
-              </Table.Row>
-            </Table.Header>
-
-          </Table>
-        </Box>
-      );
-    }
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Sortable header cells with sticky columns"
+                code={sortableHeaderCellsWithStickyColumns}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -2470,7 +549,9 @@ If the row is not selectable, the \`selected\` prop should not be set. In this c
           `}
         >
           <MainSection.Card
-            sandpackExample={<SandpackExample code={selected} name="Selected example" />}
+            sandpackExample={
+              <SandpackExample code={selected} name="Selected example" layout="column" />
+            }
           />
         </MainSection.Subsection>
       </MainSection>


### PR DESCRIPTION
### Summary

#### What changed?

Migrated examples in the docs from the old editor to the sandpack editor for the Table component.

#### Why?

Migrated examples in the docs from the old editor to the sandpack editor for the Table component.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-4873)

### Checklist

- [n/a] Added unit and Flow Tests
- [n/a] Added documentation + accessibility tests
- [n/a] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [n/a] Checked stakeholder feedback (e.g. Gestalt designers)
