### PR TITLE
SideNavigation: Remove Tooltip on dropdown open

### DIFF
--- a/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.js
+++ b/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.js
@@ -83,7 +83,10 @@ function ItemIconButton({
     : new FixedZIndex(1);
   const dropdownZIndex = new CompositeZIndex([tooltipZIndex]);
   return (
-    <MaybeTooltip disabled={open} tooltip={{ ...tooltip, zIndex: tooltipZIndex }}>
+    <MaybeTooltip
+      disabled={open}
+      tooltip={{ text: tooltip.text, accessibilityLabel: '', zIndex: tooltipZIndex }}
+    >
       {/* Interactive elements require an a11yLabel on them or their children. That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */}
       <TapArea
         accessibilityControls={id}

--- a/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.js
+++ b/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.js
@@ -3,7 +3,7 @@ import { cloneElement, type Element, type Node, useEffect, useId, useRef, useSta
 import Dropdown from '../Dropdown.js';
 import Pog from '../Pog.js';
 import TapArea from '../TapArea.js';
-import Tooltip from '../Tooltip.js';
+import MaybeTooltip from '../utils/MaybeTooltip.js';
 import { CompositeZIndex, FixedZIndex, type Indexable } from '../zIndex.js';
 
 type Props = {|
@@ -83,7 +83,7 @@ function ItemIconButton({
     : new FixedZIndex(1);
   const dropdownZIndex = new CompositeZIndex([tooltipZIndex]);
   return (
-    <Tooltip accessibilityLabel="" text={tooltip.text} zIndex={tooltipZIndex}>
+    <MaybeTooltip disabled={open} tooltip={{ ...tooltip, zIndex: tooltipZIndex }}>
       {/* Interactive elements require an a11yLabel on them or their children. That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */}
       <TapArea
         accessibilityControls={id}
@@ -155,7 +155,7 @@ function ItemIconButton({
           </Dropdown>
         )}
       </TapArea>
-    </Tooltip>
+    </MaybeTooltip>
   );
 }
 


### PR DESCRIPTION
### Summary

Moving to 

#### What changed?

Tweaking the SideNavigation to use `MaybeTooltip` and turning off the tooltip completely when the dropdown menu is open.


#### Why?

Without this fix, the tooltip can't be seen if the dropdown is open, and the primary action has already been pressed.

https://github.com/pinterest/gestalt/assets/5509813/219947a3-130e-4d65-93f2-b1c314e58e85

[See example here](https://gestalt.pinterest.systems/web/sidenavigation#Primary-action)

### Links

- [Slack](https://pinterest.slack.com/archives/C13KLG5P0/p1691794954357239)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
