### PR TITLE
Internal: Add Url Param to toggle Dev Example Mode

### DIFF
--- a/docs/docs-components/AppLayout.js
+++ b/docs/docs-components/AppLayout.js
@@ -2,6 +2,7 @@
 import { useEffect, useState, Fragment, type Node } from 'react';
 import { Box, Divider, DeviceTypeProvider, Flex } from 'gestalt';
 import { useRouter } from 'next/router';
+import { useAppContext } from './appContext.js';
 import DocsSideNavigation, { MIN_NAV_WIDTH_PX } from './DocsSideNavigation.js';
 import Footer from './Footer.js';
 import Header from './Header.js';
@@ -25,6 +26,7 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
   const { isMobile } = useDocsConfig();
   const { isSidebarOpen, setIsSidebarOpen } = useNavigationContext();
   const router = useRouter();
+  const { setDevExampleMode } = useAppContext();
 
   const [shouldHideSideNav, setShouldHideSideNav] = useState(true);
 
@@ -37,6 +39,11 @@ export default function AppLayout({ children, colorScheme }: Props): Node {
   useEffect(() => {
     setShouldHideSideNav(fullWidthPages.some((page) => router?.route.includes(page)));
   }, [router]);
+
+  // query param to handle dev code samples
+  if (router.query.devexample) {
+    setDevExampleMode(router.query.devexample === 'true' ? 'development' : 'default');
+  }
 
   useEffect(() => {
     const handleScroll = () => setIsSidebarOpen(false);

--- a/docs/docs-components/DevelopmentEditor.js
+++ b/docs/docs-components/DevelopmentEditor.js
@@ -99,8 +99,18 @@ export default function DevelopmentEditor({ code }: {| code: ?string | (() => No
                 <br />
                 <br />
                 To enable/disable the development preview, you can enable it on the site settings
-                dropdown in the page header. If the default preview is enabled and you want to
-                render your local changes in Sandpack append
+                dropdown in the page header.
+                <br />
+                <br />
+                To share a deploy url with this mode enabled, share the nelify url with a
+                <br />
+                <code>?devexample=true</code>
+                <br />
+                appended at the end of the url.
+                <br />
+                <br />
+                If the default preview is enabled and you want to render your local changes in
+                Sandpack append
                 <br />
                 <code>?localFiles=true</code>
                 <br /> after the component name in the URL.{' '}

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -78,8 +78,8 @@ function Header() {
       process.env.NODE_ENV === 'production' &&
       window?.location?.href?.startsWith('https://deploy-preview-');
 
-    if (isDeployPreviewEnvironment) setShowDevelopmentEditorSwitch(true);
-    if (process.env.NODE_ENV === 'development') setShowDevelopmentEditorSwitch(true);
+    if (isDeployPreviewEnvironment || process.env.NODE_ENV === 'development')
+      setShowDevelopmentEditorSwitch(true);
   }, [setShowDevelopmentEditorSwitch, router.pathname, router.query]);
 
   const { colorScheme, setColorScheme, devExampleMode, setDevExampleMode } = useAppContext();

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -79,7 +79,8 @@ function Header() {
       window?.location?.href?.startsWith('https://deploy-preview-');
 
     if (isDeployPreviewEnvironment) setShowDevelopmentEditorSwitch(true);
-  }, [setShowDevelopmentEditorSwitch, router.query]);
+    if (process.env.NODE_ENV === 'development') setShowDevelopmentEditorSwitch(true);
+  }, [setShowDevelopmentEditorSwitch, router.pathname, router.query]);
 
   const { colorScheme, setColorScheme, devExampleMode, setDevExampleMode } = useAppContext();
 

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -63,13 +63,10 @@ function Header() {
   );
 
   useEffect(() => {
-    const devModeSetFromUrl = router.query.devexample && router.query.devexample.length > 0;
+    const devModeSetFromUrl = router.query.devexample && router.query.devexample === 'true';
 
     // do not show switch if set via url
-    if (
-      devModeSetFromUrl &&
-      (router.query.devexample === 'true' || router.query.devexample === 'false')
-    ) {
+    if (devModeSetFromUrl) {
       setShowDevelopmentEditorSwitch(false);
       return;
     }

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -63,12 +63,23 @@ function Header() {
   );
 
   useEffect(() => {
+    const devModeSetFromUrl = router.query.devexample && router.query.devexample.length > 0;
+
+    // do not show switch if set via url
     if (
+      devModeSetFromUrl &&
+      (router.query.devexample === 'true' || router.query.devexample === 'false')
+    ) {
+      setShowDevelopmentEditorSwitch(false);
+      return;
+    }
+
+    const isDeployPreviewEnvironment =
       process.env.NODE_ENV === 'production' &&
-      window?.location?.href?.startsWith('https://deploy-preview-')
-    )
-      setShowDevelopmentEditorSwitch(true);
-  }, [setShowDevelopmentEditorSwitch]);
+      window?.location?.href?.startsWith('https://deploy-preview-');
+
+    if (isDeployPreviewEnvironment) setShowDevelopmentEditorSwitch(true);
+  }, [setShowDevelopmentEditorSwitch, router.query]);
 
   const { colorScheme, setColorScheme, devExampleMode, setDevExampleMode } = useAppContext();
 

--- a/docs/markdown/get_started/developers/contributing/development_process.md
+++ b/docs/markdown/get_started/developers/contributing/development_process.md
@@ -180,7 +180,7 @@ git push -f origin HEAD
 
 - Check the status of your PR https://github.com/pinterest/gestalt/pull/XXXX and access the deploy preview using the built site URL https://deploy-preview-XXXX--gestalt.netlify.app from Netlify. 
 
-- When sharing development urls, you may have to remind viewers to toggle on development mode from the header menu. To simplify sharing, you can add a `?devexample=true` parameter to the docs url to enable the examples by default.
+- When sharing preview urls, you may have to remind viewers to toggle on development mode from the header menu. This is necessary to see unpublished changes in the code examples. To simplify sharing, you can add a `?devexample=true` parameter to the url to enable the examples by default.
 
 
 <details>

--- a/docs/markdown/get_started/developers/contributing/development_process.md
+++ b/docs/markdown/get_started/developers/contributing/development_process.md
@@ -178,7 +178,10 @@ git push -f origin HEAD
 
 - After a Gestalt maintainer adds a correct semver label and approves a Pull Request, the PR will be ready to merge. Coordinate with the reviewer to determine when the PR should be merged.
 
-- Check the status of your PR https://github.com/pinterest/gestalt/pull/XXXX and access the deploy preview using the built site URL https://deploy-preview-XXXX--gestalt.netlify.app from Netlify.
+- Check the status of your PR https://github.com/pinterest/gestalt/pull/XXXX and access the deploy preview using the built site URL https://deploy-preview-XXXX--gestalt.netlify.app from Netlify. 
+
+- When sharing development urls, you may have to remind viewers to toggle on development mode from the header menu. To simplify sharing, you can add a `?devexample=true` parameter to the docs url to enable the examples by default.
+
 
 <details>
   <summary><b>My pull request fails on "Semver / Require Label (pull_request)", how do I fix it?</b></summary>

--- a/scripts/releaseSteps.js
+++ b/scripts/releaseSteps.js
@@ -55,7 +55,7 @@ async function getReleaseNotes({ lastCommitMessage, newVersion, releaseType }) {
 
 - ${lastCommitMessage.replace(/(\(#\d+\))/g, (value) => {
     const PR = value.replace('(', '').replace(')', '').replace('#', '');
-    return `([#${PR}](https://github.com/pinterest/gestalt/pull/${PR})) - [Preview link](https://deploy-preview-${PR}--gestalt.netlify.app)`;
+    return `([#${PR}](https://github.com/pinterest/gestalt/pull/${PR})) - [Preview link](https://deploy-preview-${PR}--gestalt.netlify.app?devexample=true)`;
   })}`;
 }
 


### PR DESCRIPTION
Sometimes we need to explicitly remind people to turn on DevExample Mode. 

This makes it a query param.

So you can say `<deployurl>/web/tiledata?devexample=true`

And have the previews run everywhere. Since we anticipate future PRs to utilize this, this well help us make sharing links easier for review.


One thing to note, passing this param once will probably always enable devmode for people in the deployment versions (probably okay) since I believe this state is actually preserved in localstorage. But also, every deploy url is different.