### PR TITLE
WashAnimated: Remove space tokens 

### DIFF
--- a/packages/gestalt/src/WashAnimated.css
+++ b/packages/gestalt/src/WashAnimated.css
@@ -20,7 +20,7 @@ html[dir="rtl"] .hover {
 @keyframes animate-in {
   to {
     opacity: 1;
-    padding: var(--space-400);
+    padding: 8px;
     transform: translateY(-8px) translateX(-8px);
   }
 }
@@ -28,7 +28,7 @@ html[dir="rtl"] .hover {
 @keyframes animate-in-rtl {
   to {
     opacity: 1;
-    padding: var(--space-400);
+    padding: 8px;
     transform: translateY(-8px) translateX(8px);
   }
 }


### PR DESCRIPTION
#### What changed?
Spacing tokens that were in the animate field and this caused weird behavior in Wash Animated on hover:

Before:
<img width="319" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/d7687a3b-b95b-4d27-bf41-abc77d33ca23">

After:
<img width="252" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/6e9cb050-f1cf-4608-9a1a-7f73be45c69a">


It seems like our visual tests didn't catch this, even though the page was visibly different. Something for us to investigate
