### PR TITLE
TagData, TileData: Multi-line Tooltips

### DIFF
--- a/docs/examples/tagdata/tooltip.js
+++ b/docs/examples/tagdata/tooltip.js
@@ -1,22 +1,31 @@
 // @flow strict
-import { type Node, useState } from 'react';
-import { Flex, TagData } from 'gestalt';
+import { type Node } from 'react';
+import { Flex, TagData, Text } from 'gestalt';
 
 export default function Example(): Node {
-  const [isSelected, setSelected] = useState(false);
-
   return (
-    <Flex justifyContent="center" alignItems="center" height="100%" width="100%">
+    <Flex justifyContent="center" alignItems="center" height="100%" width="100%" gap={2}>
       <TagData
         showCheckbox
         text="CPM"
         size="lg"
-        selected={isSelected}
-        onTap={() => {
-          setSelected((selected) => !selected);
-        }}
         onRemove={() => {}}
         tooltip={{ text: 'Average cost per 1K paid impressions' }}
+      />
+      <TagData
+        showCheckbox
+        text="MAU"
+        size="lg"
+        selected
+        onRemove={() => {}}
+        tooltip={{
+          text: (
+            <Text>
+              <strong>Monthly Active Users</strong>
+              <p>The total monthly users over the last 30 days</p>
+            </Text>
+          ),
+        }}
       />
     </Flex>
   );

--- a/docs/examples/tagdata/tooltip.js
+++ b/docs/examples/tagdata/tooltip.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Flex, TagData, Text } from 'gestalt';
+import { Flex, TagData } from 'gestalt';
 
 export default function Example(): Node {
   return (
@@ -19,12 +19,7 @@ export default function Example(): Node {
         selected
         onRemove={() => {}}
         tooltip={{
-          text: (
-            <Text>
-              <strong>Monthly Active Users</strong>
-              <p>The total monthly users over the last 30 days</p>
-            </Text>
-          ),
+          text: ['Monthly Active Users', 'The total monthly users over the last 30 days'],
         }}
       />
     </Flex>

--- a/docs/examples/tiledata/tooltip.js
+++ b/docs/examples/tiledata/tooltip.js
@@ -11,7 +11,7 @@ export default function Example(): Node {
           text: [
             'Monthly Active Users',
             'The total monthly users over the last 30 days',
-            ' MAU has gone up by 10% over the last 30 days',
+            'MAU has gone up by 10% over the last 30 days',
           ],
         }}
         title="MAU"

--- a/docs/examples/tiledata/tooltip.js
+++ b/docs/examples/tiledata/tooltip.js
@@ -1,11 +1,26 @@
 // @flow strict
 import { type Node } from 'react';
-import { Flex, TileData } from 'gestalt';
+import { Flex, Text, TileData } from 'gestalt';
 
 export default function Example(): Node {
   return (
-    <Flex justifyContent="center" alignItems="center" width="100%" height="100%">
-      <TileData tooltip={{ text: 'Weekly Active Users' }} title="WAU" value="1.25M" selected />{' '}
+    <Flex justifyContent="center" alignItems="center" width="100%" height="100%" gap={2}>
+      <TileData tooltip={{ text: 'Weekly Active Users' }} title="WAU" value="1.25M" />{' '}
+      <TileData
+        tooltip={{
+          text: (
+            <Text>
+              <strong>Monthly Active Users</strong>
+              <p>The total monthly users over the last 30 days</p>
+              <p>MAU has gone up by 10% over the last 30 days</p>
+            </Text>
+          ),
+        }}
+        title="MAU"
+        value="2.25M"
+        selected
+        trend={{ value: 10, accessibilityLabel: 'Increased by 10%' }}
+      />{' '}
     </Flex>
   );
 }

--- a/docs/examples/tiledata/tooltip.js
+++ b/docs/examples/tiledata/tooltip.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Flex, Text, TileData } from 'gestalt';
+import { Flex, TileData } from 'gestalt';
 
 export default function Example(): Node {
   return (
@@ -8,13 +8,11 @@ export default function Example(): Node {
       <TileData tooltip={{ text: 'Weekly Active Users' }} title="WAU" value="1.25M" />{' '}
       <TileData
         tooltip={{
-          text: (
-            <Text>
-              <strong>Monthly Active Users</strong>
-              <p>The total monthly users over the last 30 days</p>
-              <p>MAU has gone up by 10% over the last 30 days</p>
-            </Text>
-          ),
+          text: [
+            'Monthly Active Users',
+            'The total monthly users over the last 30 days',
+            ' MAU has gone up by 10% over the last 30 days',
+          ],
         }}
         title="MAU"
         value="2.25M"

--- a/docs/pages/web/tagdata.js
+++ b/docs/pages/web/tagdata.js
@@ -208,7 +208,7 @@ export default function TagDataPage({ generatedDocGen }: {| generatedDocGen: Doc
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description="Use `tooltip` to display clarifying information on hover or focus. We recommend using tooltips to provide the user additional context/details. You can also pass in a `Text` element to create rich tooltips for TagData."
+          description="Use `tooltip` to display clarifying information on hover or focus. We recommend using tooltips to provide the user additional context/details. You can also pass in a list of strings to create multi-line tooltips for TagData."
           title="Tooltip"
         >
           <MainSection.Card

--- a/docs/pages/web/tagdata.js
+++ b/docs/pages/web/tagdata.js
@@ -208,7 +208,7 @@ export default function TagDataPage({ generatedDocGen }: {| generatedDocGen: Doc
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description="Use `tooltip` to display clarifying information on hover or focus. We recommend using tooltips to provide the user additional context/details."
+          description="Use `tooltip` to display clarifying information on hover or focus. We recommend using tooltips to provide the user additional context/details. You can also pass in a `Text` element to create rich tooltips for TagData."
           title="Tooltip"
         >
           <MainSection.Card

--- a/docs/pages/web/tiledata.js
+++ b/docs/pages/web/tiledata.js
@@ -133,7 +133,7 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description="Use `tooltip` to display clarifying information on hover/focus. We recommend using tooltips when trying to provide the user additional context/details."
+          description="Use `tooltip` to display clarifying information on hover/focus. We recommend using tooltips when trying to provide the user additional context/details.  You can also pass in a `Text` element to create rich tooltips for TileData."
           title="Tooltip"
         >
           <MainSection.Card

--- a/docs/pages/web/tiledata.js
+++ b/docs/pages/web/tiledata.js
@@ -133,7 +133,7 @@ export default function TileDataPage({ generatedDocGen }: {| generatedDocGen: Do
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description="Use `tooltip` to display clarifying information on hover/focus. We recommend using tooltips when trying to provide the user additional context/details.  You can also pass in a `Text` element to create rich tooltips for TileData."
+          description="Use `tooltip` to display clarifying information on hover/focus. We recommend using tooltips when trying to provide the user additional context/details.  You can also pass in a list of strings to create multi-line tooltips for TileData."
           title="Tooltip"
         >
           <MainSection.Card

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -2189,7 +2189,6 @@ interface TooltipProps {
   zIndex?: Indexable | undefined;
 }
 
-// Remove 'b'
 type TooltipTemp = Omit<TooltipProps, 'text'>;
 
 interface ExtendedTooltipProps extends TooltipTemp {

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -2196,10 +2196,6 @@ interface ExtendedTooltipProps extends TooltipTemp {
   text: string | string[];
 }
 
-interface ExtendedTooltipProps extends TooltipProps {
-
-}
-
 interface UpsellProps {
   message: string | React.ReactElement<typeof Text>;
   children?: React.ReactElement<typeof Upsell.Form>;

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1930,7 +1930,7 @@ interface TagDataProps {
   size?: 'sm' | 'md' | 'lg';
   showCheckbox?: boolean;
   text: string;
-  tooltip?: TooltipProps;
+  tooltip?: ExtendedTooltipProps;
 }
 
 interface CommonTapAreaProps {

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -2137,7 +2137,7 @@ interface TileDataProps {
   selected?: boolean | undefined;
   showCheckbox?: boolean | undefined;
   title: string;
-  tooltip?: TooltipProps | undefined;
+  tooltip?: ExtendedTooltipProps | undefined;
   trend?: TrendObject | undefined;
   trendSentiment?: 'good' | 'bad' | 'neutral' | 'auto' | undefined;
   value: string;
@@ -2187,6 +2187,17 @@ interface TooltipProps {
   inline?: boolean | undefined;
   link?: Node | undefined;
   zIndex?: Indexable | undefined;
+}
+
+// Remove 'b'
+type TooltipTemp = Omit<TooltipProps, 'text'>;
+
+interface ExtendedTooltipProps extends TooltipTemp {
+  text: string | string[];
+}
+
+interface ExtendedTooltipProps extends TooltipProps {
+
 }
 
 interface UpsellProps {

--- a/packages/gestalt/src/TagData.js
+++ b/packages/gestalt/src/TagData.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useId } from 'react';
+import { type Element, type Node, useId } from 'react';
 import classnames from 'classnames';
 import borderStyles from './Borders.css';
 import Box from './Box.js';
@@ -52,7 +52,7 @@ type TooltipProps = {|
   accessibilityLabel?: string,
   inline?: boolean,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
-  text: string,
+  text: string | Element<typeof Text>,
   zIndex?: Indexable,
 |};
 

--- a/packages/gestalt/src/TagData.js
+++ b/packages/gestalt/src/TagData.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Element, type Node, useId } from 'react';
+import { type Node, useId } from 'react';
 import classnames from 'classnames';
 import borderStyles from './Borders.css';
 import Box from './Box.js';
@@ -52,7 +52,7 @@ type TooltipProps = {|
   accessibilityLabel?: string,
   inline?: boolean,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
-  text: string | Element<typeof Text>,
+  text: string | $ReadOnlyArray<string>,
   zIndex?: Indexable,
 |};
 

--- a/packages/gestalt/src/TileData.js
+++ b/packages/gestalt/src/TileData.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Element, type Node, useId } from 'react';
+import { type Node, useId } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
 import InternalCheckbox from './Checkbox/InternalCheckbox.js';
@@ -7,7 +7,6 @@ import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import InternalDatapoint from './Datapoint/InternalDatapoint.js';
 import Flex from './Flex.js';
 import TapArea from './TapArea.js';
-import Text from './Text.js';
 import styles from './TileData.css';
 import getCheckboxColors from './utils/datavizcolors/getCheckboxColor.js';
 import getDataVisualizationColor from './utils/datavizcolors/getDataVisualizationColor.js';
@@ -19,7 +18,7 @@ type TooltipProps = {|
   accessibilityLabel?: string,
   inline?: boolean,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
-  text: string | Element<typeof Text>,
+  text: string | $ReadOnlyArray<string>,
   zIndex?: Indexable,
 |};
 

--- a/packages/gestalt/src/TileData.js
+++ b/packages/gestalt/src/TileData.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useId } from 'react';
+import { type Element, type Node, useId } from 'react';
 import classnames from 'classnames';
 import Box from './Box.js';
 import InternalCheckbox from './Checkbox/InternalCheckbox.js';
@@ -7,6 +7,7 @@ import { useColorScheme } from './contexts/ColorSchemeProvider.js';
 import InternalDatapoint from './Datapoint/InternalDatapoint.js';
 import Flex from './Flex.js';
 import TapArea from './TapArea.js';
+import Text from './Text.js';
 import styles from './TileData.css';
 import getCheckboxColors from './utils/datavizcolors/getCheckboxColor.js';
 import getDataVisualizationColor from './utils/datavizcolors/getDataVisualizationColor.js';
@@ -18,7 +19,7 @@ type TooltipProps = {|
   accessibilityLabel?: string,
   inline?: boolean,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
-  text: string,
+  text: string | Element<typeof Text>,
   zIndex?: Indexable,
 |};
 

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -1,5 +1,13 @@
 // @flow strict
-import { type Node, useEffect, useReducer, useRef } from 'react';
+import {
+  Children,
+  cloneElement,
+  type Element,
+  type Node,
+  useEffect,
+  useReducer,
+  useRef,
+} from 'react';
 import Box from '../Box.js';
 import Controller from '../Controller.js';
 import Layer from '../Layer.js';
@@ -60,7 +68,7 @@ type Props = {|
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   inline?: boolean,
   link?: Node,
-  text: string,
+  text: string | Element<typeof Text>,
   zIndex?: Indexable,
 |};
 
@@ -137,9 +145,16 @@ export default function InternalTooltip({
               role="tooltip"
               tabIndex={0}
             >
-              <Text color="inverse" size="100">
-                {text}
-              </Text>
+              {typeof text === 'string' && (
+                <Text color="inverse" size="100">
+                  {text}
+                </Text>
+              )}
+
+              {typeof text !== 'string' &&
+                Children.only<Element<typeof Text>>(text).type.displayName === 'Text' &&
+                cloneElement(text, { color: 'inverse', size: '100' })}
+
               {Boolean(link) && <Box marginTop={1}>{link}</Box>}
             </Box>
           </Controller>

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node, useEffect, useReducer, useRef } from 'react';
+import { Fragment, type Node, useEffect, useReducer, useRef } from 'react';
 import Box from '../Box.js';
 import Controller from '../Controller.js';
 import Layer from '../Layer.js';
@@ -107,7 +107,15 @@ export default function InternalTooltip({
       const lines = [];
       // first and last line should not have a <p> tag, (adds extra padding)
       text.map((line, idx) =>
-        lines.push(idx === 0 || idx === text.length - 1 ? line : <p>{line}</p>),
+        lines.push(
+          text.length === 1 || idx === text.length - 1 ? (
+            line
+          ) : (
+            <Fragment>
+              {line} <br /> <br />
+            </Fragment>
+          ),
+        ),
       );
       return lines;
     }

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -104,19 +104,18 @@ export default function InternalTooltip({
 
   const getTooltipText = () => {
     if (Array.isArray(text)) {
-      const lines = [];
       // first and last line should not have a <p> tag, (adds extra padding)
-      text.map((line, idx) =>
-        lines.push(
-          text.length === 1 || idx === text.length - 1 ? (
-            line
-          ) : (
-            <Fragment>
-              {line} <br /> <br />
-            </Fragment>
-          ),
-        ),
-      );
+      const lines = text.map((line, idx) => {
+        if (typeof line !== 'string') return '';
+
+        return text.length === 1 || idx === text.length - 1 ? (
+          line
+        ) : (
+          <Fragment>
+            {line} <br /> <br />
+          </Fragment>
+        );
+      });
       return lines;
     }
     return text;

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -1,13 +1,5 @@
 // @flow strict
-import {
-  Children,
-  cloneElement,
-  type Element,
-  type Node,
-  useEffect,
-  useReducer,
-  useRef,
-} from 'react';
+import { type Node, useEffect, useReducer, useRef } from 'react';
 import Box from '../Box.js';
 import Controller from '../Controller.js';
 import Layer from '../Layer.js';
@@ -68,7 +60,7 @@ type Props = {|
   idealDirection?: 'up' | 'right' | 'down' | 'left',
   inline?: boolean,
   link?: Node,
-  text: string | Element<typeof Text>,
+  text: string | $ReadOnlyArray<string>,
   zIndex?: Indexable,
 |};
 
@@ -110,6 +102,18 @@ export default function InternalTooltip({
     dispatch({ type: 'hoverOutText' });
   }, mouseLeaveDelay);
 
+  const getTooltipText = () => {
+    if (Array.isArray(text)) {
+      const lines = [];
+      // first and last line should not have a <p> tag, (adds extra padding)
+      text.map((line, idx) =>
+        lines.push(idx === 0 || idx === text.length - 1 ? line : <p>{line}</p>),
+      );
+      return lines;
+    }
+    return text;
+  };
+
   return (
     <Box display={inline ? 'inlineBlock' : 'block'}>
       <Box
@@ -145,15 +149,9 @@ export default function InternalTooltip({
               role="tooltip"
               tabIndex={0}
             >
-              {typeof text === 'string' && (
-                <Text color="inverse" size="100">
-                  {text}
-                </Text>
-              )}
-
-              {typeof text !== 'string' &&
-                Children.only<Element<typeof Text>>(text).type.displayName === 'Text' &&
-                cloneElement(text, { color: 'inverse', size: '100' })}
+              <Text color="inverse" size="100">
+                {getTooltipText()}
+              </Text>
 
               {Boolean(link) && <Box marginTop={1}>{link}</Box>}
             </Box>

--- a/packages/gestalt/src/utils/MaybeTooltip.js
+++ b/packages/gestalt/src/utils/MaybeTooltip.js
@@ -1,5 +1,6 @@
 // @flow strict
-import { type Node } from 'react';
+import { type Element, type Node } from 'react';
+import Text from '../Text.js';
 import InternalTooltip from '../Tooltip/InternalTooltip.js';
 import { type Indexable } from '../zIndex.js';
 
@@ -7,7 +8,7 @@ type TooltipProps = {|
   accessibilityLabel?: string,
   inline?: boolean,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
-  text: string,
+  text: string | Element<typeof Text>,
   zIndex?: Indexable,
 |};
 

--- a/packages/gestalt/src/utils/MaybeTooltip.js
+++ b/packages/gestalt/src/utils/MaybeTooltip.js
@@ -1,6 +1,5 @@
 // @flow strict
-import { type Element, type Node } from 'react';
-import Text from '../Text.js';
+import { type Node } from 'react';
 import InternalTooltip from '../Tooltip/InternalTooltip.js';
 import { type Indexable } from '../zIndex.js';
 
@@ -8,7 +7,7 @@ type TooltipProps = {|
   accessibilityLabel?: string,
   inline?: boolean,
   idealDirection?: 'up' | 'right' | 'down' | 'left',
-  text: string | Element<typeof Text>,
+  text: string | $ReadOnlyArray<string>,
   zIndex?: Indexable,
 |};
 


### PR DESCRIPTION
Making tooltips more rich for dataviz components. This enables rich text.

### Summary


#### What changed?

Continuing to build on Internal Tooltip. This adds support for the `string[]` element to enable paragraphs and more spacing.

#### Why?

The m1On teams needs this to enable denser views and add more clarity around these elements.

<img width="278" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/5442393d-7921-42e6-9c02-b85cf2ae585e">


### Links

- [Original thread](https://pinterest.slack.com/archives/C13KLG5P0/p1694560363775429?thread_ts=1674168008.120529&cid=C13KLG5P0)
- [Design Discussion](https://pinterest.slack.com/archives/GD6AMGH9C/p1694562105160289)


### Checklist

- [X] Added unit and Flow Tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers)
