### PR TITLE
Docs: development mode switch shown when activated from url

### DIFF
--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -58,19 +58,19 @@ function Header() {
     );
   }, [router.events, router.pathname, mainNavigationTabs]);
 
-  const isDeployPreviewEnvironment =
-    process.env.NODE_ENV === 'production' &&
-    window?.location?.href?.startsWith('https://deploy-preview-');
-
   const [showDevelopmentEditorSwitch, setShowDevelopmentEditorSwitch] = useState(
-    isDeployPreviewEnvironment || process.env.NODE_ENV === 'development',
+    process.env.NODE_ENV === 'development',
   );
 
   useEffect(() => {
+    const isDeployPreviewEnvironment =
+      process.env.NODE_ENV === 'production' &&
+      window?.location?.href?.startsWith('https://deploy-preview-');
+
     const devModeSetFromUrl = router.query.devexample && router.query.devexample === 'true';
 
-    // show switch if set via url
-    if (devModeSetFromUrl) {
+    // show switch if set via url or is a deployment URL
+    if (devModeSetFromUrl || isDeployPreviewEnvironment) {
       setShowDevelopmentEditorSwitch(true);
     }
   }, [setShowDevelopmentEditorSwitch, router.pathname, router.query]);

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -58,32 +58,24 @@ function Header() {
     );
   }, [router.events, router.pathname, mainNavigationTabs]);
 
+  const isDeployPreviewEnvironment =
+    process.env.NODE_ENV === 'production' &&
+    window?.location?.href?.startsWith('https://deploy-preview-');
+
   const [showDevelopmentEditorSwitch, setShowDevelopmentEditorSwitch] = useState(
-    process.env.NODE_ENV === 'development',
+    isDeployPreviewEnvironment || process.env.NODE_ENV === 'development',
   );
 
   useEffect(() => {
     const devModeSetFromUrl = router.query.devexample && router.query.devexample === 'true';
 
-    // do not show switch if set via url
+    // show switch if set via url
     if (devModeSetFromUrl) {
-      setShowDevelopmentEditorSwitch(false);
-      return;
-    }
-
-    const isDeployPreviewEnvironment =
-      process.env.NODE_ENV === 'production' &&
-      window?.location?.href?.startsWith('https://deploy-preview-');
-
-    if (isDeployPreviewEnvironment || process.env.NODE_ENV === 'development')
       setShowDevelopmentEditorSwitch(true);
+    }
   }, [setShowDevelopmentEditorSwitch, router.pathname, router.query]);
 
   const { colorScheme, setColorScheme, devExampleMode, setDevExampleMode } = useAppContext();
-
-  const devExampleModeButtonLabel = `Toggle dev example mode ${
-    devExampleMode === 'development' ? 'off' : 'on'
-  }`;
 
   const darkModeButtonLabel = `Toggle ${colorScheme === 'dark' ? 'light' : 'dark'} mode`;
   const onChangeColorScheme = () => {
@@ -177,7 +169,7 @@ function Header() {
 
         <Box paddingX={2} display={isMobileSearchExpandedOpen ? 'none' : 'flex'}>
           <Flex alignItems="center" gap={3}>
-            {devExampleMode === 'development' ? (
+            {showDevelopmentEditorSwitch && devExampleMode === 'development' ? (
               <Badge
                 text="Dev mode"
                 position="middle"
@@ -198,7 +190,9 @@ function Header() {
                 onClick={onChangeDevExampleMode}
                 selected={devExampleMode === 'development'}
                 tooltip={{
-                  text: devExampleModeButtonLabel,
+                  text: `Toggle dev example mode ${
+                    devExampleMode === 'development' ? 'off' : 'on'
+                  }`,
                   inline: true,
                   idealDirection: 'down',
                   accessibilityLabel: '',

--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -169,7 +169,7 @@ function Header() {
 
         <Box paddingX={2} display={isMobileSearchExpandedOpen ? 'none' : 'flex'}>
           <Flex alignItems="center" gap={3}>
-            {showDevelopmentEditorSwitch && devExampleMode === 'development' ? (
+            {devExampleMode === 'development' ? (
               <Badge
                 text="Dev mode"
                 position="middle"


### PR DESCRIPTION
### Summary

#### What changed?

Docs: development mode switch shown when activated from url

#### Why?

Because sometimes I find myself in dev mode and can't toggle it off as it's set in locale storage.

It's bothered me about 2-3 times already. Removing the switch doesn't really provide a better experience over all. 

<img width="1399" alt="Screenshot 2023-07-26 at 6 11 47 PM" src="https://github.com/pinterest/gestalt/assets/10593890/1614b517-67bb-45c1-94e5-fc6a59e5fdbc">


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
