### PR TITLE
Docs: fix max width for blog post titles

### DIFF
--- a/docs/pages/whats_new.js
+++ b/docs/pages/whats_new.js
@@ -25,14 +25,8 @@ export type Post = {|
 |};
 
 function PostLayout({ audience, content, imageAltText, imageSrc, title, imageColor }: Post): Node {
-  const colorStyle = {
-    __style: {
-      backgroundColor: imageColor ? `var(--color-${imageColor})` : 'white',
-    },
-  };
-
   return (
-    <Flex direction="column" gap={2}>
+    <Flex direction="column" gap={2} maxWidth={POST_WIDTH_PX}>
       <Flex direction="column" gap={1}>
         <Heading size="400">{title}</Heading>
         <Flex gap={2}>{audience.map((item) => badges[item])}</Flex>
@@ -48,7 +42,11 @@ function PostLayout({ audience, content, imageAltText, imageSrc, title, imageCol
           lgMarginBottom={0}
           borderStyle="sm"
           rounding={2}
-          dangerouslySetInlineStyle={colorStyle}
+          dangerouslySetInlineStyle={{
+            __style: {
+              backgroundColor: imageColor ? `var(--color-${imageColor})` : 'white',
+            },
+          }}
         >
           <Mask rounding={2} height={POST_IMAGE_HEIGHT_PX - 2}>
             <Image
@@ -61,7 +59,7 @@ function PostLayout({ audience, content, imageAltText, imageSrc, title, imageCol
           </Mask>
         </Box>
       )}
-      <Flex maxWidth={POST_WIDTH_PX}>
+      <Flex>
         <Markdown text={content} />
       </Flex>
     </Flex>


### PR DESCRIPTION
Before
![Screen Shot 2023-06-05 at 12 35 08 PM](https://github.com/pinterest/gestalt/assets/12059539/53cb1380-70a1-401f-9850-ce7861ce7a0b)

After
![Screen Shot 2023-06-05 at 12 34 58 PM](https://github.com/pinterest/gestalt/assets/12059539/1da69d04-a8f1-4b73-bc31-f1bf81a1f983)
