### PR TITLE
Button: fixes ` name` prop documentation and Flow

### DIFF
--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -117,6 +117,15 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
             ],
           },
           {
+            name: 'name',
+            type: 'string',
+            description: [
+              'The name attribute specifies the name of the <button> element.',
+
+              'The name attribute is used to reference form-data after the form has been submitted.',
+            ],
+          },
+          {
             name: 'onClick',
             type: '({ event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> }) => void',
             required: false,

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -693,7 +693,6 @@ interface CommonButtonProps {
   disabled?: boolean | undefined;
   fullWidth?: boolean | undefined;
   iconEnd?: Icons | undefined;
-  name?: string | undefined;
   onClick?: ButtonEventHandlerType | undefined;
   size?: 'sm' | 'md' | 'lg' | undefined;
   tabIndex?: -1 | 0 | undefined;
@@ -707,15 +706,17 @@ interface ButtonLinkProps extends CommonButtonProps {
 }
 
 interface ButtonButtonProps extends CommonButtonProps {
-  role?: 'button' | undefined;
-  type?: 'button' | undefined;
   accessibilityControls?: string | undefined;
   accessibilityExpanded?: boolean | undefined;
   accessibilityHaspopup?: boolean | undefined;
+  name?: string | undefined;
   selected?: boolean | undefined;
+  role?: 'button' | undefined;
+  type?: 'button' | undefined;
 }
 
 interface ButtonSubmitProps extends CommonButtonProps {
+  name?: string | undefined;
   role: 'button';
   type: 'submit';
 }

--- a/packages/gestalt/src/Button.flowtest.js
+++ b/packages/gestalt/src/Button.flowtest.js
@@ -17,7 +17,7 @@ const MissingProp = <Button />;
 
 const IncompatibleLinkProps = (
   // $FlowExpectedError[incompatible-type]
-  <Button text="Next" role="link" onClick={() => {}} />
+  <Button text="Next" role="link" name="d" onClick={() => {}} />
 );
 
 const IncompatibleSubmitProps = (

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -55,7 +55,6 @@ type BaseButton = {|
   disabled?: boolean,
   iconEnd?: $Keys<typeof icons>,
   fullWidth?: boolean,
-  name?: string,
   onClick?: ({|
     event:
       | SyntheticMouseEvent<HTMLButtonElement>
@@ -77,12 +76,14 @@ type ButtonType = {|
   selected?: boolean,
   type?: 'button',
   role?: 'button',
+  name?: string,
 |};
 
 type SubmitButtonType = {|
   ...BaseButton,
   type: 'submit',
   role?: 'button',
+  name?: string,
 |};
 
 type LinkButtonType = {|


### PR DESCRIPTION
### Breaking change

Breaking change because before you could pass name to Button role="link" which was dead code. Now you cant.

```
yarn codemod detectManualReplacement ~/path/to/your/code
--component=Button
--prop=name
```
We can use the above codemod to detect Button with name used on them and see if they are also role="link" but it's much faster to rely on Flow complaining.

### Summary

#### What changed?

Button: fixes ` name` prop documentation and Flow

#### Why?

Previously missing
