### PR TITLE
TileData: fix typo + copyediting

### DIFF
--- a/docs/pages/web/tiledata.js
+++ b/docs/pages/web/tiledata.js
@@ -42,7 +42,7 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
             type="don't"
             title="When not to use"
             description={`
-        - When grouping Datapoints that aren't selectable
+        - When grouping data points that aren't selectable
         - For selectable information that is not part of a data visualization
       `}
           />
@@ -67,7 +67,7 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
           <MainSection.Card
             cardSize="sm"
             type="don't"
-            description="Use TileData to present a single option. If TileData's don't need to be selected, then use a [Datapoint](https://gestalt.pinterest.systems/web/datapoint) instead."
+            description="Use TileData to present a single option. If TileData's don't need to be selected, then use [Datapoint](https://gestalt.pinterest.systems/web/datapoint) instead."
             sandpackExample={
               <SandpackExample
                 code={singleTileDont}
@@ -83,7 +83,7 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
           <MainSection.Card
             cardSize="sm"
             type="do"
-            description="Use the `showCheckbox` property when multiple Tiledata can be selected. See the [group](https://gestalt.pinterest.systems/web/tiledata#Group) variant for more details."
+            description="Use the `showCheckbox` prop when multiple Tiledatas can be selected. See the [group variant](https://gestalt.pinterest.systems/web/tiledata#Group) for more details."
             sandpackExample={
               <SandpackExample
                 code={multipleCheckboxDo}
@@ -118,14 +118,14 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
       <MainSection
         name="Localization"
         description={`
-        Be sure to localize \`title\`, \`value\`, \`trend.accessibilityLabel\`, and \`tooltip.accessibilityLabel\` in TileData. 
+        Be sure to localize \`title\`, \`value\`, \`trend.accessibilityLabel\`, and \`tooltip.accessibilityLabel\` in TileData.
 
-        When the title of the TileData reaches its max width, either intentionally or through localization, the title will wrap as needed to display the full text. Keep this in mind when selecting wording for your TileData menu items. Note that localization can lengthen text by 20 to 30 percent. `}
+        When the title of TileData reaches its max width, either intentionally or through localization, the title will wrap as needed to display the full text. Keep this in mind when selecting wording for TileData menu items. Note that localization can lengthen text by 20 to 30 percent. `}
       />
 
       <MainSection name="Variants">
         <MainSection.Subsection
-          description="TileData can be used along side the colors provided from the Data Visualization [Color Palette](https://gestalt.pinterest.systems/foundations/data_visualization/palette#12-Color-categorical-palette). You may use colors to distinguish different data lines."
+          description="TileData can be used along side the colors provided from the Data Visualization [color palette](https://gestalt.pinterest.systems/foundations/data_visualization/palette#12-Color-categorical-palette). You may use colors to distinguish different data lines."
           title="Colors"
         >
           <MainSection.Card
@@ -142,7 +142,7 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
         </MainSection.Subsection>
 
         <MainSection.Subsection
-          description="Disabled TileData cannot be interacted with using the mouse or keyboard. This is commonly used to disable interaction when there are pending permissions or data pre-requisites have not been met."
+          description="Disabled TileDatas cannot be interacted with using the mouse or keyboard. This is commonly used to disable interaction when there are pending permissions or data prerequisites have not been met."
           title="Disabled"
         >
           <MainSection.Card
@@ -167,7 +167,7 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
           description={`
       **[Datapoint](/web/datapoint)**
       Used to display data at-a-glance data for a user to quickly view key metrics.
-      
+
       **[Checkbox](/web/checkbox)**
       Used when presenting a user with a list of choices for which there can be multiple selections.
 

--- a/packages/gestalt/src/TileData.js
+++ b/packages/gestalt/src/TileData.js
@@ -48,39 +48,39 @@ type Props = {|
    */
   color?: DataVisualizationColors,
   /**
-   * Indicates if TileData should be disabled. Disabled TileData is inactive and cannot be interacted with.
+   * Indicates if TileData should be disabled. Disabled TileDatas are inactive and cannot be interacted with. See the [disabled variant](https://gestalt.pinterest.systems/web/tiledata#Disabled) to learn more.
    */
   disabled?: boolean,
   /**
-   * An optional identifier to be passed back in the onTap callback. It can be helpful to distinguish multiple TileDatas.
+   * An optional identifier to be passed back in the `onTap` callback. It can be helpful to distinguish multiple TileDatas.
    */
   id?: string,
   /**
-   * Handler if the item selection state is changed.
+   * Handler called when the item selection state is changed.
    */
   onTap?: TileChangeHandler,
   /**
-   * Controls whether the TileData is selected or not. Use it alongside the OnTap handler.
+   * Controls whether TileData is selected or not. Use this prop along with the `onTap` handler.
    */
   selected?: boolean,
   /**
-   * Shows a visible checkbox when TileData is in a selected state. See when using in a [group](https://gestalt.pinterest.systems/web/tiledata#Group).
+   * Shows a visible checkbox when TileData is in a selected state. See the [group variant](https://gestalt.pinterest.systems/web/tiledata#Group) to learn more.
    */
   showCheckbox?: boolean,
   /**
-   * The header text for the component.
+   * The header text for TileData.
    */
   title: string,
   /**
-   * Adds a Tooltip on hover/focus of the TileData. See the with [Tooltip](https://gestalt.pinterest.systems/web/tooltip) variant to learn more.
+   * Adds a tooltip on hover/focus of TileData. See the [with tooltip](https://gestalt.pinterest.systems/web/tiledata#Tooltip) variant to learn more.
    */
   tooltip?: TooltipProps,
   /**
-   * Object detailing the trend value (change in time - e.g., +30%), and accessibilityLabel to describe the trend's icon (e.g., "Trending up").  See the [trend](https://gestalt.pinterest.systems/web/datapoint#Trend) variant to learn more.
+   * Object detailing the trend value (change in time - e.g., +30%), and accessibility label to describe the trend's icon (e.g., "Trending up").  See the [trend variant](https://gestalt.pinterest.systems/web/datapoint#Trend) to learn more.
    */
   trend?: TrendObject,
   /**
-   * A visual indicator whether the trend is considered "good", "bad" or "neutral". By setting \`trendSentiment\` to \`auto\`, a positive trend will be considered "good", a negative trend will be considered "bad" and a trend of zero will be considered "neutral".  See the [trendSentiment](https://gestalt.pinterest.systems/web/datapoint#Trend-sentiment) variant to learn more.
+   * A visual indicator whether the trend is considered "good", "bad" or "neutral". By setting \`trendSentiment\` to \`auto\`, a positive trend will be considered "good", a negative trend will be considered "bad" and a trend of zero will be considered "neutral".  See the [trendSentiment variant](https://gestalt.pinterest.systems/web/datapoint#Trend-sentiment) to learn more.
    */
   trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto',
   /**
@@ -109,7 +109,7 @@ const getBackgroundShade = (theme: Theme, color: DataVisualizationColors) => {
 };
 
 /**
- * [TileData](https://gestalt.pinterest.systems/web/tiledata) enables users to select a multiple categories to compare with each other in a graph or chart view, while still being able to see all of the data points.
+ * [TileData](https://gestalt.pinterest.systems/web/tiledata) enables users to select multiple categories to compare with each other in a graph or chart view, while still being able to see all of the data points.
  *
  * ![TileData light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TileData.spec.mjs-snapshots/TileData-chromium-darwin.png)
  * ![TileData dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TileData-dark.spec.mjs-snapshots/TileData-dark-chromium-darwin.png)


### PR DESCRIPTION
Noticed an extraneous `a` in TileData's header description. Took a quick pass of copyediting while looking at that file