### PR TITLE
SheetMobile: add event to `onOutsideClick`

### DIFF
--- a/packages/gestalt/src/Backdrop.js
+++ b/packages/gestalt/src/Backdrop.js
@@ -7,7 +7,7 @@ import { useAnimation, ANIMATION_STATE } from './animation/AnimationContext.js';
 type Props = {|
   children?: Node,
   closeOnOutsideClick: boolean,
-  onClick?: (event: MouseEvent) => void,
+  onClick?: (event: SyntheticMouseEvent<HTMLDivElement>) => void,
 |};
 
 function Backdrop({ children, closeOnOutsideClick, onClick }: Props): Node {

--- a/packages/gestalt/src/SheetMobile.js
+++ b/packages/gestalt/src/SheetMobile.js
@@ -70,7 +70,9 @@ type Props = {|
   /**
    * Callback fired when clicking on the backdrop (gray area) outside of SheetMobile.
    */
-  onOutsideClick?: () => void,
+  onOutsideClick?: ({|
+    event: SyntheticMouseEvent<HTMLDivElement>,
+  |}) => void,
   /**
    * The main SheetMobile content section has a "default" padding. For those cases where full bleed is needed, set `padding` to "none".
    */

--- a/packages/gestalt/src/SheetMobile/PartialPage.js
+++ b/packages/gestalt/src/SheetMobile/PartialPage.js
@@ -48,7 +48,9 @@ type Props = {|
   heading?: Node,
   onAnimationEnd: ?({| animationState: 'in' | 'out' |}) => void,
   onDismiss: () => void,
-  onOutsideClick?: () => void,
+  onOutsideClick?: ({|
+    event: SyntheticMouseEvent<HTMLDivElement>,
+  |}) => void,
   padding?: 'default' | 'none',
   primaryAction?: {|
     accessibilityLabel: string,
@@ -155,13 +157,16 @@ export default function PartialPage({
   }, [animationState, onDismiss]);
 
   // Handle click outside the bottom sheet
-  const handleBackdropClick = useCallback(() => {
-    onOutsideClick?.();
+  const handleBackdropClick: (event: SyntheticMouseEvent<HTMLDivElement>) => void = useCallback(
+    (event) => {
+      onOutsideClick?.({ event });
 
-    if (closeOnOutsideClick) {
-      onExternalDismiss();
-    }
-  }, [closeOnOutsideClick, onExternalDismiss, onOutsideClick]);
+      if (closeOnOutsideClick) {
+        onExternalDismiss();
+      }
+    },
+    [closeOnOutsideClick, onExternalDismiss, onOutsideClick],
+  );
 
   return (
     <StopScrollBehavior>


### PR DESCRIPTION

### Summary

#### What changed?

SheetMobile: add event to `onOutsideClick`

#### Why?

Needed in Pinboard
