### PR TITLE
Docs: Fix ToC overflow

### DIFF
--- a/docs/docs-components/Toc.js
+++ b/docs/docs-components/Toc.js
@@ -205,7 +205,7 @@ export default function Toc({ cards }: Props): Node {
       mdMarginTop={-6}
       lgMarginTop={-8}
       maxHeight={`calc(100% - ${HEADER_HEIGHT_PX}px - ${FOOTER_HEIGHT_PX}px)`}
-      overflow="visible"
+      overflow="auto"
       paddingX={1}
       paddingY={8} // re-apply just the padding we need
       position="fixed"


### PR DESCRIPTION
### Summary

Fixed a bug caused by previous change. Overflow rule for ToC component was set wrong.