### PR TITLE
Image: Fix web hydration issue

### DIFF
--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -162,7 +162,7 @@ export default class Image extends PureComponent<Props> {
     const isScaledImage = shouldScaleImage(fit);
     const fitStyles = fit === 'cover' || fit === 'contain' ? styles.scaledImg : undefined;
     const imageStyles = classnames(styles.img, fitStyles);
-    const elementTimingValue = elementTiming ? elementTiming : `avatar-${src}`;
+    const elementTimingValue = elementTiming ? elementTiming : `image-${src}`;
 
     return (
       <Box

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -179,7 +179,6 @@ export default class Image extends PureComponent<Props> {
           className={imageStyles}
           crossOrigin={crossOrigin}
           decoding={decoding}
-          elementtiming={elementTiming}
           fetchpriority={fetchPriority}
           loading={loading}
           onError={this.handleError}
@@ -188,6 +187,7 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
+          {...(elementTiming ? { elementtiming: elementTiming : {})}
           {...(isScaledImage ? { style: { objectFit: fit } } : {})}
         />
         {childContent}

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -187,7 +187,7 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
-          {...(elementTiming ? { elementtiming: elementTiming : {})}
+          {...(elementTiming ? { elementtiming: elementTiming } : {})}
           {...(isScaledImage ? { style: { objectFit: fit } } : {})}
         />
         {childContent}

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -162,7 +162,14 @@ export default class Image extends PureComponent<Props> {
     const isScaledImage = shouldScaleImage(fit);
     const fitStyles = fit === 'cover' || fit === 'contain' ? styles.scaledImg : undefined;
     const imageStyles = classnames(styles.img, fitStyles);
+    
     const elementTimingValue = elementTiming ? { elementtiming: elementTiming } : {};
+    const styleValue = isScaledImage ? { style: { objectFit: fit } } : {};
+    const conditionalProps = {
+      ...elementTimingValue,
+      ...styleValue,
+    };
+    
 
     return (
       <Box
@@ -188,8 +195,7 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
-          {...elementTimingValue}
-          {...(isScaledImage ? { style: { objectFit: fit } } : {})}
+          {...conditionalProps}
         />
         {childContent}
       </Box>

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -187,7 +187,7 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
-          {...(elementTiming ? { elementtiming: elementTiming } : {})}
+          {...(elementTiming ? { elementtiming: String(elementTiming) } : {})}
           {...(isScaledImage ? { style: { objectFit: fit } } : {})}
         />
         {childContent}

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -180,7 +180,6 @@ export default class Image extends PureComponent<Props> {
           className={imageStyles}
           crossOrigin={crossOrigin}
           decoding={decoding}
-          elementtiming={elementTimingValue}
           fetchpriority={fetchPriority}
           loading={loading}
           onError={this.handleError}

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -162,7 +162,7 @@ export default class Image extends PureComponent<Props> {
     const isScaledImage = shouldScaleImage(fit);
     const fitStyles = fit === 'cover' || fit === 'contain' ? styles.scaledImg : undefined;
     const imageStyles = classnames(styles.img, fitStyles);
-    const elementTimingValue = elementTiming ? elementTiming : `image-${src}`;
+    const elementTimingValue = elementTiming ? { elementtiming: elementTiming } : {};
 
     return (
       <Box
@@ -189,6 +189,7 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
+          {...elementTimingValue}
           {...(isScaledImage ? { style: { objectFit: fit } } : {})}
         />
         {childContent}

--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -162,6 +162,7 @@ export default class Image extends PureComponent<Props> {
     const isScaledImage = shouldScaleImage(fit);
     const fitStyles = fit === 'cover' || fit === 'contain' ? styles.scaledImg : undefined;
     const imageStyles = classnames(styles.img, fitStyles);
+    const elementTimingValue = elementTiming ? elementTiming : `avatar-${src}`;
 
     return (
       <Box
@@ -179,6 +180,7 @@ export default class Image extends PureComponent<Props> {
           className={imageStyles}
           crossOrigin={crossOrigin}
           decoding={decoding}
+          elementtiming={elementTimingValue}
           fetchpriority={fetchPriority}
           loading={loading}
           onError={this.handleError}
@@ -187,7 +189,6 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
-          {...(elementTiming ? { elementtiming: String(elementTiming) } : {})}
           {...(isScaledImage ? { style: { objectFit: fit } } : {})}
         />
         {childContent}


### PR DESCRIPTION
Fixing this hydration error:

> Warning: Extra attributes from the server: elementtiming
>     at img

### Summary

#### What changed?

If no element timing prop is passed, use the src as a value.

#### Why?

This causes a hydration issue. I'm guessing the server adds the attribute, but the browser removes it because it is empty. This causes a mismatch in HTML, throwing a hydration error.

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
