### PR TITLE
SideNavigation: Rename `title` prop to `mobileTitle`

### DIFF
--- a/docs/docs-components/DocsSideNavigation.js
+++ b/docs/docs-components/DocsSideNavigation.js
@@ -114,7 +114,7 @@ export default function DocsSideNavigation({ showBorder }: {| showBorder?: boole
     <SideNavigation
       accessibilityLabel="Page navigation"
       header={header}
-      title="Menu"
+      mobileTitle="Menu"
       dismissButton={{
         onDismiss: closeSideNavigation,
         accessibilityLabel: 'Dismiss side navigation',

--- a/docs/examples/devicetypeprovider/implementation.js
+++ b/docs/examples/devicetypeprovider/implementation.js
@@ -28,7 +28,7 @@ export default function Example(): Node {
           >
             <Box height={450} width={280} color="default" id="sidenav">
               <SideNavigation
-                title="Advertisement"
+                mobileTitle="Advertisement"
                 accessibilityLabel="Mobile device example"
                 dismissButton={{
                   onDismiss: () => {},

--- a/docs/examples/sidenavigation/mobileExample.js
+++ b/docs/examples/sidenavigation/mobileExample.js
@@ -9,7 +9,7 @@ export default function Example(): Node {
     <DeviceTypeProvider deviceType="mobile">
       <Box position="absolute" top bottom left right id="sidenavigation">
         <SideNavigation
-          title="Advertisement"
+          mobileTitle="Advertisement"
           accessibilityLabel="Mobile device example"
           dismissButton={{
             onDismiss: () => setShowNav(false),

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1619,7 +1619,7 @@ interface SideNavigationProps {
   footer?: Node | undefined;
   header?: Node | undefined;
   showBorder?: boolean | undefined;
-  title?: string | undefined;
+  mobileTitle?: string | undefined;
 }
 
 interface SideNavigationSectionProps {

--- a/packages/gestalt/src/SideNavigation.js
+++ b/packages/gestalt/src/SideNavigation.js
@@ -47,7 +47,7 @@ export type Props = {|
   /**
    * Title for mobile navigation.
    */
-  title?: string,
+  mobileTitle?: string,
 |};
 
 /**
@@ -66,7 +66,7 @@ export default function SideNavigation({
   footer,
   header,
   showBorder,
-  title,
+  mobileTitle,
 }: Props): Node {
   const navigationChildren = getChildrenToArray({ children, filterLevel: 'main' });
   const { accessibilityDismissButtonLabel } = useDefaultLabelContext('SideNavigation');
@@ -96,7 +96,7 @@ export default function SideNavigation({
               }
             }
             showBorder={showBorder}
-            title={title}
+            mobileTitle={mobileTitle}
             id={id}
           >
             {navigationChildren}

--- a/packages/gestalt/src/SideNavigation/Mobile.js
+++ b/packages/gestalt/src/SideNavigation/Mobile.js
@@ -20,7 +20,7 @@ export default function SideNavigationMobile({
   footer,
   header,
   id,
-  title,
+  mobileTitle,
   dismissButton,
   showBorder,
 }: Props): Node {
@@ -53,7 +53,7 @@ export default function SideNavigationMobile({
                   <Flex.Item flex="grow">
                     <Flex height="100%" alignItems="center" justifyContent="start">
                       <Heading size="400" lineClamp={1}>
-                        {title}
+                        {mobileTitle}
                       </Heading>
                     </Flex>
                   </Flex.Item>


### PR DESCRIPTION
### Summary

Renamed `title` prop of SideNavigation to `mobileTitle` because the title of SideNavigation appears only for mobile.

### Breaking Change

The old icon needs to be replaced with custom SVG component manually. Run the following codemod to locate the usages:

```bash
yarn codemod modifyProp . --component=SideNavigation --previousProp=title --nextProp=mobileTitle
```

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6239)

### Checklist

- [n/a] Added unit and Flow Tests
- [n/a] Added documentation + accessibility tests
- [n/a] Verified accessibility: keyboard & screen reader interaction
- [n/a] Checked dark mode, responsiveness, and right-to-left support
- [n/a] Checked stakeholder feedback (e.g. Gestalt designers)
