### PR TITLE
Table: Add SortableHeaderCell End align

### DIFF
--- a/docs/examples/table/sortableTableCells.js
+++ b/docs/examples/table/sortableTableCells.js
@@ -21,21 +21,41 @@ export default function SortableHeaderExample(): Node {
         <Table.Header>
           <Table.Row>
             <Table.SortableHeaderCell
-              onSortChange={() => onSortChange('name')}
-              sortOrder={sortOrder}
-              status={sortCol === 'name' ? 'active' : 'inactive'}
-            >
-              <Text weight="bold">Name</Text>
-            </Table.SortableHeaderCell>
-            <Table.SortableHeaderCell
               onSortChange={() => onSortChange('id')}
               sortOrder={sortOrder}
               status={sortCol === 'id' ? 'active' : 'inactive'}
             >
               <Text weight="bold">Id</Text>
             </Table.SortableHeaderCell>
+            <Table.SortableHeaderCell
+              onSortChange={() => onSortChange('name')}
+              sortOrder={sortOrder}
+              status={sortCol === 'name' ? 'active' : 'inactive'}
+            >
+              <Text weight="bold">Name</Text>
+            </Table.SortableHeaderCell>
+
+            <Table.SortableHeaderCell
+              align="end"
+              onSortChange={() => onSortChange('cost')}
+              sortOrder={sortOrder}
+              status={sortCol === 'cost' ? 'active' : 'inactive'}
+            >
+              <Text weight="bold">Cost</Text>
+            </Table.SortableHeaderCell>
           </Table.Row>
         </Table.Header>
+        <Table.Row>
+          <Table.Cell>
+            <Text>123</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text>Snax</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text align="end">$50</Text>
+          </Table.Cell>
+        </Table.Row>
       </Table>
     </Box>
   );

--- a/docs/pages/web/table.js
+++ b/docs/pages/web/table.js
@@ -514,7 +514,8 @@ When Table.RowExpandable is uncontrolled, use the clickable expand/collapse icon
 
         <MainSection.Subsection
           title="Sortable header cells"
-          description="Sortable header cells are clickable in an accessible way and have an icon to display whether the table is currently being sorted by that column."
+          description={`Sortable header cells are clickable in an accessible way and have an icon to display whether the table is currently being sorted by that column.  <br/>
+          Depending on the table contents, use the \`align\` property to set the alignment of the header cell and sort icon position.`}
         >
           <MainSection.Card
             cardSize="lg"

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1800,7 +1800,7 @@ interface TableHeaderCellProps {
 }
 
 interface TableSortableHeaderCellProps {
-  align?:'start'|'end';
+  align?: 'start' | 'end';
   children: Node;
   onSortChange: AbstractEventHandler<
     React.MouseEvent<HTMLTableCellElement> | React.KeyboardEvent<HTMLTableCellElement>

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1800,6 +1800,7 @@ interface TableHeaderCellProps {
 }
 
 interface TableSortableHeaderCellProps {
+  align?:'start'|'end';
   children: Node;
   onSortChange: AbstractEventHandler<
     React.MouseEvent<HTMLTableCellElement> | React.KeyboardEvent<HTMLTableCellElement>

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -7,6 +7,10 @@ import TapArea from './TapArea.js';
 
 type Props = {|
   /**
+   * Sets the alignment of the cell content
+   */
+  align?: 'start' | 'end',
+  /**
    * The content of the table cell.
    */
   children: Node,
@@ -59,6 +63,7 @@ type Props = {|
  * Use [Table.SortableHeaderCell](https://gestalt.pinterest.systems/web/table#Table.SortableHeaderCell) to define a header cell with sorting functionality in Table.
  */
 export default function TableSortableHeaderCell({
+  align = 'start',
   children,
   colSpan,
   onSortChange,
@@ -97,7 +102,14 @@ export default function TableSortableHeaderCell({
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
         >
-          <Box display="flex" alignItems="center">
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent={align}
+            dangerouslySetInlineStyle={{
+              __style: { flexDirection: align === 'end' ? 'row-reverse' : 'row' },
+            }}
+          >
             {children}
             <Box
               marginStart={2}

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -81,6 +81,11 @@ export default function TableSortableHeaderCell({
   const shouldShowIcon = status === 'active' || isHovered || isFocused;
   const visibility = shouldShowIcon ? 'visible' : 'hidden';
 
+  const iconMarginProps = {
+    marginStart: align === 'start' ? 2 : undefined,
+    marginEnd: align === 'end' ? 2 : undefined,
+  };
+
   return (
     <TableHeaderCell
       colSpan={colSpan}
@@ -112,7 +117,7 @@ export default function TableSortableHeaderCell({
           >
             {children}
             <Box
-              marginStart={2}
+              {...iconMarginProps}
               dangerouslySetInlineStyle={{
                 __style: { visibility },
               }}

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -81,11 +81,6 @@ export default function TableSortableHeaderCell({
   const shouldShowIcon = status === 'active' || isHovered || isFocused;
   const visibility = shouldShowIcon ? 'visible' : 'hidden';
 
-  const iconMarginProps = {
-    marginStart: align === 'start' ? 2 : undefined,
-    marginEnd: align === 'end' ? 2 : undefined,
-  };
-
   return (
     <TableHeaderCell
       colSpan={colSpan}
@@ -117,7 +112,8 @@ export default function TableSortableHeaderCell({
           >
             {children}
             <Box
-              {...iconMarginProps}
+              marginStart={align === 'start' ? 2 : undefined}
+              marginEnd={align === 'end' ? 2 : undefined}
               dangerouslySetInlineStyle={{
                 __style: { visibility },
               }}

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -7,7 +7,7 @@ import TapArea from './TapArea.js';
 
 type Props = {|
   /**
-   * Sets the alignment of the cell content
+   * Sets the alignment of the cell content and reverses the sort icon position.
    */
   align?: 'start' | 'end',
   /**

--- a/packages/gestalt/src/TableSortableHeaderCell.test.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.test.js
@@ -23,3 +23,14 @@ test('renders correctly when active', () => {
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('sortable cell has end align', () => {
+  const tree = renderer
+    .create(
+      <TableSortableHeaderCell align="end" sortOrder="asc" status="active" onSortChange={() => {}}>
+        column name
+      </TableSortableHeaderCell>,
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -35,6 +35,11 @@ exports[`renders correctly when active 1`] = `
     >
       <div
         className="box xsDisplayFlex xsItemsCenter"
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
       >
         column name
         <div
@@ -100,6 +105,11 @@ exports[`renders correctly when inactive 1`] = `
     >
       <div
         className="box xsDisplayFlex xsItemsCenter"
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
       >
         column name
         <div
@@ -114,6 +124,76 @@ exports[`renders correctly when inactive 1`] = `
             aria-hidden={true}
             aria-label=""
             className="icon subtleIcon iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
+          >
+            <path
+              d="test-file-stub"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</th>
+`;
+
+exports[`sortable cell has end align 1`] = `
+<th
+  className="th"
+  scope="col"
+  style={
+    Object {
+      "left": undefined,
+      "right": undefined,
+    }
+  }
+>
+  <div
+    className="box xsDisplayInlineBlock"
+  >
+    <div
+      aria-disabled={false}
+      className="hideOutline tapTransition rounding0 accessibilityOutline pointer"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        className="box justifyEnd xsDisplayFlex xsItemsCenter"
+        style={
+          Object {
+            "flexDirection": "row-reverse",
+          }
+        }
+      >
+        column name
+        <div
+          className="box marginStart2"
+          style={
+            Object {
+              "visibility": "visible",
+            }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="icon defaultIcon iconBlock"
             height={16}
             role="img"
             viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -183,7 +183,7 @@ exports[`sortable cell has end align 1`] = `
       >
         column name
         <div
-          className="box marginStart2"
+          className="box marginEnd2"
           style={
             Object {
               "visibility": "visible",


### PR DESCRIPTION
### Summary

Enabling the SortableHeaderCell to align to the right as expected. Previously, the arrow was in the way for 

#### What changed?

Adding an `align= start | end` and moving the icon when end-aligned. 

The end property also reverses the order so that the text is the last thing to appear.

#### Why?

We have a few [customers](https://jira.pinadmin.com/secure/RapidBoard.jspa?rapidView=1936&view=planning&selectedIssue=GESTALT-5154&quickFilter=12031&issueLimit=100) that ran into issues with this.

Before:
The icon would go away, and the alignment looks poor

![image](https://github.com/pinterest/gestalt/assets/5509813/1ea47579-f169-42fd-9b77-709495934699)

After:

LTR
![image](https://github.com/pinterest/gestalt/assets/5509813/8bdb7cbf-ea98-4f7b-948a-dfa804725e11)

RTL
![image](https://github.com/pinterest/gestalt/assets/5509813/1a63de78-d6fb-44be-bf63-6f21d0a13b97)


### Links

- [Jira](https://jira.pinadmin.com/secure/RapidBoard.jspa?rapidView=1936&view=planning&selectedIssue=GESTALT-5154&quickFilter=12031&issueLimit=100)
- [Figma](https://www.figma.com/file/HbBD5AgCNvupMVKBkTgdsH/Table-Enhancements?type=design&node-id=603-45434&mode=design&t=XS678P7HLRVDvyCg-0)

### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
