### PR TITLE
Icon: support rtl to "mute" icon

### DIFF
--- a/packages/gestalt/src/Icon.js
+++ b/packages/gestalt/src/Icon.js
@@ -73,6 +73,7 @@ const flipOnRtlIconNames = [
   'flipVertical',
   'hand-pointing',
   'link',
+  'mute',
   'reorder-images',
   'send',
   'sound',

--- a/packages/gestalt/src/Video/__snapshots__/Controls.test.js.snap
+++ b/packages/gestalt/src/Video/__snapshots__/Controls.test.js.snap
@@ -161,7 +161,7 @@ exports[`VideoControls for double digit minutes 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon lightIcon iconBlock"
+        className="rtlSupport icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -337,7 +337,7 @@ exports[`VideoControls for double digit seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon lightIcon iconBlock"
+        className="rtlSupport icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -513,7 +513,7 @@ exports[`VideoControls for single digit minutes 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon lightIcon iconBlock"
+        className="rtlSupport icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -689,7 +689,7 @@ exports[`VideoControls for single digit seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon lightIcon iconBlock"
+        className="rtlSupport icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"
@@ -865,7 +865,7 @@ exports[`VideoControls rounds for partial seconds 1`] = `
       <svg
         aria-hidden={null}
         aria-label="Unmute"
-        className="icon lightIcon iconBlock"
+        className="rtlSupport icon lightIcon iconBlock"
         height={20}
         role="img"
         viewBox="0 0 24 24"

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -290,7 +290,7 @@ exports[`Video with children 1`] = `
         <svg
           aria-hidden={null}
           aria-label="Unmute"
-          className="icon lightIcon iconBlock"
+          className="rtlSupport icon lightIcon iconBlock"
           height={20}
           role="img"
           viewBox="0 0 24 24"


### PR DESCRIPTION
### Summary

#### What changed?

Icon: support rtl to "mute" icon

#### Why?

https://jira.pinadmin.com/browse/BUG-161879
![image](https://github.com/pinterest/gestalt/assets/10593890/485c166f-d274-4c68-aa9b-07806cda37b3)

