### PR TITLE
WIP Masonry: Add support for pin leveling

### DIFF
--- a/docs/integration-test-helpers/masonry/ExampleGridItem.js
+++ b/docs/integration-test-helpers/masonry/ExampleGridItem.js
@@ -5,10 +5,16 @@ type Props = {|
   // $FlowFixMe[unclear-type]
   data: Object,
   expanded: boolean,
+  heightAdjustment?: number,
   itemIdx: number,
 |};
 
-export default function ExampleGridItem({ data = {}, itemIdx, expanded }: Props): Element<'div'> {
+export default function ExampleGridItem({
+  data = {},
+  heightAdjustment,
+  itemIdx,
+  expanded,
+}: Props): Element<'div'> {
   const [counter, setCounter] = useState<number>(0);
 
   useEffect(() => {
@@ -22,6 +28,16 @@ export default function ExampleGridItem({ data = {}, itemIdx, expanded }: Props)
 
   const isTwoColItem = data.columnSpan === 2;
 
+  let itemHeight = data.height;
+  if (heightAdjustment) {
+    itemHeight += heightAdjustment;
+  }
+  if (expanded) {
+    itemHeight += 100;
+  }
+
+  const borderHeight = 1;
+
   return (
     <div
       style={{
@@ -30,14 +46,15 @@ export default function ExampleGridItem({ data = {}, itemIdx, expanded }: Props)
     >
       <div
         style={{
-          height: expanded ? data.height + 100 : data.height,
-          border: '1px solid #ff0000',
+          height: itemHeight,
+          border: `${borderHeight}px solid ${heightAdjustment ? 'red' : 'black'}`,
           background: isTwoColItem ? 'black' : data.color,
           color: isTwoColItem ? 'white' : undefined,
         }}
       >
         <div>
-          {data.name} • {data.height}px
+          {data.name} • {data.height + borderHeight * 2}px
+          {heightAdjustment ? ` • heightAdjustment: ${heightAdjustment}` : ''}
           {isTwoColItem ? ` • columnSpan: ${data.columnSpan}` : ''}
         </div>
         <div>Slot Index: {itemIdx}</div>

--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -299,9 +299,16 @@ export default class MasonryContainer extends Component<Props, State> {
 
   renderItem: $ElementType<React$ElementConfig<typeof Masonry>, 'renderItem'> =
     // $FlowFixMe[missing-local-annot]
-    ({ data, itemIdx }) => {
+    ({ data, itemIdx, heightAdjustment }) => {
       const { expanded } = this.state;
-      return <ExampleGridItem expanded={expanded} data={data} itemIdx={itemIdx} />;
+      return (
+        <ExampleGridItem
+          data={data}
+          expanded={expanded}
+          heightAdjustment={heightAdjustment}
+          itemIdx={itemIdx}
+        />
+      );
     };
 
   render(): Element<'div'> {

--- a/packages/gestalt/src/Masonry/ItemAttributeStore.js
+++ b/packages/gestalt/src/Masonry/ItemAttributeStore.js
@@ -1,0 +1,41 @@
+// @flow strict
+import { type ItemAttributes, type ItemCache } from './types.js';
+
+export default class MeasurementStore<T: { ... } | $ReadOnlyArray<mixed>> implements ItemCache<T> {
+  map: WeakMap<T, ItemAttributes> = new WeakMap();
+
+  get(key: T): ?ItemAttributes {
+    return this.map.get(key);
+  }
+
+  getAttribute(key: T, attribute: string): $Values<ItemAttributes> {
+    const value = this.map.get(key);
+    return value ? value[attribute] : undefined;
+  }
+
+  has(key: T): boolean {
+    return this.map.has(key);
+  }
+
+  hasAttribute(key: T, attribute: string): boolean {
+    const value = this.map.get(key);
+    return value ? Boolean(value[attribute]) : false;
+  }
+
+  set(key: T, value: ItemAttributes): void {
+    this.map.set(key, value);
+  }
+
+  setAttribute(key: T, attribute: string, attributeValue: $Values<ItemAttributes>): void {
+    const value = this.map.get(key);
+    const newValue = { ...value };
+    // $FlowFixMe[prop-missing]
+    newValue[attribute] = attributeValue;
+    // $FlowFixMe[prop-missing]
+    this.map.set(key, newValue);
+  }
+
+  reset(): void {
+    this.map = new WeakMap();
+  }
+}

--- a/packages/gestalt/src/Masonry/types.js
+++ b/packages/gestalt/src/Masonry/types.js
@@ -1,5 +1,4 @@
 // @flow strict
-
 export type Position = {|
   top: number,
   left: number,
@@ -12,3 +11,18 @@ export type NodeData<T> = {|
   heights: $ReadOnlyArray<number>,
   positions: $ReadOnlyArray<{| item: T, position: Position |}>,
 |};
+
+export type ItemAttributes = {|
+  position: Position,
+  heightAdjustment?: number,
+|};
+
+export interface ItemCache<K> {
+  get(key: K): ?ItemAttributes;
+  getAttribute(key: K, attribute: string): $Values<ItemAttributes>;
+  has(key: K): boolean;
+  hasAttribute(key: K, attribute: string): boolean;
+  set(key: K, value: ItemAttributes): void;
+  setAttribute(key: K, attribute: string, attributeValue: $Values<ItemAttributes>): void;
+  reset(): void;
+}


### PR DESCRIPTION
After talking through pin leveling with @jportella93, I was inspired to take a crack at it. It's hard. 😅 

This PR does a few things:
- Combines the existing positionStore and a new heightAdjustmentStore into a single itemAttributeStore. We should probably fold the measurementStore into this eventually.
- Attempts to identify the two items just above the 2-col module and passes along the necessary heightAdjustment based on the additionalWhitespace
- Adjusts the layout position of the 2-col module to take up the additional whitespace

But there are problems. I'm not sure if this will be technically possible given the current constraint that item heights cannot change after the first render. This is leads to overlapping items. There are a couple of possible solutions I see to this:
- Introduce some way for items to communicate changes in their height to Masonry. This feels gross.
- Only lay out a 2-col module in a large enough batch of items that it includes the items just above the module. We would adjust the layout of the target items _and_ update their heights in the measurementStore, and optimistically assume that the item height was adjusted correctly in userland. This feels brittle.

I don't really like either of these solutions. 😕 But I'm also not sure what would be a better approach.

_Overlapping pins, I think because they're still honoring their original heights_
![Screen Shot 2023-06-30 at 4 42 45 PM](https://github.com/pinterest/gestalt/assets/12059539/008be868-b539-4dcf-ad3b-732ced09224c)

_the whitespace here was so large that an additional pin could fit in it, leading to targeting the wrong item_
![Screen Shot 2023-06-30 at 4 42 37 PM](https://github.com/pinterest/gestalt/assets/12059539/eed4be8c-1e9d-4d38-9045-5b05d85c8d9e)