### PR TITLE
DateField: Add locale format translations

### DIFF
--- a/flow-typed/npm/@mui/material_vx.x.x.js
+++ b/flow-typed/npm/@mui/material_vx.x.x.js
@@ -17,3 +17,7 @@ declare module '@mui/x-date-pickers/LocalizationProvider' {
 declare module '@mui/x-date-pickers/DateField' {
   declare module.exports: any;
 }
+
+declare module '@mui/x-date-pickers/locales' {
+  declare module.exports: any;
+}

--- a/flow-typed/npm/@mui/x-date-pickers_vx.x.x.js
+++ b/flow-typed/npm/@mui/x-date-pickers_vx.x.x.js
@@ -5,3 +5,5 @@ declare module '@actions/material' {
 declare module '@mui/material/styles' {
   declare module.exports: any;
 }
+
+

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -246,6 +246,9 @@ function InternalDateField({
   value,
 }: InternalDateFieldProps): Node {
   let translations;
+
+  // converts date-fns localeData.code (e.g. es-EN) from to the format expected by the MUI Locale (esEN)
+  // https://mui.com/x/react-date-pickers/localization/
   if (localeData && localeData.code) {
     // turns en-US to enUS
     const split = localeData.code.split('-');

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -6,6 +6,7 @@ import { StyledEngineProvider } from '@mui/material/styles';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { unstable_useDateField as useDateField } from '@mui/x-date-pickers/DateField';
 import { DatePicker as MUIDatePicker } from '@mui/x-date-pickers/DatePicker';
+// eslint-disable-next-line import/no-namespace
 import * as locales from '@mui/x-date-pickers/locales';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import classnames from 'classnames';

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -246,7 +246,7 @@ function InternalDateField({
   value,
 }: InternalDateFieldProps): Node {
   let translations;
-  if (localeData) {
+  if (localeData && localeData.code) {
     // turns en-US to enUS
     const split = localeData.code.split('-');
     if (split.length === 1) {

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -6,6 +6,7 @@ import { StyledEngineProvider } from '@mui/material/styles';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { unstable_useDateField as useDateField } from '@mui/x-date-pickers/DateField';
 import { DatePicker as MUIDatePicker } from '@mui/x-date-pickers/DatePicker';
+import * as locales from '@mui/x-date-pickers/locales';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import classnames from 'classnames';
 import { Box, Flex, Pog, Status, TapArea, Text } from 'gestalt';
@@ -243,9 +244,28 @@ function InternalDateField({
   readOnly = false,
   value,
 }: InternalDateFieldProps): Node {
+  let translations;
+  if (localeData) {
+    // turns en-US to enUS
+    const split = localeData.code.split('-');
+    if (split.length === 1) {
+      // turns 'es' into 'enES'
+      split.push(split[0].toUpperCase());
+    }
+    const code = split.join('');
+
+    if (locales[code] !== undefined) {
+      translations = locales[code].components.MuiLocalizationProvider.defaultProps.localeText;
+    }
+  }
+
   return (
     <StyledEngineProvider injectFirst>
-      <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={localeData}>
+      <LocalizationProvider
+        dateAdapter={AdapterDateFns}
+        adapterLocale={localeData}
+        localeText={translations}
+      >
         <Box>
           {label ? (
             <label


### PR DESCRIPTION
### Summary

Not sure what the impact of the namespace import here could be.

#### What changed?

We take the code from localeData, and make it so that we can get it from the MUI locales object, and pass it in to `localeText`. A light transformation is needed between the two.

#### Why?

For birthday picking, translations are an issue.

Before:
![image](https://github.com/pinterest/gestalt/assets/5509813/611f1f5e-5e0a-4b7c-b95b-11dbe76ad396)


After:
![image](https://github.com/pinterest/gestalt/assets/5509813/15610b08-1c29-46d3-a892-8c0e12621807)


### Links



### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
