### PR TITLE
Docs: add Component Status pages for iOS and Android

### DIFF
--- a/docs/docs-components/data/componentStatusMessaging.js
+++ b/docs/docs-components/data/componentStatusMessaging.js
@@ -56,6 +56,14 @@ export const COMPONENT_STATUS_MESSAGING = Object.freeze({
     notAvailable: 'Component does not respond to changing viewport sizes in web and mobile web.',
     planned: 'Component is slotted to be built responsively for web and mobile web.',
   },
+  status: {
+    shortTitle: 'Status',
+    title: 'Component Status',
+    ready: 'Component is ready for use.',
+    partial: 'Component is ready for use, however some features may not be available.',
+    notAvailable: 'Component is not currently available.',
+    planned: 'Component is slotted to be built.',
+  },
 });
 
 export const COMPONENT_A11Y_STATUS_MESSAGING = Object.freeze({

--- a/docs/docs-components/siteIndex.js
+++ b/docs/docs-components/siteIndex.js
@@ -46,6 +46,7 @@ const siteIndex: $ReadOnlyArray<siteIndexType> = [
     sectionName: 'Android',
     pages: [
       'Overview',
+      'Component status',
       'Avatar',
       'Button',
       'ButtonGroup',
@@ -67,6 +68,7 @@ const siteIndex: $ReadOnlyArray<siteIndexType> = [
     sectionName: 'iOS',
     pages: [
       'Overview',
+      'Component status',
       'Avatar',
       'Button',
       {

--- a/docs/pages/android/component_status.js
+++ b/docs/pages/android/component_status.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Fragment, type Node } from 'react';
+import { type Node } from 'react';
 import { Badge, Box, Column, Flex, Link, Table, Text } from 'gestalt';
 import componentData from '../../docs-components/data/components.js';
 import {
@@ -15,21 +15,21 @@ function DeprecatedStatus() {
   return <StatusData text="Deprecated" status="deprecated" />;
 }
 
-const webComponentData = getByPlatform(componentData, { platform: 'web' });
-const sortedComponentList = [...webComponentData].sort(({ name: aName }, { name: bName }) => {
+const androidComponentData = getByPlatform(componentData, { platform: 'android' });
+const sortedComponentList = [...androidComponentData].sort(({ name: aName }, { name: bName }) => {
   if (aName < bName) return -1;
   if (aName > bName) return 1;
   return 0;
 });
 
-const statusFields = ['figmaStatus', 'documentation', 'responsive', 'mobileAdaptive'];
+const statusFields = ['figmaStatus', 'documentation', 'status'];
 
 export default function ComponentStatus(): Node {
   return (
-    <Page title="Web component status" hideSideNav hideEditLink>
+    <Page title="Android component status" hideSideNav hideEditLink>
       <PageHeader
-        name="Web component status"
-        description="A detailed synopsis of our web components and their implementation status."
+        name="Android component status"
+        description="A detailed synopsis of our Android components and their implementation status."
         type="guidelines"
       />
       <Flex direction="column" gap={12}>
@@ -94,7 +94,8 @@ export default function ComponentStatus(): Node {
                     <Text size="200" inline>
                       <Link
                         href={
-                          path ?? `/web/${name.replace(/ /g, '_').replace(/'/g, '').toLowerCase()}`
+                          path ??
+                          `/android/${name.replace(/ /g, '_').replace(/'/g, '').toLowerCase()}`
                         }
                         display="inlineBlock"
                       >

--- a/docs/pages/ios/component_status.js
+++ b/docs/pages/ios/component_status.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Fragment, type Node } from 'react';
+import { type Node } from 'react';
 import { Badge, Box, Column, Flex, Link, Table, Text } from 'gestalt';
 import componentData from '../../docs-components/data/components.js';
 import {
@@ -15,21 +15,21 @@ function DeprecatedStatus() {
   return <StatusData text="Deprecated" status="deprecated" />;
 }
 
-const webComponentData = getByPlatform(componentData, { platform: 'web' });
-const sortedComponentList = [...webComponentData].sort(({ name: aName }, { name: bName }) => {
+const iosComponentData = getByPlatform(componentData, { platform: 'ios' });
+const sortedComponentList = [...iosComponentData].sort(({ name: aName }, { name: bName }) => {
   if (aName < bName) return -1;
   if (aName > bName) return 1;
   return 0;
 });
 
-const statusFields = ['figmaStatus', 'documentation', 'responsive', 'mobileAdaptive'];
+const statusFields = ['figmaStatus', 'documentation', 'status'];
 
 export default function ComponentStatus(): Node {
   return (
-    <Page title="Web component status" hideSideNav hideEditLink>
+    <Page title="iOS component status" hideSideNav hideEditLink>
       <PageHeader
-        name="Web component status"
-        description="A detailed synopsis of our web components and their implementation status."
+        name="iOS component status"
+        description="A detailed synopsis of our iOS components and their implementation status."
         type="guidelines"
       />
       <Flex direction="column" gap={12}>
@@ -94,7 +94,7 @@ export default function ComponentStatus(): Node {
                     <Text size="200" inline>
                       <Link
                         href={
-                          path ?? `/web/${name.replace(/ /g, '_').replace(/'/g, '').toLowerCase()}`
+                          path ?? `/ios/${name.replace(/ /g, '_').replace(/'/g, '').toLowerCase()}`
                         }
                         display="inlineBlock"
                       >

--- a/docs/pages/web/component_status.js
+++ b/docs/pages/web/component_status.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Fragment, type Node } from 'react';
+import { type Node } from 'react';
 import { Badge, Box, Column, Flex, Link, Table, Text } from 'gestalt';
 import componentData from '../../docs-components/data/components.js';
 import {

--- a/playwright/accessibility/android__component_status.spec.mjs
+++ b/playwright/accessibility/android__component_status.spec.mjs
@@ -2,7 +2,7 @@
 import { test } from '@playwright/test';
 import expectAccessiblePage from './expectAccessiblePage.mjs';
 
-test('Web component status check', async ({ page }) => {
-  await page.goto('/web/component_status');
+test('Android component status check', async ({ page }) => {
+  await page.goto('/android/component_status');
   await expectAccessiblePage({ page });
 });

--- a/playwright/accessibility/ios__component_status.spec.mjs
+++ b/playwright/accessibility/ios__component_status.spec.mjs
@@ -2,7 +2,7 @@
 import { test } from '@playwright/test';
 import expectAccessiblePage from './expectAccessiblePage.mjs';
 
-test('Web component status check', async ({ page }) => {
-  await page.goto('/web/component_status');
+test('iOS component status check', async ({ page }) => {
+  await page.goto('/ios/component_status');
   await expectAccessiblePage({ page });
 });


### PR DESCRIPTION
Since [`/web/component_status`](https://gestalt.pinterest.systems/web/component_status) now only covers web components, we're no longer surfacing component status for iOS and Android. This PR adds Component Status pages for both platforms.

This doesn't address Figma-only components, which will need to be surfaced elsewhere. There isn't an obvious place in the docs for those components, so that will need design 👀.