### PR TITLE
Callout: Support Text Type in Callout

### DIFF
--- a/docs/examples/callout/variantMessage.js
+++ b/docs/examples/callout/variantMessage.js
@@ -23,16 +23,8 @@ export default function ResponsiveExample(): Node {
             </Text>
           }
           primaryAction={{
-            accessibilityLabel: 'Get started: Verified Merchant Program',
-            href: 'https://pinterest.com',
-            label: 'Get started',
-            target: 'blank',
-          }}
-          secondaryAction={{
-            accessibilityLabel: 'Learn more: Verified Merchant Program',
-            href: 'https://pinterest.com',
-            label: 'Learn more',
-            target: 'blank',
+            accessibilityLabel: 'Manually verify tag',
+            label: 'Verify Tag',
           }}
           title="We have not yet detected your tag"
           type="info"

--- a/docs/examples/callout/variantMessage.js
+++ b/docs/examples/callout/variantMessage.js
@@ -14,19 +14,23 @@ export default function ResponsiveExample(): Node {
           iconAccessibilityLabel="Info"
           message={
             <Text inline>
-              It may take up to 10 minutes to automatically detect a newly installed tag. If you
-              would like to manually verify your tag, please click the{' '}
+              You have invited{' '}
               <Text inline weight="bold">
-                Verify Tag
+                Leaf Media Agency
               </Text>{' '}
-              button.
+              to your business hierarchy. Once they accept, you will be able to manage their
+              business account.
             </Text>
           }
           primaryAction={{
-            accessibilityLabel: 'Manually verify tag',
-            label: 'Verify Tag',
+            accessibilityLabel: 'Resend invite',
+            label: 'Cancel invite',
           }}
-          title="We have not yet detected your tag"
+          secondaryAction={{
+            accessibilityLabel: 'Cancel invite',
+            label: 'Cancel invite',
+          }}
+          title="You've sent an invite"
           type="info"
         />
       </Box>

--- a/docs/examples/callout/variantMessage.js
+++ b/docs/examples/callout/variantMessage.js
@@ -1,0 +1,43 @@
+// @flow strict
+import React, { type Node } from 'react';
+import { Box, Callout, Flex, Text } from 'gestalt';
+
+export default function ResponsiveExample(): Node {
+  return (
+    <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+      <Box paddingY={8} paddingX={8}>
+        <Callout
+          dismissButton={{
+            accessibilityLabel: 'Dismiss this banner',
+            onDismiss: () => {},
+          }}
+          iconAccessibilityLabel="Info"
+          message={
+            <Text inline>
+              It may take up to 10 minutes to automatically detect a newly installed tag. If you
+              would like to manually verify your tag, please click the{' '}
+              <Text inline weight="bold">
+                Verify Tag
+              </Text>{' '}
+              button.
+            </Text>
+          }
+          primaryAction={{
+            accessibilityLabel: 'Get started: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Get started',
+            target: 'blank',
+          }}
+          secondaryAction={{
+            accessibilityLabel: 'Learn more: Verified Merchant Program',
+            href: 'https://pinterest.com',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="We have not yet detected your tag"
+          type="info"
+        />
+      </Box>
+    </Flex>
+  );
+}

--- a/docs/examples/callout/variantMessage.js
+++ b/docs/examples/callout/variantMessage.js
@@ -24,7 +24,7 @@ export default function ResponsiveExample(): Node {
           }
           primaryAction={{
             accessibilityLabel: 'Resend invite',
-            label: 'Cancel invite',
+            label: 'Resend invite',
           }}
           secondaryAction={{
             accessibilityLabel: 'Cancel invite',

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -19,6 +19,7 @@ import placeAtTop from '../../examples/callout/placeAtTop.js';
 import productMessages from '../../examples/callout/productMessages.js';
 import variantError from '../../examples/callout/variantError.js';
 import variantInfo from '../../examples/callout/variantInfo.js';
+import variantMessage from '../../examples/callout/variantMessage.js';
 import variantRecommendation from '../../examples/callout/variantRecommendation.js';
 import variantSuccess from '../../examples/callout/variantSuccess.js';
 import variantWarning from '../../examples/callout/variantWarning.js';
@@ -309,6 +310,24 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           />
         </MainSection.Subsection>
       </MainSection>
+
+      <MainSection.Subsection
+        description={`
+The \`message\` prop accepts either a string or [Text](/web/text). Use a string for simple messages without any visual style. Callout will handle the message style and adherence to design guidelines. If a message with more complex style is required, such as bold text or inline links, use Text to wrap your message with any additional Text or Link usages contained within.
+`}
+        title="Message"
+      >
+        <MainSection.Card
+          cardSize="lg"
+          sandpackExample={
+            <SandpackExample
+              name="Callout 'message' prop example"
+              code={variantMessage}
+              layout="column"
+            />
+          }
+        />
+      </MainSection.Subsection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
 

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node } from 'react';
+import { Children, type Element, type Node } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
 import Button from './Button.js';
@@ -41,9 +41,9 @@ type Props = {|
   /**
    * Main content of Callout. Content should be [localized](https://gestalt.pinterest.systems/web/callout#Localization).
    *
-   * See [Best Practices](https://gestalt.pinterest.systems/web/callout#Best-practices) for more info.
+   * See the [Message variant](https://gestalt.pinterest.systems/web/callout#Message) to learn more. Refer to the [Best Practices](https://gestalt.pinterest.systems/web/callout#Best-practices) for content guidelines.
    */
-  message: string,
+  message: string | Element<typeof Text>,
   /**
    * Main action for users to take on Callout. If `href` is supplied, the action will serve as a link. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
    * If no `href` is supplied, the action will be a button.
@@ -242,7 +242,13 @@ export default function Callout({
                   </Text>
                 </Box>
               )}
-              <Text align={responsiveMinWidth === 'xs' ? 'center' : undefined}>{message}</Text>
+              {typeof message === 'string' ? (
+                <Text align={responsiveMinWidth === 'xs' ? 'center' : undefined}>{message}</Text>
+              ) : null}
+              {typeof message !== 'string' &&
+              Children.only<Element<typeof Text>>(message).type.displayName === 'Text'
+                ? message
+                : null}
             </Box>
           </Box>
         </Box>

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -41,7 +41,7 @@ type Props = {|
   /**
    * Main content of Callout. Content should be [localized](https://gestalt.pinterest.systems/web/callout#Localization).
    *
-   * See the [Message variant](https://gestalt.pinterest.systems/web/callout#Message) to learn more. Refer to the [Best Practices](https://gestalt.pinterest.systems/web/callout#Best-practices) for content guidelines.
+   * See the [message variant](https://gestalt.pinterest.systems/web/callout#Message) to learn more. Refer to the [Best Practices](https://gestalt.pinterest.systems/web/callout#Best-practices) for content guidelines.
    */
   message: string | Element<typeof Text>,
   /**

--- a/packages/gestalt/src/Callout.test.js
+++ b/packages/gestalt/src/Callout.test.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { create } from 'react-test-renderer';
 import Callout from './Callout.js';
+import Text from './Text.js';
 
 describe('<Callout />', () => {
   test('Error Callout', () => {
@@ -104,6 +105,39 @@ describe('<Callout />', () => {
         }}
         type="info"
         title="A Title"
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('callout with rich text message', () => {
+    const tree = create(
+      <Callout
+        dismissButton={{
+          accessibilityLabel: 'Dismiss this banner',
+          onDismiss: () => {},
+        }}
+        iconAccessibilityLabel="Info"
+        message={
+          <Text inline>
+            You have invited{' '}
+            <Text inline weight="bold">
+              Leaf Media Agency
+            </Text>{' '}
+            to your business hierarchy. Once they accept, you will be able to manage their business
+            account.
+          </Text>
+        }
+        primaryAction={{
+          accessibilityLabel: 'Resend invite',
+          label: 'Resend invite',
+        }}
+        secondaryAction={{
+          accessibilityLabel: 'Cancel invite',
+          label: 'Cancel invite',
+        }}
+        title="You've sent an invite"
+        type="info"
       />,
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/gestalt/src/__snapshots__/Callout.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Callout.test.js.snap
@@ -165,6 +165,189 @@ exports[`<Callout /> Warning Callout 1`] = `
 </div>
 `;
 
+exports[`<Callout /> callout with rich text message 1`] = `
+<div
+  className="box infoWeak paddingX6 paddingY6 relative rounding4 smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+>
+  <div
+    className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className="box justifyCenter marginBottom4 smDirectionRow smMarginBottom0 smPaddingY3 xsDirectionColumn xsDisplayFlex xsItemsCenter"
+    >
+      <div
+        className="box marginBottom4 marginTop0 smMarginBottomAuto smMarginTopAuto"
+      >
+        <svg
+          aria-hidden={null}
+          aria-label="Info"
+          className="icon infoIcon iconBlock"
+          height={32}
+          role="img"
+          viewBox="0 0 24 24"
+          width={32}
+        >
+          <path
+            d="test-file-stub"
+          />
+        </svg>
+      </div>
+      <div
+        className="box marginBottomAuto marginTopAuto paddingX6"
+        style={
+          Object {
+            "maxWidth": 648,
+          }
+        }
+      >
+        <div
+          className="box marginBottomAuto marginTopAuto smDisplayBlock xsDirectionColumn xsDisplayFlex xsItemsCenter"
+        >
+          <div
+            className="box marginBottom2"
+          >
+            <div
+              className="Text fontSize400 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              You've sent an invite
+            </div>
+          </div>
+          <span
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
+          >
+            You have invited
+             
+            <span
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Leaf Media Agency
+            </span>
+             
+            to your business hierarchy. Once they accept, you will be able to manage their business account.
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="box marginStartAuto smDisplayFlex smMarginEnd4 smPaddingY3"
+    >
+      <div
+        className="box justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock xsItemsCenter"
+      >
+        <button
+          aria-label="Cancel invite"
+          className="button hideOutline block accessibilityOutline parentButton"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <div
+            className="button hideOutline block accessibilityOutline tapTransition lg transparent enabled childrenDiv"
+          >
+            <div
+              className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            >
+              Cancel invite
+            </div>
+          </div>
+        </button>
+      </div>
+      <div
+        className="box justifyCenter paddingX1 smDisplayFlex smMarginBottomAuto smMarginTopAuto xsDisplayBlock xsItemsCenter"
+      >
+        <button
+          aria-label="Resend invite"
+          className="button hideOutline block accessibilityOutline parentButton"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <div
+            className="button hideOutline block accessibilityOutline tapTransition lg white enabled childrenDiv"
+          >
+            <div
+              className="Text fontSize300 defaultText alignCenter fontWeightSemiBold"
+            >
+              Resend invite
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    className="rtlPos"
+  >
+    <button
+      aria-label="Dismiss this banner"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="button tapTransition enabled"
+      >
+        <div
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
+            }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon defaultIcon iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<Callout /> message + title + primaryAction + dismissButton 1`] = `
 <div
   className="box infoWeak paddingX6 paddingY6 relative rounding4 smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"


### PR DESCRIPTION
Based on a slack convo with a customer.

### Summary

#### What changed?
Adding support for Rich Text Type in a Callout. message E.g. Bold, italics.

Before
<img width="799" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/77c7349c-90c1-4dea-a390-1ad6d44fad9f">

After
<img width="813" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/9550d036-68f8-4dee-90bd-58d31079c7d0">

#### Why?

Slimbanner supports a text prop for the message, but callout does not. Seems like it would be a consistency thing among the two message props. Pending design review. 

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
