### PR TITLE
Internal: clean up component data types

### DIFF
--- a/docs/docs-components/OverviewList.js
+++ b/docs/docs-components/OverviewList.js
@@ -1,11 +1,10 @@
 // @flow strict
 import { type Node } from 'react';
-import { type Category } from './data/components.js';
-import { type Platform, type PlatformData } from './data/types.js';
+import { type ComponentCategory, type Platform, type PlatformData } from './data/types.js';
 import IllustrationCard from './IllustrationCard.js';
 import IllustrationSection from './IllustrationSection.js';
 
-const getIllustrationCardColor = (category: Category, hasDarkBackground?: boolean) => {
+const getIllustrationCardColor = (category: ComponentCategory, hasDarkBackground?: boolean) => {
   const tealBackgrounds = ['Foundations'];
   const grayBackgrounds = ['Utilities', 'Building blocks'];
 

--- a/docs/docs-components/data/components.js
+++ b/docs/docs-components/data/components.js
@@ -1,5 +1,4 @@
 // @flow strict
-import { type Element } from 'react';
 import { type ComponentData } from './types.js';
 import Box from '../../graphics/building-blocks/Box.svg';
 import Column from '../../graphics/building-blocks/Column.svg';
@@ -15,7 +14,6 @@ import SheetMobile from '../../graphics/building-blocks/SheetMobile.svg';
 import Sticky from '../../graphics/building-blocks/Sticky.svg';
 import TapArea from '../../graphics/building-blocks/TapArea.svg';
 import ZIndexClasses from '../../graphics/building-blocks/ZIndexClasses.svg';
-import Accessibility from '../../graphics/foundations/accessibility.svg';
 import ActivationCard from '../../graphics/general/ActivationCard.svg';
 import Avatar from '../../graphics/general/Avatar.svg';
 import AvatarGroup from '../../graphics/general/AvatarGroup.svg';
@@ -74,66 +72,6 @@ import HookFocusVisible from '../../graphics/utilities/hook-focus-visible.svg';
 import HookReducedMotion from '../../graphics/utilities/hook-reduced-motion.svg';
 import ProviderColorScheme from '../../graphics/utilities/provider-color-scheme.svg';
 import ProviderHandlers from '../../graphics/utilities/provider-global-events-handler.svg';
-
-export type Category =
-  | 'Actions'
-  | 'Avatars'
-  | 'Building blocks'
-  | 'Controls'
-  | 'Data'
-  | 'Fields and forms'
-  | 'Foundations'
-  | 'Help and guidance'
-  | 'Indicators'
-  | 'Loading'
-  | 'Messaging'
-  | 'Navigation'
-  | 'Overlays'
-  | 'Pilot'
-  | 'Pins and imagery'
-  | 'Structure'
-  | 'Team support'
-  | 'Text'
-  | 'Utilities'
-  | null;
-
-type StatusType = 'notAvailable' | 'partial' | 'planned' | 'ready';
-
-export type AccessibleStatus = {|
-  a11yComprehension: ?StatusType,
-  a11yNavigation: ?StatusType,
-  a11yScreenreader: ?StatusType,
-  a11yVisual: ?StatusType,
-  summary: ?StatusType,
-|};
-
-type PlatformStatus = {|
-  accessible: AccessibleStatus,
-  badge: null | 'New' | 'Pilot' | 'Experimental',
-  deprecated?: boolean,
-  documentation: StatusType,
-  figma: ?StatusType,
-  figmaOnly?: boolean,
-|};
-
-export type ListItemType = {|
-  alias?: $ReadOnlyArray<string>,
-  android?: PlatformStatus,
-  category: Category,
-  description: string,
-  hasDarkBackground?: boolean,
-  ios?: PlatformStatus,
-  name: string,
-  path?: string,
-  previouslyNamed?: $ReadOnlyArray<string>,
-  status?: {|
-    ...PlatformStatus,
-    android: StatusType,
-    ios: StatusType,
-    responsive: StatusType,
-  |}, // web status
-  svg: Element<typeof Accessibility>,
-|};
 
 const componentData: $ReadOnlyArray<ComponentData> = [
   {
@@ -359,7 +297,6 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         category: [],
         status: {
           documentation: 'notAvailable',
-          figmaOnly: true,
           status: 'ready',
         },
       },
@@ -818,7 +755,6 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         status: {
           badge: 'Pilot',
           documentation: 'notAvailable',
-          figmaOnly: true,
           status: 'ready',
         },
       },
@@ -1496,7 +1432,6 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         category: [],
         status: {
           documentation: 'notAvailable',
-          figmaOnly: true,
           status: 'ready',
         },
       },
@@ -1595,7 +1530,6 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         category: [],
         status: {
           documentation: 'notAvailable',
-          figmaOnly: true,
           status: 'ready',
         },
       },

--- a/docs/docs-components/data/types.js
+++ b/docs/docs-components/data/types.js
@@ -15,10 +15,6 @@ export type DesignOverview = {|
 
 export type StatusType = 'notAvailable' | 'partial' | 'planned' | 'ready';
 
-/**
- * All components should be in a single list. That list can be filtered by category/platform/etc where needed.
- */
-
 export type ComponentAccessibility = {|
   a11yComprehension?: StatusType,
   a11yNavigation?: StatusType,
@@ -58,7 +54,6 @@ export type ComponentStatus = {|
   accessible?: ComponentAccessibility,
   badge?: 'New' | 'Pilot' | 'Experimental',
   documentation: StatusType,
-  figmaOnly?: boolean,
   figmaStatus?: StatusType,
   mobileAdaptive?: StatusType,
   responsive?: StatusType,

--- a/docs/docs-components/data/utils/test-fixtures.js
+++ b/docs/docs-components/data/utils/test-fixtures.js
@@ -121,7 +121,6 @@ const mockComponentList: $ReadOnlyArray<ComponentData> = [
         category: [],
         status: {
           documentation: 'notAvailable',
-          figmaOnly: true,
           status: 'ready',
         },
       },

--- a/docs/pages/web/component_status.js
+++ b/docs/pages/web/component_status.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Fragment, type Node } from 'react';
+import { type Node } from 'react';
 import { Badge, Box, Column, Flex, Link, Table, Text } from 'gestalt';
 import componentData from '../../docs-components/data/components.js';
 import {
@@ -86,37 +86,25 @@ export default function ComponentStatus(): Node {
           </Table.Header>
           <Table.Body>
             {sortedComponentList.map(({ name, path, status: statusObj }) => {
-              const { badge, figmaOnly, status } = statusObj;
+              const { badge, status } = statusObj;
 
               return (
                 <Table.Row key={name}>
                   <Table.Cell>
                     <Text size="200" inline>
-                      {figmaOnly ? (
-                        <Fragment>
-                          {name}
-                          {badge ? (
-                            <Box display="inlineBlock" marginStart={2}>
-                              <Badge type="info" text={badge} />
-                            </Box>
-                          ) : null}
-                        </Fragment>
-                      ) : (
-                        <Link
-                          href={
-                            path ??
-                            `/web/${name.replace(/ /g, '_').replace(/'/g, '').toLowerCase()}`
-                          }
-                          display="inlineBlock"
-                        >
-                          {name}
-                          {badge ? (
-                            <Box display="inlineBlock" marginStart={2}>
-                              <Badge type="info" text={badge} />
-                            </Box>
-                          ) : null}
-                        </Link>
-                      )}
+                      <Link
+                        href={
+                          path ?? `/web/${name.replace(/ /g, '_').replace(/'/g, '').toLowerCase()}`
+                        }
+                        display="inlineBlock"
+                      >
+                        {name}
+                        {badge ? (
+                          <Box display="inlineBlock" marginStart={2}>
+                            <Badge type="info" text={badge} />
+                          </Box>
+                        ) : null}
+                      </Link>
                     </Text>
                   </Table.Cell>
                   {statusFields.map((item) =>


### PR DESCRIPTION
A lil bit of cleanup after #3054 

- Remove the outdated types that were exported from `/data/components.js` in favor of the current ones in `/data/types.js`
- Remove the `figmaOnly` field from platform types — this is unnecessary, as it can be derived by a component only having data for the `figma` platform