### PR TITLE
Text: Add CJK wrapping to Text

### DIFF
--- a/docs/examples/text/cjkText.js
+++ b/docs/examples/text/cjkText.js
@@ -1,0 +1,102 @@
+// @flow strict
+import React from 'react';
+import { Box, Flex, Text } from 'gestalt';
+
+export default function CJK(): Node {
+  // eslint-disable-next-line react/no-unstable-nested-components
+  function NarrowShell({ text, useKeepAll }: {| text: string, useKeepAll: boolean |}) {
+    return (
+      <Box width={24} color="dark">
+        <Text overflow="normal" size="200" color="inverse">
+          {useKeepAll ? <div style={{ wordBreak: 'keep-all' }}>{text}</div> : text}
+        </Text>
+      </Box>
+    );
+  }
+
+  const languages = [
+    {
+      id: 'English',
+      code: 'en',
+      lang: 'Your account options and more',
+    },
+    {
+      id: 'Chinese',
+      code: 'zh',
+      lang: '帐户和更多选项',
+    },
+    {
+      id: 'Korean',
+      code: 'ko',
+      lang: '계정 및추 가옵션',
+    },
+  ];
+
+  return (
+    <Box
+      marginTop={10}
+      padding={4}
+      width="100%"
+      height="100%"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      direction="column"
+    >
+      <Flex direction="column" gap={8}>
+        <Box>
+          <Box marginBottom={2}>
+            <Text weight="bold">With Keep-All</Text>
+          </Box>
+          <Flex direction="row" gap={4}>
+            {languages.map(({ id, lang, code }) => (
+              <Box key={id}>
+                <Box marginBottom={2}>
+                  <Text size="200">{id}</Text>
+                </Box>
+                <div lang={code}>
+                  <Box key={id} width={120} color="dark" rounding={2} padding={2}>
+                    <NarrowShell text={lang} />
+                  </Box>
+                </div>
+              </Box>
+            ))}
+          </Flex>
+        </Box>
+
+        <Box>
+          <Box marginBottom={2}>
+            <Text weight="bold">Without Keep-All</Text>
+          </Box>
+          <Flex direction="row" gap={4}>
+            {languages.map(({ id, lang }) => (
+              <Box key={id}>
+                <Box marginBottom={2}>
+                  <Text size="200">{id}</Text>
+                </Box>
+                <Box key={id} width={120} color="dark" rounding={2} padding={2}>
+                  <NarrowShell text={lang} />
+                </Box>
+              </Box>
+            ))}
+          </Flex>
+        </Box>
+      </Flex>
+    </Box>
+  );
+
+  /*
+  return (
+    <Box width="100%" height="100%" display="flex" direction="column" alignItems="center">
+      <Box padding={2}>
+        <Box rounding={2} padding={2}>
+          <Flex direction="column" gap={8}>
+            <NarrowToolTipShell text={kor} />
+            <NarrowToolTipShell text={eng} />
+            <NarrowToolTipShell useKeepAll text={kor} />
+          </Flex>
+        </Box>
+      </Box>
+    </Box>
+  ) */
+}

--- a/docs/examples/text/cjkText.js
+++ b/docs/examples/text/cjkText.js
@@ -3,16 +3,6 @@ import React, { type Node } from 'react';
 import { Box, Flex, Text } from 'gestalt';
 
 export default function cjkText(): Node {
-  function NarrowShell({ text, useKeepAll }: {| text: string, useKeepAll?: boolean |}) {
-    return (
-      <Box width={24} color="dark">
-        <Text overflow="normal" size="200" color="inverse">
-          {useKeepAll ? <div style={{ wordBreak: 'keep-all' }}>{text}</div> : text}
-        </Text>
-      </Box>
-    );
-  }
-
   const languages = [
     {
       id: 'English',
@@ -33,21 +23,19 @@ export default function cjkText(): Node {
 
   return (
     <Box
-      marginTop={10}
       padding={4}
       width="100%"
       height="100%"
       display="flex"
-      justifyContent="center"
       alignItems="center"
       direction="column"
     >
-      <Flex direction="column" gap={8}>
-        <Box>
-          <Box marginBottom={2}>
+      <Flex direction="row" gap={8}>
+        <Flex gap={2} direction="column">
+          <Box>
             <Text weight="bold">With Keep-All</Text>
           </Box>
-          <Flex direction="row" gap={4}>
+          <Flex direction="column" gap={4}>
             {languages.map(({ id, lang, code }) => (
               <Box key={id}>
                 <Box marginBottom={2}>
@@ -55,31 +43,39 @@ export default function cjkText(): Node {
                 </Box>
                 <div lang={code}>
                   <Box key={id} width={120} color="dark" rounding={2} padding={2}>
-                    <NarrowShell text={lang} />
+                    <Box width={24} color="dark">
+                      <Text overflow="normal" size="200" color="inverse">
+                        {lang}
+                      </Text>
+                    </Box>
                   </Box>
                 </div>
               </Box>
             ))}
           </Flex>
-        </Box>
+        </Flex>
 
-        <Box>
-          <Box marginBottom={2}>
+        <Flex gap={2} direction="column">
+          <Box>
             <Text weight="bold">Without Keep-All</Text>
           </Box>
-          <Flex direction="row" gap={4}>
+          <Flex direction="column" gap={4}>
             {languages.map(({ id, lang }) => (
               <Box key={id}>
                 <Box marginBottom={2}>
                   <Text size="200">{id}</Text>
                 </Box>
-                <Box key={id} width={120} color="dark" rounding={2} padding={2}>
-                  <NarrowShell text={lang} />
+                <Box key={id} width={70} color="dark" rounding={2} padding={2}>
+                  <Box width={24} color="dark">
+                    <Text overflow="normal" size="200" color="inverse">
+                      {lang}
+                    </Text>
+                  </Box>
                 </Box>
               </Box>
             ))}
           </Flex>
-        </Box>
+        </Flex>
       </Flex>
     </Box>
   );

--- a/docs/examples/text/cjkText.js
+++ b/docs/examples/text/cjkText.js
@@ -1,10 +1,9 @@
 // @flow strict
-import React from 'react';
+import React, { type Node } from 'react';
 import { Box, Flex, Text } from 'gestalt';
 
-export default function CJK(): Node {
-  // eslint-disable-next-line react/no-unstable-nested-components
-  function NarrowShell({ text, useKeepAll }: {| text: string, useKeepAll: boolean |}) {
+export default function cjkText(): Node {
+  function NarrowShell({ text, useKeepAll }: {| text: string, useKeepAll?: boolean |}) {
     return (
       <Box width={24} color="dark">
         <Text overflow="normal" size="200" color="inverse">
@@ -84,19 +83,4 @@ export default function CJK(): Node {
       </Flex>
     </Box>
   );
-
-  /*
-  return (
-    <Box width="100%" height="100%" display="flex" direction="column" alignItems="center">
-      <Box padding={2}>
-        <Box rounding={2} padding={2}>
-          <Flex direction="column" gap={8}>
-            <NarrowToolTipShell text={kor} />
-            <NarrowToolTipShell text={eng} />
-            <NarrowToolTipShell useKeepAll text={kor} />
-          </Flex>
-        </Box>
-      </Box>
-    </Box>
-  ) */
 }

--- a/docs/pages/web/text.js
+++ b/docs/pages/web/text.js
@@ -9,6 +9,7 @@ import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
+import cjkText from '../../examples/text/cjkText.js';
 import doMinimalStyle from '../../examples/text/doMinimalStyle.js';
 import dontCenterAlign from '../../examples/text/dontCenterAlign.js';
 import dontMixStyles from '../../examples/text/dontMixStyles.js';
@@ -185,6 +186,15 @@ export default function TextPage({ generatedDocGen }: {| generatedDocGen: DocGen
           title="Text-wrapping and hyphenation"
           description="Hyphenation on iOS is turned off by default to avoid incorrect word breaks when strings of text wrap to the next line. This is especially helpful for international languages where an incorrect word break can greatly change the meaning of a word or sentence."
         />
+
+        <MainSection.Subsection
+          title="Word Breaks and CJK languages"
+          description={`Chinese, Japanese and Korean languages and may not be broken in the middle of a word. This creates text-wrapping issues and tall containers. To avoid this, the Text component uses the CSS property \`word-break:keep-all\` to keep words on CJK languages together when CJK is detected.  
+          <br /> Be sure to consider text overflow, and making sure a container is wide enough to support a CJK term.
+          `}
+        >
+          <SandpackExample code={cjkText} name="CJK Text" hideEditor hideControls />
+        </MainSection.Subsection>
       </MainSection>
       <MainSection name="Variants">
         <MainSection.Subsection

--- a/docs/pages/web/text.js
+++ b/docs/pages/web/text.js
@@ -189,11 +189,17 @@ export default function TextPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
         <MainSection.Subsection
           title="Word Breaks and CJK languages"
-          description={`Chinese, Japanese and Korean languages and may not be broken in the middle of a word. This creates text-wrapping issues and tall containers. To avoid this, the Text component uses the CSS property \`word-break:keep-all\` to keep words on CJK languages together when CJK is detected.  
+          description={`Chinese, Japanese and Korean languages may be broken in the middle of a word. This creates text-wrapping issues and tall containers. To avoid this, Text uses the CSS property \`word-break:keep-all\` to keep words on CJK languages together when CJK is detected.  
           <br /> Be sure to consider text overflow, and making sure a container is wide enough to support a CJK term.
           `}
         >
-          <SandpackExample code={cjkText} name="CJK Text" hideEditor hideControls />
+          <SandpackExample
+            previewHeight={550}
+            code={cjkText}
+            name="CJK Text"
+            hideEditor
+            hideControls
+          />
         </MainSection.Subsection>
       </MainSection>
       <MainSection name="Variants">

--- a/packages/gestalt/src/Text.css
+++ b/packages/gestalt/src/Text.css
@@ -1,3 +1,9 @@
 .Text {
   composes: antialiased sansSerif from "./Typography.css";
 }
+
+*:lang(zh) .Text,
+*:lang(ko) .Text,
+*:lang(ja) .Text {
+  word-break: keep-all;
+}

--- a/packages/gestalt/src/Text.css
+++ b/packages/gestalt/src/Text.css
@@ -2,6 +2,11 @@
   composes: antialiased sansSerif from "./Typography.css";
 }
 
+/**
+See keep-all usage for CJK languages. 
+If a language code is specified higher in the parent-tree, then this class is applied 
+https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
+**/
 *:lang(zh) .Text,
 *:lang(ko) .Text,
 *:lang(ja) .Text {

--- a/packages/gestalt/src/Text.css
+++ b/packages/gestalt/src/Text.css
@@ -7,6 +7,7 @@ See keep-all usage for CJK languages.
 If a language code is specified higher in the parent-tree, then this class is applied 
 https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
 **/
+
 *:lang(zh) .Text,
 *:lang(ko) .Text,
 *:lang(ja) .Text {


### PR DESCRIPTION
### Summary

Adding CJK support to wrap `Text`.

#### What changed?

Introduces a css rule:
```
*:lang(zh) .Text,
*:lang(ko) .Text,
*:lang(ja) .Text {
  word-break: keep-all;
}
```

CJK languages should use a `keep-all` word-break to preserve the words. 

See the #Word-Breaks-and-CJK-languages section.

#### Why?

We noticed that in small width containers the text was not getting wrapped as expected. This creates a poor user experience.

Before:
<img width="110" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/5b1f15c2-dc3f-46e6-825c-c985327f3fe7">

After:
<img width="150" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/fa8ba457-a2a4-4398-9ccb-3bb5003b7a98">

We still need to verify the downstream changes and verify if these changes break surfaces

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [X] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
