### PR TITLE
DatePicker: fixes in Flow|TypeScript types

### DIFF
--- a/docs/examples/datepicker/controlled.js
+++ b/docs/examples/datepicker/controlled.js
@@ -4,7 +4,7 @@ import { Box, Flex } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValue, setDateValue] = useState<Date | void>(undefined);
+  const [dateValue, setDateValue] = useState<Date | null>(null);
 
   return (
     <Flex alignItems="start" height="100%" justifyContent="center" width="100%">

--- a/docs/examples/datepicker/disable.js
+++ b/docs/examples/datepicker/disable.js
@@ -4,8 +4,8 @@ import { Box, Flex } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValueDisableFuture, setDateValueDisableFuture] = useState<void | Date>(undefined);
-  const [dateValueDisablePast, setDatealueDisablePast] = useState<void | Date>(undefined);
+  const [dateValueDisableFuture, setDateValueDisableFuture] = useState<Date | null>(null);
+  const [dateValueDisablePast, setDatealueDisablePast] = useState<Date | null>(null);
 
   return (
     <Flex alignItems="start" gap={4} height="100%" justifyContent="center" width="100%">

--- a/docs/examples/datepicker/disableSelected.js
+++ b/docs/examples/datepicker/disableSelected.js
@@ -4,7 +4,7 @@ import { Box, Flex } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValue, setDateValue] = useState<void | Date>(new Date(2020, 2, 9));
+  const [dateValue, setDateValue] = useState<Date | null>(new Date(2020, 2, 9));
 
   return (
     <Flex alignItems="start" height="100%" justifyContent="center" width="100%">

--- a/docs/examples/datepicker/disabled.js
+++ b/docs/examples/datepicker/disabled.js
@@ -4,7 +4,7 @@ import { Box, Flex } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValue, setDateValue] = useState<Date | void>(new Date(1985, 6, 4));
+  const [dateValue, setDateValue] = useState<Date | null>(new Date(1985, 6, 4));
 
   return (
     <Flex alignItems="start" height="100%" justifyContent="center" width="100%">

--- a/docs/examples/datepicker/error.js
+++ b/docs/examples/datepicker/error.js
@@ -4,7 +4,7 @@ import { Box, Flex } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValue, setDateValue] = useState<Date | void>(undefined);
+  const [dateValue, setDateValue] = useState<Date | null>(null);
 
   return (
     <Flex alignItems="start" height="100%" justifyContent="center" width="100%">

--- a/docs/examples/datepicker/helperText.js
+++ b/docs/examples/datepicker/helperText.js
@@ -4,7 +4,7 @@ import { Box, Flex } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValue, setDateValue] = useState<Date | void>(undefined);
+  const [dateValue, setDateValue] = useState<Date | null>(null);
 
   return (
     <Flex alignItems="start" height="100%" justifyContent="center" width="100%">

--- a/docs/examples/datepicker/preselected.js
+++ b/docs/examples/datepicker/preselected.js
@@ -4,7 +4,7 @@ import { Box, Flex } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [dateValue, setDateValue] = useState<Date | void>(new Date(1985, 6, 4));
+  const [dateValue, setDateValue] = useState<Date | null>(new Date(1985, 6, 4));
 
   return (
     <Flex alignItems="start" height="100%" justifyContent="center" width="100%">

--- a/docs/examples/datepicker/range.js
+++ b/docs/examples/datepicker/range.js
@@ -4,8 +4,8 @@ import { Box, Flex } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 
 export default function Example(): Node {
-  const [startDate, setStartDate] = useState<Date | void>(undefined);
-  const [endDate, setEndDate] = useState<Date | void>(undefined);
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
   const endDateInput = useRef<null | HTMLInputElement>(null);
   const startDateInput = useRef<null | HTMLInputElement>(null);
 

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -295,7 +295,7 @@ import { it } from 'date-fns/locale';
         >
           {({ localeDataCode }) => {
             // eslint-disable-next-line react-hooks/rules-of-hooks
-            const [date, setDate] = useState(new Date());
+            const [date, setDate] = useState<Date | null>(new Date());
 
             return (
               <Box width="100%" height="100%" color="default">

--- a/packages/gestalt-datepicker/dist/index.d.ts
+++ b/packages/gestalt-datepicker/dist/index.d.ts
@@ -364,14 +364,14 @@ export interface DatePickerProps {
   minDate?: Date | undefined;
   name?: string | undefined;
   nextRef?: { current: HTMLElement | null } | undefined;
-  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: Date }>;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: Date | null }>;
   placeholder?: string | undefined;
-  rangeEndDate?: Date | undefined;
+  rangeEndDate?: Date | null | undefined;
   rangeSelector?: 'start' | 'end' | undefined;
-  rangeStartDate?: Date | undefined;
+  rangeStartDate?: Date | null | undefined;
   ref?: { current: HTMLElement | null } | undefined;
   selectLists?: ('month' | 'year')[] | undefined;
-  value?: Date | undefined;
+  value?: Date | null | undefined;
 }
 
 export interface DateFieldProps {

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -10,9 +10,9 @@ import {
 import InternalDatePicker from './DatePicker/InternalDatePicker.js';
 
 // LocaleData type from https://github.com/date-fns/date-fns/blob/81ab18785146405ca2ae28710cdfbb13a294ec50/src/locale/af/index.js.flow
-// flowlint unclear-type:off
 // NOTE: DO NOT USE PER-LINE FLOW SUPPRESSIONS HERE
 // They will get picked up by the docgen and bork the type displayed on the docs
+// flowlint unclear-type:off
 type LocaleData = {|
   code?: string,
   formatDistance?: (...args: $ReadOnlyArray<any>) => any,
@@ -104,7 +104,7 @@ export type Props = {|
    */
   onChange: ({|
     event: SyntheticInputEvent<HTMLInputElement>,
-    value: Date,
+    value: Date | null,
   |}) => void,
   /**
    * Placeholder text shown if the user has not yet input a value. The default placeholder value shows the date format for each locale, e.g. MM/DD/YYYY.
@@ -113,7 +113,7 @@ export type Props = {|
   /**
    * Required for date range selection. End date on a date range selection. See the [date range example](https://gestalt.pinterest.systems/web/datepicker#Date-range) to learn more.
    */
-  rangeEndDate?: Date,
+  rangeEndDate?: Date | null,
   /**
    * Required for date range selection. Defines the datepicker start/end role in a date range selection.See the [date range picker example](https://gestalt.pinterest.systems/web/datepicker#Date-range) to learn more.
    */
@@ -121,7 +121,7 @@ export type Props = {|
   /**
    * Required for date range selection. Start date on a date range selection. See the [date range picker example](https://gestalt.pinterest.systems/web/datepicker#Date-range) to learn more.
    */
-  rangeStartDate?: Date,
+  rangeStartDate?: Date | null,
   /**
    * Required for date range selection. Pass a ref object to DatePicker to autofocus on the unselected date range field. See the [date range picker example](https://gestalt.pinterest.systems/web/datepicker#Date-range) to learn more.
    */
@@ -133,7 +133,7 @@ export type Props = {|
   /**
    * DatePicker can be a controlled component. `value` sets the current value of the input. See the [controlled component date example](https://gestalt.pinterest.systems/web/datepicker#Controlled-component) to learn more.
    */
-  value?: Date,
+  value?: Date | null,
 |};
 
 /**

--- a/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
+++ b/packages/gestalt-datepicker/src/DatePicker.jsdom.test.js
@@ -6,12 +6,12 @@ import DatePicker from './DatePicker.js';
 const initialDate = new Date(2018, 11, 14);
 
 function DatePickerWrap({ showMonthYearDropdown }: {| showMonthYearDropdown?: boolean |}) {
-  const [date, setDate] = useState(initialDate);
+  const [date, setDate] = useState<Date | null>(initialDate);
 
   return (
     <DatePicker
       id="fake_id"
-      onChange={(e) => setDate(e.value)}
+      onChange={({ value }) => setDate(value)}
       value={date}
       selectLists={showMonthYearDropdown ? ['year', 'month'] : undefined}
     />
@@ -20,7 +20,7 @@ function DatePickerWrap({ showMonthYearDropdown }: {| showMonthYearDropdown?: bo
 
 describe('DatePicker', () => {
   const mockOnChange = jest.fn<
-    [{| event: SyntheticInputEvent<HTMLInputElement>, value: Date |}],
+    [{| event: SyntheticInputEvent<HTMLInputElement>, value: Date | null |}],
     void,
   >();
 

--- a/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.js
@@ -120,7 +120,7 @@ const InternalDatePickerWithForwardRef: AbstractComponent<Props, HTMLInputElemen
         dayClassName={() => classnames(styles['react-datepicker__days'])}
         disabled={disabled}
         dropdownMode="select"
-        endDate={rangeEndDate}
+        endDate={rangeEndDate ?? undefined}
         excludeDates={excludeDates && [...excludeDates]}
         highlightDates={initRangeHighlight ? [initRangeHighlight] : []}
         id={id}
@@ -167,7 +167,7 @@ const InternalDatePickerWithForwardRef: AbstractComponent<Props, HTMLInputElemen
         showPopperArrow={false}
         showMonthDropdown={selectLists?.includes('month')}
         showYearDropdown={selectLists?.includes('year')}
-        startDate={rangeStartDate}
+        startDate={rangeStartDate ?? undefined}
       />
     </div>
   );


### PR DESCRIPTION
### Breaking changes

Run codemod to detect DatePicker. Also, Flow|TypeScript complains could help fixing this.
```
yarn codemod detectManualReplacement ~/path/to/your/code
--component=DatePicker
```


### Summary

#### What changed?

DatePicker returns "Date" objects and "null", "null" value was not in the type. 

Major breaking change as it might affect useState value when implementing the upgrade

#### Why?

Flow errors