### PR TITLE
Text: Swap word-break property

### DIFF
--- a/docs/examples/text/variantOverflowTruncation.js
+++ b/docs/examples/text/variantOverflowTruncation.js
@@ -4,7 +4,7 @@ import { Box, Flex, Text } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Flex alignItems="center" justifyContent="center" width="100%" height="100%">
+    <Flex justifyContent="center" width="100%" height="100%">
       <Flex direction="column" gap={{ column: 2, row: 0 }} width={200}>
         <Text>breakWord (default):</Text>
         <Box color="secondary" padding={2} rounding={2}>

--- a/packages/gestalt/src/Typography.css
+++ b/packages/gestalt/src/Typography.css
@@ -75,7 +75,8 @@
 /* overflow */
 
 .breakWord {
-  word-break: break-word;
+  /* Use word-wrap internally as a result of existing usage (e.g. Instances of Text can break with word-break. E.g TileData) */
+  word-wrap: break-word;
 }
 
 .breakAll {


### PR DESCRIPTION
### Summary

#### What changed?

Use CSS property of `word-wrap` instead of `word-break` for word break. This is how it was before.

#### Why?

Our old word-break property and the new one seems to create a difference.  Likely this case: [Read here](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap). It's hard to catch these cases since we don't know the width of where text is used. Rather not break things

This breaks TileData. It happens on a case-by-case basis. Likely due to width of container that could be handled differently:
<img width="416" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/180a7b4f-1865-4744-8756-46b93841eb38">


The usage of `Text` is the same.
```
 <Text size={size === 'lg' ? '500' : '400'} weight="bold" color={textColor}>
          {value}
          <AccessibilityPause />
        </Text>
```

Swapping to the previous seems to work

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
