### PR TITLE
Tokens: New disabled token for text and icons

### DIFF
--- a/docs/pages/foundations/color/usage.js
+++ b/docs/pages/foundations/color/usage.js
@@ -236,10 +236,11 @@ export default function ColorUsagePage(): Node {
           title="Standard text colors"
           description={`
           Typography colors are used on text elements such as headings and body.
-          Use the tokens:
-          **$color-text-default** - The default text color, such as headings and body text.
-          **$color-text-subtle** - For secondary, subtle text color, such as additional info or sub-header.
-          **$color-text-shopping** - For text related to shopping products or surfaces.
+          Token uses:
+          **$color-text-default** - Use as the default text color for headings and body text.
+          **$color-text-subtle** - Use for secondary info such helper text or subheadings.
+          **$color-text-disabled** - Use for text inside of disabled UI controls.
+          **$color-text-shopping** - Use for text related to shopping products or surfaces.
 
           `}
         >
@@ -251,6 +252,11 @@ export default function ColorUsagePage(): Node {
             />
             <ColorTile description="Subtle" textColor="inverse" fullTokenName="color-text-subtle" />
             <ColorTile
+              description="Disabled"
+              textColor="default"
+              fullTokenName="color-text-disabled"
+            />
+            <ColorTile
               description="Shopping"
               textColor="inverse"
               fullTokenName="color-text-shopping"
@@ -260,7 +266,7 @@ export default function ColorUsagePage(): Node {
         <MainSection.Subsection
           title="Status text colors"
           description={`
-          Text colors used to indicate status. Each color has a purposeful meaning. Use the tokens:
+          Text colors used to indicate status. Each color has a purposeful meaning. Token uses:
           **$color-text-success** - Use as text color to indicate success.
           **$color-text-warning** - Use as text color to indicate a warning or caution.
           **$color-text-error** - Use as text color to indicate an error.
@@ -303,6 +309,7 @@ export default function ColorUsagePage(): Node {
 
       **$color-text-icon-default** - Use as the default color for icons.
       **$color-text-icon-subtle** - Use as the secondary color for icons.
+      **$color-text-icon-disabled** - Use for icons inside of disabled UI controls.
       **$color-text-icon-info** - Use for info icons.
       **$color-text-icon-recommendation** - Use for recommendation icons.
       **$color-text-icon-success** - Use for success icons.
@@ -321,6 +328,11 @@ export default function ColorUsagePage(): Node {
             description="Subtle"
             textColor="inverse"
             fullTokenName="color-text-icon-subtle"
+          />
+          <ColorTile
+            description="Disabled"
+            textColor="default"
+            fullTokenName="color-text-icon-disabled"
           />
           <ColorTile description="Info" textColor="inverse" fullTokenName="color-text-icon-info" />
           <ColorTile

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -11,6 +11,11 @@
         "darkValue": "{color.gray.roboflow.400.value}",
         "comment": "Secondary, subtle text color"
       },
+      "disabled": {
+        "value": "{color.gray.roboflow.400.value}",
+        "darkValue": "{color.gray.roboflow.600.value}",
+        "comment": "Disabled text color"
+      },
       "success": {
         "value": "{color.green.matchacado.600.value}",
         "darkValue": "{color.green.matchacado.400.value}",
@@ -60,6 +65,11 @@
           "darkValue": "{color.gray.roboflow.400.value}",
           "comment": "Subtle, secondary color for icons"
         },
+        "disabled": {
+          "value": "{color.gray.roboflow.400.value}",
+          "darkValue": "{color.gray.roboflow.600.value}",
+          "comment": "Disabled color for icons"
+      },
         "success": {
           "value": "{color.green.matchacado.600.value}",
           "darkValue": "{color.green.matchacado.400.value}",


### PR DESCRIPTION

### Summary
Added disabled text and icon token and updated the Color docs.

#### What changed?

Added disabled token to the base.js file. And updated the color Usage page to reflect the new token. Also re-worded the typography section to match the style of the rest of the doc.
<img width="718" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/5563ba9a-fdb3-46d9-a264-9aebf7aebf0c">
<img width="716" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/214e879a-2b95-433a-b167-d99ca4f52c4b">
<img width="939" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/b9adff4b-2a0e-4418-a732-c43922a2ae96">
<img width="929" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/c5f204b6-bbeb-4638-89be-af68a25e3c93">


#### Why?

A color that looks more disabled than our subtle color is needed. Subtle is for secondary text, but there is a conflict when there is a subhead or helper text in a subtle color on the page, then also a disabled element with the same color. Android and iOS devs also need the token so they can implement on their end.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6295)
- [Figma](https://www.figma.com/file/cPXcu0NmmxRf5ywyybuxTU/Gestalt-foundations?type=design&node-id=7073%3A3468&t=f9QuM2lMLIuBBx2Q-1)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
