### PR TITLE
Box: add support for `<p>` in `as`

### DIFF
--- a/docs/examples/box/as.js
+++ b/docs/examples/box/as.js
@@ -16,31 +16,42 @@ export default function Example(): Node {
           borderStyle="sm"
         >
           <Text color="light" weight="bold">
-            Top Nav Menu: as=&quot;nav&quot;
+            Top Nav Menu: <code>as=&quot;nav&quot;</code>
           </Text>
         </Box>
         <Box column={6} display="inlineBlock" borderStyle="sm">
           <Box width="100%" padding={2}>
-            <Text>HTML output:</Text>
-            <Text>{'<nav>Menu</nav>'}</Text>
+            <Text>
+              HTML output:
+              <br />
+              <code>{'<nav>Menu</nav>'}</code>
+            </Text>
           </Box>
         </Box>
       </Flex>
+
       <Flex height="100%" width="100%">
         <Box as="article" column={6} color="successBase" width="100%" padding={2} borderStyle="sm">
           <Heading color="light" size="500">
             Article 1
           </Heading>
           <Text color="light" weight="bold">
-            Article: as=&quot;article&quot;
+            Article: <code>as=&quot;article&quot;</code>
           </Text>
         </Box>
         <Box column={6} display="inlineBlock" borderStyle="sm">
           <Box width="100%" padding={2}>
-            <Text>HTML output:</Text>
-            <Text>{'<article>'}</Text>
-            <Text>{'<h2>Article 1</h2>'}</Text>
-            <Text>{'</article>'}</Text>
+            <Text>
+              HTML output:
+              <br />
+              <code>
+                {'<article>'}
+                <br />
+                {'  <h2>Article 1</h2>'}
+                <br />
+                {'</article>'}
+              </code>
+            </Text>
           </Box>
         </Box>
       </Flex>

--- a/packages/gestalt/src/Box.js
+++ b/packages/gestalt/src/Box.js
@@ -133,6 +133,7 @@ type Props = {
     | 'header'
     | 'main'
     | 'nav'
+    | 'p'
     | 'section'
     | 'summary',
   /**

--- a/packages/gestalt/src/boxTypes.js
+++ b/packages/gestalt/src/boxTypes.js
@@ -25,6 +25,7 @@ export type As =
   | 'header'
   | 'main'
   | 'nav'
+  | 'p'
   | 'section'
   | 'summary';
 export type Bottom = boolean;


### PR DESCRIPTION
The [`<p>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) is useful for semantic text. We should support it!