### PR TITLE
PopoverEducational: removing flex null spacing

### DIFF
--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -180,9 +180,11 @@ export default function PopoverEducational({
             <Box padding={4} tabIndex={0}>
               <Flex direction="column" gap={3}>
                 {textElement}
-                <Flex.Item flex="grow" alignSelf="end">
-                  {primaryAction ? <PrimaryAction {...primaryAction} /> : null}
-                </Flex.Item>
+                {primaryAction ? (
+                  <Flex.Item flex="grow" alignSelf="end">
+                    <PrimaryAction {...primaryAction} />
+                  </Flex.Item>
+                ) : null}
               </Flex>
             </Box>
           ) : null)}


### PR DESCRIPTION
### Summary

#### What changed?

PopoverEducational: removing flex null spacing

### BEFORE 
<img width="303" alt="Screenshot 2023-07-18 at 6 15 16 PM" src="https://github.com/pinterest/gestalt/assets/10593890/53afb007-4cf9-4ba7-ac0f-9da19e891754">


### AFTER 
<img width="368" alt="Screenshot 2023-07-18 at 6 14 42 PM" src="https://github.com/pinterest/gestalt/assets/10593890/00909bd3-4703-4a9a-a976-e17f15d8346b">


#### Why?

What is the purpose of this PR? Please include the context around these changes for Future Us. In addition to _what_ is changing, we need to know _why_ these changes are needed. Imagine someone is looking at these changes a year from now and needs to know why they were made.

### 