### PR TITLE
Docs: adds a new metric statsboards to web/tooling page

### DIFF
--- a/docs/pages/get_started/developers/tooling/web.js
+++ b/docs/pages/get_started/developers/tooling/web.js
@@ -347,7 +347,7 @@ The following table lists the currently available metrics to track Gestalt adopt
                   'http://go/metrics_gestalt_percentage',
                 ],
                 [
-                  'Gestalt Components',
+                  'Non-building-block Gestalt Components',
                   '# total non-building-block Gestalt components / (# native DOM elements + # total Gestalt component)',
                   'http://go/metrics_gestalt_highorder_percentage',
                 ],

--- a/docs/pages/get_started/developers/tooling/web.js
+++ b/docs/pages/get_started/developers/tooling/web.js
@@ -347,6 +347,11 @@ The following table lists the currently available metrics to track Gestalt adopt
                   'http://go/metrics_gestalt_percentage',
                 ],
                 [
+                  'Gestalt Components',
+                  '# total non-building-block Gestalt components / (# native DOM elements + # total Gestalt component)',
+                  'http://go/metrics_gestalt_highorder_percentage',
+                ],
+                [
                   'Gestalt Components: component level',
                   '# total Gestalt components; # per component',
                   'http://go/metrics_gestalt_component',


### PR DESCRIPTION
### Summary

#### What changed?

Docs: adds a new metric statsboards to web/tooling page



![Screenshot 2023-06-20 at 2 33 55 PM](https://github.com/pinterest/gestalt/assets/10593890/3a245241-36d6-4326-a0b0-e86761f32737)
<img width="1535" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/3fc61e3f-e98b-415f-b6eb-7245d8953da0">
