### PR TITLE
TapArea: full space with no children example in Docs

### DIFF
--- a/docs/examples/taparea/fullSpace.js
+++ b/docs/examples/taparea/fullSpace.js
@@ -1,0 +1,11 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, TapArea } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box height="100%" width="100%" color="secondary">
+      <TapArea fullHeight fullWidth onTap={() => {}} />
+    </Box>
+  );
+}

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -71,6 +71,8 @@ TapArea with link interaction can be paired with GlobalEventsHandlerProvider. Se
             sandpackExample={<SandpackExample name="Height & Width Example" code={heightWidth} />}
           />
           <MainSection.Card
+            cardSize="lg"
+            title="Full space with no children"
             sandpackExample={
               <SandpackExample name="Full space with no children" code={fullSpace} />
             }

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -12,6 +12,7 @@ import QualityChecklist from '../../docs-components/QualityChecklist.js';
 import SandpackExample from '../../docs-components/SandpackExample.js';
 import accessibility from '../../examples/taparea/accessibility.js';
 import compressBehavior from '../../examples/taparea/compressBehavior.js';
+import fullSpace from '../../examples/taparea/fullSpace.js';
 import heightWidth from '../../examples/taparea/heightWidth.js';
 import inlineUsage from '../../examples/taparea/inlineUsage.js';
 import main from '../../examples/taparea/main.js';
@@ -68,6 +69,11 @@ TapArea with link interaction can be paired with GlobalEventsHandlerProvider. Se
         <MainSection.Subsection title="Height & width">
           <MainSection.Card
             sandpackExample={<SandpackExample name="Height & Width Example" code={heightWidth} />}
+          />
+          <MainSection.Card
+            sandpackExample={
+              <SandpackExample name="Full space with no children" code={fullSpace} />
+            }
           />
         </MainSection.Subsection>
 


### PR DESCRIPTION
### Summary

#### What changed?

TapArea: full space with no children example in Docs