### PR TITLE
Docs: Add Text tile to Android overview page

### DIFF
--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -2691,7 +2691,7 @@ const GENERAL_COMPONENT_LIST: $ReadOnlyArray<ListItemType> = [
       },
       badge: null,
       deprecated: false,
-      documentation: 'planned',
+      documentation: 'ready',
       figma: null,
     },
     iOS: {


### PR DESCRIPTION
### Summary

#### What changed?

Added a new Text tile to Android component Overview page

#### Why?

To keep the Android Overview page updated. 

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6304)