### PR TITLE
List: Update Condensed List Spacing Tokens

### DIFF
--- a/packages/gestalt/src/List.css
+++ b/packages/gestalt/src/List.css
@@ -41,19 +41,19 @@ html[dir="rtl"] .bulletList:first-child {
 }
 
 .listItemCondensed {
-  margin-bottom: var(--space-400);
-  margin-top: var(--space-400);
+  margin-bottom: var(--space-200);
+  margin-top: var(--space-200);
 }
 
 /* last should precede first for single item lists */
 
 .listItemCondensed:last-child {
   margin-bottom: 0;
-  margin-top: var(--space-400);
+  margin-top: var(--space-200);
 }
 
 .listItemCondensed:first-child {
-  margin-bottom: var(--space-400);
+  margin-bottom: var(--space-200);
   margin-top: 0;
 }
 
@@ -70,13 +70,13 @@ html[dir="rtl"] .bulletList:first-child {
 }
 
 .list .list > .listItemCondensed:last-child {
-  margin-bottom: var(--space-400);
-  margin-top: var(--space-400);
+  margin-bottom: var(--space-200);
+  margin-top: var(--space-200);
 }
 
 .list .list > .listItemCondensed:first-child {
-  margin-bottom: var(--space-400);
-  margin-top: var(--space-400);
+  margin-bottom: var(--space-200);
+  margin-top: var(--space-200);
 }
 
 .noStyle {


### PR DESCRIPTION
#### What changed?
Fixing some List spacing tokens that were not correct for condensed items

## BEFORE
<img width="937" alt="Screenshot 2023-09-27 at 12 09 11 PM" src="https://github.com/pinterest/gestalt/assets/10593890/2d487c2c-6983-44e6-9c99-2b336a393f9c">
## AFTER
<img width="780" alt="Screenshot 2023-09-27 at 12 09 20 PM" src="https://github.com/pinterest/gestalt/assets/10593890/bf232fcc-6369-4dcd-bdcb-342251106550">



