### PR TITLE
Docs: Data visualization videos

### DIFF
--- a/docs/docs-components/COMPONENT_DATA.js
+++ b/docs/docs-components/COMPONENT_DATA.js
@@ -241,6 +241,13 @@ const FOUNDATION_GUIDELINES_LIST: $ReadOnlyArray<ListItemType> = [
     category: 'Foundations',
     path: '/foundations/content_standards/voice',
   },
+  {
+    svg: <DataVisualization />,
+    name: 'Data visualization',
+    description: 'Guidelines and best practices for creating and using data visualizations',
+    category: 'Foundations',
+    path: '/foundations/data_visualization/overview',
+  },
 
   {
     svg: <DesignTokens />,
@@ -249,13 +256,6 @@ const FOUNDATION_GUIDELINES_LIST: $ReadOnlyArray<ListItemType> = [
       'An expanded color palette for charts, graphs and other data visualizations. Includes guidelines for accessibility and usage.',
     category: 'Foundations',
     path: '/foundations/design_tokens',
-  },
-  {
-    svg: <DataVisualization />,
-    name: 'Data visualization',
-    description: 'Data visualization',
-    category: 'Foundations',
-    path: '/foundations/data_visualization/overview',
   },
   {
     svg: <Elevation />,

--- a/docs/examples/datavisualization/desktopgraphExample.js
+++ b/docs/examples/datavisualization/desktopgraphExample.js
@@ -9,7 +9,7 @@ export default function Example(): Node {
     <Flex gap={4} direction="column">
       <Box height="100%" margin="auto">
         <Video
-          aspectRatio={1920 / 1016}
+          aspectRatio={1920 / 1080}
           controls
           onPlayError={({ error }) => error && setPlaying(false)}
           onPlay={() => setPlaying(true)}
@@ -18,7 +18,7 @@ export default function Example(): Node {
           onEnded={() => setPlaying(false)}
           playing={playing}
           loop
-          src="https://github.com/pinterest/gestalt/assets/96082362/6378b31d-9f2f-45d0-816b-c107b5a179dc"
+          src="https://github.com/pinterest/gestalt/assets/96082362/000de356-e9d2-483e-9991-025f509f0f65"
         />
       </Box>
       <Box smPadding={2} marginTop={-2}>

--- a/docs/examples/datavisualization/graphtotableExample.js
+++ b/docs/examples/datavisualization/graphtotableExample.js
@@ -9,7 +9,7 @@ export default function Example(): Node {
     <Flex gap={4} direction="column">
       <Box height="100%" margin="auto">
         <Video
-          aspectRatio={1920 / 1016}
+          aspectRatio={1920 / 1080}
           controls
           onPlayError={({ error }) => error && setPlaying(false)}
           onPlay={() => setPlaying(true)}
@@ -18,7 +18,7 @@ export default function Example(): Node {
           onEnded={() => setPlaying(false)}
           playing={playing}
           loop
-          src="https://github.com/pinterest/gestalt/assets/96082362/8e595e5f-9e7f-4b44-9b9c-b011d805ad73"
+          src="https://github.com/pinterest/gestalt/assets/96082362/ee58618c-55de-4057-9a6b-2d2352c1068b"
         />
       </Box>
       <Box smPadding={2} marginTop={-2}>

--- a/docs/examples/datavisualization/mobilegraphExample.js
+++ b/docs/examples/datavisualization/mobilegraphExample.js
@@ -18,7 +18,7 @@ export default function Example(): Node {
           onEnded={() => setPlaying(false)}
           playing={playing}
           loop
-          src="https://github.com/pinterest/gestalt/assets/96082362/cb332732-0176-4f7e-ada9-2232d5732152"
+          src="https://github.com/pinterest/gestalt/assets/96082362/96d7a4c7-da92-41b4-b7d8-f0785c01d471"
         />
       </Box>
       <Box smPadding={2} marginTop={-2}>

--- a/docs/examples/datavisualization/mobilegraphExample.js
+++ b/docs/examples/datavisualization/mobilegraphExample.js
@@ -9,7 +9,7 @@ export default function Example(): Node {
     <Flex gap={4} direction="column">
       <Box height="100%" margin="auto">
         <Video
-          aspectRatio={1920 / 1016}
+          aspectRatio={1920 / 1080}
           controls
           onPlayError={({ error }) => error && setPlaying(false)}
           onPlay={() => setPlaying(true)}
@@ -18,7 +18,7 @@ export default function Example(): Node {
           onEnded={() => setPlaying(false)}
           playing={playing}
           loop
-          src="https://github.com/pinterest/gestalt/assets/96082362/96d7a4c7-da92-41b4-b7d8-f0785c01d471"
+          src="https://github.com/pinterest/gestalt/assets/96082362/cb332732-0176-4f7e-ada9-2232d5732152"
         />
       </Box>
       <Box smPadding={2} marginTop={-2}>

--- a/docs/pages/foundations/data_visualization/charts_and_graphs.js
+++ b/docs/pages/foundations/data_visualization/charts_and_graphs.js
@@ -709,7 +709,7 @@ export default function ChartsandGraphsPage(): Node {
                 name="Desktop Chart Interaction Example"
                 hideEditor
                 hideControls
-                previewHeight={500}
+                previewHeight={528}
               />
             </Flex.Item>
           </Flex>
@@ -727,7 +727,7 @@ export default function ChartsandGraphsPage(): Node {
                 name="Mobile Chart Interaction Example"
                 hideEditor
                 hideControls
-                previewHeight={500}
+                previewHeight={516}
               />
             </Flex.Item>
           </Flex>
@@ -749,7 +749,7 @@ export default function ChartsandGraphsPage(): Node {
                 name="Chart to Table Example"
                 hideEditor
                 hideControls
-                previewHeight={500}
+                previewHeight={508}
               />
             </Flex.Item>
           </Flex>


### PR DESCRIPTION
### Summary
Data visualization clean up.

#### What changed?

Updated videos to be larger and of higher quality. Added a better description for the Data visualization link on the Foundations overview page.
<img width="391" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/3289977c-7e0b-417f-ab27-05b2034cb4b4">

<img width="415" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/0b3079de-0d89-4881-b294-1f2237b87eca">


#### Why?

Videos were blurring before. This makes them sharper. We only had a description under the Data visualization heading and graphic that said "Data visualization". This provides a more descriptive sentence to match other Foundations docs.
### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6311)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
