### PR TITLE
GlobalEventsHandlerProvider: migrating OnLinkNavigationProvider to `linkHandlers.onNavigation`

### DIFF
--- a/docs/docs-components/App.js
+++ b/docs/docs-components/App.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { ColorSchemeProvider, OnLinkNavigationProvider } from 'gestalt';
+import { ColorSchemeProvider, GlobalEventsHandlerProvider } from 'gestalt';
 import { AppContextConsumer, AppContextProvider } from './appContext.js';
 import AppLayout from './AppLayout.js';
 import DocsExperimentProvider from './contexts/DocsExperimentProvider.js';
@@ -67,13 +67,13 @@ export default function App({ children, files }: Props): Node {
         <AppContextConsumer>
           {({ colorScheme }) => (
             <ColorSchemeProvider colorScheme={colorScheme} id="gestalt-docs">
-              <OnLinkNavigationProvider onNavigation={useOnNavigation}>
+              <GlobalEventsHandlerProvider linkHandlers={{ onNavigation: useOnNavigation }}>
                 <NavigationContextProvider>
                   <LocalFilesProvider files={files}>
                     <AppLayout colorScheme={colorScheme}>{children}</AppLayout>
                   </LocalFilesProvider>
                 </NavigationContextProvider>
-              </OnLinkNavigationProvider>
+              </GlobalEventsHandlerProvider>
             </ColorSchemeProvider>
           )}
         </AppContextConsumer>

--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -4032,7 +4032,7 @@ const UTILITIES_LIST: $ReadOnlyArray<ListItemType> = [
     svg: <ProviderHandlers />,
     name: 'GlobalEventsHandlerProvider',
     aliases: [],
-    previouslyNamed: [],
+    previouslyNamed: ['OnLinkNavigationProvider'],
     path: '/web/utilities/globaleventshandlerprovider',
     hasDarkBackground: false,
     description:

--- a/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
@@ -6,7 +6,7 @@ import {
   Divider,
   Flex,
   Icon,
-  OnLinkNavigationProvider,
+  GlobalEventsHandlerProvider,
   RadioGroup,
   Upsell,
 } from 'gestalt';
@@ -26,8 +26,8 @@ export default function Example(): Node {
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <OnLinkNavigationProvider
-        onNavigation={onNavigationMode === 'custom' ? useOnNavigation : undefined}
+      <GlobalEventsHandlerProvider
+        linkHandlers={{ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }}
       >
         <Flex direction="column" gap={2}>
           <Flex direction="column" gap={2}>
@@ -108,7 +108,7 @@ export default function Example(): Node {
             />
           </Flex>
         </Flex>
-      </OnLinkNavigationProvider>
+      </GlobalEventsHandlerProvider>
     </Flex>
   );
 }

--- a/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
@@ -1,15 +1,15 @@
 // @flow strict
-import { useMemo, useCallback, type Node, useState } from 'react';
+import { type Node, useCallback, useMemo, useState } from 'react';
 import {
   ActivationCard,
   Callout,
   Divider,
   Flex,
-  Icon,
   GlobalEventsHandlerProvider,
+  Icon,
+  Link,
   RadioGroup,
   Upsell,
-  Link,
 } from 'gestalt';
 
 export default function Example(): Node {

--- a/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
@@ -9,13 +9,19 @@ import {
   GlobalEventsHandlerProvider,
   RadioGroup,
   Upsell,
+  Link,
 } from 'gestalt';
 
 export default function Example(): Node {
   const [onNavigationMode, setOnNavigationMode] = useState<'default' | 'custom'>('default');
 
   const useOnNavigation = useCallback(
-    ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
+    ({
+      href,
+    }: {|
+      href: $ElementType<React$ElementConfig<typeof Link>, 'href'>,
+      target?: $ElementType<React$ElementConfig<typeof Link>, 'target'>,
+    |}) => {
       const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
         event.preventDefault();
         // eslint-disable-next-line no-alert

--- a/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
@@ -49,7 +49,7 @@ export default function Example(): Node {
               <RadioGroup.RadioButton
                 checked={onNavigationMode === 'custom'}
                 id="custom"
-                label="Custom OnLinkNavigationProvider Navigation"
+                label="Custom GlobalEventsHandlerProvider Navigation"
                 name="custom2"
                 onChange={() => setOnNavigationMode('custom')}
                 value="custom"

--- a/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useState } from 'react';
+import { useMemo, useCallback, type Node, useState } from 'react';
 import {
   ActivationCard,
   Callout,
@@ -14,21 +14,27 @@ import {
 export default function Example(): Node {
   const [onNavigationMode, setOnNavigationMode] = useState<'default' | 'custom'>('default');
 
-  const useOnNavigation = ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
-    const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
-      event.preventDefault();
-      // eslint-disable-next-line no-alert
-      alert(`Disabled link: ${href}. Opening help.pinterest.com instead.`);
-    };
+  const useOnNavigation = useCallback(
+    ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
+      const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
+        event.preventDefault();
+        // eslint-disable-next-line no-alert
+        alert(`Disabled link: ${href}. Opening help.pinterest.com instead.`);
+      };
 
-    return onNavigationClick;
-  };
+      return onNavigationClick;
+    },
+    [],
+  );
+
+  const linkHandlers = useMemo(
+    () => ({ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }),
+    [onNavigationMode, useOnNavigation],
+  );
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <GlobalEventsHandlerProvider
-        linkHandlers={{ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }}
-      >
+      <GlobalEventsHandlerProvider linkHandlers={linkHandlers}>
         <Flex direction="column" gap={2}>
           <Flex direction="column" gap={2}>
             <RadioGroup id="navigation-type" legend="Navigation type">

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
@@ -25,7 +25,7 @@ export default function Example(): Node {
     [],
   );
 
-  const linkHandlers = useMemo(() => ({ onNavigation: useOnNavigation }), []);
+  const linkHandlers = useMemo(() => ({ onNavigation: useOnNavigation }), [useOnNavigation]);
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useRef, useState } from 'react';
+import { useMemo, useCallback, type Node, useRef, useState } from 'react';
 import { Button, Dropdown, Flex, GlobalEventsHandlerProvider, Text } from 'gestalt';
 
 export default function Example(): Node {
@@ -12,19 +12,24 @@ export default function Example(): Node {
     },
   };
 
-  const useOnNavigation = ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
-    const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
-      event.preventDefault();
-      // eslint-disable-next-line no-alert
-      alert(`Disabled link: ${href}. Opening help.pinterest.com instead.`);
-    };
+  const useOnNavigation = useCallback(
+    ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
+      const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
+        event.preventDefault();
+        // eslint-disable-next-line no-alert
+        alert(`Disabled link: ${href}. Opening help.pinterest.com instead.`);
+      };
 
-    return onNavigationClick;
-  };
+      return onNavigationClick;
+    },
+    [],
+  );
+
+  const linkHandlers = useMemo(() => ({ onNavigation: useOnNavigation }), []);
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <GlobalEventsHandlerProvider linkHandlers={{ onNavigation: useOnNavigation }}>
+      <GlobalEventsHandlerProvider linkHandlers={linkHandlers}>
         <Flex direction="column" gap={2}>
           <Text>Example url: {window.location.href}</Text>
           <Flex justifyContent="center">

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { useMemo, useCallback, type Node, useRef, useState } from 'react';
-import { Button, Dropdown, Flex, GlobalEventsHandlerProvider, Text } from 'gestalt';
+import { Button, Dropdown, Flex, GlobalEventsHandlerProvider, Text, Link } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
@@ -13,7 +13,12 @@ export default function Example(): Node {
   };
 
   const useOnNavigation = useCallback(
-    ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
+    ({
+      href,
+    }: {|
+      href: $ElementType<React$ElementConfig<typeof Link>, 'href'>,
+      target?: $ElementType<React$ElementConfig<typeof Link>, 'target'>,
+    |}) => {
       const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
         event.preventDefault();
         // eslint-disable-next-line no-alert

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
@@ -1,6 +1,6 @@
 // @flow strict
-import { useMemo, useCallback, type Node, useRef, useState } from 'react';
-import { Button, Dropdown, Flex, GlobalEventsHandlerProvider, Text, Link } from 'gestalt';
+import { type Node, useCallback, useMemo, useRef, useState } from 'react';
+import { Button, Dropdown, Flex, GlobalEventsHandlerProvider, Link, Text } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node, useRef, useState } from 'react';
-import { Button, Dropdown, Flex, OnLinkNavigationProvider, Text } from 'gestalt';
+import { Button, Dropdown, Flex, GlobalEventsHandlerProvider, Text } from 'gestalt';
 
 export default function Example(): Node {
   const [open, setOpen] = useState(false);
@@ -24,7 +24,7 @@ export default function Example(): Node {
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <OnLinkNavigationProvider onNavigation={useOnNavigation}>
+      <GlobalEventsHandlerProvider linkHandlers={{ onNavigation: useOnNavigation }}>
         <Flex direction="column" gap={2}>
           <Text>Example url: {window.location.href}</Text>
           <Flex justifyContent="center">
@@ -63,7 +63,7 @@ export default function Example(): Node {
             )}
           </Flex>
         </Flex>
-      </OnLinkNavigationProvider>
+      </GlobalEventsHandlerProvider>
     </Flex>
   );
 }

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useRef, useState } from 'react';
+import { useCallback, useMemo, type Node, useRef, useState } from 'react';
 import { Button, Divider, Dropdown, Flex, GlobalEventsHandlerProvider, RadioGroup } from 'gestalt';
 
 export default function Example(): Node {
@@ -7,21 +7,27 @@ export default function Example(): Node {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<null | HTMLButtonElement | HTMLAnchorElement>(null);
 
-  const useOnNavigation = ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
-    const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
-      event.preventDefault();
-      // eslint-disable-next-line no-alert
-      alert(`Disabled link: ${href}. Opening help.pinterest.com instead.`);
-    };
+  const useOnNavigation = useCallback(
+    ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
+      const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
+        event.preventDefault();
+        // eslint-disable-next-line no-alert
+        alert(`Disabled link: ${href}. Opening help.pinterest.com instead.`);
+      };
 
-    return onNavigationClick;
-  };
+      return onNavigationClick;
+    },
+    [],
+  );
+
+  const linkHandlers = useMemo(
+    () => ({ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }),
+    [onNavigationMode, useOnNavigation],
+  );
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <GlobalEventsHandlerProvider
-        linkHandlers={{ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }}
-      >
+      <GlobalEventsHandlerProvider linkHandlers={linkHandlers}>
         <Flex direction="column" gap={2}>
           <Flex direction="column" gap={2}>
             <RadioGroup id="navigation-type" legend="Navigation type">

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node, useRef, useState } from 'react';
-import { Button, Divider, Dropdown, Flex, OnLinkNavigationProvider, RadioGroup } from 'gestalt';
+import { Button, Divider, Dropdown, Flex, GlobalEventsHandlerProvider, RadioGroup } from 'gestalt';
 
 export default function Example(): Node {
   const [onNavigationMode, setOnNavigationMode] = useState<'default' | 'custom'>('default');
@@ -19,8 +19,8 @@ export default function Example(): Node {
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <OnLinkNavigationProvider
-        onNavigation={onNavigationMode === 'custom' ? useOnNavigation : undefined}
+      <GlobalEventsHandlerProvider
+        linkHandlers={{ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }}
       >
         <Flex direction="column" gap={2}>
           <Flex direction="column" gap={2}>
@@ -75,7 +75,7 @@ export default function Example(): Node {
             )}
           </Flex>
         </Flex>
-      </OnLinkNavigationProvider>
+      </GlobalEventsHandlerProvider>
     </Flex>
   );
 }

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
@@ -42,7 +42,7 @@ export default function Example(): Node {
               <RadioGroup.RadioButton
                 checked={onNavigationMode === 'custom'}
                 id="custom3"
-                label="Custom OnLinkNavigationProvider Navigation"
+                label="Custom GlobalEventsHandlerProvider Navigation"
                 name="custom"
                 onChange={() => setOnNavigationMode('custom')}
                 value="custom"

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
@@ -1,6 +1,14 @@
 // @flow strict
 import { useCallback, useMemo, type Node, useRef, useState } from 'react';
-import { Button, Divider, Dropdown, Flex, GlobalEventsHandlerProvider, RadioGroup } from 'gestalt';
+import {
+  Button,
+  Divider,
+  Dropdown,
+  Flex,
+  GlobalEventsHandlerProvider,
+  RadioGroup,
+  Link,
+} from 'gestalt';
 
 export default function Example(): Node {
   const [onNavigationMode, setOnNavigationMode] = useState<'default' | 'custom'>('default');
@@ -8,7 +16,12 @@ export default function Example(): Node {
   const anchorRef = useRef<null | HTMLButtonElement | HTMLAnchorElement>(null);
 
   const useOnNavigation = useCallback(
-    ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
+    ({
+      href,
+    }: {|
+      href: $ElementType<React$ElementConfig<typeof Link>, 'href'>,
+      target?: $ElementType<React$ElementConfig<typeof Link>, 'target'>,
+    |}) => {
       const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
         event.preventDefault();
         // eslint-disable-next-line no-alert

--- a/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersDropdown.js
@@ -1,13 +1,13 @@
 // @flow strict
-import { useCallback, useMemo, type Node, useRef, useState } from 'react';
+import { type Node, useCallback, useMemo, useRef, useState } from 'react';
 import {
   Button,
   Divider,
   Dropdown,
   Flex,
   GlobalEventsHandlerProvider,
-  RadioGroup,
   Link,
+  RadioGroup,
 } from 'gestalt';
 
 export default function Example(): Node {

--- a/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
@@ -19,7 +19,12 @@ export default function Example(): Node {
   const [onNavigationMode, setOnNavigationMode] = useState<'default' | 'custom'>('default');
 
   const useOnNavigation = useCallback(
-    ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
+    ({
+      href,
+    }: {|
+      href: $ElementType<React$ElementConfig<typeof Link>, 'href'>,
+      target?: $ElementType<React$ElementConfig<typeof Link>, 'target'>,
+    |}) => {
       const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
         event.preventDefault();
         // eslint-disable-next-line no-alert

--- a/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useState } from 'react';
+import { useCallback, useMemo, type Node, useState } from 'react';
 import {
   Box,
   Button,
@@ -18,21 +18,27 @@ import {
 export default function Example(): Node {
   const [onNavigationMode, setOnNavigationMode] = useState<'default' | 'custom'>('default');
 
-  const useOnNavigation = ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
-    const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
-      event.preventDefault();
-      // eslint-disable-next-line no-alert
-      alert(`Disabled link: ${href}. Opening help.pinterest.com instead.`);
-    };
+  const useOnNavigation = useCallback(
+    ({ href }: {| href: string, target?: null | 'self' | 'blank' |}) => {
+      const onNavigationClick = ({ event }: {| +event: SyntheticEvent<> |}) => {
+        event.preventDefault();
+        // eslint-disable-next-line no-alert
+        alert(`Disabled link: ${href}. Opening help.pinterest.com instead.`);
+      };
 
-    return onNavigationClick;
-  };
+      return onNavigationClick;
+    },
+    [],
+  );
+
+  const linkHandlers = useMemo(
+    () => ({ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }),
+    [onNavigationMode, useOnNavigation],
+  );
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <GlobalEventsHandlerProvider
-        linkHandlers={{ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }}
-      >
+      <GlobalEventsHandlerProvider linkHandlers={linkHandlers}>
         <Flex direction="column" gap={2}>
           <Flex direction="column" gap={2}>
             <RadioGroup id="navigation-type" legend="Navigation type">

--- a/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
@@ -53,7 +53,7 @@ export default function Example(): Node {
               <RadioGroup.RadioButton
                 checked={onNavigationMode === 'custom'}
                 id="custom1"
-                label="Custom OnLinkNavigationProvider Navigation"
+                label="Custom GlobalEventsHandlerProvider Navigation"
                 name="custom"
                 onChange={() => setOnNavigationMode('custom')}
                 value="custom"

--- a/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
@@ -1,15 +1,15 @@
 // @flow strict
-import { useCallback, useMemo, type Node, useState } from 'react';
+import { type Node, useCallback, useMemo, useState } from 'react';
 import {
   Box,
   Button,
   Divider,
   Flex,
+  GlobalEventsHandlerProvider,
   IconButton,
   Image,
   Link,
   Mask,
-  GlobalEventsHandlerProvider,
   RadioGroup,
   TapArea,
   Text,

--- a/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
+++ b/docs/examples/globaleventshandlerprovider/linkHandlersLinkButton.js
@@ -9,7 +9,7 @@ import {
   Image,
   Link,
   Mask,
-  OnLinkNavigationProvider,
+  GlobalEventsHandlerProvider,
   RadioGroup,
   TapArea,
   Text,
@@ -30,8 +30,8 @@ export default function Example(): Node {
 
   return (
     <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <OnLinkNavigationProvider
-        onNavigation={onNavigationMode === 'custom' ? useOnNavigation : undefined}
+      <GlobalEventsHandlerProvider
+        linkHandlers={{ onNavigation: onNavigationMode === 'custom' ? useOnNavigation : undefined }}
       >
         <Flex direction="column" gap={2}>
           <Flex direction="column" gap={2}>
@@ -88,7 +88,7 @@ export default function Example(): Node {
             </Box>
           </Flex>
         </Flex>
-      </OnLinkNavigationProvider>
+      </GlobalEventsHandlerProvider>
     </Flex>
   );
 }

--- a/docs/pages/get_started/developers/eslint_plugin.js
+++ b/docs/pages/get_started/developers/eslint_plugin.js
@@ -247,7 +247,7 @@ yarn unlink eslint-plugin-gestalt
           description={`
         Do not allow role=&apos;link&apos; on Button, TapArea, and IconButton in cases where an alternative with additional functionality must be used instead such as for use with a routing library.
 
-        Deprecation due to: [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) enables external link navigation in Gestalt components.
+        Deprecation due to: [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) enables external link navigation in Gestalt components.
       `}
         />
       </MainSection>

--- a/docs/pages/get_started/developers/eslint_plugin.js
+++ b/docs/pages/get_started/developers/eslint_plugin.js
@@ -247,7 +247,7 @@ yarn unlink eslint-plugin-gestalt
           description={`
         Do not allow role=&apos;link&apos; on Button, TapArea, and IconButton in cases where an alternative with additional functionality must be used instead such as for use with a routing library.
 
-        Deprecation due to: [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) enables external link navigation in Gestalt components.
+        Deprecation due to: [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) enables external link navigation in Gestalt components.
       `}
         />
       </MainSection>

--- a/docs/pages/web/activationcard.js
+++ b/docs/pages/web/activationcard.js
@@ -134,7 +134,7 @@ export default function ActivationCardPage({
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)**
 GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
       `}
         />

--- a/docs/pages/web/activationcard.js
+++ b/docs/pages/web/activationcard.js
@@ -134,8 +134,8 @@ export default function ActivationCardPage({
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)**
-OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
       `}
         />
       </MainSection>

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -122,7 +122,7 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
             required: false,
             description: [
               'Callback invoked when the user clicks (press and release) on Button with the mouse or keyboard. Required with `role="button"` or `type="button"` Buttons.',
-              'See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.',
+              'See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.',
             ],
           },
           {
@@ -662,9 +662,9 @@ Use TapArea to make non-button elements interactive, like an Image. This ensures
 **[Tabs](/web/tabs)**
 Tabs are intended for page-level navigation between multiple URLs.
 
-**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)**
 GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
-See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
       `}
         />
       </MainSection>

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -122,7 +122,7 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
             required: false,
             description: [
               'Callback invoked when the user clicks (press and release) on Button with the mouse or keyboard. Required with `role="button"` or `type="button"` Buttons.',
-              'See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.',
+              'See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.',
             ],
           },
           {
@@ -662,9 +662,9 @@ Use TapArea to make non-button elements interactive, like an Image. This ensures
 **[Tabs](/web/tabs)**
 Tabs are intended for page-level navigation between multiple URLs.
 
-**[OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)**
-OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
-See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
       `}
         />
       </MainSection>

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -265,7 +265,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           description={`
         Callouts can have either one primary action, or a primary action and a secondary action. These actions can be [Links](/web/link), by specifying the \`href\` property, or [Buttons](/web/button), when no \`href\` is supplied.
 
-        Callout actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+        Callout actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
 
         For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a Button that opens a [Modal](/web/modal) with an application flow. Be sure to localize the labels of the actions.
 
@@ -324,8 +324,8 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       **[ActivationCard](/web/activationcard)**
       ActivationCards are used in groups to communicate a user’s stage in a series of steps toward an overall action.
 
-      **[OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)**
-      OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
+      **[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+      GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
 
     `}
         />

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -265,7 +265,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           description={`
         Callouts can have either one primary action, or a primary action and a secondary action. These actions can be [Links](/web/link), by specifying the \`href\` property, or [Buttons](/web/button), when no \`href\` is supplied.
 
-        Callout actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+        Callout actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
 
         For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a Button that opens a [Modal](/web/modal) with an application flow. Be sure to localize the labels of the actions.
 
@@ -324,7 +324,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       **[ActivationCard](/web/activationcard)**
       ActivationCards are used in groups to communicate a user’s stage in a series of steps toward an overall action.
 
-      **[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+      **[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)**
       GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
 
     `}

--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -237,7 +237,7 @@ export default function ComponentPage({
           <MainSection.Card
             cardSize="md"
             title="Link"
-            description={`If an item navigates to a new page, use Dropdown.Link with the required \`href\` prop. If the item navigates to a page outside of the current context, (either a non-Pinterest site or a different Pinterest sub-site), the \`isExternal\` prop should also be specified to display the "up-right" icon. Optional additional actions to be taken on navigation are handled by \`onClick\`. Dropdown.Link can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+            description={`If an item navigates to a new page, use Dropdown.Link with the required \`href\` prop. If the item navigates to a page outside of the current context, (either a non-Pinterest site or a different Pinterest sub-site), the \`isExternal\` prop should also be specified to display the "up-right" icon. Optional additional actions to be taken on navigation are handled by \`onClick\`. Dropdown.Link can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
             `}
             sandpackExample={<SandpackExample code={link} name="Link example" layout="column" />}
           />
@@ -353,7 +353,7 @@ If users need to select from a short, simple list (without needing sections, sub
 **[ComboBox](/web/combobox)**
 If users need the ability to choose an option by typing in an input and filtering a long list of options, use ComboBox.
 
-**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)**
 GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
           `}
         />

--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -237,7 +237,7 @@ export default function ComponentPage({
           <MainSection.Card
             cardSize="md"
             title="Link"
-            description={`If an item navigates to a new page, use Dropdown.Link with the required \`href\` prop. If the item navigates to a page outside of the current context, (either a non-Pinterest site or a different Pinterest sub-site), the \`isExternal\` prop should also be specified to display the "up-right" icon. Optional additional actions to be taken on navigation are handled by \`onClick\`. Dropdown.Link can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+            description={`If an item navigates to a new page, use Dropdown.Link with the required \`href\` prop. If the item navigates to a page outside of the current context, (either a non-Pinterest site or a different Pinterest sub-site), the \`isExternal\` prop should also be specified to display the "up-right" icon. Optional additional actions to be taken on navigation are handled by \`onClick\`. Dropdown.Link can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
             `}
             sandpackExample={<SandpackExample code={link} name="Link example" layout="column" />}
           />
@@ -353,8 +353,8 @@ If users need to select from a short, simple list (without needing sections, sub
 **[ComboBox](/web/combobox)**
 If users need the ability to choose an option by typing in an input and filtering a long list of options, use ComboBox.
 
-**[OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)**
-OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
           `}
         />
       </MainSection>

--- a/docs/pages/web/helpbutton.js
+++ b/docs/pages/web/helpbutton.js
@@ -90,7 +90,7 @@ export default function DocsPage({ generatedDocGen }: DocsType): Node {
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Link"
-          description="HelpButton's popover content can contain a link to additional information. If needed, this interaction can be paired with [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)."
+          description="HelpButton's popover content can contain a link to additional information. If needed, this interaction can be paired with [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)."
         >
           <MainSection.Card
             cardSize="sm"

--- a/docs/pages/web/helpbutton.js
+++ b/docs/pages/web/helpbutton.js
@@ -90,7 +90,7 @@ export default function DocsPage({ generatedDocGen }: DocsType): Node {
       <MainSection name="Variants">
         <MainSection.Subsection
           title="Link"
-          description="HelpButton's popover content can contain a link to additional information. If needed, this interaction can be paired with [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)."
+          description="HelpButton's popover content can contain a link to additional information. If needed, this interaction can be paired with [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)."
         >
           <MainSection.Card
             cardSize="sm"

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -79,7 +79,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             name: 'onClick',
             type: '({| event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> |}) => void',
             description:
-              'Callback fired when the component is clicked, pressed or tapped. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.',
+              'Callback fired when the component is clicked, pressed or tapped. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.',
           },
           {
             name: 'padding',
@@ -193,7 +193,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             type: 'link',
             required: true,
             description:
-              'Sets link interaction in the component. See the [role](#Role) variant and [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.',
+              'Sets link interaction in the component. See the [role](#Role) variant and [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.',
           },
           {
             name: 'target',
@@ -354,7 +354,7 @@ If IconButton is disabled, it's also unreachable from keyboard navigation.`}
 
 \`rel\` is optional. Use "nofollow" for external links to specify to web crawlers not follow the link.
 
-IconButtons that act as links can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.`}
+IconButtons that act as links can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.`}
             sandpackExample={<SandpackExample code={roleLink} name="Role link example" />}
           />
           <MainSection.Card
@@ -523,8 +523,8 @@ Button allows users to take actions, and make choices using text labels to expre
 **[Icon](/web/icon)**
 IconButtons use icons instead of text to convey available actions on a screen. Use an existing one from the Gestalt [Icon](/web/icon) library.
 
-**[OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)**
-OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
 
 **[Dropdown](/web/dropdown)**
 It's most common to anchor Dropdown to [Button](/web/button) or IconButton.

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -79,7 +79,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             name: 'onClick',
             type: '({| event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> |}) => void',
             description:
-              'Callback fired when the component is clicked, pressed or tapped. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.',
+              'Callback fired when the component is clicked, pressed or tapped. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.',
           },
           {
             name: 'padding',
@@ -193,7 +193,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             type: 'link',
             required: true,
             description:
-              'Sets link interaction in the component. See the [role](#Role) variant and [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.',
+              'Sets link interaction in the component. See the [role](#Role) variant and [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.',
           },
           {
             name: 'target',
@@ -354,7 +354,7 @@ If IconButton is disabled, it's also unreachable from keyboard navigation.`}
 
 \`rel\` is optional. Use "nofollow" for external links to specify to web crawlers not follow the link.
 
-IconButtons that act as links can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.`}
+IconButtons that act as links can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.`}
             sandpackExample={<SandpackExample code={roleLink} name="Role link example" />}
           />
           <MainSection.Card
@@ -523,7 +523,7 @@ Button allows users to take actions, and make choices using text labels to expre
 **[Icon](/web/icon)**
 IconButtons use icons instead of text to convey available actions on a screen. Use an existing one from the Gestalt [Icon](/web/icon) library.
 
-**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)**
 GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
 
 **[Dropdown](/web/dropdown)**

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -512,7 +512,7 @@ The "visit" icon should also match [Text](/web/text)'s \`size\` and \`color\`. \
 **[Text](/web/text)**
 Text provides Link with style: size, color, and font.
 
-**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)**
 GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
 
 **[Button](/web/button)**

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -512,8 +512,8 @@ The "visit" icon should also match [Text](/web/text)'s \`size\` and \`color\`. \
 **[Text](/web/text)**
 Text provides Link with style: size, color, and font.
 
-**[OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)**
-OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
 
 **[Button](/web/button)**
 Button allows users to take actions, and make choices using text labels to express what action will occur when the user interacts with it.

--- a/docs/pages/web/sheetmobile.js
+++ b/docs/pages/web/sheetmobile.js
@@ -337,7 +337,7 @@ Handlers:
 - onOpen: executed when SheetMobile opens
 - onClose: executed when SheetMobile closes
 
-See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) for more information.`}
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#SheetMobile-handlers) for more information.`}
           columns={2}
         >
           <MainSection.Card

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -343,7 +343,7 @@ Due to localization constraints, the contents of \`message\` and \`helperLink\` 
           description={`
 SlimBanners can have a primary action. This action can be a [Link](/web/link), by specifying the \`href\` property, or a [Button](/web/button), when no \`href\` is supplied.
 
-SlimBanner actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+SlimBanner actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
 
 For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a button that opens a [Modal](/web/modal) with an application flow. Be sure to localize the labels of the actions.
 

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -343,7 +343,7 @@ Due to localization constraints, the contents of \`message\` and \`helperLink\` 
           description={`
 SlimBanners can have a primary action. This action can be a [Link](/web/link), by specifying the \`href\` property, or a [Button](/web/button), when no \`href\` is supplied.
 
-SlimBanner actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+SlimBanner actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
 
 For example, “Learn more” may link to a separate documentation site, while “Apply now” could be a button that opens a [Modal](/web/modal) with an application flow. Be sure to localize the labels of the actions.
 

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -162,7 +162,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description: [
               'Callback fired when a TapArea component is clicked (pressed and released) with a mouse or keyboard.',
               'Required with button-role + button-type buttons.',
-              'See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.',
+              'See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.',
             ],
             href: 'basic-taparea',
           },
@@ -305,7 +305,7 @@ function TapAreaExample() {
           id="link_buttons"
           description={`If you have a \`Link\` or \`Button\` inside of TapArea, you can apply \`e.stopPropagation()\` so the \`onTap\` doesn't get triggered.
 
-TapArea with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+TapArea with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
   `}
           name="TapArea with Link/Button"
           defaultCode={`
@@ -669,8 +669,8 @@ function MenuButtonExample() {
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)**
-OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
       `}
         />
       </MainSection>

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -162,7 +162,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description: [
               'Callback fired when a TapArea component is clicked (pressed and released) with a mouse or keyboard.',
               'Required with button-role + button-type buttons.',
-              'See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.',
+              'See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.',
             ],
             href: 'basic-taparea',
           },
@@ -305,7 +305,7 @@ function TapAreaExample() {
           id="link_buttons"
           description={`If you have a \`Link\` or \`Button\` inside of TapArea, you can apply \`e.stopPropagation()\` so the \`onTap\` doesn't get triggered.
 
-TapArea with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+TapArea with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
   `}
           name="TapArea with Link/Button"
           defaultCode={`
@@ -669,7 +669,7 @@ function MenuButtonExample() {
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+**[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)**
 GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
       `}
         />

--- a/docs/pages/web/upsell.js
+++ b/docs/pages/web/upsell.js
@@ -471,7 +471,7 @@ export default function DocsPage({
           description={`
       Upsells can have either one primary action, or a primary action and a secondary action. These actions can be buttons, when no \`href\` is supplied, or links, by specifying the \`href\`  property.
 
-      Upsell actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+      Upsell actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
 
       For example, “Learn more” may link to a separate documentation site, while “Send invite” could be a button that opens a [Modal](/web/modal) with an invite flow. Be sure to localize the labels of the actions.
 
@@ -749,7 +749,7 @@ If the \`message\` text requires more complex style, such as bold text or inline
       **[Toast](/web/toast)**
       Toast provides feedback on a user interaction, like a confirmation that appears when a Pin has been saved. Unlike Upsell and Callout, Toasts don’t contain actions. They’re also less persistent, and disappear after a certain duration.
 
-      **[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+      **[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers)**
       GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
 
       **[ActivationCard](/web/activationcard)**

--- a/docs/pages/web/upsell.js
+++ b/docs/pages/web/upsell.js
@@ -471,7 +471,7 @@ export default function DocsPage({
           description={`
       Upsells can have either one primary action, or a primary action and a secondary action. These actions can be buttons, when no \`href\` is supplied, or links, by specifying the \`href\`  property.
 
-      Upsell actions with link interaction can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+      Upsell actions with link interaction can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
 
       For example, “Learn more” may link to a separate documentation site, while “Send invite” could be a button that opens a [Modal](/web/modal) with an invite flow. Be sure to localize the labels of the actions.
 
@@ -749,8 +749,8 @@ If the \`message\` text requires more complex style, such as bold text or inline
       **[Toast](/web/toast)**
       Toast provides feedback on a user interaction, like a confirmation that appears when a Pin has been saved. Unlike Upsell and Callout, Toasts don’t contain actions. They’re also less persistent, and disappear after a certain duration.
 
-      **[OnLinkNavigationProvider](/web/utilities/onlinknavigationprovider)**
-      OnLinkNavigationProvider allows external link navigation control across all children components with link behavior.
+      **[GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)**
+      GlobalEventsHandlerProvider allows external link navigation control across all children components with link behavior.
 
       **[ActivationCard](/web/activationcard)**
       ActivationCards are used in groups to communicate a user’s stage in a series of steps toward an overall action.

--- a/docs/pages/web/utilities/globaleventshandlerprovider.js
+++ b/docs/pages/web/utilities/globaleventshandlerprovider.js
@@ -1,12 +1,17 @@
 // @flow strict
 import { type Node } from 'react';
+import { SlimBanner } from 'gestalt';
 import docgen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
 import SandpackExample from '../../../docs-components/SandpackExample.js';
-import SheetMobileHandlers from '../../../examples/globaleventshandlerprovider/sheetMobileHandlers.js';
+import linkHandlersCalloutUpsell from '../../../examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js';
+import linkHandlersdangerouslyDisableOnNavigation from '../../../examples/globaleventshandlerprovider/linkHandlersdangerouslyDisableOnNavigation.js';
+import linkHandlersDropdown from '../../../examples/globaleventshandlerprovider/linkHandlersDropdown.js';
+import linkHandlersLinkButton from '../../../examples/globaleventshandlerprovider/linkHandlersLinkButton.js';
+import sheetMobileHandlers from '../../../examples/globaleventshandlerprovider/sheetMobileHandlers.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -19,8 +24,8 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
-      <MainSection name="Variants">
-        <MainSection.Subsection title="GlobalEventsHandlerProvider in SheetMobile">
+      <MainSection name="SheetMobile handlers">
+        <MainSection.Subsection title="onOpen, onClose">
           <MainSection.Card
             cardSize="lg"
             description={`GlobalEventsHandlerProvider has one prop for each component subscribing to the provider.
@@ -31,8 +36,113 @@ In the example below, SheetMobile's logs when opens and closes.
 `}
             sandpackExample={
               <SandpackExample
-                code={SheetMobileHandlers}
+                code={sheetMobileHandlers}
                 name="GlobalEventsHandlerProvider in SheetMobile"
+              />
+            }
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
+      <MainSection name="Link handlers">
+        <MainSection.Subsection
+          title="onNavigation: custom navigation"
+          description={`
+Components with links use simple \`<a>\` tags. In order to replace the default link behavior with custom ones (e.g. [react-router](https://www.google.com/search?q=react-router&oq=react-router&aqs=chrome..69i57j0l9.2115j0j7&sourceid=chrome&ie=UTF-8)), \`onNavigation\` provides an interface to pass external logic into the 'onClick' event handler in children links.
+
+This example illustrates a custom navigation implementations to externally control the link functionality of Link: setting a default navigation logic with GlobalEventsHandlerProvider.
+
+If \`onNavigation\` prop is passed to GlobalEventsHandlerProvider, it's passed down to all children links and sets a customized default link navigation behavior. \`onNavigation\` is a higher-order function: it takes named arguments: \`href\` and \`target\` and returns an event handler function. In the component's \`onClick\` event handler, the \`onClick\` prop gets called first, followed by the function passed down by the GlobalEventsHandlerProvider.
+
+If \`onNavigation\` is a hook function, it can contain complex logic, including [React hooks](https://reactjs.org/docs/hooks-reference.html), to perform side effects.
+
+In this example, the \`useOnNavigation\` hook function is passed to GlobalEventsHandlerProvider and executes the following actions:
+- Disable the default link behavior
+- Show an alert message
+- Open a different URL in a new window
+
+The returned \`onNavigationClick\` function inside the hook function uses the event access to [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault). It could also be used to [stopPropagation()](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation).
+      `}
+        >
+          <SlimBanner
+            iconAccessibilityLabel="Localize the default label"
+            message="Accessible links in Gestalt announce to assistive technologies that the link opens in a new tab. Always make sure your external logic aligns with the 'target' prop values. For example, if your external logic opens a url in a new tab, set 'target' to 'blank'. Localize the default label with DefaultLabelProvider."
+            type="warning"
+            helperLink={{
+              text: 'Learn more',
+              accessibilityLabel: 'Learn more about DefaultLabelProvider',
+              href: '/web/utilities/defaultlabelprovider',
+              onClick: () => {},
+            }}
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="onNavigation: disabling default navigation"
+          description={`
+All components that consume from the GlobalEventsHandlerProvider also allow to disable the default navigation logic set in the provider from the component itself.
+
+The triggering events, like \`onClick\`, provide access to the event and "dangerouslyDisableOnNavigation".
+
+"dangerouslyDisableOnNavigation" is a callback function that, when called, disables the logic set in GlobalEventsHandlerProvider in that component instance.
+
+"dangerouslyDisableOnNavigation" can be used to use the native anchor element directly or to use an alternative navigation
+logic.
+
+Don't forget to call <code>event.preventDefault</code> when implementing an alternative navigation, e.g. router logic inside the onClick event. <code>event.preventDefault</code> will prevent your underlying anchor and the alternative navigation to act at the same time, having two navigations occurring at the same time.
+
+The example below demonstrates the correct use of "dangerouslyDisableOnNavigation".
+`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample
+                code={linkHandlersdangerouslyDisableOnNavigation}
+                name="Example - dangerouslyDisableOnNavigation"
+                layout="column"
+              />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Implementation in Link, Button, IconButton, TapArea">
+          <MainSection.Card
+            title="Examples from start to end: Link, Button, IconButton, TapArea"
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample
+                code={linkHandlersLinkButton}
+                name="Example - Link, Button, IconButton, TapArea"
+                layout="column"
+              />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Implementation in Callout, Upsell, ActivationCard">
+          <MainSection.Card
+            title="Examples from top to bottom: Callout, Upsell, ActivationCard"
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample
+                code={linkHandlersCalloutUpsell}
+                name="Example - Callout, Upsell, ActivationCard"
+                layout="column"
+                previewHeight={650}
+              />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Implementation in Dropdown">
+          <MainSection.Card
+            title="Examples: Dropdown.Link"
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample
+                code={linkHandlersDropdown}
+                name="Example - Dropdown"
+                layout="column"
               />
             }
           />

--- a/docs/pages/web/utilities/globaleventshandlerprovider.js
+++ b/docs/pages/web/utilities/globaleventshandlerprovider.js
@@ -8,7 +8,7 @@ import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
 import SandpackExample from '../../../docs-components/SandpackExample.js';
 import linkHandlersCalloutUpsell from '../../../examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js';
-import linkHandlersdangerouslyDisableOnNavigation from '../../../examples/globaleventshandlerprovider/linkHandlersdangerouslyDisableOnNavigation.js';
+import linkHandlersDangerouslyDisableOnNavigation from '../../../examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js';
 import linkHandlersDropdown from '../../../examples/globaleventshandlerprovider/linkHandlersDropdown.js';
 import linkHandlersLinkButton from '../../../examples/globaleventshandlerprovider/linkHandlersLinkButton.js';
 import sheetMobileHandlers from '../../../examples/globaleventshandlerprovider/sheetMobileHandlers.js';
@@ -97,7 +97,7 @@ The example below demonstrates the correct use of "dangerouslyDisableOnNavigatio
             cardSize="lg"
             sandpackExample={
               <SandpackExample
-                code={linkHandlersdangerouslyDisableOnNavigation}
+                code={linkHandlersDangerouslyDisableOnNavigation}
                 name="Example - dangerouslyDisableOnNavigation"
                 layout="column"
               />

--- a/docs/pages/web/utilities/onlinknavigationprovider.js
+++ b/docs/pages/web/utilities/onlinknavigationprovider.js
@@ -3,15 +3,8 @@ import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import docgen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
-import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
-import QualityChecklist from '../../../docs-components/QualityChecklist.js';
-import SandpackExample from '../../../docs-components/SandpackExample.js';
-import dangerouslyDisableOnNavigation from '../../../examples/onlinknavigationprovider/dangerouslyDisableOnNavigation.js';
-import examplesCalloutUpsell from '../../../examples/onlinknavigationprovider/examplesCalloutUpsell.js';
-import examplesDropdown from '../../../examples/onlinknavigationprovider/examplesDropdown.js';
-import examplesLinkButton from '../../../examples/onlinknavigationprovider/examplesLinkButton.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -20,125 +13,22 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
         type="utility"
-      />
-
-      <GeneratedPropTable generatedDocGen={generatedDocGen} />
-
-      <MainSection name="Usage">
-        <MainSection.Subsection
-          title="Custom link navigation context"
-          description={`
-Components with links use simple \`<a>\` tags. In order to replace the default link behavior with custom ones (e.g. [react-router](https://www.google.com/search?q=react-router&oq=react-router&aqs=chrome..69i57j0l9.2115j0j7&sourceid=chrome&ie=UTF-8)), \`onNavigation\` provides an interface to pass external logic into the 'onClick' event handler in children links.
-
-This example illustrates a custom navigation implementations to externally control the link functionality of Link: setting a default navigation logic with OnLinkNavigationProvider.
-
-If \`onNavigation\` prop is passed to OnLinkNavigationProvider, it's passed down to all children links and sets a customized default link navigation behavior. \`onNavigation\` is a higher-order function: it takes named arguments: \`href\` and \`target\` and returns an event handler function. In the component's \`onClick\` event handler, the \`onClick\` prop gets called first, followed by the function passed down by the OnLinkNavigationProvider.
-
-If \`onNavigation\` is a hook function, it can contain complex logic, including [React hooks](https://reactjs.org/docs/hooks-reference.html), to perform side effects.
-
-In this example, the \`useOnNavigation\` hook function is passed to OnLinkNavigationProvider and executes the following actions:
-- Disable the default link behavior
-- Show an alert message
-- Open a different URL in a new window
-
-The returned \`onNavigationClick\` function inside the hook function uses the event access to [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault). It could also be used to [stopPropagation()](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation).
-      `}
-        >
+        badge="deprecated"
+        slimBanner={
           <SlimBanner
-            iconAccessibilityLabel="Localize the default label"
-            message="Accessible links in Gestalt announce to assistive technologies that the link opens in a new tab. Always make sure your external logic aligns with the 'target' prop values. For example, if your external logic opens a url in a new tab, set 'target' to 'blank'. Localize the default label with DefaultLabelProvider."
-            type="warning"
+            type="error"
+            iconAccessibilityLabel="Info"
+            message="OnLinkNavigationProvider is soon to be deprecated, use GlobalEventsHandlerProvider's `linkHandlers.onNavigation` instead."
             helperLink={{
-              text: 'Learn more',
-              accessibilityLabel: 'Learn more about DefaultLabelProvider',
-              href: '/web/utilities/defaultlabelprovider',
+              text: 'View GlobalEventsHandlerProvider',
+              accessibilityLabel: 'View GlobalEventsHandlerProvider documentation',
+              href: '/web/utilities/globaleventshandlerprovider',
               onClick: () => {},
             }}
           />
-        </MainSection.Subsection>
-      </MainSection>
-      <MainSection name="Variants">
-        <MainSection.Subsection
-          title="Disabling the provider"
-          description={`
-All components that consume from the OnLinkNavigationProvider also allow to disable the default navigation logic set in the provider from the component itself.
-
-The triggering events, like \`onClick\`, provide access to the event and "dangerouslyDisableOnNavigation".
-
-"dangerouslyDisableOnNavigation" is a callback function that, when called, disables the logic set in OnLinkNavigationProvider in that component instance.
-
-"dangerouslyDisableOnNavigation" can be used to use the native anchor element directly or to use an alternative navigation
-logic.
-
-Don't forget to call <code>event.preventDefault</code> when implementing an alternative navigation, e.g. router logic inside the onClick event. <code>event.preventDefault</code> will prevent your underlying anchor and the alternative navigation to act at the same time, having two navigations occurring at the same time.
-
-The example below demonstrates the correct use of "dangerouslyDisableOnNavigation".
-`}
-        >
-          <MainSection.Card
-            cardSize="lg"
-            sandpackExample={
-              <SandpackExample
-                code={dangerouslyDisableOnNavigation}
-                name="Example - dangerouslyDisableOnNavigation"
-                layout="column"
-              />
-            }
-          />
-        </MainSection.Subsection>
-      </MainSection>
-
-      <MainSection name="Examples">
-        <MainSection.Subsection title="Link, Button, IconButton, TapArea">
-          <MainSection.Card
-            title="Examples from start to end: Link, Button, IconButton, TapArea"
-            cardSize="lg"
-            sandpackExample={
-              <SandpackExample
-                code={examplesLinkButton}
-                name="Example - Link, Button, IconButton, TapArea"
-                layout="column"
-              />
-            }
-          />
-        </MainSection.Subsection>
-
-        <MainSection.Subsection title="Callout, Upsell, ActivationCard">
-          <MainSection.Card
-            title="Examples from top to bottom: Callout, Upsell, ActivationCard"
-            cardSize="lg"
-            sandpackExample={
-              <SandpackExample
-                code={examplesCalloutUpsell}
-                name="Example - Callout, Upsell, ActivationCard"
-                layout="column"
-                previewHeight={650}
-              />
-            }
-          />
-        </MainSection.Subsection>
-
-        <MainSection.Subsection title="Dropdown">
-          <MainSection.Card
-            title="Examples: Dropdown.Link"
-            cardSize="lg"
-            sandpackExample={
-              <SandpackExample code={examplesDropdown} name="Example - Dropdown" layout="column" />
-            }
-          />
-        </MainSection.Subsection>
-      </MainSection>
-
-      <MainSection name="Related">
-        <MainSection.Subsection
-          description={`
-      **[Link](/web/link)** / **[Button](/web/button)** / **[IconButton](/web/iconbutton)** / **[TapArea](/web/taparea)**  / **[DropDown](/web/dropdown)** / **[Callout](/web/callout)** / **[Upsell](/web/upsell)** / **[ActivationCard](/web/activationcard)**
-      If these components are under a OnLinkNavigationProvider, their link behavior defaults to the logic defined in OnLinkNavigationProvider. In order to disable the onNavigation logic, we can return "dangerouslyDisableOnNavigation" in the \`onClick\` callback. See each component page for more information.
-    `}
-        />
-      </MainSection>
-
-      <QualityChecklist component={generatedDocGen?.displayName} />
+        }
+      />
+      <GeneratedPropTable generatedDocGen={generatedDocGen} />
     </Page>
   );
 }

--- a/docs/pages/web/utilities/onlinknavigationprovider.js
+++ b/docs/pages/web/utilities/onlinknavigationprovider.js
@@ -22,7 +22,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             helperLink={{
               text: 'View GlobalEventsHandlerProvider',
               accessibilityLabel: 'View GlobalEventsHandlerProvider documentation',
-              href: '/web/utilities/globaleventshandlerprovider',
+              href: '/web/utilities/globaleventshandlerprovider#Link-handlers',
               onClick: () => {},
             }}
           />

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -48,7 +48,7 @@ type Props = {|
    * - `accessibilityLabel`: Supply a short, descriptive label for screen-readers to replace button texts that do not provide sufficient context about the button component behavior. Texts like `Click Here,` `Follow,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the button text.
    * - `onClick`: Callback fired when the button component is clicked (pressed and released) with a mouse or keyboard.
    *
-   * ActivationCard can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * ActivationCard can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    */
   link?: LinkData,
   /**

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -48,7 +48,7 @@ type Props = {|
    * - `accessibilityLabel`: Supply a short, descriptive label for screen-readers to replace button texts that do not provide sufficient context about the button component behavior. Texts like `Click Here,` `Follow,` or `Read More` can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the button text.
    * - `onClick`: Callback fired when the button component is clicked (pressed and released) with a mouse or keyboard.
    *
-   * ActivationCard can be paired with OnLinkNavigationProvider. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * ActivationCard can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    */
   link?: LinkData,
   /**

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -45,7 +45,7 @@ type Props = {|
    */
   message: string,
   /**
-   * Main action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * Main action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/callout#Accessibility).
    */
@@ -66,7 +66,7 @@ type Props = {|
     target?: null | 'self' | 'blank',
   |},
   /**
-   * Secondary action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * Secondary action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/callout#Accessibility).
    */

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -45,7 +45,7 @@ type Props = {|
    */
   message: string,
   /**
-   * Main action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * Main action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/callout#Accessibility).
    */
@@ -66,7 +66,7 @@ type Props = {|
     target?: null | 'self' | 'blank',
   |},
   /**
-   * Secondary action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * Secondary action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/callout#Accessibility).
    */

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -36,7 +36,7 @@ type Props = {|
    */
   isExternal?: boolean,
   /**
-   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation. To learn more about `mobileOnDismissStart`, see the [animation variant in SheetMobile](https://deploy-preview-2879--gestalt.netlify.app/web/sheetmobile#Animation). `mobileOnDismissStart` is the equivalent of `onDismissStart` in SheetMobile.
+   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation. To learn more about `mobileOnDismissStart`, see the [animation variant in SheetMobile](https://deploy-preview-2879--gestalt.netlify.app/web/sheetmobile#Animation). `mobileOnDismissStart` is the equivalent of `onDismissStart` in SheetMobile.
    */
   onClick?: ({|
     event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -36,7 +36,7 @@ type Props = {|
    */
   isExternal?: boolean,
   /**
-   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation. To learn more about `mobileOnDismissStart`, see the [animation variant in SheetMobile](https://deploy-preview-2879--gestalt.netlify.app/web/sheetmobile#Animation). `mobileOnDismissStart` is the equivalent of `onDismissStart` in SheetMobile.
+   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation. To learn more about `mobileOnDismissStart`, see the [animation variant in SheetMobile](https://deploy-preview-2879--gestalt.netlify.app/web/sheetmobile#Animation). `mobileOnDismissStart` is the equivalent of `onDismissStart` in SheetMobile.
    */
   onClick?: ({|
     event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,

--- a/packages/gestalt/src/HelpButton.js
+++ b/packages/gestalt/src/HelpButton.js
@@ -74,7 +74,7 @@ type Props = {|
    * - `text` is the displayed text for the link. See the [link variant](https://gestalt.pinterest.systems/web/helpbutton#With-a-link) for more details.
    * - `target` see the [target Link variant](https://gestalt.pinterest.systems/web/link#Target) to learn more. If not defined the link will open in a new window.
    * - Optionally use `accessibilityLabel` to supply a short, descriptive label for screen-readers to replace link texts that don't provide sufficient context about the link component behavior. Texts like "Click Here", or "Read More" can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text. It populates `aria-label`. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text. See [ Link's accessibility guidelines](https://gestalt.pinterest.systems/web/link#Accessibility) for more information.
-   * - Optionally provide an `onClick` callback, which is fired when the link is clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * - Optionally provide an `onClick` callback, which is fired when the link is clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    */
   link?: LinkType,
   /**

--- a/packages/gestalt/src/HelpButton.js
+++ b/packages/gestalt/src/HelpButton.js
@@ -74,7 +74,7 @@ type Props = {|
    * - `text` is the displayed text for the link. See the [link variant](https://gestalt.pinterest.systems/web/helpbutton#With-a-link) for more details.
    * - `target` see the [target Link variant](https://gestalt.pinterest.systems/web/link#Target) to learn more. If not defined the link will open in a new window.
    * - Optionally use `accessibilityLabel` to supply a short, descriptive label for screen-readers to replace link texts that don't provide sufficient context about the link component behavior. Texts like "Click Here", or "Read More" can be confusing when a screen reader reads them out of context. In those cases, we must pass an alternative text to replace the link text. It populates `aria-label`. Screen readers read the `accessibilityLabel` prop, if present, instead of the link text. See [ Link's accessibility guidelines](https://gestalt.pinterest.systems/web/link#Accessibility) for more information.
-   * - Optionally provide an `onClick` callback, which is fired when the link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * - Optionally provide an `onClick` callback, which is fired when the link is clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    */
   link?: LinkType,
   /**

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -97,7 +97,7 @@ type Props = {|
    */
   onBlur?: ({| event: SyntheticFocusEvent<HTMLAnchorElement> |}) => void,
   /**
-   * Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    */
   onClick?: ({|
     event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -14,6 +14,7 @@ import getAriaLabel from './accessibility/getAriaLabel.js';
 import NewTabAccessibilityLabel from './accessibility/NewTabAccessibilityLabel.js';
 import Box from './Box.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
+import { useGlobalEventsHandlerContext } from './contexts/GlobalEventsHandlerProvider.js';
 import { useOnLinkNavigation } from './contexts/OnLinkNavigationProvider.js';
 import focusStyles from './Focus.css';
 import getRoundingClassName from './getRoundingClassName.js';
@@ -215,6 +216,15 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
   // and when onNavigation prop is passed to it
   const defaultOnNavigation = useOnLinkNavigation({ href, target });
 
+  // Consumes GlobalEventsHandlerProvider
+  const { linkHandlers } = useGlobalEventsHandlerContext() ?? {
+    linkHandlers: { onNavigation: undefined },
+  };
+
+  const { onNavigation } = linkHandlers ?? { onNavigation: undefined };
+
+  const onNavigationHandler = onNavigation?.({ href, target }) ?? defaultOnNavigation;
+
   const handleKeyPress = (event: SyntheticKeyboardEvent<HTMLAnchorElement>) => {
     // Check to see if space or enter were pressed
     if (onClick && keyPressShouldTriggerTap(event)) {
@@ -250,8 +260,8 @@ const LinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = forwardR
             dangerouslyDisableOnNavigation,
           });
         }
-        if (defaultOnNavigation && defaultOnNavigationIsEnabled) {
-          defaultOnNavigation({ event });
+        if (onNavigationHandler && defaultOnNavigationIsEnabled) {
+          onNavigationHandler({ event });
         }
       }}
       onFocus={(event) => {

--- a/packages/gestalt/src/Link.js
+++ b/packages/gestalt/src/Link.js
@@ -97,7 +97,7 @@ type Props = {|
    */
   onBlur?: ({| event: SyntheticFocusEvent<HTMLAnchorElement> |}) => void,
   /**
-   * Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * Callback fired when Link is clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    */
   onClick?: ({|
     event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,

--- a/packages/gestalt/src/Link/InternalLink.js
+++ b/packages/gestalt/src/Link/InternalLink.js
@@ -10,6 +10,7 @@ import {
 import classnames from 'classnames';
 import { type AriaCurrent } from '../ariaTypes.js';
 import buttonStyles from '../Button.css';
+import { useGlobalEventsHandlerContext } from '../contexts/GlobalEventsHandlerProvider.js';
 import { useOnLinkNavigation } from '../contexts/OnLinkNavigationProvider.js';
 import focusStyles from '../Focus.css';
 import getRoundingClassName, { type Rounding } from '../getRoundingClassName.js';
@@ -182,6 +183,15 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
   // and when onNavigation prop is passed to it
   const defaultOnNavigation = useOnLinkNavigation({ href, target });
 
+  // Consumes GlobalEventsHandlerProvider
+  const { linkHandlers } = useGlobalEventsHandlerContext() ?? {
+    linkHandlers: { onNavigation: undefined },
+  };
+
+  const { onNavigation } = linkHandlers ?? { onNavigation: undefined };
+
+  const onNavigationHandler = onNavigation?.({ href, target }) ?? defaultOnNavigation;
+
   const handleKeyPress = (event: SyntheticKeyboardEvent<HTMLAnchorElement>) => {
     // Check to see if space or enter were pressed
     if (onClick && keyPressShouldTriggerTap(event)) {
@@ -214,8 +224,8 @@ const InternalLinkWithForwardRef: AbstractComponent<Props, HTMLAnchorElement> = 
           event,
           dangerouslyDisableOnNavigation,
         });
-        if (defaultOnNavigation && defaultOnNavigationIsEnabled) {
-          defaultOnNavigation({ event });
+        if (onNavigationHandler && defaultOnNavigationIsEnabled) {
+          onNavigationHandler({ event });
         }
       }}
       onFocus={(event) => {

--- a/packages/gestalt/src/ModalAlert.js
+++ b/packages/gestalt/src/ModalAlert.js
@@ -51,13 +51,13 @@ type Props = {|
    */
   type?: 'default' | 'warning' | 'error',
   /**
-   * Main action for users to take on ModalAlert. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * Main action for users to take on ModalAlert. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/modalalert#Accessibility).
    */
   primaryAction: ActionDataType,
   /**
-   * Secondary action for users to take on ModalAlert. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * Secondary action for users to take on ModalAlert. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/modalalert#Accessibility).
    */

--- a/packages/gestalt/src/ModalAlert.js
+++ b/packages/gestalt/src/ModalAlert.js
@@ -51,13 +51,13 @@ type Props = {|
    */
   type?: 'default' | 'warning' | 'error',
   /**
-   * Main action for users to take on ModalAlert. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * Main action for users to take on ModalAlert. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/modalalert#Accessibility).
    */
   primaryAction: ActionDataType,
   /**
-   * Secondary action for users to take on ModalAlert. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * Secondary action for users to take on ModalAlert. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/modalalert#Accessibility).
    */

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -86,7 +86,7 @@ type Props = {|
    */
   onDismiss: () => void,
   /**
-   * Main action for users to take on PopoverEducational. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * Main action for users to take on PopoverEducational. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [accessibility guidelines for Button](https://gestalt.pinterest.systems/web/button#ARIA-attributes).
    * See the [primary action variant](https://gestalt.pinterest.systems/web/popovereducational#Primary-action) to learn more.

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -86,7 +86,7 @@ type Props = {|
    */
   onDismiss: () => void,
   /**
-   * Main action for users to take on PopoverEducational. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * Main action for users to take on PopoverEducational. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [accessibility guidelines for Button](https://gestalt.pinterest.systems/web/button#ARIA-attributes).
    * See the [primary action variant](https://gestalt.pinterest.systems/web/popovereducational#Primary-action) to learn more.

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -131,7 +131,7 @@ type Props = {|
    */
   message: string | Element<typeof Text>,
   /**
-   * Main action for users to take on SlimBanner. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
+   * Main action for users to take on SlimBanner. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/slimbanner#Accessibility).
    * See the [Primary action](https://gestalt.pinterest.systems/web/slimbanner#Primary-action) variant to learn more.

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -131,7 +131,7 @@ type Props = {|
    */
   message: string | Element<typeof Text>,
   /**
-   * Main action for users to take on SlimBanner. If `href` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.
+   * Main action for users to take on SlimBanner. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
    * The `accessibilityLabel` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/slimbanner#Accessibility).
    * See the [Primary action](https://gestalt.pinterest.systems/web/slimbanner#Primary-action) variant to learn more.

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -199,7 +199,7 @@ type Props = {|
    */
   bgColor?: BgColor,
   /**
-   * If your app requires client navigation, be sure to use [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) and/or `onChange` to navigate instead of getting a full page refresh just using `href`.
+   * If your app requires client navigation, be sure to use [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) and/or `onChange` to navigate instead of getting a full page refresh just using `href`.
    */
   onChange: OnChangeHandler,
   /**

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -199,7 +199,7 @@ type Props = {|
    */
   bgColor?: BgColor,
   /**
-   * If your app requires client navigation, be sure to use [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) and/or `onChange` to navigate instead of getting a full page refresh just using `href`.
+   * If your app requires client navigation, be sure to use [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) and/or `onChange` to navigate instead of getting a full page refresh just using `href`.
    */
   onChange: OnChangeHandler,
   /**

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -99,7 +99,7 @@ type Props = {|
    */
   message: string | Element<typeof Text>,
   /**
-   * Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.'
+   * Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.'
    * If no \`href\` is supplied, the action will be a button.
    * The \`accessibilityLabel\` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/upsell#Accessibility).
    */
@@ -120,7 +120,7 @@ type Props = {|
     target?: null | 'self' | 'blank',
   |},
   /**
-   * Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.'
+   * Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.'
    * If no \`href\` is supplied, the action will be a button.
    * The \`accessibilityLabel\` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/upsell#Accessibility).
    */

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -99,7 +99,7 @@ type Props = {|
    */
   message: string | Element<typeof Text>,
   /**
-   * Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.'
+   * Main action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.'
    * If no \`href\` is supplied, the action will be a button.
    * The \`accessibilityLabel\` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/upsell#Accessibility).
    */
@@ -120,7 +120,7 @@ type Props = {|
     target?: null | 'self' | 'blank',
   |},
   /**
-   * Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) to learn more about link navigation.'
+   * Secondary action for people to take on Upsell. If \`href\` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) to learn more about link navigation.'
    * If no \`href\` is supplied, the action will be a button.
    * The \`accessibilityLabel\` should follow the [Accessibility guidelines](https://gestalt.pinterest.systems/web/upsell#Accessibility).
    */

--- a/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
+++ b/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
@@ -26,7 +26,7 @@ type Props = {|
   /**
    * Handlers consumed by [SheetMobile](https://gestalt.pinterest.systems/web/sheetmobile#External-handlers).
    */
-  sheetMobileHandlers?: {| onOpen?: NoopType, onClose?: NoopType |},
+  sheetMobileHandlers?: {| onOpen?: () => void, onClose?: () => void |},
   /**
    * Handlers consumed by [Link](https://gestalt.pinterest.systems/web/link#External-handlers).
    */

--- a/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
+++ b/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
@@ -3,7 +3,7 @@ import { type Context, createContext, type Element, type Node, useContext } from
 
 export type NoopType = () => void;
 
-export type OnLinkNavigationType = ({|
+type OnLinkNavigationType = ({|
   href: string,
   target?: null | 'self' | 'blank',
 |}) => ?({|
@@ -30,7 +30,14 @@ type Props = {|
   /**
    * Handlers consumed by [Link](https://gestalt.pinterest.systems/web/link#External-handlers).
    */
-  linkHandlers?: {| onNavigation?: OnLinkNavigationType |},
+  linkHandlers?: {|
+    onNavigation?: ({|
+      href: string,
+      target?: null | 'self' | 'blank',
+    |}) => ?({|
+      +event: SyntheticEvent<>,
+    |}) => void,
+  |},
 |};
 
 const GlobalEventsHandlerContext: Context<GlobalEventsHandlerContextType> =

--- a/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
+++ b/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
@@ -3,8 +3,19 @@ import { type Context, createContext, type Element, type Node, useContext } from
 
 export type NoopType = () => void;
 
+export type OnLinkNavigationType = ({|
+  href: string,
+  target?: null | 'self' | 'blank',
+|}) => ?({|
+  +event: SyntheticEvent<>,
+|}) => void;
+
 type GlobalEventsHandlerContextType = {|
   sheetMobileHandlers?: {| onOpen?: NoopType, onClose?: NoopType |},
+  linkHandlers?: {| onNavigation?: OnLinkNavigationType |},
+  buttonHandlers?: {| onNavigation?: OnLinkNavigationType |},
+  iconButtonHandlers?: {| onNavigation?: OnLinkNavigationType |},
+  tapAreaHandlers?: {| onNavigation?: OnLinkNavigationType |},
 |} | void;
 
 type Props = {|
@@ -16,6 +27,10 @@ type Props = {|
    * Handlers consumed by [SheetMobile](https://gestalt.pinterest.systems/web/sheetmobile#External-handlers).
    */
   sheetMobileHandlers?: {| onOpen?: NoopType, onClose?: NoopType |},
+  /**
+   * Handlers consumed by [Link](https://gestalt.pinterest.systems/web/link#External-handlers).
+   */
+  linkHandlers?: {| onNavigation?: OnLinkNavigationType |},
 |};
 
 const GlobalEventsHandlerContext: Context<GlobalEventsHandlerContextType> =
@@ -29,8 +44,18 @@ const { Provider } = GlobalEventsHandlerContext;
 export default function GlobalEventsHandlerProvider({
   children,
   sheetMobileHandlers,
+  linkHandlers,
 }: Props): Element<typeof Provider> {
-  return <Provider value={{ sheetMobileHandlers }}>{children}</Provider>;
+  return (
+    <Provider
+      value={{
+        sheetMobileHandlers,
+        linkHandlers,
+      }}
+    >
+      {children}
+    </Provider>
+  );
 }
 
 export function useGlobalEventsHandlerContext(): GlobalEventsHandlerContextType {

--- a/packages/gestalt/src/contexts/OnLinkNavigationProvider.js
+++ b/packages/gestalt/src/contexts/OnLinkNavigationProvider.js
@@ -29,7 +29,7 @@ const { Provider } = OnLinkNavigationContext;
 /**
  * [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) is a [React context provider](https://reactjs.org/docs/context.html#contextprovider) to externally control the link behavior of components further down the tree.
  *
- * **NOTE** OnLinkNavigationProvider is soon to be deprecated, use [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) instead.**NOTE**
+ * **NOTE** OnLinkNavigationProvider is soon to be deprecated, use [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) instead.**NOTE**
  */
 export default function OnLinkNavigationProvider({
   children,

--- a/packages/gestalt/src/contexts/OnLinkNavigationProvider.js
+++ b/packages/gestalt/src/contexts/OnLinkNavigationProvider.js
@@ -28,6 +28,8 @@ const { Provider } = OnLinkNavigationContext;
 
 /**
  * [OnLinkNavigationProvider](https://gestalt.pinterest.systems/web/utilities/onlinknavigationprovider) is a [React context provider](https://reactjs.org/docs/context.html#contextprovider) to externally control the link behavior of components further down the tree.
+ *
+ * **NOTE** OnLinkNavigationProvider is soon to be deprecated, use [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) instead.**NOTE**
  */
 export default function OnLinkNavigationProvider({
   children,


### PR DESCRIPTION
### Summary

#### What changed?

GlobalEventsHandlerProvider: migrating OnLinkNavigationProvider to `linkHandlers.onNavigation`

#### Why?

OnLinkNavigationProvider logic can be consolidated into GlobalEventsHandlerProvider. No need to have separate providers