### PR TITLE
Image: web - conditionally add imagetiming attribute

### DIFF
--- a/packages/gestalt/src/Image.js
+++ b/packages/gestalt/src/Image.js
@@ -162,6 +162,14 @@ export default class Image extends PureComponent<Props> {
     const isScaledImage = shouldScaleImage(fit);
     const fitStyles = fit === 'cover' || fit === 'contain' ? styles.scaledImg : undefined;
     const imageStyles = classnames(styles.img, fitStyles);
+    const elementTimingValue: {| elementtiming?: string |} = elementTiming
+      ? { elementtiming: elementTiming }
+      : {};
+    const styleValue = isScaledImage ? { style: { objectFit: fit } } : {};
+    const conditionalProps = {
+      ...elementTimingValue,
+      ...styleValue,
+    };
 
     return (
       <Box
@@ -179,7 +187,6 @@ export default class Image extends PureComponent<Props> {
           className={imageStyles}
           crossOrigin={crossOrigin}
           decoding={decoding}
-          elementtiming={elementTiming}
           fetchpriority={fetchPriority}
           loading={loading}
           onError={this.handleError}
@@ -188,7 +195,7 @@ export default class Image extends PureComponent<Props> {
           sizes={sizes}
           src={src}
           srcSet={srcSet}
-          {...(isScaledImage ? { style: { objectFit: fit } } : {})}
+          {...conditionalProps}
         />
         {childContent}
       </Box>


### PR DESCRIPTION
### Summary
Fixing this hydration error:

Warning: Extra attributes from the server: elementtiming
at img

#### What changed?

If no element timing prop is passed, use the src as a value.

#### Why?

This causes a hydration issue. I'm guessing the server adds the attribute, but the browser removes it because it is empty. This causes a mismatch in HTML, throwing a hydration error.

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
