### PR TITLE
Docs: add link to UX Writing Cheat Sheet

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "default": true,
   "MD013": false,
+  "MD026": { "punctuation": ".,;:。，；：" },
   "MD033": false,
   "MD034": false
 }

--- a/docs/markdown/foundations/content_standards/resources.md
+++ b/docs/markdown/foundations/content_standards/resources.md
@@ -4,12 +4,15 @@ description: For more information about something that’s not covered here, rea
 fullwidth: true
 ---
 
-**Pinterest resources**
-- <PrivateLink display="inlineBlock" href="http://pinch.pinadmin.com/Pinterest Content Design Hub">Pinterest Content Design Hub</PrivateLink> : A central hub for everything Content Design at Pinterest. 
-- <PrivateLink display="inlineBlock" href="http://pinch.pinadmin.com/Pinterest Dictionary">Pinterest Dictionary</PrivateLink>: A glossary of Content Design terminology at Pinterest. 
+## Pinterest resources
+
+- <PrivateLink display="inlineBlock" href="http://pinch.pinadmin.com/Pinterest Content Design Hub">Pinterest Content Design Hub</PrivateLink> : The central hub for everything Content Design at Pinterest
+- <PrivateLink display="inlineBlock" href="http://pinch.pinadmin.com/Pinterest Dictionary">Pinterest Dictionary</PrivateLink>: A glossary of Content Design terminology at Pinterest
+- <PrivateLink display="inlineBlock" href="http://pinch.pinadmin.com/UXwritingcheatsheet">UX Writing Cheat Sheet</PrivateLink>: A resource for teams without a designated content designer
 - [Pinterest Brand Guidelines](https://brand.pinterest.com/): Standards for brand design at Pinterest. *Always check with the brand design team to make sure you're using the latest guidelines.*
 
-**There’s a world outside of Pinterest?!**
-- [Writing + content strategy resources](https://docs.google.com/document/d/1KIpmqk6peL8C-qAbFcEKBlwCZz3fhRntAJDK7mtsJik/edit): Bay Area-writing classes, articles about writing and more!
+## There’s a world outside of Pinterest?!
+
+- [Writing + content strategy resources](https://docs.google.com/document/d/1KIpmqk6peL8C-qAbFcEKBlwCZz3fhRntAJDK7mtsJik/edit): Bay Area writing classes, articles about writing and more!
 - [The AP Style Guide](https://owl.purdue.edu/owl/subject_specific_writing/journalism_and_journalistic_writing/ap_style.html): When in doubt, refer to…
 - [A Progressive’s Style Guide](https://s3.amazonaws.com/s3.sumofus.org/images/SUMOFUS_PROGRESSIVE-STYLEGUIDE.pdf): When in doubt about how to refer to a specific group of people, refer to…


### PR DESCRIPTION
Created by Hartley after the Content Design layoffs. This PR also includes linting the existing markdown file.