### PR TITLE
Docs: Migrate TextField, Module, Upsell, ActivationCard examples to Sandpack

### DIFF
--- a/docs/examples/activationcard/completeVariant.js
+++ b/docs/examples/activationcard/completeVariant.js
@@ -1,0 +1,18 @@
+// @flow strict
+import { type Node } from 'react';
+import { ActivationCard, Box, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex>
+        <ActivationCard
+          message="Tag is installed and healthy"
+          status="complete"
+          statusMessage="Completed"
+          title="Nice work"
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/activationcard/mainExample.js
+++ b/docs/examples/activationcard/mainExample.js
@@ -1,0 +1,25 @@
+// @flow strict
+import { type Node } from 'react';
+import { ActivationCard, Box } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <ActivationCard
+        dismissButton={{
+          accessibilityLabel: 'Dismiss card',
+          onDismiss: () => {},
+        }}
+        link={{
+          href: 'https://pinterest.com',
+          label: 'Learn more',
+          accessibilityLabel: 'Learn more: website claim status',
+        }}
+        message="We will notify you via email as soon as your site has been successfully claimed."
+        status="pending"
+        statusMessage="Pending"
+        title="Claim your website"
+      />
+    </Box>
+  );
+}

--- a/docs/examples/activationcard/needsAttentionVariant.js
+++ b/docs/examples/activationcard/needsAttentionVariant.js
@@ -1,0 +1,27 @@
+// @flow strict
+import { type Node } from 'react';
+import { ActivationCard, Box, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex>
+        <ActivationCard
+          dismissButton={{
+            accessibilityLabel: 'Dismiss card',
+            onDismiss: () => {},
+          }}
+          link={{
+            accessibilityLabel: 'Learn more about tag health',
+            href: 'https://pinterest.com',
+            label: 'Learn more',
+          }}
+          message="Oops! Your tag must be healthy to continue."
+          status="needsAttention"
+          statusMessage="Needs attention"
+          title="Tag is unhealthy"
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/activationcard/notStartedVariant.js
+++ b/docs/examples/activationcard/notStartedVariant.js
@@ -1,0 +1,27 @@
+// @flow strict
+import { type Node } from 'react';
+import { ActivationCard, Box, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex>
+        <ActivationCard
+          dismissButton={{
+            accessibilityLabel: 'Dismiss card',
+            onDismiss: () => {},
+          }}
+          link={{
+            href: 'https://pinterest.com',
+            label: 'Claim your website now',
+            accessibilityLabel: '',
+          }}
+          message="Grow distribution and track Pins linked to your website"
+          status="notStarted"
+          statusMessage="Not started"
+          title="Claim your website"
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/activationcard/pendingVariant.js
+++ b/docs/examples/activationcard/pendingVariant.js
@@ -1,0 +1,27 @@
+// @flow strict
+import { type Node } from 'react';
+import { ActivationCard, Box, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex>
+        <ActivationCard
+          dismissButton={{
+            accessibilityLabel: 'Dismiss card',
+            onDismiss: () => {},
+          }}
+          link={{
+            href: 'https://pinterest.com',
+            label: 'Learn more',
+            accessibilityLabel: 'Learn more: website claim status',
+          }}
+          message="We will notify you via email as soon as your site has been successfully claimed."
+          status="pending"
+          statusMessage="Pending"
+          title="Claim your website"
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/module/exampleWithExternalControl.js
+++ b/docs/examples/module/exampleWithExternalControl.js
@@ -1,0 +1,81 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, Module, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [extExpandedId, setExtExpandedId] = useState<number | string | null>(null);
+  const mapIds = {
+    'first-0': 0,
+    'first-1': 1,
+    'second-0': 0,
+    'second-1': 1,
+  };
+
+  return (
+    <Box padding={8} height="100%" display="flex" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Flex direction="column" gap={{ column: 4, row: 0 }}>
+          <Flex direction="column" gap={{ column: 2, row: 0 }}>
+            <Box marginStart={2}>
+              <Text>Step 1</Text>
+            </Box>
+
+            <Module.Expandable
+              accessibilityExpandLabel="Expand the module"
+              accessibilityCollapseLabel="Collapse the module"
+              expandedIndex={
+                typeof extExpandedId === 'string' ? mapIds[extExpandedId] : extExpandedId
+              }
+              id="ModuleExampleStep1"
+              items={[
+                {
+                  title: 'Title1',
+                  summary: ['summary1'],
+                  children: <Text size="200">Children1</Text>,
+                },
+                {
+                  title: 'Title2',
+                  summary: ['summary2'],
+                  children: <Text size="200">Children2</Text>,
+                },
+              ]}
+              onExpandedChange={(index) => {
+                if (index) setExtExpandedId(Number.isFinite(index) ? `first-${index}` : index);
+              }}
+            />
+          </Flex>
+
+          <Flex direction="column" gap={{ column: 2, row: 0 }}>
+            <Box marginStart={2}>
+              <Text>Step 2</Text>
+            </Box>
+
+            <Module.Expandable
+              id="ModuleExampleStep2"
+              accessibilityExpandLabel="Expand the module"
+              accessibilityCollapseLabel="Collapse the module"
+              expandedIndex={
+                typeof extExpandedId === 'string' ? mapIds[extExpandedId] : extExpandedId
+              }
+              onExpandedChange={(index) => {
+                if (index) setExtExpandedId(Number.isFinite(index) ? `second-${index}` : index);
+              }}
+              items={[
+                {
+                  title: 'Title1',
+                  summary: ['summary1'],
+                  children: <Text size="200">Children1</Text>,
+                },
+                {
+                  title: 'Title2',
+                  summary: ['summary2'],
+                  children: <Text size="200">Children2</Text>,
+                },
+              ]}
+            />
+          </Flex>
+        </Flex>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/module/expandable.js
+++ b/docs/examples/module/expandable.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Module, Text } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Module.Expandable
+          accessibilityExpandLabel="Expand the module"
+          accessibilityCollapseLabel="Collapse the module"
+          id="ModuleExample - default"
+          items={[
+            {
+              children: <Text size="200">Children1</Text>,
+              summary: ['summary1', 'summary2', 'summary3'],
+              title: 'Title',
+            },
+          ]}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/module/expandableGroup.js
+++ b/docs/examples/module/expandableGroup.js
@@ -1,0 +1,34 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Module, Text } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Module.Expandable
+          id="ModuleExample "
+          accessibilityExpandLabel="Expand the module"
+          accessibilityCollapseLabel="Collapse the module"
+          items={[
+            {
+              children: <Text size="200">Children1</Text>,
+              summary: ['summary1'],
+              title: 'Title1',
+            },
+            {
+              children: <Text size="200">Children2</Text>,
+              summary: ['summary2'],
+              title: 'Title2',
+            },
+            {
+              children: <Text size="200">Children3</Text>,
+              summary: ['summary3'],
+              title: 'Title3',
+            },
+          ]}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/module/expandableWithErrorType.js
+++ b/docs/examples/module/expandableWithErrorType.js
@@ -1,0 +1,41 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Module, Text, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+  const moduleType = !value ? 'error' : 'info';
+  const summaryInfo = !value ? 'Name is missing' : `Name: ${value}`;
+  const iconAccessibilityLabel = !value ? 'This module contains an error' : undefined;
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Module.Expandable
+          accessibilityExpandLabel="Expand the module"
+          accessibilityCollapseLabel="Collapse the module"
+          id="ModuleExample "
+          items={[
+            {
+              children: (
+                <Text size="200">
+                  <TextField
+                    errorMessage={!value ? "This field can't be blank!" : null}
+                    id="aboutme"
+                    label="Enter Your Name"
+                    onChange={(e) => setValue(e.value)}
+                    value={value}
+                  />
+                </Text>
+              ),
+              iconAccessibilityLabel,
+              summary: [summaryInfo],
+              title: 'Personal Info',
+              type: moduleType,
+            },
+          ]}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/module/expandableWithIconBadgeIconButton.js
+++ b/docs/examples/module/expandableWithIconBadgeIconButton.js
@@ -1,0 +1,61 @@
+// @flow strict
+import { type Node, useRef, useState } from 'react';
+import { Box, IconButton, Module, Popover, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [showPopover, setShowPopover] = useState(false);
+  const anchorRef = useRef<HTMLElement | null>(null);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Module.Expandable
+          accessibilityExpandLabel="Expand the module"
+          accessibilityCollapseLabel="Collapse the module"
+          id="ModuleExample "
+          items={[
+            {
+              children: <Text size="200">Children1</Text>,
+              icon: 'lock',
+              iconAccessibilityLabel: 'title icon',
+              title: 'Example with icon',
+            },
+            {
+              badge: { text: 'New' },
+              children: <Text size="200">Children2</Text>,
+              title: 'Example with badge',
+            },
+            {
+              children: <Text size="200">Children3</Text>,
+              iconButton: (
+                <IconButton
+                  bgColor="lightGray"
+                  icon="question-mark"
+                  iconColor="darkGray"
+                  accessibilityLabel="Get help"
+                  size="xs"
+                  onClick={() => setShowPopover((currVal) => !currVal)}
+                  ref={anchorRef}
+                />
+              ),
+              title: 'Example with icon button',
+            },
+          ]}
+        />
+
+        {showPopover && (
+          <Popover
+            anchor={anchorRef.current}
+            idealDirection="right"
+            onDismiss={() => setShowPopover(false)}
+            shouldFocus={false}
+          >
+            <Box padding={3}>
+              <Text weight="bold">Help content!</Text>
+            </Box>
+          </Popover>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/module/mainExample.js
+++ b/docs/examples/module/mainExample.js
@@ -1,0 +1,32 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Module, Text } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" width="100%" justifyContent="between" gap={{ column: 2, row: 0 }}>
+        <Module
+          icon="lock"
+          iconAccessibilityLabel="Module Locked - check permission settings"
+          id="ModuleExample - header"
+          title="Title"
+        >
+          <Text size="200">This is example content.</Text>
+        </Module>
+        <Module.Expandable
+          accessibilityExpandLabel="Expand the module"
+          accessibilityCollapseLabel="Collapse the module"
+          id="ModuleExample - header expandable"
+          items={[
+            {
+              children: <Text size="200">Content here</Text>,
+              summary: ['summary'],
+              title: 'Title',
+            },
+          ]}
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/module/staticVariant.js
+++ b/docs/examples/module/staticVariant.js
@@ -1,0 +1,19 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Module, Text } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={{ column: 2, row: 0 }} maxWidth={800} flex="grow">
+        <Module id="ModuleExample - default - 1">
+          <Text size="200">This is example content.</Text>
+        </Module>
+
+        <Module id="ModuleExample - default - 2" title="Title">
+          <Text size="200">This is example content.</Text>
+        </Module>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/module/staticWithBadge.js
+++ b/docs/examples/module/staticWithBadge.js
@@ -1,0 +1,22 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Module, Text } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Module badge={{ text: 'Beta' }} id="ModuleExample - badge" title="Title">
+          <Text size="200">This is example content.</Text>
+        </Module>
+        <Module
+          badge={{ text: 'Not started', type: 'neutral' }}
+          id="ModuleExample - badge neutral"
+          title="Title"
+        >
+          <Text size="200">This is example content.</Text>
+        </Module>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/module/staticWithErrorType.js
+++ b/docs/examples/module/staticWithErrorType.js
@@ -1,0 +1,32 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, Module, Text, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Module
+          id="ModuleExample - error"
+          title="Personal Info"
+          iconAccessibilityLabel={!value ? 'This module contains an error' : undefined}
+          type={!value ? 'error' : 'info'}
+        >
+          <Flex direction="column" gap={{ column: 4, row: 0 }}>
+            <Text size="200">This is example content.</Text>
+
+            <TextField
+              errorMessage={!value ? "This field can't be blank!" : null}
+              id="first-name"
+              label="Enter Your Name"
+              onChange={(e) => setValue(e.value)}
+              value={value}
+            />
+          </Flex>
+        </Module>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/module/staticWithIcon.js
+++ b/docs/examples/module/staticWithIcon.js
@@ -1,0 +1,20 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Module, Text } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Module
+          icon="lock"
+          iconAccessibilityLabel="Module Locked - check permission settings"
+          id="ModuleExample - icon"
+          title="Title"
+        >
+          <Text size="200">This is example content.</Text>
+        </Module>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/module/staticWithIconButton.js
+++ b/docs/examples/module/staticWithIconButton.js
@@ -1,0 +1,47 @@
+// @flow strict
+import { type Node, useRef, useState } from 'react';
+import { Box, IconButton, Module, Popover, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [showPopover, setShowPopover] = useState(false);
+  const anchorRef = useRef<HTMLElement | null>(null);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box column={12} maxWidth={800} padding={2}>
+        <Module
+          iconButton={
+            <IconButton
+              bgColor="lightGray"
+              icon="question-mark"
+              iconColor="darkGray"
+              accessibilityLabel="Get help"
+              size="xs"
+              onClick={() => {
+                setShowPopover((currVal) => !currVal);
+              }}
+              ref={anchorRef}
+            />
+          }
+          id="ModuleExample - iconButton"
+          title="Title"
+        >
+          <Text size="200">This is example content.</Text>
+        </Module>
+
+        {showPopover && (
+          <Popover
+            anchor={anchorRef.current}
+            idealDirection="right"
+            onDismiss={() => setShowPopover(false)}
+            shouldFocus={false}
+          >
+            <Box padding={3}>
+              <Text weight="bold">Help content!</Text>
+            </Box>
+          </Popover>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/considerAllFieldsAsRequired.js
+++ b/docs/examples/textfield/considerAllFieldsAsRequired.js
@@ -1,0 +1,45 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [name, setName] = useState({
+    first: '',
+    middle: '',
+    last: '',
+  });
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={{ column: 3, row: 0 }}>
+        <TextField
+          id="best-practices-do-required-firstName"
+          label="First name"
+          onChange={({ value }) => {
+            setName((nameFields) => ({ ...nameFields, first: value }));
+          }}
+          type="text"
+          value={name.first}
+        />
+        <TextField
+          id="best-practices-do-required-middleName"
+          label="Middle name (optional)"
+          onChange={({ value }) => {
+            setName((nameFields) => ({ ...nameFields, middle: value }));
+          }}
+          type="text"
+          value={name.middle}
+        />
+        <TextField
+          id="best-practices-do-required-lastName"
+          label="Last name"
+          onChange={({ value }) => {
+            setName((nameFields) => ({ ...nameFields, last: value }));
+          }}
+          type="text"
+          value={name.last}
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/disabledExample.js
+++ b/docs/examples/textfield/disabledExample.js
@@ -1,0 +1,22 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <TextField
+        disabled
+        id="variants-disabled"
+        label="New password"
+        onChange={({ value }) => {
+          setValue(value);
+        }}
+        placeholder="6-18 characters"
+        value={value}
+      />
+    </Box>
+  );
+}

--- a/docs/examples/textfield/disabledExample.js
+++ b/docs/examples/textfield/disabledExample.js
@@ -11,8 +11,8 @@ export default function Example(): Node {
         disabled
         id="variants-disabled"
         label="New password"
-        onChange={({ value }) => {
-          setValue(value);
+        onChange={(e) => {
+          setValue(e.value);
         }}
         placeholder="6-18 characters"
         value={value}

--- a/docs/examples/textfield/dontDisplayGenericErrorMessages.js
+++ b/docs/examples/textfield/dontDisplayGenericErrorMessages.js
@@ -1,0 +1,25 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box padding={2} color="light">
+        <TextField
+          autoComplete="new-password"
+          errorMessage="There is an error"
+          id="best-practices-dont-error-message"
+          label="Password"
+          onChange={({ value }) => {
+            setValue(value);
+          }}
+          type="password"
+          value={value}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/dontDisplayGenericErrorMessages.js
+++ b/docs/examples/textfield/dontDisplayGenericErrorMessages.js
@@ -13,8 +13,8 @@ export default function Example(): Node {
           errorMessage="There is an error"
           id="best-practices-dont-error-message"
           label="Password"
-          onChange={({ value }) => {
-            setValue(value);
+          onChange={(e) => {
+            setValue(e.value);
           }}
           type="password"
           value={value}

--- a/docs/examples/textfield/dontMarkFieldsAsRequired.js
+++ b/docs/examples/textfield/dontMarkFieldsAsRequired.js
@@ -1,0 +1,47 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [name, setName] = useState({
+    first: '',
+    middle: '',
+    last: '',
+  });
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={{ column: 3, row: 0 }}>
+        <TextField
+          helperText="* This field is required."
+          id="best-practices-dont-required-firstName"
+          label="First name"
+          onChange={({ value }) => {
+            setName((nameFields) => ({ ...nameFields, first: value }));
+          }}
+          type="text"
+          value={name.first}
+        />
+        <TextField
+          id="best-practices-dont-required-middleName"
+          label="Middle name"
+          onChange={({ value }) => {
+            setName((nameFields) => ({ ...nameFields, middle: value }));
+          }}
+          type="text"
+          value={name.middle}
+        />
+        <TextField
+          helperText="* This field is required."
+          id="best-practices-dont-required-lastName"
+          label="Last name"
+          onChange={({ value }) => {
+            setName((nameFields) => ({ ...nameFields, last: value }));
+          }}
+          type="text"
+          value={name.last}
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/dontPlaceUnrelatedFieldsSameLine.js
+++ b/docs/examples/textfield/dontPlaceUnrelatedFieldsSameLine.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [passwordValue, setPasswordValue] = useState('');
+  const [zipCodeValue, setZipCodeValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 0, row: 4 }}>
+        <TextField
+          autoComplete="new-password"
+          id="best-practices-dont-related-password"
+          label="Password"
+          onChange={({ value }) => {
+            setPasswordValue(value);
+          }}
+          type="password"
+          value={passwordValue}
+        />
+        <TextField
+          id="best-practices-dont-related-zip-code"
+          label="ZIP Code"
+          onChange={({ value }) => {
+            setZipCodeValue(value);
+          }}
+          value={zipCodeValue}
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/dontPutEssentialInformationPlaceholder.js
+++ b/docs/examples/textfield/dontPutEssentialInformationPlaceholder.js
@@ -12,8 +12,8 @@ export default function Example(): Node {
           autoComplete="new-password"
           id="best-practices-dont-placeholder"
           label=""
-          onChange={({ value }) => {
-            setValue(value);
+          onChange={(e) => {
+            setValue(e.value);
           }}
           placeholder="Password should be at least 20 characters in length"
           type="password"

--- a/docs/examples/textfield/dontPutEssentialInformationPlaceholder.js
+++ b/docs/examples/textfield/dontPutEssentialInformationPlaceholder.js
@@ -1,0 +1,25 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box padding={2} color="light">
+        <TextField
+          autoComplete="new-password"
+          id="best-practices-dont-placeholder"
+          label=""
+          onChange={({ value }) => {
+            setValue(value);
+          }}
+          placeholder="Password should be at least 20 characters in length"
+          type="password"
+          value={value}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/dontRemoveLabel.js
+++ b/docs/examples/textfield/dontRemoveLabel.js
@@ -1,0 +1,25 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <div className="skip-accessibility-check">
+        <Box padding={2} color="light">
+          <TextField
+            autoComplete="username"
+            id="best-practices-dont-label"
+            label=""
+            onChange={(e) => {
+              setValue(e.value);
+            }}
+            value={value}
+          />
+        </Box>
+      </div>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/ensureVisibleLabel.js
+++ b/docs/examples/textfield/ensureVisibleLabel.js
@@ -12,8 +12,8 @@ export default function Example(): Node {
           autoComplete="username"
           id="best-practices-do-label"
           label="Username"
-          onChange={({ value }) => {
-            setValue(value);
+          onChange={(e) => {
+            setValue(e.value);
           }}
           type="text"
           value={value}

--- a/docs/examples/textfield/ensureVisibleLabel.js
+++ b/docs/examples/textfield/ensureVisibleLabel.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box padding={2} color="light">
+        <TextField
+          autoComplete="username"
+          id="best-practices-do-label"
+          label="Username"
+          onChange={({ value }) => {
+            setValue(value);
+          }}
+          type="text"
+          value={value}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/errorMessageExample.js
+++ b/docs/examples/textfield/errorMessageExample.js
@@ -1,0 +1,21 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <TextField
+        errorMessage={!value ? "This field can't be blank!" : null}
+        id="variants-error-message"
+        label="New username"
+        onChange={({ value }) => {
+          setValue(value);
+        }}
+        value={value}
+      />
+    </Box>
+  );
+}

--- a/docs/examples/textfield/errorMessageExample.js
+++ b/docs/examples/textfield/errorMessageExample.js
@@ -11,8 +11,8 @@ export default function Example(): Node {
         errorMessage={!value ? "This field can't be blank!" : null}
         id="variants-error-message"
         label="New username"
-        onChange={({ value }) => {
-          setValue(value);
+        onChange={(e) => {
+          setValue(e.value);
         }}
         value={value}
       />

--- a/docs/examples/textfield/helperTextExplainOptionalInfo.js
+++ b/docs/examples/textfield/helperTextExplainOptionalInfo.js
@@ -13,8 +13,8 @@ export default function Example(): Node {
           helperText="Password should be at least 20 characters long"
           id="variants-helper-text"
           label="Password"
-          onChange={({ value }) => {
-            setValue(value);
+          onChange={(e) => {
+            setValue(e.value);
           }}
           type="password"
           value={value}

--- a/docs/examples/textfield/helperTextExplainOptionalInfo.js
+++ b/docs/examples/textfield/helperTextExplainOptionalInfo.js
@@ -1,0 +1,25 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box padding={2} color="light">
+        <TextField
+          autoComplete="new-password"
+          helperText="Password should be at least 20 characters long"
+          id="variants-helper-text"
+          label="Password"
+          onChange={({ value }) => {
+            setValue(value);
+          }}
+          type="password"
+          value={value}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/labelVisibilityExample.js
+++ b/docs/examples/textfield/labelVisibilityExample.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Box,Flex, Text, TextField } from 'gestalt';
+import { Box, Flex, Text, TextField } from 'gestalt';
 
 export default function Example(): Node {
   return (

--- a/docs/examples/textfield/labelVisibilityExample.js
+++ b/docs/examples/textfield/labelVisibilityExample.js
@@ -1,0 +1,22 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box,Flex, Text, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 2, row: 0 }} direction="column">
+        <Text weight="bold" size="300">
+          First name
+        </Text>
+        <TextField
+          id="textfieldexampleHiddenLabel"
+          onChange={() => {}}
+          label="First name"
+          labelDisplay="hidden"
+          size="lg"
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/labelsExample.js
+++ b/docs/examples/textfield/labelsExample.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box,Flex, Text, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 0, row: 6 }}>
+        <TextField
+          id="textfieldexampleA11yVisible"
+          onChange={() => {}}
+          label="First name"
+          size="lg"
+        />
+        <Flex gap={{ column: 2, row: 0 }} direction="column">
+          <Text weight="bold" size="300">
+            First name
+          </Text>
+          <TextField
+            id="textfieldexampleA11yHiddenLabel"
+            onChange={() => {}}
+            label="First name"
+            labelDisplay="hidden"
+            size="lg"
+          />
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/labelsExample.js
+++ b/docs/examples/textfield/labelsExample.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Box,Flex, Text, TextField } from 'gestalt';
+import { Box, Flex, Text, TextField } from 'gestalt';
 
 export default function Example(): Node {
   return (

--- a/docs/examples/textfield/maximumLengthExample.js
+++ b/docs/examples/textfield/maximumLengthExample.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node, useState } from 'react';
-import { Box,TextField } from 'gestalt';
+import { Box, TextField } from 'gestalt';
 
 export default function TextFieldExample(): Node {
   const [value, setValue] = useState('');

--- a/docs/examples/textfield/maximumLengthExample.js
+++ b/docs/examples/textfield/maximumLengthExample.js
@@ -12,7 +12,7 @@ export default function TextFieldExample(): Node {
         id="maxLength"
         label="Title"
         helperText="Enter a title that captures the imagination of Pinners"
-        onChange={({ value }) => setValue(value)}
+        onChange={(e) => setValue(e.value)}
         placeholder="Enter your pin title"
         value={value}
         onBlur={() => {}}

--- a/docs/examples/textfield/maximumLengthExample.js
+++ b/docs/examples/textfield/maximumLengthExample.js
@@ -1,0 +1,27 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box,TextField } from 'gestalt';
+
+export default function TextFieldExample(): Node {
+  const [value, setValue] = useState('');
+  const characterCount = 20;
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <TextField
+        id="maxLength"
+        label="Title"
+        helperText="Enter a title that captures the imagination of Pinners"
+        onChange={({ value }) => setValue(value)}
+        placeholder="Enter your pin title"
+        value={value}
+        onBlur={() => {}}
+        onFocus={() => {}}
+        maxLength={{
+          characterCount,
+          errorAccessibilityLabel: 'Limit reached. You can only use 20 characters in this field.',
+        }}
+      />
+    </Box>
+  );
+}

--- a/docs/examples/textfield/maximumLengthExampleSingleLine.js
+++ b/docs/examples/textfield/maximumLengthExampleSingleLine.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node, useState } from 'react';
-import { Box,Flex, TextField } from 'gestalt';
+import { Box, Flex, TextField } from 'gestalt';
 
 export default function TextFieldExample(): Node {
   const [valueA, setValueA] = useState('Delicious vegan soup');

--- a/docs/examples/textfield/maximumLengthExampleSingleLine.js
+++ b/docs/examples/textfield/maximumLengthExampleSingleLine.js
@@ -1,0 +1,40 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box,Flex, TextField } from 'gestalt';
+
+export default function TextFieldExample(): Node {
+  const [valueA, setValueA] = useState('Delicious vegan soup');
+  const [valueB, setValueB] = useState('Delicious vegan noodle soup');
+
+  const characterCount = 20;
+  const errorAccessibilityLabel = 'Limit reached. You can only use 20 characters in this field.';
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={12}>
+        <TextField
+          id="maxLengthReached"
+          label="Title"
+          helperText="Enter a title that captures the imagination of Pinners"
+          onChange={({ value }) => setValueA(value)}
+          placeholder="Enter your pin title"
+          value={valueA}
+          onBlur={() => {}}
+          onFocus={() => {}}
+          maxLength={{ characterCount, errorAccessibilityLabel }}
+        />
+        <TextField
+          id="maxLengthExceeded"
+          label="Title"
+          helperText="Enter a title that captures the imagination of Pinners"
+          onChange={({ value }) => setValueB(value)}
+          placeholder="Enter your pin title"
+          value={valueB}
+          onBlur={() => {}}
+          onFocus={() => {}}
+          maxLength={{ characterCount, errorAccessibilityLabel }}
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/mobileExample1.js
+++ b/docs/examples/textfield/mobileExample1.js
@@ -1,0 +1,28 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Image, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={2}>
+        <TextField
+          id="enterKeyHint"
+          mobileEnterKeyHint="next"
+          label="Text virtual keyboard with 'next'"
+          onChange={() => {}}
+          onBlur={() => {}}
+          onFocus={() => {}}
+        />
+        <Box height={100} width={200}>
+          <Image
+            alt="Image of a screenshot of a virtual keyboard on a mobile screen showing a text virtual keyboard with 'next'"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/qdMLb8t/IMG-2518.jpg"
+          />
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/mobileExample2.js
+++ b/docs/examples/textfield/mobileExample2.js
@@ -1,0 +1,28 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Image, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={2}>
+        <TextField
+          id="decimal"
+          mobileInputMode="decimal"
+          label="Decimal virtual keyboard"
+          onChange={() => {}}
+          onBlur={() => {}}
+          onFocus={() => {}}
+        />
+        <Box height={100} width={200}>
+          <Image
+            alt="Image of a screenshot of a virtual keyboard on a mobile screen showing a decimal virtual keyboard"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/WxYtCdx/IMG-2520.jpg"
+          />
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/mobileExample3.js
+++ b/docs/examples/textfield/mobileExample3.js
@@ -1,0 +1,29 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Image, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={2}>
+        <TextField
+          id="none"
+          mobileInputMode="numeric"
+          label="Numeric virtual keyboard"
+          type="date"
+          onChange={() => {}}
+          onBlur={() => {}}
+          onFocus={() => {}}
+        />
+        <Box height={100} width={200}>
+          <Image
+            alt="Image of a screenshot of a virtual keyboard on a mobile screen showing a numeric virtual keyboard"
+            naturalHeight={1}
+            naturalWidth={1}
+            src="https://i.ibb.co/tpZ9pV8/IMG-2519.jpg"
+          />
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/mobileExample4.js
+++ b/docs/examples/textfield/mobileExample4.js
@@ -1,0 +1,12 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box } from 'gestalt';
+import { DatePicker } from 'gestalt-datepicker';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <DatePicker id="datepicker" label="No virtual keyboard" onChange={() => {}} />
+    </Box>
+  );
+}

--- a/docs/examples/textfield/onlyPlaceRelatedFieldsSameLine.js
+++ b/docs/examples/textfield/onlyPlaceRelatedFieldsSameLine.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [cityValue, setCityValue] = useState('');
+  const [stateValue, setStateValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 0, row: 4 }}>
+        <TextField
+          id="best-practices-do-related-city"
+          label="City"
+          onChange={({ value }) => {
+            setCityValue(value);
+          }}
+          type="text"
+          value={cityValue}
+        />
+        <TextField
+          id="best-practices-do-related-state"
+          label="State"
+          onChange={({ value }) => {
+            setStateValue(value);
+          }}
+          type="text"
+          value={stateValue}
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/passwordExample.js
+++ b/docs/examples/textfield/passwordExample.js
@@ -1,0 +1,20 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [password, setPassword] = useState<string>('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <TextField
+        id="enter-password"
+        label="Account password"
+        onChange={({ value }) => setPassword(value)}
+        placeholder="Password"
+        type="password"
+        value={password}
+      />
+    </Box>
+  );
+}

--- a/docs/examples/textfield/provideClearUsefulErrorMessages.js
+++ b/docs/examples/textfield/provideClearUsefulErrorMessages.js
@@ -13,8 +13,8 @@ export default function Example(): Node {
           errorMessage="Password is too short! You need 20+ characters"
           id="best-practices-do-error-message"
           label="Password"
-          onChange={({ value }) => {
-            setValue(value);
+          onChange={(e) => {
+            setValue(e.value);
           }}
           type="password"
           value={value}

--- a/docs/examples/textfield/provideClearUsefulErrorMessages.js
+++ b/docs/examples/textfield/provideClearUsefulErrorMessages.js
@@ -1,0 +1,25 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box padding={2} color="light">
+        <TextField
+          autoComplete="new-password"
+          errorMessage="Password is too short! You need 20+ characters"
+          id="best-practices-do-error-message"
+          label="Password"
+          onChange={({ value }) => {
+            setValue(value);
+          }}
+          type="password"
+          value={value}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/readOnlyExample.js
+++ b/docs/examples/textfield/readOnlyExample.js
@@ -10,7 +10,7 @@ export default function Example(): Node {
       <TextField
         id="variants-readonly"
         label="Email address"
-        onChange={({ value }) => setValue(value)}
+        onChange={(e) => setValue(e.value)}
         placeholder="Name"
         value={value}
         readOnly

--- a/docs/examples/textfield/readOnlyExample.js
+++ b/docs/examples/textfield/readOnlyExample.js
@@ -1,0 +1,20 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('****maz@pinterest.com');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <TextField
+        id="variants-readonly"
+        label="Email address"
+        onChange={({ value }) => setValue(value)}
+        placeholder="Name"
+        value={value}
+        readOnly
+      />
+    </Box>
+  );
+}

--- a/docs/examples/textfield/tagsExample.js
+++ b/docs/examples/textfield/tagsExample.js
@@ -1,32 +1,29 @@
 // @flow strict
 import { type Node, useRef, useState } from 'react';
-import { Box, Tag, TextArea } from 'gestalt';
+import { Box, Tag, TextField } from 'gestalt';
 
 type ChangeTagHandler = ({|
-  event: SyntheticInputEvent<HTMLTextAreaElement>,
+  event: SyntheticInputEvent<HTMLInputElement>,
   value: string,
 |}) => void;
 
 type KeyDownHandler = ({|
-  event: SyntheticKeyboardEvent<HTMLTextAreaElement>,
+  event: SyntheticKeyboardEvent<HTMLInputElement>,
   value: string,
 |}) => void;
 
-const CITIES = ['San Francisco', 'New York'];
-
 export default function Example(): Node {
   const [value, setValue] = useState('');
-  const [tags, setTags] = useState(CITIES);
-
-  const ref = useRef<HTMLTextAreaElement | null>(null);
+  const [tags, setTags] = useState(['a@pinterest.com', 'b@pinterest.com']);
+  const ref = useRef<HTMLElement | null>(null);
 
   const onChangeTagManagement: ChangeTagHandler = (e) => {
-    // Create new tags around new lines
-    const tagInput = e.value.split(/\\n+/);
+    // Create new tags around spaces, commas, and semicolons.
+    const tagInput = e.value.split(/[\\s,;]+/);
     if (tagInput.length > 1) {
       setTags([
         ...tags,
-        // Avoid creating a tag on content on the last line, and filter out
+        // Avoid creating a tag on content after the separators, and filter out
         // empty tags
         ...tagInput.splice(0, tagInput.length - 1).filter((val) => val !== ''),
       ]);
@@ -43,6 +40,10 @@ export default function Example(): Node {
     if (keyCode === 8 /* Backspace */ && selectionEnd === 0) {
       // Remove tag on backspace if the cursor is at the beginning of the field
       setTags([...tags.slice(0, -1)]);
+    } else if (keyCode === 13 /* Enter */ && value.trim() !== '') {
+      // Create a new tag on enter
+      setTags([...tags, value.trim()]);
+      setValue('');
     }
   };
 
@@ -62,14 +63,14 @@ export default function Example(): Node {
 
   return (
     <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
-      <Box width="100%">
-        <TextArea
-          id="cities"
-          label="Cities"
+      <Box padding={2} color="light">
+        <TextField
+          autoComplete="off"
+          id="variants-tags"
+          label="Emails"
           ref={ref}
           onChange={onChangeTagManagement}
           onKeyDown={onKeyDownTagManagement}
-          placeholder={value.length > 0 || tags.length > 0 ? '' : "Cities you've lived in"}
           tags={renderedTags}
           value={value}
         />

--- a/docs/examples/textfield/textFieldRefAnchorPopover.js
+++ b/docs/examples/textfield/textFieldRefAnchorPopover.js
@@ -1,0 +1,42 @@
+// @flow strict
+import { type Node, useRef, useState } from 'react';
+import { Box, Popover, Text, TextField } from 'gestalt';
+
+export default function TextFieldPopoverExample(): Node {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLElement | null>(null);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box padding={2} color="light">
+        <TextField
+          id="variants-refs"
+          label="Focus the TextField to show the Popover"
+          onChange={() => {}}
+          onBlur={() => {
+            setOpen(false);
+          }}
+          onFocus={() => {
+            setOpen(true);
+          }}
+          ref={anchorRef}
+        />
+        {open && (
+          <Popover
+            anchor={anchorRef.current}
+            idealDirection="down"
+            onDismiss={() => {
+              setOpen(false);
+            }}
+            shouldFocus={false}
+            size="md"
+          >
+            <Box padding={3}>
+              <Text weight="bold">Example with Popover</Text>
+            </Box>
+          </Popover>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/textfield/useHelperTextImportantInformation.js
+++ b/docs/examples/textfield/useHelperTextImportantInformation.js
@@ -13,8 +13,8 @@ export default function Example(): Node {
           helperText="Password should be at least 20 characters in length"
           id="best-practices-do-helper-text"
           label="New password"
-          onChange={({ value }) => {
-            setValue(value);
+          onChange={(e) => {
+            setValue(e.value);
           }}
           type="password"
           value={value}

--- a/docs/examples/textfield/useHelperTextImportantInformation.js
+++ b/docs/examples/textfield/useHelperTextImportantInformation.js
@@ -1,0 +1,25 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box padding={2} color="light">
+        <TextField
+          autoComplete="new-password"
+          helperText="Password should be at least 20 characters in length"
+          id="best-practices-do-helper-text"
+          label="New password"
+          onChange={({ value }) => {
+            setValue(value);
+          }}
+          type="password"
+          value={value}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/actionsVariant.js
+++ b/docs/examples/upsell/actionsVariant.js
@@ -1,0 +1,122 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Column,
+  Flex,
+  Label,
+  Layer,
+  Modal,
+  Text,
+  TextArea,
+  TextField,
+  Upsell,
+} from 'gestalt';
+
+export default function Example(): Node {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box marginStart={-1} marginEnd={-1}>
+        <Upsell
+          dismissButton={{
+            accessibilityLabel: 'Dismiss banner',
+            onDismiss: () => {},
+          }}
+          message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+          primaryAction={{
+            accessibilityLabel: 'Send ads invite',
+            label: 'Send invite',
+            onClick: () => {
+              setShowModal(!showModal);
+            },
+          }}
+          secondaryAction={{
+            accessibilityLabel: 'Learn more: Verified Merchant Program',
+            href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="Give $30, get $60 in ads credit"
+        />
+
+        {showModal && (
+          <Layer>
+            <Modal
+              accessibilityModalLabel="Invite a friend to the Verified Merchant Program"
+              footer={
+                <Flex flex="grow" justifyContent="end">
+                  <ButtonGroup>
+                    <Button
+                      onClick={() => {
+                        setShowModal(!showModal);
+                      }}
+                      size="lg"
+                      text="Cancel"
+                    />
+                    <Button color="red" size="lg" text="Send invite" />
+                  </ButtonGroup>
+                </Flex>
+              }
+              heading="Verified Merchant Program Invitation"
+              onDismiss={() => {
+                setShowModal(!showModal);
+              }}
+              size="md"
+              subHeading="When your friend spends their first $30 on ads, you’ll earn $60 of ads credit, and they’ll get $30 of ads credit, too."
+            >
+              <Flex direction="row">
+                <Column span={12}>
+                  <Box display="flex" paddingY={2} paddingX={8}>
+                    <Column span={4}>
+                      <Label htmlFor="name">
+                        <Text align="forceLeft" weight="bold">
+                          Friend&apos;s Name
+                        </Text>
+                      </Label>
+                    </Column>
+
+                    <Column span={8}>
+                      <TextField id="name" onChange={() => undefined} />
+                    </Column>
+                  </Box>
+
+                  <Box display="flex" paddingY={2} paddingX={8}>
+                    <Column span={4}>
+                      <Label htmlFor="email">
+                        <Text align="forceLeft" weight="bold">
+                          Friend&apos;s E-mail
+                        </Text>
+                      </Label>
+                    </Column>
+
+                    <Column span={8}>
+                      <TextField id="email" onChange={() => undefined} />
+                    </Column>
+                  </Box>
+
+                  <Box display="flex" paddingY={2} paddingX={8}>
+                    <Column span={4}>
+                      <Label htmlFor="desc">
+                        <Text align="forceLeft" weight="bold">
+                          Personal Message
+                        </Text>
+                      </Label>
+                    </Column>
+
+                    <Column span={8}>
+                      <TextArea id="desc" onChange={() => undefined} />
+                    </Column>
+                  </Box>
+                </Column>
+              </Flex>
+            </Modal>
+          </Layer>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/dontShowSameOnceDismissed.js
+++ b/docs/examples/upsell/dontShowSameOnceDismissed.js
@@ -1,0 +1,36 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={{ column: 4, row: 0 }}>
+        <Upsell
+          dismissButton={{
+            accessibilityLabel: 'Dismiss banner',
+            onDismiss: () => {},
+          }}
+          imageData={{
+            component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
+          }}
+          message="Install the Pinterest tag to track your website traffic, conversions and more."
+          primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
+          title="Measure ad performance"
+        />
+        <Upsell
+          dismissButton={{
+            accessibilityLabel: 'Dismiss banner',
+            onDismiss: () => {},
+          }}
+          imageData={{
+            component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
+          }}
+          message="Install the Pinterest tag to track your website traffic, conversions and more."
+          primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
+          title="Measure ad performance"
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/dontStack.js
+++ b/docs/examples/upsell/dontStack.js
@@ -1,0 +1,55 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Button, ButtonGroup, Divider, Flex, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box>
+        <Box alignItems="center" display="flex" marginBottom={4}>
+          <Icon accessibilityLabel="" color="brandPrimary" icon="pinterest" size={32} />
+          <ButtonGroup>
+            <Button color="transparent" iconEnd="arrow-down" text="Business" />
+            <Button color="transparent" iconEnd="arrow-down" text="Create" />
+            <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
+            <Button color="transparent" iconEnd="arrow-down" text="Ads" />
+          </ButtonGroup>
+        </Box>
+
+        <Divider />
+
+        <Box marginTop={8}>
+          <Flex direction="column" gap={{ column: 2, row: 0 }}>
+            <Upsell
+              imageData={{
+                component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
+              }}
+              message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
+              primaryAction={{ label: 'Claim now', accessibilityLabel: 'Claim ads credit now' }}
+              title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
+            />
+            <Upsell
+              dismissButton={{
+                accessibilityLabel: 'Dismiss banner',
+                onDismiss: () => {},
+              }}
+              imageData={{
+                component: (
+                  <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />
+                ),
+              }}
+              message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+              primaryAction={{
+                accessibilityLabel: 'Send ads invite',
+                href: 'https://pinterest.com',
+                label: 'Send invite',
+                target: 'blank',
+              }}
+              title="Give $30, get $60 in ads credit"
+            />
+          </Flex>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/dontUseForCriticalInfo.js
+++ b/docs/examples/upsell/dontUseForCriticalInfo.js
@@ -1,0 +1,29 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        imageData={{
+          component: (
+            <Icon
+              icon="workflow-status-warning"
+              accessibilityLabel="Warning"
+              color="default"
+              size={32}
+            />
+          ),
+        }}
+        message="There was a problem connecting your account."
+        primaryAction={{ label: 'Try again', accessibilityLabel: 'Try linking account again' }}
+        title="Could not link account"
+      />
+    </Box>
+  );
+}

--- a/docs/examples/upsell/iconVariant.js
+++ b/docs/examples/upsell/iconVariant.js
@@ -1,0 +1,27 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        imageData={{
+          component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
+        }}
+        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+        primaryAction={{
+          href: 'https://pinterest.com',
+          label: 'Send invite',
+          accessibilityLabel: 'Invite friend to use ads',
+          target: 'blank',
+        }}
+        title="Give $30, get $60 in ads credit"
+      />
+    </Box>
+  );
+}

--- a/docs/examples/upsell/imageVariant.js
+++ b/docs/examples/upsell/imageVariant.js
@@ -1,0 +1,37 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Image, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        imageData={{
+          component: (
+            <Image
+              alt=""
+              color="rgb(231, 186, 176)"
+              naturalHeight={751}
+              naturalWidth={564}
+              src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+            />
+          ),
+          mask: { rounding: 4 },
+          width: 128,
+        }}
+        message="Check out our resources for adapting to these times."
+        primaryAction={{
+          href: 'https://pinterest.com',
+          label: 'Visit',
+          accessibilityLabel: 'Visit our Stay Safe resources',
+          target: 'blank',
+        }}
+        title="Stay healthy and safe"
+      />
+    </Box>
+  );
+}

--- a/docs/examples/upsell/labelsExample.js
+++ b/docs/examples/upsell/labelsExample.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        imageData={{
+          component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
+        }}
+        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+        primaryAction={{
+          href: 'https://pinterest.com',
+          label: 'Send invite',
+          accessibilityLabel: 'Invite friend to use ads',
+          target: 'blank',
+        }}
+        secondaryAction={{
+          accessibilityLabel: 'Learn more: Verified Merchant Program',
+          href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
+          label: 'Learn more',
+          target: 'blank',
+        }}
+        title="Give $30, get $60 in ads credit"
+      />
+    </Box>
+  );
+}

--- a/docs/examples/upsell/loclizeLabelsExample.js
+++ b/docs/examples/upsell/loclizeLabelsExample.js
@@ -1,0 +1,22 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        imageData={{
+          component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
+        }}
+        message="Verfolgen Sie die Anzeigenkonvertierung - Umsatz, Traffic und mehr - mit dem Pinterest Tag"
+        primaryAction={{
+          label: 'Beanspruche jetzt',
+          accessibilityLabel: 'Beanspruche Guthaben jetzt',
+          target: 'blank',
+        }}
+        title="Fast fertig! Beenden Sie die Installation Ihres Pinterest-Tags und erhalten Sie ein Guthaben von 10 Euro"
+      />
+    </Box>
+  );
+}

--- a/docs/examples/upsell/mainExample.js
+++ b/docs/examples/upsell/mainExample.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        imageData={{
+          component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
+        }}
+        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+        primaryAction={{
+          accessibilityLabel: 'Send ads invite',
+          href: 'https://pinterest.com',
+          label: 'Send invite',
+          target: 'blank',
+        }}
+        secondaryAction={{
+          accessibilityLabel: 'Learn more: Verified Merchant Program',
+          href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
+          label: 'Learn more',
+          target: 'blank',
+        }}
+        title="Give $30, get $60 in ads credit"
+      />
+    </Box>
+  );
+}

--- a/docs/examples/upsell/messagePropForVisualStyle.js
+++ b/docs/examples/upsell/messagePropForVisualStyle.js
@@ -1,0 +1,29 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Link, Text, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={6}>
+        <Text weight="bold">Simple message string</Text>
+        <Upsell
+          message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+          title="Give $30, get $60 in ads credit"
+        />
+        <Text weight="bold">Rich message with Text component</Text>
+        <Upsell
+          message={
+            <Text inline>
+              Earn $60 of ads credit, and give $30 of ads credit to a friend.{' '}
+              <Link accessibilityLabel="Learn more about credit" display="inline" href="#Message">
+                Learn more
+              </Link>
+            </Text>
+          }
+          title="Give $30, get $60 in ads credit"
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/multipleTextField.js
+++ b/docs/examples/upsell/multipleTextField.js
@@ -1,0 +1,77 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Image, TextField, Upsell } from 'gestalt';
+
+type SubmitHandler = ({|
+  event:
+    | SyntheticMouseEvent<HTMLButtonElement>
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLButtonElement>,
+|}) => void;
+
+export default function Example(): Node {
+  const [nameValue, setNameValue] = useState('');
+  const [emailValue, setEmailValue] = useState('');
+  const handleSubmit: SubmitHandler = ({ event }) => {
+    event.preventDefault();
+    // your submit logic using state values
+  };
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        imageData={{
+          component: (
+            <Image
+              alt="Succulent plant against pink background"
+              color="rgb(231, 186, 176)"
+              naturalHeight={751}
+              naturalWidth={564}
+              src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+            />
+          ),
+          mask: { rounding: 4 },
+          width: 128,
+        }}
+        message="Learn how to grow your business with a Pinterest ads expert today!"
+        title="Interested in a free ads consultation?"
+      >
+        <Upsell.Form
+          onSubmit={handleSubmit}
+          submitButtonAccessibilityLabel="Submit info for contact"
+          submitButtonText="Contact me"
+        >
+          <Box display="block" smDisplay="flex">
+            <Box flex="grow" smMarginEnd={1} marginEnd={0} smMarginBottom={0} marginBottom={2}>
+              <TextField
+                id="name"
+                onChange={({ value }) => setNameValue(value)}
+                placeholder="Name"
+                label="Full name"
+                labelDisplay="hidden"
+                value={nameValue}
+              />
+            </Box>
+
+            <Box flex="grow" smMarginStart={1} marginStart={0}>
+              <TextField
+                id="email"
+                onChange={({ value }) => setEmailValue(value)}
+                placeholder="Email"
+                type="email"
+                label="Email address"
+                labelDisplay="hidden"
+                value={emailValue}
+              />
+            </Box>
+          </Box>
+        </Upsell.Form>
+      </Upsell>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/placeAtTopOfPage.js
+++ b/docs/examples/upsell/placeAtTopOfPage.js
@@ -1,0 +1,43 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Button, ButtonGroup, Divider, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box>
+        <Box alignItems="center" display="flex" marginBottom={4}>
+          <Icon accessibilityLabel="" color="brandPrimary" icon="pinterest" size={32} />
+          <ButtonGroup>
+            <Button color="transparent" iconEnd="arrow-down" text="Business" />
+            <Button color="transparent" iconEnd="arrow-down" text="Create" />
+            <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
+            <Button color="transparent" iconEnd="arrow-down" text="Ads" />
+          </ButtonGroup>
+        </Box>
+
+        <Divider />
+
+        <Box marginTop={8}>
+          <Upsell
+            dismissButton={{
+              accessibilityLabel: 'Dismiss banner',
+              onDismiss: () => {},
+            }}
+            imageData={{
+              component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
+            }}
+            message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+            primaryAction={{
+              accessibilityLabel: 'Send ads invite',
+              href: 'https://pinterest.com',
+              label: 'Send invite',
+              target: 'blank',
+            }}
+            title="Give $30, get $60 in ads credit"
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/planTiming.js
+++ b/docs/examples/upsell/planTiming.js
@@ -1,0 +1,41 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, Icon, Text, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 4, row: 0 }} direction="column">
+        <Text>First Upsell:</Text>
+        <Upsell
+          dismissButton={{
+            accessibilityLabel: 'Dismiss banner',
+            onDismiss: () => {},
+          }}
+          imageData={{
+            component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
+          }}
+          message="Install the Pinterest tag to track your website traffic, conversions and more."
+          primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag now' }}
+          secondaryAction={{
+            accessibilityLabel: 'Learn more: Pinterest tag',
+            href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
+            label: 'Learn more',
+            target: 'blank',
+          }}
+          title="Measure ad performance"
+        />
+
+        <Text>Follow-up Upsell:</Text>
+        <Upsell
+          imageData={{
+            component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
+          }}
+          message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
+          primaryAction={{ label: 'Claim now', accessibilityLabel: 'Claim ads credit' }}
+          title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/singleTextField.js
+++ b/docs/examples/upsell/singleTextField.js
@@ -1,0 +1,50 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Icon, TextField, Upsell } from 'gestalt';
+
+type SubmitHandler = ({|
+  event:
+    | SyntheticMouseEvent<HTMLButtonElement>
+    | SyntheticMouseEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLAnchorElement>
+    | SyntheticKeyboardEvent<HTMLButtonElement>,
+|}) => void;
+
+export default function FormExample(): Node {
+  const [value, setValue] = useState('');
+  const handleSubmit: SubmitHandler = ({ event }) => {
+    event.preventDefault();
+    // your submit logic using state values
+  };
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        imageData={{
+          component: <Icon icon="pinterest" accessibilityLabel="Pin" color="default" size={32} />,
+        }}
+        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+        title="Give $30, get $60 in ads credit"
+      >
+        <Upsell.Form
+          onSubmit={handleSubmit}
+          submitButtonAccessibilityLabel="Submit name for ads credit"
+          submitButtonText="Submit"
+        >
+          <TextField
+            id="nameField"
+            onChange={(e) => setValue(e.value)}
+            placeholder="Name"
+            value={value}
+            label="Full name"
+            labelDisplay="hidden"
+          />
+        </Upsell.Form>
+      </Upsell>
+    </Box>
+  );
+}

--- a/docs/examples/upsell/textVariant.js
+++ b/docs/examples/upsell/textVariant.js
@@ -1,0 +1,17 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss this banner',
+          onDismiss: () => {},
+        }}
+        message="Single line Upsell with no title or call to action."
+      />
+    </Box>
+  );
+}

--- a/docs/examples/upsell/useForMarketing.js
+++ b/docs/examples/upsell/useForMarketing.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Icon, Upsell } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Upsell
+        dismissButton={{
+          accessibilityLabel: 'Dismiss banner',
+          onDismiss: () => {},
+        }}
+        imageData={{
+          component: <Icon accessibilityLabel="" color="default" icon="pinterest" size={32} />,
+        }}
+        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
+        primaryAction={{
+          accessibilityLabel: 'Send ads invite',
+          href: 'https://pinterest.com',
+          label: 'Send invite',
+          target: 'blank',
+        }}
+        secondaryAction={{
+          accessibilityLabel: 'Learn more: Ads credit',
+          href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
+          label: 'Learn more',
+          target: 'blank',
+        }}
+        title="Give $30, get $60 in ads credit"
+      />
+    </Box>
+  );
+}

--- a/docs/pages/web/activationcard.js
+++ b/docs/pages/web/activationcard.js
@@ -2,7 +2,6 @@
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
-import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';

--- a/docs/pages/web/activationcard.js
+++ b/docs/pages/web/activationcard.js
@@ -8,6 +8,12 @@ import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import completeVariant from '../../examples/activationcard/completeVariant.js';
+import mainExample from '../../examples/activationcard/mainExample.js';
+import needsAttentionVariant from '../../examples/activationcard/needsAttentionVariant.js';
+import notStartedVariant from '../../examples/activationcard/notStartedVariant.js';
+import pendingVariant from '../../examples/activationcard/pendingVariant.js';
 
 export default function ActivationCardPage({
   generatedDocGen,
@@ -16,27 +22,9 @@ export default function ActivationCardPage({
 |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader
-        name={generatedDocGen?.displayName}
-        description={generatedDocGen?.description}
-        defaultCode={`
-<ActivationCard
-  dismissButton={{
-    accessibilityLabel: 'Dismiss card',
-    onDismiss: ()=>{},
-  }}
-  link={{
-    href: "https://pinterest.com",
-    label:"Learn more",
-    accessibilityLabel: "Learn more: website claim status"
-  }}
-  message="We will notify you via email as soon as your site has been successfully claimed."
-  status="pending"
-  statusMessage="Pending"
-  title="Claim your website"
-/>
-  `}
-      />
+      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+        <SandpackExample name="Main Example" code={mainExample} layout="column" hideEditor />
+      </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 
@@ -63,71 +51,35 @@ export default function ActivationCardPage({
         </MainSection.Subsection>
       </MainSection>
 
-      <Example
-        name="Not started and Pending Cards"
-        defaultCode={`
-<Flex gap={{ column: 0, row: 2 }}>
-  <ActivationCard
-    dismissButton={{
-      accessibilityLabel: 'Dismiss card',
-      onDismiss: () => {},
-    }}
-    link={{
-      href: "https://pinterest.com",
-      label:"Claim your website now",
-      accessibilityLabel: ""
-    }}
-    message="Grow distribution and track Pins linked to your website"
-    status="notStarted"
-    statusMessage="Not started"
-    title="Claim your website"
-  />
-  <ActivationCard
-    dismissButton={{
-      accessibilityLabel: 'Dismiss card',
-      onDismiss: ()=>{},
-    }}
-    link={{
-      href: "https://pinterest.com",
-      label:"Learn more",
-      accessibilityLabel: "Learn more: website claim status"
-    }}
-    message="We will notify you via email as soon as your site has been successfully claimed."
-    status="pending"
-    statusMessage="Pending"
-    title="Claim your website"
-  />
-</Flex>
-  `}
-      />
-      <Example
-        name="Needs attention and Complete Cards"
-        defaultCode={`
-<Flex gap={{ column: 0, row: 2 }}>
-  <ActivationCard
-    dismissButton={{
-      accessibilityLabel: 'Dismiss card',
-      onDismiss: () => {},
-    }}
-    link={{
-      accessibilityLabel: "Learn more about tag health",
-      href: "https://pinterest.com",
-      label: "Learn more"
-    }}
-    message="Oops! Your tag must be healthy to continue."
-    status="needsAttention"
-    statusMessage="Needs attention"
-    title="Tag is unhealthy"
-  />
-  <ActivationCard
-    message="Tag is installed and healthy"
-    status="complete"
-    statusMessage="Completed"
-    title="Nice work"
-  />
-</Flex>
-  `}
-      />
+      <MainSection name="Variants">
+        <MainSection.Subsection title="Not Started">
+          <MainSection.Card
+            sandpackExample={
+              <SandpackExample name="Not Started Variant" code={notStartedVariant} />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Pending">
+          <MainSection.Card
+            sandpackExample={<SandpackExample name="Pending Variant" code={pendingVariant} />}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Needs Attention">
+          <MainSection.Card
+            sandpackExample={
+              <SandpackExample name="Needs Attention Variant" code={needsAttentionVariant} />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Complete">
+          <MainSection.Card
+            sandpackExample={<SandpackExample name="Complete Variant" code={completeVariant} />}
+          />
+        </MainSection.Subsection>
+      </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
 

--- a/docs/pages/web/module.js
+++ b/docs/pages/web/module.js
@@ -7,6 +7,18 @@ import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import exampleWithExternalControl from '../../examples/module/exampleWithExternalControl.js';
+import expandable from '../../examples/module/expandable.js';
+import expandableGroup from '../../examples/module/expandableGroup.js';
+import expandableWithErrorType from '../../examples/module/expandableWithErrorType.js';
+import expandableWithIconBadgeIconButton from '../../examples/module/expandableWithIconBadgeIconButton.js';
+import mainExample from '../../examples/module/mainExample.js';
+import staticVariant from '../../examples/module/staticVariant.js';
+import staticWithBadge from '../../examples/module/staticWithBadge.js';
+import staticWithErrorType from '../../examples/module/staticWithErrorType.js';
+import staticWithIcon from '../../examples/module/staticWithIcon.js';
+import staticWithIconButton from '../../examples/module/staticWithIconButton.js';
 
 export default function DocsPage({
   generatedDocGen,
@@ -18,34 +30,9 @@ export default function DocsPage({
       <PageHeader
         name={generatedDocGen.Module?.displayName}
         description={generatedDocGen.Module?.description}
-        defaultCode={`
-      function ModuleExample() {
-        return (
-          <Flex direction="column" width="100%" justifyContent="between" gap={{ column: 2, row: 0 }}>
-            <Module
-              icon="lock"
-              iconAccessibilityLabel="Module Locked - check permission settings"
-              id="ModuleExample - header"
-              title="Title"
-              >
-              <Text size="200">This is example content.</Text>
-            </Module>
-            <Module.Expandable
-            accessibilityExpandLabel="Expand the module"
-            accessibilityCollapseLabel="Collapse the module"
-            id="ModuleExample - header expandable"
-            items={[
-              {
-                children: <Text size="200">Content here</Text>,
-                summary: ['summary'],
-                title: 'Title',
-              }]}>
-          </Module.Expandable>
-          </Flex>
-        );
-      }
-      `}
-      />
+      >
+        <SandpackExample name="Main Example" code={mainExample} layout="column" hideEditor />
+      </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen.Module} />
 
@@ -97,21 +84,7 @@ export default function DocsPage({
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample() {
-  return (
-    <Flex direction="column" gap={{ column: 2, row: 0 }} maxWidth={800} flex="grow">
-      <Module id="ModuleExample - default - 1">
-        <Text size="200">This is example content.</Text>
-      </Module>
-
-      <Module id="ModuleExample - default - 2" title="Title">
-        <Text size="200">This is example content.</Text>
-      </Module>
-    </Flex>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="Static Variant" code={staticVariant} />}
           />
         </MainSection.Subsection>
 
@@ -125,22 +98,7 @@ function ModuleExample() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample() {
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Module
-        icon="lock"
-        iconAccessibilityLabel="Module Locked - check permission settings"
-        id="ModuleExample - icon"
-        title="Title"
-        >
-        <Text size="200">This is example content.</Text>
-      </Module>
-    </Box>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="Static With Icon" code={staticWithIcon} />}
           />
         </MainSection.Subsection>
 
@@ -152,49 +110,9 @@ function ModuleExample() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample() {
-  const [showPopover, setShowPopover] = React.useState(false);
-  const anchorRef = React.useRef(null);
-
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Module
-        iconButton={
-          <IconButton
-            bgColor="lightGray"
-            icon="question-mark"
-            iconColor="darkGray"
-            accessibilityLabel="Get help"
-            size="xs"
-            onClick={({ event }) => {
-              setShowPopover((currVal) => !currVal);
-            }}
-            ref={anchorRef}
-          />
-        }
-        id="ModuleExample - iconButton"
-        title="Title"
-        >
-        <Text size="200">This is example content.</Text>
-      </Module>
-
-      {showPopover && (
-        <Popover
-          anchor={anchorRef.current}
-          idealDirection="right"
-          onDismiss={() => setShowPopover(false)}
-          shouldFocus={false}
-          >
-            <Box padding={3}>
-              <Text weight="bold">Help content!</Text>
-            </Box>
-        </Popover>
-      )}
-    </Box>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="Static With IconButton" code={staticWithIconButton} />
+            }
           />
         </MainSection.Subsection>
 
@@ -204,28 +122,7 @@ function ModuleExample() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample() {
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Module
-        badge={{ text: 'Beta' }}
-        id="ModuleExample - badge"
-        title="Title"
-        >
-        <Text size="200">This is example content.</Text>
-      </Module>
-      <Module
-        badge={{text: 'Not started', type: 'neutral' }}
-        id="ModuleExample - badge neutral"
-        title="Title"
-        >
-        <Text size="200">This is example content.</Text>
-      </Module>
-    </Box>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="Static With Badge" code={staticWithBadge} />}
           />
         </MainSection.Subsection>
 
@@ -235,34 +132,9 @@ function ModuleExample() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample() {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Module
-        id="ModuleExample - error"
-        title="Personal Info"
-        iconAccessibilityLabel={!value ? "This module contains an error" : null}
-        type={!value ? "error" : "info"}
-      >
-        <Flex direction="column" gap={{ column: 4, row: 0 }}>
-          <Text size="200">This is example content.</Text>
-
-          <TextField
-            errorMessage={!value ? "This field can't be blank!" : null}
-            id="first-name"
-            label="Enter Your Name"
-            onChange={({ value }) => setValue(value)}
-            value={value}
-          />
-        </Flex>
-      </Module>
-    </Box>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="Static With Error Type" code={staticWithErrorType} />
+            }
           />
         </MainSection.Subsection>
 
@@ -272,25 +144,7 @@ function ModuleExample() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample1() {
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Module.Expandable
-        accessibilityExpandLabel="Expand the module"
-        accessibilityCollapseLabel="Collapse the module"
-        id="ModuleExample - default"
-        items={[
-          {
-            children: <Text size="200">Children1</Text>,
-            summary: ['summary1', 'summary2', 'summary3'],
-            title: 'Title',
-          }]}>
-      </Module.Expandable>
-    </Box>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="Expandable" code={expandable} />}
           />
         </MainSection.Subsection>
 
@@ -300,35 +154,7 @@ function ModuleExample1() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample2() {
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Module.Expandable
-        id="ModuleExample2"
-        accessibilityExpandLabel="Expand the module"
-        accessibilityCollapseLabel="Collapse the module"
-        items={[
-          {
-            children: <Text size="200">Children1</Text>,
-            summary: ['summary1'],
-            title: 'Title1',
-          },
-          {
-            children: <Text size="200">Children2</Text>,
-            summary: ['summary2'],
-            title: 'Title2',
-          },
-          {
-            children: <Text size="200">Children3</Text>,
-            summary: ['summary3'],
-            title: 'Title3',
-          }]}>
-      </Module.Expandable>
-    </Box>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="Expandable Group" code={expandableGroup} />}
           />
         </MainSection.Subsection>
 
@@ -344,61 +170,12 @@ function ModuleExample2() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample3() {
-  const [showPopover, setShowPopover] = React.useState(false);
-  const anchorRef = React.useRef(null);
-
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Module.Expandable
-        accessibilityExpandLabel="Expand the module"
-        accessibilityCollapseLabel="Collapse the module"
-        id="ModuleExample3"
-        items={[
-          {
-            children: <Text size="200">Children1</Text>,
-            icon: 'lock',
-            iconAccessibilityLabel: "title icon",
-            title: 'Example with icon',
-          },
-          {
-            badge: { text: 'New' },
-            children: <Text size="200">Children2</Text>,
-            title: 'Example with badge',
-          },
-          {
-            children: <Text size="200">Children3</Text>,
-            iconButton: <IconButton
-              bgColor="lightGray"
-              icon="question-mark"
-              iconColor="darkGray"
-              accessibilityLabel="Get help"
-              size="xs"
-              onClick={({event}) => setShowPopover((currVal) => !currVal)}
-              ref={anchorRef}
-            />,
-            title: 'Example with icon button',
-          }
-        ]}>
-      </Module.Expandable>
-
-      {showPopover && (
-        <Popover
-          anchor={anchorRef.current}
-          idealDirection="right"
-          onDismiss={() => setShowPopover(false)}
-          shouldFocus={false}
-          >
-            <Box padding={3}>
-              <Text weight="bold">Help content!</Text>
-            </Box>
-        </Popover>
-      )}
-    </Box>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Expandable With Icon, Badge & IconButton"
+                code={expandableWithIconBadgeIconButton}
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -408,114 +185,22 @@ function ModuleExample3() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample4() {
-  const [value, setValue] = React.useState('');
-  const moduleType = !value ? 'error' : 'info';
-  const summaryInfo = !value ? 'Name is missing' : 'Name: ' + value;
-  const iconAccessibilityLabel = !value ? "This module contains an error" : null;
-
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Module.Expandable
-        accessibilityExpandLabel="Expand the module"
-        accessibilityCollapseLabel="Collapse the module"
-        id="ModuleExample4"
-        items={[
-          {
-            children: <Text size="200">
-              <TextField
-                errorMessage={!value ? "This field can't be blank!" : null}
-                id="aboutme"
-                label="Enter Your Name"
-                onChange={({ value }) => setValue(value)}
-                value={value}
-              />
-            </Text>,
-            iconAccessibilityLabel,
-            summary: [summaryInfo],
-            title: 'Personal Info',
-            type: moduleType
-          }]}>
-      </Module.Expandable>
-    </Box>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="Expandable With Error Type" code={expandableWithErrorType} />
+            }
           />
         </MainSection.Subsection>
 
         <MainSection.Subsection title="Example with external control">
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ModuleExample5() {
-  const [extExpandedId, setExtExpandedId] = React.useState(null);
-  const mapIds = {
-      'first-0': 0,
-      'first-1': 1,
-      'second-0': 0,
-      'second-1': 1,
-  }
-  return (
-    <Box column={12} maxWidth={800} padding={2}>
-      <Flex direction="column" gap={{ column: 4, row: 0 }}>
-        <Flex direction="column" gap={{ column: 2, row: 0 }}>
-          <Box marginStart={2}>
-            <Text>Step 1</Text>
-          </Box>
-
-          <Module.Expandable
-            accessibilityExpandLabel="Expand the module"
-            accessibilityCollapseLabel="Collapse the module"
-            expandedIndex={extExpandedId && extExpandedId.startsWith('first') && mapIds[extExpandedId]}
-            id="ModuleExampleStep1"
-            items={[
-              {
-                title: 'Title1',
-                summary: ['summary1'],
-                children: <Text size="200">Children1</Text>,
-              },
-              {
-                title: 'Title2',
-                summary: ['summary2'],
-                children: <Text size="200">Children2</Text>,
-              },
-            ]}
-            onExpandedChange={(index) => setExtExpandedId(Number.isFinite(index) ? \`first-$\{index}\`: index)}
-          />
-        </Flex>
-
-        <Flex direction="column" gap={{ column: 2, row: 0 }}>
-          <Box marginStart={2}>
-            <Text>Step 2</Text>
-          </Box>
-
-          <Module.Expandable
-            id="ModuleExampleStep2"
-            accessibilityExpandLabel="Expand the module"
-            accessibilityCollapseLabel="Collapse the module"
-            expandedIndex={extExpandedId && extExpandedId.startsWith('second') && mapIds[extExpandedId]}
-            onExpandedChange={(index) => setExtExpandedId(Number.isFinite(index) ? \`second-$\{index}\`: index)}
-            items={[
-              {
-                title: 'Title1',
-                summary: ['summary1'],
-                children: <Text size="200">Children1</Text>,
-              },
-              {
-                title: 'Title2',
-                summary: ['summary2'],
-                children: <Text size="200">Children2</Text>,
-              },
-            ]}
-          />
-        </Flex>
-      </Flex>
-    </Box>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Example With External Control"
+                code={exampleWithExternalControl}
+                previewHeight={500}
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/web/numberfield.js
+++ b/docs/pages/web/numberfield.js
@@ -318,7 +318,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
 
         <MainSection.Subsection
           title="EnterKeyHint"
-          description={`The \`enterKeyHint\` prop presents to the user a more accurate action label for the enter key on virtual keyboards. These are the values for each use case:
+          description={`The \`mobileEnterKeyHint\` prop presents to the user a more accurate action label for the enter key on virtual keyboards. These are the values for each use case:
 
 - "enter": inserting a new line
 - "done": there is nothing more to input and the input editor will be closed

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -8,7 +8,32 @@ import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
+import considerAllFieldsAsRequired from '../../examples/textfield/considerAllFieldsAsRequired.js';
+import disabledExample from '../../examples/textfield/disabledExample.js';
+import dontDisplayGenericErrorMessages from '../../examples/textfield/dontDisplayGenericErrorMessages.js';
+import dontMarkFieldsAsRequired from '../../examples/textfield/dontMarkFieldsAsRequired.js';
+import dontPlaceUnrelatedFieldsSameLine from '../../examples/textfield/dontPlaceUnrelatedFieldsSameLine.js';
+import dontPutEssentialInformationPlaceholder from '../../examples/textfield/dontPutEssentialInformationPlaceholder.js';
+import dontRemoveLabel from '../../examples/textfield/dontRemoveLabel.js';
+import ensureVisibleLabel from '../../examples/textfield/ensureVisibleLabel.js';
+import errorMessageExample from '../../examples/textfield/errorMessageExample.js';
+import helperTextExplainOptionalInfo from '../../examples/textfield/helperTextExplainOptionalInfo.js';
+import labelsExample from '../../examples/textfield/labelsExample.js';
+import labelVisibilityExample from '../../examples/textfield/labelVisibilityExample.js';
 import main from '../../examples/textfield/main.js';
+import maximumLengthExample from '../../examples/textfield/maximumLengthExample.js';
+import maximumLengthExampleSingleLine from '../../examples/textfield/maximumLengthExampleSingleLine.js';
+import mobileExample1 from '../../examples/textfield/mobileExample1.js';
+import mobileExample2 from '../../examples/textfield/mobileExample2.js';
+import mobileExample3 from '../../examples/textfield/mobileExample3.js';
+import mobileExample4 from '../../examples/textfield/mobileExample4.js';
+import onlyPlaceRelatedFieldsSameLine from '../../examples/textfield/onlyPlaceRelatedFieldsSameLine.js';
+import passwordExample from '../../examples/textfield/passwordExample.js';
+import provideClearUsefulErrorMessages from '../../examples/textfield/provideClearUsefulErrorMessages.js';
+import readOnlyExample from '../../examples/textfield/readOnlyExample.js';
+import tagsExample from '../../examples/textfield/tagsExample.js';
+import textFieldRefAnchorPopover from '../../examples/textfield/textFieldRefAnchorPopover.js';
+import useHelperTextImportantInformation from '../../examples/textfield/useHelperTextImportantInformation.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -19,6 +44,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           name={`Main ${generatedDocGen?.displayName} example`}
           hideEditor
           previewHeight={150}
+          layout="column"
         />
       </PageHeader>
 
@@ -50,53 +76,28 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             cardSize="sm"
             type="do"
             description="Use helper text for important information. Helper text helps users understand how to complete the text field or to indicate any needed input."
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Box padding={2} color="white">
-      <TextField
-        autoComplete="new-password"
-        helperText="Password should be at least 20 characters in length"
-        id="best-practices-do-helper-text"
-        label="New password"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
-        type="password"
-        value={value}
-      />
-    </Box>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Use Helper Text for Important Information"
+                code={useHelperTextImportantInformation}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="sm"
             type="don't"
             description="Put essential information in the placeholder text, since it disappears when the user types. The placeholder text is not a replacement for the label."
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Box padding={2} color="white">
-      <TextField
-        autoComplete="new-password"
-        id="best-practices-dont-placeholder"
-        label=""
-        onChange={({ value }) => {
-          setValue(value);
-        }}
-        placeholder="Password should be at least 20 characters in length"
-        type="password"
-        value={value}
-      />
-    </Box>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Don’t Put Essential Information in Placeholder"
+                code={dontPutEssentialInformationPlaceholder}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -105,53 +106,28 @@ function Example(props) {
             cardSize="sm"
             type="do"
             description="Always ensure the text field has a visible label. The label provides context and supports users when filling in information."
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Box padding={2} color="white">
-      <TextField
-        autoComplete="username"
-        id="best-practices-do-label"
-        label="Username"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
-        type="text"
-        value={value}
-      />
-    </Box>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Ensure TextField Has a Visible Label"
+                code={ensureVisibleLabel}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="sm"
             type="don't"
             description="Remove the label, as this creates accessibility and usability issues."
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <div className="skip-accessibility-check">
-      <Box padding={2} color="white">
-        <TextField
-          autoComplete="username"
-          id="best-practices-dont-label"
-          label=""
-          onChange={({ value }) => {
-            setValue(value);
-          }}
-          type="username"
-          value={value}
-        />
-      </Box>
-    </div>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Do Not Remove the Label"
+                code={dontRemoveLabel}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -160,69 +136,28 @@ function Example(props) {
             cardSize="sm"
             type="do"
             description="Only place related fields on the same line."
-            defaultCode={`
-function Example(props) {
-  const [cityValue, setCityValue] = React.useState('');
-  const [stateValue, setStateValue] = React.useState('');
-
-  return (
-    <Flex gap={{ column: 0, row: 4 }}>
-      <TextField
-        id="best-practices-do-related-city"
-        label="City"
-        onChange={({ value }) => {
-          setCityValue(value);
-        }}
-        type="text"
-        value={cityValue}
-      />
-      <TextField
-        id="best-practices-do-related-state"
-        label="State"
-        onChange={({ value }) => {
-          setStateValue(value);
-        }}
-        type="text"
-        value={stateValue}
-      />
-    </Flex>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Only Place Related Fields on the Same Line"
+                code={onlyPlaceRelatedFieldsSameLine}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="sm"
             type="don't"
             description="Place unrelated text fields on the same line, as this can create comprehension issues."
-            defaultCode={`
-function Example(props) {
-  const [passwordValue, setPasswordValue] = React.useState('');
-  const [zipCodeValue, setZipCodeValue] = React.useState('');
-
-  return (
-    <Flex gap={{ column: 0, row: 4 }}>
-      <TextField
-        autoComplete="new-password"
-        id="best-practices-dont-related-password"
-        label="Password"
-        onChange={({ value }) => {
-          setPasswordValue(value);
-        }}
-        type="password"
-        value={passwordValue}
-      />
-      <TextField
-        id="best-practices-dont-related-zip-code"
-        label="ZIP Code"
-        onChange={({ value }) => {
-          setZipCodeValue(value);
-        }}
-        value={zipCodeValue}
-      />
-    </Flex>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Do Not Place Unrelated Text Fields on the Same Line"
+                code={dontPlaceUnrelatedFieldsSameLine}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -231,53 +166,28 @@ function Example(props) {
             cardSize="sm"
             type="do"
             description="Provide clear and useful error messages that help the user fix the issue. Error messages should be displayed in a timely manner — typically once the field loses focus or when the form is submitted."
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Box padding={2} color="white">
-      <TextField
-        autoComplete="new-password"
-        errorMessage="Password is too short! You need 20+ characters"
-        id="best-practices-do-error-message"
-        label="Password"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
-        type="password"
-        value={value}
-      />
-    </Box>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Provide Clear and Useful Error Messages"
+                code={provideClearUsefulErrorMessages}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="sm"
             type="don't"
             description={`Display generic error messages, such as "There is an error".`}
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Box padding={2} color="white">
-      <TextField
-        autoComplete="new-password"
-        errorMessage="There is an error"
-        id="best-practices-dont-error-message"
-        label="Password"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
-        type="password"
-        value={value}
-      />
-    </Box>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Do Not Display Generic Error Messages"
+                code={dontDisplayGenericErrorMessages}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -286,95 +196,28 @@ function Example(props) {
             cardSize="md"
             type="do"
             description="Consider all text fields as required, unless explicitly noted as optional."
-            defaultCode={`
-function Example(props) {
-  const [name, setName] = React.useState({
-    first: '',
-    middle: '',
-    last: '',
-  });
-
-  return (
-    <Flex direction="column" gap={{ column: 3, row: 0 }}>
-      <TextField
-        id="best-practices-do-required-firstName"
-        label="First name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, first: value }));
-        }}
-        type="text"
-        value={name.first}
-      />
-      <TextField
-        id="best-practices-do-required-middleName"
-        label="Middle name (optional)"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, middle: value }));
-        }}
-        type="text"
-        value={name.middle}
-      />
-      <TextField
-        id="best-practices-do-required-lastName"
-        label="Last name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, last: value }));
-        }}
-        type="text"
-        value={name.last}
-      />
-    </Flex>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Consider All TextFields as Required"
+                code={considerAllFieldsAsRequired}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Mark fields as required."
-            defaultCode={`
-function Example(props) {
-  const [name, setName] = React.useState({
-    first: '',
-    second: '',
-    third: '',
-  });
-
-  return (
-    <Flex direction="column" gap={{ column: 3, row: 0 }}>
-      <TextField
-        helperText="* This field is required."
-        id="best-practices-dont-required-firstName"
-        label="First name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, first: value }));
-        }}
-        type="text"
-        value={name.first}
-      />
-      <TextField
-        id="best-practices-dont-required-middleName"
-        label="Middle name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, middle: value }));
-        }}
-        type="text"
-        value={name.middle}
-      />
-      <TextField
-        helperText="* This field is required."
-        id="best-practices-dont-required-lastName"
-        label="Last name"
-        onChange={({ value }) => {
-          setName((nameFields) => ({ ...nameFields, last: value }));
-        }}
-        type="text"
-        value={name.last}
-      />
-    </Flex>
-  );
-}
-            `}
+            sandpackExample={
+              <SandpackExample
+                name="Do Not Mark Fields as Required"
+                code={dontMarkFieldsAsRequired}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -392,26 +235,7 @@ function Example(props) {
       If TextField is labeled by content elsewhere on the page, or a more complex label is needed, the \`labelDisplay\` prop can be used to visually hide the label. In this case, it is still available to screen reader users, but will not appear visually on the screen.`}
         >
           <MainSection.Card
-            defaultCode={`
-<Flex gap={{ column: 0, row: 6 }}>
-  <TextField
-    id="textfieldexampleA11yVisible"
-    onChange={() => {}}
-    label='First name'
-    size='lg'
-  />
-  <Flex gap={{ column: 2, row: 0 }} direction="column">
-    <Text weight="bold" size="300">First name</Text>
-    <TextField
-      id="textfieldexampleA11yHiddenLabel"
-      onChange={() => {}}
-      label='First name'
-      labelDisplay="hidden"
-      size='lg'
-    />
-  </Flex>
-</Flex>
-`}
+            sandpackExample={<SandpackExample name="Labels Example" code={labelsExample} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -459,27 +283,12 @@ function Example(props) {
           `}
         >
           <MainSection.Card
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Box padding={2} color="white">
-      <TextField
-        autoComplete="new-password"
-        helperText="Password should be at least 20 characters long"
-        id="variants-helper-text"
-        label="Password"
-        onChange={({ value }) => {
-          setValue(value);
-        }}
-        type="password"
-        value={value}
-      />
-    </Box>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Helper Text to Explain More about Optional Info"
+                code={helperTextExplainOptionalInfo}
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -488,18 +297,9 @@ function Example(props) {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Flex gap={{ column: 2, row: 0 }} direction="column">
-  <Text weight="bold" size="300">First name</Text>
-  <TextField
-    id="textfieldexampleHiddenLabel"
-    onChange={() => {}}
-    label='First name'
-    labelDisplay="hidden"
-    size='lg'
-  />
-</Flex>
-`}
+            sandpackExample={
+              <SandpackExample name="Label Visibility Example" code={labelVisibilityExample} />
+            }
           />
         </MainSection.Subsection>
 
@@ -508,22 +308,9 @@ function Example(props) {
           description="Read-only TextFields are used to present information to the user without allowing them to edit the content. Typically they are used to show content or information that the user does not have permission or access to edit."
         >
           <MainSection.Card
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('****maz@pinterest.com');
-
-  return (
-    <TextField
-      id="variants-readonly"
-      label="Email address"
-      onChange={({ value }) => setValue(value)}
-      placeholder="Name"
-      value={value}
-      readOnly
-    />
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="Read-only Text Field Example" code={readOnlyExample} />
+            }
           />
         </MainSection.Subsection>
 
@@ -532,22 +319,9 @@ function Example(props) {
           description={`TextField with \`type="password"\` shows obfuscated characters by default. An icon button at the end of the field allows the user to toggle password visibility. This creates a more accessible experience by allowing the user to confirm what they have entered before submitting the form.`}
         >
           <MainSection.Card
-            defaultCode={`
-          function Example(props) {
-            const [password, setPassword] = React.useState();
-
-            return (
-              <TextField
-                id="enter-password"
-                label="Account password"
-                onChange={({ value }) => setPassword(value)}
-                placeholder="Password"
-                type="password"
-                value={password}
-              />
-            );
-          }
-          `}
+            sandpackExample={
+              <SandpackExample name="Password Text Field Example" code={passwordExample} />
+            }
           />
         </MainSection.Subsection>
 
@@ -556,24 +330,9 @@ function Example(props) {
           description="`disabled` TextFields cannot be interacted with using the mouse or keyboard. They also do not need to meet contrast requirements, so do not use them to present info to the user (use `readOnly` instead)."
         >
           <MainSection.Card
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <TextField
-      disabled
-      id="variants-disabled"
-      label="New password"
-      onChange={({ value }) => {
-        setValue(value);
-      }}
-      placeholder="6-18 characters"
-      value={value}
-    />
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="Disabled Text Field Example" code={disabledExample} />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -584,23 +343,9 @@ Don't use \`errorMessage\` to provide feedback on character count errors. See th
           `}
         >
           <MainSection.Card
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <TextField
-      errorMessage={!value ? "This field can't be blank!" : null}
-      id="variants-error-message"
-      label="New username"
-      onChange={({ value }) => {
-        setValue(value);
-      }}
-      value={value}
-    />
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="Error Message Example" code={errorMessageExample} />
+            }
           />
         </MainSection.Subsection>
 
@@ -615,67 +360,7 @@ function Example(props) {
           `}
         >
           <MainSection.Card
-            defaultCode={`
-function Example(props) {
-  const [value, setValue] = React.useState('');
-  const [tags, setTags] = React.useState(['a@pinterest.com', 'b@pinterest.com']);
-  const ref = React.useRef();
-
-  const onChangeTagManagement = ({ value }) => {
-    // Create new tags around spaces, commas, and semicolons.
-    const tagInput = value.split(/[\\s,;]+/);
-    if (tagInput.length > 1) {
-      setTags([
-        ...tags,
-        // Avoid creating a tag on content after the separators, and filter out
-        // empty tags
-        ...tagInput.splice(0, tagInput.length - 1).filter(val => val !== ''),
-      ]);
-    }
-    setValue(tagInput[tagInput.length - 1]);
-  }
-
-  const onKeyDownTagManagement = ({ event: { keyCode, target: { selectionEnd } } }) => {
-    if (keyCode === 8 /* Backspace */ && selectionEnd === 0) {
-      // Remove tag on backspace if the cursor is at the beginning of the field
-      setTags([...tags.slice(0, -1)]);
-    } else if (keyCode === 13 /* Enter */ && value.trim() !== '') {
-      // Create a new tag on enter
-      setTags([...tags, value.trim()]);
-      setValue('');
-    }
-  }
-
-  const renderedTags = tags.map((tag, idx) => (
-    <Tag
-      key={tag}
-      onRemove={() => {
-        const newTags = [...tags];
-        newTags.splice(idx, 1);
-        setTags([...newTags]);
-        ref.current.focus();
-      }}
-      accessibilityRemoveIconLabel={\`Remove \${tag} tag\`}
-      text={tag}
-    />
-  ));
-
-  return (
-    <Box padding={2} color="white">
-      <TextField
-        autoComplete="off"
-        id="variants-tags"
-        label="Emails"
-        ref={ref}
-        onChange={onChangeTagManagement}
-        onKeyDown={onKeyDownTagManagement}
-        tags={renderedTags}
-        value={value}
-      />
-    </Box>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="Tags Text Field Example" code={tagsExample} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -684,7 +369,7 @@ function Example(props) {
           description={`TextField supports some props to improve the mobile experience. Browsers display virtual keyboard when the user interacts with TextField.  \`enterKeyHint\` and \`inputMode\` allow customizing the virtual keyboard for a better data input.
 
 
-The \`enterKeyHint\` prop presents to the user a more accurate action label for the enter key on virtual keyboards. These are the values for each use case:
+The \`mobileEnterKeyHint\` prop presents to the user a more accurate action label for the enter key on virtual keyboards. These are the values for each use case:
 
 - "enter": inserting a new line
 - "done": there is nothing more to input and the input editor will be closed
@@ -694,7 +379,7 @@ The \`enterKeyHint\` prop presents to the user a more accurate action label for 
 - "search": taking the user to the results of searching for the text they have typed
 - "send": delivering the text to its target
 
-The \`inputMode\` prop presents to the user a more accurate action label for the enter key on virtual keyboards. These are the values for each use case:
+The \`mobileInputMode\` prop presents to the user a more accurate action label for the enter key on virtual keyboards. These are the values for each use case:
 
 - "none": No virtual keyboard. For when the page implements its own keyboard input control, for example DatePicker displays the calendar picker.
 - "text": Standard input keyboard for the user's current locale.
@@ -706,81 +391,36 @@ Use \`type\` when TextField needs to capture phone numbers, emails or URLs.
         >
           <MainSection.Card
             title="Text virtual keyboard with 'next'"
-            defaultCode={`
-<Flex gap={2}>
-  <TextField
-    id="enterKeyHint"
-    enterKeyHint="next"
-    label="Text virtual keyboard with 'next'"
-    onChange={() => {}}
-    onBlur={() => {}}
-    onFocus={() => {}}
-  />
-  <Box height={100} width={200}>
-    <Image
-      alt="Image of a screenshot of a virtual keyboard on a mobile screen showing a text virtual keyboard with 'next'"
-      naturalHeight={1}
-      naturalWidth={1}
-      src="https://i.ibb.co/qdMLb8t/IMG-2518.jpg"
-    />
-  </Box>
-</Flex>
-
-`}
+            sandpackExample={
+              <SandpackExample name="Mobile Style Example" code={mobileExample1} layout="column" />
+            }
           />
           <MainSection.Card
-            defaultCode={`
-<Flex gap={2}>
-  <TextField
-    id="decimal"
-    inputMode="decimal"
-    label="Decimal virtual keyboard"
-    onChange={() => {}}
-    onBlur={() => {}}
-    onFocus={() => {}}
-  />
-  <Box height={100} width={200}>
-    <Image
-      alt="Image of a screenshot of a virtual keyboard on a mobile screen showing a decimal virtual keyboard"
-      naturalHeight={1}
-      naturalWidth={1}
-      src="https://i.ibb.co/WxYtCdx/IMG-2520.jpg"
-    />
-  </Box>
-</Flex>
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Mobile Style Example (1)"
+                code={mobileExample2}
+                layout="column"
+              />
+            }
           />
           <MainSection.Card
-            defaultCode={`
-<Flex gap={2}>
-  <TextField
-    id="none"
-    inputMode="numeric"
-    label="Numeric virtual keyboard"
-    type="date"
-    onChange={() => {}}
-    onBlur={() => {}}
-    onFocus={() => {}}
-  />
-  <Box height={100} width={200}>
-    <Image
-      alt="Image of a screenshot of a virtual keyboard on a mobile screen showing a numeric virtual keyboard"
-      naturalHeight={1}
-      naturalWidth={1}
-      src="https://i.ibb.co/tpZ9pV8/IMG-2519.jpg"
-    />
-  </Box>
-</Flex>
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Mobile Style Example (2)"
+                code={mobileExample3}
+                layout="column"
+              />
+            }
           />
           <MainSection.Card
-            defaultCode={`
-<DatePicker
-  id="datepicker"
-  label="No virtual keyboard"
-  onChange={() => {}}
-/>
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Mobile Style Example (3)"
+                code={mobileExample4}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -795,64 +435,22 @@ When \`maxLength\` is passed to TextField, the component displays a character co
 The first example shows an empty Textfield with \`maxLength\` set to 20 characters. The second example shows the warning and problem Status.`}
         >
           <MainSection.Card
-            defaultCode={`
-function TextFieldExample() {
-  const [value, setValue] = React.useState('');
-  const characterCount = 20;
-
-  return (
-    <TextField
-      id="maxLength"
-      label="Title"
-      helperText="Enter a title that captures the imagination of Pinners"
-      onChange={({ value }) => setValue(value)}
-      placeholder="Enter your pin title"
-      value={value}
-      onBlur={() => {}}
-      onFocus={() => {}}
-      maxLength={{ characterCount, errorAccessibilityLabel: 'Limit reached. You can only use 20 characters in this field.' }}
-    />
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Maximum Length Text Field Example"
+                code={maximumLengthExample}
+                layout="column"
+              />
+            }
           />
           <MainSection.Card
-            defaultCode={`
-            function TextFieldExample() {
-  const [valueA, setValueA] = React.useState('Delicious vegan soup');
-  const [valueB, setValueB] = React.useState('Delicious vegan noodle soup');
-
-  const characterCount = 20;
-  const errorAccessibilityLabel = "Limit reached. You can only use 20 characters in this field.";
-
-  return (
-    <Flex direction="column" gap={12}>
-      <TextField
-        id="maxLengthReached"
-        label="Title"
-        helperText="Enter a title that captures the imagination of Pinners"
-        onChange={({ value }) => setValueA(value)}
-        placeholder="Enter your pin title"
-        value={valueA}
-        onBlur={() => {}}
-        onFocus={() => {}}
-        maxLength={{ characterCount, errorAccessibilityLabel }}
-      />
-      <TextField
-        id="maxLengthExceeded"
-        label="Title"
-        helperText="Enter a title that captures the imagination of Pinners"
-        onChange={({ value }) => setValueB(value)}
-        placeholder="Enter your pin title"
-        value={valueB}
-        onBlur={() => {}}
-        onFocus={() => {}}
-        maxLength={{ characterCount, errorAccessibilityLabel }}
-      />
-    </Flex>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Maximum Length Single Line Text Field"
+                code={maximumLengthExampleSingleLine}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -862,44 +460,12 @@ function TextFieldExample() {
           `}
         >
           <MainSection.Card
-            defaultCode={`
-function TextFieldPopoverExample() {
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef();
-
-  return (
-    <Box padding={2} color="white">
-      <TextField
-        id="variants-refs"
-        label="Focus the TextField to show the Popover"
-        onChange={() => {}}
-        onBlur={() => {
-          setOpen(false);
-        }}
-        onFocus={() => {
-          setOpen(true);
-        }}
-        ref={anchorRef}
-      />
-      {open && (
-        <Popover
-          anchor={anchorRef.current}
-          idealDirection="down"
-          onDismiss={() => {
-            setOpen(false);
-          }}
-          shouldFocus={false}
-          size="md"
-        >
-          <Box padding={3}>
-            <Text weight="bold">Example with Popover</Text>
-          </Box>
-        </Popover>
-      )}
-    </Box>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="TextField Ref for Anchoring Popover"
+                code={textFieldRefAnchorPopover}
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/web/upsell.js
+++ b/docs/pages/web/upsell.js
@@ -7,6 +7,23 @@ import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import actionsVariant from '../../examples/upsell/actionsVariant.js';
+import dontShowSameOnceDismissed from '../../examples/upsell/dontShowSameOnceDismissed.js';
+import dontStack from '../../examples/upsell/dontStack.js';
+import dontUseForCriticalInfo from '../../examples/upsell/dontUseForCriticalInfo.js';
+import iconVariant from '../../examples/upsell/iconVariant.js';
+import imageVariant from '../../examples/upsell/imageVariant.js';
+import labelsExample from '../../examples/upsell/labelsExample.js';
+import loclizeLabelsExample from '../../examples/upsell/loclizeLabelsExample.js';
+import mainExample from '../../examples/upsell/mainExample.js';
+import messagePropForVisualStyle from '../../examples/upsell/messagePropForVisualStyle.js';
+import multipleTextField from '../../examples/upsell/multipleTextField.js';
+import placeAtTopOfPage from '../../examples/upsell/placeAtTopOfPage.js';
+import planTiming from '../../examples/upsell/planTiming.js';
+import singleTextField from '../../examples/upsell/singleTextField.js';
+import textVariant from '../../examples/upsell/textVariant.js';
+import useForMarketing from '../../examples/upsell/useForMarketing.js';
 
 export default function DocsPage({
   generatedDocGen,
@@ -18,32 +35,15 @@ export default function DocsPage({
       <PageHeader
         name={generatedDocGen?.Upsell?.displayName}
         description={generatedDocGen?.Upsell?.description}
-        defaultCode={`
-<Upsell
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: () => {},
-  }}
-  imageData={{
-    component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
-  }}
-  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-  primaryAction={{
-    accessibilityLabel: "Send ads invite",
-    href: 'https://pinterest.com',
-    label: 'Send invite',
-    target: 'blank',
-  }}
-  secondaryAction={{
-    accessibilityLabel: 'Learn more: Verified Merchant Program',
-    href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
-    label: 'Learn more',
-    target: 'blank',
-  }}
-  title="Give $30, get $60 in ads credit"
-/>;
-    `}
-      />
+      >
+        <SandpackExample
+          name="Main Example"
+          code={mainExample}
+          layout="column"
+          hideEditor
+          previewHeight={240}
+        />
+      </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen?.Upsell} />
 
@@ -89,31 +89,15 @@ export default function DocsPage({
             cardSize="lg"
             type="do"
             description="Use Upsells for marketing new products or encouraging upgrades."
-            defaultCode={`
-<Upsell
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: () => {},
-  }}
-  imageData={{
-    component: <Icon accessibilityLabel="" color="default" icon="pinterest" size={32} />,
-  }}
-  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-  primaryAction={{
-    accessibilityLabel: "Send ads invite",
-    href: 'https://pinterest.com',
-    label: 'Send invite',
-    target: 'blank',
-  }}
-  secondaryAction={{
-    accessibilityLabel: 'Learn more: Ads credit',
-    href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
-    label: 'Learn more',
-    target: 'blank',
-  }}
-  title="Give $30, get $60 in ads credit"
-/>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Use for Marketing New Products & Encouraging Upgrades"
+                code={useForMarketing}
+                layout="column"
+                previewHeight={240}
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="lg"
@@ -121,41 +105,15 @@ export default function DocsPage({
             description={`
         Place Upsell at the top of the page under the primary navigation when possible.
         `}
-            defaultCode={`
-<Box>
-  <Box alignItems="center" display="flex" marginBottom={4}>
-    <Icon accessibilityLabel="" color="brandPrimary" icon="pinterest" size={32} />
-    <ButtonGroup>
-      <Button color="transparent" iconEnd="arrow-down" text="Business" />
-      <Button color="transparent" iconEnd="arrow-down" text="Create" />
-      <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
-      <Button color="transparent" iconEnd="arrow-down" text="Ads" />
-    </ButtonGroup>
-  </Box>
-
-  <Divider />
-
-  <Box marginTop={8}>
-    <Upsell
-      dismissButton={{
-        accessibilityLabel: 'Dismiss banner',
-        onDismiss: () => {},
-      }}
-      imageData={{
-        component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
-      }}
-      message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-      primaryAction={{
-        accessibilityLabel: "Send ads invite",
-        href: 'https://pinterest.com',
-        label: 'Send invite',
-        target: 'blank',
-      }}
-      title="Give $30, get $60 in ads credit"
-    />
-  </Box>
-</Box>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Place at Top of Page Under Primary Navigation"
+                code={placeAtTopOfPage}
+                layout="column"
+                previewHeight={300}
+                hideEditor
+              />
+            }
           />
 
           <MainSection.Card
@@ -164,39 +122,15 @@ export default function DocsPage({
             description={`
         Plan for the timing of your Upsells with new product launches. Try to create different messages for each time an Upsell appears to the user.
         `}
-            defaultCode={`
-<Flex gap={{ column: 4, row: 0 }} direction="column">
-  <Text>First Upsell:</Text>
-  <Upsell
-    dismissButton={{
-      accessibilityLabel: 'Dismiss banner',
-      onDismiss: () => {},
-    }}
-    imageData={{
-      component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
-    }}
-    message="Install the Pinterest tag to track your website traffic, conversions and more."
-    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag now' }}
-    secondaryAction={{
-      accessibilityLabel: 'Learn more: Pinterest tag',
-      href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
-      label: 'Learn more',
-      target: 'blank',
-    }}
-    title="Measure ad performance"
-  />
-
-  <Text>Follow-up Upsell:</Text>
-  <Upsell
-    imageData={{
-      component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
-    }}
-    message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
-    primaryAction={{ label: 'Claim now', accessibilityLabel: "Claim ads credit" }}
-    title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
-  />
-</Flex>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Plan Timing with New Product Launches"
+                code={planTiming}
+                layout="column"
+                previewHeight={520}
+                hideEditor
+              />
+            }
           />
 
           <MainSection.Card
@@ -205,20 +139,16 @@ export default function DocsPage({
             description={`
           Use Upsells for critical information, such as errors or warnings. Use [Callout](/web/callout) instead. Upsells should not be used for general information either.
         `}
-            defaultCode={`
-<Upsell
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: () => {},
-  }}
-  imageData={{
-    component: <Icon icon="workflow-status-warning" accessibilityLabel="Warning" color="default" size={32} />,
-  }}
-  message="There was a problem connecting your account."
-  primaryAction={{ label: 'Try again', accessibilityLabel: 'Try linking account again' }}
-  title="Could not link account"
-/>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Don't Use for Critical Information, Use Callout Instead"
+                code={dontUseForCriticalInfo}
+                layout="column"
+                previewHeight={200}
+                hideEditor
+                hideControls
+              />
+            }
           />
 
           <MainSection.Card
@@ -227,51 +157,16 @@ export default function DocsPage({
             description={`
         Stack Upsells on a page. In the case that they must be stacked, [Callouts](/web/callout) will appear above Upsells.
         `}
-            defaultCode={`
-<Box>
-  <Box alignItems="center" display="flex" marginBottom={4}>
-    <Icon accessibilityLabel="" color="brandPrimary" icon="pinterest" size={32} />
-    <ButtonGroup>
-      <Button color="transparent" iconEnd="arrow-down" text="Business" />
-      <Button color="transparent" iconEnd="arrow-down" text="Create" />
-      <Button color="transparent" iconEnd="arrow-down" text="Analytics" />
-      <Button color="transparent" iconEnd="arrow-down" text="Ads" />
-    </ButtonGroup>
-  </Box>
-
-  <Divider />
-
-  <Box marginTop={8}>
-    <Flex direction="column" gap={{ column: 2, row: 0 }}>
-      <Upsell
-        imageData={{
-          component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
-        }}
-        message="Track ads conversion—sales, traffic and more—with the Pinterest tag"
-        primaryAction={{ label: 'Claim now', accessibilityLabel: 'Claim ads credit now' }}
-        title="So close! Finish installing your Pinterest tag, get $10 in ads credit"
-      />
-      <Upsell
-        dismissButton={{
-          accessibilityLabel: 'Dismiss banner',
-          onDismiss: () => {},
-        }}
-        imageData={{
-          component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
-        }}
-        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-        primaryAction={{
-          accessibilityLabel: 'Send ads invite',
-          href: 'https://pinterest.com',
-          label: 'Send invite',
-          target: 'blank',
-        }}
-        title="Give $30, get $60 in ads credit"
-      />
-    </Flex>
-  </Box>
-</Box>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Do Not Stack on a Page"
+                code={dontStack}
+                layout="column"
+                previewHeight={480}
+                hideEditor
+                hideControls
+              />
+            }
           />
 
           <MainSection.Card
@@ -280,34 +175,16 @@ export default function DocsPage({
             description={`
         Keep showing the same Upsell once it has been dismissed. Upsells should only appear a maximum of 2 times to the same user, as they have diminishing returns.
         `}
-            defaultCode={`
-<Flex direction="column" gap={{ column: 4, row: 0 }}>
-  <Upsell
-    dismissButton={{
-      accessibilityLabel: 'Dismiss banner',
-      onDismiss: () => {},
-    }}
-    imageData={{
-      component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
-    }}
-    message="Install the Pinterest tag to track your website traffic, conversions and more."
-    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
-    title="Measure ad performance"
-  />
-  <Upsell
-    dismissButton={{
-      accessibilityLabel: 'Dismiss banner',
-      onDismiss: () => {},
-    }}
-    imageData={{
-      component: <Icon icon="ads-stats" accessibilityLabel="" color="default" size={32} />,
-    }}
-    message="Install the Pinterest tag to track your website traffic, conversions and more."
-    primaryAction={{ label: 'Install now', accessibilityLabel: 'Install Pinterest tag' }}
-    title="Measure ad performance"
-  />
-</Flex>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Do Not Show the Same Once Dismissed"
+                code={dontShowSameOnceDismissed}
+                layout="column"
+                previewHeight={320}
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -327,31 +204,14 @@ export default function DocsPage({
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Upsell
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: () => {},
-  }}
-  imageData={{
-    component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
-  }}
-  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-  primaryAction={{
-    href: 'https://pinterest.com',
-    label: 'Send invite',
-    accessibilityLabel: 'Invite friend to use ads',
-    target: 'blank',
-  }}
-  secondaryAction={{
-    accessibilityLabel: 'Learn more: Verified Merchant Program',
-    href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
-    label: 'Learn more',
-    target: 'blank',
-  }}
-  title="Give $30, get $60 in ads credit"
-/>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Labels for Screen Readers and Localization"
+                code={labelsExample}
+                layout="column"
+                previewHeight={280}
+              />
+            }
           />
         </MainSection.Subsection>
       </AccessibilitySection>
@@ -363,20 +223,13 @@ export default function DocsPage({
         <MainSection.Subsection>
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Upsell
-  imageData={{
-    component: <Icon icon="send" accessibilityLabel="" color="default" size={32} />,
-  }}
-  message="Verfolgen Sie die Anzeigenkonvertierung - Umsatz, Traffic und mehr - mit dem Pinterest Tag"
-  primaryAction={{
-    label: 'Beanspruche jetzt',
-    accessibilityLabel: 'Beanspruche Guthaben jetzt',
-    target: 'blank',
-  }}
-  title="Fast fertig! Beenden Sie die Installation Ihres Pinterest-Tags und erhalten Sie ein Guthaben von 10 Euro"
-/>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Remember to Localize All Labels"
+                code={loclizeLabelsExample}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -388,15 +241,13 @@ export default function DocsPage({
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Upsell
-  dismissButton={{
-    accessibilityLabel: 'Dismiss this banner',
-    onDismiss: () => {},
-  }}
-  message="Single line Upsell with no title or call to action."
-/>;
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Text-Only for Short Message with Dismiss"
+                code={textVariant}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -406,25 +257,13 @@ export default function DocsPage({
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Upsell
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: () => {},
-  }}
-  imageData={{
-    component: <Icon icon="pinterest" accessibilityLabel="" color="default" size={32} />,
-  }}
-  message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-  primaryAction={{
-    href: 'https://pinterest.com',
-    label: 'Send invite',
-    accessibilityLabel: 'Invite friend to use ads',
-    target: 'blank',
-  }}
-  title="Give $30, get $60 in ads credit"
-/>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Icon to Add Additional Meaning"
+                code={iconVariant}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -434,35 +273,13 @@ export default function DocsPage({
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-<Upsell
-  dismissButton={{
-    accessibilityLabel: 'Dismiss banner',
-    onDismiss: () => {},
-  }}
-  imageData={{
-    component: (
-      <Image
-        alt=""
-        color="rgb(231, 186, 176)"
-        naturalHeight={751}
-        naturalWidth={564}
-        src="https://i.ibb.co/7bQQYkX/stock2.jpg"
-      />
-    ),
-    mask: { rounding: 4 },
-    width: 128,
-  }}
-  message="Check out our resources for adapting to these times."
-  primaryAction={{
-    href: 'https://pinterest.com',
-    label: 'Visit',
-    accessibilityLabel: 'Visit our Stay Safe resources',
-    target: 'blank',
-  }}
-  title="Stay healthy and safe"
-/>;
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Image to Add Visual Interest"
+                code={imageVariant}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
 
@@ -480,111 +297,13 @@ export default function DocsPage({
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example(props) {
-  const [showModal, setShowModal] = React.useState(false);
-
-  return (
-    <Box marginStart={-1} marginEnd={-1}>
-      <Upsell
-        dismissButton={{
-          accessibilityLabel: 'Dismiss banner',
-          onDismiss: () => {},
-        }}
-        message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-        primaryAction={{
-          accessibilityLabel: 'Send ads invite',
-          label: 'Send invite',
-          onClick: () => {
-            setShowModal(!showModal);
-          },
-        }}
-        secondaryAction={{
-          accessibilityLabel: 'Learn more: Verified Merchant Program',
-          href: 'https://help.pinterest.com/en/business/article/verified-merchant-program',
-          label: 'Learn more',
-          target: 'blank',
-        }}
-        title="Give $30, get $60 in ads credit"
-      />
-
-      {showModal && (
-        <Layer>
-          <Modal
-            accessibilityModalLabel="Invite a friend to the Verified Merchant Program"
-            footer={
-              <Flex flex="grow" justifyContent="end">
-                <ButtonGroup>
-                  <Button
-                    onClick={() => {
-                      setShowModal(!showModal);
-                    }}
-                    size="lg"
-                    text="Cancel"
-                  />
-                  <Button color="red" size="lg" text="Send invite" />
-                </ButtonGroup>
-              </Flex>
+            sandpackExample={
+              <SandpackExample
+                name="Actions Can Be One Primary or One Primary & One Secondary"
+                code={actionsVariant}
+                layout="column"
+              />
             }
-            heading="Verified Merchant Program Invitation"
-            onDismiss={() => {
-              setShowModal(!showModal);
-            }}
-            size="md"
-            subHeading="When your friend spends their first $30 on ads, you’ll earn $60 of ads credit, and they’ll get $30 of ads credit, too."
-          >
-            <Flex direction="row">
-              <Column span={12}>
-                <Box display="flex" paddingY={2} paddingX={8}>
-                  <Column span={4}>
-                    <Label htmlFor="name">
-                      <Text align="left" weight="bold">
-                        Friend's Name
-                      </Text>
-                    </Label>
-                  </Column>
-
-                  <Column span={8}>
-                    <TextField id="name" onChange={() => undefined} />
-                  </Column>
-                </Box>
-
-                <Box display="flex" paddingY={2} paddingX={8}>
-                  <Column span={4}>
-                    <Label htmlFor="email">
-                      <Text align="left" weight="bold">
-                        Friend's E-mail
-                      </Text>
-                    </Label>
-                  </Column>
-
-                  <Column span={8}>
-                    <TextField id="email" onChange={() => undefined} />
-                  </Column>
-                </Box>
-
-                <Box display="flex" paddingY={2} paddingX={8}>
-                  <Column span={4}>
-                    <Label htmlFor="desc">
-                      <Text align="left" weight="bold">
-                        Personal Message
-                      </Text>
-                    </Label>
-                  </Column>
-
-                  <Column span={8}>
-                    <TextArea id="desc" onChange={() => undefined} />
-                  </Column>
-                </Box>
-              </Column>
-            </Flex>
-          </Modal>
-        </Layer>
-      )}
-    </Box>
-  );
-}
-        `}
           />
         </MainSection.Subsection>
 
@@ -595,119 +314,25 @@ function Example(props) {
           <MainSection.Card
             cardSize="lg"
             title="Single TextField"
-            defaultCode={`
-function FormExample(props) {
-  const [value, setValue] = React.useState('');
-  const handleSubmit = ({ event }) => {
-    event.preventDefault();
-    // your submit logic using state values
-  };
-
-  return (
-    <Upsell
-      dismissButton={{
-        accessibilityLabel: 'Dismiss banner',
-        onDismiss: ()=>{},
-      }}
-      imageData={{
-        component: <Icon icon="pinterest" accessibilityLabel="Pin" color="default" size={32}/>
-      }}
-      message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-      title="Give $30, get $60 in ads credit"
-    >
-      <Upsell.Form
-        onSubmit={handleSubmit}
-        submitButtonAccessibilityLabel="Submit name for ads credit"
-        submitButtonText="Submit"
-      >
-        <TextField
-          id="nameField"
-          onChange={({ value }) => setValue(value)}
-          placeholder="Name"
-          value={value}
-          label="Full name"
-          labelDisplay="hidden"
-        />
-      </Upsell.Form>
-    </Upsell>
-  );
-}
-      `}
+            sandpackExample={
+              <SandpackExample
+                name="Inputs to Collect Information from Users Example (1)"
+                code={singleTextField}
+                layout="column"
+              />
+            }
           />
 
           <MainSection.Card
             cardSize="lg"
             title="Multiple TextFields"
-            defaultCode={`
-function Example(props) {
-  const [nameValue, setNameValue] = React.useState('');
-  const [emailValue, setEmailValue] = React.useState('');
-  const handleSubmit = ({ event }) => {
-    event.preventDefault();
-    // your submit logic using state values
-  };
-
-  return (
-    <Upsell
-      dismissButton={{
-        accessibilityLabel: 'Dismiss banner',
-        onDismiss: () => {},
-      }}
-      imageData={{
-        component:
-          <Image
-            alt="Succulent plant against pink background"
-            color="rgb(231, 186, 176)"
-            naturalHeight={751}
-            naturalWidth={564}
-            src="https://i.ibb.co/7bQQYkX/stock2.jpg"
-          />,
-          mask: {rounding: 4},
-        width: 128,
-      }}
-      message="Learn how to grow your business with a Pinterest ads expert today!"
-      title="Interested in a free ads consultation?"
-    >
-      <Upsell.Form
-        onSubmit={handleSubmit}
-        submitButtonAccessibilityLabel="Submit info for contact"
-        submitButtonText="Contact me"
-      >
-        <Box display="block" smDisplay="flex">
-          <Box
-            flex="grow"
-            smMarginEnd={1}
-            marginEnd={0}
-            smMarginBottom={0}
-            marginBottom={2}
-          >
-            <TextField
-              id="name"
-              onChange={({ value }) => setNameValue(value)}
-              placeholder="Name"
-              label="Full name"
-              labelDisplay="hidden"
-              value={nameValue}
-            />
-          </Box>
-
-          <Box flex="grow" smMarginStart={1} marginStart={0}>
-            <TextField
-              id="email"
-              onChange={({ value }) => setEmailValue(value)}
-              placeholder="Email"
-              type="email"
-              label="Email address"
-              labelDisplay="hidden"
-              value={emailValue}
-            />
-          </Box>
-        </Box>
-      </Upsell.Form>
-    </Upsell>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Inputs to Collect Information from Users Example (2)"
+                code={multipleTextField}
+                layout="column"
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -720,20 +345,14 @@ If the \`message\` text requires more complex style, such as bold text or inline
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-            <Flex direction="column" gap={6}>
-  <Text weight="bold">Simple message string</Text>
-  <Upsell
-    message="Earn $60 of ads credit, and give $30 of ads credit to a friend"
-    title="Give $30, get $60 in ads credit"
-  />
-  <Text weight="bold">Rich message with Text component</Text>
-  <Upsell
-    message={<Text display="inline">Earn $60 of ads credit, and give $30 of ads credit to a friend. <Link accessibilityLabel="Learn more about credit" display="inline" href="#Message">Learn more</Link></Text>}
-    title="Give $30, get $60 in ads credit"
-  />
-  </Flex>
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Message: String or Text for Visual Style"
+                code={messagePropForVisualStyle}
+                layout="column"
+                previewHeight={400}
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>


### PR DESCRIPTION
### Summary

Migrated the examples of below components to Sandpack:
 - TextField
 - Module
 - Upsell
 - ActivationCard

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6272)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [n/a] Added unit and Flow Tests
- [n/a] Added documentation + accessibility tests
- [n/a] Verified accessibility: keyboard & screen reader interaction
- [n/a] Checked dark mode, responsiveness, and right-to-left support
- [n/a] Checked stakeholder feedback (e.g. Gestalt designers)
