### PR TITLE
WIP Internal: implement system props for dataTestId

### DIFF
--- a/docs/docs-components/docgen.js
+++ b/docs/docs-components/docgen.js
@@ -23,12 +23,30 @@ export type DocGen = {|
   |},
 |};
 
+function addSystemProps(docGenArg: DocGen): DocGen {
+  return {
+    ...docGenArg,
+    props: {
+      ...docGenArg.props,
+      dataTestId: {
+        defaultValue: null,
+        required: false,
+        description:
+          'A string that is used as a data attribute `data-test-id` on the underlying element.',
+        flowType: {
+          name: 'string',
+        },
+      },
+    },
+  };
+}
+
 export type DocType = {|
   generatedDocGen: DocGen,
 |};
 
 export default function docGen(componentName: string): DocGen {
-  return metadata[componentName];
+  return addSystemProps(metadata[componentName]);
 }
 
 export function multipleDocGen(componentNames: $ReadOnlyArray<string>): {|

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -6,6 +6,7 @@ import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import Icon from './Icon.js';
 import Image from './Image.js';
 import Mask from './Mask.js';
+import { type SystemProps } from './systemProps.js';
 
 const sizes = {
   xs: 24,
@@ -16,6 +17,7 @@ const sizes = {
 };
 
 type Props = {|
+  ...SystemProps,
   /**
    * String that clients such as VoiceOver will read to describe the element. Will default to `name` prop if not provided.
    */
@@ -50,10 +52,17 @@ type Props = {|
  *
  */
 
-function Avatar(props: Props): Node {
+function Avatar({
+  accessibilityLabel,
+  dataTestId,
+  name,
+  outline,
+  size = 'fit',
+  src,
+  verified,
+}: Props): Node {
   const [isImageLoaded, setIsImageLoaded] = useState(true);
   const { colorGray0, colorGray100 } = useColorScheme();
-  const { accessibilityLabel, name, outline, size = 'fit', src, verified } = props;
   const width = size === 'fit' ? '100%' : sizes[size];
   const height = size === 'fit' ? '' : sizes[size];
 
@@ -74,7 +83,7 @@ function Avatar(props: Props): Node {
       height={height}
       position="relative"
       rounding="circle"
-      data-test-id="gestalt-avatar-svg"
+      data-test-id={dataTestId ?? 'gestalt-avatar-svg'}
     >
       {src && isImageLoaded ? (
         <Mask rounding="circle" wash>

--- a/packages/gestalt/src/systemProps.js
+++ b/packages/gestalt/src/systemProps.js
@@ -1,0 +1,5 @@
+// @flow strict
+
+export type SystemProps = {|
+  dataTestId?: string,
+|};


### PR DESCRIPTION
*** THIS IS A WIP PROPOSAL AND SHOULD NOT BE MERGED UNTIL `dataTestId` HAS BEEN IMPLEMENTED IN EVERY COMPONENT ***

*****

## The Problem

In order to fully support needs across Pinterest, but particularly M10n, all Gestalt components and sub-components need to implement dataTestId. In addition, we need to enable easier experimentation on Gestalt components that can be controlled at the callsite. [ExperimentProvider](https://github.com/pinterest/gestalt/blob/9b2a9c38daa265d892f19696ad84bcb1a3f1eac6/packages/gestalt/src/contexts/ExperimentProvider.js#L4) only provides global experiment control, and all attempts to make it more callsite-specific have been overly-convoluted and wonky.

## A Solution

GitHub’s design system, [Primer](https://primer.style/react/), has the concept of “[system props](https://primer.style/react/system-props)”. These are common props that are applied to all components by default. While Primer uses these for styles — something I think we should not do, as it would open the floodgates to custom components — I think we could apply the same concept to both dataTestId and experiments.

### dataTestId 

We need to implement this prop on every component and sub-component. While the implementation will be specific to each component (i.e. which HTML element this is assigned to under the hood), the docs can be mostly generic.

### Experiments

[I’ve kicked around some ideas related to this](https://paper.dropbox.com/doc/Experimentation-in-Gestalt-2.0--B6_04hMIWcWPwY851WD661cRAg-RNTRK1YN01g3yUOiKy8ld) (and [Jack Hsu](mailto:jackhsu@pinterest.com) has had some good ideas as well), but haven’t implemented anything. The tl;dr of that doc is that I think we should bring back per-component experiment props, but a single prop that has a similar “register the experiment name” approach as ExperimentProvider. This prop wouldn’t need to be created for each experiment; it would exist already (on every component and sub-component), and can be used where needed for an arbitrary number of simultaneous experiments.

This idea isn’t ready for primetime yet, but it would build on the same system props approach.

## Implementation

As noted above, we will need to manually implement dataTestId in each component. We will also need to manually add any relevant code for each experiment to be run in the future. What the system props approach would do is provide a common external interface for these props.

This PR prototypes a way of adding these shared system props to every component and sub-component automatically as part of the `docGen` process. This reduces the boilerplate needed for props documentation and ensures that every component uses the same interface for these props.