### PR TITLE
GlobalEventsHandlerProvider, Button: RFC + added buttonHandlers to GlobalEventsHandlerProvider

### DIFF
--- a/docs/examples/globaleventshandlerprovider/buttonHandlers.js
+++ b/docs/examples/globaleventshandlerprovider/buttonHandlers.js
@@ -20,7 +20,7 @@ export default function Example(): Node {
     <GlobalEventsHandlerProvider buttonHandlers={buttonHandlers}>
       <Box padding={2}>
         <Button
-          auxData={{ name: 'form-button', surface: 'campaign-edit' }}
+          providerAuxData={{ name: 'form-button', surface: 'campaign-edit' }}
           color="red"
           text="Apply"
           size="lg"

--- a/docs/examples/globaleventshandlerprovider/buttonHandlers.js
+++ b/docs/examples/globaleventshandlerprovider/buttonHandlers.js
@@ -1,0 +1,31 @@
+// @flow strict
+import { type Node, useCallback, useMemo } from 'react';
+import { Box, Button, GlobalEventsHandlerProvider } from 'gestalt';
+
+export default function Example(): Node {
+  const onClick = useCallback(
+    // eslint-disable-next-line no-console
+    ({ name, surface }: { [string]: string | number }) => console.log(name, surface),
+    [],
+  );
+
+  const buttonHandlers = useMemo(
+    () => ({
+      onClick,
+    }),
+    [onClick],
+  );
+
+  return (
+    <GlobalEventsHandlerProvider buttonHandlers={buttonHandlers}>
+      <Box padding={2}>
+        <Button
+          auxData={{ name: 'form-button', surface: 'campaign-edit' }}
+          color="red"
+          text="Apply"
+          size="lg"
+        />
+      </Box>
+    </GlobalEventsHandlerProvider>
+  );
+}

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -133,6 +133,14 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
             ],
           },
           {
+            name: 'providerAuxData',
+            type: '{ [string]: string | number }',
+            required: false,
+            description: [
+              '`providerAuxData` works with [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider). `providerAuxData` is passed as argument to the handlers for interactive events in Button (p.e. onClick) so that the external logic can be customized on each component instance. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider) to learn more',
+            ],
+          },
+          {
             name: 'size',
             type: `'sm' | 'md' | 'lg'`,
             required: false,

--- a/docs/pages/web/utilities/globaleventshandlerprovider.js
+++ b/docs/pages/web/utilities/globaleventshandlerprovider.js
@@ -7,6 +7,7 @@ import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
 import SandpackExample from '../../../docs-components/SandpackExample.js';
+import buttonHandlers from '../../../examples/globaleventshandlerprovider/buttonHandlers.js';
 import linkHandlersCalloutUpsell from '../../../examples/globaleventshandlerprovider/linkHandlersCalloutUpsell.js';
 import linkHandlersDangerouslyDisableOnNavigation from '../../../examples/globaleventshandlerprovider/linkHandlersDangerouslyDisableOnNavigation.js';
 import linkHandlersDropdown from '../../../examples/globaleventshandlerprovider/linkHandlersDropdown.js';
@@ -143,6 +144,23 @@ The example below demonstrates the correct use of "dangerouslyDisableOnNavigatio
                 code={linkHandlersDropdown}
                 name="Example - Dropdown"
                 layout="column"
+              />
+            }
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
+      <MainSection name="Button handlers">
+        <MainSection.Subsection title="onClick">
+          <MainSection.Card
+            cardSize="lg"
+            description={`Pending
+`}
+            sandpackExample={
+              <SandpackExample
+                code={buttonHandlers}
+                layout="column"
+                name="GlobalEventsHandlerProvider in Button"
               />
             }
           />

--- a/docs/pages/web/utilities/globaleventshandlerprovider.js
+++ b/docs/pages/web/utilities/globaleventshandlerprovider.js
@@ -150,12 +150,15 @@ The example below demonstrates the correct use of "dangerouslyDisableOnNavigatio
         </MainSection.Subsection>
       </MainSection>
 
-      <MainSection name="Button handlers">
+      <MainSection name="Interactive event handlers">
         <MainSection.Subsection title="onClick">
           <MainSection.Card
             cardSize="lg"
-            description={`Pending
-`}
+            description={`
+Gestalt supports passing external logic to interactive event handlers such as \`onClick\`, \`onBlur\` and  \`onChange\`. Many components contain The following components API have event handlers. The following example shows a standard use case.
+
+GlobalEventsHandlerProvider doesn't supports all components' event handlers. They are implemented as needed.
+  `}
             sandpackExample={
               <SandpackExample
                 code={buttonHandlers}

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -13,6 +13,7 @@ import NewTabAccessibilityLabel from './accessibility/NewTabAccessibilityLabel.j
 import styles from './Button.css';
 import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
+import { useGlobalEventsHandlerContext } from './contexts/GlobalEventsHandlerProvider.js';
 import Flex from './Flex.js';
 import focusStyles from './Focus.css';
 import Icon, { type IconColor } from './Icon.js';
@@ -43,6 +44,7 @@ type Target = null | 'self' | 'blank';
 
 type BaseButton = {|
   accessibilityLabel?: string,
+  auxData?: { [string]: string | number },
   color?:
     | 'gray'
     | 'red'
@@ -142,6 +144,7 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
 >(function Button(props: unionProps, ref): Node {
   const {
     accessibilityLabel,
+    auxData,
     color = 'gray',
     dataTestId,
     disabled = false,
@@ -174,6 +177,9 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
     height: innerRef?.current?.clientHeight,
     width: innerRef?.current?.clientWidth,
   });
+
+  // Consumes GlobalEventsHandlerProvider
+  const handlers = useGlobalEventsHandlerContext();
 
   const { accessibilityNewTabLabel } = useDefaultLabelContext('Link');
 
@@ -228,13 +234,14 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
   const handleClick = (
     event: SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticMouseEvent<HTMLAnchorElement>,
     dangerouslyDisableOnNavigation: () => void,
-  ) =>
-    onClick
-      ? onClick({
-          event,
-          dangerouslyDisableOnNavigation: dangerouslyDisableOnNavigation ?? (() => {}),
-        })
-      : undefined;
+  ): void => {
+    handlers?.buttonHandlers?.onClick?.({ ...auxData });
+
+    onClick?.({
+      event,
+      dangerouslyDisableOnNavigation: dangerouslyDisableOnNavigation ?? (() => {}),
+    });
+  };
 
   const handleLinkClick = ({
     event,

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -44,7 +44,7 @@ type Target = null | 'self' | 'blank';
 
 type BaseButton = {|
   accessibilityLabel?: string,
-  auxData?: { [string]: string | number },
+  providerAuxData?: { [string]: string | number },
   color?:
     | 'gray'
     | 'red'
@@ -144,13 +144,13 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
 >(function Button(props: unionProps, ref): Node {
   const {
     accessibilityLabel,
-    auxData,
     color = 'gray',
     dataTestId,
     disabled = false,
     fullWidth = false,
     iconEnd,
     onClick,
+    providerAuxData,
     tabIndex = 0,
     selected = false,
     size = 'md',
@@ -235,7 +235,7 @@ const ButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwardRe
     event: SyntheticKeyboardEvent<HTMLAnchorElement> | SyntheticMouseEvent<HTMLAnchorElement>,
     dangerouslyDisableOnNavigation: () => void,
   ): void => {
-    handlers?.buttonHandlers?.onClick?.({ ...auxData });
+    handlers?.buttonHandlers?.onClick?.({ ...providerAuxData });
 
     onClick?.({
       event,

--- a/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
+++ b/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
@@ -11,6 +11,7 @@ type OnLinkNavigationType = ({|
 |}) => void;
 
 type GlobalEventsHandlerContextType = {|
+  buttonHandlers?: {| onClick?: ({ [string]: string | number }) => void |},
   sheetMobileHandlers?: {| onOpen?: NoopType, onClose?: NoopType |},
   linkHandlers?: {| onNavigation?: OnLinkNavigationType |},
 |} | void;
@@ -21,9 +22,9 @@ type Props = {|
    */
   children: Node,
   /**
-   * Handlers consumed by [SheetMobile](https://gestalt.pinterest.systems/web/sheetmobile#External-handlers).
+   * Handlers consumed by [Button](https://gestalt.pinterest.systems/web/sheetmobile#External-handlers).
    */
-  sheetMobileHandlers?: {| onOpen?: () => void, onClose?: () => void |},
+  buttonHandlers?: {| onClick?: ({ [string]: string | number }) => void |},
   /**
    * Handlers consumed by [Link](https://gestalt.pinterest.systems/web/link#External-handlers).
    */
@@ -35,6 +36,10 @@ type Props = {|
       +event: SyntheticEvent<>,
     |}) => void,
   |},
+  /**
+   * Handlers consumed by [SheetMobile](https://gestalt.pinterest.systems/web/sheetmobile#External-handlers).
+   */
+  sheetMobileHandlers?: {| onOpen?: () => void, onClose?: () => void |},
 |};
 
 const GlobalEventsHandlerContext: Context<GlobalEventsHandlerContextType> =
@@ -47,12 +52,14 @@ const { Provider } = GlobalEventsHandlerContext;
  */
 export default function GlobalEventsHandlerProvider({
   children,
+  buttonHandlers,
   sheetMobileHandlers,
   linkHandlers,
 }: Props): Element<typeof Provider> {
   return (
     <Provider
       value={{
+        buttonHandlers,
         sheetMobileHandlers,
         linkHandlers,
       }}

--- a/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
+++ b/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
@@ -22,7 +22,7 @@ type Props = {|
    */
   children: Node,
   /**
-   * Handlers consumed by [Button](https://gestalt.pinterest.systems/web/sheetmobile#External-handlers).
+   * Handlers consumed by [Button](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#onClick).
    */
   buttonHandlers?: {| onClick?: ({ [string]: string | number }) => void |},
   /**

--- a/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
+++ b/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
@@ -81,7 +81,13 @@ GlobalEventsHandlerProvider shares default logic across components, unidirection
 <Button providerAuxData={{ name: "apply-button", surface: "advertiser-tools"}}>
 ```
 
-Considerations:
+## Documentation
+
+This component will be documented in the [Gestalt Docs under the utilities category, GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) and in [PDocs](https://pdocs.pinadmin.com/docs/webapp/gestalt-providers)
+
+We'll create an ESLint rule to enforce the usage of `providerAuxData` within sections of the site. The ESLint will communicate the PDocs link and how to use the prop.
+
+## Drawbacks
 
 - A limitation to this implementation is that we cannot enforce a specific Flow type shared between `providerAuxData` and the event types in GlobalEventsHandlerProvider. To minimize this, it's encouraged to create an Eslint rule linking to documentation if components need to share `providerAuxData` with GlobalEventsHandlerProvider. If the logic doesn't need to be customized, this can be skipped.
 
@@ -104,14 +110,6 @@ const { sheetMobileHandlers, linkHandlers, buttonHandlers } = useGlobalEventsHan
 ```
 
 See the existing implementation on this [PR](https://github.com/pinternal/pinboard/pull/12301/files)
-
-## Documentation
-
-This component will be documented in the [Gestalt Docs under the utilities category, GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) and in [PDocs](https://pdocs.pinadmin.com/docs/webapp/gestalt-providers)
-
-We'll create an ESLint rule to enforce the usage of `providerAuxData` within sections of the site. The ESLint will communicate the PDocs link and how to use the prop.
-
-## Drawbacks
 
 ## Backwards Compatibility Analysis
 

--- a/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
+++ b/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
@@ -46,6 +46,8 @@ Enabling external logic (such as logging) on interaction event handlers in Gesta
 
 - centralize and document logic passed to the GlobalEventsHandlerProvider via PDocs
 
+- enforce external logic when needed
+
 - escale faster the addition of logic to other composed components: from Buttons to PageHeaders, SideNavigation, etc rather than additional wrappers for each new component and adding more ESLint rules.
 
 - prevent bugs: wrappers with time tend to accumulate bugs and bad practices as they become not owned and engineers keep adding code patches

--- a/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
+++ b/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
@@ -1,0 +1,123 @@
+- Start Date: July 2023
+- RFC PR: https://github.com/pinterest/gestalt/pull/3094
+- Authors: Alberto Carreras, acarreras
+
+# GlobalEventsHandlerProvider and providerAuxData
+
+## Summary
+
+GlobalEventsHandlerProvider was built in Gestalt to share external handlers with consuming components. It's versatile API that can support external logic on each interactive event handlers (onClick, onBlur, onFocus, and so forth).
+
+## Motivation
+
+Monetization teams at Pinterest (https://ads.pinterest.com/) log and track user interaction in specific interactive components. For instance, Button, Checkbox, Dropdown, IconButton, Link, NumberField, RadioButton, SearchField, SelectList, Switch, TapArea, TextArea, and TextField. One of the use cases for these logs is to extend the insights on experimentation allowing the monetization team to track user flows and increase campaigns optimizations.
+
+For developer velocity, reusability, and consistency, there's a suite of Gestalt components wrapped in additional logic and re-exported with an extended API.
+
+These wrapped Gestalt components are under an Eslint rule that prevent direct consumption of those Gestalt components.
+
+### Problem
+
+Gestalt wrappers have a set of problems:
+
+- The wrapper's API extend Gestalt component API. Engineers should be able to go to Gestalt documentation to consult component API and have it match with the code they are working with
+
+- Wrappers reduce adoption of other high level components. For example, PageHeader has primary actions. These primary baction buttons cannot be replaced with wrappers. Therefore, PageHeader won't be adopted because their buttons cannot use the wrapper with additional logic. We would have to create a wrapper on PageHeader to add logic to the onClick.
+
+- Wrappers mask adoption for Gestalt components.
+
+- Changes in Gestalt componts are harder to propagate to each wrapper API. Wrappers increase maintenance for the Gestalt team and with time wrappers API can end up being substantially different from the Gestalt component they are extending.
+
+- For each wrapper, we need an Eslint rules to avoid direct Gestalt usage. Despite Eslint rules, engineers mstill use them increaseing the usage of disabled comments in imports.
+
+See previous [onInteraction proposal](https://paper.dropbox.com/doc/Proposal-New-onInteraction-functionality-in-Gestalt-components--B416h3YCf4BRIgvCtDUTVrKLAg-rOblYZwoXPm1MzHeLbVyx)
+
+### Impact
+
+Enabling external logic (such as logging) on interaction event handlers in Gestalt components via GlobalEventsHandlerProvider allows to:
+
+- increase adoption of Gestalt components
+
+- reduce lines of code and increase code quality, we don't need wrappers
+
+- consistent and documented APIs
+
+- reduce maintenance work
+
+- centralize and document logic passed to the GlobalEventsHandlerProvider via PDocs
+
+- escale faster the addition of logic to other composed components: from Buttons to PageHeaders, SideNavigation, etc rather than additional wrappers for each new component and adding more ESLint rules.
+
+- prevent bugs: wrappers with time tend to accumulate bugs and bad practices as they become not owned and engineers keep adding code patches
+
+- less ESLint rules to prevent direct import from Gestalt
+
+## Detailed Design
+
+GlobalEventsHandlerProvider is already a Gestast utility. The API is flexible and can reach any component.
+
+```javascript
+<GlobalEventsHandlerProvider componentHandler={{ handlerOne: () => {}, handlerTwo: () => {} }}>
+  {children}
+<GlobalEventsHandlerProvider >
+```
+
+This is a hypothetical implementation of GlobalEventsHandlerProvider passing down to Button logging logic to interaction event handlers
+
+```javascript
+<GlobalEventsHandlerProvider
+  buttonHandlers={{ onClick: ({ name, surface }) => log("button", "campaign_form", name, surface)}}
+>
+  {children}
+<GlobalEventsHandlerProvider >
+
+```
+
+GlobalEventsHandlerProvider shares default logic across components, unidirectionally: parent to child. To make more versatile this API and be able to provide some custom data to the logic, for instance, to be able to log specific data about the component being interacted with, we are adding a new prop \`provider\`
+
+```javascript
+<Button providerAuxData={{ name: "apply-button", surface: "advertiser-tools"}}>
+```
+
+Considerations:
+
+- SheetMobile is built into other components: Dropdown/Popover are adaptive components and, in mobile devices, they replace Popover with SheetMobile. SheetMobile is not accessible/exposed in these cases.
+- Button and other interactive components are built into other components in many case, they not accessible/exposed in these cases.
+
+## Documentation
+
+This component will be documented in the [Gestalt Docs under the utilities category, GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) and in [PDocs](https://pdocs.pinadmin.com/docs/webapp/gestalt-providers)
+
+We'll create an ESLint rule to enforce the usage of \`providerAuxData\` within sections of the site. The ESLint will communicate the PDocs link and how to use the prop.
+
+## Drawbacks
+
+## Backwards Compatibility Analysis
+
+No. New props in API. It is not a breaking change
+
+## Alternatives
+
+Previous implementation approaches are on the following [onInteraction proposal document](https://paper.dropbox.com/doc/Proposal-New-onInteraction-functionality-in-Gestalt-components--B416h3YCf4BRIgvCtDUTVrKLAg-rOblYZwoXPm1MzHeLbVyx)
+
+## Open Questions
+
+Any other alternative?
+
+## Help Needed
+
+- Any other alternative?
+
+- Any blind spot in the current implementation?
+
+## Frequently Asked Questions
+
+--
+
+## Related Discussions
+
+--
+
+## Feedback
+
+## Action

--- a/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
+++ b/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
@@ -73,7 +73,7 @@ This is a hypothetical implementation of GlobalEventsHandlerProvider passing dow
 
 ```
 
-GlobalEventsHandlerProvider shares default logic across components, unidirectionally: parent to child. To make more versatile this API and be able to provide some custom data to the logic, for instance, to be able to log specific data about the component being interacted with, we are adding a new prop \`provider\`
+GlobalEventsHandlerProvider shares default logic across components, unidirectionally: parent to child. To make more versatile this API and be able to provide some custom data to the logic, for instance, to be able to log specific data about the component being interacted with, we are adding a new prop \`providerAuxData\`. Interactive events handlers exposed in GlobalEventsHandlerProvider have all access to the \`providerAuxData\` object.
 
 ```javascript
 <Button providerAuxData={{ name: "apply-button", surface: "advertiser-tools"}}>
@@ -81,8 +81,27 @@ GlobalEventsHandlerProvider shares default logic across components, unidirection
 
 Considerations:
 
-- SheetMobile is built into other components: Dropdown/Popover are adaptive components and, in mobile devices, they replace Popover with SheetMobile. SheetMobile is not accessible/exposed in these cases.
-- Button and other interactive components are built into other components in many case, they not accessible/exposed in these cases.
+- A limitation to this implementation is that we cannot enforce a specific Flow type shared between \`providerAuxData\` and the event types in GlobalEventsHandlerProvider. To minimize this, it's encouraged to create an Eslint rule linking to documentation if components need to share \`providerAuxData\` with GlobalEventsHandlerProvider. If the logic doesn't need to be customized, this can be skipped.
+
+- React Providers overwrite Providers from the same Context that are above in the app tree. GlobalEventsHandlerProvider can be used in differents sections of the code to apply different logic in different site sections. Some of the logic might be global to the whole app.
+
+To prevent duplication of code or overriding logic, we recommend keeping the logic passed to GlobalEventsHandlerProvider in a single custom React hook so it can be reimplemented on each level where GlobalEventsHandlerProvider is implemented easily and consistently.
+
+A custom hook can also be build to receive arguments and provide custom returns.
+
+```javascript
+
+const { sheetMobileHandlers, linkHandlers, buttonHandlers } = useGlobalEventsHandlerProvider()
+
+<GlobalEventsHandlerProvider
+  buttonHandlers={buttonHandlers} sheetMobileHandlers={sheetMobileHandlers} linkHandlers={linkHandlers}
+>
+  {children}
+<GlobalEventsHandlerProvider >
+
+```
+
+See the existing implementation on this [PR](https://github.com/pinternal/pinboard/pull/12301/files)
 
 ## Documentation
 

--- a/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
+++ b/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md
@@ -10,7 +10,7 @@ GlobalEventsHandlerProvider was built in Gestalt to share external handlers with
 
 ## Motivation
 
-Monetization teams at Pinterest (https://ads.pinterest.com/) log and track user interaction in specific interactive components. For instance, Button, Checkbox, Dropdown, IconButton, Link, NumberField, RadioButton, SearchField, SelectList, Switch, TapArea, TextArea, and TextField. One of the use cases for these logs is to extend the insights on experimentation allowing the monetization team to track user flows and increase campaigns optimizations.
+Monetization teams at Pinterest (https://ads.pinterest.com/) log and track user interaction in specific interactive components and events. For instance, Button, Checkbox, Dropdown, IconButton, Link, NumberField, RadioButton, SearchField, SelectList, Switch, TapArea, TextArea, and TextField. One of the use cases for these logs is to extend the insights on experimentation allowing the monetization team to track user flows and increase campaigns optimizations.
 
 For developer velocity, reusability, and consistency, there's a suite of Gestalt components wrapped in additional logic and re-exported with an extended API.
 
@@ -20,15 +20,15 @@ These wrapped Gestalt components are under an Eslint rule that prevent direct co
 
 Gestalt wrappers have a set of problems:
 
-- The wrapper's API extend Gestalt component API. Engineers should be able to go to Gestalt documentation to consult component API and have it match with the code they are working with
+- The wrappers' API extend Gestalt component API. Engineers should be able to go to Gestalt documentation to consult component API and have it match with the code they are working with. There's no way to enforce a matching API between Gestalt and their wrappers.
 
-- Wrappers reduce adoption of other high level components. For example, PageHeader has primary actions. These primary baction buttons cannot be replaced with wrappers. Therefore, PageHeader won't be adopted because their buttons cannot use the wrapper with additional logic. We would have to create a wrapper on PageHeader to add logic to the onClick.
+- Wrappers reduce adoption of other high level components. For example, PageHeader has primary actions. These primary action buttons cannot be replaced with wrappers. Therefore, PageHeader won't be adopted because their buttons cannot use the wrapper with additional logic. We would have to create a wrapper on PageHeader to add logic to the onClick.
 
 - Wrappers mask adoption for Gestalt components.
 
-- Changes in Gestalt componts are harder to propagate to each wrapper API. Wrappers increase maintenance for the Gestalt team and with time wrappers API can end up being substantially different from the Gestalt component they are extending.
+- Changes in Gestalt componts are harder to propagate to each wrapper API. Wrappers increase maintenance for the Gestalt team and with time wrappers' API can end up being substantially different from the Gestalt component they are extending.
 
-- For each wrapper, we need an Eslint rules to avoid direct Gestalt usage. Despite Eslint rules, engineers mstill use them increaseing the usage of disabled comments in imports.
+- For each wrapper, we need an Eslint rules to avoid direct Gestalt usage. Despite Eslint rules, engineers still use them increasing the amount of disabled comments in imports.
 
 See previous [onInteraction proposal](https://paper.dropbox.com/doc/Proposal-New-onInteraction-functionality-in-Gestalt-components--B416h3YCf4BRIgvCtDUTVrKLAg-rOblYZwoXPm1MzHeLbVyx)
 
@@ -75,7 +75,7 @@ This is a hypothetical implementation of GlobalEventsHandlerProvider passing dow
 
 ```
 
-GlobalEventsHandlerProvider shares default logic across components, unidirectionally: parent to child. To make more versatile this API and be able to provide some custom data to the logic, for instance, to be able to log specific data about the component being interacted with, we are adding a new prop \`providerAuxData\`. Interactive events handlers exposed in GlobalEventsHandlerProvider have all access to the \`providerAuxData\` object.
+GlobalEventsHandlerProvider shares default logic across components, unidirectionally: parent to child. To make more versatile this API and be able to provide some custom data to the logic, for instance, to be able to log specific data about the component being interacted with, we are adding a new prop `providerAuxData`. Interactive events handlers exposed in GlobalEventsHandlerProvider have access to the `providerAuxData` object.
 
 ```javascript
 <Button providerAuxData={{ name: "apply-button", surface: "advertiser-tools"}}>
@@ -83,7 +83,7 @@ GlobalEventsHandlerProvider shares default logic across components, unidirection
 
 Considerations:
 
-- A limitation to this implementation is that we cannot enforce a specific Flow type shared between \`providerAuxData\` and the event types in GlobalEventsHandlerProvider. To minimize this, it's encouraged to create an Eslint rule linking to documentation if components need to share \`providerAuxData\` with GlobalEventsHandlerProvider. If the logic doesn't need to be customized, this can be skipped.
+- A limitation to this implementation is that we cannot enforce a specific Flow type shared between `providerAuxData` and the event types in GlobalEventsHandlerProvider. To minimize this, it's encouraged to create an Eslint rule linking to documentation if components need to share `providerAuxData` with GlobalEventsHandlerProvider. If the logic doesn't need to be customized, this can be skipped.
 
 - React Providers overwrite Providers from the same Context that are above in the app tree. GlobalEventsHandlerProvider can be used in differents sections of the code to apply different logic in different site sections. Some of the logic might be global to the whole app.
 
@@ -109,7 +109,7 @@ See the existing implementation on this [PR](https://github.com/pinternal/pinboa
 
 This component will be documented in the [Gestalt Docs under the utilities category, GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider) and in [PDocs](https://pdocs.pinadmin.com/docs/webapp/gestalt-providers)
 
-We'll create an ESLint rule to enforce the usage of \`providerAuxData\` within sections of the site. The ESLint will communicate the PDocs link and how to use the prop.
+We'll create an ESLint rule to enforce the usage of `providerAuxData` within sections of the site. The ESLint will communicate the PDocs link and how to use the prop.
 
 ## Drawbacks
 


### PR DESCRIPTION
### RFC

New RFC for this extension of GlobalEventsHandlerProvider and component APIs.
https://github.com/pinterest/gestalt/blob/51fa52331376c4f6677ba2659f507c1f78f254cd/rfcs/rfcs/2023-07-globalEventsHandlersProvider-providerAuxData/README.md

ALSO Pinboard implementation prototype here: https://github.com/pinternal/pinboard/pull/14238/files 

### Summary

#### What changed?

GlobalEventsHandlerProvider for Button's onClick. 
Button has new prop `providerAuxData`. The object is passed to the GlobalEventsHandlerProvider handler for  Button's onClick.

#### Why?

See RFC