### PR TITLE
Masonry: add hook to log whitespace above 2-col modules

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -38,6 +38,8 @@ type Props = {|
   // The initial data from the server side render.
   // $FlowFixMe[unclear-type]
   initialItems?: $ReadOnlyArray<?Object>,
+  // Whether or not to log whitespace.
+  logWhitespace?: boolean,
   // Whether or not to require tests to trigger fetch completion manually.
   manualFetch?: boolean,
   // External measurement store.
@@ -311,6 +313,7 @@ export default class MasonryContainer extends Component<Props, State> {
       externalCache,
       finiteLength,
       flexible,
+      logWhitespace,
       measurementStore,
       noScroll,
       offsetTop,
@@ -396,6 +399,12 @@ export default class MasonryContainer extends Component<Props, State> {
         {mountGrid && (
           <MasonryComponent
             _batchPaints={batchPaints}
+            _logTwoColWhitespace={
+              logWhitespace
+                ? // eslint-disable-next-line no-console
+                  (whitespace) => console.log('Whitespace above 2-col module:', whitespace)
+                : undefined
+            }
             _twoColItems={twoColItems}
             columnWidth={columnWidth}
             gutterWidth={0}

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -60,6 +60,7 @@ export default function TestPage({
   randomNumberSeeds: $ReadOnlyArray<number>,
 |}): Node {
   const router = useRouter();
+  // These should match playwright/masonry/utils/getServerURL.mjs
   const {
     batchPaints,
     constrained,
@@ -67,6 +68,7 @@ export default function TestPage({
     externalCache,
     finiteLength,
     flexible,
+    logWhitespace,
     manualFetch,
     noScroll,
     offsetTop,
@@ -109,6 +111,7 @@ export default function TestPage({
               ? generateRealisticExampleItems({ name: 'InitialPin', pinHeightsSample })
               : generateExampleItems({ name: 'InitialPin' })
           }
+          logWhitespace={booleanize(logWhitespace)}
           manualFetch={booleanize(manualFetch)}
           MasonryComponent={Masonry}
           measurementStore={measurementStore}

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -113,6 +113,12 @@ type Props<T> = {|
    * This is an experimental prop and may be removed in the future.
    */
   _twoColItems?: boolean,
+  /**
+   * Experimental prop to log the additional whitespace shown above two-column items.
+   *
+   * This is an experimental prop and may be removed in the future.
+   */
+  _logTwoColWhitespace?: (number) => void,
 |};
 
 type State<T> = {|
@@ -477,6 +483,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       scrollContainer,
       _batchPaints,
       _twoColItems,
+      _logTwoColWhitespace,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
     const { positionStore } = this;
@@ -507,6 +514,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
         gutter,
         heightsCache: this.heightsStore,
         justify: layout === 'basicCentered' ? 'center' : 'start',
+        logWhitespace: _logTwoColWhitespace,
         minCols,
         rawItemCount: items.length,
         width,

--- a/playwright/masonry/utils/getServerURL.mjs
+++ b/playwright/masonry/utils/getServerURL.mjs
@@ -10,6 +10,7 @@ const normalizeValue = (val /*: boolean | number */) => {
   return String(val);
 };
 
+// These are used in docs/pages/integration-test/masonry.js
 /*::
 type Options = ?{|
   batchPaints?: boolean,
@@ -18,6 +19,7 @@ type Options = ?{|
   externalCache?: boolean,
   finiteLength?: boolean,
   flexible?: boolean,
+  logWhitespace?: boolean,
   manualFetch?: boolean,
   noScroll?: boolean,
   offsetTop?: number,


### PR DESCRIPTION
In preparation for the upcoming 2-col module experiment, we need to know how much whitespace is present above 2-col modules. This will inform the effort we put into implementing pin leveling, either for the initial launch of the experiment or at all.

This PR adds hook into the 2-col layout function to log this whitespace, via an experimental prop. We can hook this up to Statsboard in Pinboard to log real-world values. The PR also updates the existing integration test route to test out this logging.

![Screen Shot 2023-06-28 at 5 35 56 PM](https://github.com/pinterest/gestalt/assets/12059539/df4b1f39-01d5-4cdf-9e37-ff59a98dcfaa)
