### PR TITLE
Docs: Migrate CheckBox, RadioGroup, ZIndex classes, SegmentedControl examples to Sandpack

### DIFF
--- a/docs/examples/checkbox/dontUseForOneSelection.js
+++ b/docs/examples/checkbox/dontUseForOneSelection.js
@@ -1,0 +1,43 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+  const [checked4, setChecked4] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Fieldset legend="Pick one topic from the list">
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Checkbox
+            checked={checked1}
+            id="Fashion2"
+            label="Fashion"
+            onChange={({ checked }) => setChecked1(checked)}
+          />
+          <Checkbox
+            checked={checked2}
+            id="Beauty2"
+            label="Beauty"
+            onChange={({ checked }) => setChecked2(checked)}
+          />
+          <Checkbox
+            checked={checked3}
+            id="Interior_design_3"
+            label="Interior design"
+            onChange={({ checked }) => setChecked3(checked)}
+          />
+          <Checkbox
+            checked={checked4}
+            id="Other4"
+            label="Other"
+            onChange={({ checked }) => setChecked4(checked)}
+          />
+        </Flex>
+      </Fieldset>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/dontUseNumerousInTableRows.js
+++ b/docs/examples/checkbox/dontUseNumerousInTableRows.js
@@ -1,0 +1,89 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Table, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Table accessibilityLabel="Campaign selection" maxHeight={200}>
+        <Table.Header sticky>
+          <Table.Row>
+            <Table.HeaderCell>&nbsp;</Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Active</Text>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Name</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked1}
+                  id="4"
+                  onChange={({ checked }) => setChecked1(checked)}
+                  size="sm"
+                  label="Select Summertime picnic row"
+                  labelDisplay="hidden"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Checkbox id="5" onChange={() => {}} size="sm" label="off" />
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Summertime picnic</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked2}
+                  id="6"
+                  onChange={({ checked }) => setChecked2(checked)}
+                  size="sm"
+                  label="Select Summer 1950 row"
+                  labelDisplay="hidden"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Checkbox checked id="7" onChange={() => {}} size="sm" label="on" />
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Summer 1950</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked3}
+                  id="8"
+                  onChange={({ checked }) => setChecked3(checked)}
+                  size="sm"
+                  label="Select Back to school row"
+                  labelDisplay="hidden"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Checkbox id="9" onChange={() => {}} size="sm" label="off" />
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Back to school</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/dontUseToToggleState.js
+++ b/docs/examples/checkbox/dontUseToToggleState.js
@@ -1,0 +1,19 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Checkbox
+        checked={checked1}
+        id="location"
+        label="Turn location tracking off"
+        helperText="Change will auto-save"
+        onChange={({ checked }) => setChecked1(checked)}
+      />
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/dontUseTruncatedText.js
+++ b/docs/examples/checkbox/dontUseTruncatedText.js
@@ -1,0 +1,41 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={{ column: 4, row: 0 }}>
+        <Text size="400" weight="bold">
+          Which one?
+        </Text>
+        <Fieldset legendDisplay="hidden" legend="Which one?">
+          <Flex direction="column" gap={{ column: 2, row: 0 }}>
+            <Checkbox
+              checked={checked1}
+              id="Overeasy2"
+              label="Overeasy with a touch of salt and maybe a slice of bacon on top that isn't fully cooked and has no pepper."
+              onChange={({ checked }) => setChecked1(checked)}
+            />
+            <Checkbox
+              checked={checked2}
+              id="Sunny2"
+              label="Sunny side up"
+              onChange={({ checked }) => setChecked2(checked)}
+            />
+            <Checkbox
+              checked={checked3}
+              id="Scramboiled3"
+              label="Scramboiled--this is when you boil an egg, then you scrambled it in the pan along with the shells."
+              onChange={({ checked }) => setChecked3(checked)}
+            />
+          </Flex>
+        </Fieldset>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/dontVerticallyCenterInputs.js
+++ b/docs/examples/checkbox/dontVerticallyCenterInputs.js
@@ -1,0 +1,66 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex, Label, Link, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Fieldset legend="Data personalization">
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Flex gap={2} alignItems="center">
+            <Checkbox
+              checked={checked1}
+              id="sites2"
+              onChange={({ checked }) => setChecked1(checked)}
+            />
+            <Text inline>
+              <Label htmlFor="sites2">
+                Use sites you visit to improve which recommendations and ads you see on Pinterest.
+              </Label>
+              <Link href="#" display="inline">
+                Learn more
+              </Link>
+            </Text>
+          </Flex>
+
+          <Flex gap={2} alignItems="center">
+            <Checkbox
+              checked={checked2}
+              id="partner2"
+              onChange={({ checked }) => setChecked2(checked)}
+            />
+            <Text inline>
+              <Label htmlFor="partner2">
+                Use partner info to improve which recommendations and ads you see on Pinterest.
+              </Label>
+              <Link href="#" display="inline">
+                Learn more
+              </Link>
+            </Text>
+          </Flex>
+
+          <Flex gap={2} alignItems="center">
+            <Checkbox
+              checked={checked3}
+              id="activity2"
+              onChange={({ checked }) => setChecked3(checked)}
+            />
+            <Text inline>
+              <Label htmlFor="activity2">
+                Use your activity to improve ads you see about Pinterest on other sites or apps you
+                may visit.
+              </Label>
+              <Link href="#" display="inline">
+                Learn more
+              </Link>
+            </Text>
+          </Flex>
+        </Flex>
+      </Fieldset>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/errorMessageExample.js
+++ b/docs/examples/checkbox/errorMessageExample.js
@@ -1,0 +1,17 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Checkbox } from 'gestalt';
+
+export default function CheckboxExample(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Checkbox
+        id="error"
+        errorMessage="You must agree to the Terms and Conditions"
+        label="I agree to the Terms and Conditions"
+        name="error"
+        onChange={() => {}}
+      />
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/keepLabelsAndLegendsClear.js
+++ b/docs/examples/checkbox/keepLabelsAndLegendsClear.js
@@ -1,0 +1,50 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex, Icon, Text, Tooltip } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={{ column: 4, row: 0 }}>
+        <Text size="400" weight="bold">
+          How do you like your eggs?
+        </Text>
+        <Text>Select all the options that apply</Text>
+        <Fieldset
+          legendDisplay="hidden"
+          legend="How do you like your eggs? Select all the options that apply"
+        >
+          <Flex direction="column" gap={{ column: 2, row: 0 }}>
+            <Checkbox
+              checked={checked1}
+              id="Overeasy"
+              label="Overeasy"
+              onChange={({ checked }) => setChecked1(checked)}
+            />
+            <Checkbox
+              checked={checked2}
+              id="Sunny"
+              label="Sunny side up"
+              onChange={({ checked }) => setChecked2(checked)}
+            />
+            <Flex gap={{ row: 2, column: 0 }} alignItems="center">
+              <Checkbox
+                checked={checked3}
+                id="Scramboiled"
+                label="Scramboiled"
+                onChange={({ checked }) => setChecked3(checked)}
+              />
+              <Tooltip text="A hardboiled egg that is then scrambled" idealDirection="up">
+                <Icon icon="info-circle" accessibilityLabel="" size={14} color="default" />
+              </Tooltip>
+            </Flex>
+          </Flex>
+        </Fieldset>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/labelVisibilityExample.js
+++ b/docs/examples/checkbox/labelVisibilityExample.js
@@ -1,0 +1,77 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Table, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(true);
+  const [checked3, setChecked3] = useState(true);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Table accessibilityLabel="Campaign selection" maxHeight={200}>
+        <Table.Header sticky>
+          <Table.Row>
+            <Table.HeaderCell>&nbsp;</Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Name</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked1}
+                  id="label-visibility-example-checkbox-1"
+                  onChange={({ checked }) => setChecked1(checked)}
+                  label="Select Summertime picnic row"
+                  labelDisplay="hidden"
+                  size="sm"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Summertime picnic</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked2}
+                  id="label-visibility-example-checkbox-2"
+                  onChange={({ checked }) => setChecked2(checked)}
+                  label="Select Summer 1950 row"
+                  labelDisplay="hidden"
+                  size="sm"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Summer 1950</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked3}
+                  id="label-visibility-example-checkbox-3"
+                  onChange={({ checked }) => setChecked3(checked)}
+                  label="Select Back to school row"
+                  labelDisplay="hidden"
+                  size="sm"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Back to school</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/legendsExample.js
+++ b/docs/examples/checkbox/legendsExample.js
@@ -1,0 +1,39 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  const [checkedEn, setCheckedEn] = useState(false);
+  const [checkedSp, setCheckedSp] = useState(false);
+  const [checkedCh, setCheckedCh] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Fieldset legend="What languages would you like to learn?">
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Checkbox
+            checked={checkedEn}
+            id="english"
+            label="English"
+            name="english"
+            onChange={({ checked }) => setCheckedEn(checked)}
+          />
+          <Checkbox
+            checked={checkedSp}
+            id="spanish"
+            label="Spanish"
+            name="spanish"
+            onChange={({ checked }) => setCheckedSp(checked)}
+          />
+          <Checkbox
+            checked={checkedCh}
+            id="chinese"
+            label="Chinese"
+            name="chinese"
+            onChange={({ checked }) => setCheckedCh(checked)}
+          />
+        </Flex>
+      </Fieldset>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/sizeExample.js
+++ b/docs/examples/checkbox/sizeExample.js
@@ -1,0 +1,28 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 0, row: 6 }}>
+        <Checkbox
+          checked={checked1}
+          id="sm"
+          label="Small size"
+          onChange={({ checked }) => setChecked1(checked)}
+          size="sm"
+        />
+        <Checkbox
+          checked={checked2}
+          id="md"
+          label="Medium size"
+          onChange={({ checked }) => setChecked2(checked)}
+        />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/stateExample.js
+++ b/docs/examples/checkbox/stateExample.js
@@ -1,0 +1,25 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Checkbox, Flex } from 'gestalt';
+
+const noop = () => {};
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={6} wrap>
+        <Checkbox checked={false} id="Unchecked" label="Unchecked" onChange={noop} />
+        <Checkbox checked id="Checked" label="Checked" onChange={noop} />
+        <Checkbox
+          checked={false}
+          id="ErrorState"
+          label="Error"
+          errorMessage="error message"
+          onChange={noop}
+        />
+        <Checkbox checked id="Indeterminate" label="Indeterminate" indeterminate onChange={noop} />
+        <Checkbox checked={false} id="Disabled" label="Disabled" disabled onChange={noop} />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/useAtStartOfTableRow.js
+++ b/docs/examples/checkbox/useAtStartOfTableRow.js
@@ -1,0 +1,77 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Table, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Table accessibilityLabel="Campaign selection" maxHeight={200}>
+        <Table.Header sticky>
+          <Table.Row>
+            <Table.HeaderCell>&nbsp;</Table.HeaderCell>
+            <Table.HeaderCell>
+              <Text weight="bold">Name</Text>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked1}
+                  id="1"
+                  onChange={({ checked }) => setChecked1(checked)}
+                  size="sm"
+                  label="Select Summertime picnic row"
+                  labelDisplay="hidden"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Summertime picnic</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked2}
+                  id="2"
+                  onChange={({ checked }) => setChecked2(checked)}
+                  size="sm"
+                  label="Select Summer 1950 row"
+                  labelDisplay="hidden"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Summer 1950</Text>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Box width={20}>
+                <Checkbox
+                  checked={checked3}
+                  id="3"
+                  onChange={({ checked }) => setChecked3(checked)}
+                  size="sm"
+                  label="Select Back to school row"
+                  labelDisplay="hidden"
+                />
+              </Box>
+            </Table.Cell>
+            <Table.Cell>
+              <Text>Back to school</Text>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/useForMultiSelection.js
+++ b/docs/examples/checkbox/useForMultiSelection.js
@@ -1,0 +1,43 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+  const [checked4, setChecked4] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Fieldset legend="Select what you enjoy">
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Checkbox
+            checked={checked1}
+            id="Fashion"
+            label="Fashion"
+            onChange={({ checked }) => setChecked1(checked)}
+          />
+          <Checkbox
+            checked={checked2}
+            id="Beauty"
+            label="Beauty"
+            onChange={({ checked }) => setChecked2(checked)}
+          />
+          <Checkbox
+            checked={checked3}
+            id="Interior_design"
+            label="Interior design"
+            onChange={({ checked }) => setChecked3(checked)}
+          />
+          <Checkbox
+            checked={checked4}
+            id="Other"
+            label="Other"
+            onChange={({ checked }) => setChecked4(checked)}
+          />
+        </Flex>
+      </Fieldset>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/useSingleInForms.js
+++ b/docs/examples/checkbox/useSingleInForms.js
@@ -1,0 +1,23 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Button, Checkbox, Flex, TextField } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={{ column: 6, row: 0 }}>
+        <TextField id="name" label="Name" onChange={() => {}} value="" />
+        <TextField id="email" label="Email" onChange={() => {}} value="" />
+        <Checkbox
+          checked={checked1}
+          id="terms"
+          label="I agree to the Terms and Conditions"
+          onChange={({ checked }) => setChecked1(checked)}
+        />
+        <Button accessibilityLabel="Submit" color="red" text="Submit" size="lg" />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/useVerticalAlignment.js
+++ b/docs/examples/checkbox/useVerticalAlignment.js
@@ -1,0 +1,36 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+  const [checked3, setChecked3] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Fieldset legend="Data personalization">
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Checkbox
+            checked={checked1}
+            id="sites"
+            label="Use sites you visit to improve which recommendations and ads you see on Pinterest"
+            onChange={({ checked }) => setChecked1(checked)}
+          />
+          <Checkbox
+            checked={checked2}
+            id="partner"
+            label="Use partner info to improve which recommendations and ads you see on Pinterest"
+            onChange={({ checked }) => setChecked2(checked)}
+          />
+          <Checkbox
+            checked={checked3}
+            id="activity"
+            label="Use your activity to improve ads you see about Pinterest on other sites or apps you may visit"
+            onChange={({ checked }) => setChecked3(checked)}
+          />
+        </Flex>
+      </Fieldset>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/withHelperTextExample.js
+++ b/docs/examples/checkbox/withHelperTextExample.js
@@ -1,0 +1,48 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex } from 'gestalt';
+
+export default function Example(): Node {
+  const [checkedEn, setCheckedEn] = useState(false);
+  const [checkedSp, setCheckedSp] = useState(false);
+  const [checkedCh, setCheckedCh] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Fieldset legend="What languages would you like to learn?">
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Checkbox
+            checked={checkedEn}
+            id="english-info"
+            label="English"
+            helperText="USA, India, and Pakistan have the top number of English speakers "
+            name="languages"
+            onChange={({ checked }) => {
+              setCheckedEn(checked);
+            }}
+          />
+          <Checkbox
+            checked={checkedSp}
+            id="spanish-info"
+            label="Spanish"
+            helperText="Mexico, Colombia, and Spain are the top three Spanish-speaking countries"
+            name="languages"
+            onChange={({ checked }) => {
+              setCheckedSp(checked);
+            }}
+          />
+          <Checkbox
+            checked={checkedCh}
+            id="chinese-info"
+            label="Chinese"
+            helperText="Chinese has many varieties, including Cantonese and Mandarin"
+            name="languages"
+            onChange={({ checked }) => {
+              setCheckedCh(checked);
+            }}
+          />
+        </Flex>
+      </Fieldset>
+    </Box>
+  );
+}

--- a/docs/examples/checkbox/withImageExample.js
+++ b/docs/examples/checkbox/withImageExample.js
@@ -1,0 +1,59 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Checkbox, Fieldset, Flex, Image } from 'gestalt';
+
+export default function CheckboxExample(): Node {
+  const [checkedCoral, setCheckedCoral] = useState(false);
+  const [checkedBlue, setCheckedBlue] = useState(false);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Fieldset legend="Which backgrounds would you like to use?" legendDisplay="hidden">
+        <Flex direction="column" gap={{ column: 4, row: 0 }}>
+          <Checkbox
+            checked={checkedCoral}
+            id="coral"
+            label="Coral"
+            helperText="Botanical art in coral and green"
+            image={
+              <Box height={100} width={80}>
+                <Image
+                  alt="Botanical art in coral and green"
+                  src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+                  fit="contain"
+                  naturalWidth={1}
+                  naturalHeight={1}
+                />
+              </Box>
+            }
+            name="favorite art"
+            onChange={({ checked }) => {
+              setCheckedCoral(checked);
+            }}
+          />
+          <Checkbox
+            checked={checkedBlue}
+            id="blue"
+            label="Blue"
+            helperText="Typography and shoe in blue"
+            image={
+              <Box height={100} width={80}>
+                <Image
+                  alt="Typography and shoe in blue"
+                  src="https://i.ibb.co/jVR29XV/stock5.jpg"
+                  fit="contain"
+                  naturalWidth={1}
+                  naturalHeight={1}
+                />
+              </Box>
+            }
+            name="favorite art"
+            onChange={({ checked }) => {
+              setCheckedBlue(checked);
+            }}
+          />
+        </Flex>
+      </Fieldset>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/addingAPopoverExample.js
+++ b/docs/examples/radiogroup/addingAPopoverExample.js
@@ -1,0 +1,71 @@
+// @flow strict
+import { type Node, useRef, useState } from 'react';
+import { Box, Layer, Link, Popover, RadioGroup, Text } from 'gestalt';
+
+export default function RadioButtonPopoverExample(): Node {
+  const [open, setOpen] = useState(false);
+  const [option, setOption] = useState('');
+  const anchorCatRef = useRef<HTMLElement | null>(null);
+  const anchorDogRef = useRef<HTMLElement | null>(null);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="Tell us about yourself" id="popoverExample">
+        <Box display="inlineBlock" ref={anchorCatRef}>
+          <RadioGroup.RadioButton
+            id="cat"
+            checked={option === 'cat'}
+            label="I'm a cat person"
+            onChange={() => {
+              setOpen(true);
+              setOption('cat');
+            }}
+            value="cat"
+          />
+        </Box>
+        <Box display="inlineBlock" ref={anchorDogRef}>
+          <RadioGroup.RadioButton
+            id="dog"
+            checked={option === 'dog'}
+            label="I'm a dog person"
+            onChange={() => {
+              setOpen(true);
+              setOption('dog');
+            }}
+            value="dog"
+          />
+        </Box>
+        {open && (
+          <Layer>
+            <Popover
+              anchor={option === 'cat' ? anchorCatRef.current : anchorDogRef.current}
+              idealDirection="right"
+              onDismiss={() => setOpen(false)}
+              positionRelativeToAnchor={false}
+              shouldFocus={false}
+              size="md"
+            >
+              <Box padding={3}>
+                <Text color="default">
+                  <Link
+                    href={
+                      option === 'cat'
+                        ? 'https://www.pinterest.com/search/pins/?q=cats'
+                        : 'https://www.pinterest.com/search/pins/?q=dogs'
+                    }
+                    target="blank"
+                    underline="always"
+                  >
+                    {option === 'cat'
+                      ? 'Check out cats on Pinterest!'
+                      : 'Check out dogs on Pinterest!'}
+                  </Link>
+                </Text>
+              </Box>
+            </Popover>
+          </Layer>
+        )}
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/directionExample.js
+++ b/docs/examples/radiogroup/directionExample.js
@@ -1,0 +1,73 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, RadioGroup } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [favorite, setFavorite] = useState('');
+  const [favoriteFood, setFavoriteFood] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={8} wrap>
+        <RadioGroup legend="What is your favorite pet?" id="directionExample-1">
+          <RadioGroup.RadioButton
+            checked={favorite === 'dogs'}
+            id="favoriteDog"
+            label="Dogs"
+            name="favorite"
+            onChange={() => setFavorite('dogs')}
+            value="dogs"
+          />
+          <RadioGroup.RadioButton
+            checked={favorite === 'cats'}
+            id="favoriteCat"
+            label="Cats"
+            name="favorite"
+            onChange={() => setFavorite('cats')}
+            value="cats"
+          />
+          <RadioGroup.RadioButton
+            checked={favorite === 'plants'}
+            id="favoritePlants"
+            label="Plants"
+            name="favorite"
+            onChange={() => setFavorite('plants')}
+            value="plants"
+          />
+        </RadioGroup>
+
+        <RadioGroup
+          legend="What is your favorite snack?"
+          errorMessage="Please select one"
+          direction="row"
+          id="directionExample"
+        >
+          <RadioGroup.RadioButton
+            checked={favoriteFood === 'pizza'}
+            id="favoritePizza"
+            label="Pizza"
+            name="favoriteFood"
+            onChange={() => setFavoriteFood('pizza')}
+            value="pizza"
+          />
+          <RadioGroup.RadioButton
+            checked={favoriteFood === 'curry'}
+            id="favoriteCurry"
+            label="Curry"
+            name="favoriteFood"
+            onChange={() => setFavoriteFood('curry')}
+            value="curry"
+          />
+          <RadioGroup.RadioButton
+            checked={favoriteFood === 'sushi'}
+            id="favoriteSushi"
+            label="Sushi"
+            name="favoriteFood"
+            onChange={() => setFavoriteFood('sushi')}
+            value="sushi"
+          />
+        </RadioGroup>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/dontUseToSelectMultipleItems.js
+++ b/docs/examples/radiogroup/dontUseToSelectMultipleItems.js
@@ -1,0 +1,38 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, RadioGroup } from 'gestalt';
+
+const noop = () => {};
+
+export default function RadioButtonExample(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="Choose all of your favorite hobbies" id="bestPracticeDont">
+        <RadioGroup.RadioButton
+          checked={false}
+          id="knitting-dont"
+          label="Knitting"
+          name="hobby-dont"
+          onChange={noop}
+          value="knitting"
+        />
+        <RadioGroup.RadioButton
+          checked={false}
+          id="reading-dont"
+          label="Reading"
+          name="hobby-dont"
+          onChange={noop}
+          value="reading"
+        />
+        <RadioGroup.RadioButton
+          checked={false}
+          id="pottery-dont"
+          label="Pottery"
+          name="hobby-dont"
+          onChange={noop}
+          value="pottery"
+        />
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/dontUseToToggleStateOnMobile.js
+++ b/docs/examples/radiogroup/dontUseToToggleStateOnMobile.js
@@ -1,0 +1,43 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Flex, RadioGroup, Text } from 'gestalt';
+
+const noop = () => {};
+
+export default function RadioButtonExample(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 4, row: 0 }} direction="column">
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Text size="400" weight="bold">
+            Auto-renew subscription
+          </Text>
+          <Text size="200">Change will auto-save</Text>
+        </Flex>
+        <RadioGroup
+          direction="row"
+          legend="Auto-renew subscription"
+          legendDisplay="hidden"
+          id="bestPracticeFeedsDont"
+        >
+          <RadioGroup.RadioButton
+            checked={false}
+            id="on-dont"
+            label="On"
+            name="feed-dont"
+            onChange={noop}
+            value="on"
+          />
+          <RadioGroup.RadioButton
+            checked={false}
+            id="Off-do"
+            label="Off"
+            name="feed-dont"
+            onChange={noop}
+            value="Off"
+          />
+        </RadioGroup>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/dontUseTruncatedText.js
+++ b/docs/examples/radiogroup/dontUseTruncatedText.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, RadioGroup } from 'gestalt';
+
+const noop = () => {};
+
+export default function RadioButtonExample(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="Campaign budget" id="bestPracticeLabelsDont">
+        <RadioGroup.RadioButton
+          checked={false}
+          id="daily-dont"
+          label="Daily-Daily spend limit. Choose this option to set a cap for the amount your campaign can spend each day."
+          name="spend-dont"
+          onChange={noop}
+          value="daily"
+        />
+        <RadioGroup.RadioButton
+          checked={false}
+          id="lifetime-dont"
+          label="Lifetime-Lifetime spend limit. Choose this option to seta a cap for the amount your campaign can spend over the course of its lifetime."
+          name="spend-dont"
+          onChange={noop}
+          value="lifetime"
+        />
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/keepLabelsAndLegendsClear.js
+++ b/docs/examples/radiogroup/keepLabelsAndLegendsClear.js
@@ -1,0 +1,58 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, IconButton, Label, RadioGroup, Text } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [favorite, setFavorite] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="Campaign budget" id="bestPracticeBudget">
+        <Flex gap={{ row: 2, column: 0 }} alignItems="center" justifyContent="start">
+          <RadioGroup.RadioButton
+            checked={favorite === 'daily'}
+            id="daily"
+            name="budget"
+            onChange={() => setFavorite('daily')}
+            value="daily"
+          />
+          <Label htmlFor="daily">
+            <Flex alignItems="center">
+              <Text>Daily</Text>
+              <IconButton
+                size="sm"
+                icon="info-circle"
+                iconColor="gray"
+                accessibilityLabel="info"
+                tooltip={{ text: 'Sets a cap for the amount your campaign can spend each day' }}
+              />
+            </Flex>
+          </Label>
+        </Flex>
+        <Flex gap={{ row: 2, column: 0 }} alignItems="center" justifyContent="start">
+          <RadioGroup.RadioButton
+            checked={favorite === 'lifetime'}
+            id="lifetime"
+            name="budget"
+            onChange={() => setFavorite('lifetime')}
+            value="lifetime"
+          />
+          <Label htmlFor="lifetime">
+            <Flex alignItems="center">
+              <Text>Lifetime</Text>
+              <IconButton
+                size="sm"
+                icon="info-circle"
+                iconColor="gray"
+                accessibilityLabel="info"
+                tooltip={{
+                  text: 'Sets a cap for the amount your campaign can spend over the course of its lifetime',
+                }}
+              />
+            </Flex>
+          </Label>
+        </Flex>
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/legendVisibilityExample.js
+++ b/docs/examples/radiogroup/legendVisibilityExample.js
@@ -1,0 +1,51 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, Heading, Link, RadioGroup, Text } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [goal, setGoal] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex direction="column" gap={{ column: 4, row: 0 }}>
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Heading size="400">Primary company account goal</Heading>
+          <Text size="200">
+            Choose your primary goal for this account to help us better understand your needs
+            <Text inline size="200" weight="bold">
+              <Link display="inline" target="blank" href="https://www.pinterest.com/">
+                Additional information
+              </Link>
+            </Text>
+          </Text>
+        </Flex>
+        <RadioGroup legend="Primary company account goal" legendDisplay="hidden" id="legendExample">
+          <RadioGroup.RadioButton
+            checked={goal === 'sell'}
+            id="sell"
+            label="Sell more products"
+            name="account goals"
+            onChange={() => setGoal('sell')}
+            value="sell"
+          />
+          <RadioGroup.RadioButton
+            checked={goal === 'leads'}
+            id="leads"
+            label="Generate more leads for the company"
+            name="account goals"
+            onChange={() => setGoal('leads')}
+            value="leads"
+          />
+          <RadioGroup.RadioButton
+            checked={goal === 'interest'}
+            id="interest"
+            label="Create content on Pinterest to attract an audience"
+            name="account goals"
+            onChange={() => setGoal('interest')}
+            value="interest"
+          />
+        </RadioGroup>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/main.js
+++ b/docs/examples/radiogroup/main.js
@@ -6,7 +6,14 @@ export default function Example(): Node {
   const [favorite, setFavorite] = useState<void | string>();
 
   return (
-    <Box width="100%" height="100%" padding={4} display="flex" justifyContent="center">
+    <Box
+      width="100%"
+      height="100%"
+      padding={4}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
       <RadioGroup legend="Gender" id="header-example">
         <RadioGroup.RadioButton
           checked={favorite === 'Female'}

--- a/docs/examples/radiogroup/sizeExample.js
+++ b/docs/examples/radiogroup/sizeExample.js
@@ -1,0 +1,79 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, RadioGroup } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [favorite, setFavorite] = useState('');
+  const [favoriteFood, setFavoriteFood] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 0, row: 8 }}>
+        <RadioGroup
+          legend="What is your favorite snack?"
+          errorMessage="Please select one"
+          id="sizeExample"
+        >
+          <RadioGroup.RadioButton
+            checked={favorite === 'pizza'}
+            id="favoriteSizePizzaSm"
+            label="Pizza"
+            name="favoriteFoodSm"
+            onChange={() => setFavorite('pizza')}
+            value="pizza"
+            size="sm"
+          />
+          <RadioGroup.RadioButton
+            checked={favorite === 'curry'}
+            id="favoriteSizeCurrySm"
+            label="Curry"
+            name="favoriteFoodSm"
+            onChange={() => setFavorite('curry')}
+            value="curry"
+            size="sm"
+          />
+          <RadioGroup.RadioButton
+            checked={favorite === 'sushi'}
+            id="favoriteSizeSushiSm"
+            label="Sushi"
+            name="favoriteFoodSm"
+            onChange={() => setFavorite('sushi')}
+            value="sushi"
+            size="sm"
+          />
+        </RadioGroup>
+
+        <RadioGroup
+          legend="What is your favorite snack?"
+          errorMessage="Please select one"
+          id="sizeExampleMd"
+        >
+          <RadioGroup.RadioButton
+            checked={favoriteFood === 'pizza'}
+            id="favoriteSizePizza"
+            label="Pizza"
+            name="favoriteFood-size"
+            onChange={() => setFavoriteFood('pizza')}
+            value="pizza"
+          />
+          <RadioGroup.RadioButton
+            checked={favoriteFood === 'curry'}
+            id="favoriteSizeCurry"
+            label="Curry"
+            name="favoriteFood-size"
+            onChange={() => setFavoriteFood('curry')}
+            value="curry"
+          />
+          <RadioGroup.RadioButton
+            checked={favoriteFood === 'sushi'}
+            id="favoriteSizeSushi"
+            label="Sushi"
+            name="favoriteFood-size"
+            onChange={() => setFavoriteFood('sushi')}
+            value="sushi"
+          />
+        </RadioGroup>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/statesExample.js
+++ b/docs/examples/radiogroup/statesExample.js
@@ -3,7 +3,7 @@ import { type Node, useState } from 'react';
 import { Box, RadioGroup } from 'gestalt';
 
 export default function RadioButtonExample(): Node {
-  const [favorite, setFavorite] = useState('');
+  const [state, setState] = useState('checked');
 
   return (
     <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
@@ -13,15 +13,15 @@ export default function RadioButtonExample(): Node {
           id="unchecked"
           label="Unchecked"
           name="stateExample"
-          onChange={() => setFavorite('unchecked')}
+          onChange={() => setState('unchecked')}
           value="unchecked"
         />
         <RadioGroup.RadioButton
-          checked
+          checked={state === 'checked'}
           id="checked"
           label="Checked"
           name="stateExample"
-          onChange={() => setFavorite('checked')}
+          onChange={() => setState('checked')}
           value="checked"
         />
         <RadioGroup.RadioButton
@@ -29,7 +29,7 @@ export default function RadioButtonExample(): Node {
           id="uncheckedDisabled"
           label="Unchecked and disabled"
           name="stateExample"
-          onChange={() => setFavorite('uncheckedDisabled')}
+          onChange={() => setState('uncheckedDisabled')}
           value="uncheckedDisabled"
           disabled
         />
@@ -38,7 +38,7 @@ export default function RadioButtonExample(): Node {
           id="checkedDisabled"
           label="Checked and disabled"
           name="stateExample"
-          onChange={() => setFavorite('checkedDisabled')}
+          onChange={() => setState('checkedDisabled')}
           value="checkedDisabled"
           disabled
         />

--- a/docs/examples/radiogroup/statesExample.js
+++ b/docs/examples/radiogroup/statesExample.js
@@ -1,0 +1,48 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, RadioGroup } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [favorite, setFavorite] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="Which state is your favorite?" id="rowExample">
+        <RadioGroup.RadioButton
+          checked={false}
+          id="unchecked"
+          label="Unchecked"
+          name="stateExample"
+          onChange={() => setFavorite('unchecked')}
+          value="unchecked"
+        />
+        <RadioGroup.RadioButton
+          checked
+          id="checked"
+          label="Checked"
+          name="stateExample"
+          onChange={() => setFavorite('checked')}
+          value="checked"
+        />
+        <RadioGroup.RadioButton
+          checked={false}
+          id="uncheckedDisabled"
+          label="Unchecked and disabled"
+          name="stateExample"
+          onChange={() => setFavorite('uncheckedDisabled')}
+          value="uncheckedDisabled"
+          disabled
+        />
+        <RadioGroup.RadioButton
+          checked
+          id="checkedDisabled"
+          label="Checked and disabled"
+          name="stateExample"
+          onChange={() => setFavorite('checkedDisabled')}
+          value="checkedDisabled"
+          disabled
+        />
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/useToSelectOnlyOneOption.js
+++ b/docs/examples/radiogroup/useToSelectOnlyOneOption.js
@@ -1,0 +1,38 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box,RadioGroup } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [favorite, setFavorite] = useState('reading');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="If you had to pick one, which hobby would you pick?" id="bestPracticeDo">
+        <RadioGroup.RadioButton
+          checked={favorite === 'knitting'}
+          id="knitting"
+          label="Knitting"
+          name="hobby"
+          onChange={() => setFavorite('knitting')}
+          value="knitting"
+        />
+        <RadioGroup.RadioButton
+          checked={favorite === 'reading'}
+          id="reading"
+          label="Reading"
+          name="hobby"
+          onChange={() => setFavorite('reading')}
+          value="reading"
+        />
+        <RadioGroup.RadioButton
+          checked={favorite === 'pottery'}
+          id="pottery"
+          label="Pottery"
+          name="hobby"
+          onChange={() => setFavorite('pottery')}
+          value="pottery"
+        />
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/useToSelectOnlyOneOption.js
+++ b/docs/examples/radiogroup/useToSelectOnlyOneOption.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node, useState } from 'react';
-import { Box,RadioGroup } from 'gestalt';
+import { Box, RadioGroup } from 'gestalt';
 
 export default function RadioButtonExample(): Node {
   const [favorite, setFavorite] = useState('reading');

--- a/docs/examples/radiogroup/useWhenNeedClearAnswer.js
+++ b/docs/examples/radiogroup/useWhenNeedClearAnswer.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Button, Flex, RadioGroup } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [favorite, setFavorite] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Flex gap={{ column: 4, row: 0 }} direction="column">
+        <RadioGroup legend="Feed preference" id="bestPracticeFeedsDo">
+          <RadioGroup.RadioButton
+            checked={favorite === 'grid'}
+            id="grid-do"
+            label="Grid"
+            name="feed-do"
+            onChange={() => setFavorite('grid')}
+            value="grid"
+          />
+          <RadioGroup.RadioButton
+            checked={favorite === 'list'}
+            id="list-do"
+            label="List"
+            name="feed-do"
+            onChange={() => setFavorite('list')}
+            value="list"
+          />
+        </RadioGroup>
+        <Button color="red" text="Submit" />
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/withAnErrorExample.js
+++ b/docs/examples/radiogroup/withAnErrorExample.js
@@ -1,0 +1,45 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, RadioGroup } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [availability, setAvailability] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup
+        legend="Which time slot works best for you?"
+        errorMessage="Please select one"
+        id="VariantWithErrorMessage"
+      >
+        <RadioGroup.RadioButton
+          checked={availability === 'monday'}
+          id="mondayError"
+          label="Monday"
+          helperText="Morning and afternoon"
+          name="Availability with error"
+          onChange={() => setAvailability('monday')}
+          value="monday"
+        />
+        <RadioGroup.RadioButton
+          checked={availability === 'tuesday'}
+          id="tuesdayError"
+          label="Tuesday"
+          helperText="Morning, afternoon, and evening"
+          name="Availability with error"
+          onChange={() => setAvailability('tuesday')}
+          value="tuesday"
+        />
+        <RadioGroup.RadioButton
+          checked={availability === 'wednesday'}
+          id="WednesdayError"
+          label="Wednesday"
+          helperText="Evening only"
+          name="Availability with error"
+          onChange={() => setAvailability('wednesday')}
+          value="wednesday"
+        />
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/withCustomLabelsExample.js
+++ b/docs/examples/radiogroup/withCustomLabelsExample.js
@@ -1,0 +1,58 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, IconButton, Label, RadioGroup, Text } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [favorite, setFavorite] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="Campaign budget" id="bestPracticeBudget">
+        <Flex gap={{ row: 2, column: 0 }} alignItems="center">
+          <RadioGroup.RadioButton
+            checked={favorite === 'daily'}
+            id="daily-label-ex-custom"
+            name="budget-custom-label"
+            onChange={() => setFavorite('daily')}
+            value="daily"
+          />
+          <Label htmlFor="daily-label-ex-custom">
+            <Flex alignItems="center">
+              <Text>Daily</Text>
+              <IconButton
+                size="sm"
+                icon="info-circle"
+                iconColor="gray"
+                accessibilityLabel="info"
+                tooltip={{ text: 'Sets a cap for the amount your campaign can spend each day' }}
+              />
+            </Flex>
+          </Label>
+        </Flex>
+        <Flex gap={{ row: 2, column: 0 }} alignItems="center">
+          <RadioGroup.RadioButton
+            checked={favorite === 'lifetime'}
+            id="lifetime-label-ex-custom"
+            name="budget-custom-label"
+            onChange={() => setFavorite('lifetime')}
+            value="lifetime"
+          />
+          <Label htmlFor="lifetime-label-ex-custom">
+            <Flex alignItems="center">
+              <Text>Lifetime</Text>
+              <IconButton
+                size="sm"
+                icon="info-circle"
+                iconColor="gray"
+                accessibilityLabel="info"
+                tooltip={{
+                  text: 'Sets a cap for the amount your campaign can spend over the course of its lifetime',
+                }}
+              />
+            </Flex>
+          </Label>
+        </Flex>
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/withHelperTextExample.js
+++ b/docs/examples/radiogroup/withHelperTextExample.js
@@ -1,0 +1,41 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, RadioGroup } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [availability, setAvailability] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="Which time slot works best for you?" id="helperTextExample">
+        <RadioGroup.RadioButton
+          checked={availability === 'monday'}
+          id="monday"
+          label="Monday"
+          helperText="Morning and afternoon"
+          name="Availability"
+          onChange={() => setAvailability('monday')}
+          value="monday"
+        />
+        <RadioGroup.RadioButton
+          checked={availability === 'tuesday'}
+          id="tuesday"
+          label="Tuesday"
+          helperText="Morning, afternoon, and evening"
+          name="Availability"
+          onChange={() => setAvailability('tuesday')}
+          value="tuesday"
+        />
+        <RadioGroup.RadioButton
+          checked={availability === 'wednesday'}
+          id="Wednesday"
+          label="Wednesday"
+          helperText="Evening only"
+          name="Availability"
+          onChange={() => setAvailability('wednesday')}
+          value="wednesday"
+        />
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/radiogroup/withImageExample.js
+++ b/docs/examples/radiogroup/withImageExample.js
@@ -1,0 +1,74 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Image, RadioGroup } from 'gestalt';
+
+export default function RadioButtonExample(): Node {
+  const [artPreference, setArtPreference] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="Pick a placeholder image" id="imageExample">
+        <RadioGroup.RadioButton
+          checked={artPreference === 'coral'}
+          id="coral"
+          label="Coral"
+          helperText="Botanical art in coral and green"
+          image={
+            <Box height={100} width={80}>
+              <Image
+                alt="Botanical art in coral and green"
+                src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+                fit="cover"
+                naturalWidth={1}
+                naturalHeight={1}
+              />
+            </Box>
+          }
+          name="Art Preference"
+          onChange={() => setArtPreference('coral')}
+          value="coral"
+        />
+        <RadioGroup.RadioButton
+          checked={artPreference === 'blue'}
+          id="blue"
+          label="Blue"
+          helperText="Typography and shoe in blue"
+          image={
+            <Box height={100} width={80}>
+              <Image
+                alt="Typography and shoe in blue"
+                src="https://i.ibb.co/jVR29XV/stock5.jpg"
+                fit="cover"
+                naturalWidth={1}
+                naturalHeight={1}
+              />
+            </Box>
+          }
+          name="Art Preference"
+          onChange={() => setArtPreference('blue')}
+          value="blue"
+        />
+        <RadioGroup.RadioButton
+          checked={artPreference === 'green'}
+          id="green"
+          label="Green"
+          helperText="Abstract art in green"
+          image={
+            <Box height={100} width={80}>
+              <Image
+                alt="Abstract art in green"
+                src="https://i.ibb.co/FY2MKr5/stock6.jpg"
+                fit="cover"
+                naturalWidth={1}
+                naturalHeight={1}
+              />
+            </Box>
+          }
+          name="Art Preference"
+          onChange={() => setArtPreference('green')}
+          value="green"
+        />
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/examples/segmentedcontrol/defaultExample.js
+++ b/docs/examples/segmentedcontrol/defaultExample.js
@@ -1,27 +1,32 @@
 // @flow strict
 import { type Node, useState } from 'react';
-import { Box, Icon, SegmentedControl, Text } from 'gestalt';
+import { Box, Flex, Icon, SegmentedControl, Text } from 'gestalt';
 
-export default function Example(): Node {
+export default function SegmentedControlExample(): Node {
   const [itemIndex, setItemIndex] = useState(0);
+
   const items = [
     'News',
     'You',
     'Messages',
-    <Icon key="pin-icon" icon="pin" accessibilityLabel="Pin" color="default" />,
+    <Icon key="icon" icon="pin" accessibilityLabel="Pin" color="default" />,
   ];
-  const content = ['News content', 'You content', 'Messages content', 'Pins content'];
-  return (
-    <Box padding={4} height="100%">
-      <SegmentedControl
-        items={items}
-        selectedItemIndex={itemIndex}
-        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
-      />
 
-      <Box borderStyle="sm" marginTop={2} padding={6} rounding={2} height="80%">
-        <Text>{content[itemIndex]}</Text>
-      </Box>
+  const content = ['News content', 'You content', 'Messages content', 'Pins content'];
+
+  return (
+    <Box padding={8} height="100%">
+      <Flex direction="column" gap={{ column: 2, row: 0 }}>
+        <SegmentedControl
+          items={items}
+          selectedItemIndex={itemIndex}
+          onChange={({ activeIndex }) => setItemIndex(activeIndex)}
+        />
+
+        <Box borderStyle="shadow" padding={6} rounding={2}>
+          <Text>{content[itemIndex]}</Text>
+        </Box>
+      </Flex>
     </Box>
   );
 }

--- a/docs/examples/segmentedcontrol/mainExample.js
+++ b/docs/examples/segmentedcontrol/mainExample.js
@@ -1,0 +1,27 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Icon, SegmentedControl, Text } from 'gestalt';
+
+export default function Example(): Node {
+  const [itemIndex, setItemIndex] = useState(0);
+  const items = [
+    'News',
+    'You',
+    'Messages',
+    <Icon key="pin-icon" icon="pin" accessibilityLabel="Pin" color="default" />,
+  ];
+  const content = ['News content', 'You content', 'Messages content', 'Pins content'];
+  return (
+    <Box padding={4} height="100%">
+      <SegmentedControl
+        items={items}
+        selectedItemIndex={itemIndex}
+        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
+      />
+
+      <Box borderStyle="sm" marginTop={2} padding={6} rounding={2} height="80%">
+        <Text>{content[itemIndex]}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/segmentedcontrol/responsiveExample.js
+++ b/docs/examples/segmentedcontrol/responsiveExample.js
@@ -1,0 +1,38 @@
+// @flow strict
+import { type Node, useState } from 'react';
+import { Box, Flex, Heading, SegmentedControl } from 'gestalt';
+
+export default function SegmentedControlExample(): Node {
+  const [item1Index, setItem1Index] = useState(0);
+  const [item2Index, setItem2Index] = useState(0);
+  const items = ['Short', 'Really really really long title'];
+
+  return (
+    <Box padding={8}>
+      <Flex direction="column" gap={{ column: 6, row: 0 }}>
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Heading size="400">Equal widths</Heading>
+          <SegmentedControl
+            items={items}
+            onChange={({ activeIndex }) => {
+              setItem1Index(activeIndex);
+            }}
+            selectedItemIndex={item1Index}
+          />
+        </Flex>
+
+        <Flex direction="column" gap={{ column: 2, row: 0 }}>
+          <Heading size="400">Responsive widths</Heading>
+          <SegmentedControl
+            items={items}
+            onChange={({ activeIndex }) => {
+              setItem2Index(activeIndex);
+            }}
+            responsive
+            selectedItemIndex={item2Index}
+          />
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/sidenavigation/footerVariant.js
+++ b/docs/examples/sidenavigation/footerVariant.js
@@ -1,0 +1,64 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, Fieldset, Flex, SideNavigation, Text } from 'gestalt';
+import { DatePicker } from 'gestalt-datepicker';
+
+export default function Example(): Node {
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Box width="100%" height="100%">
+        <Box height="100%" width={280} overflow="scroll">
+          <SideNavigation
+            accessibilityLabel="Footer example"
+            footer={
+              <Flex direction="column" gap={{ column: 4, row: 0 }}>
+                <Text size="300" weight="bold">
+                  Filters
+                </Text>
+                <Fieldset legend="Campaign filters" legendDisplay="hidden">
+                  <Flex direction="column" gap={{ column: 4, row: 0 }}>
+                    <DatePicker
+                      id="example-start-date"
+                      label="Start"
+                      onChange={() => {}}
+                      rangeSelector="start"
+                      value={new Date()}
+                    />
+                    <DatePicker
+                      id="example-end-date"
+                      label="End"
+                      onChange={() => {}}
+                      rangeSelector="end"
+                      value={new Date(+7)}
+                    />
+                  </Flex>
+                </Fieldset>
+              </Flex>
+            }
+          >
+            <SideNavigation.Section label="Campaigns">
+              {[
+                {
+                  label: 'Active',
+                  counter: { number: '200', accessibilityLabel: '200 Pins' },
+                },
+                {
+                  label: 'Draft',
+                  counter: { number: '100', accessibilityLabel: '100 Pins' },
+                },
+              ].map(({ label, counter }) => (
+                <SideNavigation.TopItem
+                  key={label}
+                  href="#"
+                  label={label}
+                  icon="ads-stats"
+                  counter={counter}
+                />
+              ))}
+            </SideNavigation.Section>
+          </SideNavigation>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/zindex_classes/foundationalComponentsExample.js
+++ b/docs/examples/zindex_classes/foundationalComponentsExample.js
@@ -1,0 +1,226 @@
+// @flow strict
+import { Fragment, type Node, useEffect, useRef, useState } from 'react';
+import {
+  Box,
+  Button,
+  CompositeZIndex,
+  FixedZIndex,
+  Flex,
+  Image,
+  Layer,
+  Mask,
+  OverlayPanel,
+  Popover,
+  SearchField,
+  TapArea,
+  Text,
+  TextArea,
+} from 'gestalt';
+
+export default function ScrollBoundaryContainerExample(): Node {
+  const [showSheet, setShowSheet] = useState(false);
+
+  /* ======= Z-INDEX  ======= */
+  const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
+  const SHEET_ZINDEX = new CompositeZIndex([PAGE_HEADER_ZINDEX]);
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Button text="Edit Pin" onClick={() => setShowSheet(true)} size="lg" />
+
+      {showSheet && (
+        <Layer zIndex={SHEET_ZINDEX}>
+          <OverlayPanel
+            accessibilityDismissButtonLabel="Close edit Pin overlay panel"
+            accessibilityLabel="Edit your Pin details"
+            heading="Edit Pin"
+            footer={
+              <Flex>
+                <Flex.Item flex="grow">
+                  <Button
+                    color="white"
+                    text="Delete"
+                    size="lg"
+                    onClick={() => setShowSheet(false)}
+                  />
+                </Flex.Item>
+
+                <Flex gap={{ column: 0, row: 2 }}>
+                  <Button text="Cancel" size="lg" onClick={() => setShowSheet(false)} />
+
+                  <Button
+                    text="Done"
+                    color="red"
+                    size="lg"
+                    type="submit"
+                    onClick={() => setShowSheet(false)}
+                  />
+                </Flex>
+              </Flex>
+            }
+            onDismiss={() => setShowSheet(false)}
+            size="lg"
+          >
+            <Box display="flex" height={400} paddingX={8}>
+              <Flex gap={{ row: 8, column: 0 }} width="100%">
+                <Box width={200} paddingX={2} rounding={4}>
+                  <Mask rounding={4}>
+                    <Image
+                      alt="Tropic greens: The taste of Petrol and Porcelain | Interior design, Vintage Sets and Unique Pieces agave"
+                      color="rgb(231, 186, 176)"
+                      naturalHeight={751}
+                      naturalWidth={564}
+                      src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+                    />
+                  </Mask>
+                </Box>
+
+                <Flex.Item flex="grow">
+                  <Flex direction="column" gap={{ column: 8, row: 0 }}>
+                    <SelectBoard />
+
+                    <TextArea
+                      id="note"
+                      onChange={() => {}}
+                      placeholder="Add note"
+                      label="Note"
+                      value=""
+                    />
+                  </Flex>
+                </Flex.Item>
+              </Flex>
+            </Box>
+          </OverlayPanel>
+        </Layer>
+      )}
+    </Box>
+  );
+}
+
+function SelectBoard() {
+  const [openPopover, setOpenPopover] = useState(false);
+  const [selectedBoard, setSelectedBoard] = useState('Fashion');
+  const anchorRef = useRef<HTMLElement | null>(null);
+
+  const handleSelect = (data: string) => {
+    setSelectedBoard(data);
+    setOpenPopover(false);
+  };
+
+  return (
+    <Fragment>
+      <Flex direction="column" gap={{ column: 2, row: 0 }}>
+        <Text size="100">Board</Text>
+
+        <Button
+          iconEnd="arrow-down"
+          accessibilityLabel="Select Board"
+          onClick={() => setOpenPopover(!openPopover)}
+          text={selectedBoard}
+          ref={anchorRef}
+        />
+      </Flex>
+
+      {openPopover && (
+        <Layer>
+          <Popover
+            anchor={anchorRef.current}
+            idealDirection="down"
+            onDismiss={() => setOpenPopover(false)}
+            positionRelativeToAnchor={false}
+            size="xl"
+          >
+            <Box width={360}>
+              <Box flex="grow" marginEnd={4} marginStart={4} marginTop={6} marginBottom={8}>
+                <Flex direction="column" gap={{ column: 6, row: 0 }}>
+                  <Text align="center" color="default" weight="bold">
+                    Save to board
+                  </Text>
+                  <SearchBoardField />
+                </Flex>
+              </Box>
+
+              <Box height={300} overflow="scrollY">
+                <Box marginEnd={4} marginStart={4}>
+                  <Flex direction="column" gap={{ column: 8, row: 0 }}>
+                    <List title="Top choices" onSelect={handleSelect} />
+                    <List title="All boards" onSelect={handleSelect} />
+                  </Flex>
+                </Box>
+              </Box>
+            </Box>
+          </Popover>
+        </Layer>
+      )}
+    </Fragment>
+  );
+}
+
+function List({ title, onSelect }: {| title: string, onSelect: (data: string) => void |}) {
+  return (
+    <Flex direction="column" gap={{ column: 4, row: 0 }}>
+      <Text color="default" size="100">
+        {title}
+      </Text>
+
+      <Flex direction="column" gap={{ column: 4, row: 0 }}>
+        {[
+          [
+            'https://i.ibb.co/s3PRJ8v/photo-1496747611176-843222e1e57c.webp',
+            'Fashion',
+            'Thumbnail image: a white dress with red flowers',
+          ],
+          [
+            'https://i.ibb.co/swC1qpp/IMG-0494.jpg',
+            'Food',
+            'Thumbnail image: a paella with shrimp, green peas, red peppers and yellow rice',
+          ],
+          [
+            'https://i.ibb.co/PFVF3JH/photo-1583847268964-b28dc8f51f92.webp',
+            'Home',
+            'Thumbnail image: a living room with a white couch, two paints in the wall and wooden furniture',
+          ],
+        ].map((data) => (
+          <TapArea key={data[1]} onTap={() => onSelect(data[1])} rounding={2}>
+            <Flex gap={{ row: 2, column: 0 }} alignItems="center">
+              <Box height={50} width={50} overflow="hidden" rounding={2}>
+                <Mask rounding={2}>
+                  <Image
+                    alt={data[2]}
+                    color="rgb(231, 186, 176)"
+                    naturalHeight={50}
+                    naturalWidth={50}
+                    src={data[0]}
+                  />
+                </Mask>
+              </Box>
+
+              <Text align="center" color="default" weight="bold">
+                {data[1]}
+              </Text>
+            </Flex>
+          </TapArea>
+        ))}
+      </Flex>
+    </Flex>
+  );
+}
+
+function SearchBoardField() {
+  const ref = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  return (
+    <SearchField
+      accessibilityLabel="Search boards field"
+      id="searchField"
+      onChange={() => {}}
+      placeholder="Search boards"
+      size="lg"
+      ref={ref}
+    />
+  );
+}

--- a/docs/examples/zindex_classes/foundationalComponentsExample.js
+++ b/docs/examples/zindex_classes/foundationalComponentsExample.js
@@ -17,12 +17,12 @@ import {
   TextArea,
 } from 'gestalt';
 
+/* ======= Z-INDEX  ======= */
+const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
+const SHEET_ZINDEX = new CompositeZIndex([PAGE_HEADER_ZINDEX]);
+
 export default function ScrollBoundaryContainerExample(): Node {
   const [showSheet, setShowSheet] = useState(false);
-
-  /* ======= Z-INDEX  ======= */
-  const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
-  const SHEET_ZINDEX = new CompositeZIndex([PAGE_HEADER_ZINDEX]);
 
   return (
     <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">

--- a/docs/examples/zindex_classes/layerExample.js
+++ b/docs/examples/zindex_classes/layerExample.js
@@ -1,0 +1,137 @@
+// @flow strict
+import { Fragment, type Node, useState } from 'react';
+import {
+  Box,
+  Button,
+  CompositeZIndex,
+  FixedZIndex,
+  Flex,
+  Heading,
+  IconButton,
+  Image,
+  Layer,
+  Modal,
+  Text,
+  Tooltip,
+} from 'gestalt';
+
+/* ======= Z-INDEX  ======= */
+const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
+const MODAL_ZINDEX = new CompositeZIndex([PAGE_HEADER_ZINDEX]);
+
+export default function ScrollBoundaryContainerExample(): Node {
+  const [showModal, setShowModal] = useState(false);
+  const [alignText, setAlignText] = useState('forceLeft');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <Fragment>
+        <Box display="flex" justifyContent="center">
+          <Button
+            accessibilityLabel="Edit this Pin"
+            color="gray"
+            onClick={() => setShowModal(true)}
+            text="Open edit modal"
+            size="lg"
+          />
+        </Box>
+        {showModal && (
+          <Layer zIndex={MODAL_ZINDEX}>
+            <Modal
+              accessibilityModalLabel="Edit Pin"
+              heading="Edit"
+              size="lg"
+              onDismiss={() => setShowModal(false)}
+              footer={
+                <Box flex="grow" paddingX={3} paddingY={3}>
+                  <Box
+                    justifyContent="end"
+                    marginStart={-1}
+                    marginEnd={-1}
+                    marginTop={-1}
+                    marginBottom={-1}
+                    display="flex"
+                    wrap
+                  >
+                    <Box paddingX={1} paddingY={1}>
+                      <Button text="Cancel" size="lg" onClick={() => setShowModal(false)} />
+                    </Box>
+                    <Box paddingX={1} paddingY={1}>
+                      <Button
+                        text="Save"
+                        color="red"
+                        size="lg"
+                        type="submit"
+                        onClick={() => setShowModal(false)}
+                      />
+                    </Box>
+                  </Box>
+                </Box>
+              }
+            >
+              <Box column={12} display="flex" justifyContent="center">
+                <Box column={6} paddingX={4}>
+                  <Image
+                    alt="Tropic greens: The taste of Petrol and Porcelain | Interior design, Vintage Sets and Unique Pieces agave"
+                    color="rgb(231, 186, 176)"
+                    naturalHeight={751}
+                    naturalWidth={564}
+                    src="https://i.ibb.co/7bQQYkX/stock2.jpg"
+                  >
+                    <Box padding={3}>
+                      <Heading align={alignText} color="light" size="500">
+                        Tropic greens: The taste of Petrol and Porcelain
+                      </Heading>
+                    </Box>
+                  </Image>
+                </Box>
+                <Flex direction="column" gap={{ column: 4, row: 0 }}>
+                  <Heading size="400">Text Overlay</Heading>
+                  <Text size="300">Add text directly onto your Pin</Text>
+                  <Text size="300" weight="bold">
+                    Alignment
+                  </Text>
+                  <Flex>
+                    <Tooltip text="Align left">
+                      <IconButton
+                        accessibilityLabel="Align left"
+                        bgColor="white"
+                        icon="text-align-left"
+                        iconColor="darkGray"
+                        onClick={() => setAlignText('left')}
+                        size="lg"
+                        selected={alignText === 'left'}
+                      />
+                    </Tooltip>
+                    <Tooltip text="Align center">
+                      <IconButton
+                        accessibilityLabel="Align center"
+                        bgColor="white"
+                        icon="text-align-center"
+                        iconColor="darkGray"
+                        onClick={() => setAlignText('center')}
+                        size="lg"
+                        selected={alignText === 'center'}
+                      />
+                    </Tooltip>
+                    <Tooltip text="Align right">
+                      <IconButton
+                        accessibilityLabel="Align right"
+                        bgColor="white"
+                        icon="text-align-right"
+                        iconColor="darkGray"
+                        onClick={() => setAlignText('right')}
+                        size="lg"
+                        selected={alignText === 'right'}
+                      />
+                    </Tooltip>
+                  </Flex>
+                </Flex>
+              </Box>
+            </Modal>
+          </Layer>
+        )}
+      </Fragment>
+    </Box>
+  );
+}

--- a/docs/pages/web/checkbox.js
+++ b/docs/pages/web/checkbox.js
@@ -8,7 +8,24 @@ import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
+import dontUseForOneSelection from '../../examples/checkbox/dontUseForOneSelection.js';
+import dontUseNumerousInTableRows from '../../examples/checkbox/dontUseNumerousInTableRows.js';
+import dontUseToToggleState from '../../examples/checkbox/dontUseToToggleState.js';
+import dontUseTruncatedText from '../../examples/checkbox/dontUseTruncatedText.js';
+import dontVerticallyCenterInputs from '../../examples/checkbox/dontVerticallyCenterInputs.js';
+import errorMessageExample from '../../examples/checkbox/errorMessageExample.js';
+import keepLabelsAndLegendsClear from '../../examples/checkbox/keepLabelsAndLegendsClear.js';
+import labelVisibilityExample from '../../examples/checkbox/labelVisibilityExample.js';
+import legendsExample from '../../examples/checkbox/legendsExample.js';
 import main from '../../examples/checkbox/main.js';
+import sizeExample from '../../examples/checkbox/sizeExample.js';
+import stateExample from '../../examples/checkbox/stateExample.js';
+import useAtStartOfTableRow from '../../examples/checkbox/useAtStartOfTableRow.js';
+import useForMultiSelection from '../../examples/checkbox/useForMultiSelection.js';
+import useSingleInForms from '../../examples/checkbox/useSingleInForms.js';
+import useVerticalAlignment from '../../examples/checkbox/useVerticalAlignment.js';
+import withHelperTextExample from '../../examples/checkbox/withHelperTextExample.js';
+import withImageExample from '../../examples/checkbox/withImageExample.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
@@ -54,89 +71,28 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
             cardSize="md"
             type="do"
             description="Use checkboxes for multi-selection of related list items"
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
-  const [checked4, setChecked4] = React.useState(false);
-
-  return (
-    <Fieldset legend="Select what you enjoy">
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Checkbox
-          checked={checked1}
-          id="Fashion"
-          label="Fashion"
-          onChange={({ checked }) => setChecked1(checked)}
-        />
-        <Checkbox
-          checked={checked2}
-          id="Beauty"
-          label="Beauty"
-          onChange={({ checked }) => setChecked2(checked)}
-        />
-        <Checkbox
-          checked={checked3}
-          id="Interior_design"
-          label="Interior design"
-          onChange={({ checked }) => setChecked3(checked)}
-        />
-        <Checkbox
-          checked={checked4}
-          id="Other"
-          label="Other"
-          onChange={({ checked }) => setChecked4(checked)}
-        />
-      </Flex>
-    </Fieldset>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Use for multi selection"
+                code={useForMultiSelection}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Use checkboxes for one selection. Use [RadioGroup](/web/radiogroup) instead."
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
-  const [checked4, setChecked4] = React.useState(false);
-
-  return (
-    <Fieldset legend="Pick one topic from the list">
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Checkbox
-          checked={checked1}
-          id="Fashion2"
-          label="Fashion"
-          onChange={({ checked }) => setChecked1(checked)}
-        />
-        <Checkbox
-          checked={checked2}
-          id="Beauty2"
-          label="Beauty"
-          onChange={({ checked }) => setChecked2(checked)}
-        />
-        <Checkbox
-          checked={checked3}
-          id="Interior_design_3"
-          label="Interior design"
-          onChange={({ checked }) => setChecked3(checked)}
-        />
-        <Checkbox
-          checked={checked4}
-          id="Other4"
-          label="Other"
-          onChange={({ checked }) => setChecked4(checked)}
-        />
-      </Flex>
-    </Fieldset>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Don't use for one selection"
+                code={dontUseForOneSelection}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -144,61 +100,28 @@ function Example() {
             cardSize="md"
             type="do"
             description="Use a single Checkbox in forms where the selection only takes effect after submitting the form"
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-
-  return (
-    <Flex direction="column" gap={{ column: 6, row: 0 }}>
-      <TextField
-        id="name"
-        label="Name"
-        onChange={() => {}}
-        value=""
-      />
-      <TextField
-        id="email"
-        label="Email"
-        onChange={() => {}}
-        value=""
-      />
-      <Checkbox
-        checked={checked1}
-        id="terms"
-        label="I agree to the Terms and Conditions"
-        onChange={({ checked }) => setChecked1(checked)}
-      />
-      <Button
-        accessibilityLabel='Submit'
-        color="red"
-        text="Submit"
-        size="lg"
-      />
-    </Flex>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Use single in forms"
+                code={useSingleInForms}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Use a Checkbox to turn a state on and off with immediate effect. Use [Switch](/web/switch) instead."
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-
-  return (
-    <Checkbox
-      checked={checked1}
-      id="location"
-      label="Turn location tracking off"
-      helperText="Change will auto-save"
-      onChange={({ checked }) => setChecked1(checked)}
-    />
-
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Don't use to toggle state"
+                code={dontUseToToggleState}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -206,87 +129,28 @@ function Example() {
             cardSize="md"
             type="do"
             description="Keep labels and legends clear and brief to avoid too many lines of text that are hard to scan and slow the user down. If clarification is needed, use info [Tooltips](/web/tooltip) or helperText."
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
-
-  return (
-    <Flex direction="column" gap={{ column: 4, row: 0 }}>
-      <Text size={400} weight="bold">How do you like your eggs?</Text>
-      <Text>Select all the options that apply</Text>
-      <Fieldset legendDisplay="hidden" legend="How do you like your eggs? Select all the options that apply">
-        <Flex direction="column" gap={{ column: 2, row: 0 }}>
-          <Checkbox
-            checked={checked1}
-            id="Overeasy"
-            label="Overeasy"
-            onChange={({ checked }) => setChecked1(checked)}
-          />
-          <Checkbox
-            checked={checked2}
-            id="Sunny"
-            label="Sunny side up"
-            onChange={({ checked }) => setChecked2(checked)}
-          />
-          <Flex gap={{ row: 2, column: 0 }} alignItems="center">
-            <Checkbox
-              checked={checked3}
-              id="Scramboiled"
-              label="Scramboiled"
-              onChange={({ checked }) => setChecked3(checked)}
-            />
-            <Tooltip text="A hardboiled egg that is then scrambled" idealDirection="up">
-              <Icon icon="info-circle" accessibilityLabel="" size={14} color="default"/>
-            </Tooltip>
-          </Flex>
-        </Flex>
-      </Fieldset>
-    </Flex>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Keep labels and legends clear"
+                code={keepLabelsAndLegendsClear}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Use lengthy text that truncates and doesn’t offer clear instructions for what you are expected to select"
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
-
-  return (
-    <Flex direction="column" gap={{ column: 4, row: 0 }}>
-      <Text size={400} weight="bold">Which one?</Text>
-      <Fieldset legendDisplay="hidden" legend="Which one?">
-        <Flex direction="column" gap={{ column: 2, row: 0 }}>
-          <Checkbox
-            checked={checked1}
-            id="Overeasy2"
-            label="Overeasy with a touch of salt and maybe a slice of bacon on top that isn't fully cooked and has no pepper."
-            onChange={({ checked }) => setChecked1(checked)}
-          />
-          <Checkbox
-            checked={checked2}
-            id="Sunny2"
-            label="Sunny side up"
-            onChange={({ checked }) => setChecked2(checked)}
-          />
-          <Checkbox
-            checked={checked3}
-            id="Scramboiled3"
-            label="Scramboiled--this is when you boil an egg, then you scrambled it in the pan along with the shells."
-            onChange={({ checked }) => setChecked3(checked)}
-          />
-        </Flex>
-      </Fieldset>
-    </Flex>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Don't use truncated text"
+                code={dontUseTruncatedText}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -294,185 +158,28 @@ function Example() {
             cardSize="md"
             type="do"
             description="Use Checkbox at the start of a table row to make it clear which rows are multi-selectable"
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
-
-  return (
-    <Table accessibilityLabel="Campaign selection" maxHeight={200}>
-      <Table.Header sticky>
-        <Table.Row>
-          <Table.HeaderCell/>
-          <Table.HeaderCell>
-            <Text weight="bold">Name</Text>
-          </Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked1}
-                id="1"
-                onChange={({ checked }) => setChecked1(checked)}
-                size="sm"
-                label="Select Summertime picnic row"
-                labelDisplay="hidden"
+            sandpackExample={
+              <SandpackExample
+                name="Use at start of table row"
+                code={useAtStartOfTableRow}
+                layout="column"
+                hideEditor
               />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Summertime picnic</Text>
-          </Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked2}
-                id="2"
-                onChange={({ checked }) => setChecked2(checked)}
-                size="sm"
-                label="Select Summer 1950 row"
-                labelDisplay="hidden"
-              />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Summer 1950</Text>
-          </Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked3}
-                id="3"
-                onChange={({ checked }) => setChecked3(checked)}
-                size="sm"
-                label="Select Back to school row"
-                labelDisplay="hidden"
-              />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Back to school</Text>
-          </Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Use numerous checkboxes in table rows that make it hard to tell what items apply to multi-select actions"
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
-
-  return (
-    <Table accessibilityLabel="Campaign selection" maxHeight={200}>
-      <Table.Header sticky>
-        <Table.Row>
-          <Table.HeaderCell/>
-          <Table.HeaderCell>
-            <Text weight="bold">Active</Text>
-          </Table.HeaderCell>
-          <Table.HeaderCell>
-            <Text weight="bold">Name</Text>
-          </Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked1}
-                id="4"
-                onChange={({ checked }) => setChecked1(checked)}
-                size="sm"
-                label="Select Summertime picnic row"
-                labelDisplay="hidden"
+            sandpackExample={
+              <SandpackExample
+                name="Don't use numerous in table rows"
+                code={dontUseNumerousInTableRows}
+                layout="column"
+                hideEditor
+                hideControls
               />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Checkbox
-              id="5"
-              onChange={() => {}}
-              size="sm"
-              label="off"
-            />
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Summertime picnic</Text>
-          </Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked2}
-                id="6"
-                onChange={({ checked }) => setChecked2(checked)}
-                size="sm"
-                label="Select Summer 1950 row"
-                labelDisplay="hidden"
-              />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Checkbox
-              checked
-              id="7"
-              onChange={() => {}}
-              size="sm"
-              label="on"
-            />
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Summer 1950</Text>
-          </Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked3}
-                id="8"
-                onChange={({ checked }) => setChecked3(checked)}
-                size="sm"
-                label="Select Back to school row"
-                labelDisplay="hidden"
-              />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Checkbox
-              id="9"
-              onChange={() => {}}
-              size="sm"
-              label="off"
-            />
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Back to school</Text>
-          </Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -480,105 +187,28 @@ function Example() {
             cardSize="md"
             type="do"
             description="Use vertical alignment of multi-line labels so that the first line is vertically centered with the checkbox input"
-            defaultCode={`
-            function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
-
-  return (
-    <Fieldset legend="Data personalization">
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Checkbox
-          checked={checked1}
-          id="sites"
-          label="Use sites you visit to improve which recommendations and ads you see on Pinterest"
-          onChange={({ checked }) => setChecked1(checked)}
-        />
-        <Checkbox
-          checked={checked2}
-          id="partner"
-          label="Use partner info to improve which recommendations and ads you see on Pinterest"
-          onChange={({ checked }) => setChecked2(checked)}
-        />
-        <Checkbox
-          checked={checked3}
-          id="activity"
-          label="Use your activity to improve ads you see about Pinterest on other sites or apps you may visit"
-          onChange={({ checked }) => setChecked3(checked)}
-        />
-      </Flex>
-    </Fieldset>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Use vertical alignment of multi-line labels"
+                code={useVerticalAlignment}
+                layout="column"
+                hideEditor
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Vertically center checkbox inputs with their respective custom labels"
-            defaultCode={`
-            function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(false);
-  const [checked3, setChecked3] = React.useState(false);
-
-  return (
-    <Fieldset legend="Data personalization">
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Flex gap={2} alignItems="center">
-          <Checkbox
-            checked={checked1}
-            id="sites2"
-            onChange={({ checked }) => setChecked1(checked)}
-          />
-          <Text inline>
-            <Label htmlFor="sites2">
-              Use sites you visit to improve which recommendations and ads you see on Pinterest.
-            </Label>
-            <Link href="#" display="inline">
-              Learn more
-            </Link>
-          </Text>
-        </Flex>
-
-        <Flex gap={2} alignItems="center">
-          <Checkbox
-            checked={checked2}
-            id="partner2"
-            onChange={({ checked }) => setChecked2(checked)}
-          />
-          <Text inline>
-            <Label htmlFor="partner2">
-              Use partner info to improve which recommendations and ads you see on Pinterest.
-            </Label>
-            <Link href="#" display="inline">
-              Learn more
-            </Link>
-          </Text>
-        </Flex>
-
-        <Flex gap={2} alignItems="center">
-          <Checkbox
-            checked={checked3}
-            id="activity2"
-            onChange={({ checked }) => setChecked3(checked)}
-          />
-          <Text inline>
-            <Label htmlFor="activity2">
-              Use your activity to improve ads you see about Pinterest on other sites or apps you
-              may visit.
-            </Label>
-            <Link href="#" display="inline">
-              Learn more
-            </Link>
-          </Text>
-        </Flex>
-      </Flex>
-    </Fieldset>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="Don't vertically center inputs"
+                code={dontVerticallyCenterInputs}
+                layout="column"
+                hideEditor
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -598,41 +228,7 @@ If Checkbox is labeled by content elsewhere on the page, or a more complex label
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example() {
-    const [checkedEn, setCheckedEn] = React.useState(false);
-    const [checkedSp, setCheckedSp] = React.useState(false);
-    const [checkedCh, setCheckedCh] = React.useState(false);
-
-  return (
-    <Fieldset legend="What languages would you like to learn?">
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Checkbox
-          checked={checkedEn}
-          id="english"
-          label="English"
-          name="english"
-          onChange={({ checked }) => setCheckedEn(checked)}
-        />
-        <Checkbox
-          checked={checkedSp}
-          id="spanish"
-          label="Spanish"
-          name="spanish"
-          onChange={({ checked }) => setCheckedSp(checked)}
-        />
-        <Checkbox
-          checked={checkedCh}
-          id="chinese"
-          label="Chinese"
-          name="chinese"
-          onChange={({ checked }) => setCheckedCh(checked)}
-        />
-      </Flex>
-    </Fieldset>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="Legends example" code={legendsExample} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -651,19 +247,9 @@ function Example() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function CheckboxExample() {
-  return (
-      <Checkbox
-        id="error"
-        errorMessage="You must agree to the Terms and Conditions"
-        label="I agree to the Terms and Conditions"
-        name="error"
-        onChange={() => {}}
-      />
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="Error message example" code={errorMessageExample} />
+            }
           />
         </MainSection.Subsection>
       </AccessibilitySection>
@@ -679,30 +265,7 @@ function CheckboxExample() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example() {
-    const [checked1, setChecked1] = React.useState(false);
-    const [checked2, setChecked2] = React.useState(false);
-
-  return (
-    <Flex gap={{ column: 0, row: 6 }}>
-      <Checkbox
-        checked={checked1}
-        id="sm"
-        label="Small size"
-        onChange={({ checked }) => setChecked1(checked)}
-        size="sm"
-      />
-      <Checkbox
-        checked={checked2}
-        id="md"
-        label="Medium size"
-        onChange={({ checked }) => setChecked2(checked)}
-      />
-    </Flex>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="Size example" code={sizeExample} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -714,104 +277,15 @@ Indeterminate is a state that is neither checked nor unchecked — e.g. a "Selec
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example() {
-    const [checked1, setChecked1] = React.useState(false);
-    const [checked2, setChecked2] = React.useState(true);
-    const [checked3, setChecked3] = React.useState(false);
-    const [checked4, setChecked4] = React.useState(false);
-    const [checked5, setChecked5] = React.useState(false);
-
-  return (
-    <Flex gap={6} wrap>
-      <Checkbox
-        checked={false}
-        id="Unchecked"
-        label="Unchecked"
-        onChange={() => setChecked1(false)}
-      />
-      <Checkbox
-        checked={checked2}
-        id="Checked"
-        label="Checked"
-        onChange={() => setChecked2(true)}
-      />
-      <Checkbox
-        checked={checked4}
-        id="ErrorState"
-        label="Error"
-        errorMessage="error message"
-        onChange={({ checked }) => setChecked4(checked)}
-      />
-      <Checkbox
-        checked={checked3}
-        id="Indeterminate"
-        label="Indeterminate"
-        indeterminate
-        onChange={({ checked }) => setChecked3(checked)}
-      />
-      <Checkbox
-        checked={checked4}
-        id="Disabled"
-
-        label="Disabled"
-        disabled
-        onChange={({ checked }) => setChecked4(checked)}
-      />
-
-    </Flex>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="State example" code={stateExample} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection title="With helperText" description="Checkbox supports helperText">
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example() {
-    const [checkedEn, setCheckedEn] = React.useState(false);
-    const [checkedSp, setCheckedSp] = React.useState(false);
-    const [checkedCh, setCheckedCh] = React.useState(false);
-
-  return (
-    <Fieldset legend="What languages would you like to learn?">
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Checkbox
-          checked={checkedEn}
-          id="english-info"
-          label="English"
-          helperText="USA, India, and Pakistan have the top number of English speakers "
-          name="languages"
-          onChange={({ checked }) => {
-            setCheckedEn(checked);
-          }}
-        />
-        <Checkbox
-          checked={checkedSp}
-          id="spanish-info"
-          label="Spanish"
-          helperText="Mexico, Colombia, and Spain are the top three Spanish-speaking countries"
-          name="languages"
-          onChange={({ checked }) => {
-            setCheckedSp(checked);
-          }}
-        />
-        <Checkbox
-          checked={checkedCh}
-          id="chinese-info"
-          label="Chinese"
-          helperText="Chinese has many varieties, including Cantonese and Mandarin"
-          name="languages"
-          onChange={({ checked }) => {
-            setCheckedCh(checked);
-          }}
-        />
-      </Flex>
-    </Fieldset>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="With helperText example" code={withHelperTextExample} />
+            }
           />
         </MainSection.Subsection>
 
@@ -823,41 +297,7 @@ Spacing is already accounted for; simply specify the width and height.`}
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function CheckboxExample() {
-    const [checkedCoral, setCheckedCoral] = React.useState(false);
-    const [checkedBlue, setCheckedBlue] = React.useState(false);
-
-  return (
-    <Fieldset legend="Which backgrounds would you like to use?" legendDisplay="hidden">
-      <Flex direction="column" gap={{ column: 4, row: 0 }}>
-        <Checkbox
-          checked={checkedCoral}
-          id="coral"
-          label="Coral"
-          helperText="Botanical art in coral and green"
-          image={<Box height={100} width={80}><Image alt="Botanical art in coral and green" src="https://i.ibb.co/7bQQYkX/stock2.jpg" fit="contain" naturalWidth={1} naturalHeight={1}/></Box>}
-          name="favorite art"
-          onChange={({ checked }) => {
-            setCheckedCoral(checked);
-          }}
-        />
-        <Checkbox
-          checked={checkedBlue}
-          id="blue"
-          label="Blue"
-          helperText="Typography and shoe in blue"
-          image={<Box height={100} width={80}><Image alt="Typography and shoe in blue" src="https://i.ibb.co/jVR29XV/stock5.jpg" fit="contain" naturalWidth={1} naturalHeight={1}/></Box>}
-          name="favorite art"
-          onChange={({ checked }) => {
-            setCheckedBlue(checked);
-          }}
-        />
-      </Flex>
-    </Fieldset>
-  );
-}
-`}
+            sandpackExample={<SandpackExample name="With image example" code={withImageExample} />}
           />
         </MainSection.Subsection>
 
@@ -867,79 +307,9 @@ function CheckboxExample() {
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function Example() {
-  const [checked1, setChecked1] = React.useState(false);
-  const [checked2, setChecked2] = React.useState(true);
-  const [checked3, setChecked3] = React.useState(true);
-
-  return (
-    <Table accessibilityLabel="Campaign selection" maxHeight={200}>
-      <Table.Header sticky>
-        <Table.Row>
-          <Table.HeaderCell/>
-          <Table.HeaderCell>
-            <Text weight="bold">Name</Text>
-          </Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked1}
-                id="label-visibility-example-checkbox-1"
-                onChange={({ checked }) => setChecked1(checked)}
-                label="Select Summertime picnic row"
-                labelDisplay="hidden"
-                size="sm"
-              />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Summertime picnic</Text>
-          </Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked2}
-                id="label-visibility-example-checkbox-2"
-                onChange={({ checked }) => setChecked2(checked)}
-                label="Select Summer 1950 row"
-                labelDisplay="hidden"
-                size="sm"
-              />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Summer 1950</Text>
-          </Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>
-            <Box width={20}>
-              <Checkbox
-                checked={checked3}
-                id="label-visibility-example-checkbox-3"
-                onChange={({ checked }) => setChecked3(checked)}
-                label="Select Back to school row"
-                labelDisplay="hidden"
-                size="sm"
-              />
-            </Box>
-          </Table.Cell>
-          <Table.Cell>
-            <Text>Back to school</Text>
-          </Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample name="Label visibility example" code={labelVisibilityExample} />
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/web/radiogroup.js
+++ b/docs/pages/web/radiogroup.js
@@ -7,7 +7,22 @@ import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
+import addingAPopoverExample from '../../examples/radiogroup/addingAPopoverExample.js';
+import directionExample from '../../examples/radiogroup/directionExample.js';
+import dontUseToSelectMultipleItems from '../../examples/radiogroup/dontUseToSelectMultipleItems.js';
+import dontUseToToggleStateOnMobile from '../../examples/radiogroup/dontUseToToggleStateOnMobile.js';
+import dontUseTruncatedText from '../../examples/radiogroup/dontUseTruncatedText.js';
+import keepLabelsAndLegendsClear from '../../examples/radiogroup/keepLabelsAndLegendsClear.js';
+import legendVisibilityExample from '../../examples/radiogroup/legendVisibilityExample.js';
 import main from '../../examples/radiogroup/main.js';
+import sizeExample from '../../examples/radiogroup/sizeExample.js';
+import statesExample from '../../examples/radiogroup/statesExample.js';
+import useToSelectOnlyOneOption from '../../examples/radiogroup/useToSelectOnlyOneOption.js';
+import useWhenNeedClearAnswer from '../../examples/radiogroup/useWhenNeedClearAnswer.js';
+import withAnErrorExample from '../../examples/radiogroup/withAnErrorExample.js';
+import withCustomLabelsExample from '../../examples/radiogroup/withCustomLabelsExample.js';
+import withHelperTextExample from '../../examples/radiogroup/withHelperTextExample.js';
+import withImageExample from '../../examples/radiogroup/withImageExample.js';
 
 export default function DocsPage({
   generatedDocGen,
@@ -73,79 +88,28 @@ export default function DocsPage({
             cardSize="md"
             type="do"
             description="Use RadioGroup to select only one option from a list of 2 or more items."
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState('reading');
-
-  return (
-      <RadioGroup legend="If you had to pick one, which hobby would you pick?" id="bestPracticeDo">
-        <RadioGroup.RadioButton
-          checked={favorite === 'knitting'}
-          id="knitting"
-          label="Knitting"
-          name="hobby"
-          onChange={() => setFavorite('knitting')}
-          value="knitting"
-        />
-        <RadioGroup.RadioButton
-          checked={favorite === 'reading'}
-          id="reading"
-          label="Reading"
-          name="hobby"
-          onChange={() => setFavorite('reading')}
-          value="reading"
-        />
-        <RadioGroup.RadioButton
-          checked={favorite === 'pottery'}
-          id="pottery"
-          label="Pottery"
-          name="hobby"
-          onChange={() => setFavorite('pottery')}
-          value="pottery"
-        />
-      </RadioGroup>
-  );
-}
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Use to select only one option"
+                code={useToSelectOnlyOneOption}
+                hideEditor
+                layout="column"
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Use RadioGroup to select multiple items."
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState();
-
-  return (
-      <RadioGroup legend="Choose all of your favorite hobbies" id="bestPracticeDont">
-        <RadioGroup.RadioButton
-          checked={false}
-          id="knitting-dont"
-          label="Knitting"
-          name="hobby-dont"
-          onChange={() => setFavorite('knitting')}
-          value="knitting"
-        />
-        <RadioGroup.RadioButton
-          checked={false}
-          id="reading-dont"
-          label="Reading"
-          name="hobby-dont"
-          onChange={() => setFavorite('reading')}
-          value="reading"
-        />
-        <RadioGroup.RadioButton
-          checked={false}
-          id="pottery-dont"
-          label="Pottery"
-          name="hobby-dont"
-          onChange={() => setFavorite('pottery')}
-          value="pottery"
-        />
-      </RadioGroup>
-  );
-}
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Don't use to select multiple items"
+                code={dontUseToSelectMultipleItems}
+                hideEditor
+                layout="column"
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -153,77 +117,28 @@ function RadioButtonExample() {
             cardSize="md"
             type="do"
             description="Keep labels and legends clear and brief to avoid too many lines of text that are hard to scan and slow the user down. If clarification is needed, use [IconButtons with Tooltips](/web/iconbutton#With-Tooltip) or `helperText`."
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState();
-
-  return (
-      <RadioGroup legend="Campaign budget" id="bestPracticeBudget">
-        <Flex gap={{ row: 2, column: 0 }} alignItems="center" justifyContent="start">
-          <RadioGroup.RadioButton
-            checked={favorite === "daily"}
-            id="daily"
-            name="budget"
-            onChange={() => setFavorite('daily')}
-            value="daily"
-          />
-          <Label htmlFor="daily">
-            <Flex alignItems="center">
-              <Text>Daily</Text>
-              <IconButton size="sm" icon="info-circle" iconColor="gray" accessibilityLabel="info" tooltip={{text: "Sets a cap for the amount your campaign can spend each day"}}/>
-            </Flex>
-          </Label>
-        </Flex>
-        <Flex gap={{ row: 2, column: 0 }} alignItems="center" justifyContent="start">
-          <RadioGroup.RadioButton
-            checked={favorite === "lifetime"}
-            id="lifetime"
-            name="budget"
-            onChange={() => setFavorite('lifetime')}
-            value="lifetime"
-          />
-          <Label htmlFor="lifetime">
-            <Flex alignItems="center">
-              <Text>Lifetime</Text>
-              <IconButton size="sm" icon="info-circle" iconColor="gray" accessibilityLabel="info" tooltip={{text: "Sets a cap for the amount your campaign can spend over the course of its lifetime"}}/>
-            </Flex>
-          </Label>
-        </Flex>
-      </RadioGroup>
-  );
-}
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Keep labels and legends clear"
+                code={keepLabelsAndLegendsClear}
+                hideEditor
+                layout="column"
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Use lengthy text that truncates and doesn’t offer clear instructions for how to make a selection."
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState();
-
-  return (
-      <RadioGroup legend="Campaign budget" id="bestPracticeLabelsDont">
-        <RadioGroup.RadioButton
-          checked={false}
-          id="daily-dont"
-          label="Daily-Daily spend limit. Choose this option to set a cap for the amount your campaign can spend each day."
-          name="spend-dont"
-          onChange={() => setFavorite('daily')}
-          value="daily"
-        />
-        <RadioGroup.RadioButton
-          checked={false}
-          id="lifetime-dont"
-          label="Lifetime-Lifetime spend limit. Choose this option to seta a cap for the amount your campaign can spend over the course of its lifetime."
-          name="spend-dont"
-          onChange={() => setFavorite('lifetime')}
-          value="lifetime"
-        />
-      </RadioGroup>
-  );
-}
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Don't use truncated text"
+                code={dontUseTruncatedText}
+                hideEditor
+                layout="column"
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection columns={2}>
@@ -231,74 +146,28 @@ function RadioButtonExample() {
             cardSize="md"
             type="do"
             description="Use RadioGroup when you need a clear answer to a binary question that requires form submission."
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState();
-
-  return (
-    <Flex gap={{ column: 4, row: 0 }} direction="column">
-      <RadioGroup legend="Feed preference" id="bestPracticeFeedsDo">
-        <RadioGroup.RadioButton
-          checked={favorite === "grid"}
-          id="grid-do"
-          label="Grid"
-          name="feed-do"
-          onChange={() => setFavorite('grid')}
-          value="grid"
-        />
-        <RadioGroup.RadioButton
-          checked={favorite === "list"}
-          id="list-do"
-          label="List"
-          name="feed-do"
-          onChange={() => setFavorite('list')}
-          value="list"
-        />
-      </RadioGroup>
-      <Button color="red" text="Submit"/>
-    </Flex>
-  );
-}
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Use when need clear answer to a binary question"
+                code={useWhenNeedClearAnswer}
+                hideEditor
+                layout="column"
+              />
+            }
           />
           <MainSection.Card
             cardSize="md"
             type="don't"
             description="Use a RadioGroup to turn a state on and off with immediate effect on mobile; use [Switch](/web/switch) instead."
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState();
-
-  return (
-    <Flex gap={{ column: 4, row: 0 }} direction="column">
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Text size="400" weight="bold">Auto-renew subscription</Text>
-        <Text size="200">
-          Change will auto-save
-        </Text>
-      </Flex>
-      <RadioGroup direction="row" legend="Auto-renew subscription" legendDisplay="hidden" id="bestPracticeFeedsDont">
-        <RadioGroup.RadioButton
-          checked={false}
-          id="on-dont"
-          label="On"
-          name="feed-dont"
-          onChange={() => setFavorite('on')}
-          value="on"
-        />
-        <RadioGroup.RadioButton
-          checked={false}
-          id="Off-do"
-          label="Off"
-          name="feed-dont"
-          onChange={() => setFavorite('Off')}
-          value="Off"
-        />
-      </RadioGroup>
-      </Flex>
-  );
-}
-        `}
+            sandpackExample={
+              <SandpackExample
+                name="Don't use to toggle state on mobile"
+                code={dontUseToToggleStateOnMobile}
+                hideEditor
+                layout="column"
+                hideControls
+              />
+            }
           />
         </MainSection.Subsection>
       </MainSection>
@@ -327,70 +196,7 @@ function RadioButtonExample() {
           description="RadioGroups can be shown in a column or row by specifying the `direction` property."
         >
           <MainSection.Card
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState();
-  const [favoriteFood, setFavoriteFood] = React.useState();
-
-  return (
-    <Flex gap={8} wrap>
-      <RadioGroup legend="What is your favorite pet?" id="directionExample-1">
-        <RadioGroup.RadioButton
-          checked={favorite === 'dogs'}
-          id="favoriteDog"
-          label="Dogs"
-          name="favorite"
-          onChange={() => setFavorite('dogs')}
-          value="dogs"
-        />
-        <RadioGroup.RadioButton
-          checked={favorite === 'cats'}
-          id="favoriteCat"
-          label="Cats"
-          name="favorite"
-          onChange={() => setFavorite('cats')}
-          value="cats"
-        />
-        <RadioGroup.RadioButton
-          checked={favorite === 'plants'}
-          id="favoritePlants"
-          label="Plants"
-          name="favorite"
-          onChange={() => setFavorite('plants')}
-          value="plants"
-        />
-      </RadioGroup>
-
-      <RadioGroup legend="What is your favorite snack?" errorMessage="Please select one" direction="row" id="directionExample">
-        <RadioGroup.RadioButton
-          checked={favoriteFood === 'pizza'}
-          id="favoritePizza"
-          label="Pizza"
-          name="favoriteFood"
-          onChange={() => setFavoriteFood('pizza')}
-          value="pizza"
-        />
-        <RadioGroup.RadioButton
-          checked={favoriteFood === 'curry'}
-          id="favoriteCurry"
-          label="Curry"
-          name="favoriteFood"
-          onChange={() => setFavoriteFood('curry')}
-          value="curry"
-        />
-        <RadioGroup.RadioButton
-          checked={favoriteFood === 'sushi'}
-          id="favoriteSushi"
-          label="Sushi"
-          name="favoriteFood"
-          onChange={() => setFavoriteFood('sushi')}
-          value="sushi"
-        />
-      </RadioGroup>
-    </Flex>
-  );
-}
-          `}
+            sandpackExample={<SandpackExample name="Direction example" code={directionExample} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -398,73 +204,7 @@ function RadioButtonExample() {
           description="RadioButtons can be either `sm` (16px) or `md` (24px), which is the default."
         >
           <MainSection.Card
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState();
-  const [favoriteFood, setFavoriteFood] = React.useState();
-
-  return (
-    <Flex gap={{ column: 0, row: 8 }}>
-      <RadioGroup legend="What is your favorite snack?" errorMessage="Please select one" id="sizeExample">
-        <RadioGroup.RadioButton
-          checked={favorite === 'pizza'}
-          id="favoriteSizePizzaSm"
-          label="Pizza"
-          name="favoriteFoodSm"
-          onChange={() => setFavorite('pizza')}
-          value="pizza"
-          size="sm"
-        />
-        <RadioGroup.RadioButton
-          checked={favorite === 'curry'}
-          id="favoriteSizeCurrySm"
-          label="Curry"
-          name="favoriteFoodSm"
-          onChange={() => setFavorite('curry')}
-          value="curry"
-          size="sm"
-        />
-        <RadioGroup.RadioButton
-          checked={favorite === 'sushi'}
-          id="favoriteSizeSushiSm"
-          label="Sushi"
-          name="favoriteFoodSm"
-          onChange={() => setFavorite('sushi')}
-          value="sushi"
-          size="sm"
-        />
-      </RadioGroup>
-
-      <RadioGroup legend="What is your favorite snack?" errorMessage="Please select one" id="sizeExampleMd">
-        <RadioGroup.RadioButton
-          checked={favoriteFood === 'pizza'}
-          id="favoriteSizePizza"
-          label="Pizza"
-          name="favoriteFood-size"
-          onChange={() => setFavoriteFood('pizza')}
-          value="pizza"
-        />
-        <RadioGroup.RadioButton
-          checked={favoriteFood === 'curry'}
-          id="favoriteSizeCurry"
-          label="Curry"
-          name="favoriteFood-size"
-          onChange={() => setFavoriteFood('curry')}
-          value="curry"
-        />
-        <RadioGroup.RadioButton
-          checked={favoriteFood === 'sushi'}
-          id="favoriteSizeSushi"
-          label="Sushi"
-          name="favoriteFood-size"
-          onChange={() => setFavoriteFood('sushi')}
-          value="sushi"
-        />
-      </RadioGroup>
-    </Flex>
-  );
-}
-        `}
+            sandpackExample={<SandpackExample name="Size example" code={sizeExample} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -472,50 +212,7 @@ function RadioButtonExample() {
           description="Disabled RadioButtons cannot be accessed by the keyboard and therefore should not contain any necessary info to complete the choice presented."
         >
           <MainSection.Card
-            defaultCode={`
-function RadioButtonExample() {
-  const [favorite, setFavorite] = React.useState();
-
-  return (
-      <RadioGroup legend="Which state is your favorite?" id="rowExample">
-        <RadioGroup.RadioButton
-          checked={false}
-          id="unchecked"
-          label="Unchecked"
-          name="stateExample"
-          onChange={() => setFavorite('unchecked')}
-          value="unchecked"
-        />
-        <RadioGroup.RadioButton
-          checked={true}
-          id="checked"
-          label="Checked"
-          name="stateExample"
-          onChange={() => setFavorite('checked')}
-          value="checked"
-        />
-        <RadioGroup.RadioButton
-          checked={false}
-          id="uncheckedDisabled"
-          label="Unchecked and disabled"
-          name="stateExample"
-          onChange={() => setFavorite('uncheckedDisabled')}
-          value="uncheckedDisabled"
-          disabled
-        />
-        <RadioGroup.RadioButton
-          checked={true}
-          id="checkedDisabled"
-          label="Checked and disabled"
-          name="stateExample"
-          onChange={() => setFavorite('checkedDisabled')}
-          value="checkedDisabled"
-          disabled
-        />
-      </RadioGroup>
-  );
-}
-        `}
+            sandpackExample={<SandpackExample name="States example" code={statesExample} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -523,43 +220,9 @@ function RadioButtonExample() {
           description="Use `helperText` to provide extra context or information for each option."
         >
           <MainSection.Card
-            defaultCode={`
-function RadioButtonExample() {
-  const [availability, setAvailability] = React.useState();
-
-  return (
-    <RadioGroup legend="Which time slot works best for you?" id="helperTextExample">
-        <RadioGroup.RadioButton
-          checked={availability === 'monday'}
-          id="monday"
-          label="Monday"
-          helperText="Morning and afternoon"
-          name="Availability"
-          onChange={() => setAvailability('monday')}
-          value="monday"
-        />
-        <RadioGroup.RadioButton
-          checked={availability === 'tuesday'}
-          id="tuesday"
-          label="Tuesday"
-          helperText="Morning, afternoon, and evening"
-          name="Availability"
-          onChange={() => setAvailability('tuesday')}
-          value="tuesday"
-        />
-        <RadioGroup.RadioButton
-          checked={availability === 'wednesday'}
-          id="Wednesday"
-          label="Wednesday"
-          helperText="Evening only"
-          name="Availability"
-          onChange={() => setAvailability('wednesday')}
-          value="wednesday"
-        />
-    </RadioGroup>
-  );
-}
-        `}
+            sandpackExample={
+              <SandpackExample name="With helperText example" code={withHelperTextExample} />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -567,47 +230,13 @@ function RadioButtonExample() {
           description="When including images, you can use the `helperText` property to clearly describe the information being presented by the image, or use the image's `alt` text to provide more context."
         >
           <MainSection.Card
-            defaultCode={`
-function RadioButtonExample() {
-  const [artPreference, setArtPreference] = React.useState();
-
-  return (
-    <RadioGroup legend="Pick a placeholder image" id="imageExample">
-      <RadioGroup.RadioButton
-        checked={artPreference === 'coral'}
-        id="coral"
-        label="Coral"
-        helperText="Botanical art in coral and green"
-        image={<Box height={100} width={80}><Image alt="Botanical art in coral and green" src="https://i.ibb.co/7bQQYkX/stock2.jpg" fit="cover" naturalWidth={1} naturalHeight={1}/></Box>}
-
-        name="Art Preference"
-        onChange={() => setArtPreference('coral')}
-        value="coral"
-      />
-      <RadioGroup.RadioButton
-        checked={artPreference === 'blue'}
-        id="blue"
-        label="Blue"
-        helperText="Typography and shoe in blue"
-        image={<Box height={100} width={80}><Image alt="Typography and shoe in blue" src="https://i.ibb.co/jVR29XV/stock5.jpg" fit="cover" naturalWidth={1} naturalHeight={1}/></Box>}
-        name="Art Preference"
-        onChange={() => setArtPreference('blue')}
-        value="blue"
-      />
-      <RadioGroup.RadioButton
-        checked={artPreference === 'green'}
-        id="green"
-        label="Green"
-        helperText="Abstract art in green"
-        image={<Box height={100} width={80}><Image alt="Abstract art in green" src="https://i.ibb.co/FY2MKr5/stock6.jpg" fit="cover" naturalWidth={1} naturalHeight={1}/></Box>}
-        name="Art Preference"
-        onChange={() => setArtPreference('green')}
-        value="green"
-      />
-    </RadioGroup>
-  );
-}
-`}
+            sandpackExample={
+              <SandpackExample
+                name="With image example"
+                code={withImageExample}
+                previewHeight={400}
+              />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -615,43 +244,9 @@ function RadioButtonExample() {
           description="Use `errorMessage` to show an error message below the radio options."
         >
           <MainSection.Card
-            defaultCode={`
-function RadioButtonExample() {
-  const [availability, setAvailability] = React.useState();
-
-  return (
-    <RadioGroup legend="Which time slot works best for you?" errorMessage="Please select one" id="VariantWithErrorMessage">
-        <RadioGroup.RadioButton
-          checked={availability === 'monday'}
-          id="mondayError"
-          label="Monday"
-          helperText="Morning and afternoon"
-          name="Availability with error"
-          onChange={() => setAvailability('monday')}
-          value="monday"
-        />
-        <RadioGroup.RadioButton
-          checked={availability === 'tuesday'}
-          id="tuesdayError"
-          label="Tuesday"
-          helperText="Morning, afternoon, and evening"
-          name="Availability with error"
-          onChange={() => setAvailability('tuesday')}
-          value="tuesday"
-        />
-        <RadioGroup.RadioButton
-          checked={availability === 'wednesday'}
-          id="WednesdayError"
-          label="Wednesday"
-          helperText="Evening only"
-          name="Availability with error"
-          onChange={() => setAvailability('wednesday')}
-          value="wednesday"
-        />
-    </RadioGroup>
-  );
-}
-          `}
+            sandpackExample={
+              <SandpackExample name="With an error example" code={withAnErrorExample} />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -659,46 +254,9 @@ function RadioButtonExample() {
           description="The `label` on RadioGroup.RadioButton can be replaced with a custom [Label](/web/label), as demonstrated below. Ensure the `htmlFor` property matches the `id` on the RadioButton."
         >
           <MainSection.Card
-            defaultCode={`
-        function RadioButtonExample() {
-          const [favorite, setFavorite] = React.useState();
-
-          return (
-              <RadioGroup legend="Campaign budget" id="bestPracticeBudget">
-                <Flex gap={{ row: 2, column: 0 }} alignItems="center">
-                  <RadioGroup.RadioButton
-                    checked={favorite === "daily"}
-                    id="daily-label-ex-custom"
-                    name="budget-custom-label"
-                    onChange={() => setFavorite('daily')}
-                    value="daily"
-                  />
-                  <Label htmlFor="daily-label-ex-custom">
-                    <Flex alignItems="center">
-                      <Text>Daily</Text>
-                      <IconButton size="sm" icon="info-circle" iconColor="gray" accessibilityLabel="info" tooltip={{text: "Sets a cap for the amount your campaign can spend each day"}}/>
-                    </Flex>
-                  </Label>
-                </Flex>
-                <Flex gap={{ row: 2, column: 0 }} alignItems="center">
-                  <RadioGroup.RadioButton
-                    checked={favorite === "lifetime"}
-                    id="lifetime-label-ex-custom"
-                    name="budget-custom-label"
-                    onChange={() => setFavorite('lifetime')}
-                    value="lifetime"
-                  />
-                  <Label htmlFor="lifetime-label-ex-custom">
-                    <Flex alignItems="center">
-                      <Text>Lifetime</Text>
-                      <IconButton size="sm" icon="info-circle" iconColor="gray" accessibilityLabel="info" tooltip={{text: "Sets a cap for the amount your campaign can spend over the course of its lifetime"}}/>
-                    </Flex>
-                  </Label>
-                </Flex>
-              </RadioGroup>
-          );
-        }
-                `}
+            sandpackExample={
+              <SandpackExample name="With custom labels example" code={withCustomLabelsExample} />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -710,53 +268,9 @@ function RadioButtonExample() {
         `}
         >
           <MainSection.Card
-            defaultCode={`
-function RadioButtonExample() {
-  const [goal, setGoal] = React.useState();
-
-  return (
-    <Flex direction="column" gap={{ column: 4, row: 0 }}>
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Heading size="400">Primary company account goal</Heading>
-        <Text size="200">
-          Choose your primary goal for this account to help us better understand your needs
-          <Text inline size="200" weight="bold">
-            <Link display="inline" target="blank" href="https://www.pinterest.com/">
-              Additional information
-            </Link>
-          </Text>
-        </Text>
-      </Flex>
-      <RadioGroup legend="Primary company account goal" legendDisplay="hidden" id="legendExample">
-        <RadioGroup.RadioButton
-          checked={goal === "sell"}
-          id="sell"
-          label="Sell more products"
-          name="account goals"
-          onChange={() => setGoal('sell')}
-          value="sell"
-        />
-        <RadioGroup.RadioButton
-          checked={goal === "leads"}
-          id="leads"
-          label="Generate more leads for the company"
-          name="account goals"
-          onChange={() => setGoal('leads')}
-          value="leads"
-        />
-        <RadioGroup.RadioButton
-          checked={goal === "interest"}
-          id="interest"
-          label="Create content on Pinterest to attract an audience"
-          name="account goals"
-          onChange={() => setGoal('interest')}
-          value="interest"
-        />
-      </RadioGroup>
-    </Flex>
-  );
-}
-        `}
+            sandpackExample={
+              <SandpackExample name="Legend visibility example" code={legendVisibilityExample} />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -766,77 +280,9 @@ function RadioButtonExample() {
   `}
         >
           <MainSection.Card
-            defaultCode={`
-
-function RadioButtonPopoverExample() {
-  const [open, setOpen] = React.useState(false);
-  const [option, setOption] = React.useState(false);
-  const anchorCatRef = React.useRef();
-  const anchorDogRef = React.useRef();
-
-  return (
-    <RadioGroup legend="Tell us about yourself" id="popoverExample">
-      <Box display="inlineBlock" ref={anchorCatRef}>
-        <RadioGroup.RadioButton
-          id="cat"
-          checked={option === "cat"}
-          label="I'm a cat person"
-          onChange={() => {
-            setOpen(true)
-            setOption("cat")}
-          }
-          value="cat"
-        />
-      </Box>
-      <Box display="inlineBlock" ref={anchorDogRef}>
-        <RadioGroup.RadioButton
-          id="dog"
-          checked={option === "dog"}
-          label="I'm a dog person"
-          onChange={() => {
-            setOpen(true)
-            setOption('dog')}
-          }
-          value="dog"
-        />
-      </Box>
-      {open &&
-        <Layer>
-          <Popover
-            anchor={option === "cat" ? anchorCatRef.current  : anchorDogRef.current}
-            idealDirection="right"
-            onDismiss={() => setOpen(false)}
-            positionRelativeToAnchor={false}
-            shouldFocus={false}
-            size="md"
-          >
-            <Box padding={3}>
-              <Text
-                color="default"
-              >
-                <Link
-                  href={
-                    option === "cat"
-                      ? "https://www.pinterest.com/search/pins/?q=cats"
-                      : "https://www.pinterest.com/search/pins/?q=dogs"
-                  }
-                  target='blank'
-                  underline="always"
-                >
-                  { option === "cat"
-                      ? "Check out cats on Pinterest!"
-                      : "Check out dogs on Pinterest!"
-                  }
-                </Link>
-              </Text>
-            </Box>
-          </Popover>
-        </Layer>
-      }
-    </RadioGroup>
-  );
-}
-          `}
+            sandpackExample={
+              <SandpackExample name="Adding a popover example" code={addingAPopoverExample} />
+            }
           />
         </MainSection.Subsection>
       </MainSection>

--- a/docs/pages/web/segmentedcontrol.js
+++ b/docs/pages/web/segmentedcontrol.js
@@ -2,7 +2,6 @@
 import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
-import Example from '../../docs-components/Example.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
@@ -10,12 +9,14 @@ import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
 import defaultExample from '../../examples/segmentedcontrol/defaultExample.js';
+import mainExample from '../../examples/segmentedcontrol/mainExample.js';
+import responsiveExample from '../../examples/segmentedcontrol/responsiveExample.js';
 
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="SegmentedControl">
       <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
-        <SandpackExample code={defaultExample} name="SegmentedControl Main Example" hideEditor />
+        <SandpackExample code={mainExample} name="SegmentedControl Main Example" hideEditor />
       </PageHeader>
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
@@ -45,84 +46,21 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <AccessibilitySection name={generatedDocGen?.displayName} />
 
       <MainSection name="Variants">
-        <Example
+        <MainSection.Card
+          cardSize="lg"
           description="Segmented Control is a naive component, meaning you need to wire any additional behavior when the user clicks on an item.
 
     If you'd like the tabs to control hiding or showing content, that state should
     live in a parent component.
     "
-          name="Example"
-          defaultCode={`
-function SegmentedControlExample() {
-  const [itemIndex, setItemIndex] = React.useState(0);
-
-  const items = [
-    'News',
-    'You',
-    'Messages',
-    <Icon
-      icon="pin"
-      accessibilityLabel="Pin"
-      color="default"
-    />,
-  ];
-
-  const content = [
-    'News content',
-    'You content',
-    'Messages content',
-    'Pins content',
-  ];
-
-  return (
-    <Flex direction="column" gap={{ column: 2, row: 0 }}>
-      <SegmentedControl
-        items={items}
-        selectedItemIndex={itemIndex}
-        onChange={({ activeIndex }) => setItemIndex(activeIndex)}
-      />
-
-      <Box borderStyle="shadow" padding={6} rounding={2}>
-        <Text>{content[itemIndex]}</Text>
-      </Box>
-    </Flex>
-  );
-}
-    `}
+          title="Default"
+          sandpackExample={<SandpackExample name="Default Example" code={defaultExample} />}
         />
-        <Example
+        <MainSection.Card
+          cardSize="lg"
           description="Segmented Control can have responsive widths where the width of an item is based on its content."
-          name="Example: Responsive"
-          defaultCode={`
-function SegmentedControlExample() {
-  const [item1Index, setItem1Index] = React.useState(0);
-  const [item2Index, setItem2Index] = React.useState(0);
-  const items = ['Short', 'Really really really long title'];
-
-  return (
-    <Flex direction="column" gap={{ column: 6, row: 0 }}>
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Heading size="400">Equal widths</Heading>
-        <SegmentedControl
-        items={items}
-        onChange={({ activeIndex }) => { setItem1Index(activeIndex); }}
-        selectedItemIndex={item1Index}
-        />
-      </Flex>
-
-      <Flex direction="column" gap={{ column: 2, row: 0 }}>
-        <Heading size="400">Responsive widths</Heading>
-        <SegmentedControl
-        items={items}
-        onChange={({ activeIndex }) => { setItem2Index(activeIndex); }}
-        responsive
-        selectedItemIndex={item2Index}
-        />
-      </Flex>
-    </Flex>
-  );
-}
-    `}
+          title="Responsive"
+          sandpackExample={<SandpackExample name="Responsive Example" code={responsiveExample} />}
         />
       </MainSection>
 

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -17,6 +17,7 @@ import correctIconExample from '../../examples/sidenavigation/correctIconExample
 import correctLengthExample from '../../examples/sidenavigation/correctLengthExample.js';
 import counterExample from '../../examples/sidenavigation/counterExample.js';
 import customIconsExample from '../../examples/sidenavigation/customIconsExample.js';
+import footerVariant from '../../examples/sidenavigation/footerVariant.js';
 import headerExample from '../../examples/sidenavigation/headerExample.js';
 import iconsExample from '../../examples/sidenavigation/iconsExample.js';
 import incorrectGroupingExample from '../../examples/sidenavigation/incorrectGroupingExample.js';
@@ -302,60 +303,7 @@ export default function SideNavigationPage({
           description="Footers allow for filters, additional external links or other UI controls to be included at the bottom of the navigation."
         >
           <MainSection.Card
-            defaultCode={`
-<Box width="100%" height="100%">
-  <Box height="100%" width={280} overflow="scroll">
-    <SideNavigation
-      accessibilityLabel="Footer example"
-      footer={
-        <Flex direction="column" gap={{ column: 4, row: 0 }}>
-          <Text size="300" weight="bold">
-            Filters
-          </Text>
-          <Fieldset legend="Campaign filters" legendDisplay="hidden">
-            <Flex direction="column" gap={{ column: 4, row: 0 }}>
-              <DatePicker
-                id="example-start-date"
-                label="Start"
-                onChange={() => {}}
-                rangeSelector="start"
-                value={new Date()}
-              />
-              <DatePicker
-                id="example-end-date"
-                label="End"
-                onChange={() => {}}
-                rangeSelector="end"
-                value={new Date(+7)}
-              />
-            </Flex>
-          </Fieldset>
-        </Flex>
-      }
-    >
-      <SideNavigation.Section label="Campaigns">
-        {[
-          {
-            label: 'Active',
-            counter: { number: '200', accessibilityLabel: '200 Pins' },
-          },
-          {
-            label: 'Draft',
-            counter: { number: '100', accessibilityLabel: '100 Pins' },
-          },
-        ].map(({ label, counter }, idx) => (
-          <SideNavigation.TopItem
-            key={idx}
-            href="#"
-            label={label}
-            icon="ads-stats"
-            counter={counter}
-          />
-        ))}
-      </SideNavigation.Section>
-    </SideNavigation>
-  </Box>
-</Box>`}
+            sandpackExample={<SandpackExample name="Footer Variant Example" code={footerVariant} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -376,14 +324,15 @@ export default function SideNavigationPage({
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Icons"
-          columns={2}
           description="Icons are used when simple, clear icons help users with scanning the content of a menu. Only supported in SideNavigation.TopItem and SideNavigation.Group."
         >
           <MainSection.Card
+            cardSize="lg"
             title="Gestalt icon"
             sandpackExample={<SandpackExample code={iconsExample} name="Icons example" />}
           />
           <MainSection.Card
+            cardSize="lg"
             title="Custom icon"
             sandpackExample={
               <SandpackExample code={customIconsExample} name="Custom icon example" />

--- a/docs/pages/web/zindex_classes.js
+++ b/docs/pages/web/zindex_classes.js
@@ -5,6 +5,9 @@ import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
 import QualityChecklist from '../../docs-components/QualityChecklist.js';
+import SandpackExample from '../../docs-components/SandpackExample.js';
+import foundationalComponentsExample from '../../examples/zindex_classes/foundationalComponentsExample.js';
+import layerExample from '../../examples/zindex_classes/layerExample.js';
 
 export default function DocsPage(): Node {
   return (
@@ -288,207 +291,14 @@ The following example sets a z-index in the Layer wrapping [OverlayPanel](/web/o
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ScrollBoundaryContainerExample() {
-  const [showSheet, setShowSheet] = React.useState(false);
-  const [open, setOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState(null);
-  const anchorDropdownRef = React.useRef(null);
-  const handleSelect = ({ item }) => setSelected(item);
-
-  /* ======= Z-INDEX  ======= */
-  const PAGE_HEADER_ZINDEX = new FixedZIndex(10)
-  const SHEET_ZINDEX = new CompositeZIndex([PAGE_HEADER_ZINDEX])
-
-  const SearchBoardField = () => {
-    const ref = React.useRef();
-
-    React.useEffect(() => {
-      ref.current.focus();
-    }, []);
-
-    return (
-      <SearchField
-        accessibilityLabel="Search boards field"
-        id="searchField"
-        onChange={() => {}}
-        placeholder="Search boards"
-        size="lg"
-        ref={ref}
-      />
-    )
-  }
-
-  const SelectBoard = () => {
-    const [openPopover, setOpenPopover] = React.useState(false);
-    const [selectedBoard, setSelectedBoard] = React.useState('Fashion');
-    const anchorRef = React.useRef();
-
-    const List = ({ title }) => (
-      <Flex direction="column" gap={{ column: 4, row: 0 }}>
-        <Text color="default" size="100">
-          { title }
-        </Text>
-        <Flex direction="column" gap={{ column: 4, row: 0 }}>
-          {[
-            ['https://i.ibb.co/s3PRJ8v/photo-1496747611176-843222e1e57c.webp', 'Fashion', 'Thumbnail image: a white dress with red flowers'],
-            ['https://i.ibb.co/swC1qpp/IMG-0494.jpg', 'Food', 'Thumbnail image: a paella with shrimp, green peas, red peppers and yellow rice'],
-            ['https://i.ibb.co/PFVF3JH/photo-1583847268964-b28dc8f51f92.webp', 'Home', 'Thumbnail image: a living room with a white couch, two paints in the wall and wooden furniture'],
-          ].map((data, index) => (
-              <TapArea
-                key={index}
-                onTap={() => {
-                  setSelectedBoard(data[1]);
-                  setOpenPopover(false);
-                }}
-                rounding={2}
-              >
-                <Flex gap={{ row: 2, column: 0 }} alignItems="center">
-                  <Box height={50} width={50} overflow="hidden" rounding={2}>
-                    <Mask rounding={2}>
-                      <Image
-                        alt={data[2]}
-                        color="rgb(231, 186, 176)"
-                        naturalHeight={50}
-                        naturalWidth={50}
-                        src={data[0]}
-                      />
-                    </Mask>
-                  </Box>
-                  <Text align="center" color="default" weight="bold">
-                    {data[1]}
-                  </Text>
-                </Flex>
-              </TapArea>
-          ))}
-        </Flex>
-      </Flex>
-    );
-
-    return (
-      <React.Fragment>
-          <Flex direction="column" gap={{ column: 2, row: 0 }}>
-            <Text size="100">Board</Text>
-            <Button
-              iconEnd="arrow-down"
-              label="Select Board"
-              onClick={() => setOpenPopover(!openPopover)}
-              text={selectedBoard}
-              ref={anchorRef}
-            />
-          </Flex>
-        {openPopover && (
-          <Layer>
-            <Popover
-              anchor={anchorRef.current}
-              idealDirection="down"
-              onDismiss={() => setOpenPopover(false)}
-              positionRelativeToAnchor={false}
-              size="xl"
-            >
-              <Box width={360}>
-                <Box flex="grow" marginEnd={4} marginStart={4} marginTop={6} marginBottom={8}>
-                  <Flex direction="column" gap={{ column: 6, row: 0 }}>
-                    <Text align="center" color="default" weight="bold">
-                      Save to board
-                    </Text>
-                    <SearchBoardField/>
-                  </Flex>
-                </Box>
-                <Box height={300} overflow="scrollY">
-                  <Box marginEnd={4} marginStart={4}>
-                    <Flex direction="column" gap={{ column: 8, row: 0 }}>
-                      <List title="Top choices"/>
-                      <List title="All boards"/>
-                    </Flex>
-                  </Box>
-                </Box>
-              </Box>
-            </Popover>
-          </Layer>
-        )}
-      </React.Fragment>
-    )
-  }
-
-  return (
-    <React.Fragment>
-      <Button
-        text="Edit Pin"
-        onClick={() => setShowSheet(true)}
-        size="lg"
-      />
-      {showSheet && (
-        <Layer zIndex={SHEET_ZINDEX}>
-          <OverlayPanel
-            accessibilityDismissButtonLabel="Close edit Pin overlay panel"
-            accessibilitySheetLabel="Edit your Pin details"
-            heading="Edit Pin"
-            footer={
-                <Flex>
-                  <Flex.Item
-                    flex="grow"
-                  >
-                    <Button
-                      color="white"
-                      text="Delete"
-                      size="lg"
-                      onClick={() => setShowSheet(false)}
-                    />
-                  </Flex.Item>
-                  <Flex gap={{ column: 0, row: 2 }}>
-                    <Button
-                      text="Cancel"
-                      size="lg"
-                      onClick={() => setShowSheet(false)}
-                    />
-                    <Button
-                      text="Done"
-                      color="red"
-                      size="lg"
-                      type="submit"
-                      onClick={() => setShowSheet(false)}
-                    />
-                  </Flex>
-                </Flex>
+            sandpackExample={
+              <SandpackExample
+                name="z-index in foundational components"
+                code={foundationalComponentsExample}
+                previewHeight={400}
+                layout="column"
+              />
             }
-            onDismiss={() => setShowSheet(false)}
-            size="lg"
-          >
-            <Box display="flex" height={400} paddingX={8}>
-              <Flex gap={{ row: 8, column: 0 }} width="100%">
-                <Box width={200} paddingX={2} rounding={4}>
-                  <Mask rounding={4}>
-                    <Image
-                      alt="Tropic greens: The taste of Petrol and Porcelain | Interior design, Vintage Sets and Unique Pieces agave"
-                      color="rgb(231, 186, 176)"
-                      naturalHeight={751}
-                      naturalWidth={564}
-                      src="https://i.ibb.co/7bQQYkX/stock2.jpg"
-                    />
-                  </Mask>
-                </Box>
-                <Flex.Item flex="grow">
-                  <Flex direction="column" gap={{ column: 8, row: 0 }}>
-                    <SelectBoard/>
-                    <TextArea
-                      id="note"
-                      onChange={() => {}}
-                      placeholder="Add note"
-                      label="Note"
-                      value=""
-                    />
-                  </Flex>
-                </Flex.Item>
-              </Flex>
-              </Box>
-          </OverlayPanel>
-        </Layer>
-      )}
-    </React.Fragment>
-  )
-}
-`}
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -504,148 +314,14 @@ The following example sets a z-index in the Layer wrapping [Modal](/web/modal) t
         >
           <MainSection.Card
             cardSize="lg"
-            defaultCode={`
-function ScrollBoundaryContainerExample() {
-  const [showModal, setShowModal] = React.useState(false);
-  const [alignText, setAlignText] = React.useState('left')
-
-  /* ======= Z-INDEX  ======= */
-  const PAGE_HEADER_ZINDEX = new FixedZIndex(10)
-  const MODAL_ZINDEX = new CompositeZIndex([PAGE_HEADER_ZINDEX])
-
-  return (
-    <>
-      <Box
-        display="flex"
-        justifyContent="center"
-      >
-        <Button
-          accessibilityLabel="Edit this Pin"
-          bgColor="white"
-          onClick={() => setShowModal(true)}
-          text="Open edit modal"
-          size="lg"
-        />
-      </Box>
-      {showModal && (
-        <Layer zIndex={MODAL_ZINDEX}>
-          <Modal
-            accessibilityModalLabel="Edit Pin"
-            heading="Edit"
-            size="lg"
-            onDismiss={() => setShowModal(false)}
-            footer={
-              <Box
-                flex="grow"
-                paddingX={3}
-                paddingY={3}
-              >
-                <Box
-                  justifyContent="end"
-                  marginStart={-1}
-                  marginEnd={-1}
-                  marginTop={-1}
-                  marginBottom={-1}
-                  display="flex"
-                  wrap
-                >
-                  <Box
-                    paddingX={1}
-                    paddingY={1}
-                  >
-                    <Button
-                      text="Cancel"
-                      size="lg"
-                      onClick={() => setShowModal(false)}
-                    />
-                  </Box>
-                  <Box
-                    paddingX={1}
-                    paddingY={1}
-                  >
-                    <Button
-                      text="Save"
-                      color="red"
-                      size="lg"
-                      type="submit"
-                      onClick={() => setShowModal(false)}
-                    />
-                  </Box>
-                </Box>
-              </Box>
+            sandpackExample={
+              <SandpackExample
+                name="z-index in Layer"
+                code={layerExample}
+                previewHeight={400}
+                layout="column"
+              />
             }
-          >
-              <Box
-                column={12}
-                display="flex"
-                justifyContent="center"
-              >
-                <Box column={6} paddingX={4}>
-                  <Image
-                    alt="Tropic greens: The taste of Petrol and Porcelain | Interior design, Vintage Sets and Unique Pieces agave"
-                    color="rgb(231, 186, 176)"
-                    naturalHeight={751}
-                    naturalWidth={564}
-                    src="https://i.ibb.co/7bQQYkX/stock2.jpg"
-                  >
-                    <Box padding={3}>
-                      <Heading
-                        align={alignText}
-                        color="white"
-                        size="lg"
-                      >
-                        Tropic greens: The taste of Petrol and Porcelain
-                      </Heading>
-                    </Box>
-                  </Image>
-                </Box>
-                <Flex direction="column" gap={{ column: 4, row: 0 }}>
-                  <Heading size="400" weight="bold">Text Overlay</Heading>
-                  <Text size="300">Add text directly onto your Pin</Text>
-                  <Text size="300" weight="bold">Alignment</Text>
-                  <Flex>
-                    <Tooltip text="Align left">
-                      <IconButton
-                        accessibilityLabel="Align left"
-                        bgColor="white"
-                        icon="text-align-left"
-                        iconColor="darkGray"
-                        onClick={() => setAlignText('left')}
-                        size="lg"
-                        selected={alignText === 'left'}
-                      />
-                    </Tooltip>
-                    <Tooltip text="Align center">
-                      <IconButton
-                        accessibilityLabel="Align center"
-                        bgColor="white"
-                        icon="text-align-center"
-                        iconColor="darkGray"
-                        onClick={() => setAlignText('center')}
-                        size="lg"
-                        selected={alignText === 'center'}
-                      />
-                    </Tooltip>
-                    <Tooltip text="Align right">
-                      <IconButton
-                        accessibilityLabel="Align right"
-                        bgColor="white"
-                        icon="text-align-right"
-                        iconColor="darkGray"
-                        onClick={() => setAlignText('right')}
-                        size="lg"
-                        selected={alignText === 'right'}
-                      />
-                    </Tooltip>
-                  </Flex>
-                </Flex>
-            </Box>
-          </Modal>
-        </Layer>
-      )}
-    </>
-  )
-}`}
           />{' '}
         </MainSection.Subsection>
         <MainSection.Subsection


### PR DESCRIPTION
### Summary

Migrated the examples of below components to Sandpack:
 - CheckBox
 - RadioGroup
 - ZIndex classes
 - SegmentedControl
 
 - +1 Example of SideNavigation

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6291)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [n/a] Added unit and Flow Tests
- [n/a] Added documentation + accessibility tests
- [n/a] Verified accessibility: keyboard & screen reader interaction
- [n/a] Checked dark mode, responsiveness, and right-to-left support
- [n/a] Checked stakeholder feedback (e.g. Gestalt designers)
