### PR TITLE
Masonry: Fix height initialization when reusing cached positions for multi-column pins

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -20,7 +20,9 @@ import getRandomNumberGenerator from './items-utils/getRandomNumberGenerator.js'
 
 const TWO_COL_MINDEX = 50;
 
-type Props = {|
+type MasonryProps<T> = $PropertyType<Masonry<T>, 'props'>;
+
+type Props<T> = {|
   // The actual Masonry component to be used (if using an experimental version of Masonry).
   MasonryComponent: typeof Masonry,
   // Experimental prop to batch paints of measured items.
@@ -36,21 +38,21 @@ type Props = {|
   // Grid items should have flexible width.
   flexible?: boolean,
   // The initial data from the server side render.
-  // $FlowFixMe[unclear-type]
-  initialItems?: $ReadOnlyArray<?Object>,
+  initialItems?: $PropertyType<MasonryProps<T>, 'items'>,
   // Whether or not to log whitespace.
   logWhitespace?: boolean,
   // Whether or not to require tests to trigger fetch completion manually.
   manualFetch?: boolean,
   // External measurement store.
-  // $FlowFixMe[unclear-type]
-  measurementStore: Object,
+  measurementStore: $PropertyType<MasonryProps<T>, 'measurementStore'>,
   // Prevent scrolling on Masonry
   noScroll?: boolean,
   // Positions the element inside of a relative container, offset from the top.
   offsetTop?: number,
   // An array of realistic pin heights as sampled from actual Pin data.
   pinHeightsSample?: $ReadOnlyArray<number>,
+  // External position store
+  positionStore: $PropertyType<MasonryProps<T>, 'positionStore'>,
   // If we should position the grid within a scrollContainer besides the window.
   scrollContainer?: boolean,
   // Insert two-column items into the feed
@@ -72,7 +74,7 @@ type State = {|
   mounted: boolean,
 |};
 
-export default class MasonryContainer extends Component<Props, State> {
+export default class MasonryContainer extends Component<Props<{ ... }>, State> {
   state: State = {
     expanded: false,
     hasScrollContainer: !!this.props.scrollContainer,
@@ -201,12 +203,6 @@ export default class MasonryContainer extends Component<Props, State> {
     }));
   };
 
-  pushFirstItemDown: () => void = () => {
-    const { measurementStore } = this.props;
-    measurementStore.setItemPosition(measurementStore.getGridCell(0, 0), { top: 100, row: 1 });
-    this.forceUpdate();
-  };
-
   customLoadItems: ({| force: boolean, from?: number, name?: string |}) => void = ({
     name,
     from = 0,
@@ -318,6 +314,7 @@ export default class MasonryContainer extends Component<Props, State> {
       measurementStore,
       noScroll,
       offsetTop,
+      positionStore,
       twoColItems,
       virtualBoundsBottom,
       virtualBoundsTop,
@@ -412,6 +409,7 @@ export default class MasonryContainer extends Component<Props, State> {
             items={items}
             layout={flexible ? 'flexible' : undefined}
             measurementStore={externalCache ? measurementStore : undefined}
+            positionStore={externalCache ? positionStore : undefined}
             ref={this.gridRef}
             renderItem={this.renderItem}
             virtualize={virtualize}
@@ -449,11 +447,6 @@ export default class MasonryContainer extends Component<Props, State> {
           <button id="insert-null-items" onClick={this.handleInsertNullItems} type="submit">
             Insert null items
           </button>
-          {externalCache && (
-            <button id="push-first-down" onClick={this.pushFirstItemDown} type="submit">
-              Push first item down
-            </button>
-          )}
           <button id="push-grid-down" onClick={this.handlePushGridDown} type="submit">
             Push grid down
           </button>

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -13,7 +13,13 @@ import MasonryContainer from '../../integration-test-helpers/masonry/MasonryCont
 // This can get bumped up another order of magnitude or so if needed…perf drops off pretty rapidly after that
 const REALISTIC_PINS_DATASET_SIZE = 1000;
 
-const measurementStore = Masonry.createMeasurementStore<{ ... }, mixed>();
+type MasonryProps = $PropertyType<Masonry<{ ... }>, 'props'>;
+
+type MeasurementStore = $PropertyType<MasonryProps, 'measurementStore'>;
+type PositionStore = $PropertyType<MasonryProps, 'positionStore'>;
+
+const measurementStore: MeasurementStore = Masonry.createMeasurementStore();
+const positionStore: PositionStore = Masonry.createMeasurementStore();
 
 // This is the counterpart to `normalizeValue` in `playwright/masonry/utils/getServerURL.mjs`
 function booleanize(value: string): boolean {
@@ -118,6 +124,7 @@ export default function TestPage({
           noScroll={booleanize(noScroll)}
           offsetTop={offsetTop}
           pinHeightsSample={realisticPinHeights ? pinHeightsSample : undefined}
+          positionStore={positionStore}
           scrollContainer={booleanize(scrollContainer)}
           twoColItems={booleanize(twoColItems)}
           virtualize={booleanize(virtualize)}


### PR DESCRIPTION
### Summary

#### What changed?

This PR fixes a bug with using an externally managed position store where heights are incorrectly initialized to 0 when remounting a grid. The end result is that after the initial mount, the new pages are rendered starting at 0 which causes overlap in the grid

<img width="1055" alt="image" src="https://github.com/pinterest/gestalt/assets/6487551/ed4cc344-fae4-405c-9cfa-8833910d7ea3">

I also updated the Masonry test page so that we can test mount/unmount with an external position cache

#### Why?

In https://github.com/pinterest/gestalt/pull/3146, we added support for the position cache to be externally managed for multi-column grids. This was meant to reduce the overhead when remounting a grid, however it resulted in the bug described above.
