### PR TITLE
IconButton: add `name` prop

### DIFF
--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -82,7 +82,15 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             description:
               'Icon displayed in IconButton to convey the behavior of the component. Refer to the [iconography](/foundations/iconography/library#Search-icon-library) guidelines regarding the available icon options.',
           },
+          {
+            name: 'name',
+            type: 'string',
+            description: [
+              'The name attribute specifies the name of the <button> element.',
 
+              'The name attribute is used to reference form-data after the form has been submitted.',
+            ],
+          },
           {
             name: 'onClick',
             type: '({| event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement> | SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>, {| dangerouslyDisableOnNavigation: () => void |}> |}) => void',

--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -64,6 +64,7 @@ type IconButtonType = {|
   accessibilityExpanded?: boolean,
   accessibilityHaspopup?: boolean,
   accessibilityPopupRole?: 'menu' | 'dialog',
+  name?: string,
   role?: 'button',
   selected?: boolean,
   type?: 'submit' | 'button',
@@ -231,6 +232,7 @@ const IconButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwa
       accessibilityExpanded,
       accessibilityHaspopup,
       accessibilityPopupRole,
+      name,
       selected,
       type,
     } = props;
@@ -243,6 +245,7 @@ const IconButtonWithForwardRef: AbstractComponent<unionProps, unionRefs> = forwa
         className={classnames(styles.parentButton)}
         data-test-id={dataTestId}
         disabled={disabled}
+        name={name}
         onBlur={() => {
           handleBlur();
           handleOnBlur();


### PR DESCRIPTION
### Summary

#### What changed?

IconButton: add `name` prop

#### Why?

It helps with testing as per:
<img width="955" alt="Screenshot 2023-08-11 at 6 49 01 PM" src="https://github.com/pinterest/gestalt/assets/10593890/f387578f-faef-4e16-8db7-7cfc826c15e2">


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
