### PR TITLE
Toast: CSS fix in width

### DIFF
--- a/packages/gestalt/src/Toast.css
+++ b/packages/gestalt/src/Toast.css
@@ -21,8 +21,7 @@
   margin-right: 32px;
 
   /*  Ensure that maxWidth isn't greater than viewport width (for small screens)  */
-  max-width: "min(716px, 100vw)";
-  width: 100%;
+  max-width: min(716px, 100vw);
 }
 
 @media (--g-sm) {


### PR DESCRIPTION

### Summary

#### What changed?

Toast: CSS fix in width

#### Why?

Before
<img width="408" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/c9d985ae-847e-49e9-8e0f-740537581f09">

After
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/ecca547f-1c6e-4338-8439-456cb7133f42)
