### PR TITLE
Checkbox: Update InternalCheckbox.css

### DIFF
--- a/packages/gestalt/src/Checkbox/InternalCheckbox.css
+++ b/packages/gestalt/src/Checkbox/InternalCheckbox.css
@@ -4,23 +4,23 @@
 }
 
 .border {
-  composes: borderColorDarkGray from "./Borders.css";
+  composes: borderColorDarkGray from "../Borders.css";
 }
 
 .borderSelected {
-  composes: borderColorSelected from "./Borders.css";
+  composes: borderColorSelected from "../Borders.css";
 }
 
 .borderDarkGray {
-  composes: borderColorDarkGray from "./Borders.css";
+  composes: borderColorDarkGray from "../Borders.css";
 }
 
 .borderDisabled {
-  composes: borderColorLightGrayDisabled from "./Borders.css";
+  composes: borderColorLightGrayDisabled from "../Borders.css";
 }
 
 .borderError {
-  composes: borderColorRed from "./Borders.css";
+  composes: borderColorRed from "../Borders.css";
 }
 
 .borderHovered {


### PR DESCRIPTION
Looks like relative imports from `./Borders.css` were incorrect.

Didn't notice any snapshot issues, so it went under the radar, since the classes were likely added.

But it could have caused a visual regression.

Actual:
![image](https://github.com/pinterest/gestalt/assets/5509813/9c71a34d-8d3f-4645-8efa-fc3ba466979d)

Expected:
![image](https://github.com/pinterest/gestalt/assets/5509813/97b2a0fa-f6c4-4c75-aa28-fadebb5be5ab)

