### PR TITLE
Module: Center the collapse/expand icon 

### DIFF
--- a/packages/gestalt/src/Module/ExpandableItem.js
+++ b/packages/gestalt/src/Module/ExpandableItem.js
@@ -84,6 +84,7 @@ export default function ModuleExpandableItem({
               )}
             </Box>
 
+            {/* Adding a max height because the line height is 24, and we don't want the icon container to expand */}
             {Boolean(children) && (
               <Box id={id} padding={1} display="flex" alignItems="center" maxHeight={24}>
                 <Icon

--- a/packages/gestalt/src/Module/ExpandableItem.js
+++ b/packages/gestalt/src/Module/ExpandableItem.js
@@ -85,7 +85,7 @@ export default function ModuleExpandableItem({
             </Box>
 
             {Boolean(children) && (
-              <Box id={id} padding={1}>
+              <Box id={id} padding={1} display="flex" alignItems="center" maxHeight={24}>
                 <Icon
                   accessibilityLabel={
                     isCollapsed ? accessibilityExpandLabel : accessibilityCollapseLabel

--- a/packages/gestalt/src/Module/__snapshots__/ExpandableItem.test.js.snap
+++ b/packages/gestalt/src/Module/__snapshots__/ExpandableItem.test.js.snap
@@ -777,8 +777,13 @@ exports[`ModuleExpandableItem renders correctly with when expanded 1`] = `
             </div>
           </div>
           <div
-            className="box paddingX1 paddingY1"
+            className="box paddingX1 paddingY1 xsDisplayFlex xsItemsCenter"
             id="uniqueTestID"
+            style={
+              Object {
+                "maxHeight": 24,
+              }
+            }
           >
             <svg
               aria-hidden={null}

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -94,8 +94,13 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
               </div>
             </div>
             <div
-              className="box paddingX1 paddingY1"
+              className="box paddingX1 paddingY1 xsDisplayFlex xsItemsCenter"
               id="uniqueTestID-0"
+              style={
+                Object {
+                  "maxHeight": 24,
+                }
+              }
             >
               <svg
                 aria-hidden={null}
@@ -209,8 +214,13 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
               </div>
             </div>
             <div
-              className="box paddingX1 paddingY1"
+              className="box paddingX1 paddingY1 xsDisplayFlex xsItemsCenter"
               id="uniqueTestID-1"
+              style={
+                Object {
+                  "maxHeight": 24,
+                }
+              }
             >
               <svg
                 aria-hidden={null}
@@ -346,8 +356,13 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
               </div>
             </div>
             <div
-              className="box paddingX1 paddingY1"
+              className="box paddingX1 paddingY1 xsDisplayFlex xsItemsCenter"
               id="uniqueTestID-2"
+              style={
+                Object {
+                  "maxHeight": 24,
+                }
+              }
             >
               <svg
                 aria-hidden={null}
@@ -495,8 +510,13 @@ exports[`Module Expandable renders correctly with one item 1`] = `
               </div>
             </div>
             <div
-              className="box paddingX1 paddingY1"
+              className="box paddingX1 paddingY1 xsDisplayFlex xsItemsCenter"
               id="uniqueTestID-0"
+              style={
+                Object {
+                  "maxHeight": 24,
+                }
+              }
             >
               <svg
                 aria-hidden={null}
@@ -591,8 +611,13 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
               </div>
             </div>
             <div
-              className="box paddingX1 paddingY1"
+              className="box paddingX1 paddingY1 xsDisplayFlex xsItemsCenter"
               id="uniqueTestID-0"
+              style={
+                Object {
+                  "maxHeight": 24,
+                }
+              }
             >
               <svg
                 aria-hidden={null}
@@ -711,8 +736,13 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
               </div>
             </div>
             <div
-              className="box paddingX1 paddingY1"
+              className="box paddingX1 paddingY1 xsDisplayFlex xsItemsCenter"
               id="uniqueTestID-1"
+              style={
+                Object {
+                  "maxHeight": 24,
+                }
+              }
             >
               <svg
                 aria-hidden={null}
@@ -848,8 +878,13 @@ exports[`renders correctly with multiple items with expandedId 1`] = `
               </div>
             </div>
             <div
-              className="box paddingX1 paddingY1"
+              className="box paddingX1 paddingY1 xsDisplayFlex xsItemsCenter"
               id="uniqueTestID-2"
+              style={
+                Object {
+                  "maxHeight": 24,
+                }
+              }
             >
               <svg
                 aria-hidden={null}


### PR DESCRIPTION
### Summary
Adding items-center and a maxheight to the wrapper at the end.

#### Why?

See this thread:
https://pinterest.slack.com/archives/C13KLG5P0/p1692124542365889

Icon was not centered


Before:
<img width="84" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/59d26fb6-bc75-4b46-b6f5-d3693bf34a71">


After:
<img width="106" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/0d5ba451-065a-4620-8d6d-ba8db43417c3">


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
