### PR TITLE
Internal: Update local test check

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -47,11 +47,14 @@ then
   exit 1
 fi
 
-# We're going to run visual locally for now and only when files in the gestalt library are changed
-if  [ -z "${GITHUB_ACTIONS:-}" ] && [ -n "$(git diff  HEAD master -- gestalt)" ]; then
+if  [ -z "${GITHUB_ACTIONS:-}" ] && git diff HEAD master --name-only | grep -q packages/gestalt; then
+  echo "Found changes to Components"
   echo "Running playwright tests locally"
   yarn run playwright:visual-test
+else
+  echo "Skipping visual tests for components"
 fi
+
 
 echo "👌 Looks good to me!"
 echo "📑 Done!"


### PR DESCRIPTION
#### What changed?
Visual tests were not always running locally as expected. This updates old Bash script.

The old git diff command was paginating, and the grep command was not always finding instances.

This adds a `--name-only` flag to the git diff so we get a complete list of the files, and greps everything at once. 

 It also wraps the function an if else statement to continue executing due to `set -euo pipefail` requirements

