### PR TITLE
Internal: Cleaner Logging for DocGen Errors

### DIFF
--- a/scripts/generateMetadata.js
+++ b/scripts/generateMetadata.js
@@ -41,7 +41,7 @@ async function docgen(filePath) {
     return parsed;
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.log(error);
+    console.log(`'DocGen Error: ${error} at ${filePath}`);
     return null;
   }
 }


### PR DESCRIPTION
When we run `yarn start` we usually see a bunch of errors from docgen.

We were logging the entire stacktrace, and this made the terminal log output larger.  This updates the logging method to give more details on the filepath with missing docgen and the issue.


Before:
<img width="935" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/5509813/50735a3a-ecac-46be-8806-3443ac81c9f2">


After:
<img width="1032" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/5509813/b4c5a583-05a9-48e5-8491-79298ba3587e">


