### PR TITLE
WONT MERGE ActivationCard, Callout, OverlayPanel, PopoverEducational, SheetMobile, SlimBanner, Toast, Upsell: extended dataTestId from Button

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -321,6 +321,7 @@ type TrendObject = {
 
 interface ActionData {
   accessibilityLabel: string;
+  dataTestId?: string,
   disabled?: boolean;
   href?: string | undefined;
   label: string;
@@ -404,7 +405,7 @@ interface DefaultLabelProviderProps {
           accessibilityRemoveIconLabel: string;
           accessibilityWarningIconLabel: string;
         };
-        TagData:{
+        TagData: {
           accessibilityRemoveIconLabel: string;
         };
         TextField: {
@@ -483,6 +484,7 @@ interface ActivationCardProps {
   link?:
     | {
         accessibilityLabel: string;
+        dataTestId?: string;
         href: string;
         label: string;
         onClick?: ButtonEventHandlerType | undefined;
@@ -1315,11 +1317,13 @@ interface OverlayPanelProps {
     subtext?: string | undefined;
     primaryAction?: {
       accessibilityLabel?: string | undefined;
+      dataTestId?: string;
       text?: string | undefined;
       onClick?: BareButtonEventHandlerType | undefined;
     };
     secondaryAction?: {
       accessibilityLabel?: string | undefined;
+      dataTestId?: string;
       text?: string | undefined;
       onClick?: BareButtonEventHandlerType | undefined;
     };
@@ -1435,6 +1439,7 @@ interface PopoverEducationalProps {
   primaryAction?:
     | {
         accessibilityLabel?: string | undefined;
+        dataTestId?: string,
         href?: string | undefined;
         text: string | undefined;
         onClick?: ButtonEventHandlerType | undefined;
@@ -1587,6 +1592,7 @@ interface SheetMobileProps {
   onAnimationEnd?: OnAnimationEndType | undefined;
   primaryAction?: {
     accessibilityLabel: string;
+    dataTestId?: string,
     label: string;
     onClick: AbstractEventHandler<
       | React.MouseEvent<HTMLButtonElement>
@@ -1693,6 +1699,7 @@ interface SlimBannerProps {
   primaryAction?:
     | {
         accessibilityLabel: string;
+        dataTestId?: string,
         label: string;
         disabled?: boolean | undefined;
         href?: string | undefined;
@@ -1871,26 +1878,26 @@ interface TagProps {
 
 interface TagDataProps {
   accessibilityRemoveIconLabel?: string | undefined;
-  baseColor?: 'primary' | 'secondary'
-  color?: DataVisualizationColors,
-  disabled?: boolean,
-  id?: string,
-  onTap?: | AbstractEventHandler<
-  | React.MouseEvent<HTMLDivElement>
-  | React.KeyboardEvent<HTMLDivElement>
-  | React.MouseEvent<HTMLAnchorElement>
-  | React.KeyboardEvent<HTMLAnchorElement>,
-  { selected: boolean; id?: string | undefined }
->
-| undefined,
-onRemove: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>>,
-selected?: boolean,
-size?: 'sm' | 'md' | 'lg',
-showCheckbox?: boolean,
-text: string,
-tooltip?: TooltipProps,
+  baseColor?: 'primary' | 'secondary';
+  color?: DataVisualizationColors;
+  disabled?: boolean;
+  id?: string;
+  onTap?:
+    | AbstractEventHandler<
+        | React.MouseEvent<HTMLDivElement>
+        | React.KeyboardEvent<HTMLDivElement>
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.KeyboardEvent<HTMLAnchorElement>,
+        { selected: boolean; id?: string | undefined }
+      >
+    | undefined;
+  onRemove: AbstractEventHandler<React.MouseEvent<HTMLButtonElement>>;
+  selected?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+  showCheckbox?: boolean;
+  text: string;
+  tooltip?: TooltipProps;
 }
-
 
 interface CommonTapAreaProps {
   accessibilityLabel?: string | undefined;
@@ -2075,6 +2082,7 @@ interface ToastProps {
     | undefined;
   primaryAction?: {
     accessibilityLabel: string;
+    dataTestId?: string,
     label: string;
     href?: string | undefined;
     onClick?: ButtonEventHandlerType | undefined;
@@ -2129,6 +2137,7 @@ interface UpsellProps {
 interface UpsellFormProps {
   children: Node;
   onSubmit: BareButtonEventHandlerType;
+  submitButtonDataTestId?: string,
   submitButtonText: string;
   submitButtonAccessibilityLabel: string;
   submitButtonDisabled?: boolean | undefined;

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -321,7 +321,7 @@ type TrendObject = {
 
 interface ActionData {
   accessibilityLabel: string;
-  dataTestId?: string,
+  dataTestId?: string;
   disabled?: boolean;
   href?: string | undefined;
   label: string;
@@ -1439,7 +1439,7 @@ interface PopoverEducationalProps {
   primaryAction?:
     | {
         accessibilityLabel?: string | undefined;
-        dataTestId?: string,
+        dataTestId?: string;
         href?: string | undefined;
         text: string | undefined;
         onClick?: ButtonEventHandlerType | undefined;
@@ -1592,7 +1592,7 @@ interface SheetMobileProps {
   onAnimationEnd?: OnAnimationEndType | undefined;
   primaryAction?: {
     accessibilityLabel: string;
-    dataTestId?: string,
+    dataTestId?: string;
     label: string;
     onClick: AbstractEventHandler<
       | React.MouseEvent<HTMLButtonElement>
@@ -1699,7 +1699,7 @@ interface SlimBannerProps {
   primaryAction?:
     | {
         accessibilityLabel: string;
-        dataTestId?: string,
+        dataTestId?: string;
         label: string;
         disabled?: boolean | undefined;
         href?: string | undefined;
@@ -2082,7 +2082,7 @@ interface ToastProps {
     | undefined;
   primaryAction?: {
     accessibilityLabel: string;
-    dataTestId?: string,
+    dataTestId?: string;
     label: string;
     href?: string | undefined;
     onClick?: ButtonEventHandlerType | undefined;
@@ -2137,7 +2137,7 @@ interface UpsellProps {
 interface UpsellFormProps {
   children: Node;
   onSubmit: BareButtonEventHandlerType;
-  submitButtonDataTestId?: string,
+  submitButtonDataTestId?: string;
   submitButtonText: string;
   submitButtonAccessibilityLabel: string;
   submitButtonDisabled?: boolean | undefined;

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -18,6 +18,7 @@ const STATUS_ICONS = {
 
 type LinkData = {|
   accessibilityLabel: string,
+  dataTestId?: string,
   href: string,
   label: string,
   onClick?: ({|
@@ -74,7 +75,7 @@ type Props = {|
 |};
 
 function ActivationCardLink({ data }: {| data: LinkData |}): Node {
-  const { accessibilityLabel, href, label, onClick, rel, target } = data;
+  const { accessibilityLabel, dataTestId, href, label, onClick, rel, target } = data;
 
   return (
     <Box
@@ -87,6 +88,7 @@ function ActivationCardLink({ data }: {| data: LinkData |}): Node {
     >
       <Button
         accessibilityLabel={accessibilityLabel}
+        dataTestId={dataTestId}
         color="gray"
         href={href}
         fullWidth

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -51,7 +51,7 @@ type BaseButton = {|
     | 'semiTransparentWhite'
     | 'transparentWhiteText'
     | 'white',
-  dataTestId?: string,
+  dataTestId: string,
   disabled?: boolean,
   iconEnd?: $Keys<typeof icons>,
   fullWidth?: boolean,

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -51,7 +51,7 @@ type BaseButton = {|
     | 'semiTransparentWhite'
     | 'transparentWhiteText'
     | 'white',
-  dataTestId: string,
+  dataTestId?: string,
   disabled?: boolean,
   iconEnd?: $Keys<typeof icons>,
   fullWidth?: boolean,

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -13,6 +13,7 @@ import useResponsiveMinWidth from './useResponsiveMinWidth.js';
 
 export type ActionDataType = {|
   accessibilityLabel: string,
+  dataTestId?: string,
   disabled?: boolean,
   href?: string,
   label: string,
@@ -51,6 +52,7 @@ type Props = {|
    */
   primaryAction?: {|
     accessibilityLabel: string,
+    dataTestId?: string,
     disabled?: boolean,
     href?: string,
     label: string,
@@ -72,6 +74,7 @@ type Props = {|
    */
   secondaryAction?: {|
     accessibilityLabel: string,
+    dataTestId?: string,
     disabled?: boolean,
     href?: string,
     label: string,
@@ -106,7 +109,7 @@ function CalloutAction({
   type: string,
 |}): Node {
   const color = type === 'primary' ? 'white' : 'transparent';
-  const { accessibilityLabel, disabled, label, onClick, href, rel, target } = data;
+  const { accessibilityLabel, dataTestId, disabled, label, onClick, href, rel, target } = data;
 
   return (
     <Box
@@ -123,6 +126,7 @@ function CalloutAction({
         <Button
           accessibilityLabel={accessibilityLabel}
           color={color}
+          dataTestId={dataTestId}
           disabled={disabled}
           href={href}
           fullWidth
@@ -136,6 +140,7 @@ function CalloutAction({
       ) : (
         <Button
           accessibilityLabel={accessibilityLabel}
+          dataTestId={dataTestId}
           disabled={disabled}
           color={color}
           onClick={onClick}

--- a/packages/gestalt/src/OverlayPanel.js
+++ b/packages/gestalt/src/OverlayPanel.js
@@ -45,6 +45,7 @@ type Props = {|
     subtext?: string,
     primaryAction?: {|
       accessibilityLabel?: string,
+      dataTestId?: string,
       text?: string,
       onClick?: ({|
         event:
@@ -56,6 +57,7 @@ type Props = {|
     |},
     secondaryAction?: {|
       accessibilityLabel?: string,
+      dataTestId?: string,
       text?: string,
       onClick?: ({|
         event:

--- a/packages/gestalt/src/OverlayPanel/ConfirmationPopover.js
+++ b/packages/gestalt/src/OverlayPanel/ConfirmationPopover.js
@@ -17,6 +17,7 @@ type Props = {|
   onDismiss: () => void,
   primaryAction?: {|
     accessibilityLabel?: string,
+    dataTestId?: string,
     text?: string,
     onClick?: ({|
       event:
@@ -28,6 +29,7 @@ type Props = {|
   |},
   secondaryAction?: {|
     accessibilityLabel?: string,
+    dataTestId?: string,
     text?: string,
     onClick?: ({|
       event:
@@ -100,6 +102,7 @@ export default function ConfirmationPopover({
                 accessibilityLabel={
                   secondaryAction?.accessibilityLabel ?? secondaryActionTextLabelDefault
                 }
+                dataTestId={secondaryAction?.dataTestId}
                 color="gray"
                 text={secondaryAction?.text ?? secondaryActionTextDefault}
                 onClick={({ event }) => {
@@ -109,6 +112,7 @@ export default function ConfirmationPopover({
               />
               <Button
                 color="red"
+                dataTestId={primaryAction?.dataTestId}
                 accessibilityLabel={
                   primaryAction?.accessibilityLabel ?? primaryActionTextLabelDefault
                 }

--- a/packages/gestalt/src/OverlayPanel/InternalOverlayPanel.js
+++ b/packages/gestalt/src/OverlayPanel/InternalOverlayPanel.js
@@ -39,6 +39,7 @@ type InternalSheetProps = {|
     subtext?: string,
     primaryAction?: {|
       accessibilityLabel?: string,
+      dataTestId?: string,
       text?: string,
       onClick?: ({|
         event:
@@ -50,6 +51,7 @@ type InternalSheetProps = {|
     |},
     secondaryAction?: {|
       accessibilityLabel?: string,
+      dataTestId?: string,
       text?: string,
       onClick?: ({|
         event:

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -14,6 +14,7 @@ type IdealDirection = 'up' | 'right' | 'down' | 'left';
 type Role = 'dialog' | 'tooltip';
 type PrimaryActionType = {|
   accessibilityLabel?: string,
+  dataTestId?: string,
   href?: string,
   text: string,
   onClick?: ({|
@@ -30,6 +31,7 @@ type PrimaryActionType = {|
 
 function PrimaryAction({
   accessibilityLabel,
+  dataTestId,
   href,
   text,
   onClick,
@@ -39,6 +41,7 @@ function PrimaryAction({
   return href ? (
     <Button
       accessibilityLabel={accessibilityLabel}
+      dataTestId={dataTestId}
       color="white"
       fullWidth={false}
       href={href}
@@ -52,6 +55,7 @@ function PrimaryAction({
     <Button
       accessibilityLabel={accessibilityLabel}
       color="white"
+      dataTestId={dataTestId}
       fullWidth={false}
       onClick={onClick}
       role="button"

--- a/packages/gestalt/src/SheetMobile.js
+++ b/packages/gestalt/src/SheetMobile.js
@@ -82,6 +82,7 @@ type Props = {|
    */
   primaryAction?: {|
     accessibilityLabel: string,
+    dataTestId?: string,
     href?: string,
     label: string,
     onClick: ({|

--- a/packages/gestalt/src/SheetMobile/FullPage.js
+++ b/packages/gestalt/src/SheetMobile/FullPage.js
@@ -35,6 +35,7 @@ type Props = {|
   padding?: 'default' | 'none',
   primaryAction?: {|
     accessibilityLabel: string,
+    dataTestId?: string,
     href?: string,
     label: string,
     onClick: OnClickType,

--- a/packages/gestalt/src/SheetMobile/Header.js
+++ b/packages/gestalt/src/SheetMobile/Header.js
@@ -32,6 +32,7 @@ type Props = {|
   onDismiss?: () => void,
   primaryAction: ?{|
     accessibilityLabel: string,
+    dataTestId?: string,
     href?: string,
     label: string,
     onClick: OnClickType,
@@ -152,6 +153,7 @@ export default function Header({
           <Flex.Item flex="shrink">
             <PrimaryAction
               accessibilityLabel={primaryAction.accessibilityLabel}
+              dataTestId={primaryAction.dataTestId}
               href={primaryAction.href}
               rel={primaryAction?.rel}
               target={primaryAction?.target}

--- a/packages/gestalt/src/SheetMobile/PartialPage.js
+++ b/packages/gestalt/src/SheetMobile/PartialPage.js
@@ -54,6 +54,7 @@ type Props = {|
   padding?: 'default' | 'none',
   primaryAction?: {|
     accessibilityLabel: string,
+    dataTestId?: string,
     href?: string,
     label: string,
     onClick: OnClickType,

--- a/packages/gestalt/src/SheetMobile/PrimaryAction.js
+++ b/packages/gestalt/src/SheetMobile/PrimaryAction.js
@@ -5,6 +5,7 @@ import Link from '../Link.js';
 
 type Props = {|
   accessibilityLabel: string,
+  dataTestId?: string,
   href?: string,
   label: string,
   onClick?: $ElementType<ElementConfig<typeof Button>, 'onClick'>,
@@ -15,6 +16,7 @@ type Props = {|
 
 export default function PrimaryAction({
   accessibilityLabel,
+  dataTestId,
   href,
   label,
   onClick,
@@ -26,6 +28,7 @@ export default function PrimaryAction({
     return (
       <Button
         accessibilityLabel={accessibilityLabel}
+        dataTestId={dataTestId}
         href={href}
         rel={rel}
         target={target}
@@ -40,6 +43,7 @@ export default function PrimaryAction({
   return (
     <Button
       accessibilityLabel={accessibilityLabel}
+      dataTestId={dataTestId}
       text={label}
       size={size}
       onClick={onClick}

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -57,6 +57,7 @@ function HelperLink({ accessibilityLabel, href, onClick, target, text }: HelperL
 
 type PrimaryActionType = {|
   accessibilityLabel: string,
+  dataTestId?: string,
   disabled?: boolean,
   href?: string,
   label: string,
@@ -74,6 +75,7 @@ type PrimaryActionType = {|
 
 function PrimaryAction({
   accessibilityLabel,
+  dataTestId,
   disabled,
   href,
   label,
@@ -85,6 +87,7 @@ function PrimaryAction({
     <Button
       accessibilityLabel={accessibilityLabel}
       color="white"
+      dataTestId={dataTestId}
       disabled={disabled}
       fullWidth
       href={href}
@@ -99,6 +102,7 @@ function PrimaryAction({
     <Button
       accessibilityLabel={accessibilityLabel}
       color="white"
+      dataTestId={dataTestId}
       disabled={disabled}
       fullWidth
       onClick={onClick}

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -74,6 +74,7 @@ type Props = {|
    */
   primaryAction?: {|
     accessibilityLabel: string,
+    dataTestId?: string,
     href?: string,
     label: string,
     onClick?: $ElementType<ElementConfig<typeof Button>, 'onClick'>,
@@ -214,6 +215,7 @@ export default function Toast({
               primaryAction?.label ? (
                 <PrimaryAction
                   accessibilityLabel={primaryAction.accessibilityLabel}
+                  dataTestId={primaryAction?.dataTestId}
                   href={primaryAction.href}
                   rel={primaryAction?.rel}
                   size="sm"

--- a/packages/gestalt/src/Toast/PrimaryAction.js
+++ b/packages/gestalt/src/Toast/PrimaryAction.js
@@ -5,6 +5,7 @@ import Link from '../Link.js';
 
 type Props = {|
   accessibilityLabel: string,
+  dataTestId?: string,
   href?: string,
   label: string,
   onClick?: $ElementType<ElementConfig<typeof Button>, 'onClick'>,
@@ -15,6 +16,7 @@ type Props = {|
 
 export default function PrimaryAction({
   accessibilityLabel,
+  dataTestId,
   href,
   label,
   onClick,
@@ -26,6 +28,7 @@ export default function PrimaryAction({
     return (
       <Button
         accessibilityLabel={accessibilityLabel}
+        dataTestId={dataTestId}
         href={href}
         rel={rel}
         target={target}

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -16,6 +16,7 @@ import useResponsiveMinWidth from './useResponsiveMinWidth.js';
 
 export type ActionDataType = {|
   accessibilityLabel: string,
+  dataTestId?: string,
   disabled?: boolean,
   href?: string,
   label: string,
@@ -39,12 +40,13 @@ type UpsellActionProps = {|
 
 function UpsellAction({ data, stacked, type }: UpsellActionProps): Node {
   const color = type === 'primary' ? 'red' : 'gray';
-  const { accessibilityLabel, disabled, href, label, onClick, rel, target } = data;
+  const { accessibilityLabel, disabled, href, label, onClick, rel, target, dataTestId } = data;
 
   const commonProps = {
     accessibilityLabel,
     color,
     disabled,
+    dataTestId,
     fullWidth: true,
     onClick,
     size: 'lg',
@@ -105,6 +107,7 @@ type Props = {|
    */
   primaryAction?: {|
     accessibilityLabel: string,
+    dataTestId?: string,
     disabled?: boolean,
     href?: string,
     label: string,
@@ -126,6 +129,7 @@ type Props = {|
    */
   secondaryAction?: {|
     accessibilityLabel: string,
+    dataTestId?: string,
     disabled?: boolean,
     href?: string,
     label: string,

--- a/packages/gestalt/src/UpsellForm.js
+++ b/packages/gestalt/src/UpsellForm.js
@@ -21,6 +21,10 @@ type Props = {|
       | SyntheticKeyboardEvent<HTMLButtonElement>,
   |}) => void,
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  submitButtonTextDataTestId?: string,
+  /**
    * Text content of the submit button. Be sure to localize!
    */
   submitButtonText: string,
@@ -41,6 +45,7 @@ export default function UpsellForm({
   children,
   onSubmit,
   submitButtonText,
+  submitButtonTextDataTestId,
   submitButtonAccessibilityLabel,
   submitButtonDisabled,
 }: Props): Node {
@@ -64,6 +69,7 @@ export default function UpsellForm({
           <Button
             accessibilityLabel={submitButtonAccessibilityLabel}
             color="red"
+            dataTestId={submitButtonTextDataTestId}
             disabled={submitButtonDisabled}
             fullWidth={isXsWidth}
             text={submitButtonText}


### PR DESCRIPTION
### Summary

#### What changed?

Component: extended dataTestId

#### Why?

Extend Button's dataTestId to components using Button internally
