### PR TITLE
Docs: fix non-standard Datapoint casing

### DIFF
--- a/docs/pages/foundations/data_visualization/available_components.js
+++ b/docs/pages/foundations/data_visualization/available_components.js
@@ -24,10 +24,10 @@ export default function DocsPage(): Node {
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          title="DataPoint"
+          title="Datapoint"
           description={`Datapoint displays at-a-glance data for a user to quickly view key metrics.
 
-[Go to the DataPoint component](/web/datapoint)`}
+[Go to the Datapoint component](/web/datapoint)`}
         >
           <Box
             maxWidth={960}
@@ -45,7 +45,7 @@ export default function DocsPage(): Node {
               src="https://github.com/pinterest/gestalt/assets/96082362/c9c06e33-82f7-4112-8f65-514158a4aba5"
               naturalWidth={1800}
               naturalHeight={384}
-              alt="DataPoint showing total number of impressions, a positive trend and an info icon."
+              alt="Datapoint showing total number of impressions, a positive trend and an info icon."
             />
           </Box>
         </MainSection.Subsection>

--- a/docs/pages/foundations/data_visualization/charts_and_graphs.js
+++ b/docs/pages/foundations/data_visualization/charts_and_graphs.js
@@ -535,7 +535,7 @@ export default function ChartsandGraphsPage(): Node {
             marginTop={2}
           >
             <Image
-              alt="A spacing spec that shows how to use 24px spacing between Headings, DataPoints and a line chart, with 16px between a line chart and its legend."
+              alt="A spacing spec that shows how to use 24px spacing between Headings, Datapoints and a line chart, with 16px between a line chart and its legend."
               naturalHeight={1494}
               naturalWidth={3024}
               src="https://i.pinimg.com/originals/49/89/b4/4989b46ec8b659dcb3eab22034796d0e.png"

--- a/docs/pages/foundations/data_visualization/micro_visualizations.js
+++ b/docs/pages/foundations/data_visualization/micro_visualizations.js
@@ -99,7 +99,7 @@ export default function GuidelinesPage(): Node {
         </Box>
       </MainSection>
       <MainSection
-        name="DataPoints"
+        name="Datapoints"
         description={`
         Datapoints show at-a-glance data for users to quickly understand key metrics. They display a single numerical metric and are accompanied by a trend icon to give users context about the data displayed. Datapoints can be paired with sparklines for extra visual context.
         `}
@@ -114,7 +114,7 @@ export default function GuidelinesPage(): Node {
           marginBottom={8}
         >
           <Image
-            alt="A series of DataPoints."
+            alt="A series of Datapoints."
             naturalHeight={900}
             naturalWidth={1800}
             src="https://i.pinimg.com/originals/07/77/aa/0777aafa727393f356f0c725a629fbba.png"


### PR DESCRIPTION
For better or for worse, we treat "data point" as a single word for the casing of our component ([Datapoint](https://gestalt.pinterest.systems/web/datapoint)). This PR fixes non-standard casing in a few usages introduced recently.