### PR TITLE
Internal: simplify docgen API

### DIFF
--- a/docs/docs-components/docgen.js
+++ b/docs/docs-components/docgen.js
@@ -27,37 +27,31 @@ export type DocType = {|
   generatedDocGen: DocGen,
 |};
 
-export default function docgen({ componentName }: {| componentName: string |}): DocGen {
+export default function docGen(componentName: string): DocGen {
   return metadata[componentName];
 }
 
-export function multipledocgen({
-  componentName,
-}: {|
-  componentName: $ReadOnlyArray<string> | string,
-|}): {|
+export function multipleDocGen(componentNames: $ReadOnlyArray<string>): {|
   [string]: DocGen,
 |} {
-  return Array.isArray(componentName)
-    ? componentName.reduce(
-        (prevValue: { [string]: DocGen }, currentComponentName: string) => ({
-          ...prevValue,
-          [currentComponentName]: docgen({ componentName: currentComponentName }),
-        }),
-        {},
-      )
-    : metadata[componentName];
+  return componentNames.reduce(
+    (prevValue: { [string]: DocGen }, currentComponentName: string) => ({
+      ...prevValue,
+      [currentComponentName]: docGen(currentComponentName),
+    }),
+    {},
+  );
 }
 
-export function overrideTypes(docGen: DocGen, typeOverrides: {| [string]: string |}): DocGen {
+export function overrideTypes(docGenArg: DocGen, typeOverrides: {| [string]: string |}): DocGen {
   Object.keys(typeOverrides).forEach((key) => {
-    if (docGen?.props?.[key]) {
+    if (docGenArg?.props?.[key]) {
       // eslint-disable-next-line no-param-reassign
-      docGen.props[key].flowType = {
+      docGenArg.props[key].flowType = {
         name: 'union',
         raw: typeOverrides[key],
       };
     }
   });
-  return docGen;
+  return docGenArg;
 }

--- a/docs/pages/web/activationcard.js
+++ b/docs/pages/web/activationcard.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -145,6 +145,6 @@ GlobalEventsHandlerProvider allows external link navigation control across all c
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'ActivationCard' }) },
+    props: { generatedDocGen: await docGen('ActivationCard') },
   };
 }

--- a/docs/pages/web/avatar.js
+++ b/docs/pages/web/avatar.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -235,6 +235,6 @@ export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocG
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Avatar' }) },
+    props: { generatedDocGen: await docGen('Avatar') },
   };
 }

--- a/docs/pages/web/avatargroup.js
+++ b/docs/pages/web/avatargroup.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { AvatarGroup } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -306,6 +306,6 @@ If AvatarGroup is used as a control button to show/hide Popover-component, we re
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'AvatarGroup' }) },
+    props: { generatedDocGen: await docGen('AvatarGroup') },
   };
 }

--- a/docs/pages/web/badge.js
+++ b/docs/pages/web/badge.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -223,6 +223,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Badge' }) },
+    props: { generatedDocGen: await docGen('Badge') },
   };
 }

--- a/docs/pages/web/box.js
+++ b/docs/pages/web/box.js
@@ -3,7 +3,7 @@ import React, { type Node } from 'react';
 import { Box, ColorSchemeProvider, Flex, Text } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -536,9 +536,7 @@ For a correct implementation, make sure the  ‘visually-hidden’ element is co
 }
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
-  const generatedDocGen = await docgen({ componentName: 'Box' });
-
   return {
-    props: { generatedDocGen },
+    props: { generatedDocGen: await docGen('Box') },
   };
 }

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Button, SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
-import docgen, { type DocGen, type DocType } from '../../docs-components/docgen.js';
+import docGen, { type DocGen, type DocType } from '../../docs-components/docgen.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -674,6 +674,6 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Lin
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Button' }) },
+    props: { generatedDocGen: await docGen('Button') },
   };
 }

--- a/docs/pages/web/buttongroup.js
+++ b/docs/pages/web/buttongroup.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -66,6 +66,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'ButtonGroup' }) },
+    props: { generatedDocGen: await docGen('ButtonGroup') },
   };
 }

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -336,6 +336,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Callout' }) },
+    props: { generatedDocGen: await docGen('Callout') },
   };
 }

--- a/docs/pages/web/checkbox.js
+++ b/docs/pages/web/checkbox.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -989,6 +989,6 @@ function Example() {
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Checkbox' }) },
+    props: { generatedDocGen: await docGen('Checkbox') },
   };
 }

--- a/docs/pages/web/collage.js
+++ b/docs/pages/web/collage.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -104,6 +104,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Collage' }) },
+    props: { generatedDocGen: await docGen('Collage') },
   };
 }

--- a/docs/pages/web/column.js
+++ b/docs/pages/web/column.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import Card from '../../docs-components/Card.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import Page from '../../docs-components/Page.js';
@@ -240,6 +240,6 @@ export default function ColumnPage({ generatedDocGen }: {| generatedDocGen: DocG
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Column' }) },
+    props: { generatedDocGen: await docGen('Column') },
   };
 }

--- a/docs/pages/web/combobox.js
+++ b/docs/pages/web/combobox.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -245,6 +245,6 @@ Use Fieldset to group related form items.
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'ComboBox' }) },
+    props: { generatedDocGen: await docGen('ComboBox') },
   };
 }

--- a/docs/pages/web/container.js
+++ b/docs/pages/web/container.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -44,6 +44,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Container' }) },
+    props: { generatedDocGen: await docGen('Container') },
   };
 }

--- a/docs/pages/web/datapoint.js
+++ b/docs/pages/web/datapoint.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -273,6 +273,6 @@ Use Status in instances where information is more categorical or qualitative (su
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Datapoint' }) },
+    props: { generatedDocGen: await docGen('Datapoint') },
   };
 }

--- a/docs/pages/web/datefield.js
+++ b/docs/pages/web/datefield.js
@@ -41,7 +41,7 @@ import {
 import { Box, SlimBanner } from 'gestalt';
 import { DateField } from 'gestalt-datepicker';
 import Combination from '../../docs-components/Combination.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -198,9 +198,7 @@ Use DatePicker if the user is allowed to pick a date from a calendar popup.
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
     props: {
-      generatedDocGen: await docgen({
-        componentName: 'DateField',
-      }),
+      generatedDocGen: await docGen('DateField'),
     },
   };
 }

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -42,7 +42,7 @@ import { Box } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import Combination from '../../docs-components/Combination.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -321,9 +321,7 @@ import { it } from 'date-fns/locale';
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
     props: {
-      generatedDocGen: await docgen({
-        componentName: 'DatePicker',
-      }),
+      generatedDocGen: await docGen('DatePicker'),
     },
   };
 }

--- a/docs/pages/web/divider.js
+++ b/docs/pages/web/divider.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -397,6 +397,6 @@ function Example() {
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Divider' }) },
+    props: { generatedDocGen: await docGen('Divider') },
   };
 }

--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -365,9 +365,12 @@ GlobalEventsHandlerProvider allows external link navigation control across all c
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const docGen = await multipledocgen({
-    componentName: ['Dropdown', 'DropdownItem', 'DropdownLink', 'DropdownSection'],
-  });
+  const docGen = await multipleDocGen([
+    'Dropdown',
+    'DropdownItem',
+    'DropdownLink',
+    'DropdownSection',
+  ]);
 
   docGen.Dropdown.props.children.flowType.raw =
     'React.ChildrenArray<React.Element<typeof DropdownItem | typeof DropdownSection>>';

--- a/docs/pages/web/fieldset.js
+++ b/docs/pages/web/fieldset.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -112,6 +112,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Fieldset' }) },
+    props: { generatedDocGen: await docGen('Fieldset') },
   };
 }

--- a/docs/pages/web/flex.js
+++ b/docs/pages/web/flex.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Box } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -165,9 +165,7 @@ export default function DocsPage({
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const docgen = await multipledocgen({ componentName: ['Flex', 'FlexItem'] });
-
   return {
-    props: { generatedDocGen: docgen },
+    props: { generatedDocGen: await multipleDocGen(['Flex', 'FlexItem']) },
   };
 }

--- a/docs/pages/web/heading.js
+++ b/docs/pages/web/heading.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Box, SlimBanner, Table, Text } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Markdown from '../../docs-components/Markdown.js';
@@ -386,6 +386,6 @@ For certain specific situations, it is possible to use Heading without an access
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Heading' }) },
+    props: { generatedDocGen: await docGen('Heading') },
   };
 }

--- a/docs/pages/web/helpbutton.js
+++ b/docs/pages/web/helpbutton.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -126,6 +126,6 @@ HelpButton is a more specific component than IconButton. IconButton is preferabl
 
 export async function getServerSideProps(): Promise<{| props: DocsType |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'HelpButton' }) },
+    props: { generatedDocGen: await docGen('HelpButton') },
   };
 }

--- a/docs/pages/web/icon.js
+++ b/docs/pages/web/icon.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Icon } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
-import docgen, { type DocGen, overrideTypes } from '../../docs-components/docgen.js';
+import docGen, { type DocGen, overrideTypes } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -269,8 +269,8 @@ Use Button to allow users to take an action.
 }
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
-  const docGen = await docgen({ componentName: 'Icon' });
-  const overriddenDocGen = overrideTypes(docGen, {
+  const generatedDocGen = await docGen('Icon');
+  const overriddenDocGen = overrideTypes(generatedDocGen, {
     icon: (Icon?.icons ?? []).map((icon) => `'${icon}'`).join(' | '),
   });
 

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { IconButton, SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -537,6 +537,6 @@ It's most common to anchor Dropdown to [Button](/web/button) or IconButton.
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'IconButton' }) },
+    props: { generatedDocGen: await docGen('IconButton') },
   };
 }

--- a/docs/pages/web/iconbuttonfloating.js
+++ b/docs/pages/web/iconbuttonfloating.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -219,7 +219,7 @@ IconButtonFloating is commonly paired with Dropdown to display a menu of options
 }
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
-  const generatedDocGen = await docgen({ componentName: 'IconButtonFloating' });
+  const generatedDocGen = await docGen('IconButtonFloating');
 
   generatedDocGen.props.icon = {
     ...generatedDocGen.props.icon,

--- a/docs/pages/web/image.js
+++ b/docs/pages/web/image.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import Card from '../../docs-components/Card.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import Page from '../../docs-components/Page.js';
@@ -236,6 +236,6 @@ Sometimes Images are purely presentational. For example, an Image used above an 
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Image' }) },
+    props: { generatedDocGen: await docGen('Image') },
   };
 }

--- a/docs/pages/web/label.js
+++ b/docs/pages/web/label.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -54,6 +54,6 @@ function LabelExample() {
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Label' }) },
+    props: { generatedDocGen: await docGen('Label') },
   };
 }

--- a/docs/pages/web/layer.js
+++ b/docs/pages/web/layer.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import Card from '../../docs-components/Card.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import Page from '../../docs-components/Page.js';
@@ -108,6 +108,6 @@ function zIndexExample() {
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Layer' }) },
+    props: { generatedDocGen: await docGen('Layer') },
   };
 }

--- a/docs/pages/web/letterbox.js
+++ b/docs/pages/web/letterbox.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -93,6 +93,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Letterbox' }) },
+    props: { generatedDocGen: await docGen('Letterbox') },
   };
 }

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -529,6 +529,6 @@ These components support link functionality themselves by setting \`role="link"\
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Link' }) },
+    props: { generatedDocGen: await docGen('Link') },
   };
 }

--- a/docs/pages/web/list.js
+++ b/docs/pages/web/list.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -491,9 +491,7 @@ Fieldset creates a fieldset and legend for a group of related form items, like [
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const docGen = await multipledocgen({
-    componentName: ['List', 'ListItem'],
-  });
+  const docGen = await multipleDocGen(['List', 'ListItem']);
 
   docGen.List.props.children.flowType.raw = '<Element<typeof List.Item>>';
   docGen.ListItem.props.children.flowType.raw = '<Element<typeof List | typeof List.Item>>';

--- a/docs/pages/web/mask.js
+++ b/docs/pages/web/mask.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Mask } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import Combination from '../../docs-components/Combination.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -103,6 +103,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Mask' }) },
+    props: { generatedDocGen: await docGen('Mask') },
   };
 }

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -120,7 +120,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 }
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
-  const generatedDocGen = await docgen({ componentName: 'Masonry' });
+  const generatedDocGen = await docGen('Masonry');
 
   generatedDocGen.props.loadItems = {
     ...generatedDocGen.props.loadItems,

--- a/docs/pages/web/modal.js
+++ b/docs/pages/web/modal.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -286,7 +286,7 @@ export async function getServerSideProps(): Promise<{|
 |}> {
   return {
     props: {
-      generatedDocGen: await docgen({ componentName: 'Modal' }),
+      generatedDocGen: await docGen('Modal'),
     },
   };
 }

--- a/docs/pages/web/modalalert.js
+++ b/docs/pages/web/modalalert.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -354,6 +354,6 @@ export default function ModalAlertPage({ generatedDocGen }: {| generatedDocGen: 
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'ModalAlert' }) },
+    props: { generatedDocGen: await docGen('ModalAlert') },
   };
 }

--- a/docs/pages/web/module.js
+++ b/docs/pages/web/module.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -527,10 +527,10 @@ function ModuleExample5() {
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const docgen = await multipledocgen({ componentName: ['Module', 'ModuleExpandable'] });
+  const docGen = await multipleDocGen(['Module', 'ModuleExpandable']);
 
-  docgen.Module.props.icon = {
-    ...docgen.Module.props.icon,
+  docGen.Module.props.icon = {
+    ...docGen.Module.props.icon,
     flowType: {
       name: 'string',
       raw: 'Icon[icon]',
@@ -538,6 +538,6 @@ export async function getServerSideProps(): Promise<{|
   };
 
   return {
-    props: { generatedDocGen: docgen },
+    props: { generatedDocGen: docGen },
   };
 }

--- a/docs/pages/web/numberfield.js
+++ b/docs/pages/web/numberfield.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -366,6 +366,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'NumberField' }) },
+    props: { generatedDocGen: await docGen('NumberField') },
   };
 }

--- a/docs/pages/web/overlaypanel.js
+++ b/docs/pages/web/overlaypanel.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { Link, SlimBanner, Text } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -383,10 +383,7 @@ Toast provides feedback on an interaction. Toasts appear at the bottom of a desk
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const generatedDocGen = await multipledocgen({
-    componentName: ['OverlayPanel', 'DismissingElement'],
-  });
   return {
-    props: { generatedDocGen },
+    props: { generatedDocGen: await multipleDocGen(['OverlayPanel', 'DismissingElement']) },
   };
 }

--- a/docs/pages/web/pageheader.js
+++ b/docs/pages/web/pageheader.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -414,6 +414,6 @@ PageHeader doesn't depend on DeviceTypeProvider to display a mobile view; instea
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'PageHeader' }) },
+    props: { generatedDocGen: await docGen('PageHeader') },
   };
 }

--- a/docs/pages/web/pog.js
+++ b/docs/pages/web/pog.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Pog } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import Combination from '../../docs-components/Combination.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -70,7 +70,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 }
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
-  const generatedDocGen = await docgen({ componentName: 'Pog' });
+  const generatedDocGen = await docGen('Pog');
 
   generatedDocGen.props.icon = {
     ...generatedDocGen.props.icon,

--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -319,6 +319,6 @@ ScrollBoundaryContainer is needed for proper positioning when Popover is anchore
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Popover' }) },
+    props: { generatedDocGen: await docGen('Popover') },
   };
 }

--- a/docs/pages/web/popovereducational.js
+++ b/docs/pages/web/popovereducational.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -220,6 +220,6 @@ Tooltip describes the function of an interactive element, typically [IconButton]
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'PopoverEducational' }) },
+    props: { generatedDocGen: await docGen('PopoverEducational') },
   };
 }

--- a/docs/pages/web/pulsar.js
+++ b/docs/pages/web/pulsar.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -210,6 +210,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Pulsar' }) },
+    props: { generatedDocGen: await docGen('Pulsar') },
   };
 }

--- a/docs/pages/web/radiobutton.js
+++ b/docs/pages/web/radiobutton.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -34,6 +34,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'RadioButton' }) },
+    props: { generatedDocGen: await docGen('RadioButton') },
   };
 }

--- a/docs/pages/web/radiogroup.js
+++ b/docs/pages/web/radiogroup.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -888,13 +888,9 @@ function RadioButtonPopoverExample() {
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const docGen = await multipledocgen({
-    componentName: ['RadioGroup', 'RadioGroupButton'],
-  });
-
   return {
     props: {
-      generatedDocGen: docGen,
+      generatedDocGen: await multipleDocGen(['RadioGroup', 'RadioGroupButton']),
     },
   };
 }

--- a/docs/pages/web/searchfield.js
+++ b/docs/pages/web/searchfield.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -252,6 +252,6 @@ TextArea allows for multiline text input, suitable for longer length text. Unles
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'SearchField' }) },
+    props: { generatedDocGen: await docGen('SearchField') },
   };
 }

--- a/docs/pages/web/segmentedcontrol.js
+++ b/docs/pages/web/segmentedcontrol.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -133,6 +133,6 @@ function SegmentedControlExample() {
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'SegmentedControl' }) },
+    props: { generatedDocGen: await docGen('SegmentedControl') },
   };
 }

--- a/docs/pages/web/selectlist.js
+++ b/docs/pages/web/selectlist.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -622,11 +622,9 @@ If users need the ability to choose between a yes/no option, use Checkbox.
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const docgen = await multipledocgen({
-    componentName: ['SelectList', 'SelectListOption', 'SelectListGroup'],
-  });
-
   return {
-    props: { generatedDocGen: docgen },
+    props: {
+      generatedDocGen: await multipleDocGen(['SelectList', 'SelectListOption', 'SelectListGroup']),
+    },
   };
 }

--- a/docs/pages/web/sheetmobile.js
+++ b/docs/pages/web/sheetmobile.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -402,9 +402,7 @@ export async function getStaticProps(): Promise<{|
 |}> {
   return {
     props: {
-      generatedDocGen: await multipledocgen({
-        componentName: ['SheetMobile', 'DismissingElement'],
-      }),
+      generatedDocGen: await multipleDocGen(['SheetMobile', 'DismissingElement']),
     },
   };
 }

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -530,20 +530,16 @@ For pages with a main top nav bar, every SideNav should have a PageHeader to ann
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const docGen = await multipledocgen({
-    componentName: [
-      'SideNavigation',
-      'SideNavigationSection',
-      'SideNavigationTopItem',
-      'SideNavigationNestedItem',
-      'SideNavigationGroup',
-      'SideNavigationNestedGroup',
-    ],
-  });
-
   return {
     props: {
-      generatedDocGen: docGen,
+      generatedDocGen: await multipleDocGen([
+        'SideNavigation',
+        'SideNavigationSection',
+        'SideNavigationTopItem',
+        'SideNavigationNestedItem',
+        'SideNavigationGroup',
+        'SideNavigationNestedGroup',
+      ]),
     },
   };
 }

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -457,6 +457,6 @@ Tooltip provides helpful information regarding an interactive UI element, typica
 
 export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'SlimBanner' }) },
+    props: { generatedDocGen: await docGen('SlimBanner') },
   };
 }

--- a/docs/pages/web/spinner.js
+++ b/docs/pages/web/spinner.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -171,6 +171,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Spinner' }) },
+    props: { generatedDocGen: await docGen('Spinner') },
   };
 }

--- a/docs/pages/web/status.js
+++ b/docs/pages/web/status.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -197,6 +197,6 @@ Use Callout to communicate page-level status, such as an error, and to provide a
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Status' }) },
+    props: { generatedDocGen: await docGen('Status') },
   };
 }

--- a/docs/pages/web/sticky.js
+++ b/docs/pages/web/sticky.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -31,7 +31,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 }
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
-  const generatedDocGen = await docgen({ componentName: 'Sticky' });
+  const generatedDocGen = await docGen('Sticky');
 
   ['bottom', 'left', 'right', 'top'].forEach((prop) => {
     generatedDocGen.props[prop] = {

--- a/docs/pages/web/switch.js
+++ b/docs/pages/web/switch.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -187,6 +187,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Switch' }) },
+    props: { generatedDocGen: await docGen('Switch') },
   };
 }

--- a/docs/pages/web/table.js
+++ b/docs/pages/web/table.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -575,20 +575,18 @@ Checkboxes are often used in tables to allow for selecting and editing of multip
 export async function getStaticProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const docGen = await multipledocgen({
-    componentName: [
-      'Table',
-      'TableHeader',
-      'TableBody',
-      'TableFooter',
-      'TableCell',
-      'TableHeaderCell',
-      'TableSortableHeaderCell',
-      'TableRow',
-      'TableRowExpandable',
-      'TableRowDrawer',
-    ],
-  });
+  const docGen = await multipleDocGen([
+    'Table',
+    'TableHeader',
+    'TableBody',
+    'TableFooter',
+    'TableCell',
+    'TableHeaderCell',
+    'TableSortableHeaderCell',
+    'TableRow',
+    'TableRowExpandable',
+    'TableRowDrawer',
+  ]);
 
   docGen.Table.props.children.flowType.raw =
     'React.ChildrenArray<React.Element<typeof Table.Body | typeof Table.Footer | typeof Table.Header>>';

--- a/docs/pages/web/tabs.js
+++ b/docs/pages/web/tabs.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -239,6 +239,6 @@ SegmentedControl is used to switch between views within a small area of content,
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Tabs' }) },
+    props: { generatedDocGen: await docGen('Tabs') },
   };
 }

--- a/docs/pages/web/tag.js
+++ b/docs/pages/web/tag.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -189,6 +189,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Tag' }) },
+    props: { generatedDocGen: await docGen('Tag') },
   };
 }

--- a/docs/pages/web/tagdata.js
+++ b/docs/pages/web/tagdata.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -155,8 +155,8 @@ export default function TagDataPage({ generatedDocGen }: {| generatedDocGen: Doc
       <MainSection
         name="Localization"
         description={`
-        
-      Be sure to localize \`accessibilityRemoveIconLabel\` ,\`tooltip.accessibilityLabel\`, and \`text\` props in TagData.  
+
+      Be sure to localize \`accessibilityRemoveIconLabel\` ,\`tooltip.accessibilityLabel\`, and \`text\` props in TagData.
 
       When the \`text\` of TagData reaches its max width, either intentionally or through localization, the text will be truncated with ellipses as needed to preserve the max-width. Keep this in mind when selecting wording for TagData. Note that localization can lengthen text by 20 to 30 percent.`}
       />
@@ -164,8 +164,8 @@ export default function TagDataPage({ generatedDocGen }: {| generatedDocGen: Doc
       <MainSection name="Variants">
         <MainSection.Subsection
           description={`TagData is available in 3 fixed sizes.
-          - **lg** has height of 48px. Text has a fixed size of 16px. 
-          - **md** has height of 40px. Text has a fixed size of 14px. 
+          - **lg** has height of 48px. Text has a fixed size of 16px.
+          - **md** has height of 40px. Text has a fixed size of 14px.
           - **sm** has height of 32px. Text has a fixed size of 14px.
           `}
           title="Size"
@@ -233,7 +233,7 @@ export default function TagDataPage({ generatedDocGen }: {| generatedDocGen: Doc
           description={`
     **[Tag](/web/tag)**
     Tags are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](https://gestalt.pinterest.systems/web/textfield#Tags), [TextAreas](https://gestalt.pinterest.systems/web/textarea#With-tags), [ComboBox](https://gestalt.pinterest.systems/web/combobox#Tags) or as standalone components.
-    
+
     **[TileData](/web/tiledata)**
     TileData is a flexible, visually rich component that can be used as single or multiple selections on should be only used with data visualizations.
   `}
@@ -245,6 +245,6 @@ export default function TagDataPage({ generatedDocGen }: {| generatedDocGen: Doc
 
 export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'TagData' }) },
+    props: { generatedDocGen: await docGen('TagData') },
   };
 }

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -3,7 +3,7 @@ import { type Node } from 'react';
 import { Box, SlimBanner, TapArea, Text } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import Combination from '../../docs-components/Combination.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import Example from '../../docs-components/Example.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -680,6 +680,6 @@ GlobalEventsHandlerProvider allows external link navigation control across all c
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'TapArea' }) },
+    props: { generatedDocGen: await docGen('TapArea') },
   };
 }

--- a/docs/pages/web/text.js
+++ b/docs/pages/web/text.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -326,6 +326,6 @@ export default function TextPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Text' }) },
+    props: { generatedDocGen: await docGen('Text') },
   };
 }

--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -696,6 +696,6 @@ return (
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'TextArea' }) },
+    props: { generatedDocGen: await docGen('TextArea') },
   };
 }

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -926,6 +926,6 @@ function TextFieldPopoverExample() {
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'TextField' }) },
+    props: { generatedDocGen: await docGen('TextField') },
   };
 }

--- a/docs/pages/web/tiledata.js
+++ b/docs/pages/web/tiledata.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -182,6 +182,6 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'TileData' }) },
+    props: { generatedDocGen: await docGen('TileData') },
   };
 }

--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -349,6 +349,6 @@ Once a toast is triggered, allow for a cooldown period of about 7 seconds before
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Toast' }) },
+    props: { generatedDocGen: await docGen('Toast') },
   };
 }

--- a/docs/pages/web/tooltip.js
+++ b/docs/pages/web/tooltip.js
@@ -2,7 +2,7 @@
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -799,6 +799,6 @@ Toast provides feedback on an interaction. One example of Toast is the confirmat
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'Tooltip' }) },
+    props: { generatedDocGen: await docGen('Tooltip') },
   };
 }

--- a/docs/pages/web/upsell.js
+++ b/docs/pages/web/upsell.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import { type DocGen, multipledocgen } from '../../docs-components/docgen.js';
+import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -765,9 +765,7 @@ If the \`message\` text requires more complex style, such as bold text or inline
 export async function getServerSideProps(): Promise<{|
   props: {| generatedDocGen: {| [string]: DocGen |} |},
 |}> {
-  const generatedDocGen = await multipledocgen({ componentName: ['Upsell', 'UpsellForm'] });
-
   return {
-    props: { generatedDocGen },
+    props: { generatedDocGen: await multipleDocGen(['Upsell', 'UpsellForm']) },
   };
 }

--- a/docs/pages/web/utilities/colorschemeprovider.js
+++ b/docs/pages/web/utilities/colorschemeprovider.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
@@ -44,9 +44,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
     props: {
-      generatedDocGen: await docgen({
-        componentName: 'ColorSchemeProvider',
-      }),
+      generatedDocGen: await docGen('ColorSchemeProvider'),
     },
   };
 }

--- a/docs/pages/web/utilities/defaultlabelprovider.js
+++ b/docs/pages/web/utilities/defaultlabelprovider.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import { Link, Table, Text } from 'gestalt';
-import docgen, { type DocGen } from '../../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
@@ -352,9 +352,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
     props: {
-      generatedDocGen: await docgen({
-        componentName: 'DefaultLabelProvider',
-      }),
+      generatedDocGen: await docGen('DefaultLabelProvider'),
     },
   };
 }

--- a/docs/pages/web/utilities/devicetypeprovider.js
+++ b/docs/pages/web/utilities/devicetypeprovider.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
-import docgen, { type DocGen } from '../../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
@@ -56,9 +56,7 @@ The example shows a component with different desktop and mobile UIs.`}
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
     props: {
-      generatedDocGen: await docgen({
-        componentName: 'DeviceTypeProvider',
-      }),
+      generatedDocGen: await docGen('DeviceTypeProvider'),
     },
   };
 }

--- a/docs/pages/web/utilities/globaleventshandlerprovider.js
+++ b/docs/pages/web/utilities/globaleventshandlerprovider.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
-import docgen, { type DocGen } from '../../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
@@ -155,9 +155,7 @@ The example below demonstrates the correct use of "dangerouslyDisableOnNavigatio
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
     props: {
-      generatedDocGen: await docgen({
-        componentName: 'GlobalEventsHandlerProvider',
-      }),
+      generatedDocGen: await docGen('GlobalEventsHandlerProvider'),
     },
   };
 }

--- a/docs/pages/web/utilities/scrollboundarycontainer.js
+++ b/docs/pages/web/utilities/scrollboundarycontainer.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
@@ -114,6 +114,6 @@ The following example shows the internal ScrollBoundaryContainer in action. The 
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'ScrollBoundaryContainer' }) },
+    props: { generatedDocGen: await docGen('ScrollBoundaryContainer') },
   };
 }

--- a/docs/pages/web/video.js
+++ b/docs/pages/web/video.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -363,7 +363,7 @@ function Example () {
 }
 
 export async function getStaticProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
-  const generatedDocGen = await docgen({ componentName: 'Video' });
+  const generatedDocGen = await docGen('Video');
 
   generatedDocGen.props.ref = {
     required: false,

--- a/docs/pages/web/washanimated.js
+++ b/docs/pages/web/washanimated.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -66,6 +66,6 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'WashAnimated' }) },
+    props: { generatedDocGen: await docGen('WashAnimated') },
   };
 }

--- a/scripts/templates/lowercasecomponentname.js
+++ b/scripts/templates/lowercasecomponentname.js
@@ -1,7 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import docgen, { type DocGen } from '../../docs-components/docgen.js';
+import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -10,11 +10,7 @@ import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
 import main from '../../examples/componentname/main.js';
 
-export default function ComponentNamePage({
-  generatedDocGen,
-}: {|
-  generatedDocGen: DocGen,
-|}): Node {
+export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
       <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
@@ -51,6 +47,6 @@ export default function ComponentNamePage({
 
 export async function getServerSideProps(): Promise<{| props: {| generatedDocGen: DocGen |} |}> {
   return {
-    props: { generatedDocGen: await docgen({ componentName: 'ComponentName' }) },
+    props: { generatedDocGen: await docGen('ComponentName') },
   };
 }


### PR DESCRIPTION
This PR updates a few things that have been annoying me:
- Adds casing to `docGen` and `multipleDocGen`. This doesn't matter, but it's bugged me forever.
- Changes `multipleDocGen` to only accept `$ReadOnlyArray<string>`. We already have `docGen` to handle single components, so there's no need to complicate `multipleDocGen`'s logic.
- Changes both `docGen` and `multipleDocGen` to accept strings or arrays of strings directly, without need for the named `componentName` option arg. This eliminates unnecessary boilerplate when working with these functions. We've been working with these functions for a couple of years now without needing additional options, and any options needed in the future can be added using a second arg options object.