### PR TITLE
[Masonry] Allow positionStore to be externally managed

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -69,6 +69,10 @@ type Props<T> = {|
    */
   minCols: number,
   /**
+   * Masonry internally caches positions using a position store. If `positionStore` is provided, Masonry will use it as its cache and will keep it updated with future positions.
+   */
+  positionStore?: Cache<T, Position>,
+  /**
    * A function that renders the item you would like displayed in the grid. This function is passed three props: the item's data, the item's index in the grid, and a flag indicating if Masonry is currently measuring the item.
    *
    * If present, `heightAdjustment` indicates the number of pixels this item needs to grow/shrink to accommodate a 2-column item in the grid. Items must respond to this prop by adjusting their height or layout issues will occur.
@@ -171,7 +175,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     const measurementStore: Cache<T, number> =
       props.measurementStore || Masonry.createMeasurementStore();
 
-    this.positionStore = new MeasurementStore();
+    this.positionStore = props.positionStore || Masonry.createMeasurementStore();
     this.heightsStore = new HeightsStore();
 
     this.state = {


### PR DESCRIPTION
Thanks for creating a PR! Please follow this template and delete items/sections that are not relevant to your changes, including these instructions.

Please also make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}: Description (mentioning platform if relevant)`, or `{ComponentName}, {OtherComponentName}: Description (mentioning platform if relevant)` if multiple components are affected.

### Summary

#### What changed?

This PR adds an optional `positionStore` prop to Masonry in order to allow its position cache to be externally persisted (similar to measurementStore).

#### Why?

For the two column experiment in Pinboard, it was reported that navigating _away_ from a grid and then navigating back would result in the browser freezing. I was able to repro the issue and, while I was not able to get a profile due to the browser hanging, Chrome did point to this line before crashing: https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js#L75

Our original thought when building out the graph was that, because we already had the measurements cached, re-generating the actual graph per render should be cheap. However, it seems this is not the case.  

### Links

- [Jira](https://jira.pinadmin.com/browse/SSP-208)

### Checklist
- Tested this by patching gestalt locally and updating Pinboard code to use an external positionStore. Verified that the issue no longer happens
