### PR TITLE
IconButton: reenabling tooltip when disabled 

### DIFF
--- a/packages/gestalt/src/IconButton.js
+++ b/packages/gestalt/src/IconButton.js
@@ -239,7 +239,7 @@ const IconButtonWithForwardRef: AbstractComponent<Props, HTMLButtonElement> = fo
     </button>
   );
 
-  return tooltip?.text && !disabled ? (
+  return tooltip?.text ? (
     <Tooltip
       accessibilityLabel={tooltip.accessibilityLabel}
       inline={tooltip.inline}


### PR DESCRIPTION
### Summary

#### What changed?

IconButton: reenabling tooltip when disabled  as there are use cases of disabled button tooltip messages