### PR TITLE
Tokens: Updated dark mode $color-border-container

### DIFF
--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -316,7 +316,7 @@
     "border": {
       "container": {
         "value": "{color.gray.roboflow.300.value}",
-        "darkValue": "{color.gray.roboflow.600.value}",
+        "darkValue": "{color.gray.roboflow.500.value}",
         "comment": "Used to delineate a larger container, like Card or TextArea"
       },
       "default": {

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -83,7 +83,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-background-elevation-accent: #191919;
   --color-background-elevation-floating: #2b2b2b;
   --color-background-elevation-raised: #4a4a4a;
-  --color-border-container: #4a4a4a;
+  --color-border-container: #767676;
   --color-border-default: #cdcdcd;
   --color-border-error: #f47171;
   --color-data-visualization-10: #007A72;
@@ -524,7 +524,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-background-elevation-accent: #191919;
   --color-background-elevation-floating: #2b2b2b;
   --color-background-elevation-raised: #4a4a4a;
-  --color-border-container: #4a4a4a;
+  --color-border-container: #767676;
   --color-border-default: #cdcdcd;
   --color-border-error: #f47171;
   --color-data-visualization-10: #007A72;


### PR DESCRIPTION
### Summary

#### What changed?

Updated dark mode for $color-border-container to use roboflow 500 (#767676)
<img width="863" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/1c4b96db-269f-41ce-89e0-e20efa91e4e1">

BEFORE
<img width="794" alt="Screenshot 2023-10-02 at 12 22 44 PM" src="https://github.com/pinterest/gestalt/assets/10593890/c82181b2-47ff-405b-b3f2-d364cf0fdaba">

AFTER
<img width="760" alt="Screenshot 2023-10-02 at 12 23 25 PM" src="https://github.com/pinterest/gestalt/assets/10593890/a6da8e83-54c7-46e0-b4bc-46d554f4fd67">

#### Why?

The previous color was very hard to see and wasn't perceptually on-par with the light mode color

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6973)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
