### PR TITLE
ComboBox: Fix Bottom Rendering

### DIFF
--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -501,6 +501,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
             onDismiss={handleOnDismiss}
             positionRelativeToAnchor={false}
             size="flexible"
+            key={suggestedOptions.length}
           >
             <Box
               aria-expanded={showOptionsList}


### PR DESCRIPTION
### Summary

Re-draw the combobox popover when the number of items change

#### What changed?
Before:
<img width="427" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/9f46465e-0f23-41da-afff-6b1b4dc8fbe9">

After:
<img width="443" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/1f89286a-88d2-4503-90db-d910aa3c6798">

#### Why?

[Fixes this customer bug](https://jira.pinadmin.com/browse/GESTALT-6876)


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
