### PR TITLE
TableOfContents: Add default label

### DIFF
--- a/packages/gestalt/src/TableOfContents.js
+++ b/packages/gestalt/src/TableOfContents.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type Node } from 'react';
 import Box from './Box.js';
+import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import Heading from './Heading.js';
 import styles from './TableOfContents.css';
 import TableOfContentsItemList from './TableOfContents/TableOfContentsItemList.js';
@@ -28,8 +29,15 @@ type Props = {|
  * ![TableOfContents dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TableOfContents-dark.spec.mjs-snapshots/TableOfContents-dark-chromium-darwin.png)
  */
 export default function TableOfContents({ accessibilityLabel, title, children }: Props): Node {
+  const { accessibilityLabel: accessibilityLabelDefault } =
+    useDefaultLabelContext('TableOfContents');
+
   return (
-    <div role="navigation" aria-label={accessibilityLabel} className={styles.container}>
+    <div
+      role="navigation"
+      aria-label={accessibilityLabel ?? accessibilityLabelDefault}
+      className={styles.container}
+    >
       {title ? (
         <Box paddingX={3} marginBottom={3}>
           <Heading size="400">{title}</Heading>

--- a/packages/gestalt/src/__snapshots__/TableOfContents.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableOfContents.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`TableOfContents renders 1`] = `
 <div
+  aria-label="Table of contents"
   className="container"
   role="navigation"
 >
@@ -147,6 +148,7 @@ exports[`TableOfContents renders an accessibility label 1`] = `
 
 exports[`TableOfContents renders nested items 1`] = `
 <div
+  aria-label="Table of contents"
   className="container"
   role="navigation"
 >
@@ -316,6 +318,7 @@ exports[`TableOfContents renders nested items 1`] = `
 
 exports[`TableOfContents renders without title 1`] = `
 <div
+  aria-label="Table of contents"
   className="container"
   role="navigation"
 >


### PR DESCRIPTION
### Summary

Added default accessibilty label for TableOfContents.

#### Why?

### Checklist

- [n/a] Added unit and Flow Tests
- [n/a] Added documentation + accessibility tests
- [n/a] Verified accessibility: keyboard & screen reader interaction
- [n/a] Checked dark mode, responsiveness, and right-to-left support
- [n/a] Checked stakeholder feedback (e.g. Gestalt designers)
