### PR TITLE
Docs: Re-add hero animation on home page

### DIFF
--- a/docs/pages/home.js
+++ b/docs/pages/home.js
@@ -44,7 +44,7 @@ export default function HomePage(): Node {
                 justifyContent="end"
                 marginStart={8}
               >
-                <HeroGraphic animate={false} />
+                <HeroGraphic />
               </Box>
             </Box>
           </IllustrationSection>


### PR DESCRIPTION
### Summary

#### What changed?

Re-animate the Hero graphic on the home page (turned off during Year-in-review)

#### Why?

I miss the animations 

(you know, when I reference the site 5 times a day 😅)

(( Miss you all ❤️ ))
