### PR TITLE
Docs: fix broken links

### DIFF
--- a/docs/pages/foundations/data_visualization/color/usage.js
+++ b/docs/pages/foundations/data_visualization/color/usage.js
@@ -97,7 +97,7 @@ export default function ColorPage(): Node {
       <PageHeader
         name="Data visualization guidelines"
         type="guidelines"
-        description="Details about approved color pairings, accessibility guidelines, and pairings to avoid. The [data visualization palette](/foundations/data_visualization/palette) can be implemented through our [design tokens](/foundations/design_tokens#Data-visualization)."
+        description="Details about approved color pairings, accessibility guidelines, and pairings to avoid. The [data visualization palette](/foundations/data_visualization/color/palette) can be implemented through our [design tokens](/foundations/design_tokens#Data-visualization)."
       />
       <MainSection
         name="Primary color"

--- a/docs/pages/foundations/design_tokens.js
+++ b/docs/pages/foundations/design_tokens.js
@@ -37,7 +37,7 @@ const tokenCategories = [
     id: 'data-visualization',
     infoPage: {
       name: 'Data Visualization Guidelines',
-      path: 'foundations/data_visualization/palette',
+      path: 'foundations/data_visualization/color/palette',
     },
   },
   {

--- a/docs/pages/web/tiledata.js
+++ b/docs/pages/web/tiledata.js
@@ -125,7 +125,7 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
 
       <MainSection name="Variants">
         <MainSection.Subsection
-          description="TileData can be used along side the colors provided from the Data Visualization [color palette](https://gestalt.pinterest.systems/foundations/data_visualization/palette#12-Color-categorical-palette). You may use colors to distinguish different data lines."
+          description="TileData can be used along side the colors provided from the Data Visualization [color palette](https://gestalt.pinterest.systems/foundations/data_visualization/color/palette#12-Color-categorical-palette). You may use colors to distinguish different data lines."
           title="Colors"
         >
           <MainSection.Card

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -134,6 +134,16 @@ const misc = [
     permanent: true,
   },
   {
+    source: '/foundations/data_visualization/palette',
+    destination: '/foundations/data_visualization/color/palette',
+    permanent: true,
+  },
+  {
+    source: '/foundations/data_visualization/usage',
+    destination: '/foundations/data_visualization/color/usage',
+    permanent: true,
+  },
+  {
     source: '/development',
     destination: '/get_started/developers/contributing/development_process',
     permanent: true,


### PR DESCRIPTION
These links were broken by #2980.

This PR adds redirects for the two data viz pages that were moved in the referenced PR. It also updates references to those old URLs on a few other docs pages.

These broken links were found using [the Algolia crawler](https://crawler.algolia.com/admin/crawlers/1b084526-6b1b-4fe6-be0e-c4de54b9f65c/monitoring/details?reason=http_not_found&url=https%3A%2F%2Fgestalt.pinterest.systems%2Ffoundations%2Fdata_visualization%2Fpalette).