### PR TITLE
TapArea: fix in TapArea child Flow type

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -2015,7 +2015,7 @@ interface TapAreaProps {
   accessibilityControls?: string | undefined;
   accessibilityExpanded?: boolean | undefined;
   accessibilityHaspopup?: boolean | undefined;
-  children: Node;
+  children?: Node;
   dataTestId?: string;
   disabled?: boolean | undefined;
   fullHeight?: boolean | undefined;

--- a/packages/gestalt/src/TapArea.js
+++ b/packages/gestalt/src/TapArea.js
@@ -51,7 +51,7 @@ type Props = {|
   /**
    * TapArea is a wrapper around non-button components (or children) that provides clicking / touching functionality as if they were a unified button area.
    */
-  children: Node,
+  children?: Node,
   /**
    * Available for testing purposes, if needed.
    * Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.


### PR DESCRIPTION
### Summary

#### What changed?

TapArea: fix in TapArea child Flow type

#### Why?

`TapArea fullWidth fullHeight` technically doesn't need children 

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
