### PR TITLE
Table: Headercell take full width

### DIFF
--- a/docs/examples/table/sortableTableCells.js
+++ b/docs/examples/table/sortableTableCells.js
@@ -18,6 +18,11 @@ export default function SortableHeaderExample(): Node {
   return (
     <Box height="100%" display="flex" justifyContent="center" alignItems="center">
       <Table accessibilityLabel="Sortable header cells">
+        <colgroup>
+          <col span="1" style={{ width: '10%' }} />
+          <col span="1" style={{ width: '10%' }} />
+          <col span="1" style={{ width: '80%' }} />
+        </colgroup>
         <Table.Header>
           <Table.Row>
             <Table.SortableHeaderCell
@@ -53,9 +58,7 @@ export default function SortableHeaderExample(): Node {
             <Text>Snax</Text>
           </Table.Cell>
           <Table.Cell>
-            <Box width={100}>
-              <Text align="end">$50</Text>
-            </Box>
+            <Text align="end">$50</Text>
           </Table.Cell>
         </Table.Row>
       </Table>

--- a/docs/examples/table/sortableTableCells.js
+++ b/docs/examples/table/sortableTableCells.js
@@ -53,7 +53,9 @@ export default function SortableHeaderExample(): Node {
             <Text>Snax</Text>
           </Table.Cell>
           <Table.Cell>
-            <Text align="end">$50</Text>
+            <Box width={100}>
+              <Text align="end">$50</Text>
+            </Box>
           </Table.Cell>
         </Table.Row>
       </Table>

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -130,6 +130,7 @@ export default function TableSortableHeaderCell({
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
         >
+          {/** Ideally, we would reverse the flex with row-reverse, but row-reverse will deviate from the DOM structure causing an accessibility issue in the order things are read */}
           <Box display="flex" alignItems="center" justifyContent={align}>
             {align === 'end' && (
               <SortIcon

--- a/packages/gestalt/src/TableSortableHeaderCell.js
+++ b/packages/gestalt/src/TableSortableHeaderCell.js
@@ -59,6 +59,34 @@ type Props = {|
   status: 'active' | 'inactive',
 |};
 
+function SortIcon({
+  align,
+  status,
+  sortOrder,
+  visibility,
+}: {|
+  align: 'start' | 'end',
+  status: 'active' | 'inactive',
+  sortOrder: 'asc' | 'desc',
+  visibility: 'visible' | 'hidden',
+|}) {
+  return (
+    <Box
+      marginStart={align === 'start' ? 2 : undefined}
+      marginEnd={align === 'end' ? 2 : undefined}
+      dangerouslySetInlineStyle={{
+        __style: { visibility },
+      }}
+    >
+      <Icon
+        accessibilityLabel=""
+        icon={status === 'active' && sortOrder === 'asc' ? 'sort-ascending' : 'sort-descending'}
+        color={status === 'active' ? 'default' : 'subtle'}
+      />
+    </Box>
+  );
+}
+
 /**
  * Use [Table.SortableHeaderCell](https://gestalt.pinterest.systems/web/table#Table.SortableHeaderCell) to define a header cell with sorting functionality in Table.
  */
@@ -90,7 +118,7 @@ export default function TableSortableHeaderCell({
       shouldHaveShadow={shouldHaveShadow}
       previousTotalWidth={previousTotalWidth}
     >
-      <Box display="inlineBlock">
+      <Box display="inlineBlock" width="100%">
         <TapArea
           fullWidth={false}
           onTap={(...args) => {
@@ -102,30 +130,24 @@ export default function TableSortableHeaderCell({
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
         >
-          <Box
-            display="flex"
-            alignItems="center"
-            justifyContent={align}
-            dangerouslySetInlineStyle={{
-              __style: { flexDirection: align === 'end' ? 'row-reverse' : 'row' },
-            }}
-          >
-            {children}
-            <Box
-              marginStart={align === 'start' ? 2 : undefined}
-              marginEnd={align === 'end' ? 2 : undefined}
-              dangerouslySetInlineStyle={{
-                __style: { visibility },
-              }}
-            >
-              <Icon
-                accessibilityLabel=""
-                icon={
-                  status === 'active' && sortOrder === 'asc' ? 'sort-ascending' : 'sort-descending'
-                }
-                color={status === 'active' ? 'default' : 'subtle'}
+          <Box display="flex" alignItems="center" justifyContent={align}>
+            {align === 'end' && (
+              <SortIcon
+                align={align}
+                status={status}
+                sortOrder={sortOrder}
+                visibility={visibility}
               />
-            </Box>
+            )}
+            {children}
+            {align === 'start' && (
+              <SortIcon
+                align={align}
+                status={status}
+                sortOrder={sortOrder}
+                visibility={visibility}
+              />
+            )}
           </Box>
         </TapArea>
       </Box>

--- a/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableSortableHeaderCell.test.js.snap
@@ -13,6 +13,11 @@ exports[`renders correctly when active 1`] = `
 >
   <div
     className="box xsDisplayInlineBlock"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       aria-disabled={false}
@@ -35,11 +40,6 @@ exports[`renders correctly when active 1`] = `
     >
       <div
         className="box xsDisplayFlex xsItemsCenter"
-        style={
-          Object {
-            "flexDirection": "row",
-          }
-        }
       >
         column name
         <div
@@ -83,6 +83,11 @@ exports[`renders correctly when inactive 1`] = `
 >
   <div
     className="box xsDisplayInlineBlock"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       aria-disabled={false}
@@ -105,11 +110,6 @@ exports[`renders correctly when inactive 1`] = `
     >
       <div
         className="box xsDisplayFlex xsItemsCenter"
-        style={
-          Object {
-            "flexDirection": "row",
-          }
-        }
       >
         column name
         <div
@@ -153,6 +153,11 @@ exports[`sortable cell has end align 1`] = `
 >
   <div
     className="box xsDisplayInlineBlock"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       aria-disabled={false}
@@ -175,13 +180,7 @@ exports[`sortable cell has end align 1`] = `
     >
       <div
         className="box justifyEnd xsDisplayFlex xsItemsCenter"
-        style={
-          Object {
-            "flexDirection": "row-reverse",
-          }
-        }
       >
-        column name
         <div
           className="box marginEnd2"
           style={
@@ -204,6 +203,7 @@ exports[`sortable cell has end align 1`] = `
             />
           </svg>
         </div>
+        column name
       </div>
     </div>
   </div>


### PR DESCRIPTION
Bug fix:

### Summary
Changes the header cell to take the full width, so end-align works as expected.

#### What changed?

Adding width 100%.

Getting rid of row-reverse since it's not accessible, and replacing with Icon rendering.

#### Why?

Before:

![image](https://github.com/pinterest/gestalt/assets/5509813/d83d9b4b-5af7-4f59-82b9-a617d9ac9ead)

After:
<img width="514" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/164f773d-0557-44ba-be85-0e8558b40fcf">


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
