### PR TITLE
Video: Fix flickering video controls on iOS browsers

### DIFF
--- a/packages/gestalt/src/Icon.css
+++ b/packages/gestalt/src/Icon.css
@@ -9,5 +9,11 @@
 }
 
 html[dir="rtl"] .rtlSupport {
-  transform: rotateY(180deg);
+  /*
+  Using `scale` instead of `rotateY`.
+  This is a workaround for the bug in iOS browsers with rendering rotated SVGs over video.
+  Bug repro: https://gist.github.com/diyorbek/945189e3036552d2de34ae955a1605ee
+  */
+  transform: scale(-1, 1);
+  transform-origin: center;
 }

--- a/packages/gestalt/src/Video.css
+++ b/packages/gestalt/src/Video.css
@@ -27,6 +27,7 @@
   composes: right0 from "./Layout.css";
   composes: paddingX2 from "./boxWhitespace.css";
   composes: paddingY2 from "./boxWhitespace.css";
+  z-index: 0;
   background-image: linear-gradient(
     to bottom,
     rgb(181 181 181 / 0),

--- a/packages/gestalt/src/Video.css
+++ b/packages/gestalt/src/Video.css
@@ -34,6 +34,4 @@
     rgb(0 0 0 / 0.5) 66%,
     rgb(0 0 0 / 0.7)
   );
-  /* Workaround for the bug in iOS browsers with rendering transformed SVGs over video */
-  z-index: 0;
 }

--- a/packages/gestalt/src/Video.css
+++ b/packages/gestalt/src/Video.css
@@ -27,7 +27,6 @@
   composes: right0 from "./Layout.css";
   composes: paddingX2 from "./boxWhitespace.css";
   composes: paddingY2 from "./boxWhitespace.css";
-  z-index: 0;
   background-image: linear-gradient(
     to bottom,
     rgb(181 181 181 / 0),
@@ -35,4 +34,6 @@
     rgb(0 0 0 / 0.5) 66%,
     rgb(0 0 0 / 0.7)
   );
+  /* Workaround for the bug in iOS browsers with rendering transformed SVGs over video */
+  z-index: 0;
 }


### PR DESCRIPTION
### Summary

This PR fixes a bug that is present only in iOS browsers (mobile Safari and Chrome). Apparently, rotated SVGs on top of video element causes the video element appear on top. Sometimes, it causes SVG and its container to flicker then disappear (or to partially render).

This bug was caught in RTL mode because in RTL some of the icons are flipped.

#### What changed?

`rotateY(180deg)` CSS rule was replaced by `scale(-1, 1)` as it seems to be more stable/reliable.

#### Why?

Original bug was reported here https://jira.pinadmin.com/browse/BUG-170571

### Links

- [Jira](https://jira.pinadmin.com/browse/BUG-171048)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
