### PR TITLE
Toast: Fix toast prop "variant" to "type"

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -2176,7 +2176,7 @@ interface ToastProps {
     | { avatar: React.ReactElement<typeof Avatar> }
     | { icon: React.ReactElement<typeof Icon> }
     | undefined;
-  variant?: 'default' | 'success' | 'error' | 'progress' | undefined;
+  type?: 'default' | 'success' | 'error' | 'progress' | undefined;
 }
 
 interface TooltipProps {


### PR DESCRIPTION
### Summary
Fix toast typescript type to match [props table](https://gestalt.pinterest.systems/web/toast)

#### What changed?
prop "variant" changed to prop "type"


