### PR TITLE
TableOfContents: Show maker only for active or hovered item

### DIFF
--- a/docs/docs-components/Toc.js
+++ b/docs/docs-components/Toc.js
@@ -205,7 +205,8 @@ export default function Toc({ cards }: Props): Node {
       mdMarginTop={-6}
       lgMarginTop={-8}
       maxHeight={`calc(100% - ${HEADER_HEIGHT_PX}px - ${FOOTER_HEIGHT_PX}px)`}
-      overflow="auto"
+      overflow="visible"
+      paddingX={1}
       paddingY={8} // re-apply just the padding we need
       position="fixed"
       role="navigation"

--- a/packages/gestalt/src/TableOfContents/TableOfContentsAnchor.js
+++ b/packages/gestalt/src/TableOfContents/TableOfContentsAnchor.js
@@ -28,16 +28,10 @@ type Props = {|
 
 export default function TableOfContentsAnchor({ label, active, href, onClick }: Props): Node {
   const { nestedLevel } = useNesting();
-  const {
-    handleOnFocus,
-    handleOnBlur,
-    handleOnMouseEnter,
-    handleOnMouseLeave,
-    isFocused,
-    isHovered,
-  } = useInteractiveStates();
-  const hasMarker = active || isFocused || isHovered;
-  const markerColor = active || isFocused ? 'inverse' : 'tertiary';
+  const { handleOnFocus, handleOnBlur, handleOnMouseEnter, handleOnMouseLeave, isHovered } =
+    useInteractiveStates();
+  const hasMarker = active || isHovered;
+  const markerColor = active ? 'inverse' : 'tertiary';
   const nestingPadding = NESTING_MARGIN_START_MAP[nestedLevel];
   const nestingFontSize = nestedLevel === 1 ? '300' : '200';
 
@@ -54,7 +48,7 @@ export default function TableOfContentsAnchor({ label, active, href, onClick }: 
       rounding={2}
     >
       <Flex>
-        <Box minWidth={4} color={hasMarker ? markerColor : 'default'} rounding="pill" />
+        <Box minWidth={4} color={hasMarker ? markerColor : 'transparent'} rounding="pill" />
         <div
           className={classNames(styles.item, Layout.flexGrow, {
             [Colors.secondary]: isHovered,

--- a/packages/gestalt/src/__snapshots__/TableOfContents.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TableOfContents.test.js.snap
@@ -182,7 +182,7 @@ exports[`TableOfContents renders nested items 1`] = `
           className="Flex rowGap0 columnGap0 xsDirectionRow"
         >
           <div
-            className="box default pill"
+            className="box pill"
             style={
               Object {
                 "minWidth": 4,
@@ -286,7 +286,7 @@ exports[`TableOfContents renders nested items 1`] = `
               className="Flex rowGap0 columnGap0 xsDirectionRow"
             >
               <div
-                className="box default pill"
+                className="box pill"
                 style={
                   Object {
                     "minWidth": 4,
@@ -403,7 +403,7 @@ exports[`TableOfContents renders without title 1`] = `
           className="Flex rowGap0 columnGap0 xsDirectionRow"
         >
           <div
-            className="box default pill"
+            className="box pill"
             style={
               Object {
                 "minWidth": 4,


### PR DESCRIPTION
### Summary

Removed logic for displaying marker when `TableOfContents.Item` is focused without active or hovered state.

#### Why?

`TableOfContents.Item` should have marker only in active or hovered state.

Before:
![image (1)](https://github.com/pinterest/gestalt/assets/29589560/f56c1eea-3bd3-4bf9-be0d-bef376a9a239)

After:
![Screenshot 2023-08-30 at 15 59 56](https://github.com/pinterest/gestalt/assets/29589560/4ed46299-8137-4371-b36c-757d8943d6e4)



### Checklist

- [x] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
