### PR TITLE
GlobalEventsHandlerProvider, DatePicker, DateRange, DateField: add `onMount` handlers

### DIFF
--- a/docs/docs-components/CombinationNew.js
+++ b/docs/docs-components/CombinationNew.js
@@ -50,6 +50,7 @@ type Props = {
   children: (props: { [key: string]: any, ... }, index?: number) => Node,
   hideTitle?: boolean,
   hasCheckerboard?: boolean,
+  cardSize?: 'xs',
   ...
 };
 
@@ -57,6 +58,7 @@ export default function CombinationNew({
   children,
   hideTitle,
   hasCheckerboard,
+  cardSize,
   ...props
 }: Props): Node {
   const CardArray = combinations(props).map((combination, i) => {
@@ -79,7 +81,7 @@ export default function CombinationNew({
     return (
       <MainSectionCard
         key={JSON.stringify(combination)}
-        cardSize="sm"
+        cardSize={cardSize || 'sm'}
         shadeColor={cardShadeColor}
         title={hideTitle ? undefined : combinationTitles}
       >
@@ -91,13 +93,7 @@ export default function CombinationNew({
     );
   });
   return (
-    <Flex
-      wrap
-      gap={{
-        row: 4,
-        column: 0,
-      }}
-    >
+    <Flex wrap gap={4}>
       {CardArray}
     </Flex>
   );

--- a/docs/docs-components/MainSectionCard.js
+++ b/docs/docs-components/MainSectionCard.js
@@ -13,7 +13,7 @@ import Markdown from './Markdown.js';
 import capitalizeFirstLetter from '../utils/capitalizeFirstLetter.js';
 
 type Props = {|
-  cardSize?: 'sm' | 'md' | 'lg',
+  cardSize?: 'xs' | 'sm' | 'md' | 'lg',
   children?: Node,
   defaultCode?: string,
   description?: string,
@@ -32,6 +32,7 @@ type PreviewCardProps = {|
 |};
 
 const CARD_SIZE_NAME_TO_PIXEL = {
+  xs: 90,
   sm: 236,
   md: 362,
   lg: '100%',
@@ -72,12 +73,12 @@ function MainSectionCard({
     ({ children: cardChildren }: PreviewCardProps) => (
       <Box
         alignItems="center"
-        borderStyle="sm"
+        borderStyle={cardSize === 'xs' ? 'none' : 'sm'}
         color={cardShadeColor}
         display="flex"
-        height={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
+        height={cardSize === 'xs' ? 80 : CARD_SIZE_NAME_TO_PIXEL[cardSize]}
         justifyContent="center"
-        padding={8}
+        padding={cardSize === 'xs' ? 1 : 8}
         position="relative"
         rounding={2}
       >
@@ -117,11 +118,17 @@ function MainSectionCard({
     </Box>
   );
 
+  let marginBotton = 12;
+  if (marginBottom === 'none') {
+    marginBotton = 0;
+  }
+
+  if (cardSize === 'xs') {
+    marginBotton = 4;
+  }
+
   return (
-    <Box
-      minWidth={CARD_SIZE_NAME_TO_PIXEL[cardSize]}
-      marginBottom={marginBottom === 'none' ? 0 : 12}
-    >
+    <Box minWidth={CARD_SIZE_NAME_TO_PIXEL[cardSize]} marginBottom={marginBotton}>
       {showTitleAndDescriptionAboveExample && (title || description) && TitleAndDescription}
 
       {Boolean(children) && <PreviewCard>{children}</PreviewCard>}

--- a/docs/docs-components/MainSectionSubsection.js
+++ b/docs/docs-components/MainSectionSubsection.js
@@ -1,14 +1,14 @@
 // @flow strict
 import { Children, type Node } from 'react';
 import slugify from 'slugify';
-import { Badge, Box, Flex, Heading, Tooltip } from 'gestalt';
+import { Badge, Box, Flex, Heading } from 'gestalt';
 import CopyLinkButton from './buttons/CopyLinkButton.js';
 import { copyToClipboard } from './Card.js';
 import { DOCS_COPY_MAX_WIDTH_PX } from './consts.js';
 import Markdown from './Markdown.js';
 
 type Props = {|
-  badge?: 'beta' | 'alpha',
+  badge?: 'alpha' | 'experimental',
   children?: Node,
   columns?: 1 | 2,
   description?: string,
@@ -56,16 +56,15 @@ function MainSectionSubsection({
             >
               <Heading size="400">{title}</Heading>
               {badge ? (
-                <Tooltip
-                  inline
-                  text={
-                    badge === 'beta'
-                      ? 'This tool is in beta. We are still working on it! Have feedback? Reach out to us on Slack #gestalt-eng-web!'
-                      : 'This tool is under development. More components will be supported in the future! The team is currently working on it.'
+                <Badge
+                  text={badge === 'experimental' ? 'Experimental' : 'Alpha'}
+                  position="middle"
+                  tooltip={
+                    badge === 'experimental'
+                      ? { text: 'Experimental feature.  It could be removed in the future.' }
+                      : { text: 'Alpha development state.' }
                   }
-                >
-                  <Badge text={badge === 'beta' ? 'Beta' : 'Alpha'} position="middle" />
-                </Tooltip>
+                />
               ) : null}
               <CopyLinkButton
                 name={title}

--- a/docs/pages/web/buttonlink.js
+++ b/docs/pages/web/buttonlink.js
@@ -52,6 +52,20 @@ These optional props control the behavior of ButtonLink. External links commonly
 
       <AccessibilitySection name={generatedDocGen?.displayName} />
 
+      <MainSection name="Variants">
+        <MainSection.Subsection
+          title="External handlers"
+          description={`ButtonLink consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
+
+Handlers:
+
+- [onNavigation](/web/utilities/globaleventshandlerprovider#onNavigation:-custom-navigation): executed when ButtonLink is clicked
+
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onNavigation:-custom-navigation) for more information.
+`}
+        />
+      </MainSection>
+
       <QualityChecklist component={generatedDocGen?.displayName} />
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/datefield.js
+++ b/docs/pages/web/datefield.js
@@ -162,6 +162,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           />
         </MainSection.Subsection>
         <MainSection.Subsection
+          badge="experimental"
           title="External handlers"
           description={`DateField consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
 

--- a/docs/pages/web/datefield.js
+++ b/docs/pages/web/datefield.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import { type Node } from 'react';
+import { type Node, useState } from 'react';
 import {
   af,
   arSA,
@@ -38,9 +38,9 @@ import {
   zhCN,
   zhTW,
 } from 'date-fns/locale';
-import { Box, SlimBanner } from 'gestalt';
+import { SlimBanner } from 'gestalt';
 import { DateField } from 'gestalt-datepicker';
-import Combination from '../../docs-components/Combination.js';
+import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -161,32 +161,58 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             }
           />
         </MainSection.Subsection>
+        <MainSection.Subsection
+          title="External handlers"
+          description={`DateField consumes external handlers from GlobalEventsHandlerProvider.
+
+Handlers:
+
+- onMount: executed when DateField mounts for the first time
+
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onMount) for more information.
+`}
+        />
       </MainSection>
-      <Combination
-        id="localeData"
+
+      <MainSection
         name="Supporting locales"
-        layout="4column"
-        localeDataCode={Object.keys(localeMap)}
+        description={`DateField supports multiple locales. Adjust the date format to each [date-fns locale](https://date-fns.org/v2.14.0/docs/Locale). The following locale examples show the different locale format variants.
+
+IMPORTANT: Locale data from date-fns is external to gestalt-datepicker, it's not an internal dependency. Add date-fns to your app's dependencies.
+
+~~~jsx
+import { DateField } from 'gestalt-datepicker';
+import { it } from 'date-fns/locale';
+<DateField localeData={it}/>
+~~~
+`}
       >
-        {({ localeDataCode }) => (
-          <Box width="100%" height="100%" color="default">
-            <DateField
-              id={`localeExample:${localeMap[localeDataCode].lang}`}
-              label={localeMap[localeDataCode].lang}
-              onChange={() => {}}
-              onClearInput={() => {}}
-              value={null}
-              name={localeMap[localeDataCode].lang}
-              localeData={localeMap[localeDataCode].localeData}
-            />
-          </Box>
-        )}
-      </Combination>
+        <MainSection.Subsection>
+          <CombinationNew localeData={Object.keys(localeMap)} cardSize="xs">
+            {({ localeData }) => {
+              // eslint-disable-next-line react-hooks/rules-of-hooks
+              const [date, setDate] = useState<Date | null>(new Date());
+
+              return (
+                <DateField
+                  id={`localeExample:${localeMap[localeData].lang}`}
+                  label={localeMap[localeData].lang}
+                  onChange={({ value }) => setDate(value)}
+                  onClearInput={() => setDate(null)}
+                  value={date}
+                  name={localeMap[localeData].lang}
+                  localeData={localeMap[localeData].localeData}
+                />
+              );
+            }}
+          </CombinationNew>
+        </MainSection.Subsection>
+      </MainSection>
 
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-      **[DatePicker](/DatePicker)**
+**[DatePicker](/DatePicker)**
 Use DatePicker if the user is allowed to pick a date from a calendar popup.
     `}
         />

--- a/docs/pages/web/datefield.js
+++ b/docs/pages/web/datefield.js
@@ -163,7 +163,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         </MainSection.Subsection>
         <MainSection.Subsection
           title="External handlers"
-          description={`DateField consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)..
+          description={`DateField consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
 
 Handlers:
 

--- a/docs/pages/web/datefield.js
+++ b/docs/pages/web/datefield.js
@@ -163,11 +163,11 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         </MainSection.Subsection>
         <MainSection.Subsection
           title="External handlers"
-          description={`DateField consumes external handlers from GlobalEventsHandlerProvider.
+          description={`DateField consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)..
 
 Handlers:
 
-- onMount: executed when DateField mounts for the first time
+- [onMount](/web/utilities/globaleventshandlerprovider#onMount): executed when DateField mounts for the first time
 
 See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onMount) for more information.
 `}

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -283,7 +283,7 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
         </MainSection.Subsection>
         <MainSection.Subsection
           title="External handlers"
-          description={`DatePicker consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)..
+          description={`DatePicker consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
 
 Handlers:
 

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -38,10 +38,9 @@ import {
   zhCN,
   zhTW,
 } from 'date-fns/locale';
-import { Box } from 'gestalt';
 import { DatePicker } from 'gestalt-datepicker';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
-import Combination from '../../docs-components/Combination.js';
+import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
@@ -177,7 +176,6 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
             }
           />
         </MainSection.Subsection>
-
         <MainSection.Subsection columns={2} title="States">
           <MainSection.Card
             title="Disabled"
@@ -203,7 +201,6 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
             }
           />
         </MainSection.Subsection>
-
         <MainSection.Subsection title="Helper text">
           <MainSection.Card
             sandpackExample={
@@ -215,7 +212,6 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
             }
           />
         </MainSection.Subsection>
-
         <MainSection.Subsection title="Date range">
           <MainSection.Card
             sandpackExample={
@@ -228,7 +224,6 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
             }
           />
         </MainSection.Subsection>
-
         <MainSection.Subsection
           title="Disabled dates"
           description="DatePicker supports disabling future & past dates as well as an array of selected dates."
@@ -255,7 +250,6 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
             }
           />
         </MainSection.Subsection>
-
         <MainSection.Subsection
           columns={2}
           title="Select list"
@@ -272,58 +266,65 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
             }
           />
         </MainSection.Subsection>
-
-        <Combination
-          id="idealDirection"
-          name="Ideal Direction"
+        <MainSection.Subsection
           description="Define the preferred direction for the DatePicker popover to open. If that placement doesn't fit, the opposite direction will be used."
-          layout="4column"
-          idealDirection={['down', 'left', 'right', 'up']}
+          title="Ideal Direction"
         >
-          {({ idealDirection }) => (
-            <DatePicker
-              id={`example-idealDirection-${idealDirection}`}
-              label={`Direction ${idealDirection}`}
-              onChange={() => {}}
-              idealDirection={idealDirection}
-            />
-          )}
-        </Combination>
+          <CombinationNew idealDirection={['down', 'left', 'right', 'up']}>
+            {({ idealDirection }) => (
+              <DatePicker
+                id={`example-idealDirection-${idealDirection}`}
+                label={`Direction ${idealDirection}`}
+                onChange={() => {}}
+                idealDirection={idealDirection}
+              />
+            )}
+          </CombinationNew>
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="External handlers"
+          description={`DateField consumes external handlers from GlobalEventsHandlerProvider.
 
-        <Combination
-          id="localeData"
-          name="Supporting locales"
-          description="
-Adjust the date format to each date-fns locale (https://date-fns.org/v2.14.0/docs/Locale).
-The following locale examples show the different locale format variants.
+Handlers:
+
+- onMount: executed when DateField mounts for the first time
+
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onMount) for more information.
+`}
+        />
+      </MainSection>
+      <MainSection
+        name="Supporting locales"
+        description={`DatePicker supports multiple locales. Adjust the date format to each [date-fns locale](https://date-fns.org/v2.14.0/docs/Locale). The following locale examples show the different locale format variants.
+
 IMPORTANT: Locale data from date-fns is external to gestalt-datepicker, it's not an internal dependency. Add date-fns to your app's dependencies.
+
 ~~~jsx
 import { DatePicker } from 'gestalt-datepicker';
 import { it } from 'date-fns/locale';
 <DatePicker localeData={it}/>
 ~~~
-  "
-          layout="4column"
-          localeDataCode={Object.keys(localeMap)}
-        >
-          {({ localeDataCode }) => {
-            // eslint-disable-next-line react-hooks/rules-of-hooks
-            const [date, setDate] = useState<Date | null>(new Date());
+`}
+      >
+        <MainSection.Subsection>
+          <CombinationNew localeData={Object.keys(localeMap)} cardSize="xs">
+            {({ localeData }) => {
+              // eslint-disable-next-line react-hooks/rules-of-hooks
+              const [date, setDate] = useState<Date | null>(new Date());
 
-            return (
-              <Box width="100%" height="100%" color="default">
+              return (
                 <DatePicker
-                  id={`example-${localeDataCode}`}
-                  label={localeMap[localeDataCode].lang}
+                  id={`example-${localeData}`}
+                  label={localeMap[localeData].lang}
                   onChange={({ value }) => setDate(value)}
                   value={date}
-                  localeData={localeMap[localeDataCode].localeData}
+                  localeData={localeMap[localeData].localeData}
                   selectLists={['month']}
                 />
-              </Box>
-            );
-          }}
-        </Combination>
+              );
+            }}
+          </CombinationNew>
+        </MainSection.Subsection>
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -283,11 +283,11 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
         </MainSection.Subsection>
         <MainSection.Subsection
           title="External handlers"
-          description={`DateField consumes external handlers from GlobalEventsHandlerProvider.
+          description={`DatePicker consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider)..
 
 Handlers:
 
-- onMount: executed when DateField mounts for the first time
+- [onMount](/web/utilities/globaleventshandlerprovider#onMount): executed when DateField mounts for the first time
 
 See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onMount) for more information.
 `}
@@ -295,7 +295,9 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onM
       </MainSection>
       <MainSection
         name="Supporting locales"
-        description={`DatePicker supports multiple locales. Adjust the date format to each [date-fns locale](https://date-fns.org/v2.14.0/docs/Locale). The following locale examples show the different locale format variants.
+        description={`DatePicker supports multiple locales. Adjust the date format to each [date-fns locale](https://date-fns.org/v2.14.0/docs/Locale).
+
+The following locale examples show the different locale format variants.
 
 IMPORTANT: Locale data from date-fns is external to gestalt-datepicker, it's not an internal dependency. Add date-fns to your app's dependencies.
 

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -282,6 +282,7 @@ If DatePicker presents pre-selected date values, initialize \`value\` with the p
           </CombinationNew>
         </MainSection.Subsection>
         <MainSection.Subsection
+          badge="experimental"
           title="External handlers"
           description={`DatePicker consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
 

--- a/docs/pages/web/daterange.js
+++ b/docs/pages/web/daterange.js
@@ -276,11 +276,24 @@ The \`onEndDateError\`, \`onStartDateError\` event are very noisy. If the date f
             }
           />
         </MainSection.Subsection>
+        <MainSection.Subsection
+          title="External handlers"
+          description={`DateRange consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
+
+Handlers:
+
+- [onMount](/web/utilities/globaleventshandlerprovider#onMount): executed when DateField mounts for the first time
+
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onMount) for more information.
+`}
+        />
       </MainSection>
 
       <MainSection
         name="Supporting locales"
         description={`DateRange supports multiple locales. Adjust the date format to each [date-fns locale](https://date-fns.org/v2.14.0/docs/Locale). The following locale examples show the different locale format variants.
+
+
 
 IMPORTANT: Locale data from date-fns is external to gestalt-datepicker, it's not an internal dependency. Add date-fns to your app's dependencies.
 

--- a/docs/pages/web/daterange.js
+++ b/docs/pages/web/daterange.js
@@ -277,6 +277,7 @@ The \`onEndDateError\`, \`onStartDateError\` event are very noisy. If the date f
           />
         </MainSection.Subsection>
         <MainSection.Subsection
+          badge="experimental"
           title="External handlers"
           description={`DateRange consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
 

--- a/docs/pages/web/daterange.js
+++ b/docs/pages/web/daterange.js
@@ -276,11 +276,23 @@ The \`onEndDateError\`, \`onStartDateError\` event are very noisy. If the date f
             }
           />
         </MainSection.Subsection>
-        <MainSection.Subsection
-          title="Supporting locales"
-          description="DateRange supports multiple locales. Use the Dropdown to try out different locales by passing in the `localeData` prop.
-"
-        >
+      </MainSection>
+
+      <MainSection
+        name="Supporting locales"
+        description={`DateRange supports multiple locales. Adjust the date format to each [date-fns locale](https://date-fns.org/v2.14.0/docs/Locale). The following locale examples show the different locale format variants.
+
+IMPORTANT: Locale data from date-fns is external to gestalt-datepicker, it's not an internal dependency. Add date-fns to your app's dependencies.
+
+~~~jsx
+import { DateRange } from 'gestalt-datepicker';
+import { it } from 'date-fns/locale';
+<DateRange localeData={it}/>
+~~~
+
+Use the Dropdown to try out different locales by passing in the \`localeData\` prop.`}
+      >
+        <MainSection.Subsection>
           <Flex gap={4} direction="row" wrap>
             <Flex.Item flex="none">
               <SelectList
@@ -312,6 +324,7 @@ The \`onEndDateError\`, \`onStartDateError\` event are very noisy. If the date f
           </Flex>
         </MainSection.Subsection>
       </MainSection>
+
       <MainSection
         name="Mobile"
         description={`

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -499,6 +499,17 @@ Follow these guidelines for \`bgColor\`
             sandpackExample={<SandpackExample code={selectedState} name="Selected state example" />}
           />
         </MainSection.Subsection>
+        <MainSection.Subsection
+          title="External handlers"
+          description={`IconButton consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
+
+Handlers:
+
+- [onNavigation](/web/utilities/globaleventshandlerprovider#onNavigation:-custom-navigation): executed when IconButton role="link" is clicked
+
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onNavigation:-custom-navigation) for more information.
+`}
+        />
       </MainSection>
       <MainSection
         name="Writing"

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -449,12 +449,11 @@ However, Link's underline style can be overridden at any time using the \`underl
             name="Variants - Target"
           />
         </MainSection.Subsection>
-      </MainSection>
 
-      <MainSection.Subsection
-        title="externalLinkIcon and rel"
-        columns={2}
-        description={`An external link, also called an outbound link, is a link from Pinterest to a different website. External links require specific SEO, visual, and accessibility treatments.
+        <MainSection.Subsection
+          title="externalLinkIcon and rel"
+          columns={2}
+          description={`An external link, also called an outbound link, is a link from Pinterest to a different website. External links require specific SEO, visual, and accessibility treatments.
 
 \`rel\` is optional. Use "nofollow" for external links to specify to web crawlers not follow the link. Don't use "nofollow" with urls redirecting to any Pinterest domain or subsite.
 
@@ -465,22 +464,35 @@ As the "visit" icon is a visual/graphic representation, it's hidden to assistive
 
 The "visit" icon should also match [Text](/web/text)'s \`size\` and \`color\`. \`externalLinkIcon="default"\` automatically sets the "visit" icon style to match Text's default properties: \`size="300"\` and \`color="default"\` as shown in the first example. However, for different Text treatments, \`externalLinkIcon\` can be used to match custom Text properties as shown in the second example.
       `}
-      >
-        <MainSection.Card
-          sandpackExample={
-            <SandpackExample
-              code={variantExternalIcon}
-              layout="column"
-              name="Variant - External Icon"
-            />
-          }
+        >
+          <MainSection.Card
+            sandpackExample={
+              <SandpackExample
+                code={variantExternalIcon}
+                layout="column"
+                name="Variant - External Icon"
+              />
+            }
+          />
+          <MainSection.Card
+            sandpackExample={
+              <SandpackExample code={variantRel} layout="column" name="Variant - Rel" />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="External handlers"
+          description={`Link consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
+
+Handlers:
+
+- [onNavigation](/web/utilities/globaleventshandlerprovider#onNavigation:-custom-navigation): executed when Link is clicked
+
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onNavigation:-custom-navigation) for more information.
+`}
         />
-        <MainSection.Card
-          sandpackExample={
-            <SandpackExample code={variantRel} layout="column" name="Variant - Rel" />
-          }
-        />
-      </MainSection.Subsection>
+      </MainSection>
 
       <MainSection name="Writing">
         <MainSection.Subsection columns={2}>

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -662,6 +662,18 @@ function MenuButtonExample() {
 }
 `}
         />
+
+        <MainSection.Subsection
+          title="External handlers"
+          description={`TapArea consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
+
+Handlers:
+
+- [onNavigation](/web/utilities/globaleventshandlerprovider#onNavigation:-custom-navigation): executed when TapArea role="link" is clicked
+
+See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onNavigation:-custom-navigation) for more information.
+`}
+        />
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />

--- a/docs/pages/web/utilities/globaleventshandlerprovider.js
+++ b/docs/pages/web/utilities/globaleventshandlerprovider.js
@@ -149,6 +149,11 @@ The example below demonstrates the correct use of "dangerouslyDisableOnNavigatio
         </MainSection.Subsection>
       </MainSection>
       <MainSection name="Other handlers">
+        <SlimBanner
+          iconAccessibilityLabel="Experimental feature"
+          message={`Experimental feature: The "onMount" prop is experimental and might be removed in the future.`}
+          type="warningBare"
+        />
         <MainSection.Subsection
           title="onMount"
           description={`\`onMount\` is only called when the component mounts for the first time.

--- a/docs/pages/web/utilities/globaleventshandlerprovider.js
+++ b/docs/pages/web/utilities/globaleventshandlerprovider.js
@@ -148,6 +148,20 @@ The example below demonstrates the correct use of "dangerouslyDisableOnNavigatio
           />
         </MainSection.Subsection>
       </MainSection>
+      <MainSection name="Other handlers">
+        <MainSection.Subsection
+          title="onMount"
+          description={`\`onMount\` is only called when the component mounts for the first time.
+
+It's implemented in the following components:
+
+- DateField: \`dateFieldHandlers\`
+- DatePicker: \`datePickerHandlers\`
+- DateRange: \`dateRangeHandlers\`
+
+`}
+        />
+      </MainSection>
     </Page>
   );
 }

--- a/packages/gestalt-datepicker/src/DateField.js
+++ b/packages/gestalt-datepicker/src/DateField.js
@@ -1,5 +1,6 @@
 // @flow strict-local
-import { type Node } from 'react';
+import { type Node, useEffect } from 'react';
+import { useGlobalEventsHandler } from 'gestalt';
 import InternalDateField from './DateField/InternalDateField.js';
 
 // LocaleData type from https://github.com/date-fns/date-fns/blob/81ab18785146405ca2ae28710cdfbb13a294ec50/src/locale/af/index.js.flow
@@ -158,6 +159,14 @@ function DateField({
   readOnly = false,
   value,
 }: Props): Node {
+  const { dateFieldHandlers } = useGlobalEventsHandler() || {
+    dateFieldHandlers: undefined,
+  };
+
+  useEffect(() => {
+    if (dateFieldHandlers?.onMount) dateFieldHandlers?.onMount();
+  }, [dateFieldHandlers]);
+
   return (
     <InternalDateField
       autoComplete={autoComplete}

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -80,7 +80,7 @@ const CustomTextField = forwardRef(
         ? styles.formElementErrored
         : styles.formElementNormal,
     );
-    console.log(locales);
+
     return (
       <Box ref={containerRef} rounding={4} position="relative" display="flex" flex="grow">
         <input

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -80,7 +80,7 @@ const CustomTextField = forwardRef(
         ? styles.formElementErrored
         : styles.formElementNormal,
     );
-
+    console.log(locales);
     return (
       <Box ref={containerRef} rounding={4} position="relative" display="flex" flex="grow">
         <input

--- a/packages/gestalt-datepicker/src/DatePicker.js
+++ b/packages/gestalt-datepicker/src/DatePicker.js
@@ -4,9 +4,11 @@ import {
   type Element,
   forwardRef,
   type Node,
+  useEffect,
   useImperativeHandle,
   useRef,
 } from 'react';
+import { useGlobalEventsHandler } from 'gestalt';
 import InternalDatePicker from './DatePicker/InternalDatePicker.js';
 
 // LocaleData type from https://github.com/date-fns/date-fns/blob/81ab18785146405ca2ae28710cdfbb13a294ec50/src/locale/af/index.js.flow
@@ -173,6 +175,13 @@ const DatePickerWithForwardRef: AbstractComponent<Props, HTMLInputElement> = for
 ): Node {
   const innerInputRef = useRef<null | HTMLInputElement>(null);
   useImperativeHandle(ref, () => innerInputRef.current);
+  const { datePickerHandlers } = useGlobalEventsHandler() || {
+    datePickerHandlers: undefined,
+  };
+
+  useEffect(() => {
+    if (datePickerHandlers?.onMount) datePickerHandlers?.onMount();
+  }, [datePickerHandlers]);
 
   return (
     <InternalDatePicker

--- a/packages/gestalt-datepicker/src/DateRange.js
+++ b/packages/gestalt-datepicker/src/DateRange.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import { Children, type Element, type Node, useId } from 'react';
+import { Children, type Element, type Node, useEffect, useId } from 'react';
 import {
   Box,
   Button,
@@ -9,6 +9,7 @@ import {
   Text,
   useDefaultLabel,
   useDeviceType,
+  useGlobalEventsHandler,
 } from 'gestalt';
 import InternalDateField from './DateField/InternalDateField.js';
 import borderStyles from './DateRange.css';
@@ -171,6 +172,14 @@ function DateRange({
   const componentId = useId();
   const deviceType = useDeviceType();
   const isMobile = deviceType === 'mobile';
+
+  const { dateRangeHandlers } = useGlobalEventsHandler() || {
+    dateRangeHandlers: undefined,
+  };
+
+  useEffect(() => {
+    if (dateRangeHandlers?.onMount) dateRangeHandlers?.onMount();
+  }, [dateRangeHandlers]);
 
   if (!startDateValue && endDateValue) {
     onEndDateChange({ value: null });

--- a/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
+++ b/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
@@ -11,7 +11,9 @@ type OnLinkNavigationType = ({|
 |}) => void;
 
 type GlobalEventsHandlerContextType = {|
-  datepickerHandlers?: {| onMount?: NoopType |},
+  dateFieldHandlers?: {| onMount?: NoopType |},
+  datePickerHandlers?: {| onMount?: NoopType |},
+  dateRangeHandlers?: {| onMount?: NoopType |},
   sheetMobileHandlers?: {| onOpen?: NoopType, onClose?: NoopType |},
   linkHandlers?: {| onNavigation?: OnLinkNavigationType |},
 |} | void;

--- a/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
+++ b/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
@@ -11,6 +11,7 @@ type OnLinkNavigationType = ({|
 |}) => void;
 
 type GlobalEventsHandlerContextType = {|
+  datepickerHandlers?: {| onMount?: NoopType |},
   sheetMobileHandlers?: {| onOpen?: NoopType, onClose?: NoopType |},
   linkHandlers?: {| onNavigation?: OnLinkNavigationType |},
 |} | void;
@@ -21,11 +22,23 @@ type Props = {|
    */
   children: Node,
   /**
+   * Handlers consumed by [DateField](https://gestalt.pinterest.systems/web/datefield).
+   */
+  dateFieldHandlers?: {| onMount?: () => void |},
+  /**
+   * Handlers consumed by [DatePicker](https://gestalt.pinterest.systems/web/datepicker).
+   */
+  datePickerHandlers?: {| onMount?: () => void |},
+  /**
+   * Handlers consumed by [DateRange](https://gestalt.pinterest.systems/web/daterange).
+   */
+  dateRangeHandlers?: {| onMount?: () => void |},
+  /**
    * Handlers consumed by [SheetMobile](https://gestalt.pinterest.systems/web/sheetmobile#External-handlers).
    */
   sheetMobileHandlers?: {| onOpen?: () => void, onClose?: () => void |},
   /**
-   * Handlers consumed by [Link](https://gestalt.pinterest.systems/web/link#External-handlers).
+   * Handlers consumed by [Link](https://gestalt.pinterest.systems/web/link).
    */
   linkHandlers?: {|
     onNavigation?: ({|
@@ -47,12 +60,18 @@ const { Provider } = GlobalEventsHandlerContext;
  */
 export default function GlobalEventsHandlerProvider({
   children,
+  dateFieldHandlers,
+  datePickerHandlers,
+  dateRangeHandlers,
   sheetMobileHandlers,
   linkHandlers,
 }: Props): Element<typeof Provider> {
   return (
     <Provider
       value={{
+        dateFieldHandlers,
+        datePickerHandlers,
+        dateRangeHandlers,
         sheetMobileHandlers,
         linkHandlers,
       }}

--- a/packages/gestalt/src/index.js
+++ b/packages/gestalt/src/index.js
@@ -18,7 +18,9 @@ import ColorSchemeProvider, { useColorScheme } from './contexts/ColorSchemeProvi
 import DefaultLabelProvider, { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import DeviceTypeProvider, { useDeviceType } from './contexts/DeviceTypeProvider.js';
 import ExperimentProvider from './contexts/ExperimentProvider.js';
-import GlobalEventsHandlerProvider from './contexts/GlobalEventsHandlerProvider.js';
+import GlobalEventsHandlerProvider, {
+  useGlobalEventsHandlerContext,
+} from './contexts/GlobalEventsHandlerProvider.js';
 import Datapoint from './Datapoint.js';
 import Divider from './Divider.js';
 import Dropdown from './Dropdown.js';
@@ -159,6 +161,7 @@ export {
   useDefaultLabelContext as useDefaultLabel,
   useDeviceType,
   useFocusVisible,
+  useGlobalEventsHandlerContext as useGlobalEventsHandler,
   useReducedMotion,
   Video,
   WashAnimated,


### PR DESCRIPTION
### Summary

#### What changed?

GlobalEventsHandlerProvider, DatePicker, DateRange, DateField: add `onMount` handlers

Documented GlobalEventsHandlerProvider (external handlers) in some components pages

#### Why?

Enable impression logging tests