### PR TITLE
Masonry: remove unused `heightAdjustment` field

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -77,7 +77,6 @@ type Props<T> = {|
     +data: T,
     +itemIdx: number,
     +isMeasuring: boolean,
-    +heightAdjustment?: number,
   |}) => Node,
   /**
    * A function that returns a DOM node that Masonry uses for scroll event subscription. This DOM node is intended to be the most immediate ancestor of Masonry in the DOM that will have a scroll bar; in most cases this will be the `window` itself, although sometimes Masonry is used inside containers that have `overflow: auto`. `scrollContainer` is optional, although it is required for features such as `virtualize` and `loadItems`.


### PR DESCRIPTION
We're not using this field yet and it's breaking types in Pinboard