### PR TITLE
Docs: fix empty aliases bug

### DIFF
--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -158,7 +158,7 @@ export default function PageHeader({
           <Flex direction="column" gap={6}>
             <Flex direction="column" gap={1}>
               {description && <Markdown text={description} />}
-              {aliases && (
+              {aliases && aliases.length > 0 && (
                 // using h2 to indicate to Algolia search that this is important, but don't want native browser styling
                 <h2 className="reset">
                   <Text italic>also known as {aliases.join(', ')}</Text>


### PR DESCRIPTION
The existing `aliases` check in the docs PageHeader is too simple — we don't just care if `aliases` is defined, but also if it has length

_before_
<img width="452" alt="Screen Shot 2023-06-13 at 4 47 39 PM" src="https://github.com/pinterest/gestalt/assets/12059539/c9512159-73cb-4cc5-aaa0-6ef418f79f83">

_after_
<img width="443" alt="Screen Shot 2023-06-13 at 4 48 04 PM" src="https://github.com/pinterest/gestalt/assets/12059539/df41f4cd-a9d1-45a1-af12-ca0e9ed06242">