### PR TITLE
Upsell: Update default backgrounds for elevationRaised

### DIFF
--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import styles from './ActivationCard.css';
 import Box from './Box.js';
 import Button from './Button.js';
+import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider.js';
 import Icon from './Icon.js';
 import IconButton from './IconButton.js';
@@ -231,12 +232,15 @@ export default function ActivationCard({
   const isCompleted = status === 'complete';
   const { accessibilityDismissButtonLabel } = useDefaultLabelContext('ActivationCard');
 
+  const { name: colorSchemeName } = useColorScheme();
+  const isDarkMode = colorSchemeName === 'darkMode';
+
   return (
     <Box
       display="flex"
       flex="grow"
       borderStyle="shadow"
-      color="elevationFloating"
+      color={isDarkMode ? 'elevationFloating' : 'default'}
       rounding={4}
       padding={6}
       maxWidth={400}

--- a/packages/gestalt/src/Module.js
+++ b/packages/gestalt/src/Module.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type Element, type Node } from 'react';
 import Box from './Box.js';
+import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import Flex from './Flex.js';
 import IconButton from './IconButton.js';
 import icons from './icons/index.js';
@@ -64,8 +65,17 @@ export default function Module({
   title,
   type = 'info',
 }: Props): Node {
+  const { name: colorSchemeName } = useColorScheme();
+  const isDarkMode = colorSchemeName === 'darkMode';
+
   return (
-    <Box borderStyle="shadow" color="elevationFloating" id={id} padding={6} rounding={4}>
+    <Box
+      borderStyle="shadow"
+      color={isDarkMode ? 'elevationFloating' : 'default'}
+      id={id}
+      padding={6}
+      rounding={4}
+    >
       <Flex direction="column" gap={{ column: 6, row: 0 }}>
         {title && (
           <ModuleTitle

--- a/packages/gestalt/src/ModuleExpandable.js
+++ b/packages/gestalt/src/ModuleExpandable.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type Element, Fragment, type Node, useCallback, useEffect, useState } from 'react';
 import Box from './Box.js';
+import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import Divider from './Divider.js';
 import IconButton from './IconButton.js';
 import icons from './icons/index.js';
@@ -65,6 +66,9 @@ export default function ModuleExpandable({
 }: Props): Node {
   const [expandedId, setExpandedId] = useState<?number>(getExpandedId(expandedIndex));
 
+  const { name: colorSchemeName } = useColorScheme();
+  const isDarkMode = colorSchemeName === 'darkMode';
+
   useEffect(() => {
     setExpandedId(getExpandedId(expandedIndex));
   }, [expandedIndex, setExpandedId]);
@@ -81,7 +85,7 @@ export default function ModuleExpandable({
   );
 
   return (
-    <Box borderStyle="shadow" color="elevationFloating" rounding={4}>
+    <Box borderStyle="shadow" color={isDarkMode ? 'elevationFloating' : 'default'} rounding={4}>
       {items.map(
         (
           { badge, children, icon, iconAccessibilityLabel, iconButton, summary, title, type },

--- a/packages/gestalt/src/Upsell.js
+++ b/packages/gestalt/src/Upsell.js
@@ -200,7 +200,7 @@ export default function Upsell({
   return (
     <Box
       borderStyle="shadow"
-      color="elevationFloating"
+      color={isDarkMode ? 'elevationFloating' : 'default'}
       display="flex"
       direction="column"
       smDirection="row"

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<ActivationCard /> Needs attention ActivationCard 1`] = `
 <div
-  className="box elevationFloating flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box default flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
@@ -69,7 +69,7 @@ exports[`<ActivationCard /> Needs attention ActivationCard 1`] = `
 
 exports[`<ActivationCard /> Not started ActivationCard 1`] = `
 <div
-  className="box elevationFloating flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box default flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
@@ -119,7 +119,7 @@ exports[`<ActivationCard /> Not started ActivationCard 1`] = `
 
 exports[`<ActivationCard /> Pending ActivationCard 1`] = `
 <div
-  className="box elevationFloating flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box default flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
@@ -186,7 +186,7 @@ exports[`<ActivationCard /> Pending ActivationCard 1`] = `
 
 exports[`<ActivationCard /> complete ActivationCard 1`] = `
 <div
-  className="box elevationFloating flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box default flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
@@ -247,7 +247,7 @@ exports[`<ActivationCard /> complete ActivationCard 1`] = `
 
 exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
 <div
-  className="box elevationFloating flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box default flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
@@ -406,7 +406,7 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
 
 exports[`<ActivationCard /> message + title + link 1`] = `
 <div
-  className="box elevationFloating flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box default flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",
@@ -516,7 +516,7 @@ exports[`<ActivationCard /> message + title + link 1`] = `
 
 exports[`<ActivationCard /> message + title 1`] = `
 <div
-  className="box elevationFloating flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
+  className="box default flexGrow justifyCenter paddingX6 paddingY6 relative rounding4 shadow xsDirectionColumn xsDisplayFlex"
   style={
     Object {
       "height": "100%",

--- a/packages/gestalt/src/__snapshots__/Module.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Module.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Module renders a badge correctly 1`] = `
 <div
-  className="box elevationFloating paddingX6 paddingY6 rounding4 shadow"
+  className="box default paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
@@ -91,7 +91,7 @@ exports[`Module renders a badge correctly 1`] = `
 
 exports[`Module renders a title correctly 1`] = `
 <div
-  className="box elevationFloating paddingX6 paddingY6 rounding4 shadow"
+  className="box default paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
@@ -134,7 +134,7 @@ exports[`Module renders a title correctly 1`] = `
 
 exports[`Module renders an error correctly 1`] = `
 <div
-  className="box elevationFloating paddingX6 paddingY6 rounding4 shadow"
+  className="box default paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
@@ -205,7 +205,7 @@ exports[`Module renders an error correctly 1`] = `
 
 exports[`Module renders an icon button correctly 1`] = `
 <div
-  className="box elevationFloating paddingX6 paddingY6 rounding4 shadow"
+  className="box default paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
@@ -308,7 +308,7 @@ exports[`Module renders an icon button correctly 1`] = `
 
 exports[`Module renders an icon correctly 1`] = `
 <div
-  className="box elevationFloating paddingX6 paddingY6 rounding4 shadow"
+  className="box default paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
@@ -379,7 +379,7 @@ exports[`Module renders an icon correctly 1`] = `
 
 exports[`Module renders content correctly 1`] = `
 <div
-  className="box elevationFloating paddingX6 paddingY6 rounding4 shadow"
+  className="box default paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div
@@ -400,7 +400,7 @@ exports[`Module renders content correctly 1`] = `
 
 exports[`Module renders the base correctly 1`] = `
 <div
-  className="box elevationFloating paddingX6 paddingY6 rounding4 shadow"
+  className="box default paddingX6 paddingY6 rounding4 shadow"
   id="module-test"
 >
   <div

--- a/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ModuleExpandable.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Module Expandable renders correctly with multiple items 1`] = `
 <div
-  className="box elevationFloating rounding4 shadow"
+  className="box default rounding4 shadow"
 >
   <div
     className="box paddingX6 paddingY6"
@@ -388,7 +388,7 @@ exports[`Module Expandable renders correctly with multiple items 1`] = `
 
 exports[`Module Expandable renders correctly with one item 1`] = `
 <div
-  className="box elevationFloating rounding4 shadow"
+  className="box default rounding4 shadow"
 >
   <div
     className="box paddingX6 paddingY6"
@@ -542,7 +542,7 @@ exports[`Module Expandable renders correctly with one item 1`] = `
 
 exports[`renders correctly with multiple items with expandedId 1`] = `
 <div
-  className="box elevationFloating rounding4 shadow"
+  className="box default rounding4 shadow"
 >
   <div
     className="box paddingX6 paddingY6"

--- a/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Upsell.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Upsell /> Basic Upsell 1`] = `
 <div
-  className="box elevationFloating paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+  className="box default paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
     className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
@@ -40,7 +40,7 @@ exports[`<Upsell /> Basic Upsell 1`] = `
 
 exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
 <div
-  className="box elevationFloating paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+  className="box default paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
     className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
@@ -251,7 +251,7 @@ exports[`<Upsell /> message + title + dismissButton + image + form 1`] = `
 
 exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] = `
 <div
-  className="box elevationFloating paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+  className="box default paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
     className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
@@ -422,7 +422,7 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton + image 1`] 
 
 exports[`<Upsell /> message + title + primaryAction + dismissButton 1`] = `
 <div
-  className="box elevationFloating paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+  className="box default paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
     className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
@@ -561,7 +561,7 @@ exports[`<Upsell /> message + title + primaryAction + dismissButton 1`] = `
 
 exports[`<Upsell /> message + title + primaryAction + secondaryAction 1`] = `
 <div
-  className="box elevationFloating paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+  className="box default paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
     className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
@@ -690,7 +690,7 @@ exports[`<Upsell /> message + title + primaryAction + secondaryAction 1`] = `
 
 exports[`<Upsell /> message + title + primaryAction with href 1`] = `
 <div
-  className="box elevationFloating paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+  className="box default paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
     className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
@@ -780,7 +780,7 @@ exports[`<Upsell /> message + title + primaryAction with href 1`] = `
 
 exports[`<Upsell /> message + title + primaryAction without href 1`] = `
 <div
-  className="box elevationFloating paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+  className="box default paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
     className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"
@@ -860,7 +860,7 @@ exports[`<Upsell /> message + title + primaryAction without href 1`] = `
 
 exports[`<Upsell /> message + title 1`] = `
 <div
-  className="box elevationFloating paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
+  className="box default paddingX12 paddingY6 relative rounding4 shadow smDirectionRow smPaddingX8 smPaddingY8 xsDirectionColumn xsDisplayFlex"
 >
   <div
     className="box flexWrap smDisplayFlex smMarginBottomN3 smMarginTopN3"


### PR DESCRIPTION
### Summary

Changing:
- Module, ModuleExpandable
- Upsell,
- ActivationCard

These use `elevationRaised` in light mode. But the bg is `transparent` and this causes the bg color to take place. In most cases, we want "white". In dark mode, we do want the elevationRaised as expected.

Before:
<img width="869" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/774b2499-5599-4642-9aec-bcc9610fe102">

After:
<img width="756" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/e4a76b06-4ae7-41a5-ab07-96ec9819a426">


#### What changed?

From a high level, what are the changes this PR introduces? (No need to recount line-by-line, we can see that.)

[See thread](https://pinterest.slack.com/archives/C13KLG5P0/p1693241098556749)

We may change elevationRaised in the future

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
