### PR TITLE
Docs: Fix layout of TableOfContents examples

### DIFF
--- a/docs/examples/tableofcontents/dontPlaceFarAway.js
+++ b/docs/examples/tableofcontents/dontPlaceFarAway.js
@@ -57,7 +57,7 @@ export default function Example(): Node {
         </Flex>
 
         <Box width="120px" position="relative" marginStart={10}>
-          <Box width="120px" height="100%" overflow="auto" /* position="fixed" */ top marginTop={8}>
+          <Box width="120px" height="100%" overflow="auto" position="fixed" top marginTop={8}>
             <TableOfContents title="Page Contents">
               {items.map((item) => (
                 <TableOfContents.Item key={item.label} {...item} />

--- a/docs/examples/tableofcontents/main.js
+++ b/docs/examples/tableofcontents/main.js
@@ -6,7 +6,7 @@ export default function Example(): Node {
   const { hash } = window.location;
 
   return (
-    <Box padding={8} width="340px">
+    <Box padding={8} display="flex" justifyContent="center">
       <TableOfContents title="Page Contents">
         <TableOfContents.Item label="Section 1" href="#section1" active={hash === '#section1'} />
         <TableOfContents.Item label="Section 2" href="#section2" active={hash === '#section2'}>

--- a/docs/examples/tableofcontents/nestedItemsExample.js
+++ b/docs/examples/tableofcontents/nestedItemsExample.js
@@ -6,7 +6,7 @@ export default function Example(): Node {
   const { hash } = window.location;
 
   return (
-    <Box padding={8} width="340px">
+    <Box padding={8} display="flex" justifyContent="center">
       <TableOfContents title="Title">
         <TableOfContents.Item label="Level 1" href="#level-1" active={hash === '#level-1'}>
           <TableOfContents.Item label="Level 2" href="#level-2" active={hash === '#level-2'}>

--- a/docs/examples/tableofcontents/topAlignWithContentTitle.js
+++ b/docs/examples/tableofcontents/topAlignWithContentTitle.js
@@ -57,7 +57,7 @@ export default function Example(): Node {
         </Flex>
 
         <Box width="200px" position="relative">
-          <Box width="200px" height="100%" overflow="auto" /* position="fixed" */ top marginTop={8}>
+          <Box width="200px" height="100%" overflow="auto" position="fixed" top marginTop={8}>
             <TableOfContents title="Page Contents">
               {items.map((item) => (
                 <TableOfContents.Item key={item.label} {...item} />

--- a/docs/examples/tableofcontents/withHeaderExample.js
+++ b/docs/examples/tableofcontents/withHeaderExample.js
@@ -6,7 +6,7 @@ export default function Example(): Node {
   const { hash } = window.location;
 
   return (
-    <Box padding={8} width="340px">
+    <Box padding={8} display="flex" justifyContent="center">
       <TableOfContents title="Promotions">
         <TableOfContents.Item
           label="Active coupons"


### PR DESCRIPTION
### Summary

TableOfContents should have a fixed position on a page. Examples in the docs were updated accordingly.

#### What changed?


