### PR TITLE
Docs: Fix duplicated ToC accessibility label

### DIFF
--- a/docs/docs-components/Toc.js
+++ b/docs/docs-components/Toc.js
@@ -197,7 +197,6 @@ export default function Toc({ cards }: Props): Node {
 
   return (
     <Box
-      aria-label="component page"
       // Accounting for the footer height as set in App.js
       dangerouslySetInlineStyle={{ __style: { marginBottom: FOOTER_HEIGHT_PX } }}
       // These margins counter the padding set on the <Box role="main"> in App.js
@@ -209,7 +208,6 @@ export default function Toc({ cards }: Props): Node {
       paddingX={1}
       paddingY={8} // re-apply just the padding we need
       position="fixed"
-      role="navigation"
       width={240}
     >
       <TableOfContents>


### PR DESCRIPTION
### Summary

Removed accessibility attributes from the wrapper ToC for TableOfContents in docs-components.

#### Why?

It was causing duplicated labels appear for screen readers.

Before
![Brave Browser - Chart - Gestalt 2023-09-11 at 10 40 54 PM](https://github.com/pinterest/gestalt/assets/29589560/1eca76cc-834f-45da-941c-3dd94d613612)

After
![ezgif-2-f21a9e78fb](https://github.com/pinterest/gestalt/assets/29589560/8034144f-fbe7-47b8-8688-178bb7451fc9)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
