### PR TITLE
Tooltip: Move to Internal Tooltip

### DIFF
--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -1,50 +1,7 @@
 // @flow strict
-import { type Node, useReducer, useRef } from 'react';
-import Box from './Box.js';
-import Controller from './Controller.js';
-import Layer from './Layer.js';
-import Text from './Text.js';
-import useDebouncedCallback from './useDebouncedCallback.js';
+import { type Node } from 'react';
+import InternalTooltip from './Tooltip/InternalTooltip.js';
 import { type Indexable } from './zIndex.js';
-
-const noop = () => {};
-const TIMEOUT = 100;
-
-const initialState = { hoveredIcon: false, hoveredText: false, isOpen: false };
-
-const reducer = (
-  state: {| hoveredIcon: boolean, hoveredText: boolean, isOpen: boolean |},
-  action: {| type: 'hoverInIcon' | 'hoverInText' | 'hoverOutIcon' | 'hoverOutText' |},
-) => {
-  switch (action.type) {
-    case 'hoverInIcon':
-      return {
-        ...state,
-        hoveredIcon: true,
-        isOpen: true,
-      };
-    case 'hoverInText':
-      return {
-        ...state,
-        hoveredText: true,
-        isOpen: true,
-      };
-    case 'hoverOutIcon':
-      return {
-        ...state,
-        hoveredIcon: false,
-        isOpen: !state.hoveredText ? false : state.isOpen,
-      };
-    case 'hoverOutText':
-      return {
-        ...state,
-        hoveredText: false,
-        isOpen: !state.hoveredIcon ? false : state.isOpen,
-      };
-    default:
-      throw new Error();
-  }
-};
 
 type Props = {|
   /**
@@ -94,74 +51,17 @@ export default function Tooltip({
   text,
   zIndex,
 }: Props): Node {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const { isOpen } = state;
-
-  const childRef = useRef<?HTMLElement>(null);
-  const { current: anchor } = childRef;
-
-  const mouseLeaveDelay = link ? TIMEOUT : 0;
-
-  const handleIconMouseEnter = () => {
-    dispatch({ type: 'hoverInIcon' });
-  };
-
-  const handleIconMouseLeave = useDebouncedCallback(() => {
-    dispatch({ type: 'hoverOutIcon' });
-  }, mouseLeaveDelay);
-
-  const handleTextMouseEnter = () => {
-    dispatch({ type: 'hoverInText' });
-  };
-
-  const handleTextMouseLeave = useDebouncedCallback(() => {
-    dispatch({ type: 'hoverOutText' });
-  }, mouseLeaveDelay);
-
   return (
-    <Box display={inline ? 'inlineBlock' : 'block'}>
-      <Box
-        aria-label={accessibilityLabel != null ? accessibilityLabel : text}
-        ref={childRef}
-        onFocus={handleIconMouseEnter}
-        onBlur={handleIconMouseLeave}
-        onMouseEnter={handleIconMouseEnter}
-        onMouseLeave={handleIconMouseLeave}
-      >
-        {children}
-      </Box>
-      {isOpen && !!anchor && (
-        <Layer zIndex={zIndex}>
-          <Controller
-            anchor={anchor}
-            caret={false}
-            bgColor="darkGray"
-            border={false}
-            idealDirection={idealDirection}
-            onDismiss={noop}
-            positionRelativeToAnchor={false}
-            rounding={2}
-            size={null}
-          >
-            <Box
-              maxWidth={180}
-              padding={2}
-              onBlur={link ? handleTextMouseLeave : undefined}
-              onFocus={link ? handleTextMouseEnter : undefined}
-              onMouseEnter={link ? handleTextMouseEnter : undefined}
-              onMouseLeave={link ? handleTextMouseLeave : undefined}
-              role="tooltip"
-              tabIndex={0}
-            >
-              <Text color="inverse" size="100">
-                {text}
-              </Text>
-              {Boolean(link) && <Box marginTop={1}>{link}</Box>}
-            </Box>
-          </Controller>
-        </Layer>
-      )}
-    </Box>
+    <InternalTooltip
+      accessibilityLabel={accessibilityLabel}
+      link={link}
+      idealDirection={idealDirection}
+      inline={inline}
+      text={text}
+      zIndex={zIndex}
+    >
+      {children}
+    </InternalTooltip>
   );
 }
 

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -83,23 +83,25 @@ export default function InternalTooltip({
   const mouseLeaveDelay = link ? TIMEOUT : 0;
 
   useEffect(() => {
-    dispatch({ type: 'hoverOutIcon', disabled });
+    if (disabled === true) {
+      dispatch({ type: 'hoverOutIcon', disabled });
+    }
   }, [disabled]);
 
   const handleIconMouseEnter = () => {
-    dispatch({ type: 'hoverInIcon' });
+    dispatch({ type: 'hoverInIcon', disabled });
   };
 
   const handleIconMouseLeave = useDebouncedCallback(() => {
-    dispatch({ type: 'hoverOutIcon' });
+    dispatch({ type: 'hoverOutIcon', disabled });
   }, mouseLeaveDelay);
 
   const handleTextMouseEnter = () => {
-    dispatch({ type: 'hoverInText' });
+    dispatch({ type: 'hoverInText', disabled });
   };
 
   const handleTextMouseLeave = useDebouncedCallback(() => {
-    dispatch({ type: 'hoverOutText' });
+    dispatch({ type: 'hoverOutText', disabled });
   }, mouseLeaveDelay);
 
   return (

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -1,0 +1,152 @@
+// @flow strict
+import { type Node, useEffect, useReducer, useRef } from 'react';
+import Box from '../Box.js';
+import Controller from '../Controller.js';
+import Layer from '../Layer.js';
+import Text from '../Text.js';
+import useDebouncedCallback from '../useDebouncedCallback.js';
+import { type Indexable } from '../zIndex.js';
+
+const noop = () => {};
+const TIMEOUT = 100;
+
+const initialState = { hoveredIcon: false, hoveredText: false, isOpen: false };
+
+const reducer = (
+  state: {| hoveredIcon: boolean, hoveredText: boolean, isOpen: boolean |},
+  action: {|
+    type: 'hoverInIcon' | 'hoverInText' | 'hoverOutIcon' | 'hoverOutText',
+    disabled?: boolean,
+  |},
+) => {
+  if (action.disabled) return { ...state, isOpen: false, hoveredIcon: false };
+  switch (action.type) {
+    case 'hoverInIcon':
+      return {
+        ...state,
+        hoveredIcon: true,
+        isOpen: true,
+      };
+    case 'hoverInText':
+      return {
+        ...state,
+        hoveredText: true,
+        isOpen: true,
+      };
+    case 'hoverOutIcon':
+      return {
+        ...state,
+        hoveredIcon: false,
+        isOpen: !state.hoveredText ? false : state.isOpen,
+      };
+    case 'hoverOutText':
+      return {
+        ...state,
+        hoveredText: false,
+        isOpen: !state.hoveredIcon ? false : state.isOpen,
+      };
+    default:
+      throw new Error();
+  }
+};
+
+type Props = {|
+  accessibilityLabel?: string,
+  children?: Node,
+  /**
+   * Whether to show the tooltip or not
+   */
+  disabled?: boolean,
+  idealDirection?: 'up' | 'right' | 'down' | 'left',
+  inline?: boolean,
+  link?: Node,
+  text: string,
+  zIndex?: Indexable,
+|};
+
+export default function InternalTooltip({
+  accessibilityLabel,
+  children,
+  disabled,
+  link,
+  idealDirection,
+  inline,
+  text,
+  zIndex,
+}: Props): Node {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { isOpen } = state;
+
+  const childRef = useRef<?HTMLElement>(null);
+  const { current: anchor } = childRef;
+
+  const mouseLeaveDelay = link ? TIMEOUT : 0;
+
+  useEffect(() => {
+    dispatch({ type: 'hoverOutIcon', disabled });
+  }, [disabled]);
+
+  const handleIconMouseEnter = () => {
+    dispatch({ type: 'hoverInIcon' });
+  };
+
+  const handleIconMouseLeave = useDebouncedCallback(() => {
+    dispatch({ type: 'hoverOutIcon' });
+  }, mouseLeaveDelay);
+
+  const handleTextMouseEnter = () => {
+    dispatch({ type: 'hoverInText' });
+  };
+
+  const handleTextMouseLeave = useDebouncedCallback(() => {
+    dispatch({ type: 'hoverOutText' });
+  }, mouseLeaveDelay);
+
+  return (
+    <Box display={inline ? 'inlineBlock' : 'block'}>
+      <Box
+        aria-label={accessibilityLabel != null && !disabled ? accessibilityLabel : text}
+        ref={childRef}
+        onFocus={handleIconMouseEnter}
+        onBlur={handleIconMouseLeave}
+        onMouseEnter={handleIconMouseEnter}
+        onMouseLeave={handleIconMouseLeave}
+      >
+        {children}
+      </Box>
+      {isOpen && !!anchor && (
+        <Layer zIndex={zIndex}>
+          <Controller
+            anchor={anchor}
+            caret={false}
+            bgColor="darkGray"
+            border={false}
+            idealDirection={idealDirection}
+            onDismiss={noop}
+            positionRelativeToAnchor={false}
+            rounding={2}
+            size={null}
+          >
+            <Box
+              maxWidth={180}
+              padding={2}
+              onBlur={link ? handleTextMouseLeave : undefined}
+              onFocus={link ? handleTextMouseEnter : undefined}
+              onMouseEnter={link ? handleTextMouseEnter : undefined}
+              onMouseLeave={link ? handleTextMouseLeave : undefined}
+              role="tooltip"
+              tabIndex={0}
+            >
+              <Text color="inverse" size="100">
+                {text}
+              </Text>
+              {Boolean(link) && <Box marginTop={1}>{link}</Box>}
+            </Box>
+          </Controller>
+        </Layer>
+      )}
+    </Box>
+  );
+}
+
+InternalTooltip.displayName = 'InternalTooltip';

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -19,7 +19,7 @@ const reducer = (
     disabled?: boolean,
   |},
 ) => {
-  if (action.disabled) return { ...state, isOpen: false, hoveredIcon: false };
+  if (action.disabled) return { ...state, isOpen: false, hoveredIcon: false, hoveredText: false };
   switch (action.type) {
     case 'hoverInIcon':
       return {

--- a/packages/gestalt/src/__snapshots__/TagData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TagData.test.js.snap
@@ -1271,101 +1271,114 @@ exports[`TagData renders disabled selected state 1`] = `
   }
 >
   <div
-    aria-disabled={true}
-    className="hideOutline tapTransition rounding2 fullHeight fullWidth"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    tabIndex={null}
+    className="box xsDisplayBlock"
   >
     <div
-      className="solid transparentBorder tagMedium secondary disabled tagWrapperRounded"
-      style={Object {}}
+      aria-label="This is a tooltip"
+      className="box"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
-        style={
-          Object {
-            "height": "100%",
-          }
-        }
+        aria-disabled={true}
+        className="hideOutline tapTransition rounding2 fullHeight fullWidth"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={null}
       >
         <div
-          className="box marginEnd1"
+          className="solid transparentBorder tagMedium secondary disabled tagWrapperRounded"
+          style={Object {}}
         >
           <div
-            className="box"
+            className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
+            style={
+              Object {
+                "height": "100%",
+              }
+            }
           >
             <div
-              className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
+              className="box marginEnd1"
             >
               <div
-                className="box paddingX1 relative"
+                className="box"
               >
-                <input
-                  aria-hidden={true}
-                  aria-invalid="false"
-                  checked={true}
-                  className="input sizeSm inputEnabled readOnly"
-                  disabled={true}
-                  id="readonly-checkbox-:rg:"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  type="checkbox"
-                />
                 <div
-                  className="darkGrayBg borderSelected borderRadiusSm sizeSm check"
-                  style={
-                    Object {
-                      "backgroundColor": "var(--color-gray-roboflow-300)",
-                      "borderColor": "transparent",
-                    }
-                  }
+                  className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
                 >
-                  <svg
-                    aria-hidden={true}
-                    aria-label=""
-                    className="icon inverseIcon iconBlock"
-                    height={8}
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width={8}
+                  <div
+                    className="box paddingX1 relative"
                   >
-                    <path
-                      d="test-file-stub"
+                    <input
+                      aria-hidden={true}
+                      aria-invalid="false"
+                      checked={true}
+                      className="input sizeSm inputEnabled readOnly"
+                      disabled={true}
+                      id="readonly-checkbox-:rg:"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      type="checkbox"
                     />
-                  </svg>
+                    <div
+                      className="darkGrayBg borderSelected borderRadiusSm sizeSm check"
+                      style={
+                        Object {
+                          "backgroundColor": "var(--color-gray-roboflow-300)",
+                          "borderColor": "transparent",
+                        }
+                      }
+                    >
+                      <svg
+                        aria-hidden={true}
+                        aria-label=""
+                        className="icon inverseIcon iconBlock"
+                        height={8}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={8}
+                      >
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
+            <span
+              className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
+              style={
+                Object {
+                  "WebkitLineClamp": 1,
+                }
+              }
+              title="Text Impressions"
+            >
+              Text Impressions
+            </span>
           </div>
         </div>
-        <span
-          className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
-          style={
-            Object {
-              "WebkitLineClamp": 1,
-            }
-          }
-          title="Text Impressions"
-        >
-          Text Impressions
-        </span>
       </div>
     </div>
   </div>
@@ -1382,87 +1395,100 @@ exports[`TagData renders disabled unselected state 1`] = `
   }
 >
   <div
-    aria-disabled={true}
-    className="hideOutline tapTransition rounding2 fullHeight fullWidth"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    tabIndex={null}
+    className="box xsDisplayBlock"
   >
     <div
-      className="solid transparentBorder tagMedium secondary disabled tagWrapperRounded"
-      style={Object {}}
+      aria-label="This is a tooltip"
+      className="box"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
-        style={
-          Object {
-            "height": "100%",
-          }
-        }
+        aria-disabled={true}
+        className="hideOutline tapTransition rounding2 fullHeight fullWidth"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={null}
       >
         <div
-          className="box marginEnd1"
+          className="solid transparentBorder tagMedium secondary disabled tagWrapperRounded"
+          style={Object {}}
         >
           <div
-            className="box"
+            className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
+            style={
+              Object {
+                "height": "100%",
+              }
+            }
           >
             <div
-              className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
+              className="box marginEnd1"
             >
               <div
-                className="box paddingX1 relative"
+                className="box"
               >
-                <input
-                  aria-hidden={true}
-                  aria-invalid="false"
-                  checked={false}
-                  className="input sizeSm inputEnabled readOnly"
-                  disabled={true}
-                  id="readonly-checkbox-:rh:"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  type="checkbox"
-                />
                 <div
-                  className="whiteBg border borderRadiusSm sizeSm check"
-                  style={
-                    Object {
-                      "backgroundColor": "var(--color-gray-roboflow-300)",
-                      "borderColor": "transparent",
-                    }
-                  }
-                />
+                  className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
+                >
+                  <div
+                    className="box paddingX1 relative"
+                  >
+                    <input
+                      aria-hidden={true}
+                      aria-invalid="false"
+                      checked={false}
+                      className="input sizeSm inputEnabled readOnly"
+                      disabled={true}
+                      id="readonly-checkbox-:rh:"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      type="checkbox"
+                    />
+                    <div
+                      className="whiteBg border borderRadiusSm sizeSm check"
+                      style={
+                        Object {
+                          "backgroundColor": "var(--color-gray-roboflow-300)",
+                          "borderColor": "transparent",
+                        }
+                      }
+                    />
+                  </div>
+                </div>
               </div>
             </div>
+            <span
+              className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
+              style={
+                Object {
+                  "WebkitLineClamp": 1,
+                }
+              }
+              title="Text Impressions"
+            >
+              Text Impressions
+            </span>
           </div>
         </div>
-        <span
-          className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
-          style={
-            Object {
-              "WebkitLineClamp": 1,
-            }
-          }
-          title="Text Impressions"
-        >
-          Text Impressions
-        </span>
       </div>
     </div>
   </div>

--- a/packages/gestalt/src/__snapshots__/TileData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TileData.test.js.snap
@@ -2706,88 +2706,132 @@ exports[`TileData TileData title truncates when really long 1`] = `
 
 exports[`TileData Tiledata is disabled 1`] = `
 <div
-  className="box"
-  style={
-    Object {
-      "maxWidth": 196,
-    }
-  }
+  className="box xsDisplayBlock"
 >
   <div
-    aria-disabled={true}
-    className="hideOutline tapTransition rounding4 fullWidth"
+    aria-label="This is a tooltip"
+    className="box"
     onBlur={[Function]}
-    onClick={[Function]}
     onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onMouseDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    role="button"
-    tabIndex={null}
   >
     <div
-      className="baseTile tileWidth selected disabled"
-      style={Object {}}
+      className="box"
+      style={
+        Object {
+          "maxWidth": 196,
+        }
+      }
     >
       <div
-        className="Flex rowGap2 columnGap2 xsDirectionRow"
+        aria-disabled={true}
+        className="hideOutline tapTransition rounding4 fullWidth"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={null}
       >
         <div
-          className="FlexItem"
+          className="baseTile tileWidth selected disabled"
+          style={Object {}}
         >
           <div
-            className="Flex rowGap0 columnGap1 xsDirectionColumn"
+            className="Flex rowGap2 columnGap2 xsDirectionRow"
           >
             <div
               className="FlexItem"
             >
               <div
-                className="Flex rowGap1 columnGap0 xsDirectionRow xsItemsCenter"
-                style={
-                  Object {
-                    "minHeight": 24,
-                  }
-                }
+                className="Flex rowGap0 columnGap1 xsDirectionColumn"
               >
                 <div
                   className="FlexItem"
                 >
                   <div
-                    className="box"
+                    className="Flex rowGap1 columnGap0 xsDirectionRow xsItemsCenter"
                     style={
                       Object {
-                        "minWidth": 80,
+                        "minHeight": 24,
                       }
                     }
                   >
                     <div
-                      className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
-                      style={
-                        Object {
-                          "WebkitLineClamp": 2,
-                        }
-                      }
+                      className="FlexItem"
                     >
-                      Text Impressions
                       <div
-                        className="box relative"
+                        className="box"
                         style={
                           Object {
-                            "display": "inline",
+                            "minWidth": 80,
                           }
                         }
                       >
                         <div
-                          className="box xsDisplayVisuallyHidden"
+                          className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
+                          style={
+                            Object {
+                              "WebkitLineClamp": 2,
+                            }
+                          }
                         >
-                          ,
+                          Text Impressions
+                          <div
+                            className="box relative"
+                            style={
+                              Object {
+                                "display": "inline",
+                              }
+                            }
+                          >
+                            <div
+                              className="box xsDisplayVisuallyHidden"
+                            >
+                              ,
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="FlexItem"
+                >
+                  <div
+                    className="Flex rowGap2 columnGap2 xsDirectionRow xsItemsCenter"
+                  >
+                    <div
+                      className="FlexItem"
+                    >
+                      <div
+                        className="Text fontSize400 subtleText alignStart breakWord fontWeightSemiBold"
+                      >
+                        1.23M
+                        <div
+                          className="box relative"
+                          style={
+                            Object {
+                              "display": "inline",
+                            }
+                          }
+                        >
+                          <div
+                            className="box xsDisplayVisuallyHidden"
+                          >
+                            ,
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -2799,84 +2843,53 @@ exports[`TileData Tiledata is disabled 1`] = `
               className="FlexItem"
             >
               <div
-                className="Flex rowGap2 columnGap2 xsDirectionRow xsItemsCenter"
+                className="box"
               >
                 <div
-                  className="FlexItem"
+                  className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
                 >
                   <div
-                    className="Text fontSize400 subtleText alignStart breakWord fontWeightSemiBold"
+                    className="box paddingX1 relative"
                   >
-                    1.23M
+                    <input
+                      aria-hidden={true}
+                      aria-invalid="false"
+                      checked={true}
+                      className="input sizeSm inputEnabled readOnly"
+                      disabled={true}
+                      id="readonly-checkbox-blah-:re:"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      type="checkbox"
+                    />
                     <div
-                      className="box relative"
+                      className="darkGrayBg borderSelected borderRadiusSm sizeSm check"
                       style={
                         Object {
-                          "display": "inline",
+                          "backgroundColor": "var(--color-gray-roboflow-300)",
+                          "borderColor": "transparent",
                         }
                       }
                     >
-                      <div
-                        className="box xsDisplayVisuallyHidden"
+                      <svg
+                        aria-hidden={true}
+                        aria-label=""
+                        className="icon inverseIcon iconBlock"
+                        height={8}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={8}
                       >
-                        ,
-                      </div>
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
                     </div>
                   </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="FlexItem"
-        >
-          <div
-            className="box"
-          >
-            <div
-              className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
-            >
-              <div
-                className="box paddingX1 relative"
-              >
-                <input
-                  aria-hidden={true}
-                  aria-invalid="false"
-                  checked={true}
-                  className="input sizeSm inputEnabled readOnly"
-                  disabled={true}
-                  id="readonly-checkbox-blah-:re:"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  type="checkbox"
-                />
-                <div
-                  className="darkGrayBg borderSelected borderRadiusSm sizeSm check"
-                  style={
-                    Object {
-                      "backgroundColor": "var(--color-gray-roboflow-300)",
-                      "borderColor": "transparent",
-                    }
-                  }
-                >
-                  <svg
-                    aria-hidden={true}
-                    aria-label=""
-                    className="icon inverseIcon iconBlock"
-                    height={8}
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width={8}
-                  >
-                    <path
-                      d="test-file-stub"
-                    />
-                  </svg>
                 </div>
               </div>
             </div>

--- a/packages/gestalt/src/utils/MaybeTooltip.js
+++ b/packages/gestalt/src/utils/MaybeTooltip.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import Tooltip from '../Tooltip.js';
+import InternalTooltip from '../Tooltip/InternalTooltip.js';
 import { type Indexable } from '../zIndex.js';
 
 type TooltipProps = {|
@@ -20,16 +20,18 @@ export default function MaybeTooltip({
   disabled?: boolean,
   tooltip?: TooltipProps,
 |}): Node {
-  if (!tooltip || disabled) return children;
+  if (!tooltip) return children;
+
   return (
-    <Tooltip
+    <InternalTooltip
       accessibilityLabel={tooltip.accessibilityLabel}
       inline={tooltip.inline}
-      idealDirection={tooltip.idealDirection || 'up'}
+      disabled={disabled}
+      idealDirection={tooltip?.idealDirection || 'up'}
       text={tooltip.text}
-      zIndex={tooltip.zIndex}
+      zIndex={tooltip?.zIndex}
     >
       {children}
-    </Tooltip>
+    </InternalTooltip>
   );
 }


### PR DESCRIPTION
### Summary

Moving to an internal tooltip. Original change description is in #3187.  It was reverted in #3209 due to failing tests.

#### What changed?

This fixes extra rendering that kept getting called in the useEffect 

Before:

```
useEffect(() => {
      dispatch({ type: 'hoverOutIcon', disabled });
  }, [disabled]);
 ```
  
This would dispatch the event every time on first render. So when a lot of conditional renders were happening, this would cause a `too many renders` issue.

E.g. in something like
```
{text && <Tooltip> <Child> </Tooltip}
```
Every time text would change, the element would fall into re-rendering.

  
 Now:
 ```
 useEffect(() => {
     if(disabled === true){
           dispatch({ type: 'hoverOutIcon', disabled });
     }
  }, [disabled]);
 ```
  
 This only dispatches the disabled action if the item in the disabled prop is true.
 
Also, added disabled to all of the other actions as a prop
