### PR TITLE
Tooltip: Move to Internal Tooltip with a disabled state

### DIFF
--- a/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.js
+++ b/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.js
@@ -83,55 +83,55 @@ function ItemIconButton({
     : new FixedZIndex(1);
   const dropdownZIndex = new CompositeZIndex([tooltipZIndex]);
   return (
-    /* Interactive elements require an a11yLabel on them or their children. That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */
-    <TapArea
-      accessibilityControls={id}
-      accessibilityExpanded={open}
-      accessibilityLabel={tooltip?.accessibilityLabel ?? tooltip.text}
-      onMouseEnter={() => {
-        setCompression('none');
-        setHovered(true);
-      }}
-      onMouseLeave={() => {
-        setCompression('compress');
-        setHovered(false);
-      }}
-      onFocus={() => {
-        setFocused(true);
-        setShowIconButton('show');
-      }}
-      onBlur={() => {
-        setFocused(false);
-        // With keyboard navigation, we want to hide IconButton if we keep tabbing without opening Dropdown
-        // However, Dropdown captures focus, therefore, as soon as it opens could hide IconButton and unmount itself, never displaying
-        // We prevent this by disabling this action until Dropdown gets dismissed and unselects IconButton
-        if (typeof selected === 'undefined' || forceIconButton === 'default') {
-          setShowIconButton('hide');
-        }
-      }}
-      onTap={({ event }) => {
-        // We need event.stopPropagation(); so the SideNavigation.TopItem's onClick doesn't get trigger as well
-        event.stopPropagation();
-        // As soon as IconButton gets clicked, we force its display, only if selected === false.
-        // We don't force if selected ===  undefined, which would indicate there's no Dropdown associated, just an action
-        if (selected === false) {
-          setForceIconButton?.('force');
-        }
-
-        if (selected !== undefined) {
-          setSelected((value) => !value);
-          setOpen((value) => !value);
-        }
-
-        onClick?.({ event });
-      }}
-      ref={innerRef}
-      rounding="circle"
-      tapStyle="compress"
+    <MaybeTooltip
+      disabled={open}
+      tooltip={{ text: tooltip.text, accessibilityLabel: '', zIndex: tooltipZIndex }}
     >
-      <MaybeTooltip
-        disabled={open}
-        tooltip={{ text: tooltip.text, accessibilityLabel: '', zIndex: tooltipZIndex }}
+      {/* Interactive elements require an a11yLabel on them or their children. That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */}
+      <TapArea
+        accessibilityControls={id}
+        accessibilityExpanded={open}
+        accessibilityLabel={tooltip?.accessibilityLabel ?? tooltip.text}
+        onMouseEnter={() => {
+          setCompression('none');
+          setHovered(true);
+        }}
+        onMouseLeave={() => {
+          setCompression('compress');
+          setHovered(false);
+        }}
+        onFocus={() => {
+          setFocused(true);
+          setShowIconButton('show');
+        }}
+        onBlur={() => {
+          setFocused(false);
+          // With keyboard navigation, we want to hide IconButton if we keep tabbing without opening Dropdown
+          // However, Dropdown captures focus, therefore, as soon as it opens could hide IconButton and unmount itself, never displaying
+          // We prevent this by disabling this action until Dropdown gets dismissed and unselects IconButton
+          if (typeof selected === 'undefined' || forceIconButton === 'default') {
+            setShowIconButton('hide');
+          }
+        }}
+        onTap={({ event }) => {
+          // We need event.stopPropagation(); so the SideNavigation.TopItem's onClick doesn't get trigger as well
+          event.stopPropagation();
+          // As soon as IconButton gets clicked, we force its display, only if selected === false.
+          // We don't force if selected ===  undefined, which would indicate there's no Dropdown associated, just an action
+          if (selected === false) {
+            setForceIconButton?.('force');
+          }
+
+          if (selected !== undefined) {
+            setSelected((value) => !value);
+            setOpen((value) => !value);
+          }
+
+          onClick?.({ event });
+        }}
+        ref={innerRef}
+        rounding="circle"
+        tapStyle="compress"
       >
         <Pog
           accessibilityLabel=""
@@ -142,23 +142,23 @@ function ItemIconButton({
           iconColor={iconColor}
           bgColor={bgColor}
         />
-      </MaybeTooltip>
-      {open && (
-        <Dropdown
-          anchor={innerRef.current}
-          id={id}
-          onDismiss={() => {
-            setSelected(false);
-            setOpen(false);
-          }}
-          zIndex={dropdownZIndex}
-        >
-          {dropdownItems?.map((element, idx) =>
-            cloneElement(element, { key: `sidenavigation-dropdown-item-${idx}` }),
-          )}
-        </Dropdown>
-      )}
-    </TapArea>
+        {open && (
+          <Dropdown
+            anchor={innerRef.current}
+            id={id}
+            onDismiss={() => {
+              setSelected(false);
+              setOpen(false);
+            }}
+            zIndex={dropdownZIndex}
+          >
+            {dropdownItems?.map((element, idx) =>
+              cloneElement(element, { key: `sidenavigation-dropdown-item-${idx}` }),
+            )}
+          </Dropdown>
+        )}
+      </TapArea>
+    </MaybeTooltip>
   );
 }
 

--- a/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.js
+++ b/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.js
@@ -83,55 +83,55 @@ function ItemIconButton({
     : new FixedZIndex(1);
   const dropdownZIndex = new CompositeZIndex([tooltipZIndex]);
   return (
-    <MaybeTooltip
-      disabled={open}
-      tooltip={{ text: tooltip.text, accessibilityLabel: '', zIndex: tooltipZIndex }}
+    /* Interactive elements require an a11yLabel on them or their children. That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */
+    <TapArea
+      accessibilityControls={id}
+      accessibilityExpanded={open}
+      accessibilityLabel={tooltip?.accessibilityLabel ?? tooltip.text}
+      onMouseEnter={() => {
+        setCompression('none');
+        setHovered(true);
+      }}
+      onMouseLeave={() => {
+        setCompression('compress');
+        setHovered(false);
+      }}
+      onFocus={() => {
+        setFocused(true);
+        setShowIconButton('show');
+      }}
+      onBlur={() => {
+        setFocused(false);
+        // With keyboard navigation, we want to hide IconButton if we keep tabbing without opening Dropdown
+        // However, Dropdown captures focus, therefore, as soon as it opens could hide IconButton and unmount itself, never displaying
+        // We prevent this by disabling this action until Dropdown gets dismissed and unselects IconButton
+        if (typeof selected === 'undefined' || forceIconButton === 'default') {
+          setShowIconButton('hide');
+        }
+      }}
+      onTap={({ event }) => {
+        // We need event.stopPropagation(); so the SideNavigation.TopItem's onClick doesn't get trigger as well
+        event.stopPropagation();
+        // As soon as IconButton gets clicked, we force its display, only if selected === false.
+        // We don't force if selected ===  undefined, which would indicate there's no Dropdown associated, just an action
+        if (selected === false) {
+          setForceIconButton?.('force');
+        }
+
+        if (selected !== undefined) {
+          setSelected((value) => !value);
+          setOpen((value) => !value);
+        }
+
+        onClick?.({ event });
+      }}
+      ref={innerRef}
+      rounding="circle"
+      tapStyle="compress"
     >
-      {/* Interactive elements require an a11yLabel on them or their children. That's why we set`accessibilityLabel` on `TapArea` instead of `Tooltip` */}
-      <TapArea
-        accessibilityControls={id}
-        accessibilityExpanded={open}
-        accessibilityLabel={tooltip?.accessibilityLabel ?? tooltip.text}
-        onMouseEnter={() => {
-          setCompression('none');
-          setHovered(true);
-        }}
-        onMouseLeave={() => {
-          setCompression('compress');
-          setHovered(false);
-        }}
-        onFocus={() => {
-          setFocused(true);
-          setShowIconButton('show');
-        }}
-        onBlur={() => {
-          setFocused(false);
-          // With keyboard navigation, we want to hide IconButton if we keep tabbing without opening Dropdown
-          // However, Dropdown captures focus, therefore, as soon as it opens could hide IconButton and unmount itself, never displaying
-          // We prevent this by disabling this action until Dropdown gets dismissed and unselects IconButton
-          if (typeof selected === 'undefined' || forceIconButton === 'default') {
-            setShowIconButton('hide');
-          }
-        }}
-        onTap={({ event }) => {
-          // We need event.stopPropagation(); so the SideNavigation.TopItem's onClick doesn't get trigger as well
-          event.stopPropagation();
-          // As soon as IconButton gets clicked, we force its display, only if selected === false.
-          // We don't force if selected ===  undefined, which would indicate there's no Dropdown associated, just an action
-          if (selected === false) {
-            setForceIconButton?.('force');
-          }
-
-          if (selected !== undefined) {
-            setSelected((value) => !value);
-            setOpen((value) => !value);
-          }
-
-          onClick?.({ event });
-        }}
-        ref={innerRef}
-        rounding="circle"
-        tapStyle="compress"
+      <MaybeTooltip
+        disabled={open}
+        tooltip={{ text: tooltip.text, accessibilityLabel: '', zIndex: tooltipZIndex }}
       >
         <Pog
           accessibilityLabel=""
@@ -142,23 +142,23 @@ function ItemIconButton({
           iconColor={iconColor}
           bgColor={bgColor}
         />
-        {open && (
-          <Dropdown
-            anchor={innerRef.current}
-            id={id}
-            onDismiss={() => {
-              setSelected(false);
-              setOpen(false);
-            }}
-            zIndex={dropdownZIndex}
-          >
-            {dropdownItems?.map((element, idx) =>
-              cloneElement(element, { key: `sidenavigation-dropdown-item-${idx}` }),
-            )}
-          </Dropdown>
-        )}
-      </TapArea>
-    </MaybeTooltip>
+      </MaybeTooltip>
+      {open && (
+        <Dropdown
+          anchor={innerRef.current}
+          id={id}
+          onDismiss={() => {
+            setSelected(false);
+            setOpen(false);
+          }}
+          zIndex={dropdownZIndex}
+        >
+          {dropdownItems?.map((element, idx) =>
+            cloneElement(element, { key: `sidenavigation-dropdown-item-${idx}` }),
+          )}
+        </Dropdown>
+      )}
+    </TapArea>
   );
 }
 

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -1,50 +1,7 @@
 // @flow strict
-import { type Node, useReducer, useRef } from 'react';
-import Box from './Box.js';
-import Controller from './Controller.js';
-import Layer from './Layer.js';
-import Text from './Text.js';
-import useDebouncedCallback from './useDebouncedCallback.js';
+import { type Node } from 'react';
+import InternalTooltip from './Tooltip/InternalTooltip.js';
 import { type Indexable } from './zIndex.js';
-
-const noop = () => {};
-const TIMEOUT = 100;
-
-const initialState = { hoveredIcon: false, hoveredText: false, isOpen: false };
-
-const reducer = (
-  state: {| hoveredIcon: boolean, hoveredText: boolean, isOpen: boolean |},
-  action: {| type: 'hoverInIcon' | 'hoverInText' | 'hoverOutIcon' | 'hoverOutText' |},
-) => {
-  switch (action.type) {
-    case 'hoverInIcon':
-      return {
-        ...state,
-        hoveredIcon: true,
-        isOpen: true,
-      };
-    case 'hoverInText':
-      return {
-        ...state,
-        hoveredText: true,
-        isOpen: true,
-      };
-    case 'hoverOutIcon':
-      return {
-        ...state,
-        hoveredIcon: false,
-        isOpen: !state.hoveredText ? false : state.isOpen,
-      };
-    case 'hoverOutText':
-      return {
-        ...state,
-        hoveredText: false,
-        isOpen: !state.hoveredIcon ? false : state.isOpen,
-      };
-    default:
-      throw new Error();
-  }
-};
 
 type Props = {|
   /**
@@ -94,74 +51,17 @@ export default function Tooltip({
   text,
   zIndex,
 }: Props): Node {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const { isOpen } = state;
-
-  const childRef = useRef<?HTMLElement>(null);
-  const { current: anchor } = childRef;
-
-  const mouseLeaveDelay = link ? TIMEOUT : 0;
-
-  const handleIconMouseEnter = () => {
-    dispatch({ type: 'hoverInIcon' });
-  };
-
-  const handleIconMouseLeave = useDebouncedCallback(() => {
-    dispatch({ type: 'hoverOutIcon' });
-  }, mouseLeaveDelay);
-
-  const handleTextMouseEnter = () => {
-    dispatch({ type: 'hoverInText' });
-  };
-
-  const handleTextMouseLeave = useDebouncedCallback(() => {
-    dispatch({ type: 'hoverOutText' });
-  }, mouseLeaveDelay);
-
   return (
-    <Box display={inline ? 'inlineBlock' : 'block'}>
-      <Box
-        aria-label={accessibilityLabel != null ? accessibilityLabel : text}
-        ref={childRef}
-        onFocus={handleIconMouseEnter}
-        onBlur={handleIconMouseLeave}
-        onMouseEnter={handleIconMouseEnter}
-        onMouseLeave={handleIconMouseLeave}
-      >
-        {children}
-      </Box>
-      {isOpen && !!anchor && (
-        <Layer zIndex={zIndex}>
-          <Controller
-            anchor={anchor}
-            caret={false}
-            bgColor="darkGray"
-            border={false}
-            idealDirection={idealDirection}
-            onDismiss={noop}
-            positionRelativeToAnchor={false}
-            rounding={2}
-            size={null}
-          >
-            <Box
-              maxWidth={180}
-              padding={2}
-              onBlur={link ? handleTextMouseLeave : undefined}
-              onFocus={link ? handleTextMouseEnter : undefined}
-              onMouseEnter={link ? handleTextMouseEnter : undefined}
-              onMouseLeave={link ? handleTextMouseLeave : undefined}
-              role="tooltip"
-              tabIndex={0}
-            >
-              <Text color="inverse" size="100">
-                {text}
-              </Text>
-              {Boolean(link) && <Box marginTop={1}>{link}</Box>}
-            </Box>
-          </Controller>
-        </Layer>
-      )}
-    </Box>
+    <InternalTooltip
+      accessibilityLabel={accessibilityLabel}
+      link={link}
+      idealDirection={idealDirection}
+      inline={inline}
+      text={text}
+      zIndex={zIndex}
+    >
+      {children}
+    </InternalTooltip>
   );
 }
 

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useReducer, useRef } from 'react';
+import { type Node, useEffect, useReducer, useRef } from 'react';
 import Box from '../Box.js';
 import Controller from '../Controller.js';
 import Layer from '../Layer.js';
@@ -14,8 +14,12 @@ const initialState = { hoveredIcon: false, hoveredText: false, isOpen: false };
 
 const reducer = (
   state: {| hoveredIcon: boolean, hoveredText: boolean, isOpen: boolean |},
-  action: {| type: 'hoverInIcon' | 'hoverInText' | 'hoverOutIcon' | 'hoverOutText' |},
+  action: {|
+    type: 'hoverInIcon' | 'hoverInText' | 'hoverOutIcon' | 'hoverOutText',
+    disabled?: boolean,
+  |},
 ) => {
+  if (action.disabled) return { ...state, isOpen: false, hoveredIcon: false };
   switch (action.type) {
     case 'hoverInIcon':
       return {
@@ -78,10 +82,12 @@ export default function InternalTooltip({
 
   const mouseLeaveDelay = link ? TIMEOUT : 0;
 
+  useEffect(() => {
+    dispatch({ type: 'hoverOutIcon', disabled });
+  }, [disabled]);
+
   const handleIconMouseEnter = () => {
-    if (!disabled) {
-      dispatch({ type: 'hoverInIcon' });
-    }
+    dispatch({ type: 'hoverInIcon' });
   };
 
   const handleIconMouseLeave = useDebouncedCallback(() => {
@@ -89,9 +95,7 @@ export default function InternalTooltip({
   }, mouseLeaveDelay);
 
   const handleTextMouseEnter = () => {
-    if (!disabled) {
-      dispatch({ type: 'hoverInText' });
-    }
+    dispatch({ type: 'hoverInText' });
   };
 
   const handleTextMouseLeave = useDebouncedCallback(() => {

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -120,6 +120,7 @@ export default function InternalTooltip({
   return (
     <Box display={inline ? 'inlineBlock' : 'block'}>
       <Box
+        aria-hidden={disabled ? true : undefined}
         aria-label={accessibilityLabel != null ? accessibilityLabel : text}
         ref={childRef}
         onFocus={handleIconMouseEnter}

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -89,7 +89,9 @@ export default function InternalTooltip({
   }, mouseLeaveDelay);
 
   const handleTextMouseEnter = () => {
-    dispatch({ type: 'hoverInText' });
+    if (!disabled) {
+      dispatch({ type: 'hoverInText' });
+    }
   };
 
   const handleTextMouseLeave = useDebouncedCallback(() => {

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -1,0 +1,167 @@
+// @flow strict
+import { type Node, useReducer, useRef } from 'react';
+import Box from '../Box.js';
+import Controller from '../Controller.js';
+import Layer from '../Layer.js';
+import Text from '../Text.js';
+import useDebouncedCallback from '../useDebouncedCallback.js';
+import { type Indexable } from '../zIndex.js';
+
+const noop = () => {};
+const TIMEOUT = 100;
+
+const initialState = { hoveredIcon: false, hoveredText: false, isOpen: false };
+
+const reducer = (
+  state: {| hoveredIcon: boolean, hoveredText: boolean, isOpen: boolean |},
+  action: {| type: 'hoverInIcon' | 'hoverInText' | 'hoverOutIcon' | 'hoverOutText' |},
+) => {
+  switch (action.type) {
+    case 'hoverInIcon':
+      return {
+        ...state,
+        hoveredIcon: true,
+        isOpen: true,
+      };
+    case 'hoverInText':
+      return {
+        ...state,
+        hoveredText: true,
+        isOpen: true,
+      };
+    case 'hoverOutIcon':
+      return {
+        ...state,
+        hoveredIcon: false,
+        isOpen: !state.hoveredText ? false : state.isOpen,
+      };
+    case 'hoverOutText':
+      return {
+        ...state,
+        hoveredText: false,
+        isOpen: !state.hoveredIcon ? false : state.isOpen,
+      };
+    default:
+      throw new Error();
+  }
+};
+
+type Props = {|
+  /**
+   * Label to provide more context around the Tooltip’s function or purpose. By default `text` is used but this prop allows you to override it. Learn more about when to override it in the [Accessibility](https://gestalt.pinterest.systems/web/tooltip#Labels) section.
+   */
+  accessibilityLabel?: string,
+  /**
+   * The anchor element, usually [Icon Button](https://gestalt.pinterest.systems/web/iconbutton), that triggers Tooltip on hover or focus.
+   */
+  children?: Node,
+  /**
+   * Whether to show the tooltip or not
+   */
+  disabled?: boolean,
+  /**
+   * Specifies the preferred position of Tooltip relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/web/tooltip#Ideal-direction) variant to learn more.
+   */
+  idealDirection?: 'up' | 'right' | 'down' | 'left',
+  /**
+   * Properly positions Tooltip relative to an inline element, such as [Icon Button](https://gestalt.pinterest.systems/web/iconbutton) using the inline property. See the [inline](https://gestalt.pinterest.systems/web/tooltip#Inline) variant to learn more.
+   */
+  inline?: boolean,
+  /**
+   * Displays a link at the bottom of Tooltip. See the [link](https://gestalt.pinterest.systems/web/tooltip#Link) variant to learn more.
+   */
+  link?: Node,
+  /**
+   * The text shown in Tooltip to describe its anchor element. See [localization ](https://gestalt.pinterest.systems/web/tooltip#Localization) to learn more.
+   */
+  text: string,
+  /**
+   * Specifies the stacking order of Tooltip along the z-axis in the current stacking context. See the [z-index](https://gestalt.pinterest.systems/web/tooltip#Z-index) variant to learn more.
+   */
+  zIndex?: Indexable,
+|};
+
+export default function InternalTooltip({
+  accessibilityLabel,
+  children,
+  disabled,
+  link,
+  idealDirection = 'down',
+  inline,
+  text,
+  zIndex,
+}: Props): Node {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  let { isOpen } = state;
+
+  if (disabled) isOpen = false;
+
+  const childRef = useRef<?HTMLElement>(null);
+  const { current: anchor } = childRef;
+
+  const mouseLeaveDelay = link ? TIMEOUT : 0;
+
+  const handleIconMouseEnter = () => {
+    dispatch({ type: 'hoverInIcon' });
+  };
+
+  const handleIconMouseLeave = useDebouncedCallback(() => {
+    dispatch({ type: 'hoverOutIcon' });
+  }, mouseLeaveDelay);
+
+  const handleTextMouseEnter = () => {
+    dispatch({ type: 'hoverInText' });
+  };
+
+  const handleTextMouseLeave = useDebouncedCallback(() => {
+    dispatch({ type: 'hoverOutText' });
+  }, mouseLeaveDelay);
+
+  return (
+    <Box display={inline ? 'inlineBlock' : 'block'}>
+      <Box
+        aria-label={accessibilityLabel != null ? accessibilityLabel : text}
+        ref={childRef}
+        onFocus={handleIconMouseEnter}
+        onBlur={handleIconMouseLeave}
+        onMouseEnter={handleIconMouseEnter}
+        onMouseLeave={handleIconMouseLeave}
+      >
+        {children}
+      </Box>
+      {isOpen && !!anchor && (
+        <Layer zIndex={zIndex}>
+          <Controller
+            anchor={anchor}
+            caret={false}
+            bgColor="darkGray"
+            border={false}
+            idealDirection={idealDirection}
+            onDismiss={noop}
+            positionRelativeToAnchor={false}
+            rounding={2}
+            size={null}
+          >
+            <Box
+              maxWidth={180}
+              padding={2}
+              onBlur={link ? handleTextMouseLeave : undefined}
+              onFocus={link ? handleTextMouseEnter : undefined}
+              onMouseEnter={link ? handleTextMouseEnter : undefined}
+              onMouseLeave={link ? handleTextMouseLeave : undefined}
+              role="tooltip"
+              tabIndex={0}
+            >
+              <Text color="inverse" size="100">
+                {text}
+              </Text>
+              {Boolean(link) && <Box marginTop={1}>{link}</Box>}
+            </Box>
+          </Controller>
+        </Layer>
+      )}
+    </Box>
+  );
+}
+
+InternalTooltip.displayName = 'InternalTooltip';

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -47,37 +47,16 @@ const reducer = (
 };
 
 type Props = {|
-  /**
-   * Label to provide more context around the Tooltip’s function or purpose. By default `text` is used but this prop allows you to override it. Learn more about when to override it in the [Accessibility](https://gestalt.pinterest.systems/web/tooltip#Labels) section.
-   */
   accessibilityLabel?: string,
-  /**
-   * The anchor element, usually [Icon Button](https://gestalt.pinterest.systems/web/iconbutton), that triggers Tooltip on hover or focus.
-   */
   children?: Node,
   /**
    * Whether to show the tooltip or not
    */
   disabled?: boolean,
-  /**
-   * Specifies the preferred position of Tooltip relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/web/tooltip#Ideal-direction) variant to learn more.
-   */
   idealDirection?: 'up' | 'right' | 'down' | 'left',
-  /**
-   * Properly positions Tooltip relative to an inline element, such as [Icon Button](https://gestalt.pinterest.systems/web/iconbutton) using the inline property. See the [inline](https://gestalt.pinterest.systems/web/tooltip#Inline) variant to learn more.
-   */
   inline?: boolean,
-  /**
-   * Displays a link at the bottom of Tooltip. See the [link](https://gestalt.pinterest.systems/web/tooltip#Link) variant to learn more.
-   */
   link?: Node,
-  /**
-   * The text shown in Tooltip to describe its anchor element. See [localization ](https://gestalt.pinterest.systems/web/tooltip#Localization) to learn more.
-   */
   text: string,
-  /**
-   * Specifies the stacking order of Tooltip along the z-axis in the current stacking context. See the [z-index](https://gestalt.pinterest.systems/web/tooltip#Z-index) variant to learn more.
-   */
   zIndex?: Indexable,
 |};
 
@@ -86,15 +65,13 @@ export default function InternalTooltip({
   children,
   disabled,
   link,
-  idealDirection = 'down',
+  idealDirection,
   inline,
   text,
   zIndex,
 }: Props): Node {
   const [state, dispatch] = useReducer(reducer, initialState);
-  let { isOpen } = state;
-
-  if (disabled) isOpen = false;
+  const { isOpen } = state;
 
   const childRef = useRef<?HTMLElement>(null);
   const { current: anchor } = childRef;
@@ -102,7 +79,9 @@ export default function InternalTooltip({
   const mouseLeaveDelay = link ? TIMEOUT : 0;
 
   const handleIconMouseEnter = () => {
-    dispatch({ type: 'hoverInIcon' });
+    if (!disabled) {
+      dispatch({ type: 'hoverInIcon' });
+    }
   };
 
   const handleIconMouseLeave = useDebouncedCallback(() => {
@@ -120,8 +99,7 @@ export default function InternalTooltip({
   return (
     <Box display={inline ? 'inlineBlock' : 'block'}>
       <Box
-        aria-hidden={disabled ? true : undefined}
-        aria-label={accessibilityLabel != null ? accessibilityLabel : text}
+        aria-label={accessibilityLabel != null && !disabled ? accessibilityLabel : text}
         ref={childRef}
         onFocus={handleIconMouseEnter}
         onBlur={handleIconMouseLeave}

--- a/packages/gestalt/src/__snapshots__/TagData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TagData.test.js.snap
@@ -1274,7 +1274,6 @@ exports[`TagData renders disabled selected state 1`] = `
     className="box xsDisplayBlock"
   >
     <div
-      aria-hidden={true}
       aria-label="This is a tooltip"
       className="box"
       onBlur={[Function]}
@@ -1399,7 +1398,6 @@ exports[`TagData renders disabled unselected state 1`] = `
     className="box xsDisplayBlock"
   >
     <div
-      aria-hidden={true}
       aria-label="This is a tooltip"
       className="box"
       onBlur={[Function]}

--- a/packages/gestalt/src/__snapshots__/TagData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TagData.test.js.snap
@@ -1271,101 +1271,114 @@ exports[`TagData renders disabled selected state 1`] = `
   }
 >
   <div
-    aria-disabled={true}
-    className="hideOutline tapTransition rounding2 fullHeight fullWidth"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    tabIndex={null}
+    className="box xsDisplayBlock"
   >
     <div
-      className="solid transparentBorder tagMedium secondary disabled tagWrapperRounded"
-      style={Object {}}
+      aria-label="This is a tooltip"
+      className="box"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
-        style={
-          Object {
-            "height": "100%",
-          }
-        }
+        aria-disabled={true}
+        className="hideOutline tapTransition rounding2 fullHeight fullWidth"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={null}
       >
         <div
-          className="box marginEnd1"
+          className="solid transparentBorder tagMedium secondary disabled tagWrapperRounded"
+          style={Object {}}
         >
           <div
-            className="box"
+            className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
+            style={
+              Object {
+                "height": "100%",
+              }
+            }
           >
             <div
-              className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
+              className="box marginEnd1"
             >
               <div
-                className="box paddingX1 relative"
+                className="box"
               >
-                <input
-                  aria-hidden={true}
-                  aria-invalid="false"
-                  checked={true}
-                  className="input sizeSm inputEnabled readOnly"
-                  disabled={true}
-                  id="readonly-checkbox-:rg:"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  type="checkbox"
-                />
                 <div
-                  className="darkGrayBg borderSelected borderRadiusSm sizeSm check"
-                  style={
-                    Object {
-                      "backgroundColor": "var(--color-gray-roboflow-300)",
-                      "borderColor": "transparent",
-                    }
-                  }
+                  className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
                 >
-                  <svg
-                    aria-hidden={true}
-                    aria-label=""
-                    className="icon inverseIcon iconBlock"
-                    height={8}
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width={8}
+                  <div
+                    className="box paddingX1 relative"
                   >
-                    <path
-                      d="test-file-stub"
+                    <input
+                      aria-hidden={true}
+                      aria-invalid="false"
+                      checked={true}
+                      className="input sizeSm inputEnabled readOnly"
+                      disabled={true}
+                      id="readonly-checkbox-:rg:"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      type="checkbox"
                     />
-                  </svg>
+                    <div
+                      className="darkGrayBg borderSelected borderRadiusSm sizeSm check"
+                      style={
+                        Object {
+                          "backgroundColor": "var(--color-gray-roboflow-300)",
+                          "borderColor": "transparent",
+                        }
+                      }
+                    >
+                      <svg
+                        aria-hidden={true}
+                        aria-label=""
+                        className="icon inverseIcon iconBlock"
+                        height={8}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={8}
+                      >
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
+            <span
+              className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
+              style={
+                Object {
+                  "WebkitLineClamp": 1,
+                }
+              }
+              title="Text Impressions"
+            >
+              Text Impressions
+            </span>
           </div>
         </div>
-        <span
-          className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
-          style={
-            Object {
-              "WebkitLineClamp": 1,
-            }
-          }
-          title="Text Impressions"
-        >
-          Text Impressions
-        </span>
       </div>
     </div>
   </div>
@@ -1382,87 +1395,100 @@ exports[`TagData renders disabled unselected state 1`] = `
   }
 >
   <div
-    aria-disabled={true}
-    className="hideOutline tapTransition rounding2 fullHeight fullWidth"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    tabIndex={null}
+    className="box xsDisplayBlock"
   >
     <div
-      className="solid transparentBorder tagMedium secondary disabled tagWrapperRounded"
-      style={Object {}}
+      aria-label="This is a tooltip"
+      className="box"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
-        style={
-          Object {
-            "height": "100%",
-          }
-        }
+        aria-disabled={true}
+        className="hideOutline tapTransition rounding2 fullHeight fullWidth"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={null}
       >
         <div
-          className="box marginEnd1"
+          className="solid transparentBorder tagMedium secondary disabled tagWrapperRounded"
+          style={Object {}}
         >
           <div
-            className="box"
+            className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
+            style={
+              Object {
+                "height": "100%",
+              }
+            }
           >
             <div
-              className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
+              className="box marginEnd1"
             >
               <div
-                className="box paddingX1 relative"
+                className="box"
               >
-                <input
-                  aria-hidden={true}
-                  aria-invalid="false"
-                  checked={false}
-                  className="input sizeSm inputEnabled readOnly"
-                  disabled={true}
-                  id="readonly-checkbox-:rh:"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  type="checkbox"
-                />
                 <div
-                  className="whiteBg border borderRadiusSm sizeSm check"
-                  style={
-                    Object {
-                      "backgroundColor": "var(--color-gray-roboflow-300)",
-                      "borderColor": "transparent",
-                    }
-                  }
-                />
+                  className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
+                >
+                  <div
+                    className="box paddingX1 relative"
+                  >
+                    <input
+                      aria-hidden={true}
+                      aria-invalid="false"
+                      checked={false}
+                      className="input sizeSm inputEnabled readOnly"
+                      disabled={true}
+                      id="readonly-checkbox-:rh:"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      type="checkbox"
+                    />
+                    <div
+                      className="whiteBg border borderRadiusSm sizeSm check"
+                      style={
+                        Object {
+                          "backgroundColor": "var(--color-gray-roboflow-300)",
+                          "borderColor": "transparent",
+                        }
+                      }
+                    />
+                  </div>
+                </div>
               </div>
             </div>
+            <span
+              className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
+              style={
+                Object {
+                  "WebkitLineClamp": 1,
+                }
+              }
+              title="Text Impressions"
+            >
+              Text Impressions
+            </span>
           </div>
         </div>
-        <span
-          className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
-          style={
-            Object {
-              "WebkitLineClamp": 1,
-            }
-          }
-          title="Text Impressions"
-        >
-          Text Impressions
-        </span>
       </div>
     </div>
   </div>

--- a/packages/gestalt/src/__snapshots__/TagData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TagData.test.js.snap
@@ -1274,6 +1274,7 @@ exports[`TagData renders disabled selected state 1`] = `
     className="box xsDisplayBlock"
   >
     <div
+      aria-hidden={true}
       aria-label="This is a tooltip"
       className="box"
       onBlur={[Function]}
@@ -1398,6 +1399,7 @@ exports[`TagData renders disabled unselected state 1`] = `
     className="box xsDisplayBlock"
   >
     <div
+      aria-hidden={true}
       aria-label="This is a tooltip"
       className="box"
       onBlur={[Function]}

--- a/packages/gestalt/src/__snapshots__/TileData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TileData.test.js.snap
@@ -2706,88 +2706,132 @@ exports[`TileData TileData title truncates when really long 1`] = `
 
 exports[`TileData Tiledata is disabled 1`] = `
 <div
-  className="box"
-  style={
-    Object {
-      "maxWidth": 196,
-    }
-  }
+  className="box xsDisplayBlock"
 >
   <div
-    aria-disabled={true}
-    className="hideOutline tapTransition rounding4 fullWidth"
+    aria-label="This is a tooltip"
+    className="box"
     onBlur={[Function]}
-    onClick={[Function]}
     onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onMouseDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    tabIndex={null}
   >
     <div
-      className="baseTile tileWidth selected disabled"
-      style={Object {}}
+      className="box"
+      style={
+        Object {
+          "maxWidth": 196,
+        }
+      }
     >
       <div
-        className="Flex rowGap2 columnGap2 xsDirectionRow"
+        aria-disabled={true}
+        className="hideOutline tapTransition rounding4 fullWidth"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={null}
       >
         <div
-          className="FlexItem"
+          className="baseTile tileWidth selected disabled"
+          style={Object {}}
         >
           <div
-            className="Flex rowGap0 columnGap1 xsDirectionColumn"
+            className="Flex rowGap2 columnGap2 xsDirectionRow"
           >
             <div
               className="FlexItem"
             >
               <div
-                className="Flex rowGap1 columnGap0 xsDirectionRow xsItemsCenter"
-                style={
-                  Object {
-                    "minHeight": 24,
-                  }
-                }
+                className="Flex rowGap0 columnGap1 xsDirectionColumn"
               >
                 <div
                   className="FlexItem"
                 >
                   <div
-                    className="box"
+                    className="Flex rowGap1 columnGap0 xsDirectionRow xsItemsCenter"
                     style={
                       Object {
-                        "minWidth": 80,
+                        "minHeight": 24,
                       }
                     }
                   >
                     <div
-                      className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
-                      style={
-                        Object {
-                          "WebkitLineClamp": 2,
-                        }
-                      }
+                      className="FlexItem"
                     >
-                      Text Impressions
                       <div
-                        className="box relative"
+                        className="box"
                         style={
                           Object {
-                            "display": "inline",
+                            "minWidth": 80,
                           }
                         }
                       >
                         <div
-                          className="box xsDisplayVisuallyHidden"
+                          className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
+                          style={
+                            Object {
+                              "WebkitLineClamp": 2,
+                            }
+                          }
                         >
-                          ,
+                          Text Impressions
+                          <div
+                            className="box relative"
+                            style={
+                              Object {
+                                "display": "inline",
+                              }
+                            }
+                          >
+                            <div
+                              className="box xsDisplayVisuallyHidden"
+                            >
+                              ,
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Flex rowGap2 columnGap2 xsDirectionRow xsItemsCenter"
+                  >
+                    <div
+                      className="FlexItem"
+                    >
+                      <div
+                        className="Text fontSize400 subtleText alignStart breakWord fontWeightSemiBold"
+                      >
+                        1.23M
+                        <div
+                          className="box relative"
+                          style={
+                            Object {
+                              "display": "inline",
+                            }
+                          }
+                        >
+                          <div
+                            className="box xsDisplayVisuallyHidden"
+                          >
+                            ,
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -2799,84 +2843,53 @@ exports[`TileData Tiledata is disabled 1`] = `
               className="FlexItem"
             >
               <div
-                className="Flex rowGap2 columnGap2 xsDirectionRow xsItemsCenter"
+                className="box"
               >
                 <div
-                  className="FlexItem"
+                  className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
                 >
                   <div
-                    className="Text fontSize400 subtleText alignStart breakWord fontWeightSemiBold"
+                    className="box paddingX1 relative"
                   >
-                    1.23M
+                    <input
+                      aria-hidden={true}
+                      aria-invalid="false"
+                      checked={true}
+                      className="input sizeSm inputEnabled readOnly"
+                      disabled={true}
+                      id="readonly-checkbox-blah-:re:"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      type="checkbox"
+                    />
                     <div
-                      className="box relative"
+                      className="darkGrayBg borderSelected borderRadiusSm sizeSm check"
                       style={
                         Object {
-                          "display": "inline",
+                          "backgroundColor": "var(--color-gray-roboflow-300)",
+                          "borderColor": "transparent",
                         }
                       }
                     >
-                      <div
-                        className="box xsDisplayVisuallyHidden"
+                      <svg
+                        aria-hidden={true}
+                        aria-label=""
+                        className="icon inverseIcon iconBlock"
+                        height={8}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={8}
                       >
-                        ,
-                      </div>
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
                     </div>
                   </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="FlexItem"
-        >
-          <div
-            className="box"
-          >
-            <div
-              className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
-            >
-              <div
-                className="box paddingX1 relative"
-              >
-                <input
-                  aria-hidden={true}
-                  aria-invalid="false"
-                  checked={true}
-                  className="input sizeSm inputEnabled readOnly"
-                  disabled={true}
-                  id="readonly-checkbox-blah-:re:"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  type="checkbox"
-                />
-                <div
-                  className="darkGrayBg borderSelected borderRadiusSm sizeSm check"
-                  style={
-                    Object {
-                      "backgroundColor": "var(--color-gray-roboflow-300)",
-                      "borderColor": "transparent",
-                    }
-                  }
-                >
-                  <svg
-                    aria-hidden={true}
-                    aria-label=""
-                    className="icon inverseIcon iconBlock"
-                    height={8}
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width={8}
-                  >
-                    <path
-                      d="test-file-stub"
-                    />
-                  </svg>
                 </div>
               </div>
             </div>

--- a/packages/gestalt/src/__snapshots__/TileData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TileData.test.js.snap
@@ -2709,6 +2709,7 @@ exports[`TileData Tiledata is disabled 1`] = `
   className="box xsDisplayBlock"
 >
   <div
+    aria-hidden={true}
     aria-label="This is a tooltip"
     className="box"
     onBlur={[Function]}

--- a/packages/gestalt/src/__snapshots__/TileData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TileData.test.js.snap
@@ -2709,7 +2709,6 @@ exports[`TileData Tiledata is disabled 1`] = `
   className="box xsDisplayBlock"
 >
   <div
-    aria-hidden={true}
     aria-label="This is a tooltip"
     className="box"
     onBlur={[Function]}

--- a/packages/gestalt/src/utils/MaybeTooltip.js
+++ b/packages/gestalt/src/utils/MaybeTooltip.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import Tooltip from '../Tooltip.js';
+import InternalTooltip from '../Tooltip/InternalTooltip.js';
 import { type Indexable } from '../zIndex.js';
 
 type TooltipProps = {|
@@ -20,16 +20,18 @@ export default function MaybeTooltip({
   disabled?: boolean,
   tooltip?: TooltipProps,
 |}): Node {
-  if (!tooltip || disabled) return children;
+  if (!tooltip) return children;
+
   return (
-    <Tooltip
+    <InternalTooltip
       accessibilityLabel={tooltip.accessibilityLabel}
       inline={tooltip.inline}
-      idealDirection={tooltip.idealDirection || 'up'}
+      disabled={disabled}
+      idealDirection={tooltip?.idealDirection || 'up'}
       text={tooltip.text}
-      zIndex={tooltip.zIndex}
+      zIndex={tooltip?.zIndex}
     >
       {children}
-    </Tooltip>
+    </InternalTooltip>
   );
 }


### PR DESCRIPTION
### Summary
Sidenavigation primary action dropdown is not positioned correctly. This is due to `MaybeTooltip` re-rendering the children when the tooltip should be disabled.

#### What changed?
This is a broken change introduced in this [PR](https://github.com/pinterest/gestalt/pull/3134). The TapArea is the innerRef, but when the tooltip is disabled, the dropdown placement is initially messed up because the TapArea is re-rendered. TapArea uses `useId` and the ref likely changes on every render.

~~This moves the `MaybeTooltip` to inside the tap area, so the outer ref for the dropdown is not changed.~~

This change does two things:
- Moves tooltip to `InternalTooltip`, and adds a new disabled prop. When disabled, the tooltip will never open.
-  `MaybeTooltip` will override set the tooltip behavior to be "disabled" 

#### Why?
See [Slack](https://pinterest.slack.com/archives/C13KLG5P0/p1694022120118259)

![Brave Browser - SideNavigation - Gestalt 2023-09-07 at 1 22 19 PM](https://github.com/pinterest/gestalt/assets/10593890/4004c090-c287-463c-a956-9b67a7631792)

This introduces a bug:
<img width="181" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/943de68d-b165-49fb-9bf8-32fda7d1ac93">



### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
